### PR TITLE
fix(local-inference): keep XML snippets inside JSON as data

### DIFF
--- a/crates/goose-local-inference/src/native_tool_parsing.rs
+++ b/crates/goose-local-inference/src/native_tool_parsing.rs
@@ -18,6 +18,8 @@ pub(crate) fn message_from_native_tool_text(
         append_tool_calls(&mut content, message.get("tool_calls"));
     } else if let Some(tool_calls) = parse_tool_calls_json(generated_text) {
         append_tool_calls(&mut content, Some(&tool_calls));
+    } else if serde_json::from_str::<Value>(generated_text.trim()).is_ok() {
+        return Ok(None);
     } else if generated_text.contains("<function=") {
         let (prefix, tool_calls) = parse_xml_tool_calls(generated_text);
         if let Some(prefix) = prefix {
@@ -318,6 +320,24 @@ mod tests {
     fn parses_xml_tool_calls() {
         let text = r#"<function=developer__shell><parameter=command>pwd</parameter></function>"#;
         let message = message_from_native_tool_text(text, "msg").unwrap().unwrap();
+        assert_eq!(tool_count(&message), 1);
+    }
+
+    #[test]
+    fn ignores_xml_tool_call_inside_json_string() {
+        let text = r#"{"example":"<function=developer__shell><parameter=command>pwd</parameter></function>"}"#;
+
+        assert!(message_from_native_tool_text(text, "msg")
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn parses_json_tool_call_with_xml_text_in_arguments() {
+        let text =
+            r#"{"name":"developer__shell","arguments":{"command":"echo <function=example>"}}"#;
+        let message = message_from_native_tool_text(text, "msg").unwrap().unwrap();
+
         assert_eq!(tool_count(&message), 1);
     }
 }


### PR DESCRIPTION
## Summary

- treat a complete valid non-tool JSON value as data before the native XML tool-call fallback
- preserve structured JSON tool calls and the existing standalone XML tool-call behavior
- add regression coverage for XML-looking text inside JSON and compatibility coverage for JSON tool-call arguments

## Audit issue

- Addresses [project-loupe/audit-goose#523](https://github.com/project-loupe/audit-goose/issues/523)

## Verification

- `cargo fmt --all`
- `cargo test -p goose-local-inference --features mlx native_tool_parsing::tests` (10 passed)
- `cargo build -p goose-local-inference --features mlx`
- `cargo clippy -p goose-local-inference --all-targets --features mlx -- -D warnings` (reached the component; blocked by eight pre-existing warnings in unchanged MLX/parser code)
- focused follow-up clippy with only those exact existing lint classes allowed (passed)
- `git diff --check`

_This finding was discovered by [Project Loupe](https://github.com/project-loupe/loupe)._
