### PR TITLE
refactor (acp): simplify ACP tool-call handling and fix chain summaries

### DIFF
--- a/crates/goose-cli/src/session/export.rs
+++ b/crates/goose-cli/src/session/export.rs
@@ -1,5 +1,5 @@
 use goose::conversation::message::{
-    ActionRequiredData, Message, MessageContent, ToolRequest, ToolResponse,
+    ActionRequiredData, Message, MessageContent, ToolNameParts, ToolRequest, ToolResponse,
 };
 use goose::utils::safe_truncate;
 use rmcp::model::{RawContent, ResourceContents, Role};
@@ -124,20 +124,20 @@ pub fn tool_request_to_markdown(req: &ToolRequest, export_all_content: bool) -> 
     let mut md = String::new();
     match &req.tool_call {
         Ok(call) => {
-            let parts: Vec<_> = call.name.rsplitn(2, "__").collect();
-            let (namespace, tool_name_only) = if parts.len() == 2 {
-                (parts[1], parts[0])
-            } else if is_shell_tool_name(call.name.as_ref())
-                || is_developer_file_tool_name(call.name.as_ref())
-            {
-                ("developer", parts[0])
-            } else {
-                ("Tool", parts[0])
+            let name_parts = ToolNameParts::from(call.name.as_ref());
+            let namespace = match name_parts.extension_name {
+                Some(extension_name) => extension_name,
+                None if is_shell_tool_name(call.name.as_ref())
+                    || is_developer_file_tool_name(call.name.as_ref()) =>
+                {
+                    "developer"
+                }
+                None => "Tool",
             };
 
             md.push_str(&format!(
                 "#### Tool Call: `{}` (namespace: `{}`)\n",
-                tool_name_only, namespace
+                name_parts.tool_name, namespace
             ));
             md.push_str("**Arguments:**\n");
 
@@ -586,6 +586,21 @@ mod tests {
         assert!(result.contains("**path**: `/path/to/file.txt`"));
         assert!(result.contains("**before**"));
         assert!(result.contains("**after**"));
+    }
+
+    #[test]
+    fn test_tool_request_to_markdown_splits_at_first_separator() {
+        let tool_request = ToolRequest {
+            id: "test-id".to_string(),
+            tool_call: Ok(CallToolRequestParams::new("calendar__events__list")),
+            metadata: None,
+            tool_meta: None,
+        };
+
+        let result = tool_request_to_markdown(&tool_request, true);
+
+        assert!(result.contains("#### Tool Call: `events__list`"));
+        assert!(result.contains("namespace: `calendar`"));
     }
 
     #[test]

--- a/crates/goose-cli/src/session/output.rs
+++ b/crates/goose-cli/src/session/output.rs
@@ -4,7 +4,7 @@ use console::{measure_text_width, style, Color, StyledObject, Term};
 use goose::config::Config;
 use goose::conversation::message::{
     ActionRequiredData, Message, MessageContent, SystemNotificationContent, SystemNotificationType,
-    ToolRequest, ToolResponse,
+    ToolNameParts, ToolRequest, ToolResponse,
 };
 use goose::providers::canonical::maybe_get_canonical_model;
 #[cfg(target_os = "windows")]
@@ -844,31 +844,25 @@ fn render_default_request(call: &CallToolRequestParams, debug: bool) {
     println!();
 }
 
-fn split_tool_name(tool_name: &str) -> (String, String) {
-    let parts: Vec<_> = tool_name.rsplit("__").collect();
-    let tool = parts.first().copied().unwrap_or("unknown");
-    let extension = parts
-        .split_first()
-        .map(|(_, s)| s.iter().rev().copied().collect::<Vec<_>>().join("__"))
-        .unwrap_or_default();
-    (tool.to_string(), extension_display_name(&extension))
-}
-
-fn extension_display_name(name: &str) -> String {
+fn extension_display_name(name: &str) -> &str {
     match name {
-        "code_execution" => "Code Mode".to_string(),
-        _ => name.to_string(),
+        "code_execution" => "Code Mode",
+        _ => name,
     }
 }
 
 pub fn format_subagent_tool_call_message(subagent_id: &str, tool_name: &str) -> String {
     let short_id = subagent_id.rsplit('_').next().unwrap_or(subagent_id);
-    let (tool, extension) = split_tool_name(tool_name);
+    let parts = ToolNameParts::from(tool_name);
 
-    if extension.is_empty() {
-        format!("[subagent:{}] {}", short_id, tool)
-    } else {
-        format!("[subagent:{}] {} | {}", short_id, tool, extension)
+    match parts.extension_name {
+        Some(extension_name) => format!(
+            "[subagent:{}] {} | {}",
+            short_id,
+            parts.tool_name,
+            extension_display_name(extension_name)
+        ),
+        None => format!("[subagent:{}] {}", short_id, parts.tool_name),
     }
 }
 
@@ -948,16 +942,17 @@ fn render_subagent_tool_graph(subagent_id: &str, tool_graph: &[Value]) {
 // Helper functions
 
 fn print_tool_header(call: &CallToolRequestParams) {
-    let (tool, extension) = split_tool_name(&call.name);
-    let tool_header = if extension.is_empty() {
-        format!("  {} {}", style("▸").dim(), style(&tool).dim())
-    } else {
-        format!(
+    let parts = ToolNameParts::from(call.name.as_ref());
+    let tool_header = match parts.extension_name {
+        Some(extension_name) => format!(
             "  {} {} {}",
             style("▸").dim(),
-            style(&tool).dim(),
-            style(extension).magenta().dim(),
-        )
+            style(parts.tool_name).dim(),
+            style(extension_display_name(extension_name))
+                .magenta()
+                .dim(),
+        ),
+        None => format!("  {} {}", style("▸").dim(), style(parts.tool_name).dim()),
     };
     println!();
     println!("  {}", style("─".repeat(40)).dim());
@@ -1527,6 +1522,26 @@ mod tests {
     use super::*;
     use serde_json::json;
     use std::env;
+
+    #[test]
+    fn formats_subagent_tool_call_names() {
+        assert_eq!(
+            format_subagent_tool_call_message("subagent_42", "read"),
+            "[subagent:42] read"
+        );
+        assert_eq!(
+            format_subagent_tool_call_message("subagent_42", "developer__shell"),
+            "[subagent:42] shell | developer"
+        );
+        assert_eq!(
+            format_subagent_tool_call_message("subagent_42", "code_execution__execute_typescript"),
+            "[subagent:42] execute_typescript | Code Mode"
+        );
+        assert_eq!(
+            format_subagent_tool_call_message("subagent_42", "calendar__events__list"),
+            "[subagent:42] events__list | calendar"
+        );
+    }
 
     #[test]
     fn test_short_paths_unchanged() {

--- a/crates/goose-provider-types/src/conversation.rs
+++ b/crates/goose-provider-types/src/conversation.rs
@@ -7,6 +7,7 @@ use thiserror::Error;
 
 pub mod message;
 pub mod token_usage;
+mod tool_request;
 mod tool_result_serde;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/crates/goose-provider-types/src/conversation/message.rs
+++ b/crates/goose-provider-types/src/conversation/message.rs
@@ -94,7 +94,7 @@ pub struct ToolNameParts<'a> {
 }
 
 /// A chain summary persisted on the first tool request of a chain.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct ToolChainSummary {
     pub summary: String,
     pub count: usize,

--- a/crates/goose-provider-types/src/conversation/message.rs
+++ b/crates/goose-provider-types/src/conversation/message.rs
@@ -87,63 +87,10 @@ pub struct ToolRequest {
     pub tool_meta: Option<serde_json::Value>,
 }
 
-impl ToolRequest {
-    pub fn to_readable_string(&self) -> String {
-        match &self.tool_call {
-            Ok(tool_call) => {
-                format!(
-                    "Tool: {}, Args: {}",
-                    tool_call.name,
-                    serde_json::to_string_pretty(&tool_call.arguments)
-                        .unwrap_or_else(|_| "<<invalid json>>".to_string())
-                )
-            }
-            Err(e) => format!("Invalid tool call: {}", e),
-        }
-    }
-
-    /// Returns true if this tool request was already executed externally
-    /// (e.g. by an ACP provider's underlying SDK) and the agent loop must
-    /// not redispatch it. See [`TOOL_META_EXTERNAL_DISPATCH_KEY`].
-    pub fn is_externally_dispatched(&self) -> bool {
-        self.tool_meta
-            .as_ref()
-            .and_then(|v| v.get(TOOL_META_EXTERNAL_DISPATCH_KEY))
-            .and_then(|v| v.as_bool())
-            .unwrap_or(false)
-    }
-
-    /// Returns the persisted LLM-generated title for this tool call, if any.
-    /// Set asynchronously by [`crate::acp::server`] after `provider.complete_fast`
-    /// resolves; survives session reload via SQLite. Falls back to `None` for
-    /// older sessions that predate persistence — callers should use a deterministic
-    /// title in that case.
-    pub fn persisted_title(&self) -> Option<&str> {
-        self.tool_meta
-            .as_ref()
-            .and_then(|v| v.get(TOOL_META_TITLE_KEY))
-            .and_then(|v| v.as_str())
-    }
-
-    /// Returns the persisted per-chain summary anchored on this tool request,
-    /// if any. Only the FIRST tool request in a chain (a run of consecutive
-    /// tool blocks within one assistant message) carries this. See
-    /// [`crate::acp::server`] for how chains are detected and summarized.
-    pub fn persisted_chain_summary(&self) -> Option<PersistedChainSummary> {
-        let obj = self
-            .tool_meta
-            .as_ref()
-            .and_then(|v| v.get(TOOL_META_CHAIN_SUMMARY_KEY))?;
-        let summary = obj.get("summary").and_then(|v| v.as_str())?.to_string();
-        let count = obj.get("count").and_then(|v| v.as_u64())?;
-        if count == 0 {
-            return None;
-        }
-        Some(PersistedChainSummary {
-            summary,
-            count: count as usize,
-        })
-    }
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ToolNameParts<'a> {
+    pub extension_name: Option<&'a str>,
+    pub tool_name: &'a str,
 }
 
 /// A chain summary persisted on the first tool request of a chain.
@@ -1958,79 +1905,5 @@ mod tests {
                 }
             }
         }
-    }
-
-    fn make_tool_request(meta: Option<serde_json::Value>) -> super::ToolRequest {
-        super::ToolRequest {
-            id: "id-1".to_string(),
-            tool_call: Ok(CallToolRequestParams::new("test_tool")),
-            metadata: None,
-            tool_meta: meta,
-        }
-    }
-
-    #[test]
-    fn persisted_title_returns_none_when_meta_missing() {
-        let req = make_tool_request(None);
-        assert_eq!(req.persisted_title(), None);
-    }
-
-    #[test]
-    fn persisted_title_returns_value_when_present() {
-        let meta = serde_json::json!({
-            super::TOOL_META_TITLE_KEY: "reading project configuration",
-        });
-        let req = make_tool_request(Some(meta));
-        assert_eq!(req.persisted_title(), Some("reading project configuration"));
-    }
-
-    #[test]
-    fn persisted_title_returns_none_for_non_string_value() {
-        let meta = serde_json::json!({ super::TOOL_META_TITLE_KEY: 42 });
-        let req = make_tool_request(Some(meta));
-        assert_eq!(req.persisted_title(), None);
-    }
-
-    #[test]
-    fn persisted_title_does_not_collide_with_external_dispatch() {
-        let meta = serde_json::json!({
-            super::TOOL_META_EXTERNAL_DISPATCH_KEY: true,
-            super::TOOL_META_TITLE_KEY: "running commands",
-        });
-        let req = make_tool_request(Some(meta));
-        assert!(req.is_externally_dispatched());
-        assert_eq!(req.persisted_title(), Some("running commands"));
-    }
-
-    #[test]
-    fn persisted_chain_summary_round_trips() {
-        let meta = serde_json::json!({
-            super::TOOL_META_CHAIN_SUMMARY_KEY: {
-                "summary": "applied dark mode polish",
-                "count": 4,
-            },
-        });
-        let req = make_tool_request(Some(meta));
-        let summary = req.persisted_chain_summary().expect("summary present");
-        assert_eq!(summary.summary, "applied dark mode polish");
-        assert_eq!(summary.count, 4);
-    }
-
-    #[test]
-    fn persisted_chain_summary_returns_none_for_missing_or_zero_count() {
-        let req = make_tool_request(None);
-        assert!(req.persisted_chain_summary().is_none());
-
-        let meta_zero = serde_json::json!({
-            super::TOOL_META_CHAIN_SUMMARY_KEY: { "summary": "x", "count": 0 },
-        });
-        let req_zero = make_tool_request(Some(meta_zero));
-        assert!(req_zero.persisted_chain_summary().is_none());
-
-        let meta_no_summary = serde_json::json!({
-            super::TOOL_META_CHAIN_SUMMARY_KEY: { "count": 3 },
-        });
-        let req_no_summary = make_tool_request(Some(meta_no_summary));
-        assert!(req_no_summary.persisted_chain_summary().is_none());
     }
 }

--- a/crates/goose-provider-types/src/conversation/message.rs
+++ b/crates/goose-provider-types/src/conversation/message.rs
@@ -95,7 +95,7 @@ pub struct ToolNameParts<'a> {
 
 /// A chain summary persisted on the first tool request of a chain.
 #[derive(Debug, Clone, PartialEq)]
-pub struct PersistedChainSummary {
+pub struct ToolChainSummary {
     pub summary: String,
     pub count: usize,
 }

--- a/crates/goose-provider-types/src/conversation/tool_request.rs
+++ b/crates/goose-provider-types/src/conversation/tool_request.rs
@@ -21,7 +21,14 @@ impl<'a> From<&'a str> for ToolNameParts<'a> {
 impl ToolRequest {
     pub fn tool_name_parts(&self) -> Option<ToolNameParts<'_>> {
         let tool_call = self.tool_call.as_ref().ok()?;
-        Some(ToolNameParts::from(tool_call.name.as_ref()))
+        let mut parts = ToolNameParts::from(tool_call.name.as_ref());
+        parts.extension_name = self
+            .tool_meta
+            .as_ref()
+            .and_then(|meta| meta.get("goose_extension"))
+            .and_then(serde_json::Value::as_str)
+            .or(parts.extension_name);
+        Some(parts)
     }
 
     pub fn to_readable_string(&self) -> String {
@@ -131,6 +138,20 @@ mod tests {
                 Some(ToolNameParts {
                     extension_name: None,
                     tool_name: "read",
+                })
+            );
+        }
+
+        #[test]
+        fn resolves_unprefixed_extension_from_metadata() {
+            let mut request = make_named_tool_request("write");
+            request.tool_meta = Some(serde_json::json!({"goose_extension": "developer"}));
+
+            assert_eq!(
+                request.tool_name_parts(),
+                Some(ToolNameParts {
+                    extension_name: Some("developer"),
+                    tool_name: "write",
                 })
             );
         }

--- a/crates/goose-provider-types/src/conversation/tool_request.rs
+++ b/crates/goose-provider-types/src/conversation/tool_request.rs
@@ -1,0 +1,236 @@
+use super::message::{
+    PersistedChainSummary, ToolNameParts, ToolRequest, TOOL_META_CHAIN_SUMMARY_KEY,
+    TOOL_META_EXTERNAL_DISPATCH_KEY, TOOL_META_TITLE_KEY,
+};
+
+impl<'a> From<&'a str> for ToolNameParts<'a> {
+    fn from(name: &'a str) -> Self {
+        match name.split_once("__") {
+            Some((extension_name, tool_name)) => Self {
+                extension_name: Some(extension_name),
+                tool_name,
+            },
+            None => Self {
+                extension_name: None,
+                tool_name: name,
+            },
+        }
+    }
+}
+
+impl ToolRequest {
+    pub fn tool_name_parts(&self) -> Option<ToolNameParts<'_>> {
+        let tool_call = self.tool_call.as_ref().ok()?;
+        Some(ToolNameParts::from(tool_call.name.as_ref()))
+    }
+
+    pub fn to_readable_string(&self) -> String {
+        match &self.tool_call {
+            Ok(tool_call) => {
+                format!(
+                    "Tool: {}, Args: {}",
+                    tool_call.name,
+                    serde_json::to_string_pretty(&tool_call.arguments)
+                        .unwrap_or_else(|_| "<<invalid json>>".to_string())
+                )
+            }
+            Err(e) => format!("Invalid tool call: {}", e),
+        }
+    }
+
+    /// Returns true if this tool request was already executed externally
+    /// (e.g. by an ACP provider's underlying SDK) and the agent loop must
+    /// not redispatch it. See [`TOOL_META_EXTERNAL_DISPATCH_KEY`].
+    pub fn is_externally_dispatched(&self) -> bool {
+        self.tool_meta
+            .as_ref()
+            .and_then(|v| v.get(TOOL_META_EXTERNAL_DISPATCH_KEY))
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false)
+    }
+
+    /// Returns the persisted LLM-generated title for this tool call, if any.
+    /// Set asynchronously by [`crate::acp::server`] after `provider.complete_fast`
+    /// resolves; survives session reload via SQLite. Falls back to `None` for
+    /// older sessions that predate persistence — callers should use a deterministic
+    /// title in that case.
+    pub fn persisted_title(&self) -> Option<&str> {
+        self.tool_meta
+            .as_ref()
+            .and_then(|v| v.get(TOOL_META_TITLE_KEY))
+            .and_then(|v| v.as_str())
+    }
+
+    /// Returns the persisted per-chain summary anchored on this tool request,
+    /// if any. Only the FIRST tool request in a chain (a run of consecutive
+    /// tool blocks within one assistant message) carries this. See
+    /// [`crate::acp::server`] for how chains are detected and summarized.
+    pub fn persisted_chain_summary(&self) -> Option<PersistedChainSummary> {
+        let obj = self
+            .tool_meta
+            .as_ref()
+            .and_then(|v| v.get(TOOL_META_CHAIN_SUMMARY_KEY))?;
+        let summary = obj.get("summary").and_then(|v| v.as_str())?.to_string();
+        let count = obj.get("count").and_then(|v| v.as_u64())?;
+        if count == 0 {
+            return None;
+        }
+        Some(PersistedChainSummary {
+            summary,
+            count: count as usize,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rmcp::model::CallToolRequestParams;
+
+    fn make_tool_request(meta: Option<serde_json::Value>) -> ToolRequest {
+        ToolRequest {
+            id: "id-1".to_string(),
+            tool_call: Ok(CallToolRequestParams::new("test_tool")),
+            metadata: None,
+            tool_meta: meta,
+        }
+    }
+
+    mod tool_name_parts {
+        use super::*;
+        use rmcp::model::ErrorData;
+
+        fn make_named_tool_request(name: &str) -> ToolRequest {
+            ToolRequest {
+                id: "id-1".to_string(),
+                tool_call: Ok(CallToolRequestParams::new(name.to_string())),
+                metadata: None,
+                tool_meta: None,
+            }
+        }
+
+        #[test]
+        fn splits_prefixed_name() {
+            let request = make_named_tool_request("developer__shell");
+
+            assert_eq!(
+                request.tool_name_parts(),
+                Some(ToolNameParts {
+                    extension_name: Some("developer"),
+                    tool_name: "shell",
+                })
+            );
+        }
+
+        #[test]
+        fn preserves_unprefixed_name() {
+            let request = make_named_tool_request("read");
+
+            assert_eq!(
+                request.tool_name_parts(),
+                Some(ToolNameParts {
+                    extension_name: None,
+                    tool_name: "read",
+                })
+            );
+        }
+
+        #[test]
+        fn splits_at_first_separator() {
+            let request = make_named_tool_request("calendar__events__list");
+
+            assert_eq!(
+                request.tool_name_parts(),
+                Some(ToolNameParts {
+                    extension_name: Some("calendar"),
+                    tool_name: "events__list",
+                })
+            );
+        }
+
+        #[test]
+        fn returns_none_for_invalid_call() {
+            let request = ToolRequest {
+                id: "id-1".to_string(),
+                tool_call: Err(ErrorData::invalid_request("invalid tool call", None)),
+                metadata: None,
+                tool_meta: None,
+            };
+
+            assert_eq!(request.tool_name_parts(), None);
+        }
+    }
+
+    mod persisted_title {
+        use super::*;
+
+        #[test]
+        fn returns_none_when_meta_missing() {
+            let req = make_tool_request(None);
+            assert_eq!(req.persisted_title(), None);
+        }
+
+        #[test]
+        fn returns_value_when_present() {
+            let meta = serde_json::json!({
+                TOOL_META_TITLE_KEY: "reading project configuration",
+            });
+            let req = make_tool_request(Some(meta));
+            assert_eq!(req.persisted_title(), Some("reading project configuration"));
+        }
+
+        #[test]
+        fn returns_none_for_non_string_value() {
+            let meta = serde_json::json!({ TOOL_META_TITLE_KEY: 42 });
+            let req = make_tool_request(Some(meta));
+            assert_eq!(req.persisted_title(), None);
+        }
+
+        #[test]
+        fn does_not_collide_with_external_dispatch() {
+            let meta = serde_json::json!({
+                TOOL_META_EXTERNAL_DISPATCH_KEY: true,
+                TOOL_META_TITLE_KEY: "running commands",
+            });
+            let req = make_tool_request(Some(meta));
+            assert!(req.is_externally_dispatched());
+            assert_eq!(req.persisted_title(), Some("running commands"));
+        }
+    }
+
+    mod persisted_chain_summary {
+        use super::*;
+
+        #[test]
+        fn round_trips() {
+            let meta = serde_json::json!({
+                TOOL_META_CHAIN_SUMMARY_KEY: {
+                    "summary": "applied dark mode polish",
+                    "count": 4,
+                },
+            });
+            let req = make_tool_request(Some(meta));
+            let summary = req.persisted_chain_summary().expect("summary present");
+            assert_eq!(summary.summary, "applied dark mode polish");
+            assert_eq!(summary.count, 4);
+        }
+
+        #[test]
+        fn returns_none_for_missing_or_zero_count() {
+            let req = make_tool_request(None);
+            assert!(req.persisted_chain_summary().is_none());
+
+            let meta_zero = serde_json::json!({
+                TOOL_META_CHAIN_SUMMARY_KEY: { "summary": "x", "count": 0 },
+            });
+            let req_zero = make_tool_request(Some(meta_zero));
+            assert!(req_zero.persisted_chain_summary().is_none());
+
+            let meta_no_summary = serde_json::json!({
+                TOOL_META_CHAIN_SUMMARY_KEY: { "count": 3 },
+            });
+            let req_no_summary = make_tool_request(Some(meta_no_summary));
+            assert!(req_no_summary.persisted_chain_summary().is_none());
+        }
+    }
+}

--- a/crates/goose-provider-types/src/conversation/tool_request.rs
+++ b/crates/goose-provider-types/src/conversation/tool_request.rs
@@ -21,13 +21,20 @@ impl<'a> From<&'a str> for ToolNameParts<'a> {
 impl ToolRequest {
     pub fn tool_name_parts(&self) -> Option<ToolNameParts<'_>> {
         let tool_call = self.tool_call.as_ref().ok()?;
-        let mut parts = ToolNameParts::from(tool_call.name.as_ref());
-        parts.extension_name = self
+        let name = tool_call.name.as_ref();
+        let mut parts = ToolNameParts::from(name);
+        if let Some(extension_name) = self
             .tool_meta
             .as_ref()
             .and_then(|meta| meta.get("goose_extension"))
             .and_then(serde_json::Value::as_str)
-            .or(parts.extension_name);
+        {
+            parts.extension_name = Some(extension_name);
+            parts.tool_name = name
+                .strip_prefix(extension_name)
+                .and_then(|name| name.strip_prefix("__"))
+                .unwrap_or(parts.tool_name);
+        }
         Some(parts)
     }
 
@@ -143,6 +150,20 @@ mod tests {
                 Some(ToolNameParts {
                     extension_name: Some("developer"),
                     tool_name: "write",
+                })
+            );
+        }
+
+        #[test]
+        fn strips_exact_extension_prefix_from_metadata() {
+            let mut request = make_named_tool_request("__cli__ent____tool");
+            request.tool_meta = Some(serde_json::json!({"goose_extension": "__cli__ent__"}));
+
+            assert_eq!(
+                request.tool_name_parts(),
+                Some(ToolNameParts {
+                    extension_name: Some("__cli__ent__"),
+                    tool_name: "tool",
                 })
             );
         }

--- a/crates/goose-provider-types/src/conversation/tool_request.rs
+++ b/crates/goose-provider-types/src/conversation/tool_request.rs
@@ -1,5 +1,5 @@
 use super::message::{
-    PersistedChainSummary, ToolNameParts, ToolRequest, TOOL_META_CHAIN_SUMMARY_KEY,
+    ToolChainSummary, ToolNameParts, ToolRequest, TOOL_META_CHAIN_SUMMARY_KEY,
     TOOL_META_EXTERNAL_DISPATCH_KEY, TOOL_META_TITLE_KEY,
 };
 
@@ -48,7 +48,7 @@ impl ToolRequest {
     /// Returns true if this tool request was already executed externally
     /// (e.g. by an ACP provider's underlying SDK) and the agent loop must
     /// not redispatch it. See [`TOOL_META_EXTERNAL_DISPATCH_KEY`].
-    pub fn is_externally_dispatched(&self) -> bool {
+    pub fn was_executed_externally(&self) -> bool {
         self.tool_meta
             .as_ref()
             .and_then(|v| v.get(TOOL_META_EXTERNAL_DISPATCH_KEY))
@@ -56,23 +56,14 @@ impl ToolRequest {
             .unwrap_or(false)
     }
 
-    /// Returns the persisted LLM-generated title for this tool call, if any.
-    /// Set asynchronously by [`crate::acp::server`] after `provider.complete_fast`
-    /// resolves; survives session reload via SQLite. Falls back to `None` for
-    /// older sessions that predate persistence — callers should use a deterministic
-    /// title in that case.
-    pub fn persisted_title(&self) -> Option<&str> {
+    pub fn generated_title(&self) -> Option<&str> {
         self.tool_meta
             .as_ref()
             .and_then(|v| v.get(TOOL_META_TITLE_KEY))
             .and_then(|v| v.as_str())
     }
 
-    /// Returns the persisted per-chain summary anchored on this tool request,
-    /// if any. Only the FIRST tool request in a chain (a run of consecutive
-    /// tool blocks within one assistant message) carries this. See
-    /// [`crate::acp::server`] for how chains are detected and summarized.
-    pub fn persisted_chain_summary(&self) -> Option<PersistedChainSummary> {
+    pub fn generated_chain_summary(&self) -> Option<ToolChainSummary> {
         let obj = self
             .tool_meta
             .as_ref()
@@ -82,7 +73,7 @@ impl ToolRequest {
         if count == 0 {
             return None;
         }
-        Some(PersistedChainSummary {
+        Some(ToolChainSummary {
             summary,
             count: count as usize,
         })
@@ -182,13 +173,13 @@ mod tests {
         }
     }
 
-    mod persisted_title {
+    mod generated_title {
         use super::*;
 
         #[test]
         fn returns_none_when_meta_missing() {
             let req = make_tool_request(None);
-            assert_eq!(req.persisted_title(), None);
+            assert_eq!(req.generated_title(), None);
         }
 
         #[test]
@@ -197,14 +188,14 @@ mod tests {
                 TOOL_META_TITLE_KEY: "reading project configuration",
             });
             let req = make_tool_request(Some(meta));
-            assert_eq!(req.persisted_title(), Some("reading project configuration"));
+            assert_eq!(req.generated_title(), Some("reading project configuration"));
         }
 
         #[test]
         fn returns_none_for_non_string_value() {
             let meta = serde_json::json!({ TOOL_META_TITLE_KEY: 42 });
             let req = make_tool_request(Some(meta));
-            assert_eq!(req.persisted_title(), None);
+            assert_eq!(req.generated_title(), None);
         }
 
         #[test]
@@ -214,12 +205,12 @@ mod tests {
                 TOOL_META_TITLE_KEY: "running commands",
             });
             let req = make_tool_request(Some(meta));
-            assert!(req.is_externally_dispatched());
-            assert_eq!(req.persisted_title(), Some("running commands"));
+            assert!(req.was_executed_externally());
+            assert_eq!(req.generated_title(), Some("running commands"));
         }
     }
 
-    mod persisted_chain_summary {
+    mod generated_chain_summary {
         use super::*;
 
         #[test]
@@ -231,7 +222,7 @@ mod tests {
                 },
             });
             let req = make_tool_request(Some(meta));
-            let summary = req.persisted_chain_summary().expect("summary present");
+            let summary = req.generated_chain_summary().expect("summary present");
             assert_eq!(summary.summary, "applied dark mode polish");
             assert_eq!(summary.count, 4);
         }
@@ -239,19 +230,19 @@ mod tests {
         #[test]
         fn returns_none_for_missing_or_zero_count() {
             let req = make_tool_request(None);
-            assert!(req.persisted_chain_summary().is_none());
+            assert!(req.generated_chain_summary().is_none());
 
             let meta_zero = serde_json::json!({
                 TOOL_META_CHAIN_SUMMARY_KEY: { "summary": "x", "count": 0 },
             });
             let req_zero = make_tool_request(Some(meta_zero));
-            assert!(req_zero.persisted_chain_summary().is_none());
+            assert!(req_zero.generated_chain_summary().is_none());
 
             let meta_no_summary = serde_json::json!({
                 TOOL_META_CHAIN_SUMMARY_KEY: { "count": 3 },
             });
             let req_no_summary = make_tool_request(Some(meta_no_summary));
-            assert!(req_no_summary.persisted_chain_summary().is_none());
+            assert!(req_no_summary.generated_chain_summary().is_none());
         }
     }
 }

--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -78,8 +78,8 @@ use uuid::Uuid;
 
 use self::tool_calls::chain::{extend_chain_membership, ToolChain};
 use self::tool_calls::conversion::{
-    build_initial_tool_call, extract_tool_call_update_meta, format_tool_name, goose_tool_call_meta,
-    tool_call_update_fields_from_response,
+    build_initial_tool_call, format_tool_name, tool_call_update_fields_from_response,
+    trusted_update_meta,
 };
 use self::tool_calls::enrichment::{ChainSummaryEnrichmentContext, ToolTitleEnrichmentContext};
 
@@ -1203,7 +1203,7 @@ impl GooseAcpAgent {
         );
 
         let update = ToolCallUpdate::new(ToolCallId::new(tool_response.id.clone()), fields)
-            .meta(extract_tool_call_update_meta(tool_response));
+            .meta(trusted_update_meta(tool_response));
         let tool_call_notifier = ToolCallNotifier::new(cx, session_id);
         tool_call_notifier.send_update(update)?;
 
@@ -1298,11 +1298,6 @@ impl GooseAcpAgent {
             return;
         }
 
-        let goose_meta = session
-            .tool_requests
-            .get(first_id)
-            .and_then(goose_tool_call_meta);
-
         ChainSummaryEnrichmentContext::new(
             &session.agent,
             session_id,
@@ -1313,7 +1308,6 @@ impl GooseAcpAgent {
             first_id.clone(),
             chain.message_id.clone(),
             steps,
-            goose_meta,
             chain.ids.len(),
         );
     }
@@ -2554,7 +2548,7 @@ pub async fn run(builtins: Vec<String>) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::acp::server::tool_calls::enrichment::with_tool_chain_summary_meta;
+    use crate::acp::server::tool_calls::enrichment::tool_chain_summary;
     use crate::conversation::message::ToolRequest;
     use crate::session::session_manager::SessionType;
     use agent_client_protocol::schema::v1::{
@@ -2672,17 +2666,21 @@ print(\"hello, world\")
             })),
         };
 
-        let initial_tool_call = build_initial_tool_call(&tool_request);
-        let mut meta = initial_tool_call.meta;
+        let mut initial_tool_call = build_initial_tool_call(&tool_request);
+        let goose = initial_tool_call
+            .meta
+            .as_mut()
+            .and_then(|meta| meta.get_mut("goose"))
+            .and_then(serde_json::Value::as_object_mut)
+            .expect("valid initial tool call should contain goose metadata");
         let chain_summary = tool_request
             .persisted_chain_summary()
             .expect("chain summary should be present");
-        meta = with_tool_chain_summary_meta(meta, &chain_summary.summary, chain_summary.count);
+        goose.extend([tool_chain_summary(
+            &chain_summary.summary,
+            chain_summary.count,
+        )]);
 
-        let goose = meta
-            .as_ref()
-            .and_then(|m| m.get("goose"))
-            .expect("replay meta must include a goose namespace");
         assert_eq!(
             goose.get("toolCall"),
             Some(

--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -76,12 +76,12 @@ use tracing::{debug, error, info, warn};
 use url::Url;
 use uuid::Uuid;
 
-use self::tool_calls::chain::{extend_chain_membership, ToolChain};
+use self::tool_calls::chain::{breaks_consecutive_tool_calls, ReadyToolChain, ToolChainTracker};
 use self::tool_calls::conversion::{
     build_initial_tool_call, format_tool_name, tool_call_update_fields_from_response,
     trusted_update_meta,
 };
-use self::tool_calls::enrichment::{ChainSummaryEnrichmentContext, ToolTitleEnrichmentContext};
+use self::tool_calls::enrichment::{spawn_chain_summary_enrichment, spawn_tool_title_enrichment};
 
 mod agent_requests;
 pub use agent_requests::agent_request_schemas;
@@ -172,18 +172,6 @@ const PROVIDER_CONFIG_STATUS_CHECK_CONCURRENCY: usize = 16;
 struct GooseAcpSession {
     agent: Arc<Agent>,
     tool_requests: HashMap<String, crate::conversation::message::ToolRequest>,
-    /// For each tool_call_id that belongs to a multi-tool chain (run of
-    /// consecutive ToolRequest blocks within one assistant message), the chain
-    /// it belongs to. Populated when the assistant message is processed.
-    /// Used by `handle_tool_response` to detect when a chain has fully
-    /// completed and fire a single LLM summary covering the run.
-    chain_membership: HashMap<String, Arc<ToolChain>>,
-    /// Set of tool_call_ids whose ToolResponse has already been processed.
-    /// Drives the "all responses present" check for chain completion.
-    responded_tool_ids: HashSet<String>,
-    /// Tool_call_ids of chains that have already had a summary task fired.
-    /// Idempotence guard so we summarize each chain at most once.
-    summarized_chains: HashSet<String>,
 }
 
 struct ActivePromptRun {
@@ -922,9 +910,6 @@ impl GooseAcpAgent {
         let acp_session = GooseAcpSession {
             agent,
             tool_requests,
-            chain_membership: HashMap::new(),
-            responded_tool_ids: HashSet::new(),
-            summarized_chains: HashSet::new(),
         };
         self.sessions.lock().await.insert(session_id, acp_session);
     }
@@ -1051,15 +1036,8 @@ impl GooseAcpAgent {
                 .await?;
             }
             MessageContent::ToolResponse(tool_response) => {
-                self.handle_tool_response(
-                    tool_response,
-                    session_id,
-                    session_id_str,
-                    message_id,
-                    session,
-                    cx,
-                )
-                .await?;
+                self.handle_tool_response(tool_response, session_id, session, cx)
+                    .await?;
             }
             MessageContent::Thinking(thinking) => {
                 cx.send_notification(SessionNotification::new(
@@ -1149,6 +1127,23 @@ impl GooseAcpAgent {
         Ok(())
     }
 
+    fn spawn_ready_chain_summary(
+        &self,
+        chain: ReadyToolChain,
+        agent: &Arc<Agent>,
+        session_id: &SessionId,
+        cx: &ConnectionTo<Client>,
+    ) {
+        let tool_call_notifier = ToolCallNotifier::new(cx, session_id);
+        spawn_chain_summary_enrichment(
+            agent,
+            session_id,
+            tool_call_notifier,
+            &self.session_manager,
+            chain,
+        );
+    }
+
     async fn handle_tool_request(
         &self,
         tool_request: &crate::conversation::message::ToolRequest,
@@ -1174,14 +1169,14 @@ impl GooseAcpAgent {
         }
 
         if tool_request.tool_call.is_ok() {
-            ToolTitleEnrichmentContext::new(
+            spawn_tool_title_enrichment(
                 &session.agent,
-                &tool_call_notifier,
+                tool_call_notifier,
                 &self.session_manager,
                 session_id_for_persist,
                 message_id,
-            )
-            .spawn_title_enrichment(tool_request);
+                tool_request,
+            );
         }
 
         Ok(())
@@ -1191,8 +1186,6 @@ impl GooseAcpAgent {
         &self,
         tool_response: &ToolResponse,
         session_id: &SessionId,
-        session_id_str: &str,
-        message_id: Option<&str>,
         session: &mut GooseAcpSession,
         cx: &ConnectionTo<Client>,
     ) -> Result<(), agent_client_protocol::Error> {
@@ -1206,85 +1199,7 @@ impl GooseAcpAgent {
         let tool_call_notifier = ToolCallNotifier::new(cx, session_id);
         tool_call_notifier.send_update(update)?;
 
-        // Chain summarization: when this response completes a multi-tool
-        // chain, fire one LLM summary covering the run.
-        session.responded_tool_ids.insert(tool_response.id.clone());
-        self.maybe_summarize_chain(
-            &tool_response.id,
-            session_id,
-            session_id_str,
-            session,
-            &tool_call_notifier,
-        );
-        let _ = message_id;
-
         Ok(())
-    }
-
-    /// If `tool_call_id` belongs to a multi-tool chain and every step in that
-    /// chain has now had its response processed, spawn a single LLM
-    /// summarization task that persists the chain summary on the first tool
-    /// request and notifies the client. Idempotent — fires at most once per
-    /// chain.
-    fn maybe_summarize_chain(
-        &self,
-        tool_call_id: &str,
-        session_id: &SessionId,
-        _session_id_str: &str,
-        session: &mut GooseAcpSession,
-        tool_call_notifier: &ToolCallNotifier,
-    ) {
-        let Some(chain) = session.chain_membership.get(tool_call_id).cloned() else {
-            warn!(
-                "tool chain summary: skipped — no chain registered for tool_call_id {tool_call_id}",
-            );
-            return;
-        };
-        if !chain
-            .ids
-            .iter()
-            .all(|id| session.responded_tool_ids.contains(id))
-        {
-            let total = chain.ids.len();
-            let responded = chain
-                .ids
-                .iter()
-                .filter(|id| session.responded_tool_ids.contains(*id))
-                .count();
-            let missing: Vec<&String> = chain
-                .ids
-                .iter()
-                .filter(|id| !session.responded_tool_ids.contains(*id))
-                .collect();
-            warn!(
-                "tool chain summary: waiting on {pending}/{total} responses for chain anchored at {anchor:?} (missing: {missing:?})",
-                pending = total - responded,
-                anchor = chain.ids.first(),
-            );
-            return;
-        }
-        let Some(first_id) = chain.ids.first() else {
-            warn!("tool chain summary: skipped — empty chain.ids for tool_call_id {tool_call_id}");
-            return;
-        };
-        if !session.summarized_chains.insert(first_id.clone()) {
-            debug!("tool chain summary: chain anchored at {first_id} already summarized; skipping");
-            return;
-        }
-
-        let tool_requests: Vec<ToolRequest> = chain
-            .ids
-            .iter()
-            .filter_map(|id| session.tool_requests.get(id).cloned())
-            .collect();
-
-        ChainSummaryEnrichmentContext::new(
-            &session.agent,
-            session_id,
-            tool_call_notifier,
-            &self.session_manager,
-        )
-        .spawn_chain_summary(chain.message_id.clone(), tool_requests);
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -1962,17 +1877,7 @@ impl GooseAcpAgent {
         let mut was_cancelled = false;
         let mut first_event_logged = false;
         let mut event_count: u32 = 0;
-        // Streaming chain buffer: tracks consecutive tool requests across
-        // `AgentEvent::Message` events so chains that span multiple rows are
-        // still registered. Sequential tool use (Bedrock/Anthropic) yields
-        // request → response → request → response across separate
-        // assistant/user messages, so tool responses are chain-neutral; only
-        // non-tool content (text, thinking, image, etc.) breaks the run.
-        // Holds `(tool_call_id, message_id_of_owning_row)` in arrival order;
-        // re-registered eagerly each time a request arrives so
-        // `handle_tool_response` finds the chain when subsequent responses
-        // are processed.
-        let mut chain_buffer: Vec<(String, String)> = Vec::new();
+        let mut chain_tracker = ToolChainTracker::default();
         let mut stream_error = None;
 
         while let Some(event) = stream.next().await {
@@ -2011,33 +1916,6 @@ impl GooseAcpAgent {
                             break;
                         }
 
-                        match content_item {
-                            MessageContent::ToolRequest(tr) => {
-                                if let Some(msg_id) = stored_message_id.as_deref() {
-                                    chain_buffer.push((tr.id.clone(), msg_id.to_string()));
-                                    // Re-register eagerly so the chain is in
-                                    // place by the time the matching
-                                    // `tool_response` triggers
-                                    // `maybe_summarize_chain` (sequential
-                                    // tool use interleaves request/response
-                                    // events).
-                                    extend_chain_membership(
-                                        &chain_buffer,
-                                        &mut session.chain_membership,
-                                    );
-                                }
-                            }
-                            MessageContent::ToolResponse(_) => {
-                                // Chain-neutral: a response between two
-                                // requests doesn't break the run, matching
-                                // the frontend's `groupContentSections`.
-                            }
-                            _ => {
-                                // Text, thinking, image, etc. end the run.
-                                chain_buffer.clear();
-                            }
-                        }
-
                         if let Err(error) = self
                             .handle_message_content(
                                 content_item,
@@ -2055,6 +1933,29 @@ impl GooseAcpAgent {
                         {
                             stream_error = Some(error);
                             break;
+                        }
+
+                        let ready_chain = match content_item {
+                            MessageContent::ToolRequest(tool_request) => {
+                                if let Some(message_id) = stored_message_id.as_deref() {
+                                    chain_tracker.record_request(
+                                        tool_request.clone(),
+                                        message_id.to_string(),
+                                    );
+                                }
+                                None
+                            }
+                            MessageContent::ToolResponse(tool_response) => {
+                                chain_tracker.record_response(&tool_response.id)
+                            }
+                            content if breaks_consecutive_tool_calls(content) => {
+                                chain_tracker.close_current_chain()
+                            }
+                            _ => None,
+                        };
+
+                        if let Some(chain) = ready_chain {
+                            self.spawn_ready_chain_summary(chain, &agent, &args.session_id, cx);
                         }
                     }
                     if stream_error.is_some() {
@@ -2090,14 +1991,9 @@ impl GooseAcpAgent {
             }
         }
 
-        {
-            let mut sessions = self.sessions.lock().await;
-            if let Some(session) = sessions.get_mut(&session_id) {
-                // Final safety net: in case the stream ended without any
-                // chain-breaking content, make sure a multi-tool buffer is
-                // registered. (Eager registration during the loop usually
-                // covers this.)
-                extend_chain_membership(&chain_buffer, &mut session.chain_membership);
+        if !was_cancelled && stream_error.is_none() {
+            if let Some(chain) = chain_tracker.close_current_chain() {
+                self.spawn_ready_chain_summary(chain, &agent, &args.session_id, cx);
             }
         }
         self.clear_active_run(&session_id, &run_id).await;

--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -41,7 +41,7 @@ use crate::utils::sanitize_unicode_tags;
 use agent_client_protocol::schema::v1::{
     AgentCapabilities, Annotations, AuthMethod, AuthMethodAgent, AuthenticateRequest,
     AuthenticateResponse, CancelNotification, CloseSessionRequest, CloseSessionResponse,
-    ConfigOptionUpdate, Content, ContentBlock, ContentChunk, Cost, CurrentModeUpdate,
+    ConfigOptionUpdate, ContentBlock, ContentChunk, Cost, CurrentModeUpdate,
     EmbeddedResourceResource, FileSystemCapabilities, ForkSessionRequest, ForkSessionResponse,
     ImageContent, Implementation, InitializeRequest, InitializeResponse, ListSessionsRequest,
     ListSessionsResponse, LoadSessionRequest, LoadSessionResponse, McpCapabilities, McpServer,
@@ -51,8 +51,7 @@ use agent_client_protocol::schema::v1::{
     SessionConfigOption, SessionId, SessionInfoUpdate, SessionListCapabilities,
     SessionNotification, SessionUpdate, SetSessionConfigOptionRequest,
     SetSessionConfigOptionResponse, SetSessionModeRequest, SetSessionModeResponse, StopReason,
-    TextContent, ToolCallContent, ToolCallId, ToolCallStatus, ToolCallUpdate, ToolCallUpdateFields,
-    ToolKind, Usage, UsageUpdate,
+    TextContent, ToolCallId, ToolCallUpdate, Usage, UsageUpdate,
 };
 use agent_client_protocol::util::MatchDispatchFrom;
 use agent_client_protocol::{
@@ -78,8 +77,8 @@ use uuid::Uuid;
 
 use self::tool_calls::chain::{breaks_consecutive_tool_calls, ReadyToolChain, ToolChainTracker};
 use self::tool_calls::conversion::{
-    build_initial_tool_call, default_tool_title, tool_call_update_fields_from_response,
-    trusted_update_meta,
+    build_initial_tool_call, build_permission_tool_call_update,
+    tool_call_update_fields_from_response, trusted_update_meta,
 };
 use self::tool_calls::enrichment::{spawn_chain_summary_enrichment, spawn_tool_title_enrichment};
 
@@ -1217,19 +1216,8 @@ impl GooseAcpAgent {
         let agent = agent.clone();
         let session_id = session_id.clone();
 
-        let arguments = serde_json::Value::Object(arguments);
-
-        let mut fields = ToolCallUpdateFields::new()
-            .title(default_tool_title(&tool_name, Some(&arguments)))
-            .kind(ToolKind::default())
-            .status(ToolCallStatus::Pending)
-            .raw_input(arguments);
-        if let Some(p) = prompt {
-            fields = fields.content(vec![ToolCallContent::Content(Content::new(
-                ContentBlock::Text(TextContent::new(p)),
-            ))]);
-        }
-        let tool_call_update = ToolCallUpdate::new(ToolCallId::new(request_id.clone()), fields);
+        let tool_call_update =
+            build_permission_tool_call_update(&request_id, &tool_name, arguments, prompt);
 
         fn option(kind: PermissionOptionKind) -> PermissionOption {
             let id = serde_json::to_value(kind)
@@ -1443,45 +1431,6 @@ fn message_update_meta(message_id: Option<&str>, created: i64, steer: bool) -> M
 
     let mut meta = serde_json::Map::new();
     meta.insert("goose".to_string(), serde_json::Value::Object(goose));
-    meta
-}
-
-fn replay_message_meta(message: &Message) -> Meta {
-    let mut meta = serde_json::Map::new();
-    meta.insert(
-        "goose".to_string(),
-        serde_json::Value::Object(replay_message_goose_meta(message)),
-    );
-    meta
-}
-
-fn replay_message_goose_meta(message: &Message) -> serde_json::Map<String, serde_json::Value> {
-    let mut goose = serde_json::Map::new();
-    goose.insert("created".to_string(), serde_json::json!(message.created));
-    if let Some(id) = &message.id {
-        goose.insert("messageId".to_string(), serde_json::json!(id));
-    }
-    if message.metadata.steer {
-        goose.insert("steer".to_string(), serde_json::json!(true));
-    }
-    goose
-}
-
-fn merge_replay_message_meta(meta: Option<Meta>, message: &Message) -> Meta {
-    let replay_goose = replay_message_goose_meta(message);
-    let mut meta = meta.unwrap_or_default();
-    let goose_value = meta
-        .entry("goose".to_string())
-        .or_insert_with(|| serde_json::Value::Object(serde_json::Map::new()));
-
-    if let serde_json::Value::Object(goose) = goose_value {
-        for (key, value) in replay_goose {
-            goose.insert(key, value);
-        }
-    } else {
-        *goose_value = serde_json::Value::Object(replay_goose);
-    }
-
     meta
 }
 
@@ -2617,79 +2566,6 @@ print(\"hello, world\")
     }
 
     #[test]
-    fn test_merge_replay_message_meta_preserves_existing_goose_meta() {
-        let message = Message::new(Role::Assistant, 1_700_000_000, vec![]).with_id("msg_1");
-        let existing = serde_json::from_value(serde_json::json!({
-            "goose": {
-                "mcpApp": {
-                    "resourceUri": "ui://trusted/app",
-                    "extensionName": "weather",
-                    "toolName": "weather__render",
-                },
-            },
-        }))
-        .unwrap();
-
-        let merged = merge_replay_message_meta(Some(existing), &message);
-
-        assert_eq!(
-            merged.get("goose"),
-            Some(&serde_json::json!({
-                "created": 1_700_000_000,
-                "messageId": "msg_1",
-                "mcpApp": {
-                    "resourceUri": "ui://trusted/app",
-                    "extensionName": "weather",
-                    "toolName": "weather__render",
-                },
-            })),
-        );
-    }
-
-    #[test]
-    fn test_merge_replay_message_meta_creates_fresh_when_none() {
-        let message = Message::new(Role::Assistant, 1_700_000_000, vec![]).with_id("msg_2");
-
-        let merged = merge_replay_message_meta(None, &message);
-
-        assert_eq!(
-            merged.get("goose"),
-            Some(&serde_json::json!({
-                "created": 1_700_000_000,
-                "messageId": "msg_2",
-            })),
-        );
-    }
-
-    #[test]
-    fn test_merge_replay_message_meta_includes_steer_marker() {
-        let message = Message::new(Role::User, 1_700_000_000, vec![])
-            .with_id("msg_steer")
-            .with_steer();
-
-        let merged = merge_replay_message_meta(None, &message);
-
-        assert_eq!(
-            merged.get("goose"),
-            Some(&serde_json::json!({
-                "created": 1_700_000_000,
-                "messageId": "msg_steer",
-                "steer": true,
-            })),
-            "replay must carry the steer marker so the boundary survives reload"
-        );
-    }
-
-    #[test]
-    fn test_merge_replay_message_meta_omits_steer_when_not_set() {
-        let message = Message::new(Role::Assistant, 1_700_000_000, vec![]).with_id("msg_plain");
-
-        let merged = merge_replay_message_meta(None, &message);
-
-        assert_eq!(merged.get("goose").and_then(|g| g.get("steer")), None);
-    }
-
-    #[test]
     fn test_message_update_meta_includes_created_and_message_id() {
         let meta = message_update_meta(Some("msg_live"), 1_700_000_000, false);
 
@@ -2738,20 +2614,6 @@ print(\"hello, world\")
         });
 
         assert!(prompt_error_from_message_content(&content).is_none());
-    }
-
-    #[test]
-    fn test_merge_replay_message_meta_omits_message_id_when_none() {
-        let message = Message::new(Role::Assistant, 1_700_000_000, vec![]);
-
-        let merged = merge_replay_message_meta(None, &message);
-
-        assert_eq!(
-            merged.get("goose"),
-            Some(&serde_json::json!({
-                "created": 1_700_000_000,
-            })),
-        );
     }
 
     fn make_session_with_usage(usage: TokenUsage, accumulated_usage: TokenUsage) -> Session {

--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -78,7 +78,7 @@ use uuid::Uuid;
 
 use self::tool_calls::chain::{breaks_consecutive_tool_calls, ReadyToolChain, ToolChainTracker};
 use self::tool_calls::conversion::{
-    build_initial_tool_call, format_tool_name, tool_call_update_fields_from_response,
+    build_initial_tool_call, default_tool_title, tool_call_update_fields_from_response,
     trusted_update_meta,
 };
 use self::tool_calls::enrichment::{spawn_chain_summary_enrichment, spawn_tool_title_enrichment};
@@ -1217,13 +1217,13 @@ impl GooseAcpAgent {
         let agent = agent.clone();
         let session_id = session_id.clone();
 
-        let formatted_name = format_tool_name(&tool_name);
+        let arguments = serde_json::Value::Object(arguments);
 
         let mut fields = ToolCallUpdateFields::new()
-            .title(formatted_name)
+            .title(default_tool_title(&tool_name, Some(&arguments)))
             .kind(ToolKind::default())
             .status(ToolCallStatus::Pending)
-            .raw_input(serde_json::Value::Object(arguments));
+            .raw_input(arguments);
         if let Some(p) = prompt {
             fields = fields.content(vec![ToolCallContent::Content(Content::new(
                 ContentBlock::Text(TextContent::new(p)),

--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -1272,30 +1272,11 @@ impl GooseAcpAgent {
             return;
         }
 
-        // Snapshot (name, args_json) for each step in document order.
-        let steps: Vec<(String, String)> = chain
+        let tool_requests: Vec<ToolRequest> = chain
             .ids
             .iter()
-            .filter_map(|id| {
-                let req = session.tool_requests.get(id)?;
-                let tool_call = req.tool_call.as_ref().ok()?;
-                let name = tool_call.name.to_string();
-                let args = tool_call
-                    .arguments
-                    .as_ref()
-                    .map(|a| serde_json::to_string(a).unwrap_or_default())
-                    .unwrap_or_default();
-                let args = if args.len() > 200 {
-                    format!("{}…", crate::utils::safe_truncate(&args, 200))
-                } else {
-                    args
-                };
-                Some((name, args))
-            })
+            .filter_map(|id| session.tool_requests.get(id).cloned())
             .collect();
-        if steps.len() < 2 {
-            return;
-        }
 
         ChainSummaryEnrichmentContext::new(
             &session.agent,
@@ -1303,12 +1284,7 @@ impl GooseAcpAgent {
             tool_call_notifier,
             &self.session_manager,
         )
-        .spawn_chain_summary(
-            first_id.clone(),
-            chain.message_id.clone(),
-            steps,
-            chain.ids.len(),
-        );
+        .spawn_chain_summary(chain.message_id.clone(), tool_requests);
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -2675,10 +2651,7 @@ print(\"hello, world\")
         let chain_summary = tool_request
             .generated_chain_summary()
             .expect("chain summary should be present");
-        goose.extend([tool_chain_summary(
-            &chain_summary.summary,
-            chain_summary.count,
-        )]);
+        goose.extend([tool_chain_summary(&chain_summary)]);
 
         assert_eq!(
             goose.get("toolCall"),

--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -2673,7 +2673,7 @@ print(\"hello, world\")
             .and_then(serde_json::Value::as_object_mut)
             .expect("valid initial tool call should contain goose metadata");
         let chain_summary = tool_request
-            .persisted_chain_summary()
+            .generated_chain_summary()
             .expect("chain summary should be present");
         goose.extend([tool_chain_summary(
             &chain_summary.summary,
@@ -2703,7 +2703,7 @@ print(\"hello, world\")
             tool_meta: None,
         };
 
-        let chain_summary = tool_request.persisted_chain_summary();
+        let chain_summary = tool_request.generated_chain_summary();
         assert!(
             chain_summary.is_none(),
             "non-first tool requests must not carry chain summaries",

--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -78,8 +78,8 @@ use uuid::Uuid;
 
 use self::tool_calls::chain::{extend_chain_membership, ToolChain};
 use self::tool_calls::conversion::{
-    extract_tool_call_update_meta, format_tool_name, pending_tool_call_from_request,
-    tool_call_identity_meta, tool_call_update_fields_from_response,
+    build_initial_tool_call, extract_tool_call_update_meta, format_tool_name, goose_tool_call_meta,
+    tool_call_update_fields_from_response,
 };
 use self::tool_calls::enrichment::{ChainSummaryEnrichmentContext, ToolTitleEnrichmentContext};
 
@@ -1162,10 +1162,7 @@ impl GooseAcpAgent {
             .tool_requests
             .insert(tool_request.id.clone(), tool_request.clone());
 
-        let pending_tool_call = pending_tool_call_from_request(tool_request);
-        let initial_tool_call = pending_tool_call
-            .tool_call
-            .meta(pending_tool_call.identity_meta.clone());
+        let initial_tool_call = build_initial_tool_call(tool_request);
         let tool_call_notifier = ToolCallNotifier::new(cx, session_id);
         tool_call_notifier.send_initial(initial_tool_call)?;
 
@@ -1185,12 +1182,7 @@ impl GooseAcpAgent {
                 session_id_for_persist,
                 message_id,
             )
-            .spawn_title_enrichment(
-                tool_request.id.clone(),
-                tool_call,
-                pending_tool_call.identity_meta.clone(),
-                pending_tool_call.fallback_title.clone(),
-            );
+            .spawn_title_enrichment(tool_request.id.clone(), tool_call);
         }
 
         Ok(())
@@ -1306,10 +1298,10 @@ impl GooseAcpAgent {
             return;
         }
 
-        let identity_meta = session
+        let goose_meta = session
             .tool_requests
             .get(first_id)
-            .and_then(tool_call_identity_meta);
+            .and_then(goose_tool_call_meta);
 
         ChainSummaryEnrichmentContext::new(
             &session.agent,
@@ -1321,7 +1313,7 @@ impl GooseAcpAgent {
             first_id.clone(),
             chain.message_id.clone(),
             steps,
-            identity_meta,
+            goose_meta,
             chain.ids.len(),
         );
     }
@@ -2680,8 +2672,8 @@ print(\"hello, world\")
             })),
         };
 
-        let pending_tool_call = pending_tool_call_from_request(&tool_request);
-        let mut meta = pending_tool_call.identity_meta;
+        let initial_tool_call = build_initial_tool_call(&tool_request);
+        let mut meta = initial_tool_call.meta;
         let chain_summary = tool_request
             .persisted_chain_summary()
             .expect("chain summary should be present");

--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -1173,16 +1173,15 @@ impl GooseAcpAgent {
             return Ok(());
         }
 
-        if let Ok(tool_call) = &tool_request.tool_call {
+        if tool_request.tool_call.is_ok() {
             ToolTitleEnrichmentContext::new(
                 &session.agent,
-                session_id,
                 &tool_call_notifier,
                 &self.session_manager,
                 session_id_for_persist,
                 message_id,
             )
-            .spawn_title_enrichment(tool_request.id.clone(), tool_call);
+            .spawn_title_enrichment(tool_request);
         }
 
         Ok(())

--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -213,13 +213,6 @@ pub struct GooseAcpAgent {
     recipe_path_cache: Arc<Mutex<HashMap<String, PathBuf>>>,
 }
 
-/// Shorten a session/thread id for perf log correlation.
-/// All `perf:` logs use `sid=<8-char-prefix>` so a single session's activity
-/// can be extracted with `grep 'perf:' <log> | grep 'sid=abc12345'`.
-pub(super) fn sid_short(id: &str) -> String {
-    id.chars().take(8).collect()
-}
-
 fn meta_string(
     meta: Option<&Meta>,
     key: &str,
@@ -1737,8 +1730,6 @@ impl GooseAcpAgent {
     ) -> Result<PromptResponse, agent_client_protocol::Error> {
         // The ACP session_id IS the thread ID.
         let session_id = args.session_id.0.to_string();
-        let sid = sid_short(&session_id);
-        let t_start = std::time::Instant::now();
 
         let run_id = format!("run_{}", Uuid::new_v4());
         let cancel_token = CancellationToken::new();
@@ -1825,8 +1816,6 @@ impl GooseAcpAgent {
         };
 
         let mut was_cancelled = false;
-        let mut first_event_logged = false;
-        let mut event_count: u32 = 0;
         let mut tool_requests = HashMap::new();
         let mut chain_tracker = ToolChainTracker::default();
         let mut stream_error = None;
@@ -1835,16 +1824,6 @@ impl GooseAcpAgent {
             if cancel_token.is_cancelled() {
                 was_cancelled = true;
                 break;
-            }
-            event_count += 1;
-            if !first_event_logged {
-                debug!(
-                    target: "perf",
-                    sid = %sid,
-                    ttft_ms = t_start.elapsed().as_millis() as u64,
-                    "perf: prompt first stream event (time-to-first-token from prompt start)"
-                );
-                first_event_logged = true;
             }
 
             match event {
@@ -1980,14 +1959,6 @@ impl GooseAcpAgent {
             ))?;
         }
 
-        debug!(
-            target: "perf",
-            sid = %sid,
-            ms = t_start.elapsed().as_millis() as u64,
-            events = event_count,
-            cancelled = was_cancelled,
-            "perf: prompt done"
-        );
         let stop_reason = if was_cancelled {
             StopReason::Cancelled
         } else {

--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -201,6 +201,7 @@ pub struct GooseAcpAgent {
     client_supports_acp_elicitation: OnceCell<bool>,
     client_supports_goose_custom_notifications: OnceCell<bool>,
     client_supports_recipe_param_requests: OnceCell<bool>,
+    client_supports_tool_call_label_enrichment: OnceCell<bool>,
     use_login_shell_path: OnceCell<bool>,
     client_cx: OnceCell<ConnectionTo<Client>>,
     config_dir: std::path::PathBuf,
@@ -308,6 +309,8 @@ struct GooseClientCapabilities {
     custom_notifications: Option<bool>,
     #[serde(rename = "recipeParameterRequests", default)]
     recipe_parameter_requests: Option<bool>,
+    #[serde(rename = "toolCallLabelEnrichment", default)]
+    tool_call_label_enrichment: Option<bool>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -621,6 +624,7 @@ impl GooseAcpAgent {
             client_supports_acp_elicitation: OnceCell::new(),
             client_supports_goose_custom_notifications: OnceCell::new(),
             client_supports_recipe_param_requests: OnceCell::new(),
+            client_supports_tool_call_label_enrichment: OnceCell::new(),
             use_login_shell_path: OnceCell::new(),
             client_cx: OnceCell::new(),
             config_dir: options.config_dir,
@@ -1285,6 +1289,14 @@ fn extract_client_supports_recipe_param_requests(
         .unwrap_or(false)
 }
 
+fn extract_client_supports_tool_call_label_enrichment(
+    goose_client_capabilities: Option<&GooseClientCapabilities>,
+) -> bool {
+    goose_client_capabilities
+        .and_then(|goose| goose.tool_call_label_enrichment)
+        .unwrap_or(false)
+}
+
 fn outcome_to_confirmation(outcome: &RequestPermissionOutcome) -> PermissionConfirmation {
     PermissionConfirmation {
         principal_type: PrincipalType::Tool,
@@ -1444,6 +1456,9 @@ impl GooseAcpAgent {
         );
         let _ = self.client_supports_recipe_param_requests.set(
             extract_client_supports_recipe_param_requests(goose_client_capabilities.as_ref()),
+        );
+        let _ = self.client_supports_tool_call_label_enrichment.set(
+            extract_client_supports_tool_call_label_enrichment(goose_client_capabilities.as_ref()),
         );
         let _ = self
             .client_supports_acp_elicitation
@@ -2724,6 +2739,35 @@ print(\"hello, world\")
             extract_client_capabilities_meta(&request).and_then(|meta| meta.goose);
 
         assert!(extract_client_supports_goose_custom_notifications(
+            goose_client_capabilities.as_ref()
+        ));
+    }
+
+    #[test]
+    fn test_tool_call_label_enrichment_capability() {
+        let request =
+            InitializeRequest::new(agent_client_protocol::schema::ProtocolVersion::LATEST);
+        let goose_client_capabilities =
+            extract_client_capabilities_meta(&request).and_then(|meta| meta.goose);
+        assert!(!extract_client_supports_tool_call_label_enrichment(
+            goose_client_capabilities.as_ref()
+        ));
+
+        let mut goose_meta = serde_json::Map::new();
+        goose_meta.insert(
+            "toolCallLabelEnrichment".to_string(),
+            serde_json::Value::Bool(true),
+        );
+        let mut meta = serde_json::Map::new();
+        meta.insert("goose".to_string(), serde_json::Value::Object(goose_meta));
+        let request =
+            InitializeRequest::new(agent_client_protocol::schema::ProtocolVersion::LATEST)
+                .client_capabilities(
+                    agent_client_protocol::schema::v1::ClientCapabilities::new().meta(meta),
+                );
+        let goose_client_capabilities =
+            extract_client_capabilities_meta(&request).and_then(|meta| meta.goose);
+        assert!(extract_client_supports_tool_call_label_enrichment(
             goose_client_capabilities.as_ref()
         ));
     }

--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -170,7 +170,6 @@ const PROVIDER_CONFIG_STATUS_CHECK_CONCURRENCY: usize = 16;
 /// below is keyed by session ID.
 struct GooseAcpSession {
     agent: Arc<Agent>,
-    tool_requests: HashMap<String, crate::conversation::message::ToolRequest>,
 }
 
 struct ActivePromptRun {
@@ -900,16 +899,8 @@ impl GooseAcpAgent {
         Ok(extension_data)
     }
 
-    async fn register_acp_session(
-        &self,
-        session_id: String,
-        agent: Arc<Agent>,
-        tool_requests: HashMap<String, ToolRequest>,
-    ) {
-        let acp_session = GooseAcpSession {
-            agent,
-            tool_requests,
-        };
+    async fn register_acp_session(&self, session_id: String, agent: Arc<Agent>) {
+        let acp_session = GooseAcpSession { agent };
         self.sessions.lock().await.insert(session_id, acp_session);
     }
 
@@ -917,10 +908,9 @@ impl GooseAcpAgent {
         &self,
         cx: &ConnectionTo<Client>,
         session: &Session,
-        tool_requests: HashMap<String, ToolRequest>,
     ) -> Result<(Arc<Agent>, Vec<ExtensionLoadResult>), agent_client_protocol::Error> {
         let (agent, extension_results) = self.prepare_acp_session_agent(cx, session).await?;
-        self.register_acp_session(session.id.clone(), agent.clone(), tool_requests)
+        self.register_acp_session(session.id.clone(), agent.clone())
             .await;
 
         Ok((agent, extension_results))
@@ -1009,7 +999,7 @@ impl GooseAcpAgent {
         role: &Role,
         steer: bool,
         agent: &Arc<Agent>,
-        session: &mut GooseAcpSession,
+        tool_requests: &HashMap<String, ToolRequest>,
         cx: &ConnectionTo<Client>,
     ) -> Result<(), agent_client_protocol::Error> {
         match content_item {
@@ -1029,14 +1019,19 @@ impl GooseAcpAgent {
                     session_id,
                     session_id_str,
                     message_id,
-                    session,
+                    agent,
                     cx,
                 )
                 .await?;
             }
             MessageContent::ToolResponse(tool_response) => {
-                self.handle_tool_response(tool_response, session_id, session, cx)
-                    .await?;
+                self.handle_tool_response(
+                    tool_response,
+                    tool_requests.get(&tool_response.id),
+                    session_id,
+                    cx,
+                )
+                .await?;
             }
             MessageContent::Thinking(thinking) => {
                 cx.send_notification(SessionNotification::new(
@@ -1145,17 +1140,13 @@ impl GooseAcpAgent {
 
     async fn handle_tool_request(
         &self,
-        tool_request: &crate::conversation::message::ToolRequest,
+        tool_request: &ToolRequest,
         session_id: &SessionId,
         session_id_for_persist: &str,
         message_id: Option<&str>,
-        session: &mut GooseAcpSession,
+        agent: &Arc<Agent>,
         cx: &ConnectionTo<Client>,
     ) -> Result<(), agent_client_protocol::Error> {
-        session
-            .tool_requests
-            .insert(tool_request.id.clone(), tool_request.clone());
-
         let initial_tool_call = build_initial_tool_call(tool_request);
         let tool_call_notifier = ToolCallNotifier::new(cx, session_id);
         tool_call_notifier.send_initial(initial_tool_call)?;
@@ -1169,7 +1160,7 @@ impl GooseAcpAgent {
 
         if tool_request.tool_call.is_ok() {
             spawn_tool_title_enrichment(
-                &session.agent,
+                agent,
                 tool_call_notifier,
                 &self.session_manager,
                 session_id_for_persist,
@@ -1184,14 +1175,11 @@ impl GooseAcpAgent {
     async fn handle_tool_response(
         &self,
         tool_response: &ToolResponse,
+        tool_request: Option<&ToolRequest>,
         session_id: &SessionId,
-        session: &mut GooseAcpSession,
         cx: &ConnectionTo<Client>,
     ) -> Result<(), agent_client_protocol::Error> {
-        let fields = tool_call_update_fields_from_response(
-            tool_response,
-            session.tool_requests.get(&tool_response.id),
-        );
+        let fields = tool_call_update_fields_from_response(tool_response, tool_request);
 
         let update = ToolCallUpdate::new(ToolCallId::new(tool_response.id.clone()), fields)
             .meta(trusted_update_meta(tool_response));
@@ -1527,9 +1515,7 @@ impl GooseAcpAgent {
                 agent_client_protocol::Error::resource_not_found(Some(session_id.to_string()))
                     .data(format!("Session not found: {}", session_id))
             })?;
-        let (agent, _) = self
-            .activate_acp_session(cx, &session, HashMap::new())
-            .await?;
+        let (agent, _) = self.activate_acp_session(cx, &session).await?;
         Ok(agent)
     }
 
@@ -1826,6 +1812,7 @@ impl GooseAcpAgent {
         let mut was_cancelled = false;
         let mut first_event_logged = false;
         let mut event_count: u32 = 0;
+        let mut tool_requests = HashMap::new();
         let mut chain_tracker = ToolChainTracker::default();
         let mut stream_error = None;
 
@@ -1850,19 +1837,23 @@ impl GooseAcpAgent {
                     // Agent persists messages via session_manager.add_message() internally.
                     let stored_message_id = message.id.clone();
 
-                    let mut sessions = self.sessions.lock().await;
-                    let Some(session) = sessions.get_mut(&session_id) else {
+                    let sessions = self.sessions.lock().await;
+                    if !sessions.contains_key(&session_id) {
                         stream_error = Some(
                             agent_client_protocol::Error::invalid_params()
                                 .data(format!("Session not found: {}", session_id)),
                         );
                         break;
-                    };
+                    }
 
                     for content_item in &message.content {
                         if let Some(error) = prompt_error_from_message_content(content_item) {
                             stream_error = Some(error);
                             break;
+                        }
+
+                        if let MessageContent::ToolRequest(tool_request) = content_item {
+                            tool_requests.insert(tool_request.id.clone(), tool_request.clone());
                         }
 
                         if let Err(error) = self
@@ -1875,7 +1866,7 @@ impl GooseAcpAgent {
                                 &message.role,
                                 message.metadata.steer,
                                 &agent,
-                                session,
+                                &tool_requests,
                                 cx,
                             )
                             .await

--- a/crates/goose/src/acp/server/dispatch.rs
+++ b/crates/goose/src/acp/server/dispatch.rs
@@ -119,9 +119,7 @@ impl HandleDispatchFrom<Client> for GooseAcpHandler {
                                 }
                             };
                             let session_id = req.session_id.clone();
-                            let sid = sid_short(session_id.0.as_ref());
                             let config_id = req.config_id.0.to_string();
-                            let t_handler = std::time::Instant::now();
                             match config_id.as_ref() {
                                 "provider" => {
                                     Config::global().invalidate_secrets_cache();
@@ -307,7 +305,6 @@ impl HandleDispatchFrom<Client> for GooseAcpHandler {
                                 });
                             }
 
-                            debug!(target: "perf", sid = %sid, ms = t_handler.elapsed().as_millis() as u64, config_id = %config_id, "perf: set_config_option done");
                             Ok(())
                         })?;
                         Ok(())

--- a/crates/goose/src/acp/server/dispatch.rs
+++ b/crates/goose/src/acp/server/dispatch.rs
@@ -158,7 +158,7 @@ impl HandleDispatchFrom<Client> for GooseAcpHandler {
                                 Ok(update) => update,
                                 Err(e) => {
                                     warn!(
-                                        sid = %sid,
+                                        session_id = %session_id.0,
                                         config_id = %config_id,
                                         error = ?e,
                                         "failed to build config update after config change"

--- a/crates/goose/src/acp/server/fork_session.rs
+++ b/crates/goose/src/acp/server/fork_session.rs
@@ -53,7 +53,7 @@ impl GooseAcpAgent {
 
         let (agent, extension_results) = self.prepare_acp_session_agent(cx, &goose_session).await?;
         self.apply_session_recipe(&agent, &goose_session).await?;
-        self.register_acp_session(goose_session.id.clone(), agent, HashMap::new())
+        self.register_acp_session(goose_session.id.clone(), agent)
             .await;
 
         let acp_session_id = SessionId::new(new_session_id.clone());

--- a/crates/goose/src/acp/server/load_session.rs
+++ b/crates/goose/src/acp/server/load_session.rs
@@ -95,10 +95,7 @@ fn replay_conversation_to_client(
                         goose_meta
                             .as_object_mut()
                             .expect("goose metadata was initialized as an object")
-                            .extend([tool_chain_summary(
-                                &chain_summary.summary,
-                                chain_summary.count,
-                            )]);
+                            .extend([tool_chain_summary(&chain_summary)]);
                     }
                     let tool_call = tool_call.meta(merge_replay_message_meta(meta, message));
 

--- a/crates/goose/src/acp/server/load_session.rs
+++ b/crates/goose/src/acp/server/load_session.rs
@@ -1,6 +1,5 @@
 use super::tool_calls::conversion::{
-    extract_tool_call_update_meta, pending_tool_call_from_request,
-    tool_call_update_fields_from_response,
+    build_initial_tool_call, extract_tool_call_update_meta, tool_call_update_fields_from_response,
 };
 use super::tool_calls::enrichment::with_tool_chain_summary_meta;
 use super::*;
@@ -83,8 +82,8 @@ fn replay_conversation_to_client(
                 MessageContent::ToolRequest(tool_request) => {
                     replay_tool_requests.insert(tool_request.id.clone(), tool_request.clone());
 
-                    let pending_tool_call = pending_tool_call_from_request(tool_request);
-                    let mut meta = pending_tool_call.identity_meta;
+                    let mut tool_call = build_initial_tool_call(tool_request);
+                    let mut meta = tool_call.meta.take();
                     if let Some(chain_summary) = tool_request.persisted_chain_summary() {
                         meta = with_tool_chain_summary_meta(
                             meta,
@@ -92,9 +91,7 @@ fn replay_conversation_to_client(
                             chain_summary.count,
                         );
                     }
-                    let tool_call = pending_tool_call
-                        .tool_call
-                        .meta(merge_replay_message_meta(meta, message));
+                    let tool_call = tool_call.meta(merge_replay_message_meta(meta, message));
 
                     tool_call_notifier.send_initial(tool_call)?;
                 }

--- a/crates/goose/src/acp/server/load_session.rs
+++ b/crates/goose/src/acp/server/load_session.rs
@@ -76,19 +76,12 @@ fn replay_conversation_to_client(
 ) -> Result<(), agent_client_protocol::Error> {
     let session_id = SessionId::new(session.id.clone());
     let tool_call_notifier = ToolCallNotifier::new(cx, &session_id);
-    let sid = sid_short(session_id.0.as_ref());
 
     let messages = session
         .conversation
         .as_ref()
         .map(|c| c.user_visible_messages())
         .unwrap_or_default();
-    debug!(
-        target: "perf",
-        sid = %sid,
-        messages = messages.len(),
-            "perf: load_session messages loaded"
-    );
 
     let mut replay_tool_requests = HashMap::new();
 
@@ -194,8 +187,6 @@ impl GooseAcpAgent {
         validate_absolute_cwd(&args.cwd)?;
 
         let session_id_str = args.session_id.0.to_string();
-        let sid = sid_short(&session_id_str);
-        let t_start = std::time::Instant::now();
 
         let mut session = self
             .session_manager
@@ -239,12 +230,6 @@ impl GooseAcpAgent {
 
         response = response.meta(session_response_meta(&session, &extension_results));
 
-        debug!(
-            target: "perf",
-            sid = %sid,
-            ms = t_start.elapsed().as_millis() as u64,
-            "perf: load_session_refactor done"
-        );
         self.closed_session_ids.lock().await.remove(&session_id_str);
         Ok(response)
     }

--- a/crates/goose/src/acp/server/load_session.rs
+++ b/crates/goose/src/acp/server/load_session.rs
@@ -4,6 +4,45 @@ use super::tool_calls::conversion::{
 use super::tool_calls::enrichment::tool_chain_summary;
 use super::*;
 
+fn replay_message_meta(message: &Message) -> Meta {
+    let mut meta = serde_json::Map::new();
+    meta.insert(
+        "goose".to_string(),
+        serde_json::Value::Object(replay_message_goose_meta(message)),
+    );
+    meta
+}
+
+fn replay_message_goose_meta(message: &Message) -> serde_json::Map<String, serde_json::Value> {
+    let mut goose = serde_json::Map::new();
+    goose.insert("created".to_string(), serde_json::json!(message.created));
+    if let Some(id) = &message.id {
+        goose.insert("messageId".to_string(), serde_json::json!(id));
+    }
+    if message.metadata.steer {
+        goose.insert("steer".to_string(), serde_json::json!(true));
+    }
+    goose
+}
+
+fn merge_replay_message_meta(meta: Option<Meta>, message: &Message) -> Meta {
+    let replay_goose = replay_message_goose_meta(message);
+    let mut meta = meta.unwrap_or_default();
+    let goose_value = meta
+        .entry("goose".to_string())
+        .or_insert_with(|| serde_json::Value::Object(serde_json::Map::new()));
+
+    if let serde_json::Value::Object(goose) = goose_value {
+        for (key, value) in replay_goose {
+            goose.insert(key, value);
+        }
+    } else {
+        *goose_value = serde_json::Value::Object(replay_goose);
+    }
+
+    meta
+}
+
 fn replay_audience_annotations(audience: &[Role]) -> Annotations {
     Annotations::new().audience(
         audience
@@ -214,5 +253,97 @@ impl GooseAcpAgent {
         );
         self.closed_session_ids.lock().await.remove(&session_id_str);
         Ok(response)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn merge_replay_message_meta_preserves_existing_goose_meta() {
+        let message = Message::new(Role::Assistant, 1_700_000_000, vec![]).with_id("msg_1");
+        let existing = serde_json::from_value(serde_json::json!({
+            "goose": {
+                "mcpApp": {
+                    "resourceUri": "ui://trusted/app",
+                    "extensionName": "weather",
+                    "toolName": "weather__render",
+                },
+            }
+        }))
+        .unwrap();
+
+        let merged = merge_replay_message_meta(Some(existing), &message);
+
+        assert_eq!(
+            merged.get("goose"),
+            Some(&serde_json::json!({
+                "created": 1_700_000_000,
+                "messageId": "msg_1",
+                "mcpApp": {
+                    "resourceUri": "ui://trusted/app",
+                    "extensionName": "weather",
+                    "toolName": "weather__render",
+                },
+            })),
+        );
+    }
+
+    #[test]
+    fn merge_replay_message_meta_creates_fresh_when_none() {
+        let message = Message::new(Role::Assistant, 1_700_000_000, vec![]).with_id("msg_2");
+
+        let merged = merge_replay_message_meta(None, &message);
+
+        assert_eq!(
+            merged.get("goose"),
+            Some(&serde_json::json!({
+                "created": 1_700_000_000,
+                "messageId": "msg_2",
+            })),
+        );
+    }
+
+    #[test]
+    fn merge_replay_message_meta_includes_steer_marker() {
+        let message = Message::new(Role::User, 1_700_000_000, vec![])
+            .with_id("msg_steer")
+            .with_steer();
+
+        let merged = merge_replay_message_meta(None, &message);
+
+        assert_eq!(
+            merged.get("goose"),
+            Some(&serde_json::json!({
+                "created": 1_700_000_000,
+                "messageId": "msg_steer",
+                "steer": true,
+            })),
+            "replay must carry the steer marker so the boundary survives reload"
+        );
+    }
+
+    #[test]
+    fn merge_replay_message_meta_omits_steer_when_not_set() {
+        let message = Message::new(Role::Assistant, 1_700_000_000, vec![]).with_id("msg_plain");
+
+        let merged = merge_replay_message_meta(None, &message);
+
+        assert_eq!(merged.get("goose").and_then(|g| g.get("steer")), None);
+    }
+
+    #[test]
+    fn merge_replay_message_meta_omits_message_id_when_none() {
+        let message = Message::new(Role::Assistant, 1_700_000_000, vec![]);
+
+        let merged = merge_replay_message_meta(None, &message);
+
+        assert_eq!(
+            merged.get("goose"),
+            Some(&serde_json::json!({
+                "created": 1_700_000_000,
+            })),
+        );
     }
 }

--- a/crates/goose/src/acp/server/load_session.rs
+++ b/crates/goose/src/acp/server/load_session.rs
@@ -1,7 +1,7 @@
 use super::tool_calls::conversion::{
-    build_initial_tool_call, extract_tool_call_update_meta, tool_call_update_fields_from_response,
+    build_initial_tool_call, tool_call_update_fields_from_response, trusted_update_meta,
 };
-use super::tool_calls::enrichment::with_tool_chain_summary_meta;
+use super::tool_calls::enrichment::tool_chain_summary;
 use super::*;
 
 fn replay_audience_annotations(audience: &[Role]) -> Annotations {
@@ -85,11 +85,20 @@ fn replay_conversation_to_client(
                     let mut tool_call = build_initial_tool_call(tool_request);
                     let mut meta = tool_call.meta.take();
                     if let Some(chain_summary) = tool_request.persisted_chain_summary() {
-                        meta = with_tool_chain_summary_meta(
-                            meta,
-                            &chain_summary.summary,
-                            chain_summary.count,
-                        );
+                        let goose_meta = meta
+                            .get_or_insert_default()
+                            .entry("goose".to_string())
+                            .or_insert_with(|| serde_json::Value::Object(serde_json::Map::new()));
+                        if !goose_meta.is_object() {
+                            *goose_meta = serde_json::Value::Object(serde_json::Map::new());
+                        }
+                        goose_meta
+                            .as_object_mut()
+                            .expect("goose metadata was initialized as an object")
+                            .extend([tool_chain_summary(
+                                &chain_summary.summary,
+                                chain_summary.count,
+                            )]);
                     }
                     let tool_call = tool_call.meta(merge_replay_message_meta(meta, message));
 
@@ -104,7 +113,7 @@ fn replay_conversation_to_client(
                     let update =
                         ToolCallUpdate::new(ToolCallId::new(tool_response.id.clone()), fields)
                             .meta(merge_replay_message_meta(
-                                extract_tool_call_update_meta(tool_response),
+                                trusted_update_meta(tool_response),
                                 message,
                             ));
                     tool_call_notifier.send_update(update)?;

--- a/crates/goose/src/acp/server/load_session.rs
+++ b/crates/goose/src/acp/server/load_session.rs
@@ -73,8 +73,7 @@ fn replay_conversation_to_client(
     cx: &ConnectionTo<Client>,
     session: &Session,
     supports_goose_custom_notifications: bool,
-) -> Result<HashMap<String, crate::conversation::message::ToolRequest>, agent_client_protocol::Error>
-{
+) -> Result<(), agent_client_protocol::Error> {
     let session_id = SessionId::new(session.id.clone());
     let tool_call_notifier = ToolCallNotifier::new(cx, &session_id);
     let sid = sid_short(session_id.0.as_ref());
@@ -91,8 +90,7 @@ fn replay_conversation_to_client(
             "perf: load_session messages loaded"
     );
 
-    let mut replay_tool_requests =
-        HashMap::<String, crate::conversation::message::ToolRequest>::new();
+    let mut replay_tool_requests = HashMap::new();
 
     for message in &messages {
         for content_item in &message.content {
@@ -183,7 +181,7 @@ fn replay_conversation_to_client(
         }
     }
 
-    Ok(replay_tool_requests)
+    Ok(())
 }
 
 impl GooseAcpAgent {
@@ -212,14 +210,10 @@ impl GooseAcpAgent {
             .prepare_session_for_activation(session, args.cwd.clone(), args.mcp_servers, true)
             .await?;
 
-        let replay_tool_requests = replay_conversation_to_client(
-            cx,
-            &session,
-            self.supports_goose_custom_notifications(),
-        )?;
+        replay_conversation_to_client(cx, &session, self.supports_goose_custom_notifications())?;
         let (agent, extension_results) = self.prepare_acp_session_agent(cx, &session).await?;
         self.apply_session_recipe(&agent, &session).await?;
-        self.register_acp_session(session_id_str.clone(), agent.clone(), replay_tool_requests)
+        self.register_acp_session(session_id_str.clone(), agent.clone())
             .await;
 
         session = self

--- a/crates/goose/src/acp/server/load_session.rs
+++ b/crates/goose/src/acp/server/load_session.rs
@@ -84,7 +84,7 @@ fn replay_conversation_to_client(
 
                     let mut tool_call = build_initial_tool_call(tool_request);
                     let mut meta = tool_call.meta.take();
-                    if let Some(chain_summary) = tool_request.persisted_chain_summary() {
+                    if let Some(chain_summary) = tool_request.generated_chain_summary() {
                         let goose_meta = meta
                             .get_or_insert_default()
                             .entry("goose".to_string())

--- a/crates/goose/src/acp/server/new_session.rs
+++ b/crates/goose/src/acp/server/new_session.rs
@@ -73,9 +73,7 @@ impl GooseAcpAgent {
             .await?;
 
         let reloaded_session = self.reload_session(&session.id).await?;
-        let (agent, extension_results) = self
-            .activate_acp_session(cx, &reloaded_session, HashMap::new())
-            .await?;
+        let (agent, extension_results) = self.activate_acp_session(cx, &reloaded_session).await?;
         if let Some(recipe) = &rendered_recipe {
             self.apply_recipe(&agent, recipe).await;
         }

--- a/crates/goose/src/acp/server/tool_calls/chain.rs
+++ b/crates/goose/src/acp/server/tool_calls/chain.rs
@@ -1,148 +1,204 @@
-use std::collections::HashMap;
-use std::sync::Arc;
+use crate::conversation::message::{MessageContent, ToolRequest};
 
-/// A run of consecutive ToolRequest blocks within one assistant message,
-/// tracked by `GooseAcpSession::chain_membership`. Used to drive a single
-/// LLM summary for the whole run once every step has a recorded ToolResponse.
-#[derive(Debug, Clone)]
-pub(crate) struct ToolChain {
-    /// Tool call ids in document order. Always `len() >= 2`.
-    pub(crate) ids: Vec<String>,
-    /// The message_id of the assistant message containing these tool calls.
-    /// Used to persist chain summaries back to the messages table.
-    pub(crate) message_id: String,
+pub(crate) fn breaks_consecutive_tool_calls(content: &MessageContent) -> bool {
+    matches!(
+        content,
+        MessageContent::Text(_) | MessageContent::Thinking(_) | MessageContent::Image(_)
+    )
 }
 
-/// If `buffer` holds a multi-tool run (≥ 2 tool requests), (re)register a
-/// [`ToolChain`] in `chain_membership` anchored on the **first** tool's
-/// message_id (the row `SessionManager::update_tool_request_meta` will patch
-/// when persisting the LLM-generated summary). Does **not** clear the buffer
-/// — chains can grow as more tools arrive (sequential tool use), so callers
-/// keep accumulating and re-registering with the larger set of ids.
-///
-/// The buffer contains `(tool_call_id, message_id)` pairs in arrival order,
-/// fed by the prompt stream loop. Sequential tool use (Bedrock/Anthropic)
-/// interleaves request → response → request → response across separate
-/// `AgentEvent::Message` events, so a per-event view would only see length-1
-/// chains and miss the run. Tool responses are chain-neutral (they don't
-/// split the run); only non-tool content (text, thinking, image, etc.) does,
-/// matching the frontend's `groupContentSections` behavior.
-pub(crate) fn extend_chain_membership(
-    buffer: &[(String, String)],
-    chain_membership: &mut HashMap<String, Arc<ToolChain>>,
-) {
-    if buffer.len() >= 2 {
-        let ids: Vec<String> = buffer.iter().map(|(id, _)| id.clone()).collect();
-        let message_id = buffer[0].1.clone();
-        let chain = Arc::new(ToolChain {
-            ids: ids.clone(),
+#[derive(Debug)]
+struct ToolChainStep {
+    request: ToolRequest,
+    responded: bool,
+}
+
+#[derive(Debug)]
+struct TrackedToolChain {
+    message_id: String,
+    steps: Vec<ToolChainStep>,
+}
+
+impl TrackedToolChain {
+    fn new(request: ToolRequest, message_id: String) -> Self {
+        Self {
             message_id,
-        });
-        for id in ids {
-            chain_membership.insert(id, chain.clone());
+            steps: vec![ToolChainStep {
+                request,
+                responded: false,
+            }],
         }
+    }
+
+    fn add_request(&mut self, request: ToolRequest) {
+        self.steps.push(ToolChainStep {
+            request,
+            responded: false,
+        });
+    }
+
+    fn contains(&self, tool_call_id: &str) -> bool {
+        self.steps
+            .iter()
+            .any(|step| step.request.id == tool_call_id)
+    }
+
+    fn mark_responded(&mut self, tool_call_id: &str) {
+        let Some(step) = self
+            .steps
+            .iter_mut()
+            .find(|step| step.request.id == tool_call_id)
+        else {
+            return;
+        };
+
+        step.responded = true;
+    }
+
+    fn is_complete(&self) -> bool {
+        self.steps.iter().all(|step| step.responded)
+    }
+
+    fn into_ready(self) -> ReadyToolChain {
+        ReadyToolChain {
+            message_id: self.message_id,
+            tool_requests: self.steps.into_iter().map(|step| step.request).collect(),
+        }
+    }
+}
+
+pub(crate) struct ReadyToolChain {
+    pub(crate) message_id: String,
+    pub(crate) tool_requests: Vec<ToolRequest>,
+}
+
+/// Tracks tool-chain membership and readiness for one ACP prompt stream.
+#[derive(Default)]
+pub(crate) struct ToolChainTracker {
+    current_chain: Option<TrackedToolChain>,
+    waiting_chains: Vec<TrackedToolChain>,
+}
+
+impl ToolChainTracker {
+    pub(crate) fn record_request(&mut self, request: ToolRequest, message_id: String) {
+        if let Some(chain) = &mut self.current_chain {
+            chain.add_request(request);
+        } else {
+            self.current_chain = Some(TrackedToolChain::new(request, message_id));
+        }
+    }
+
+    pub(crate) fn record_response(&mut self, tool_call_id: &str) -> Option<ReadyToolChain> {
+        if let Some(current_chain) = &mut self.current_chain {
+            if current_chain.contains(tool_call_id) {
+                current_chain.mark_responded(tool_call_id);
+                return None;
+            }
+        }
+
+        let waiting_chain_index = self
+            .waiting_chains
+            .iter()
+            .position(|chain| chain.contains(tool_call_id))?;
+
+        let waiting_chain = &mut self.waiting_chains[waiting_chain_index];
+        waiting_chain.mark_responded(tool_call_id);
+
+        if !waiting_chain.is_complete() {
+            return None;
+        }
+
+        let ready_chain = self.waiting_chains.remove(waiting_chain_index);
+        Some(ready_chain.into_ready())
+    }
+
+    pub(crate) fn close_current_chain(&mut self) -> Option<ReadyToolChain> {
+        let chain = self.current_chain.take()?;
+        if chain.steps.len() < 2 {
+            return None;
+        }
+
+        if !chain.is_complete() {
+            self.waiting_chains.push(chain);
+            return None;
+        }
+
+        Some(chain.into_ready())
     }
 }
 
 #[cfg(test)]
 mod tests {
-    mod extend_chain_membership {
-        use super::super::{extend_chain_membership, ToolChain};
-        use std::collections::HashMap;
-        use std::sync::Arc;
+    use super::ToolChainTracker;
+    use crate::conversation::message::ToolRequest;
+    use rmcp::model::CallToolRequestParams;
 
-        fn buf_entry(tool_id: &str, msg_id: &str) -> (String, String) {
-            (tool_id.to_string(), msg_id.to_string())
+    fn request(id: &str) -> ToolRequest {
+        ToolRequest {
+            id: id.to_string(),
+            tool_call: Ok(CallToolRequestParams::new(format!("tool-{id}"))),
+            metadata: None,
+            tool_meta: None,
+        }
+    }
+
+    fn request_ids(chain: &super::ReadyToolChain) -> Vec<&str> {
+        chain
+            .tool_requests
+            .iter()
+            .map(|request| request.id.as_str())
+            .collect()
+    }
+
+    #[test]
+    fn open_chain_waits_for_a_boundary() {
+        let mut tracker = ToolChainTracker::default();
+
+        for id in ["a", "b", "c"] {
+            tracker.record_request(request(id), format!("message-{id}"));
+            assert!(tracker.record_response(id).is_none());
         }
 
-        #[test]
-        fn skips_singleton_and_leaves_buffer() {
-            let mut membership: HashMap<String, Arc<ToolChain>> = HashMap::new();
-            let buffer = vec![buf_entry("a", "row_1")];
+        let ready = tracker.close_current_chain().expect("A-B-C is ready");
+        assert_eq!(request_ids(&ready), ["a", "b", "c"]);
+        assert_eq!(ready.message_id, "message-a");
+    }
 
-            extend_chain_membership(&buffer, &mut membership);
+    #[test]
+    fn closed_chain_waits_for_its_last_response() {
+        let mut tracker = ToolChainTracker::default();
+        for id in ["a", "b", "c"] {
+            tracker.record_request(request(id), format!("message-{id}"));
+        }
+        tracker.record_response("a");
+        tracker.record_response("b");
 
-            assert_eq!(buffer.len(), 1, "buffer is left intact for caller");
-            assert!(
-                membership.is_empty(),
-                "single-tool runs should not register a chain",
-            );
+        assert!(tracker.close_current_chain().is_none());
+
+        let ready = tracker.record_response("c").expect("A-B-C is ready");
+        assert_eq!(request_ids(&ready), ["a", "b", "c"]);
+    }
+
+    #[test]
+    fn boundary_separates_request_runs_and_discards_singletons() {
+        let mut tracker = ToolChainTracker::default();
+        for id in ["a", "b"] {
+            tracker.record_request(request(id), format!("message-{id}"));
+            tracker.record_response(id);
         }
 
-        #[test]
-        fn registers_each_id_against_shared_chain() {
-            let mut membership: HashMap<String, Arc<ToolChain>> = HashMap::new();
-            let buffer = vec![
-                buf_entry("a", "row_first"),
-                buf_entry("b", "row_second"),
-                buf_entry("c", "row_third"),
-            ];
+        let first = tracker.close_current_chain().expect("A-B is ready");
+        assert_eq!(request_ids(&first), ["a", "b"]);
 
-            extend_chain_membership(&buffer, &mut membership);
+        tracker.record_request(request("c"), "message-c".to_string());
+        tracker.record_response("c");
+        assert!(tracker.close_current_chain().is_none());
 
-            assert_eq!(membership.len(), 3);
-            let chain_a = membership.get("a").expect("a registered");
-            let chain_b = membership.get("b").expect("b registered");
-            let chain_c = membership.get("c").expect("c registered");
-            assert!(
-                Arc::ptr_eq(chain_a, chain_b) && Arc::ptr_eq(chain_b, chain_c),
-                "every id in the run must point at the same ToolChain Arc",
-            );
-            assert_eq!(
-                chain_a.ids,
-                vec!["a".to_string(), "b".to_string(), "c".to_string()],
-            );
+        for id in ["d", "e"] {
+            tracker.record_request(request(id), format!("message-{id}"));
+            tracker.record_response(id);
         }
-
-        #[test]
-        fn anchors_on_first_row_for_split_messages() {
-            // Sequential tool use (Bedrock/Anthropic) emits each tool request as
-            // its own assistant message, with the tool response interleaved in
-            // between. The chain should still form, anchored on the *first*
-            // tool's row id so `update_tool_request_meta` can find that
-            // ToolRequest when persisting the summary.
-            let mut membership: HashMap<String, Arc<ToolChain>> = HashMap::new();
-            let buffer = vec![
-                buf_entry("toolu_bdrk_1", "row_for_tool_1"),
-                buf_entry("toolu_bdrk_2", "row_for_tool_2"),
-            ];
-
-            extend_chain_membership(&buffer, &mut membership);
-
-            let chain = membership
-                .get("toolu_bdrk_1")
-                .expect("first tool registered");
-            assert_eq!(
-                chain.ids,
-                vec!["toolu_bdrk_1".to_string(), "toolu_bdrk_2".to_string()],
-            );
-            let chain_via_second = membership
-                .get("toolu_bdrk_2")
-                .expect("second tool registered");
-            assert!(Arc::ptr_eq(chain, chain_via_second));
-        }
-
-        #[test]
-        fn grows_chain_as_more_requests_arrive() {
-            // The streaming loop re-registers eagerly each time a new request
-            // arrives, so a chain that started at length 2 must grow to include
-            // a third tool whose response is yet to come. Both the original
-            // members and the new member must point at the new (extended) chain.
-            let mut membership: HashMap<String, Arc<ToolChain>> = HashMap::new();
-            let mut buffer = vec![buf_entry("a", "row_1"), buf_entry("b", "row_2")];
-            extend_chain_membership(&buffer, &mut membership);
-
-            buffer.push(buf_entry("c", "row_3"));
-            extend_chain_membership(&buffer, &mut membership);
-
-            let chain_a = membership.get("a").expect("a present");
-            let chain_b = membership.get("b").expect("b present");
-            let chain_c = membership.get("c").expect("c present");
-            assert!(Arc::ptr_eq(chain_a, chain_b) && Arc::ptr_eq(chain_b, chain_c));
-            assert_eq!(
-                chain_a.ids,
-                vec!["a".to_string(), "b".to_string(), "c".to_string()],
-            );
-        }
+        let second = tracker.close_current_chain().expect("D-E is ready");
+        assert_eq!(request_ids(&second), ["d", "e"]);
     }
 }

--- a/crates/goose/src/acp/server/tool_calls/conversion.rs
+++ b/crates/goose/src/acp/server/tool_calls/conversion.rs
@@ -58,17 +58,9 @@ pub(crate) fn goose_tool_call_meta(tool_request: &ToolRequest) -> Option<Meta> {
     let tool_call = tool_request.tool_call.as_ref().ok()?;
     let tool_name = tool_call.name.to_string();
     let extension_name = tool_request
-        .tool_meta
-        .as_ref()
-        .and_then(|meta| meta.get("goose_extension"))
-        .and_then(serde_json::Value::as_str)
-        .map(ToString::to_string)
-        .or_else(|| {
-            tool_request
-                .tool_name_parts()
-                .and_then(|parts| parts.extension_name)
-                .map(ToString::to_string)
-        });
+        .tool_name_parts()
+        .and_then(|parts| parts.extension_name)
+        .map(ToString::to_string);
 
     let mut tool_call_meta = serde_json::Map::new();
     tool_call_meta.insert("toolName".to_string(), serde_json::Value::String(tool_name));
@@ -122,7 +114,9 @@ fn json_u32(value: &serde_json::Value) -> Option<u32> {
     value.as_u64().and_then(|value| u32::try_from(value).ok())
 }
 
-fn extract_locations_from_meta(tool_response: &ToolResponse) -> Option<Vec<ToolCallLocation>> {
+fn extract_tool_locations_from_response(
+    tool_response: &ToolResponse,
+) -> Option<Vec<ToolCallLocation>> {
     let result = tool_response.tool_result.as_ref().ok()?;
     let meta = result.meta.as_ref()?;
     let locations_val = meta.get("tool_locations")?;
@@ -142,7 +136,7 @@ fn extract_locations_from_meta(tool_response: &ToolResponse) -> Option<Vec<ToolC
     }
 }
 
-fn extract_tool_locations(tool_request: &ToolRequest) -> Vec<ToolCallLocation> {
+fn extract_tool_locations_from_request(tool_request: &ToolRequest) -> Vec<ToolCallLocation> {
     let Some(parts) = tool_request.tool_name_parts() else {
         return Vec::new();
     };
@@ -174,7 +168,7 @@ fn extract_tool_locations(tool_request: &ToolRequest) -> Vec<ToolCallLocation> {
     vec![ToolCallLocation::new(path).line(line)]
 }
 
-pub(crate) fn extract_tool_call_update_meta(tool_response: &ToolResponse) -> Option<Meta> {
+pub(crate) fn trusted_update_meta(tool_response: &ToolResponse) -> Option<Meta> {
     let tool_result = tool_response.tool_result.as_ref().ok()?;
     let goose_meta = tool_result
         .meta
@@ -268,8 +262,11 @@ pub(crate) fn tool_call_update_fields_from_response(
     }
 
     if !is_acp_aware {
-        let locations = extract_locations_from_meta(tool_response)
-            .unwrap_or_else(|| tool_request.map(extract_tool_locations).unwrap_or_default());
+        let locations = extract_tool_locations_from_response(tool_response).unwrap_or_else(|| {
+            tool_request
+                .map(extract_tool_locations_from_request)
+                .unwrap_or_default()
+        });
         if !locations.is_empty() {
             fields = fields.locations(locations);
         }
@@ -342,16 +339,14 @@ mod tests {
             let arguments = json_object(vec![("path", serde_json::json!("/src/main.rs"))]);
             let request = ToolRequest {
                 id: "req_1".to_string(),
-                tool_call: Ok(
-                    CallToolRequestParams::new("developer__edit").with_arguments(arguments.clone())
-                ),
+                tool_call: Ok(CallToolRequestParams::new("edit").with_arguments(arguments.clone())),
                 metadata: None,
-                tool_meta: None,
+                tool_meta: Some(serde_json::json!({"goose_extension": "developer"})),
             };
 
             let tool_call = build_initial_tool_call(&request);
 
-            assert_eq!(tool_call.title, "developer: edit · /src/main.rs");
+            assert_eq!(tool_call.title, "edit · /src/main.rs");
             assert_eq!(tool_call.status, ToolCallStatus::Pending);
             assert_eq!(
                 tool_call.raw_input,
@@ -361,7 +356,7 @@ mod tests {
                 tool_call.meta.as_ref().and_then(|meta| meta.get("goose")),
                 Some(&serde_json::json!({
                     "toolCall": {
-                        "toolName": "developer__edit",
+                        "toolName": "edit",
                         "extensionName": "developer",
                     },
                 }))
@@ -409,7 +404,7 @@ mod tests {
         use super::*;
 
         #[test]
-        fn uses_goose_extension_metadata() {
+        fn prefers_goose_extension_metadata_over_name_prefix() {
             let request = ToolRequest {
                 id: "req_1".to_string(),
                 tool_call: Ok(CallToolRequestParams::new("other__query-docs")),
@@ -435,7 +430,7 @@ mod tests {
         pairs.into_iter().map(|(k, v)| (k.to_string(), v)).collect()
     }
 
-    mod extract_tool_locations {
+    mod extract_tool_locations_from_request {
         use super::*;
         use test_case::test_case;
 
@@ -454,7 +449,7 @@ mod tests {
         }
 
         fn locations(request: &ToolRequest) -> Vec<(PathBuf, Option<u32>)> {
-            super::extract_tool_locations(request)
+            super::extract_tool_locations_from_request(request)
                 .into_iter()
                 .map(|location| (location.path, location.line))
                 .collect()
@@ -495,6 +490,17 @@ mod tests {
             );
         }
 
+        #[test]
+        fn accepts_unprefixed_developer_tool_from_metadata() {
+            let mut request = request("write", serde_json::json!({"path": "/tmp/f.txt"}));
+            request.tool_meta = Some(serde_json::json!({"goose_extension": "developer"}));
+
+            assert_eq!(
+                locations(&request),
+                vec![(PathBuf::from("/tmp/f.txt"), Some(1))]
+            );
+        }
+
         #[test_case("other__read"; "other extension read")]
         #[test_case("other__write"; "other extension write")]
         #[test_case("other__edit"; "other extension edit")]
@@ -502,7 +508,7 @@ mod tests {
         #[test_case("write"; "unqualified write")]
         #[test_case("edit"; "unqualified edit")]
         #[test_case("developer__shell"; "non file developer tool")]
-        fn rejects_tools_without_a_qualified_developer_file_identity(name: &str) {
+        fn rejects_tools_without_developer_ownership(name: &str) {
             let request = request(name, serde_json::json!({"path": "/tmp/f.txt"}));
 
             assert!(locations(&request).is_empty());
@@ -529,14 +535,14 @@ mod tests {
         => None
         ; "no meta"
     )]
-    fn test_extract_locations_from_meta(
+    fn extracts_tool_locations_from_response(
         response: ToolResponse,
     ) -> Option<Vec<(PathBuf, Option<u32>)>> {
-        extract_locations_from_meta(&response)
+        extract_tool_locations_from_response(&response)
             .map(|locs| locs.into_iter().map(|loc| (loc.path, loc.line)).collect())
     }
 
-    mod extract_tool_call_update_meta {
+    mod trusted_update_meta {
         use super::*;
 
         #[test]
@@ -549,7 +555,7 @@ mod tests {
                 },
             })));
 
-            assert_eq!(extract_tool_call_update_meta(&response), None);
+            assert_eq!(trusted_update_meta(&response), None);
         }
 
         #[test]
@@ -569,8 +575,7 @@ mod tests {
                 },
             })));
 
-            let extracted =
-                extract_tool_call_update_meta(&response).expect("expected trusted meta");
+            let extracted = trusted_update_meta(&response).expect("expected trusted meta");
             assert_eq!(
                 extracted.get("goose"),
                 Some(&serde_json::json!({
@@ -602,7 +607,7 @@ mod tests {
                 ])),
             ),
             metadata: None,
-            tool_meta: None,
+            tool_meta: Some(serde_json::json!({"goose_extension": "developer"})),
         }
     }
 

--- a/crates/goose/src/acp/server/tool_calls/conversion.rs
+++ b/crates/goose/src/acp/server/tool_calls/conversion.rs
@@ -163,101 +163,29 @@ fn extract_locations_from_meta(tool_response: &ToolResponse) -> Option<Vec<ToolC
     }
 }
 
-fn extract_tool_locations(
-    tool_request: &ToolRequest,
-    tool_response: &ToolResponse,
-) -> Vec<ToolCallLocation> {
-    let mut locations = Vec::new();
-
-    if let Ok(tool_call) = &tool_request.tool_call {
-        if !is_developer_file_tool(tool_call.name.as_ref()) {
-            return locations;
-        }
-
-        let tool_name = tool_call.name.as_ref();
-        let path_str = tool_call
-            .arguments
-            .as_ref()
-            .and_then(|args| args.get("path"))
-            .and_then(|p| p.as_str());
-
-        if let Some(path_str) = path_str {
-            if matches!(tool_name, "read") {
-                let line = get_requested_line(tool_call.arguments.as_ref());
-                locations.push(ToolCallLocation::new(path_str).line(line));
-                return locations;
-            }
-
-            if matches!(tool_name, "write" | "edit") {
-                locations.push(ToolCallLocation::new(path_str).line(1));
-                return locations;
-            }
-
-            let command = tool_call
-                .arguments
-                .as_ref()
-                .and_then(|args| args.get("command"))
-                .and_then(|c| c.as_str());
-
-            if let Ok(result) = &tool_response.tool_result {
-                for content in &result.content {
-                    if let RawContent::Text(text_content) = &content.raw {
-                        let text = &text_content.text;
-
-                        match command {
-                            Some("view") => {
-                                let line = extract_view_line_range(text)
-                                    .map(|range| range.0 as u32)
-                                    .or(Some(1));
-                                locations.push(ToolCallLocation::new(path_str).line(line));
-                            }
-                            Some("str_replace") | Some("insert") => {
-                                let line = extract_first_line_number(text)
-                                    .map(|l| l as u32)
-                                    .or(Some(1));
-                                locations.push(ToolCallLocation::new(path_str).line(line));
-                            }
-                            Some("write") => {
-                                locations.push(ToolCallLocation::new(path_str).line(1));
-                            }
-                            _ => {
-                                locations.push(ToolCallLocation::new(path_str).line(1));
-                            }
-                        }
-                        break;
-                    }
-                }
-            }
-
-            if locations.is_empty() {
-                locations.push(ToolCallLocation::new(path_str).line(1));
-            }
-        }
+fn extract_tool_locations(tool_request: &ToolRequest) -> Vec<ToolCallLocation> {
+    let Ok(tool_call) = &tool_request.tool_call else {
+        return Vec::new();
+    };
+    if !is_developer_file_tool(tool_call.name.as_ref()) {
+        return Vec::new();
     }
 
-    locations
-}
+    let Some(path) = tool_call
+        .arguments
+        .as_ref()
+        .and_then(|args| args.get("path"))
+        .and_then(|path| path.as_str())
+    else {
+        return Vec::new();
+    };
 
-fn extract_view_line_range(text: &str) -> Option<(usize, usize)> {
-    let re = regex::Regex::new(r"\(lines (\d+)-(\d+|end)\)").ok()?;
-    if let Some(caps) = re.captures(text) {
-        let start = caps.get(1)?.as_str().parse::<usize>().ok()?;
-        let end = if caps.get(2)?.as_str() == "end" {
-            start
-        } else {
-            caps.get(2)?.as_str().parse::<usize>().ok()?
-        };
-        return Some((start, end));
-    }
-    None
-}
-
-fn extract_first_line_number(text: &str) -> Option<usize> {
-    let re = regex::Regex::new(r"```[^\n]*\n(\d+):").ok()?;
-    if let Some(caps) = re.captures(text) {
-        return caps.get(1)?.as_str().parse::<usize>().ok();
-    }
-    None
+    let line = match tool_call.name.as_ref() {
+        "read" => get_requested_line(tool_call.arguments.as_ref()),
+        "write" | "edit" => Some(1),
+        _ => return Vec::new(),
+    };
+    vec![ToolCallLocation::new(path).line(line)]
 }
 
 pub(crate) fn extract_tool_call_update_meta(tool_response: &ToolResponse) -> Option<Meta> {
@@ -354,11 +282,8 @@ pub(crate) fn tool_call_update_fields_from_response(
     }
 
     if !is_acp_aware {
-        let locations = extract_locations_from_meta(tool_response).unwrap_or_else(|| {
-            tool_request
-                .map(|request| extract_tool_locations(request, tool_response))
-                .unwrap_or_default()
-        });
+        let locations = extract_locations_from_meta(tool_response)
+            .unwrap_or_else(|| tool_request.map(extract_tool_locations).unwrap_or_default());
         if !locations.is_empty() {
             fields = fields.locations(locations);
         }
@@ -482,11 +407,6 @@ mod tests {
             id: "req_1".to_string(),
             tool_call: Ok(CallToolRequestParams::new("read").with_arguments(serde_json::json!({"path": "/tmp/f.txt", "line": 5}).as_object().unwrap().clone())),
             metadata: None, tool_meta: None,
-        },
-        ToolResponse {
-            id: "req_1".to_string(),
-            tool_result: Ok(CallToolResult::success(vec![RmcpContent::text("")])),
-            metadata: None,
         }
         => vec![(PathBuf::from("/tmp/f.txt"), Some(5))]
         ; "read returns requested line"
@@ -496,11 +416,6 @@ mod tests {
             id: "req_1".to_string(),
             tool_call: Ok(CallToolRequestParams::new("read").with_arguments(serde_json::json!({"path": "/tmp/f.txt"}).as_object().unwrap().clone())),
             metadata: None, tool_meta: None,
-        },
-        ToolResponse {
-            id: "req_1".to_string(),
-            tool_result: Ok(CallToolResult::success(vec![RmcpContent::text("")])),
-            metadata: None,
         }
         => vec![(PathBuf::from("/tmp/f.txt"), None)]
         ; "read without line"
@@ -510,11 +425,6 @@ mod tests {
             id: "req_1".to_string(),
             tool_call: Ok(CallToolRequestParams::new("write").with_arguments(serde_json::json!({"path": "/tmp/f.txt", "content": "hi"}).as_object().unwrap().clone())),
             metadata: None, tool_meta: None,
-        },
-        ToolResponse {
-            id: "req_1".to_string(),
-            tool_result: Ok(CallToolResult::success(vec![RmcpContent::text("")])),
-            metadata: None,
         }
         => vec![(PathBuf::from("/tmp/f.txt"), Some(1))]
         ; "write returns line 1"
@@ -524,11 +434,6 @@ mod tests {
             id: "req_1".to_string(),
             tool_call: Ok(CallToolRequestParams::new("edit").with_arguments(serde_json::json!({"path": "/tmp/f.txt", "before": "a", "after": "b"}).as_object().unwrap().clone())),
             metadata: None, tool_meta: None,
-        },
-        ToolResponse {
-            id: "req_1".to_string(),
-            tool_result: Ok(CallToolResult::success(vec![RmcpContent::text("")])),
-            metadata: None,
         }
         => vec![(PathBuf::from("/tmp/f.txt"), Some(1))]
         ; "edit returns line 1"
@@ -538,20 +443,12 @@ mod tests {
             id: "req_1".to_string(),
             tool_call: Ok(CallToolRequestParams::new("shell").with_arguments(serde_json::json!({"command": "ls"}).as_object().unwrap().clone())),
             metadata: None, tool_meta: None,
-        },
-        ToolResponse {
-            id: "req_1".to_string(),
-            tool_result: Ok(CallToolResult::success(vec![RmcpContent::text("")])),
-            metadata: None,
         }
         => Vec::<(PathBuf, Option<u32>)>::new()
         ; "non file tool returns empty"
     )]
-    fn test_extract_tool_locations(
-        request: ToolRequest,
-        response: ToolResponse,
-    ) -> Vec<(PathBuf, Option<u32>)> {
-        extract_tool_locations(&request, &response)
+    fn test_extract_tool_locations(request: ToolRequest) -> Vec<(PathBuf, Option<u32>)> {
+        extract_tool_locations(&request)
             .into_iter()
             .map(|loc| (loc.path, loc.line))
             .collect()

--- a/crates/goose/src/acp/server/tool_calls/conversion.rs
+++ b/crates/goose/src/acp/server/tool_calls/conversion.rs
@@ -5,7 +5,7 @@ use crate::mcp_utils::ToolResult;
 use agent_client_protocol::schema::v1::{
     BlobResourceContents, Content, ContentBlock, EmbeddedResource, EmbeddedResourceResource,
     ImageContent, Meta, TextContent, TextResourceContents, ToolCall, ToolCallContent, ToolCallId,
-    ToolCallLocation, ToolCallStatus, ToolCallUpdateFields,
+    ToolCallLocation, ToolCallStatus, ToolCallUpdate, ToolCallUpdateFields, ToolKind,
 };
 use rmcp::model::{CallToolResult, RawContent, ResourceContents};
 
@@ -22,7 +22,7 @@ pub(crate) fn format_tool_name(tool_name: &str) -> String {
     }
 }
 
-pub(crate) fn default_tool_title(tool_name: &str, arguments: Option<&serde_json::Value>) -> String {
+fn default_tool_title(tool_name: &str, arguments: Option<&serde_json::Value>) -> String {
     let base = format_tool_name(tool_name);
 
     let detail = arguments.and_then(|args| {
@@ -108,6 +108,28 @@ pub(crate) fn build_initial_tool_call(tool_request: &ToolRequest) -> ToolCall {
     }
 
     tool_call.meta(goose_meta)
+}
+
+pub(crate) fn build_permission_tool_call_update(
+    request_id: &str,
+    tool_name: &str,
+    arguments: serde_json::Map<String, serde_json::Value>,
+    prompt: Option<String>,
+) -> ToolCallUpdate {
+    let arguments = serde_json::Value::Object(arguments);
+    let mut fields = ToolCallUpdateFields::new()
+        .title(default_tool_title(tool_name, Some(&arguments)))
+        .kind(ToolKind::default())
+        .status(ToolCallStatus::Pending)
+        .raw_input(arguments);
+
+    if let Some(prompt) = prompt {
+        fields = fields.content(vec![ToolCallContent::Content(Content::new(
+            ContentBlock::Text(TextContent::new(prompt)),
+        ))]);
+    }
+
+    ToolCallUpdate::new(ToolCallId::new(request_id), fields)
 }
 
 fn json_u32(value: &serde_json::Value) -> Option<u32> {
@@ -399,6 +421,41 @@ mod tests {
             assert_eq!(tool_call.status, ToolCallStatus::Pending);
             assert_eq!(tool_call.raw_input, None);
             assert_eq!(tool_call.meta, None);
+        }
+    }
+
+    mod build_permission_tool_call_update {
+        use super::*;
+
+        #[test]
+        fn matches_initial_request_presentation() {
+            let arguments = json_object(vec![("command", serde_json::json!("cargo test"))]);
+            let request = ToolRequest {
+                id: "req_1".to_string(),
+                tool_call: Ok(CallToolRequestParams::new("developer__shell")
+                    .with_arguments(arguments.clone())),
+                metadata: None,
+                tool_meta: None,
+            };
+            let initial = build_initial_tool_call(&request);
+
+            let permission = build_permission_tool_call_update(
+                &request.id,
+                "developer__shell",
+                arguments,
+                Some("Allow this command?".to_string()),
+            );
+
+            assert_eq!(
+                permission.fields.title.as_deref(),
+                Some(initial.title.as_str())
+            );
+            assert_eq!(permission.fields.raw_input, initial.raw_input);
+            assert_eq!(permission.fields.status, Some(ToolCallStatus::Pending));
+            assert_eq!(
+                first_tool_call_text(&permission.fields),
+                Some("Allow this command?")
+            );
         }
     }
 

--- a/crates/goose/src/acp/server/tool_calls/conversion.rs
+++ b/crates/goose/src/acp/server/tool_calls/conversion.rs
@@ -256,12 +256,14 @@ pub(crate) fn tool_call_update_fields_from_response(
         .tool_result
         .as_ref()
         .is_ok_and(|result| result.is_acp_aware());
+    let include_content = is_failed || !is_acp_aware;
+    let include_locations = !is_acp_aware;
 
-    if is_failed || !is_acp_aware {
+    if include_content {
         fields = fields.content(build_tool_call_content(&tool_response.tool_result));
     }
 
-    if !is_acp_aware {
+    if include_locations {
         let locations = extract_tool_locations_from_response(tool_response).unwrap_or_else(|| {
             tool_request
                 .map(extract_tool_locations_from_request)

--- a/crates/goose/src/acp/server/tool_calls/conversion.rs
+++ b/crates/goose/src/acp/server/tool_calls/conversion.rs
@@ -22,7 +22,7 @@ pub(crate) fn format_tool_name(tool_name: &str) -> String {
     }
 }
 
-fn default_tool_title(tool_name: &str, arguments: Option<&serde_json::Value>) -> String {
+pub(crate) fn default_tool_title(tool_name: &str, arguments: Option<&serde_json::Value>) -> String {
     let base = format_tool_name(tool_name);
 
     let detail = arguments.and_then(|args| {

--- a/crates/goose/src/acp/server/tool_calls/conversion.rs
+++ b/crates/goose/src/acp/server/tool_calls/conversion.rs
@@ -9,12 +9,6 @@ use agent_client_protocol::schema::v1::{
 };
 use rmcp::model::{CallToolResult, RawContent, ResourceContents};
 
-pub(crate) struct PendingToolCall {
-    pub(crate) tool_call: ToolCall,
-    pub(crate) identity_meta: Option<Meta>,
-    pub(crate) fallback_title: String,
-}
-
 pub(crate) fn format_tool_name(tool_name: &str) -> String {
     let parts = ToolNameParts::from(tool_name);
     if let Some(extension_name) = parts.extension_name {
@@ -28,9 +22,7 @@ pub(crate) fn format_tool_name(tool_name: &str) -> String {
     }
 }
 
-/// Build a short fallback title from the tool name and arguments by extracting
-/// the most useful value (file path, command, query, url, etc.).
-fn summarize_tool_call(tool_name: &str, arguments: Option<&serde_json::Value>) -> String {
+fn default_tool_title(tool_name: &str, arguments: Option<&serde_json::Value>) -> String {
     let base = format_tool_name(tool_name);
 
     let detail = arguments.and_then(|args| {
@@ -62,7 +54,7 @@ fn summarize_tool_call(tool_name: &str, arguments: Option<&serde_json::Value>) -
     }
 }
 
-pub(crate) fn tool_call_identity_meta(tool_request: &ToolRequest) -> Option<Meta> {
+pub(crate) fn goose_tool_call_meta(tool_request: &ToolRequest) -> Option<Meta> {
     let tool_call = tool_request.tool_call.as_ref().ok()?;
     let tool_name = tool_call.name.to_string();
     let extension_name = tool_request
@@ -98,7 +90,7 @@ pub(crate) fn tool_call_identity_meta(tool_request: &ToolRequest) -> Option<Meta
     Some(meta)
 }
 
-pub(crate) fn pending_tool_call_from_request(tool_request: &ToolRequest) -> PendingToolCall {
+pub(crate) fn build_initial_tool_call(tool_request: &ToolRequest) -> ToolCall {
     let tool_name = match &tool_request.tool_call {
         Ok(tool_call) => tool_call.name.to_string(),
         Err(_) => "error".to_string(),
@@ -109,17 +101,13 @@ pub(crate) fn pending_tool_call_from_request(tool_request: &ToolRequest) -> Pend
         .ok()
         .and_then(|tc| tc.arguments.as_ref())
         .map(|a| serde_json::Value::Object(a.clone()));
-    let fallback_title = summarize_tool_call(&tool_name, args_value.as_ref());
-    let identity_meta = tool_call_identity_meta(tool_request);
+    let default_tool_call_title = default_tool_title(&tool_name, args_value.as_ref());
+    let goose_meta = goose_tool_call_meta(tool_request);
 
-    // Prefer the persisted LLM-generated title when available so replay (and
-    // any subsequent live initial ToolCall after the title task has already
-    // resolved) emits the nice title up front, with no flash of the
-    // deterministic fallback.
     let initial_title = tool_request
         .persisted_title()
         .map(|s| s.to_string())
-        .unwrap_or_else(|| fallback_title.clone());
+        .unwrap_or(default_tool_call_title);
 
     let mut tool_call = ToolCall::new(ToolCallId::new(tool_request.id.clone()), initial_title)
         .status(ToolCallStatus::Pending);
@@ -127,11 +115,7 @@ pub(crate) fn pending_tool_call_from_request(tool_request: &ToolRequest) -> Pend
         tool_call = tool_call.raw_input(args);
     }
 
-    PendingToolCall {
-        tool_call,
-        identity_meta,
-        fallback_title,
-    }
+    tool_call.meta(goose_meta)
 }
 
 fn get_requested_line(arguments: Option<&rmcp::model::JsonObject>) -> Option<u32> {
@@ -306,39 +290,26 @@ mod tests {
 
         #[test]
         fn with_extension() {
-            assert_eq!(format_tool_name("developer__edit"), "developer: edit");
             assert_eq!(
                 format_tool_name("platform__manage_extensions"),
                 "platform: manage extensions"
             );
-            assert_eq!(format_tool_name("todo__write"), "todo: write");
         }
 
         #[test]
         fn without_extension() {
             assert_eq!(format_tool_name("simple_tool"), "simple tool");
-            assert_eq!(format_tool_name("another_name"), "another name");
-            assert_eq!(format_tool_name("single"), "single");
         }
     }
 
-    mod summarize_tool_call {
+    mod default_tool_title {
         use super::*;
 
         #[test]
         fn no_args() {
             assert_eq!(
-                summarize_tool_call("developer__shell", None),
+                default_tool_title("developer__shell", None),
                 "developer: shell"
-            );
-        }
-
-        #[test]
-        fn with_path() {
-            let args = serde_json::json!({"path": "/src/main.rs", "content": "fn main() {}"});
-            assert_eq!(
-                summarize_tool_call("developer__edit", Some(&args)),
-                "developer: edit · /src/main.rs"
             );
         }
 
@@ -346,7 +317,7 @@ mod tests {
         fn with_command() {
             let args = serde_json::json!({"command": "cargo build"});
             assert_eq!(
-                summarize_tool_call("developer__shell", Some(&args)),
+                default_tool_title("developer__shell", Some(&args)),
                 "developer: shell · cargo build"
             );
         }
@@ -355,53 +326,113 @@ mod tests {
         fn long_value_is_truncated() {
             let long_path = "a".repeat(80);
             let args = serde_json::json!({"path": long_path});
-            let result = summarize_tool_call("developer__read_file", Some(&args));
+            let result = default_tool_title("developer__read_file", Some(&args));
             assert!(result.ends_with('…'));
             assert!(result.len() < 90);
         }
     }
 
-    #[test]
-    fn test_tool_call_identity_meta_uses_goose_extension_metadata() {
-        let request = ToolRequest {
-            id: "req_1".to_string(),
-            tool_call: Ok(CallToolRequestParams::new("context7__query-docs")),
-            metadata: None,
-            tool_meta: Some(serde_json::json!({"goose_extension": "context7"})),
-        };
+    mod build_initial_tool_call {
+        use super::*;
+        use crate::conversation::message::TOOL_META_TITLE_KEY;
+        use rmcp::model::ErrorData;
 
-        let meta = tool_call_identity_meta(&request).expect("expected metadata");
+        #[test]
+        fn uses_default_title_and_preserves_request_data() {
+            let arguments = json_object(vec![("path", serde_json::json!("/src/main.rs"))]);
+            let request = ToolRequest {
+                id: "req_1".to_string(),
+                tool_call: Ok(
+                    CallToolRequestParams::new("developer__edit").with_arguments(arguments.clone())
+                ),
+                metadata: None,
+                tool_meta: None,
+            };
 
-        assert_eq!(
-            meta.get("goose"),
-            Some(&serde_json::json!({
-                "toolCall": {
-                    "toolName": "context7__query-docs",
-                    "extensionName": "context7",
-                },
-            })),
-        );
+            let tool_call = build_initial_tool_call(&request);
+
+            assert_eq!(tool_call.title, "developer: edit · /src/main.rs");
+            assert_eq!(tool_call.status, ToolCallStatus::Pending);
+            assert_eq!(
+                tool_call.raw_input,
+                Some(serde_json::Value::Object(arguments))
+            );
+            assert_eq!(
+                tool_call.meta.as_ref().and_then(|meta| meta.get("goose")),
+                Some(&serde_json::json!({
+                    "toolCall": {
+                        "toolName": "developer__edit",
+                        "extensionName": "developer",
+                    },
+                }))
+            );
+        }
+
+        #[test]
+        fn uses_persisted_title() {
+            let arguments = json_object(vec![("command", serde_json::json!("cargo test"))]);
+            let request = ToolRequest {
+                id: "req_1".to_string(),
+                tool_call: Ok(
+                    CallToolRequestParams::new("developer__shell").with_arguments(arguments)
+                ),
+                metadata: None,
+                tool_meta: Some(serde_json::json!({
+                    (TOOL_META_TITLE_KEY): "running focused tests",
+                })),
+            };
+
+            let tool_call = build_initial_tool_call(&request);
+
+            assert_eq!(tool_call.title, "running focused tests");
+        }
+
+        #[test]
+        fn handles_invalid_request() {
+            let request = ToolRequest {
+                id: "req_1".to_string(),
+                tool_call: Err(ErrorData::invalid_request("invalid tool call", None)),
+                metadata: None,
+                tool_meta: None,
+            };
+
+            let tool_call = build_initial_tool_call(&request);
+
+            assert_eq!(tool_call.title, "error");
+            assert_eq!(tool_call.status, ToolCallStatus::Pending);
+            assert_eq!(tool_call.raw_input, None);
+            assert_eq!(tool_call.meta, None);
+        }
+    }
+
+    mod goose_tool_call_meta {
+        use super::*;
+
+        #[test]
+        fn uses_goose_extension_metadata() {
+            let request = ToolRequest {
+                id: "req_1".to_string(),
+                tool_call: Ok(CallToolRequestParams::new("other__query-docs")),
+                metadata: None,
+                tool_meta: Some(serde_json::json!({"goose_extension": "context7"})),
+            };
+
+            let meta = goose_tool_call_meta(&request).expect("expected metadata");
+
+            assert_eq!(
+                meta.get("goose"),
+                Some(&serde_json::json!({
+                    "toolCall": {
+                        "toolName": "other__query-docs",
+                        "extensionName": "context7",
+                    },
+                })),
+            );
+        }
     }
 
     fn json_object(pairs: Vec<(&str, serde_json::Value)>) -> rmcp::model::JsonObject {
         pairs.into_iter().map(|(k, v)| (k.to_string(), v)).collect()
-    }
-
-    #[test_case(None => None ; "none arguments")]
-    #[test_case(Some(json_object(vec![])) => None ; "missing line key")]
-    #[test_case(Some(json_object(vec![("line", serde_json::json!(5))])) => Some(5) ; "line present")]
-    #[test_case(Some(json_object(vec![("line", serde_json::json!("not_a_number"))])) => None ; "line not a number")]
-    fn test_get_requested_line(arguments: Option<rmcp::model::JsonObject>) -> Option<u32> {
-        get_requested_line(arguments.as_ref())
-    }
-
-    #[test_case("read", true ; "read is developer file tool")]
-    #[test_case("write", true ; "write is developer file tool")]
-    #[test_case("edit", true ; "edit is developer file tool")]
-    #[test_case("shell", false ; "shell is not developer file tool")]
-    #[test_case("analyze", false ; "analyze is not developer file tool")]
-    fn test_is_developer_file_tool(tool_name: &str, expected: bool) {
-        assert_eq!(is_developer_file_tool(tool_name), expected);
     }
 
     #[test_case(
@@ -421,6 +452,15 @@ mod tests {
         }
         => vec![(PathBuf::from("/tmp/f.txt"), None)]
         ; "read without line"
+    )]
+    #[test_case(
+        ToolRequest {
+            id: "req_1".to_string(),
+            tool_call: Ok(CallToolRequestParams::new("read").with_arguments(serde_json::json!({"path": "/tmp/f.txt", "line": "not_a_number"}).as_object().unwrap().clone())),
+            metadata: None, tool_meta: None,
+        }
+        => vec![(PathBuf::from("/tmp/f.txt"), None)]
+        ; "read ignores invalid line"
     )]
     #[test_case(
         ToolRequest {
@@ -467,19 +507,9 @@ mod tests {
     }
 
     #[test_case(
-        response_with_meta(Some(serde_json::json!({"tool_locations": [{"path": "/tmp/f.txt", "line": 5}]})))
-        => Some(vec![(PathBuf::from("/tmp/f.txt"), Some(5))])
-        ; "meta with path and line"
-    )]
-    #[test_case(
         response_with_meta(Some(serde_json::json!({"tool_locations": [{"path": "/tmp/f.txt"}]})))
         => Some(vec![(PathBuf::from("/tmp/f.txt"), None)])
         ; "meta with path no line"
-    )]
-    #[test_case(
-        response_with_meta(Some(serde_json::json!({})))
-        => None
-        ; "meta without tool_locations key"
     )]
     #[test_case(
         response_with_meta(None)
@@ -539,31 +569,6 @@ mod tests {
                 })),
             );
         }
-    }
-
-    #[test]
-    fn test_extract_tool_raw_output_preserves_structured_content() {
-        let mut result = CallToolResult::success(vec![RmcpContent::text("fallback")]);
-        result.structured_content = Some(serde_json::json!({
-            "restaurants": [
-                {
-                    "name": "Coffee Shop",
-                    "unitToken": "unit-1",
-                },
-            ],
-        }));
-
-        assert_eq!(
-            extract_tool_raw_output(&Ok(result)),
-            Some(serde_json::json!({
-                "restaurants": [
-                    {
-                        "name": "Coffee Shop",
-                        "unitToken": "unit-1",
-                    },
-                ],
-            })),
-        );
     }
 
     fn response_from_tool_result(tool_result: ToolResult<CallToolResult>) -> ToolResponse {

--- a/crates/goose/src/acp/server/tool_calls/conversion.rs
+++ b/crates/goose/src/acp/server/tool_calls/conversion.rs
@@ -97,7 +97,7 @@ pub(crate) fn build_initial_tool_call(tool_request: &ToolRequest) -> ToolCall {
     let goose_meta = goose_tool_call_meta(tool_request);
 
     let initial_title = tool_request
-        .persisted_title()
+        .generated_title()
         .map(|s| s.to_string())
         .unwrap_or(default_tool_call_title);
 
@@ -366,7 +366,7 @@ mod tests {
         }
 
         #[test]
-        fn uses_persisted_title() {
+        fn uses_generated_title() {
             let arguments = json_object(vec![("command", serde_json::json!("cargo test"))]);
             let request = ToolRequest {
                 id: "req_1".to_string(),

--- a/crates/goose/src/acp/server/tool_calls/conversion.rs
+++ b/crates/goose/src/acp/server/tool_calls/conversion.rs
@@ -1,6 +1,6 @@
 use crate::acp::tools::AcpAwareToolMeta;
 use crate::agents::extension_manager::TRUSTED_TOOL_UPDATE_META_KEY;
-use crate::conversation::message::{ToolRequest, ToolResponse};
+use crate::conversation::message::{ToolNameParts, ToolRequest, ToolResponse};
 use crate::mcp_utils::ToolResult;
 use agent_client_protocol::schema::v1::{
     BlobResourceContents, Content, ContentBlock, EmbeddedResource, EmbeddedResourceResource,
@@ -16,14 +16,15 @@ pub(crate) struct PendingToolCall {
 }
 
 pub(crate) fn format_tool_name(tool_name: &str) -> String {
-    if let Some((extension, tool)) = tool_name.split_once("__") {
+    let parts = ToolNameParts::from(tool_name);
+    if let Some(extension_name) = parts.extension_name {
         format!(
             "{}: {}",
-            extension.replace('_', " "),
-            tool.replace('_', " ")
+            extension_name.replace('_', " "),
+            parts.tool_name.replace('_', " ")
         )
     } else {
-        tool_name.replace('_', " ")
+        parts.tool_name.replace('_', " ")
     }
 }
 
@@ -71,9 +72,10 @@ pub(crate) fn tool_call_identity_meta(tool_request: &ToolRequest) -> Option<Meta
         .and_then(serde_json::Value::as_str)
         .map(ToString::to_string)
         .or_else(|| {
-            tool_name
-                .split_once("__")
-                .map(|(extension_name, _)| extension_name.to_string())
+            tool_request
+                .tool_name_parts()
+                .and_then(|parts| parts.extension_name)
+                .map(ToString::to_string)
         });
 
     let mut tool_call_meta = serde_json::Map::new();

--- a/crates/goose/src/acp/server/tool_calls/conversion.rs
+++ b/crates/goose/src/acp/server/tool_calls/conversion.rs
@@ -118,15 +118,8 @@ pub(crate) fn build_initial_tool_call(tool_request: &ToolRequest) -> ToolCall {
     tool_call.meta(goose_meta)
 }
 
-fn get_requested_line(arguments: Option<&rmcp::model::JsonObject>) -> Option<u32> {
-    arguments
-        .and_then(|args| args.get("line"))
-        .and_then(|v| v.as_u64())
-        .map(|l| l as u32)
-}
-
-fn is_developer_file_tool(tool_name: &str) -> bool {
-    matches!(tool_name, "read" | "write" | "edit")
+fn json_u32(value: &serde_json::Value) -> Option<u32> {
+    value.as_u64().and_then(|value| u32::try_from(value).ok())
 }
 
 fn extract_locations_from_meta(tool_response: &ToolResponse) -> Option<Vec<ToolCallLocation>> {
@@ -138,7 +131,7 @@ fn extract_locations_from_meta(tool_response: &ToolResponse) -> Option<Vec<ToolC
         .into_iter()
         .filter_map(|entry| {
             let path = entry.get("path")?.as_str()?;
-            let line = entry.get("line").and_then(|v| v.as_u64()).map(|l| l as u32);
+            let line = entry.get("line").and_then(json_u32);
             Some(ToolCallLocation::new(path).line(line))
         })
         .collect::<Vec<_>>();
@@ -150,13 +143,16 @@ fn extract_locations_from_meta(tool_response: &ToolResponse) -> Option<Vec<ToolC
 }
 
 fn extract_tool_locations(tool_request: &ToolRequest) -> Vec<ToolCallLocation> {
-    let Ok(tool_call) = &tool_request.tool_call else {
+    let Some(parts) = tool_request.tool_name_parts() else {
         return Vec::new();
     };
-    if !is_developer_file_tool(tool_call.name.as_ref()) {
+    if parts.extension_name != Some("developer") {
         return Vec::new();
     }
 
+    let Ok(tool_call) = &tool_request.tool_call else {
+        return Vec::new();
+    };
     let Some(path) = tool_call
         .arguments
         .as_ref()
@@ -166,8 +162,12 @@ fn extract_tool_locations(tool_request: &ToolRequest) -> Vec<ToolCallLocation> {
         return Vec::new();
     };
 
-    let line = match tool_call.name.as_ref() {
-        "read" => get_requested_line(tool_call.arguments.as_ref()),
+    let line = match parts.tool_name {
+        "read" => tool_call
+            .arguments
+            .as_ref()
+            .and_then(|arguments| arguments.get("line"))
+            .and_then(json_u32),
         "write" | "edit" => Some(1),
         _ => return Vec::new(),
     };
@@ -435,65 +435,78 @@ mod tests {
         pairs.into_iter().map(|(k, v)| (k.to_string(), v)).collect()
     }
 
-    #[test_case(
-        ToolRequest {
-            id: "req_1".to_string(),
-            tool_call: Ok(CallToolRequestParams::new("read").with_arguments(serde_json::json!({"path": "/tmp/f.txt", "line": 5}).as_object().unwrap().clone())),
-            metadata: None, tool_meta: None,
+    mod extract_tool_locations {
+        use super::*;
+        use test_case::test_case;
+
+        fn request(name: &str, arguments: serde_json::Value) -> ToolRequest {
+            ToolRequest {
+                id: "req_1".to_string(),
+                tool_call: Ok(CallToolRequestParams::new(name.to_string()).with_arguments(
+                    arguments
+                        .as_object()
+                        .expect("test arguments should be an object")
+                        .clone(),
+                )),
+                metadata: None,
+                tool_meta: None,
+            }
         }
-        => vec![(PathBuf::from("/tmp/f.txt"), Some(5))]
-        ; "read returns requested line"
-    )]
-    #[test_case(
-        ToolRequest {
-            id: "req_1".to_string(),
-            tool_call: Ok(CallToolRequestParams::new("read").with_arguments(serde_json::json!({"path": "/tmp/f.txt"}).as_object().unwrap().clone())),
-            metadata: None, tool_meta: None,
+
+        fn locations(request: &ToolRequest) -> Vec<(PathBuf, Option<u32>)> {
+            super::extract_tool_locations(request)
+                .into_iter()
+                .map(|location| (location.path, location.line))
+                .collect()
         }
-        => vec![(PathBuf::from("/tmp/f.txt"), None)]
-        ; "read without line"
-    )]
-    #[test_case(
-        ToolRequest {
-            id: "req_1".to_string(),
-            tool_call: Ok(CallToolRequestParams::new("read").with_arguments(serde_json::json!({"path": "/tmp/f.txt", "line": "not_a_number"}).as_object().unwrap().clone())),
-            metadata: None, tool_meta: None,
+
+        #[test]
+        fn reads_requested_line() {
+            let request = request(
+                "developer__read",
+                serde_json::json!({"path": "/tmp/f.txt", "line": 5}),
+            );
+
+            assert_eq!(
+                locations(&request),
+                vec![(PathBuf::from("/tmp/f.txt"), Some(5))]
+            );
         }
-        => vec![(PathBuf::from("/tmp/f.txt"), None)]
-        ; "read ignores invalid line"
-    )]
-    #[test_case(
-        ToolRequest {
-            id: "req_1".to_string(),
-            tool_call: Ok(CallToolRequestParams::new("write").with_arguments(serde_json::json!({"path": "/tmp/f.txt", "content": "hi"}).as_object().unwrap().clone())),
-            metadata: None, tool_meta: None,
+
+        #[test_case(serde_json::json!({"path": "/tmp/f.txt"}); "missing line")]
+        #[test_case(serde_json::json!({"path": "/tmp/f.txt", "line": "not_a_number"}); "invalid line")]
+        fn reads_without_valid_line(arguments: serde_json::Value) {
+            let request = request("developer__read", arguments);
+
+            assert_eq!(
+                locations(&request),
+                vec![(PathBuf::from("/tmp/f.txt"), None)]
+            );
         }
-        => vec![(PathBuf::from("/tmp/f.txt"), Some(1))]
-        ; "write returns line 1"
-    )]
-    #[test_case(
-        ToolRequest {
-            id: "req_1".to_string(),
-            tool_call: Ok(CallToolRequestParams::new("edit").with_arguments(serde_json::json!({"path": "/tmp/f.txt", "before": "a", "after": "b"}).as_object().unwrap().clone())),
-            metadata: None, tool_meta: None,
+
+        #[test_case("developer__write"; "write")]
+        #[test_case("developer__edit"; "edit")]
+        fn writes_and_edits_start_at_line_one(name: &str) {
+            let request = request(name, serde_json::json!({"path": "/tmp/f.txt"}));
+
+            assert_eq!(
+                locations(&request),
+                vec![(PathBuf::from("/tmp/f.txt"), Some(1))]
+            );
         }
-        => vec![(PathBuf::from("/tmp/f.txt"), Some(1))]
-        ; "edit returns line 1"
-    )]
-    #[test_case(
-        ToolRequest {
-            id: "req_1".to_string(),
-            tool_call: Ok(CallToolRequestParams::new("shell").with_arguments(serde_json::json!({"command": "ls"}).as_object().unwrap().clone())),
-            metadata: None, tool_meta: None,
+
+        #[test_case("other__read"; "other extension read")]
+        #[test_case("other__write"; "other extension write")]
+        #[test_case("other__edit"; "other extension edit")]
+        #[test_case("read"; "unqualified read")]
+        #[test_case("write"; "unqualified write")]
+        #[test_case("edit"; "unqualified edit")]
+        #[test_case("developer__shell"; "non file developer tool")]
+        fn rejects_tools_without_a_qualified_developer_file_identity(name: &str) {
+            let request = request(name, serde_json::json!({"path": "/tmp/f.txt"}));
+
+            assert!(locations(&request).is_empty());
         }
-        => Vec::<(PathBuf, Option<u32>)>::new()
-        ; "non file tool returns empty"
-    )]
-    fn test_extract_tool_locations(request: ToolRequest) -> Vec<(PathBuf, Option<u32>)> {
-        extract_tool_locations(&request)
-            .into_iter()
-            .map(|loc| (loc.path, loc.line))
-            .collect()
     }
 
     fn response_with_meta(meta: Option<serde_json::Value>) -> ToolResponse {

--- a/crates/goose/src/acp/server/tool_calls/enrichment.rs
+++ b/crates/goose/src/acp/server/tool_calls/enrichment.rs
@@ -11,39 +11,28 @@ use agent_client_protocol::schema::v1::{
     Meta, SessionId, ToolCallId, ToolCallUpdate, ToolCallUpdateFields,
 };
 use rmcp::model::CallToolRequestParams;
-use serde_json::{json, to_string, Map, Number, Value};
+use serde_json::{json, to_string, Map, Value};
 use std::slice::from_ref;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::{spawn, time::sleep};
 use tracing::warn;
 
-/// Add `goose.toolChainSummary = { summary, count }` to a `Meta` blob,
-/// preserving any existing `goose.*` keys such as `goose.toolCall`.
-pub(crate) fn with_tool_chain_summary_meta(
-    base: Option<Meta>,
-    summary: &str,
-    count: usize,
-) -> Option<Meta> {
-    let mut meta = base.unwrap_or_default();
-    let goose_entry = meta
-        .entry("goose".to_string())
-        .or_insert_with(|| Value::Object(Map::new()));
-    let goose_obj = match goose_entry {
-        Value::Object(obj) => obj,
-        other => {
-            *other = Value::Object(Map::new());
-            match other {
-                Value::Object(obj) => obj,
-                _ => unreachable!(),
-            }
-        }
-    };
-    let mut chain = Map::new();
-    chain.insert("summary".to_string(), Value::String(summary.to_string()));
-    chain.insert("count".to_string(), Value::Number(Number::from(count)));
-    goose_obj.insert("toolChainSummary".to_string(), Value::Object(chain));
-    Some(meta)
+pub(crate) fn tool_chain_summary(summary: &str, count: usize) -> (String, Value) {
+    (
+        "toolChainSummary".to_string(),
+        json!({
+            "summary": summary,
+            "count": count,
+        }),
+    )
+}
+
+fn build_chain_summary_update(tool_call_id: String, summary: &str, count: usize) -> ToolCallUpdate {
+    let goose_meta = Map::from_iter([tool_chain_summary(summary, count)]);
+    let mut meta = Meta::default();
+    meta.insert("goose".to_string(), Value::Object(goose_meta));
+    ToolCallUpdate::new(ToolCallId::new(tool_call_id), ToolCallUpdateFields::new()).meta(Some(meta))
 }
 
 pub(crate) struct ToolTitleEnrichmentContext {
@@ -277,7 +266,6 @@ impl ChainSummaryEnrichmentContext {
         first_tool_call_id: String,
         message_id_for_persist: String,
         steps: Vec<(String, String)>,
-        goose_meta: Option<Meta>,
         chain_count: usize,
     ) {
         let Self {
@@ -293,7 +281,6 @@ impl ChainSummaryEnrichmentContext {
             first_tool_call_id,
             message_id_for_persist,
             steps,
-            goose_meta,
             chain_count,
             tool_call_notifier,
             session_manager,
@@ -308,7 +295,6 @@ struct ChainSummaryEnrichmentJob {
     first_tool_call_id: String,
     message_id_for_persist: String,
     steps: Vec<(String, String)>,
-    goose_meta: Option<Meta>,
     chain_count: usize,
     tool_call_notifier: ToolCallNotifier,
     session_manager: Arc<SessionManager>,
@@ -323,7 +309,6 @@ impl ChainSummaryEnrichmentJob {
                 first_tool_call_id,
                 message_id_for_persist,
                 steps,
-                goose_meta,
                 chain_count,
                 tool_call_notifier,
                 session_manager,
@@ -436,57 +421,38 @@ impl ChainSummaryEnrichmentJob {
                 );
             }
 
-            let meta = with_tool_chain_summary_meta(goose_meta, &summary, chain_count);
-            let fields = ToolCallUpdateFields::new();
-            let _ = tool_call_notifier.send_update(
-                ToolCallUpdate::new(ToolCallId::new(first_tool_call_id), fields).meta(meta),
-            );
+            let _ = tool_call_notifier.send_update(build_chain_summary_update(
+                first_tool_call_id,
+                &summary,
+                chain_count,
+            ));
         });
     }
 }
 
 #[cfg(test)]
 mod tests {
-    mod with_tool_chain_summary_meta {
-        use super::super::with_tool_chain_summary_meta;
-        use crate::acp::server::tool_calls::conversion::goose_tool_call_meta;
-        use crate::conversation::message::ToolRequest;
-        use rmcp::model::CallToolRequestParams;
+    mod build_chain_summary_update {
+        use super::super::build_chain_summary_update;
         use serde_json::json;
 
         #[test]
-        fn creates_fresh_when_none() {
-            let meta = with_tool_chain_summary_meta(None, "applied dark mode", 4)
-                .expect("meta should be created");
-            assert_eq!(
-                meta.get("goose"),
-                Some(&json!({
-                    "toolChainSummary": { "summary": "applied dark mode", "count": 4 },
-                })),
-            );
-        }
+        fn contains_only_the_chain_summary_delta() {
+            let update = build_chain_summary_update("req_1".to_string(), "applied dark mode", 4);
 
-        #[test]
-        fn preserves_existing_tool_call_identity() {
-            let existing = goose_tool_call_meta(&ToolRequest {
-                id: "req_1".to_string(),
-                tool_call: Ok(CallToolRequestParams::new("developer__shell")),
-                metadata: None,
-                tool_meta: None,
-            });
-            let meta = with_tool_chain_summary_meta(existing, "ran two commands", 2)
-                .expect("meta should be created");
-            let goose = meta.get("goose").expect("goose key");
             assert_eq!(
-                goose.get("toolCall"),
-                Some(&json!({
-                    "toolName": "developer__shell",
-                    "extensionName": "developer",
-                })),
-            );
-            assert_eq!(
-                goose.get("toolChainSummary"),
-                Some(&json!({ "summary": "ran two commands", "count": 2 })),
+                serde_json::to_value(update).expect("update should serialize"),
+                json!({
+                    "toolCallId": "req_1",
+                    "_meta": {
+                        "goose": {
+                            "toolChainSummary": {
+                                "summary": "applied dark mode",
+                                "count": 4,
+                            },
+                        },
+                    },
+                }),
             );
         }
     }

--- a/crates/goose/src/acp/server/tool_calls/enrichment.rs
+++ b/crates/goose/src/acp/server/tool_calls/enrichment.rs
@@ -1,34 +1,29 @@
 use crate::acp::tool_call_notifier::ToolCallNotifier;
 use crate::agents::Agent;
-use crate::conversation::message::{
-    Message, MessageContent, ToolRequest, TOOL_META_CHAIN_SUMMARY_KEY,
-};
-use crate::model_config::get_fast_model;
+use crate::conversation::message::{ToolChainSummary, ToolRequest};
 use crate::session::SessionManager;
-use crate::session_context::with_session_id;
-use crate::tool_call_labels::generate_tool_title;
+use crate::tool_call_labels::{generate_tool_chain_summary, generate_tool_title};
 use agent_client_protocol::schema::v1::{
     Meta, SessionId, ToolCallId, ToolCallUpdate, ToolCallUpdateFields,
 };
 use serde_json::{json, Map, Value};
-use std::slice::from_ref;
 use std::sync::Arc;
-use std::time::Duration;
-use tokio::{spawn, time::sleep};
-use tracing::warn;
+use tokio::spawn;
 
-pub(crate) fn tool_chain_summary(summary: &str, count: usize) -> (String, Value) {
+const TOOL_CHAIN_SUMMARY_META_KEY: &str = "toolChainSummary";
+
+pub(crate) fn tool_chain_summary(chain_summary: &ToolChainSummary) -> (String, Value) {
     (
-        "toolChainSummary".to_string(),
-        json!({
-            "summary": summary,
-            "count": count,
-        }),
+        TOOL_CHAIN_SUMMARY_META_KEY.to_string(),
+        json!(chain_summary),
     )
 }
 
-fn build_chain_summary_update(tool_call_id: String, summary: &str, count: usize) -> ToolCallUpdate {
-    let goose_meta = Map::from_iter([tool_chain_summary(summary, count)]);
+fn build_chain_summary_update(
+    tool_call_id: String,
+    chain_summary: &ToolChainSummary,
+) -> ToolCallUpdate {
+    let goose_meta = Map::from_iter([tool_chain_summary(chain_summary)]);
     let mut meta = Meta::default();
     meta.insert("goose".to_string(), Value::Object(goose_meta));
     ToolCallUpdate::new(ToolCallId::new(tool_call_id), ToolCallUpdateFields::new()).meta(Some(meta))
@@ -39,7 +34,7 @@ pub(crate) struct ToolTitleEnrichmentContext {
     tool_call_notifier: ToolCallNotifier,
     session_manager: Arc<SessionManager>,
     session_id: String,
-    message_id_for_persist: Option<String>,
+    message_id: Option<String>,
 }
 
 impl ToolTitleEnrichmentContext {
@@ -48,14 +43,14 @@ impl ToolTitleEnrichmentContext {
         tool_call_notifier: &ToolCallNotifier,
         session_manager: &Arc<SessionManager>,
         session_id: &str,
-        message_id_for_persist: Option<&str>,
+        message_id: Option<&str>,
     ) -> Self {
         Self {
             agent: agent.clone(),
             tool_call_notifier: tool_call_notifier.clone(),
             session_manager: session_manager.clone(),
             session_id: session_id.to_string(),
-            message_id_for_persist: message_id_for_persist.map(str::to_string),
+            message_id: message_id.map(str::to_string),
         }
     }
 
@@ -67,7 +62,7 @@ impl ToolTitleEnrichmentContext {
                 self.agent.as_ref(),
                 self.session_manager.as_ref(),
                 &self.session_id,
-                self.message_id_for_persist.as_deref(),
+                self.message_id.as_deref(),
                 &tool_request,
             )
             .await
@@ -103,171 +98,26 @@ impl ChainSummaryEnrichmentContext {
         }
     }
 
-    pub(crate) fn spawn_chain_summary(
-        self,
-        first_tool_call_id: String,
-        message_id_for_persist: String,
-        steps: Vec<(String, String)>,
-        chain_count: usize,
-    ) {
-        let Self {
-            agent,
-            session_id,
-            tool_call_notifier,
-            session_manager,
-        } = self;
-
-        ChainSummaryEnrichmentJob {
-            agent,
-            sid: session_id,
-            first_tool_call_id,
-            message_id_for_persist,
-            steps,
-            chain_count,
-            tool_call_notifier,
-            session_manager,
-        }
-        .spawn();
-    }
-}
-
-struct ChainSummaryEnrichmentJob {
-    agent: Arc<Agent>,
-    sid: SessionId,
-    first_tool_call_id: String,
-    message_id_for_persist: String,
-    steps: Vec<(String, String)>,
-    chain_count: usize,
-    tool_call_notifier: ToolCallNotifier,
-    session_manager: Arc<SessionManager>,
-}
-
-impl ChainSummaryEnrichmentJob {
-    fn spawn(self) {
+    pub(crate) fn spawn_chain_summary(self, message_id: String, tool_requests: Vec<ToolRequest>) {
         spawn(async move {
-            let Self {
-                agent,
-                sid,
-                first_tool_call_id,
-                message_id_for_persist,
-                steps,
-                chain_count,
-                tool_call_notifier,
-                session_manager,
-            } = self;
-
-            let provider = match agent.provider().await {
-                Ok(provider) => provider,
-                Err(error) => {
-                    warn!(
-                        "tool chain summary: failed to get provider for chain anchored at {first_tool_call_id}: {error}",
-                    );
-                    return;
-                }
-            };
-            if provider.manages_own_context() {
-                warn!(
-                    "tool chain summary: provider manages own context; skipping chain anchored at {first_tool_call_id}",
-                );
+            let Some(first_tool_call_id) = tool_requests.first().map(|request| request.id.clone())
+            else {
                 return;
-            }
-
-            let system = "Summarize this sequence of tool calls in a short lowercase phrase \
-                 (3-8 words). No punctuation. No quotes. \
-                 Examples: applied dark mode polish, scanned for security issues, \
-                 refactored config loading";
-
-            let mut user_text = String::from("Tool call sequence:\n");
-            for (index, (name, args)) in steps.iter().enumerate() {
-                user_text.push_str(&format!("Step {}: {} {}\n", index + 1, name, args));
-            }
-            let message = Message::user().with_text(&user_text);
-            let model_config = match agent.model_config_for_session(&sid.0).await {
-                Ok(config) => config,
-                Err(_) => return,
             };
-            let fast_model_config = match get_fast_model(provider.get_name(), &model_config).await {
-                Ok(config) => config,
-                Err(_) => return,
-            };
-
-            // Match the per-tool retry policy: one retry on empty/error keeps
-            // the chain header reliable when the fast model is rate-limited or
-            // momentarily flaky, without escalating to the regular model.
-            let mut summary: Option<String> = None;
-            for attempt in 0..2 {
-                match with_session_id(
-                    Some(sid.0.to_string()),
-                    provider.complete(&fast_model_config, system, from_ref(&message), &[]),
-                )
-                .await
-                {
-                    Ok((response, _)) => {
-                        let generated_summary = response
-                            .content
-                            .iter()
-                            .filter_map(|content: &MessageContent| content.as_text())
-                            .collect::<String>()
-                            .trim()
-                            .to_string();
-                        if !generated_summary.is_empty() {
-                            summary = Some(generated_summary);
-                            break;
-                        }
-                        if attempt == 0 {
-                            warn!(
-                                "tool chain summary: fast_complete returned empty for chain anchored at {first_tool_call_id} ({} steps), retrying once",
-                                steps.len(),
-                            );
-                            sleep(Duration::from_millis(150)).await;
-                        }
-                    }
-                    Err(error) => {
-                        if attempt == 0 {
-                            warn!(
-                                "tool chain summary: fast_complete errored for chain anchored at {first_tool_call_id}: {error}, retrying once",
-                            );
-                            sleep(Duration::from_millis(150)).await;
-                        } else {
-                            warn!(
-                                "tool chain summary: fast_complete errored for chain anchored at {first_tool_call_id} after retry: {error}",
-                            );
-                        }
-                    }
-                }
-            }
-            let Some(summary) = summary else {
-                warn!(
-                    "tool chain summary: no LLM summary produced for chain anchored at {first_tool_call_id} — replay will fall back to the deterministic phrase",
-                );
+            let Some(chain_summary) = generate_tool_chain_summary(
+                self.agent.as_ref(),
+                self.session_manager.as_ref(),
+                &self.session_id.0,
+                &message_id,
+                &tool_requests,
+            )
+            .await
+            else {
                 return;
             };
 
-            let patch = json!({
-                (TOOL_META_CHAIN_SUMMARY_KEY): {
-                    "summary": &summary,
-                    "count": chain_count,
-                },
-            });
-            if let Err(error) = session_manager
-                .update_tool_request_meta(
-                    &sid.0,
-                    &message_id_for_persist,
-                    &first_tool_call_id,
-                    patch,
-                )
-                .await
-            {
-                warn!(
-                    "tool chain summary: persist failed for chain anchored at {first_tool_call_id} in {message_id_for_persist}: {error}",
-                );
-            }
-
-            let _ = tool_call_notifier.send_update(build_chain_summary_update(
-                first_tool_call_id,
-                &summary,
-                chain_count,
-            ));
+            let update = build_chain_summary_update(first_tool_call_id, &chain_summary);
+            let _ = self.tool_call_notifier.send_update(update);
         });
     }
 }
@@ -276,11 +126,18 @@ impl ChainSummaryEnrichmentJob {
 mod tests {
     mod build_chain_summary_update {
         use super::super::build_chain_summary_update;
+        use crate::conversation::message::ToolChainSummary;
         use serde_json::json;
 
         #[test]
         fn contains_only_the_chain_summary_delta() {
-            let update = build_chain_summary_update("req_1".to_string(), "applied dark mode", 4);
+            let update = build_chain_summary_update(
+                "req_1".to_string(),
+                &ToolChainSummary {
+                    summary: "applied dark mode".to_string(),
+                    count: 4,
+                },
+            );
 
             assert_eq!(
                 serde_json::to_value(update).expect("update should serialize"),

--- a/crates/goose/src/acp/server/tool_calls/enrichment.rs
+++ b/crates/goose/src/acp/server/tool_calls/enrichment.rs
@@ -1,17 +1,16 @@
 use crate::acp::tool_call_notifier::ToolCallNotifier;
 use crate::agents::Agent;
 use crate::conversation::message::{
-    Message, MessageContent, TOOL_META_CHAIN_SUMMARY_KEY, TOOL_META_TITLE_KEY,
+    Message, MessageContent, ToolRequest, TOOL_META_CHAIN_SUMMARY_KEY,
 };
 use crate::model_config::get_fast_model;
 use crate::session::SessionManager;
 use crate::session_context::with_session_id;
-use crate::utils::safe_truncate;
+use crate::tool_call_labels::generate_tool_title;
 use agent_client_protocol::schema::v1::{
     Meta, SessionId, ToolCallId, ToolCallUpdate, ToolCallUpdateFields,
 };
-use rmcp::model::CallToolRequestParams;
-use serde_json::{json, to_string, Map, Value};
+use serde_json::{json, Map, Value};
 use std::slice::from_ref;
 use std::sync::Arc;
 use std::time::Duration;
@@ -37,203 +36,46 @@ fn build_chain_summary_update(tool_call_id: String, summary: &str, count: usize)
 
 pub(crate) struct ToolTitleEnrichmentContext {
     agent: Arc<Agent>,
-    session_id: SessionId,
     tool_call_notifier: ToolCallNotifier,
     session_manager: Arc<SessionManager>,
-    session_id_for_persist: String,
+    session_id: String,
     message_id_for_persist: Option<String>,
 }
 
 impl ToolTitleEnrichmentContext {
     pub(crate) fn new(
         agent: &Arc<Agent>,
-        session_id: &SessionId,
         tool_call_notifier: &ToolCallNotifier,
         session_manager: &Arc<SessionManager>,
-        session_id_for_persist: &str,
+        session_id: &str,
         message_id_for_persist: Option<&str>,
     ) -> Self {
         Self {
             agent: agent.clone(),
-            session_id: session_id.clone(),
             tool_call_notifier: tool_call_notifier.clone(),
             session_manager: session_manager.clone(),
-            session_id_for_persist: session_id_for_persist.to_string(),
+            session_id: session_id.to_string(),
             message_id_for_persist: message_id_for_persist.map(str::to_string),
         }
     }
 
-    pub(crate) fn spawn_title_enrichment(
-        self,
-        request_id: String,
-        tool_call: &CallToolRequestParams,
-    ) {
-        let args_json = tool_call
-            .arguments
-            .as_ref()
-            .map(|a| {
-                let s = to_string(a).unwrap_or_default();
-                if s.len() > 300 {
-                    format!("{}…", safe_truncate(&s, 300))
-                } else {
-                    s
-                }
-            })
-            .unwrap_or_default();
+    pub(crate) fn spawn_title_enrichment(self, tool_request: &ToolRequest) {
+        let tool_request = tool_request.clone();
 
-        let Self {
-            agent,
-            session_id,
-            tool_call_notifier,
-            session_manager,
-            session_id_for_persist,
-            message_id_for_persist,
-        } = self;
-
-        ToolTitleEnrichmentJob {
-            agent,
-            sid: session_id,
-            request_id,
-            tool_call_notifier,
-            name: tool_call.name.to_string(),
-            session_id_for_persist,
-            message_id_for_persist,
-            session_manager,
-            args_json,
-        }
-        .spawn();
-    }
-}
-
-struct ToolTitleEnrichmentJob {
-    agent: Arc<Agent>,
-    sid: SessionId,
-    request_id: String,
-    tool_call_notifier: ToolCallNotifier,
-    name: String,
-    session_id_for_persist: String,
-    message_id_for_persist: Option<String>,
-    session_manager: Arc<SessionManager>,
-    args_json: String,
-}
-
-impl ToolTitleEnrichmentJob {
-    fn spawn(self) {
         spawn(async move {
-            let Self {
-                agent,
-                sid,
-                request_id,
-                tool_call_notifier,
-                name,
-                session_id_for_persist,
-                message_id_for_persist,
-                session_manager,
-                args_json,
-            } = self;
-
-            let title = match agent.provider().await {
-                Ok(provider) => {
-                    if provider.manages_own_context() {
-                        return;
-                    }
-
-                    let system =
-                        "Summarize this tool call in a short lowercase phrase (3-8 words). \
-                         No punctuation. No quotes. Examples: reading project configuration, \
-                         checking network connectivity, listing files in src directory";
-                    let user_text = format!("Tool: {name}\nArguments: {args_json}");
-                    let message = Message::user().with_text(&user_text);
-                    let model_config = match agent.model_config_for_session(&sid.0).await {
-                        Ok(config) => config,
-                        Err(_) => return,
-                    };
-                    let fast_model_config =
-                        match get_fast_model(provider.get_name(), &model_config).await {
-                            Ok(config) => config,
-                            Err(_) => return,
-                        };
-                    // The fast model occasionally returns an empty response
-                    // under load (rate limiting, transient network). One
-                    // retry with a short backoff is enough to recover the
-                    // common cases without paying for the regular model.
-                    let mut llm_outcome: Option<String> = None;
-                    for attempt in 0..2 {
-                        match with_session_id(
-                            Some(sid.0.to_string()),
-                            provider.complete(&fast_model_config, system, from_ref(&message), &[]),
-                        )
-                        .await
-                        {
-                            Ok((response, _)) => {
-                                let summary: String = response
-                                    .content
-                                    .iter()
-                                    .filter_map(|c: &MessageContent| c.as_text())
-                                    .collect::<String>()
-                                    .trim()
-                                    .to_string();
-                                if !summary.is_empty() {
-                                    llm_outcome = Some(summary);
-                                    break;
-                                }
-                                if attempt == 0 {
-                                    warn!(
-                                        "tool call summary: fast_complete returned empty for {request_id} ({name}), retrying once",
-                                    );
-                                    sleep(Duration::from_millis(150)).await;
-                                }
-                            }
-                            Err(e) => {
-                                if attempt == 0 {
-                                    warn!(
-                                        "tool call summary: fast_complete errored for {request_id} ({name}): {e}, retrying once",
-                                    );
-                                    sleep(Duration::from_millis(150)).await;
-                                } else {
-                                    warn!(
-                                        "tool call summary: fast_complete errored for {request_id} ({name}) after retry: {e}",
-                                    );
-                                }
-                            }
-                        }
-                    }
-                    match llm_outcome {
-                        Some(summary) => summary,
-                        None => {
-                            warn!(
-                                "tool call summary: no summary generated for {request_id} ({name}); keeping the existing title",
-                            );
-                            return;
-                        }
-                    }
-                }
-                Err(e) => {
-                    warn!("tool call summary: failed to get provider: {e}");
-                    return;
-                }
-            };
-
-            let fields = ToolCallUpdateFields::new().title(title.clone());
-            let _ = tool_call_notifier.send_update(ToolCallUpdate::new(
-                ToolCallId::new(request_id.clone()),
-                fields,
-            ));
-
-            if let Some(msg_id) = message_id_for_persist {
-                let patch = json!({
-                    (TOOL_META_TITLE_KEY): title,
-                });
-                if let Err(e) = session_manager
-                    .update_tool_request_meta(&session_id_for_persist, &msg_id, &request_id, patch)
-                    .await
-                {
-                    warn!("tool call summary: persist failed for {request_id} in {msg_id}: {e}",);
-                }
-            } else {
-                warn!(
-                    "tool call summary: missing message_id for {request_id} — title will not survive reload",
-                );
+            if let Some(title) = generate_tool_title(
+                self.agent.as_ref(),
+                self.session_manager.as_ref(),
+                &self.session_id,
+                self.message_id_for_persist.as_deref(),
+                &tool_request,
+            )
+            .await
+            {
+                let _ = self.tool_call_notifier.send_update(ToolCallUpdate::new(
+                    ToolCallId::new(tool_request.id),
+                    ToolCallUpdateFields::new().title(title),
+                ));
             }
         });
     }

--- a/crates/goose/src/acp/server/tool_calls/enrichment.rs
+++ b/crates/goose/src/acp/server/tool_calls/enrichment.rs
@@ -10,6 +10,8 @@ use serde_json::{json, Map, Value};
 use std::sync::Arc;
 use tokio::spawn;
 
+use super::chain::ReadyToolChain;
+
 const TOOL_CHAIN_SUMMARY_META_KEY: &str = "toolChainSummary";
 
 pub(crate) fn tool_chain_summary(chain_summary: &ToolChainSummary) -> (String, Value) {
@@ -29,97 +31,71 @@ fn build_chain_summary_update(
     ToolCallUpdate::new(ToolCallId::new(tool_call_id), ToolCallUpdateFields::new()).meta(Some(meta))
 }
 
-pub(crate) struct ToolTitleEnrichmentContext {
-    agent: Arc<Agent>,
+pub(crate) fn spawn_tool_title_enrichment(
+    agent: &Arc<Agent>,
     tool_call_notifier: ToolCallNotifier,
-    session_manager: Arc<SessionManager>,
-    session_id: String,
-    message_id: Option<String>,
-}
+    session_manager: &Arc<SessionManager>,
+    session_id: &str,
+    message_id: Option<&str>,
+    tool_request: &ToolRequest,
+) {
+    let agent = agent.clone();
+    let session_manager = session_manager.clone();
+    let session_id = session_id.to_string();
+    let message_id = message_id.map(str::to_string);
+    let tool_request = tool_request.clone();
 
-impl ToolTitleEnrichmentContext {
-    pub(crate) fn new(
-        agent: &Arc<Agent>,
-        tool_call_notifier: &ToolCallNotifier,
-        session_manager: &Arc<SessionManager>,
-        session_id: &str,
-        message_id: Option<&str>,
-    ) -> Self {
-        Self {
-            agent: agent.clone(),
-            tool_call_notifier: tool_call_notifier.clone(),
-            session_manager: session_manager.clone(),
-            session_id: session_id.to_string(),
-            message_id: message_id.map(str::to_string),
+    spawn(async move {
+        if let Some(title) = generate_tool_title(
+            agent.as_ref(),
+            session_manager.as_ref(),
+            &session_id,
+            message_id.as_deref(),
+            &tool_request,
+        )
+        .await
+        {
+            let _ = tool_call_notifier.send_update(ToolCallUpdate::new(
+                ToolCallId::new(tool_request.id),
+                ToolCallUpdateFields::new().title(title),
+            ));
         }
-    }
-
-    pub(crate) fn spawn_title_enrichment(self, tool_request: &ToolRequest) {
-        let tool_request = tool_request.clone();
-
-        spawn(async move {
-            if let Some(title) = generate_tool_title(
-                self.agent.as_ref(),
-                self.session_manager.as_ref(),
-                &self.session_id,
-                self.message_id.as_deref(),
-                &tool_request,
-            )
-            .await
-            {
-                let _ = self.tool_call_notifier.send_update(ToolCallUpdate::new(
-                    ToolCallId::new(tool_request.id),
-                    ToolCallUpdateFields::new().title(title),
-                ));
-            }
-        });
-    }
+    });
 }
 
-pub(crate) struct ChainSummaryEnrichmentContext {
-    agent: Arc<Agent>,
-    session_id: SessionId,
+pub(crate) fn spawn_chain_summary_enrichment(
+    agent: &Arc<Agent>,
+    session_id: &SessionId,
     tool_call_notifier: ToolCallNotifier,
-    session_manager: Arc<SessionManager>,
-}
+    session_manager: &Arc<SessionManager>,
+    chain: ReadyToolChain,
+) {
+    let agent = agent.clone();
+    let session_id = session_id.clone();
+    let session_manager = session_manager.clone();
 
-impl ChainSummaryEnrichmentContext {
-    pub(crate) fn new(
-        agent: &Arc<Agent>,
-        session_id: &SessionId,
-        tool_call_notifier: &ToolCallNotifier,
-        session_manager: &Arc<SessionManager>,
-    ) -> Self {
-        Self {
-            agent: agent.clone(),
-            session_id: session_id.clone(),
-            tool_call_notifier: tool_call_notifier.clone(),
-            session_manager: session_manager.clone(),
-        }
-    }
+    spawn(async move {
+        let ReadyToolChain {
+            message_id,
+            tool_requests,
+        } = chain;
+        let first_tool_call_id = tool_requests[0].id.clone();
 
-    pub(crate) fn spawn_chain_summary(self, message_id: String, tool_requests: Vec<ToolRequest>) {
-        spawn(async move {
-            let Some(first_tool_call_id) = tool_requests.first().map(|request| request.id.clone())
-            else {
-                return;
-            };
-            let Some(chain_summary) = generate_tool_chain_summary(
-                self.agent.as_ref(),
-                self.session_manager.as_ref(),
-                &self.session_id.0,
-                &message_id,
-                &tool_requests,
-            )
-            .await
-            else {
-                return;
-            };
+        let Some(summary) = generate_tool_chain_summary(
+            agent.as_ref(),
+            session_manager.as_ref(),
+            &session_id.0,
+            &message_id,
+            &tool_requests,
+        )
+        .await
+        else {
+            return;
+        };
 
-            let update = build_chain_summary_update(first_tool_call_id, &chain_summary);
-            let _ = self.tool_call_notifier.send_update(update);
-        });
-    }
+        let update = build_chain_summary_update(first_tool_call_id, &summary);
+        let _ = tool_call_notifier.send_update(update);
+    });
 }
 
 #[cfg(test)]

--- a/crates/goose/src/acp/server/tool_calls/enrichment.rs
+++ b/crates/goose/src/acp/server/tool_calls/enrichment.rs
@@ -78,8 +78,6 @@ impl ToolTitleEnrichmentContext {
         self,
         request_id: String,
         tool_call: &CallToolRequestParams,
-        identity_meta: Option<Meta>,
-        fallback_title: String,
     ) {
         let args_json = tool_call
             .arguments
@@ -109,8 +107,6 @@ impl ToolTitleEnrichmentContext {
             request_id,
             tool_call_notifier,
             name: tool_call.name.to_string(),
-            identity_meta,
-            fallback_title,
             session_id_for_persist,
             message_id_for_persist,
             session_manager,
@@ -126,8 +122,6 @@ struct ToolTitleEnrichmentJob {
     request_id: String,
     tool_call_notifier: ToolCallNotifier,
     name: String,
-    identity_meta: Option<Meta>,
-    fallback_title: String,
     session_id_for_persist: String,
     message_id_for_persist: Option<String>,
     session_manager: Arc<SessionManager>,
@@ -143,15 +137,13 @@ impl ToolTitleEnrichmentJob {
                 request_id,
                 tool_call_notifier,
                 name,
-                identity_meta,
-                fallback_title,
                 session_id_for_persist,
                 message_id_for_persist,
                 session_manager,
                 args_json,
             } = self;
 
-            let (title, from_llm) = match agent.provider().await {
+            let title = match agent.provider().await {
                 Ok(provider) => {
                     if provider.manages_own_context() {
                         return;
@@ -218,53 +210,41 @@ impl ToolTitleEnrichmentJob {
                         }
                     }
                     match llm_outcome {
-                        Some(summary) => (summary, true),
+                        Some(summary) => summary,
                         None => {
                             warn!(
-                                "tool call summary: falling back to deterministic title for {request_id} ({name}) — replay will not show an LLM summary for this call",
+                                "tool call summary: no summary generated for {request_id} ({name}); keeping the existing title",
                             );
-                            (fallback_title.clone(), false)
+                            return;
                         }
                     }
                 }
                 Err(e) => {
                     warn!("tool call summary: failed to get provider: {e}");
-                    (fallback_title.clone(), false)
+                    return;
                 }
             };
 
             let fields = ToolCallUpdateFields::new().title(title.clone());
-            let _ = tool_call_notifier.send_update(
-                ToolCallUpdate::new(ToolCallId::new(request_id.clone()), fields)
-                    .meta(identity_meta),
-            );
+            let _ = tool_call_notifier.send_update(ToolCallUpdate::new(
+                ToolCallId::new(request_id.clone()),
+                fields,
+            ));
 
-            // Best-effort persistence: only persist the LLM-generated title
-            // (not the deterministic fallback) so reload uses fallback_title
-            // for older or failed cases just like today.
-            if from_llm {
-                if let Some(msg_id) = message_id_for_persist {
-                    let patch = json!({
-                        (TOOL_META_TITLE_KEY): title,
-                    });
-                    if let Err(e) = session_manager
-                        .update_tool_request_meta(
-                            &session_id_for_persist,
-                            &msg_id,
-                            &request_id,
-                            patch,
-                        )
-                        .await
-                    {
-                        warn!(
-                            "tool call summary: persist failed for {request_id} in {msg_id}: {e}",
-                        );
-                    }
-                } else {
-                    warn!(
-                        "tool call summary: missing message_id for {request_id} — title will not survive reload",
-                    );
+            if let Some(msg_id) = message_id_for_persist {
+                let patch = json!({
+                    (TOOL_META_TITLE_KEY): title,
+                });
+                if let Err(e) = session_manager
+                    .update_tool_request_meta(&session_id_for_persist, &msg_id, &request_id, patch)
+                    .await
+                {
+                    warn!("tool call summary: persist failed for {request_id} in {msg_id}: {e}",);
                 }
+            } else {
+                warn!(
+                    "tool call summary: missing message_id for {request_id} — title will not survive reload",
+                );
             }
         });
     }
@@ -297,7 +277,7 @@ impl ChainSummaryEnrichmentContext {
         first_tool_call_id: String,
         message_id_for_persist: String,
         steps: Vec<(String, String)>,
-        identity_meta: Option<Meta>,
+        goose_meta: Option<Meta>,
         chain_count: usize,
     ) {
         let Self {
@@ -313,7 +293,7 @@ impl ChainSummaryEnrichmentContext {
             first_tool_call_id,
             message_id_for_persist,
             steps,
-            identity_meta,
+            goose_meta,
             chain_count,
             tool_call_notifier,
             session_manager,
@@ -328,7 +308,7 @@ struct ChainSummaryEnrichmentJob {
     first_tool_call_id: String,
     message_id_for_persist: String,
     steps: Vec<(String, String)>,
-    identity_meta: Option<Meta>,
+    goose_meta: Option<Meta>,
     chain_count: usize,
     tool_call_notifier: ToolCallNotifier,
     session_manager: Arc<SessionManager>,
@@ -343,7 +323,7 @@ impl ChainSummaryEnrichmentJob {
                 first_tool_call_id,
                 message_id_for_persist,
                 steps,
-                identity_meta,
+                goose_meta,
                 chain_count,
                 tool_call_notifier,
                 session_manager,
@@ -456,7 +436,7 @@ impl ChainSummaryEnrichmentJob {
                 );
             }
 
-            let meta = with_tool_chain_summary_meta(identity_meta, &summary, chain_count);
+            let meta = with_tool_chain_summary_meta(goose_meta, &summary, chain_count);
             let fields = ToolCallUpdateFields::new();
             let _ = tool_call_notifier.send_update(
                 ToolCallUpdate::new(ToolCallId::new(first_tool_call_id), fields).meta(meta),
@@ -469,7 +449,7 @@ impl ChainSummaryEnrichmentJob {
 mod tests {
     mod with_tool_chain_summary_meta {
         use super::super::with_tool_chain_summary_meta;
-        use crate::acp::server::tool_calls::conversion::tool_call_identity_meta;
+        use crate::acp::server::tool_calls::conversion::goose_tool_call_meta;
         use crate::conversation::message::ToolRequest;
         use rmcp::model::CallToolRequestParams;
         use serde_json::json;
@@ -488,7 +468,7 @@ mod tests {
 
         #[test]
         fn preserves_existing_tool_call_identity() {
-            let existing = tool_call_identity_meta(&ToolRequest {
+            let existing = goose_tool_call_meta(&ToolRequest {
                 id: "req_1".to_string(),
                 tool_call: Ok(CallToolRequestParams::new("developer__shell")),
                 metadata: None,

--- a/crates/goose/src/agents/reply_parts.rs
+++ b/crates/goose/src/agents/reply_parts.rs
@@ -510,7 +510,7 @@ impl Agent {
                     // Always keep externally-dispatched requests visible, even if
                     // their name happens to overlap a registered frontend tool —
                     // they're observation-only and must not be removed from history.
-                    let should_include = if coerced_req.is_externally_dispatched() {
+                    let should_include = if coerced_req.was_executed_externally() {
                         true
                     } else if let Ok(tool_call) = &coerced_req.tool_call {
                         !self.is_frontend_tool(&tool_call.name).await
@@ -547,7 +547,7 @@ impl Agent {
         for request in tool_requests {
             // Skip externally-dispatched requests (e.g. claude-acp); the
             // provider already executed the tool. Stays in filtered_message.
-            if request.is_externally_dispatched() {
+            if request.was_executed_externally() {
                 continue;
             }
             if let Ok(tool_call) = &request.tool_call {
@@ -1088,7 +1088,7 @@ mod tests {
             other => panic!("expected ToolRequest, got {other:?}"),
         };
         assert!(
-            tool_req.is_externally_dispatched(),
+            tool_req.was_executed_externally(),
             "goose.external_dispatch marker was clobbered by coercion; merged tool_meta = {:?}",
             tool_req.tool_meta
         );

--- a/crates/goose/src/lib.rs
+++ b/crates/goose/src/lib.rs
@@ -49,6 +49,7 @@ pub mod source_roots;
 pub mod sources;
 pub mod subprocess;
 pub mod token_counter;
+mod tool_call_labels;
 pub mod tool_inspection;
 pub mod tool_monitor;
 pub mod tracing;

--- a/crates/goose/src/tool_call_labels.rs
+++ b/crates/goose/src/tool_call_labels.rs
@@ -422,7 +422,7 @@ mod tests {
             .flat_map(|message| &message.content)
             .find_map(|content| match content {
                 MessageContent::ToolRequest(request) if request.id == "request-1" => {
-                    request.persisted_title()
+                    request.generated_title()
                 }
                 _ => None,
             });

--- a/crates/goose/src/tool_call_labels.rs
+++ b/crates/goose/src/tool_call_labels.rs
@@ -1,5 +1,8 @@
 use crate::agents::Agent;
-use crate::conversation::message::{Message, MessageContent, ToolRequest, TOOL_META_TITLE_KEY};
+use crate::conversation::message::{
+    Message, MessageContent, ToolChainSummary, ToolRequest, TOOL_META_CHAIN_SUMMARY_KEY,
+    TOOL_META_TITLE_KEY,
+};
 use crate::model_config::get_fast_model;
 use crate::providers::base::Provider;
 use crate::session::SessionManager;
@@ -17,6 +20,14 @@ const TOOL_TITLE_SYSTEM_PROMPT: &str =
      No punctuation. No quotes. Examples: reading project configuration, \
      checking network connectivity, listing files in src directory";
 const TOOL_TITLE_ARGUMENTS_MAX_LENGTH: usize = 300;
+const TOOL_CHAIN_SUMMARY_SYSTEM_PROMPT: &str =
+    "Summarize this sequence of tool calls in a short lowercase phrase \
+     (3-8 words). No punctuation. No quotes. \
+     Examples: applied dark mode polish, scanned for security issues, \
+     refactored config loading";
+const TOOL_CHAIN_ARGUMENTS_MAX_LENGTH: usize = 200;
+const LABEL_GENERATION_MAX_ATTEMPTS: usize = 2;
+const LABEL_GENERATION_RETRY_DELAY: Duration = Duration::from_millis(150);
 
 pub(crate) async fn generate_tool_title(
     agent: &Agent,
@@ -58,6 +69,78 @@ pub(crate) async fn generate_tool_title(
     Some(title)
 }
 
+pub(crate) async fn generate_tool_chain_summary(
+    agent: &Agent,
+    session_manager: &SessionManager,
+    session_id: &str,
+    message_id: &str,
+    tool_requests: &[ToolRequest],
+) -> Option<ToolChainSummary> {
+    let steps = prepare_tool_chain_steps(tool_requests);
+    if steps.len() < 2 {
+        return None;
+    }
+
+    let provider = agent.provider().await.ok()?;
+    if provider.manages_own_context() {
+        return None;
+    }
+
+    let model_config = agent.model_config_for_session(session_id).await.ok()?;
+    let fast_model_config = get_fast_model(provider.get_name(), &model_config)
+        .await
+        .ok()?;
+    let chain_summary = ToolChainSummary {
+        summary: generate_tool_chain_summary_with_provider(
+            provider.as_ref(),
+            &fast_model_config,
+            session_id,
+            &steps,
+        )
+        .await?,
+        count: tool_requests.len(),
+    };
+    let first_tool_call_id = &tool_requests.first()?.id;
+    let patch = json!({
+        (TOOL_META_CHAIN_SUMMARY_KEY): &chain_summary,
+    });
+    if let Err(error) = session_manager
+        .update_tool_request_meta(session_id, message_id, first_tool_call_id, patch)
+        .await
+    {
+        warn!(
+            "tool chain summary: persist failed for chain anchored at {first_tool_call_id} in {message_id}: {error}",
+        );
+    }
+
+    Some(chain_summary)
+}
+
+fn prepare_tool_chain_steps(tool_requests: &[ToolRequest]) -> Vec<(String, String)> {
+    tool_requests
+        .iter()
+        .filter_map(|request| {
+            let tool_call = request.tool_call.as_ref().ok()?;
+            let arguments = tool_call
+                .arguments
+                .as_ref()
+                .map(|arguments| {
+                    let serialized = serde_json::to_string(arguments).unwrap_or_default();
+                    if serialized.len() > TOOL_CHAIN_ARGUMENTS_MAX_LENGTH {
+                        format!(
+                            "{}…",
+                            safe_truncate(&serialized, TOOL_CHAIN_ARGUMENTS_MAX_LENGTH)
+                        )
+                    } else {
+                        serialized
+                    }
+                })
+                .unwrap_or_default();
+            Some((tool_call.name.to_string(), arguments))
+        })
+        .collect()
+}
+
 async fn generate_tool_title_with_provider(
     provider: &dyn Provider,
     model_config: &ModelConfig,
@@ -83,33 +166,66 @@ async fn generate_tool_title_with_provider(
         .unwrap_or_default();
     let message = Message::user().with_text(format!("Tool: {name}\nArguments: {args_json}"));
 
-    const MAX_ATTEMPTS: usize = 2;
-    for attempt in 0..MAX_ATTEMPTS {
+    complete_label(
+        provider,
+        model_config,
+        session_id,
+        TOOL_TITLE_SYSTEM_PROMPT,
+        &message,
+    )
+    .await
+}
+
+async fn generate_tool_chain_summary_with_provider(
+    provider: &dyn Provider,
+    model_config: &ModelConfig,
+    session_id: &str,
+    steps: &[(String, String)],
+) -> Option<String> {
+    let mut user_text = String::from("Tool call sequence:\n");
+    for (index, (name, args)) in steps.iter().enumerate() {
+        user_text.push_str(&format!("Step {}: {} {}\n", index + 1, name, args));
+    }
+    let message = Message::user().with_text(user_text);
+
+    complete_label(
+        provider,
+        model_config,
+        session_id,
+        TOOL_CHAIN_SUMMARY_SYSTEM_PROMPT,
+        &message,
+    )
+    .await
+}
+
+async fn complete_label(
+    provider: &dyn Provider,
+    model_config: &ModelConfig,
+    session_id: &str,
+    system_prompt: &str,
+    message: &Message,
+) -> Option<String> {
+    for attempt in 0..LABEL_GENERATION_MAX_ATTEMPTS {
         if let Ok((response, _)) = with_session_id(
             Some(session_id.to_string()),
-            provider.complete(
-                model_config,
-                TOOL_TITLE_SYSTEM_PROMPT,
-                from_ref(&message),
-                &[],
-            ),
+            provider.complete(model_config, system_prompt, from_ref(message), &[]),
         )
         .await
         {
-            let title = response
+            let label = response
                 .content
                 .iter()
                 .filter_map(MessageContent::as_text)
                 .collect::<String>()
                 .trim()
                 .to_string();
-            if !title.is_empty() {
-                return Some(title);
+            if !label.is_empty() {
+                return Some(label);
             }
         }
 
-        if attempt + 1 < MAX_ATTEMPTS {
-            sleep(Duration::from_millis(150)).await;
+        if attempt + 1 < LABEL_GENERATION_MAX_ATTEMPTS {
+            sleep(LABEL_GENERATION_RETRY_DELAY).await;
         }
     }
 
@@ -125,7 +241,7 @@ mod tests {
     use crate::session::{SessionManager, SessionType};
     use async_trait::async_trait;
     use goose_providers::errors::ProviderError;
-    use rmcp::model::{CallToolRequestParams, Tool};
+    use rmcp::model::{CallToolRequestParams, ErrorData, Tool};
     use serde_json::json;
     use std::collections::VecDeque;
     use std::path::PathBuf;
@@ -213,10 +329,23 @@ mod tests {
     }
 
     fn tool_request(arguments: serde_json::Value) -> ToolRequest {
+        tool_request_with("request-1", "developer__shell", arguments)
+    }
+
+    fn tool_request_with(id: &str, name: &str, arguments: serde_json::Value) -> ToolRequest {
         ToolRequest {
-            id: "request-1".to_string(),
-            tool_call: Ok(CallToolRequestParams::new("developer__shell")
+            id: id.to_string(),
+            tool_call: Ok(CallToolRequestParams::new(name.to_string())
                 .with_arguments(arguments.as_object().unwrap().clone())),
+            metadata: None,
+            tool_meta: None,
+        }
+    }
+
+    fn invalid_tool_request(id: &str) -> ToolRequest {
+        ToolRequest {
+            id: id.to_string(),
+            tool_call: Err(ErrorData::invalid_request("invalid tool call", None)),
             metadata: None,
             tool_meta: None,
         }
@@ -232,201 +361,511 @@ mod tests {
         .await
     }
 
-    #[tokio::test]
-    async fn returns_trimmed_generated_title() {
-        let provider = MockProvider::new(vec![Ok(
-            Message::assistant().with_text("  checking project status  ")
-        )]);
-
-        let title = generate_with(&provider, &tool_request(json!({"command": "git status"}))).await;
-
-        assert_eq!(title.as_deref(), Some("checking project status"));
-        assert_eq!(provider.call_count(), 1);
+    async fn generate_chain_with(
+        provider: &MockProvider,
+        steps: &[(String, String)],
+    ) -> Option<String> {
+        generate_tool_chain_summary_with_provider(
+            provider,
+            &ModelConfig::new("test-model"),
+            "session-1",
+            steps,
+        )
+        .await
     }
 
-    #[tokio::test]
-    async fn retries_once_after_empty_response() {
-        let provider = MockProvider::new(vec![
-            Ok(Message::assistant().with_text("  ")),
-            Ok(Message::assistant().with_text("reading project configuration")),
-        ]);
-
-        let title = generate_with(&provider, &tool_request(json!({}))).await;
-
-        assert_eq!(title.as_deref(), Some("reading project configuration"));
-        assert_eq!(provider.call_count(), 2);
+    fn chain_steps() -> Vec<(String, String)> {
+        vec![
+            (
+                "developer__read".to_string(),
+                "{\"path\":\"src\"}".to_string(),
+            ),
+            (
+                "developer__shell".to_string(),
+                "{\"command\":\"cargo test\"}".to_string(),
+            ),
+        ]
     }
 
-    #[tokio::test]
-    async fn retries_once_after_provider_error() {
-        let provider = MockProvider::new(vec![
-            Err(ProviderError::ExecutionError("temporary".to_string())),
-            Ok(Message::assistant().with_text("checking network connectivity")),
-        ]);
-
-        let title = generate_with(&provider, &tool_request(json!({}))).await;
-
-        assert_eq!(title.as_deref(), Some("checking network connectivity"));
-        assert_eq!(provider.call_count(), 2);
+    fn chain_tool_requests() -> Vec<ToolRequest> {
+        vec![
+            tool_request_with("request-1", "developer__read", json!({"path": "src"})),
+            tool_request_with(
+                "request-2",
+                "developer__shell",
+                json!({"command": "cargo test"}),
+            ),
+        ]
     }
 
-    #[tokio::test]
-    async fn returns_none_after_two_unsuccessful_attempts() {
-        let provider = MockProvider::new(vec![
-            Ok(Message::assistant().with_text("")),
-            Err(ProviderError::ExecutionError(
-                "still unavailable".to_string(),
-            )),
-        ]);
+    mod title_generation {
+        use super::*;
 
-        let title = generate_with(&provider, &tool_request(json!({}))).await;
+        #[tokio::test]
+        async fn returns_trimmed_generated_title() {
+            let provider = MockProvider::new(vec![Ok(
+                Message::assistant().with_text("  checking project status  ")
+            )]);
 
-        assert_eq!(title, None);
-        assert_eq!(provider.call_count(), 2);
-    }
+            let title =
+                generate_with(&provider, &tool_request(json!({"command": "git status"}))).await;
 
-    #[tokio::test]
-    async fn skips_provider_that_manages_own_context() {
-        let temp_dir = TempDir::new().unwrap();
-        let session_manager = Arc::new(SessionManager::new(temp_dir.path().join("sessions")));
-        let permission_manager =
-            Arc::new(PermissionManager::new(temp_dir.path().join("permissions")));
-        let agent = Agent::with_config(AgentConfig::new(
-            session_manager.clone(),
-            permission_manager,
-            None,
-            GooseMode::Auto,
-            true,
-            GoosePlatform::GooseCli,
-        ));
-        let session = session_manager
-            .create_session(
-                PathBuf::new(),
-                "test".to_string(),
-                SessionType::Hidden,
+            assert_eq!(title.as_deref(), Some("checking project status"));
+            assert_eq!(provider.call_count(), 1);
+        }
+
+        #[tokio::test]
+        async fn retries_once_after_empty_response() {
+            let provider = MockProvider::new(vec![
+                Ok(Message::assistant().with_text("  ")),
+                Ok(Message::assistant().with_text("reading project configuration")),
+            ]);
+
+            let title = generate_with(&provider, &tool_request(json!({}))).await;
+
+            assert_eq!(title.as_deref(), Some("reading project configuration"));
+            assert_eq!(provider.call_count(), 2);
+        }
+
+        #[tokio::test]
+        async fn retries_once_after_provider_error() {
+            let provider = MockProvider::new(vec![
+                Err(ProviderError::ExecutionError("temporary".to_string())),
+                Ok(Message::assistant().with_text("checking network connectivity")),
+            ]);
+
+            let title = generate_with(&provider, &tool_request(json!({}))).await;
+
+            assert_eq!(title.as_deref(), Some("checking network connectivity"));
+            assert_eq!(provider.call_count(), 2);
+        }
+
+        #[tokio::test]
+        async fn returns_none_after_two_unsuccessful_attempts() {
+            let provider = MockProvider::new(vec![
+                Ok(Message::assistant().with_text("")),
+                Err(ProviderError::ExecutionError(
+                    "still unavailable".to_string(),
+                )),
+            ]);
+
+            let title = generate_with(&provider, &tool_request(json!({}))).await;
+
+            assert_eq!(title, None);
+            assert_eq!(provider.call_count(), 2);
+        }
+
+        #[tokio::test]
+        async fn skips_provider_that_manages_own_context() {
+            let temp_dir = TempDir::new().unwrap();
+            let session_manager = Arc::new(SessionManager::new(temp_dir.path().join("sessions")));
+            let permission_manager =
+                Arc::new(PermissionManager::new(temp_dir.path().join("permissions")));
+            let agent = Agent::with_config(AgentConfig::new(
+                session_manager.clone(),
+                permission_manager,
+                None,
                 GooseMode::Auto,
-            )
-            .await
-            .unwrap();
-        let provider = Arc::new(MockProvider::managing_own_context());
-        agent
-            .update_provider(
-                provider.clone(),
-                ModelConfig::new("test-model"),
+                true,
+                GoosePlatform::GooseCli,
+            ));
+            let session = session_manager
+                .create_session(
+                    PathBuf::new(),
+                    "test".to_string(),
+                    SessionType::Hidden,
+                    GooseMode::Auto,
+                )
+                .await
+                .unwrap();
+            let provider = Arc::new(MockProvider::managing_own_context());
+            agent
+                .update_provider(
+                    provider.clone(),
+                    ModelConfig::new("test-model"),
+                    &session.id,
+                )
+                .await
+                .unwrap();
+
+            let title = generate_tool_title(
+                &agent,
+                session_manager.as_ref(),
                 &session.id,
+                None,
+                &tool_request(json!({})),
             )
-            .await
-            .unwrap();
+            .await;
 
-        let title = generate_tool_title(
-            &agent,
-            session_manager.as_ref(),
-            &session.id,
-            None,
-            &tool_request(json!({})),
-        )
-        .await;
+            assert_eq!(title, None);
+            assert_eq!(provider.call_count(), 0);
+        }
 
-        assert_eq!(title, None);
-        assert_eq!(provider.call_count(), 0);
-    }
+        #[tokio::test]
+        async fn preserves_short_serialized_arguments() {
+            let provider = MockProvider::new(vec![Ok(Message::assistant().with_text("title"))]);
+            let tool_request = tool_request(json!({"command": "git status"}));
 
-    #[tokio::test]
-    async fn preserves_short_serialized_arguments() {
-        let provider = MockProvider::new(vec![Ok(Message::assistant().with_text("title"))]);
-        let tool_request = tool_request(json!({"command": "git status"}));
+            generate_with(&provider, &tool_request).await;
 
-        generate_with(&provider, &tool_request).await;
+            assert_eq!(
+                provider.first_user_message(),
+                "Tool: developer__shell\nArguments: {\"command\":\"git status\"}",
+            );
+        }
 
-        assert_eq!(
-            provider.first_user_message(),
-            "Tool: developer__shell\nArguments: {\"command\":\"git status\"}",
-        );
-    }
+        #[tokio::test]
+        async fn truncates_long_serialized_arguments() {
+            let provider = MockProvider::new(vec![Ok(Message::assistant().with_text("title"))]);
+            let arguments = json!({"command": "x".repeat(400)});
+            let serialized = serde_json::to_string(arguments.as_object().unwrap()).unwrap();
+            let expected = format!(
+                "Tool: developer__shell\nArguments: {}…",
+                safe_truncate(&serialized, TOOL_TITLE_ARGUMENTS_MAX_LENGTH),
+            );
+            let tool_request = tool_request(arguments);
 
-    #[tokio::test]
-    async fn truncates_long_serialized_arguments() {
-        let provider = MockProvider::new(vec![Ok(Message::assistant().with_text("title"))]);
-        let arguments = json!({"command": "x".repeat(400)});
-        let serialized = serde_json::to_string(arguments.as_object().unwrap()).unwrap();
-        let expected = format!(
-            "Tool: developer__shell\nArguments: {}…",
-            safe_truncate(&serialized, TOOL_TITLE_ARGUMENTS_MAX_LENGTH),
-        );
-        let tool_request = tool_request(arguments);
+            generate_with(&provider, &tool_request).await;
 
-        generate_with(&provider, &tool_request).await;
+            assert_eq!(provider.first_user_message(), expected);
+        }
 
-        assert_eq!(provider.first_user_message(), expected);
-    }
-
-    #[tokio::test]
-    async fn persists_title_for_known_message_id() {
-        let temp_dir = TempDir::new().unwrap();
-        let session_manager = Arc::new(SessionManager::new(temp_dir.path().join("sessions")));
-        let permission_manager =
-            Arc::new(PermissionManager::new(temp_dir.path().join("permissions")));
-        let agent = Agent::with_config(AgentConfig::new(
-            session_manager.clone(),
-            permission_manager,
-            None,
-            GooseMode::Auto,
-            true,
-            GoosePlatform::GooseCli,
-        ));
-        let session = session_manager
-            .create_session(
-                PathBuf::new(),
-                "test".to_string(),
-                SessionType::Hidden,
+        #[tokio::test]
+        async fn persists_title_for_known_message_id() {
+            let temp_dir = TempDir::new().unwrap();
+            let session_manager = Arc::new(SessionManager::new(temp_dir.path().join("sessions")));
+            let permission_manager =
+                Arc::new(PermissionManager::new(temp_dir.path().join("permissions")));
+            let agent = Agent::with_config(AgentConfig::new(
+                session_manager.clone(),
+                permission_manager,
+                None,
                 GooseMode::Auto,
+                true,
+                GoosePlatform::GooseCli,
+            ));
+            let session = session_manager
+                .create_session(
+                    PathBuf::new(),
+                    "test".to_string(),
+                    SessionType::Hidden,
+                    GooseMode::Auto,
+                )
+                .await
+                .unwrap();
+            let provider = Arc::new(MockProvider::new(vec![Ok(
+                Message::assistant().with_text("checking project status")
+            )]));
+            agent
+                .update_provider(provider, ModelConfig::new("test-model"), &session.id)
+                .await
+                .unwrap();
+            let tool_request = tool_request(json!({"command": "git status"}));
+            let message = Message::assistant()
+                .with_id("message-1")
+                .with_tool_request(tool_request.id.clone(), tool_request.tool_call.clone());
+            session_manager
+                .add_message(&session.id, &message)
+                .await
+                .unwrap();
+
+            let title = generate_tool_title(
+                &agent,
+                session_manager.as_ref(),
+                &session.id,
+                message.id.as_deref(),
+                &tool_request,
             )
-            .await
-            .unwrap();
-        let provider = Arc::new(MockProvider::new(vec![Ok(
-            Message::assistant().with_text("checking project status")
-        )]));
-        agent
-            .update_provider(provider, ModelConfig::new("test-model"), &session.id)
-            .await
-            .unwrap();
-        let tool_request = tool_request(json!({"command": "git status"}));
-        let message = Message::assistant()
-            .with_id("message-1")
-            .with_tool_request(tool_request.id.clone(), tool_request.tool_call.clone());
-        session_manager
-            .add_message(&session.id, &message)
-            .await
-            .unwrap();
+            .await;
 
-        let title = generate_tool_title(
-            &agent,
-            session_manager.as_ref(),
-            &session.id,
-            message.id.as_deref(),
-            &tool_request,
-        )
-        .await;
+            assert_eq!(title.as_deref(), Some("checking project status"));
+            let loaded = session_manager
+                .get_session(&session.id, true)
+                .await
+                .unwrap();
+            let persisted_title = loaded
+                .conversation
+                .as_ref()
+                .unwrap()
+                .messages()
+                .iter()
+                .flat_map(|message| &message.content)
+                .find_map(|content| match content {
+                    MessageContent::ToolRequest(request) if request.id == "request-1" => {
+                        request.generated_title()
+                    }
+                    _ => None,
+                });
 
-        assert_eq!(title.as_deref(), Some("checking project status"));
-        let loaded = session_manager
-            .get_session(&session.id, true)
-            .await
-            .unwrap();
-        let persisted_title = loaded
-            .conversation
-            .as_ref()
-            .unwrap()
-            .messages()
-            .iter()
-            .flat_map(|message| &message.content)
-            .find_map(|content| match content {
-                MessageContent::ToolRequest(request) if request.id == "request-1" => {
-                    request.generated_title()
-                }
-                _ => None,
-            });
+            assert_eq!(persisted_title, Some("checking project status"));
+        }
+    }
 
-        assert_eq!(persisted_title, Some("checking project status"));
+    mod chain_summary_generation {
+        use super::*;
+
+        #[test]
+        fn prepares_valid_requests_in_order_and_ignores_invalid_requests() {
+            let mut requests = chain_tool_requests();
+            requests.insert(1, invalid_tool_request("invalid-request"));
+
+            assert_eq!(prepare_tool_chain_steps(&requests), chain_steps());
+        }
+
+        #[test]
+        fn truncates_long_serialized_arguments() {
+            let arguments = json!({"command": "x".repeat(400)});
+            let serialized = serde_json::to_string(arguments.as_object().unwrap()).unwrap();
+            let requests = vec![tool_request_with(
+                "request-1",
+                "developer__shell",
+                arguments,
+            )];
+
+            assert_eq!(
+                prepare_tool_chain_steps(&requests),
+                vec![(
+                    "developer__shell".to_string(),
+                    format!(
+                        "{}…",
+                        safe_truncate(&serialized, TOOL_CHAIN_ARGUMENTS_MAX_LENGTH)
+                    ),
+                )],
+            );
+        }
+
+        #[tokio::test]
+        async fn preserves_step_order_and_trims_result() {
+            let provider = MockProvider::new(vec![Ok(
+                Message::assistant().with_text("  inspected and tested project  ")
+            )]);
+
+            let summary = generate_chain_with(&provider, &chain_steps()).await;
+
+            assert_eq!(summary.as_deref(), Some("inspected and tested project"));
+            assert_eq!(provider.call_count(), 1);
+            assert_eq!(
+                provider.first_user_message(),
+                "Tool call sequence:\nStep 1: developer__read {\"path\":\"src\"}\nStep 2: developer__shell {\"command\":\"cargo test\"}\n",
+            );
+        }
+
+        #[tokio::test]
+        async fn retries_once_after_empty_response() {
+            let provider = MockProvider::new(vec![
+                Ok(Message::assistant().with_text("")),
+                Ok(Message::assistant().with_text("inspected and tested project")),
+            ]);
+
+            let summary = generate_chain_with(&provider, &chain_steps()).await;
+
+            assert_eq!(summary.as_deref(), Some("inspected and tested project"));
+            assert_eq!(provider.call_count(), 2);
+        }
+
+        #[tokio::test]
+        async fn retries_once_after_provider_error() {
+            let provider = MockProvider::new(vec![
+                Err(ProviderError::ExecutionError("temporary".to_string())),
+                Ok(Message::assistant().with_text("inspected and tested project")),
+            ]);
+
+            let summary = generate_chain_with(&provider, &chain_steps()).await;
+
+            assert_eq!(summary.as_deref(), Some("inspected and tested project"));
+            assert_eq!(provider.call_count(), 2);
+        }
+
+        #[tokio::test]
+        async fn returns_none_after_two_unsuccessful_attempts() {
+            let provider = MockProvider::new(vec![
+                Ok(Message::assistant().with_text("")),
+                Err(ProviderError::ExecutionError(
+                    "still unavailable".to_string(),
+                )),
+            ]);
+
+            let summary = generate_chain_with(&provider, &chain_steps()).await;
+
+            assert_eq!(summary, None);
+            assert_eq!(provider.call_count(), 2);
+        }
+
+        #[tokio::test]
+        async fn skips_provider_that_manages_own_context() {
+            let temp_dir = TempDir::new().unwrap();
+            let session_manager = Arc::new(SessionManager::new(temp_dir.path().join("sessions")));
+            let permission_manager =
+                Arc::new(PermissionManager::new(temp_dir.path().join("permissions")));
+            let agent = Agent::with_config(AgentConfig::new(
+                session_manager.clone(),
+                permission_manager,
+                None,
+                GooseMode::Auto,
+                true,
+                GoosePlatform::GooseCli,
+            ));
+            let session = session_manager
+                .create_session(
+                    PathBuf::new(),
+                    "test".to_string(),
+                    SessionType::Hidden,
+                    GooseMode::Auto,
+                )
+                .await
+                .unwrap();
+            let provider = Arc::new(MockProvider::managing_own_context());
+            agent
+                .update_provider(
+                    provider.clone(),
+                    ModelConfig::new("test-model"),
+                    &session.id,
+                )
+                .await
+                .unwrap();
+
+            let summary = generate_tool_chain_summary(
+                &agent,
+                session_manager.as_ref(),
+                &session.id,
+                "message-1",
+                &chain_tool_requests(),
+            )
+            .await;
+
+            assert_eq!(summary, None);
+            assert_eq!(provider.call_count(), 0);
+        }
+
+        #[tokio::test]
+        async fn requires_two_usable_requests_before_provider_completion() {
+            let temp_dir = TempDir::new().unwrap();
+            let session_manager = Arc::new(SessionManager::new(temp_dir.path().join("sessions")));
+            let permission_manager =
+                Arc::new(PermissionManager::new(temp_dir.path().join("permissions")));
+            let agent = Agent::with_config(AgentConfig::new(
+                session_manager.clone(),
+                permission_manager,
+                None,
+                GooseMode::Auto,
+                true,
+                GoosePlatform::GooseCli,
+            ));
+            let session = session_manager
+                .create_session(
+                    PathBuf::new(),
+                    "test".to_string(),
+                    SessionType::Hidden,
+                    GooseMode::Auto,
+                )
+                .await
+                .unwrap();
+            let provider = Arc::new(MockProvider::new(Vec::new()));
+            agent
+                .update_provider(
+                    provider.clone(),
+                    ModelConfig::new("test-model"),
+                    &session.id,
+                )
+                .await
+                .unwrap();
+
+            let summary = generate_tool_chain_summary(
+                &agent,
+                session_manager.as_ref(),
+                &session.id,
+                "message-1",
+                &[tool_request(json!({}))],
+            )
+            .await;
+
+            assert_eq!(summary, None);
+            assert_eq!(provider.call_count(), 0);
+        }
+
+        #[tokio::test]
+        async fn persists_summary_and_tool_call_count_on_first_request() {
+            let temp_dir = TempDir::new().unwrap();
+            let session_manager = Arc::new(SessionManager::new(temp_dir.path().join("sessions")));
+            let permission_manager =
+                Arc::new(PermissionManager::new(temp_dir.path().join("permissions")));
+            let agent = Agent::with_config(AgentConfig::new(
+                session_manager.clone(),
+                permission_manager,
+                None,
+                GooseMode::Auto,
+                true,
+                GoosePlatform::GooseCli,
+            ));
+            let session = session_manager
+                .create_session(
+                    PathBuf::new(),
+                    "test".to_string(),
+                    SessionType::Hidden,
+                    GooseMode::Auto,
+                )
+                .await
+                .unwrap();
+            let provider = Arc::new(MockProvider::new(vec![Ok(
+                Message::assistant().with_text("inspected and tested project")
+            )]));
+            agent
+                .update_provider(provider, ModelConfig::new("test-model"), &session.id)
+                .await
+                .unwrap();
+            let tool_requests = chain_tool_requests();
+            let message = Message::assistant()
+                .with_id("message-1")
+                .with_tool_request(
+                    tool_requests[0].id.clone(),
+                    tool_requests[0].tool_call.clone(),
+                )
+                .with_tool_request(
+                    tool_requests[1].id.clone(),
+                    tool_requests[1].tool_call.clone(),
+                );
+            session_manager
+                .add_message(&session.id, &message)
+                .await
+                .unwrap();
+
+            let summary = generate_tool_chain_summary(
+                &agent,
+                session_manager.as_ref(),
+                &session.id,
+                message.id.as_deref().unwrap(),
+                &tool_requests,
+            )
+            .await;
+
+            assert_eq!(
+                summary,
+                Some(ToolChainSummary {
+                    summary: "inspected and tested project".to_string(),
+                    count: tool_requests.len(),
+                }),
+            );
+            let loaded = session_manager
+                .get_session(&session.id, true)
+                .await
+                .unwrap();
+            let persisted_summary = loaded
+                .conversation
+                .as_ref()
+                .unwrap()
+                .messages()
+                .iter()
+                .flat_map(|message| &message.content)
+                .find_map(|content| match content {
+                    MessageContent::ToolRequest(request) if request.id == tool_requests[0].id => {
+                        request.generated_chain_summary()
+                    }
+                    _ => None,
+                })
+                .unwrap();
+
+            assert_eq!(persisted_summary.summary, "inspected and tested project");
+            assert_eq!(persisted_summary.count, tool_requests.len());
+        }
     }
 }

--- a/crates/goose/src/tool_call_labels.rs
+++ b/crates/goose/src/tool_call_labels.rs
@@ -1,0 +1,432 @@
+use crate::agents::Agent;
+use crate::conversation::message::{Message, MessageContent, ToolRequest, TOOL_META_TITLE_KEY};
+use crate::model_config::get_fast_model;
+use crate::providers::base::Provider;
+use crate::session::SessionManager;
+use crate::session_context::with_session_id;
+use crate::utils::safe_truncate;
+use goose_providers::model::ModelConfig;
+use serde_json::json;
+use std::slice::from_ref;
+use std::time::Duration;
+use tokio::time::sleep;
+use tracing::warn;
+
+const TOOL_TITLE_SYSTEM_PROMPT: &str =
+    "Summarize this tool call in a short lowercase phrase (3-8 words). \
+     No punctuation. No quotes. Examples: reading project configuration, \
+     checking network connectivity, listing files in src directory";
+const TOOL_TITLE_ARGUMENTS_MAX_LENGTH: usize = 300;
+
+pub(crate) async fn generate_tool_title(
+    agent: &Agent,
+    session_manager: &SessionManager,
+    session_id: &str,
+    message_id: Option<&str>,
+    tool_request: &ToolRequest,
+) -> Option<String> {
+    let provider = agent.provider().await.ok()?;
+    if provider.manages_own_context() {
+        return None;
+    }
+
+    let model_config = agent.model_config_for_session(session_id).await.ok()?;
+    let fast_model_config = get_fast_model(provider.get_name(), &model_config)
+        .await
+        .ok()?;
+    let title = generate_tool_title_with_provider(
+        provider.as_ref(),
+        &fast_model_config,
+        session_id,
+        tool_request,
+    )
+    .await?;
+    let request_id = &tool_request.id;
+
+    if let Some(message_id) = message_id {
+        let patch = json!({
+            (TOOL_META_TITLE_KEY): &title,
+        });
+        if let Err(error) = session_manager
+            .update_tool_request_meta(session_id, message_id, request_id, patch)
+            .await
+        {
+            warn!("tool call title: persist failed for {request_id} in {message_id}: {error}",);
+        }
+    }
+
+    Some(title)
+}
+
+async fn generate_tool_title_with_provider(
+    provider: &dyn Provider,
+    model_config: &ModelConfig,
+    session_id: &str,
+    tool_request: &ToolRequest,
+) -> Option<String> {
+    let tool_call = tool_request.tool_call.as_ref().ok()?;
+    let name = &tool_call.name;
+    let args_json = tool_call
+        .arguments
+        .as_ref()
+        .map(|arguments| {
+            let serialized = serde_json::to_string(arguments).unwrap_or_default();
+            if serialized.len() > TOOL_TITLE_ARGUMENTS_MAX_LENGTH {
+                format!(
+                    "{}…",
+                    safe_truncate(&serialized, TOOL_TITLE_ARGUMENTS_MAX_LENGTH)
+                )
+            } else {
+                serialized
+            }
+        })
+        .unwrap_or_default();
+    let message = Message::user().with_text(format!("Tool: {name}\nArguments: {args_json}"));
+
+    const MAX_ATTEMPTS: usize = 2;
+    for attempt in 0..MAX_ATTEMPTS {
+        if let Ok((response, _)) = with_session_id(
+            Some(session_id.to_string()),
+            provider.complete(
+                model_config,
+                TOOL_TITLE_SYSTEM_PROMPT,
+                from_ref(&message),
+                &[],
+            ),
+        )
+        .await
+        {
+            let title = response
+                .content
+                .iter()
+                .filter_map(MessageContent::as_text)
+                .collect::<String>()
+                .trim()
+                .to_string();
+            if !title.is_empty() {
+                return Some(title);
+            }
+        }
+
+        if attempt + 1 < MAX_ATTEMPTS {
+            sleep(Duration::from_millis(150)).await;
+        }
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agents::{AgentConfig, GoosePlatform};
+    use crate::config::{GooseMode, PermissionManager};
+    use crate::providers::base::{MessageStream, ProviderUsage, Usage};
+    use crate::session::{SessionManager, SessionType};
+    use async_trait::async_trait;
+    use goose_providers::errors::ProviderError;
+    use rmcp::model::{CallToolRequestParams, Tool};
+    use serde_json::json;
+    use std::collections::VecDeque;
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
+    use tempfile::TempDir;
+
+    struct MockProvider {
+        outcomes: Mutex<VecDeque<Result<Message, ProviderError>>>,
+        calls: AtomicUsize,
+        messages: Mutex<Vec<Vec<Message>>>,
+        manages_own_context: bool,
+    }
+
+    impl MockProvider {
+        fn new(outcomes: Vec<Result<Message, ProviderError>>) -> Self {
+            Self {
+                outcomes: Mutex::new(outcomes.into()),
+                calls: AtomicUsize::new(0),
+                messages: Mutex::new(Vec::new()),
+                manages_own_context: false,
+            }
+        }
+
+        fn managing_own_context() -> Self {
+            Self {
+                outcomes: Mutex::new(VecDeque::new()),
+                calls: AtomicUsize::new(0),
+                messages: Mutex::new(Vec::new()),
+                manages_own_context: true,
+            }
+        }
+
+        fn call_count(&self) -> usize {
+            self.calls.load(Ordering::SeqCst)
+        }
+
+        fn first_user_message(&self) -> String {
+            self.messages.lock().unwrap()[0][0].as_concat_text()
+        }
+    }
+
+    #[async_trait]
+    impl Provider for MockProvider {
+        fn get_name(&self) -> &str {
+            "tool-title-test"
+        }
+
+        async fn stream(
+            &self,
+            _model_config: &ModelConfig,
+            _system: &str,
+            _messages: &[Message],
+            _tools: &[Tool],
+        ) -> Result<MessageStream, ProviderError> {
+            unreachable!("title generation calls complete directly")
+        }
+
+        async fn complete(
+            &self,
+            _model_config: &ModelConfig,
+            _system: &str,
+            messages: &[Message],
+            _tools: &[Tool],
+        ) -> Result<(Message, ProviderUsage), ProviderError> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            self.messages.lock().unwrap().push(messages.to_vec());
+            let outcome = self
+                .outcomes
+                .lock()
+                .unwrap()
+                .pop_front()
+                .expect("test provider should have a configured outcome");
+            outcome.map(|message| {
+                (
+                    message,
+                    ProviderUsage::new("tool-title-test".to_string(), Usage::default()),
+                )
+            })
+        }
+
+        fn manages_own_context(&self) -> bool {
+            self.manages_own_context
+        }
+    }
+
+    fn tool_request(arguments: serde_json::Value) -> ToolRequest {
+        ToolRequest {
+            id: "request-1".to_string(),
+            tool_call: Ok(CallToolRequestParams::new("developer__shell")
+                .with_arguments(arguments.as_object().unwrap().clone())),
+            metadata: None,
+            tool_meta: None,
+        }
+    }
+
+    async fn generate_with(provider: &MockProvider, tool_request: &ToolRequest) -> Option<String> {
+        generate_tool_title_with_provider(
+            provider,
+            &ModelConfig::new("test-model"),
+            "session-1",
+            tool_request,
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn returns_trimmed_generated_title() {
+        let provider = MockProvider::new(vec![Ok(
+            Message::assistant().with_text("  checking project status  ")
+        )]);
+
+        let title = generate_with(&provider, &tool_request(json!({"command": "git status"}))).await;
+
+        assert_eq!(title.as_deref(), Some("checking project status"));
+        assert_eq!(provider.call_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn retries_once_after_empty_response() {
+        let provider = MockProvider::new(vec![
+            Ok(Message::assistant().with_text("  ")),
+            Ok(Message::assistant().with_text("reading project configuration")),
+        ]);
+
+        let title = generate_with(&provider, &tool_request(json!({}))).await;
+
+        assert_eq!(title.as_deref(), Some("reading project configuration"));
+        assert_eq!(provider.call_count(), 2);
+    }
+
+    #[tokio::test]
+    async fn retries_once_after_provider_error() {
+        let provider = MockProvider::new(vec![
+            Err(ProviderError::ExecutionError("temporary".to_string())),
+            Ok(Message::assistant().with_text("checking network connectivity")),
+        ]);
+
+        let title = generate_with(&provider, &tool_request(json!({}))).await;
+
+        assert_eq!(title.as_deref(), Some("checking network connectivity"));
+        assert_eq!(provider.call_count(), 2);
+    }
+
+    #[tokio::test]
+    async fn returns_none_after_two_unsuccessful_attempts() {
+        let provider = MockProvider::new(vec![
+            Ok(Message::assistant().with_text("")),
+            Err(ProviderError::ExecutionError(
+                "still unavailable".to_string(),
+            )),
+        ]);
+
+        let title = generate_with(&provider, &tool_request(json!({}))).await;
+
+        assert_eq!(title, None);
+        assert_eq!(provider.call_count(), 2);
+    }
+
+    #[tokio::test]
+    async fn skips_provider_that_manages_own_context() {
+        let temp_dir = TempDir::new().unwrap();
+        let session_manager = Arc::new(SessionManager::new(temp_dir.path().join("sessions")));
+        let permission_manager =
+            Arc::new(PermissionManager::new(temp_dir.path().join("permissions")));
+        let agent = Agent::with_config(AgentConfig::new(
+            session_manager.clone(),
+            permission_manager,
+            None,
+            GooseMode::Auto,
+            true,
+            GoosePlatform::GooseCli,
+        ));
+        let session = session_manager
+            .create_session(
+                PathBuf::new(),
+                "test".to_string(),
+                SessionType::Hidden,
+                GooseMode::Auto,
+            )
+            .await
+            .unwrap();
+        let provider = Arc::new(MockProvider::managing_own_context());
+        agent
+            .update_provider(
+                provider.clone(),
+                ModelConfig::new("test-model"),
+                &session.id,
+            )
+            .await
+            .unwrap();
+
+        let title = generate_tool_title(
+            &agent,
+            session_manager.as_ref(),
+            &session.id,
+            None,
+            &tool_request(json!({})),
+        )
+        .await;
+
+        assert_eq!(title, None);
+        assert_eq!(provider.call_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn preserves_short_serialized_arguments() {
+        let provider = MockProvider::new(vec![Ok(Message::assistant().with_text("title"))]);
+        let tool_request = tool_request(json!({"command": "git status"}));
+
+        generate_with(&provider, &tool_request).await;
+
+        assert_eq!(
+            provider.first_user_message(),
+            "Tool: developer__shell\nArguments: {\"command\":\"git status\"}",
+        );
+    }
+
+    #[tokio::test]
+    async fn truncates_long_serialized_arguments() {
+        let provider = MockProvider::new(vec![Ok(Message::assistant().with_text("title"))]);
+        let arguments = json!({"command": "x".repeat(400)});
+        let serialized = serde_json::to_string(arguments.as_object().unwrap()).unwrap();
+        let expected = format!(
+            "Tool: developer__shell\nArguments: {}…",
+            safe_truncate(&serialized, TOOL_TITLE_ARGUMENTS_MAX_LENGTH),
+        );
+        let tool_request = tool_request(arguments);
+
+        generate_with(&provider, &tool_request).await;
+
+        assert_eq!(provider.first_user_message(), expected);
+    }
+
+    #[tokio::test]
+    async fn persists_title_for_known_message_id() {
+        let temp_dir = TempDir::new().unwrap();
+        let session_manager = Arc::new(SessionManager::new(temp_dir.path().join("sessions")));
+        let permission_manager =
+            Arc::new(PermissionManager::new(temp_dir.path().join("permissions")));
+        let agent = Agent::with_config(AgentConfig::new(
+            session_manager.clone(),
+            permission_manager,
+            None,
+            GooseMode::Auto,
+            true,
+            GoosePlatform::GooseCli,
+        ));
+        let session = session_manager
+            .create_session(
+                PathBuf::new(),
+                "test".to_string(),
+                SessionType::Hidden,
+                GooseMode::Auto,
+            )
+            .await
+            .unwrap();
+        let provider = Arc::new(MockProvider::new(vec![Ok(
+            Message::assistant().with_text("checking project status")
+        )]));
+        agent
+            .update_provider(provider, ModelConfig::new("test-model"), &session.id)
+            .await
+            .unwrap();
+        let tool_request = tool_request(json!({"command": "git status"}));
+        let message = Message::assistant()
+            .with_id("message-1")
+            .with_tool_request(tool_request.id.clone(), tool_request.tool_call.clone());
+        session_manager
+            .add_message(&session.id, &message)
+            .await
+            .unwrap();
+
+        let title = generate_tool_title(
+            &agent,
+            session_manager.as_ref(),
+            &session.id,
+            message.id.as_deref(),
+            &tool_request,
+        )
+        .await;
+
+        assert_eq!(title.as_deref(), Some("checking project status"));
+        let loaded = session_manager
+            .get_session(&session.id, true)
+            .await
+            .unwrap();
+        let persisted_title = loaded
+            .conversation
+            .as_ref()
+            .unwrap()
+            .messages()
+            .iter()
+            .flat_map(|message| &message.content)
+            .find_map(|content| match content {
+                MessageContent::ToolRequest(request) if request.id == "request-1" => {
+                    request.persisted_title()
+                }
+                _ => None,
+            });
+
+        assert_eq!(persisted_title, Some("checking project status"));
+    }
+}

--- a/crates/goose/tests/providers.rs
+++ b/crates/goose/tests/providers.rs
@@ -343,7 +343,7 @@ impl ProviderFixture {
         };
 
         // Provider already executed an externally-dispatched tool — don't redispatch.
-        if tool_req.is_externally_dispatched() {
+        if tool_req.was_executed_externally() {
             return Ok(response1);
         }
 


### PR DESCRIPTION
## Summary

### Why

ACP tool-call handling mixed name parsing, client updates, generated labels, chain tracking, and request lookup inside `server.rs` and session state. This made the code difficult to follow and allowed chains to be summarized before they had ended.

### What changed

- **Standardize tool-name parsing:** ACP and CLI now use the same parser.
- **Consolidate ACP updates:** initial, terminal, permission, location, and metadata updates now use focused helpers.
- **Extract generated labels:** tool-title and chain-summary model calls now live in `tool_call_labels.rs`.
- **Fix chain-summary timing:** chains close at content boundaries or successful prompt completion and are summarized only after every tool response arrives.
- **Replace distributed chain state:** one prompt-owned tracker now represents open and closed chains directly.
- **Scope request storage:** live requests belong to the active prompt, while replay uses its own temporary map.
- **Prepare opt-in enrichment:** Goose reads and stores `toolCallLabelEnrichment`

The refactor also simplifies the implementation by removing obsolete wrappers, unreachable location parsing, and duplicate tool metadata.

### Testing
CI and manual

