### PR TITLE
Make provider smoke tests faster and more reliable

### DIFF
--- a/crates/goose/src/providers/claude_code.rs
+++ b/crates/goose/src/providers/claude_code.rs
@@ -859,10 +859,32 @@ impl Provider for ClaudeCodeProvider {
                                         .and_then(Value::as_bool)
                                         .unwrap_or(false)
                                     {
-                                        let message = parsed
-                                            .get("result")
+                                        let subtype = parsed
+                                            .get("subtype")
                                             .and_then(Value::as_str)
-                                            .unwrap_or("Unknown error");
+                                            .unwrap_or("error");
+                                        let mut details = Vec::new();
+                                        if let Some(error) =
+                                            parsed.get("error").and_then(Value::as_str)
+                                        {
+                                            details.push(error);
+                                        }
+                                        if let Some(errors) =
+                                            parsed.get("errors").and_then(Value::as_array)
+                                        {
+                                            details.extend(errors.iter().filter_map(Value::as_str));
+                                        }
+                                        if let Some(result) =
+                                            parsed.get("result").and_then(Value::as_str)
+                                        {
+                                            details.push(result);
+                                        }
+                                        let details = details.join("; ");
+                                        let message = match (subtype, details.is_empty()) {
+                                            ("success", false) => details,
+                                            (_, false) => format!("{subtype}: {details}"),
+                                            _ => subtype.to_string(),
+                                        };
                                         stream_error = Some(ProviderError::RequestFailed(format!(
                                             "Claude CLI error: {message}"
                                         )));

--- a/crates/goose/src/providers/claude_code.rs
+++ b/crates/goose/src/providers/claude_code.rs
@@ -854,6 +854,20 @@ impl Provider for ClaudeCodeProvider {
                                 }
                                 Some("result") => {
                                     process.needs_drain = false;
+                                    if parsed
+                                        .get("is_error")
+                                        .and_then(Value::as_bool)
+                                        .unwrap_or(false)
+                                    {
+                                        let message = parsed
+                                            .get("result")
+                                            .and_then(Value::as_str)
+                                            .unwrap_or("Unknown error");
+                                        stream_error = Some(ProviderError::RequestFailed(format!(
+                                            "Claude CLI error: {message}"
+                                        )));
+                                        break;
+                                    }
                                     if let Some(usage_info) = parsed.get("usage") {
                                         let new = extract_usage_tokens(usage_info);
                                         let reports_own_cache = new.cache_read_input_tokens.is_some()

--- a/ui/desktop/tests/integration/test_providers.test.ts
+++ b/ui/desktop/tests/integration/test_providers.test.ts
@@ -6,7 +6,7 @@
  * and validates the output.
  */
 
-import { expect, beforeAll } from 'vitest';
+import { beforeAll } from 'vitest';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -29,7 +29,7 @@ beforeAll(() => {
 
 const { testAgentic, testNonAgentic } = providerTest(discoverTestCases());
 
-testNonAgentic('reads files via shell tool', async (tc) => {
+testNonAgentic('reads files via shell tool', async (tc, { expect }) => {
   const testdir = fs.mkdtempSync(path.join(os.tmpdir(), 'goose-test-'));
   try {
     const tokenA = `smoke-alpha-${Math.floor(Math.random() * 32768)}`;
@@ -68,7 +68,7 @@ testNonAgentic('reads files via shell tool', async (tc) => {
   }
 });
 
-testAgentic('reads file contents', async (tc) => {
+testAgentic('reads file contents', async (tc, { expect }) => {
   const testdir = fs.mkdtempSync(path.join(os.tmpdir(), 'goose-test-'));
   try {
     fs.copyFileSync(testFile, path.join(testdir, 'test-content.txt'));

--- a/ui/desktop/tests/integration/test_providers_code_exec.test.ts
+++ b/ui/desktop/tests/integration/test_providers_code_exec.test.ts
@@ -6,7 +6,7 @@
  * that the code_execution tool was invoked.
  */
 
-import { expect, beforeAll } from 'vitest';
+import { beforeAll } from 'vitest';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -22,7 +22,7 @@ beforeAll(() => {
 
 const { testAll } = providerTest(discoverTestCases({ skipAgentic: true }));
 
-testAll('invokes code_execution tool', async (tc) => {
+testAll('invokes code_execution tool', async (tc, { expect }) => {
   const testdir = fs.mkdtempSync(path.join(os.tmpdir(), 'goose-codeexec-'));
   try {
     const output = await runGoose(

--- a/ui/desktop/tests/integration/test_providers_lib.ts
+++ b/ui/desktop/tests/integration/test_providers_lib.ts
@@ -5,7 +5,7 @@
  * allowed-failure list, agentic-provider list, and environment detection.
  */
 
-import { test } from 'vitest';
+import { test, type TestContext } from 'vitest';
 import { execSync, spawn, type ChildProcess } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
@@ -299,7 +299,7 @@ export function discoverTestCases(options?: { skipAgentic?: boolean }): TestCase
 // Test registration helpers
 // ---------------------------------------------------------------------------
 
-type ProviderTestFn = (tc: TestCase) => Promise<void>;
+type ProviderTestFn = (tc: TestCase, context: TestContext) => Promise<void>;
 
 function registerTests(label: string, cases: TestCase[], fn: ProviderTestFn): void {
   const available = cases.filter((tc) => tc.available && !tc.flaky);
@@ -307,24 +307,24 @@ function registerTests(label: string, cases: TestCase[], fn: ProviderTestFn): vo
   const skipped = cases.filter((tc) => !tc.available);
 
   if (available.length > 0) {
-    test.concurrent.each(available)(`${label} — $provider / $model`, async (tc) => {
-      await fn(tc);
+    test.concurrent.for(available)(`${label} — $provider / $model`, async (tc, context) => {
+      await fn(tc, context);
     });
   }
 
   if (flaky.length > 0) {
     // Use a longer vitest timeout (90s) so the internal runGoose timeout (55s)
     // fires first — that rejection is catchable and the test passes as "allowed".
-    test.concurrent.each(flaky)(
+    test.concurrent.for(flaky)(
       `${label} — $provider / $model (flaky)`,
-      async (tc) => {
+      { timeout: 90_000 },
+      async (tc, context) => {
         try {
-          await fn(tc);
+          await fn(tc, context);
         } catch (err) {
           console.warn(`Flaky test ${tc.provider}/${tc.model} failed (allowed): ${err}`);
         }
-      },
-      90_000
+      }
     );
   }
 

--- a/ui/desktop/tests/integration/test_providers_lib.ts
+++ b/ui/desktop/tests/integration/test_providers_lib.ts
@@ -307,7 +307,7 @@ function registerTests(label: string, cases: TestCase[], fn: ProviderTestFn): vo
   const skipped = cases.filter((tc) => !tc.available);
 
   if (available.length > 0) {
-    test.each(available)(`${label} — $provider / $model`, async (tc) => {
+    test.concurrent.each(available)(`${label} — $provider / $model`, async (tc) => {
       await fn(tc);
     });
   }
@@ -315,7 +315,7 @@ function registerTests(label: string, cases: TestCase[], fn: ProviderTestFn): vo
   if (flaky.length > 0) {
     // Use a longer vitest timeout (90s) so the internal runGoose timeout (55s)
     // fires first — that rejection is catchable and the test passes as "allowed".
-    test.each(flaky)(
+    test.concurrent.each(flaky)(
       `${label} — $provider / $model (flaky)`,
       async (tc) => {
         try {
@@ -373,7 +373,7 @@ export function runGoose(
       ['run', '--text', prompt, '--with-builtin', builtins],
       {
         cwd,
-        env: { ...process.env, ...env },
+        env: { ...process.env, ...env, GOOSE_MODE: 'auto' },
         stdio: ['ignore', 'pipe', 'pipe'],
       }
     );

--- a/ui/desktop/vitest.integration.config.ts
+++ b/ui/desktop/vitest.integration.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
     hookTimeout: 60000,
     pool: 'forks',
     singleFork: true,
+    maxConcurrency: 4,
     silent: 'passed-only',
   },
 });


### PR DESCRIPTION
## Summary

- force provider smoke-test subprocesses to use `GOOSE_MODE=auto` so headless runs do not inherit an approval mode
- run provider/model cases concurrently with a maximum concurrency of four
- surface Claude Code CLI result errors instead of reporting an empty model response

## Validation

- `pnpm --dir ui/desktop run typecheck`
- `pnpm --dir ui/desktop exec prettier --check vitest.integration.config.ts tests/integration/test_providers_lib.ts`
- `cargo clippy -p goose --all-targets -- -D warnings`
- normal and code-execution provider smoke suites run locally; expected live-provider failures remain visible rather than being changed by this PR