### PR TITLE
fix(security): detect digit-bearing mkfs types

### DIFF
--- a/crates/goose/src/security/patterns.rs
+++ b/crates/goose/src/security/patterns.rs
@@ -69,7 +69,7 @@ pub const THREAT_PATTERNS: &[ThreatPattern] = &[
     },
     ThreatPattern {
         name: "format_drive",
-        pattern: r"(format|mkfs\.[a-z][a-z0-9]*)\s+[/\\]dev[/\\][sh]d[a-z]([0-9]+)?(\s|[;&|]|$)",
+        pattern: r"(format|mkfs\.[a-z][a-z0-9]*)\s+[/\\]dev[/\\][sh]d[a-z]([0-9]+)?(\s|[;&|<>]|$)",
         description: "Formatting system drives",
         risk_level: RiskLevel::Critical,
         category: ThreatCategory::FileSystemDestruction,
@@ -407,6 +407,8 @@ mod tests {
         let pat = "format_drive";
         assert!(matches(pat, "mkfs.ext4 /dev/sda1"));
         assert!(matches(pat, "mkfs.ext4 /dev/hdb12 && reboot"));
+        assert!(matches(pat, "mkfs.ext4 /dev/sda1>/tmp/mkfs.log"));
+        assert!(matches(pat, "mkfs.ext4 /dev/sda</dev/null"));
         assert!(!matches(pat, "mkfs.ext4 /dev/sda-volume"));
         assert!(!matches(pat, "mkfs.ext4 /dev/sdaa"));
     }

--- a/crates/goose/src/security/patterns.rs
+++ b/crates/goose/src/security/patterns.rs
@@ -69,7 +69,7 @@ pub const THREAT_PATTERNS: &[ThreatPattern] = &[
     },
     ThreatPattern {
         name: "format_drive",
-        pattern: r#"(?:^|\s|[;&|(`/"'])(?:format[ \t]+|mkfs\.[a-z][a-z0-9]*[ \t]+(?:(?:[^;&|)`\s#'"\\]|\\[^\n])(?:[^;&|)`\s'"\\]|\\[^\n])*|'[^'\n]*'|"(?:\\[^\n]|[^"\\\n])*"|[ \t]+)*?)(?:[/\\]dev[/\\][sh]d[a-z](?:[0-9]+)?(?:\s|[;&|<>)`"']|$)|'[/\\]dev[/\\][sh]d[a-z](?:[0-9]+)?'(?:\s|[;&|<>)`"']|$)|"[/\\]dev[/\\][sh]d[a-z](?:[0-9]+)?"(?:\s|[;&|<>)`"']|$))"#,
+        pattern: r#"(?:^|\s|[;&|(`/"'])(?:format[ \t]+|mkfs\.[a-z][a-z0-9]*[ \t]+(?:(?:[^;&|)`\s#'"\\]|\\[^\n])(?:[^;&|)`\s'"\\]|\\[^\n])*|'[^'\n]*'|"(?:\\[^\n]|[^"\\\n])*"|[ \t]+)*?)(?:[/\\]dev[/\\][sh]d[a-z](?:[0-9]+)?(?:[ \t]+[0-9]+)?[ \t]*(?:\n|[;&|<>)`"'#]|$)|'[/\\]dev[/\\][sh]d[a-z](?:[0-9]+)?'(?:[ \t]+[0-9]+)?[ \t]*(?:\n|[;&|<>)`"'#]|$)|"[/\\]dev[/\\][sh]d[a-z](?:[0-9]+)?"(?:[ \t]+[0-9]+)?[ \t]*(?:\n|[;&|<>)`"'#]|$))"#,
         description: "Formatting system drives",
         risk_level: RiskLevel::Critical,
         category: ThreatCategory::FileSystemDestruction,
@@ -414,6 +414,7 @@ mod tests {
         assert!(matches(pat, "sh -c \"mkfs.ext4 /dev/sda1\""));
         assert!(matches(pat, "sh -c 'mkfs.ext4 /dev/sda1'"));
         assert!(matches(pat, "mkfs.ext4 -F /dev/sda1"));
+        assert!(matches(pat, "mkfs.ext4 -F /dev/sda1 4096"));
         assert!(matches(pat, "mkfs.ext4 -q -L data /dev/sda1"));
         assert!(matches(pat, "mkfs.ext4 -L 'x;y' /dev/sda1"));
         assert!(matches(pat, "mkfs.ext4 -L \"x|y\" /dev/sda1"));
@@ -429,6 +430,9 @@ mod tests {
         assert!(!matches(pat, "mkfs.ext4 # /dev/sda1"));
         assert!(!matches(pat, "mkfs.ext4 -L data # /dev/sda1"));
         assert!(!matches(pat, "mkfs.ext4 -L '/dev/sda not-a-target'"));
+        assert!(!matches(pat, "mkfs.ext4 -F -L /dev/sda /tmp/image"));
+        assert!(!matches(pat, "mkfs.ext4 -F -L '/dev/sda' /tmp/image"));
+        assert!(!matches(pat, "mkfs.ext4 -F -L \"/dev/sda\" /tmp/image"));
         assert!(!matches(pat, "mkfs.ext4 --help\necho /dev/sda1"));
         assert!(!matches(pat, "echo $(mkfs.ext4 --help) /dev/sda"));
         assert!(!matches(pat, "stat --format '%n %s' /dev/sda"));

--- a/crates/goose/src/security/patterns.rs
+++ b/crates/goose/src/security/patterns.rs
@@ -69,7 +69,7 @@ pub const THREAT_PATTERNS: &[ThreatPattern] = &[
     },
     ThreatPattern {
         name: "format_drive",
-        pattern: r#"(?:^|[\s;&|(`/"'])(?P<command>(?:[^\s;&|()`"']*[/\\])?(?:format|mkfs\.[a-z][a-z0-9]*))[ \t<>]+"#,
+        pattern: r#"(?:^|[\s;&|(`/"'])(?P<command>(?:[^\s;&|()`"']*[/\\])?(?:format|mkfs\.[a-z][a-z0-9]*))(?:[ \t<>]|\\\r?\n)+"#,
         description: "Formatting system drives",
         risk_level: RiskLevel::Critical,
         category: ThreatCategory::FileSystemDestruction,
@@ -338,7 +338,11 @@ fn shell_words_until_boundary(text: &str) -> Vec<ShellWord> {
                 quote = None;
             } else if character == '\\' && active_quote == '"' {
                 if let Some((_, escaped)) = characters.next() {
-                    value.push(escaped);
+                    if escaped == '\r' && characters.peek().is_some_and(|(_, next)| *next == '\n') {
+                        characters.next();
+                    } else if escaped != '\n' {
+                        value.push(escaped);
+                    }
                 }
             } else {
                 value.push(character);
@@ -347,14 +351,22 @@ fn shell_words_until_boundary(text: &str) -> Vec<ShellWord> {
         }
 
         if character == '\\' {
+            let Some((_, escaped)) = characters.next() else {
+                continue;
+            };
+            if escaped == '\r' && characters.peek().is_some_and(|(_, next)| *next == '\n') {
+                characters.next();
+                continue;
+            }
+            if escaped == '\n' {
+                continue;
+            }
             if start.is_none() {
                 start = Some(index);
                 discard_word = awaiting_redirection_target;
                 awaiting_redirection_target = false;
             }
-            if let Some((_, escaped)) = characters.next() {
-                value.push(escaped);
-            }
+            value.push(escaped);
             continue;
         }
 
@@ -499,15 +511,18 @@ fn format_option_value_flag(command: &str, flag: char) -> bool {
     }
 }
 
-fn format_option_next_value_flag(command: &str, option: &str) -> Option<char> {
+fn format_option_value<'a>(command: &str, option: &'a str) -> Option<(char, Option<&'a str>)> {
     let short_options = option
         .strip_prefix('-')
         .filter(|options| !options.is_empty() && !options.starts_with('-'))?;
 
-    short_options
+    let (index, flag) = short_options
         .char_indices()
-        .find(|(_, flag)| format_option_value_flag(command, *flag))
-        .and_then(|(index, flag)| (index + flag.len_utf8() == short_options.len()).then_some(flag))
+        .find(|(_, flag)| format_option_value_flag(command, *flag))?;
+    let attached = short_options
+        .get(index + flag.len_utf8()..)
+        .filter(|value| !value.is_empty());
+    Some((flag, attached))
 }
 
 fn is_non_writing_format_option(command: &str, option: &str) -> bool {
@@ -533,7 +548,13 @@ fn is_non_writing_format_option(command: &str, option: &str) -> bool {
         })
 }
 
-fn format_drive_targets(words: &[ShellWord]) -> Vec<&ShellWord> {
+struct FormatDriveTarget<'a> {
+    word: &'a ShellWord,
+    value: &'a str,
+    allows_f2fs_alias: bool,
+}
+
+fn format_drive_targets(words: &[ShellWord]) -> Vec<FormatDriveTarget<'_>> {
     let command = words
         .first()
         .expect("format command includes an executable")
@@ -550,7 +571,11 @@ fn format_drive_targets(words: &[ShellWord]) -> Vec<&ShellWord> {
     for word in &words[1..] {
         if let Some(option_flag) = pending_option_value.take() {
             if command == "mkfs.f2fs" && option_flag == 'c' {
-                targets.push(word);
+                targets.push(FormatDriveTarget {
+                    word,
+                    value: &word.value,
+                    allows_f2fs_alias: true,
+                });
             }
             continue;
         }
@@ -560,11 +585,29 @@ fn format_drive_targets(words: &[ShellWord]) -> Vec<&ShellWord> {
         }
         if !options_ended && word.value.starts_with('-') {
             non_writing |= is_non_writing_format_option(&command, &word.value);
-            pending_option_value = format_option_next_value_flag(&command, &word.value);
+            if let Some((option_flag, attached_value)) = format_option_value(&command, &word.value)
+            {
+                if command == "mkfs.f2fs" && option_flag == 'c' {
+                    if let Some(value) = attached_value {
+                        targets.push(FormatDriveTarget {
+                            word,
+                            value,
+                            allows_f2fs_alias: true,
+                        });
+                    }
+                }
+                if attached_value.is_none() {
+                    pending_option_value = Some(option_flag);
+                }
+            }
             continue;
         }
         if targets.is_empty() || command == "mkfs.f2fs" {
-            targets.push(word);
+            targets.push(FormatDriveTarget {
+                word,
+                value: &word.value,
+                allows_f2fs_alias: false,
+            });
         }
     }
 
@@ -575,11 +618,18 @@ fn format_drive_targets(words: &[ShellWord]) -> Vec<&ShellWord> {
     }
 }
 
-fn contains_system_drive(word: &str) -> bool {
+fn contains_system_drive(target: &FormatDriveTarget<'_>) -> bool {
     static SYSTEM_DRIVE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(r"(?i)^[/\\]dev[/\\][sh]d[a-z](?:[0-9]+)?$").expect("valid system drive regex")
     });
-    word.split(',').any(|device| SYSTEM_DRIVE.is_match(device))
+    target.value.split(',').any(|device| {
+        let device = if target.allows_f2fs_alias {
+            device.split_once('@').map_or(device, |(name, _)| name)
+        } else {
+            device
+        };
+        SYSTEM_DRIVE.is_match(device)
+    })
 }
 
 /// Pattern matcher for detecting security threats
@@ -610,11 +660,11 @@ impl PatternMatcher {
                         let words = shell_words_until_boundary(command_text);
                         let Some(target) = format_drive_targets(&words)
                             .into_iter()
-                            .find(|target| contains_system_drive(&target.value))
+                            .find(contains_system_drive)
                         else {
                             continue;
                         };
-                        let end_pos = command_match.start() + target.end;
+                        let end_pos = command_match.start() + target.word.end;
                         matches.push(PatternMatch {
                             threat: threat.clone(),
                             matched_text: text
@@ -697,8 +747,12 @@ mod tests {
         assert!(matches(pat, "mkfs.f2fs -g android /dev/sdc"));
         assert!(matches(pat, "mkfs.f2fs -c /dev/sdb /dev/loop0"));
         assert!(matches(pat, "mkfs.f2fs -c /dev/sdb,/dev/loop0 /dev/loop1"));
+        assert!(matches(pat, "mkfs.f2fs -c /dev/sdb@data /dev/loop0"));
+        assert!(matches(pat, "mkfs.f2fs -c/dev/sdb /dev/loop0"));
+        assert!(matches(pat, "mkfs.f2fs -c/dev/sdb@data /dev/loop0"));
         assert!(!matches(pat, "mkfs.f2fs -l /dev/sdc /tmp/image"));
         assert!(!matches(pat, "mkfs.f2fs -c /tmp/image /dev/loop0"));
+        assert!(!matches(pat, "mkfs.f2fs /dev/sdb@data /dev/loop0"));
     }
 
     #[test]
@@ -716,6 +770,8 @@ mod tests {
         assert!(matches(pat, "mkfs.ext4 -qL data /dev/sda1"));
         assert!(matches(pat, "mkfs.ext4 >/tmp/mkfs.log /dev/sda1"));
         assert!(matches(pat, "mkfs.ext4>/tmp/mkfs.log -F /dev/sda1"));
+        assert!(matches(pat, "mkfs.ext4 \\\r\n /dev/sda1"));
+        assert!(matches(pat, "mkfs.ext4 \\\n /dev/sda1"));
         assert!(matches(pat, "mkfs.ext4 2>/tmp/mkfs.log /dev/sda1"));
         assert!(matches(pat, "mkfs.ext4 </dev/null /dev/sda1"));
         assert!(matches(pat, "mkfs.ext4 -F /dev/sda1 4096"));
@@ -749,7 +805,11 @@ mod tests {
         assert!(matches(pat, "mkfs.ext4 -L-n /dev/sda1"));
         assert!(matches(pat, "mkfs.ext4 -LxN /dev/sda1"));
         assert!(matches(pat, r"mkfs.ext4 -L foo\ -n /dev/sda1"));
+        assert!(matches(pat, "mkfs.ext4 -L \"data\\\r\nlabel\" /dev/sda1"));
+        assert!(matches(pat, "mkfs.ext4 -F \\\n/dev/sda1"));
+        assert!(matches(pat, "mkfs.ext4 -L \"data\\\nlabel\" /dev/sda1"));
         assert!(!matches(pat, "mkfs.ext4 /tmp/image -L /dev/sda"));
+        assert!(!matches(pat, "mkfs.ext4 -L/dev/sda /tmp/image"));
         assert!(!matches(pat, "mkfs.ext4 >/dev/sda1 /tmp/image"));
         assert!(!matches(pat, "mkfs.ext4 --help\necho /dev/sda1"));
         assert!(!matches(pat, "echo $(mkfs.ext4 --help) /dev/sda"));

--- a/crates/goose/src/security/patterns.rs
+++ b/crates/goose/src/security/patterns.rs
@@ -69,7 +69,7 @@ pub const THREAT_PATTERNS: &[ThreatPattern] = &[
     },
     ThreatPattern {
         name: "format_drive",
-        pattern: r#"(?:^|\s|[;&|(`/"'])(?:format[ \t]+|mkfs\.[a-z][a-z0-9]*[ \t]+(?:(?:[^;&|)`\s#'"\\]|\\[^\n])(?:[^;&|)`\s'"\\]|\\[^\n])*|'[^'\n]*'|"(?:\\[^\n]|[^"\\\n])*"|[ \t]+)*?)(?:[/\\]dev[/\\][sh]d[a-z](?:[0-9]+)?(?:[ \t]+(?:[0-9]+|-[^ \t\n;&|<>)`"'#]+))*[ \t]*(?:\n|[;&|<>)`"'#]|$)|'[/\\]dev[/\\][sh]d[a-z](?:[0-9]+)?'(?:[ \t]+(?:[0-9]+|-[^ \t\n;&|<>)`"'#]+))*[ \t]*(?:\n|[;&|<>)`"'#]|$)|"[/\\]dev[/\\][sh]d[a-z](?:[0-9]+)?"(?:[ \t]+(?:[0-9]+|-[^ \t\n;&|<>)`"'#]+))*[ \t]*(?:\n|[;&|<>)`"'#]|$))"#,
+        pattern: r#"(?:^|\s|[;&|(`/"'])(?:format[ \t]+|mkfs\.[a-z][a-z0-9]*[ \t]+(?:(?:[^;&|)`\s#'"\\]|\\[^\n])(?:[^;&|)`\s'"\\]|\\[^\n])*|'[^'\n]*'|"(?:\\[^\n]|[^"\\\n])*"|[ \t]+)*?)(?:[/\\]dev[/\\][sh]d[a-z](?:[0-9]+)?(?:(?:[ \t]+[0-9]+)|(?:[ \t]+-[^ \t\n;&|<>)`"'#]+(?:[ \t]+(?:(?:[^;&|)`\s#'"\\]|\\[^\n])(?:[^;&|)`\s'"\\]|\\[^\n])*|'[^'\n]*'|"(?:\\[^\n]|[^"\\\n])*"))?))*[ \t]*(?:\n|[;&|<>)`"'#]|$)|'[/\\]dev[/\\][sh]d[a-z](?:[0-9]+)?'(?:(?:[ \t]+[0-9]+)|(?:[ \t]+-[^ \t\n;&|<>)`"'#]+(?:[ \t]+(?:(?:[^;&|)`\s#'"\\]|\\[^\n])(?:[^;&|)`\s'"\\]|\\[^\n])*|'[^'\n]*'|"(?:\\[^\n]|[^"\\\n])*"))?))*[ \t]*(?:\n|[;&|<>)`"'#]|$)|"[/\\]dev[/\\][sh]d[a-z](?:[0-9]+)?"(?:(?:[ \t]+[0-9]+)|(?:[ \t]+-[^ \t\n;&|<>)`"'#]+(?:[ \t]+(?:(?:[^;&|)`\s#'"\\]|\\[^\n])(?:[^;&|)`\s'"\\]|\\[^\n])*|'[^'\n]*'|"(?:\\[^\n]|[^"\\\n])*"))?))*[ \t]*(?:\n|[;&|<>)`"'#]|$))"#,
         description: "Formatting system drives",
         risk_level: RiskLevel::Critical,
         category: ThreatCategory::FileSystemDestruction,
@@ -417,6 +417,8 @@ mod tests {
         assert!(matches(pat, "mkfs.ext4 -F /dev/sda1 4096"));
         assert!(matches(pat, "mkfs.ext4 /dev/sda1 -F"));
         assert!(matches(pat, "mkfs.ext4 /dev/sda1 -F -q"));
+        assert!(matches(pat, "mkfs.ext4 /dev/sda1 -L data"));
+        assert!(matches(pat, "mkfs.ext4 /dev/sda1 -L 'x;y'"));
         assert!(matches(pat, "mkfs.ext4 -q -L data /dev/sda1"));
         assert!(matches(pat, "mkfs.ext4 -L 'x;y' /dev/sda1"));
         assert!(matches(pat, "mkfs.ext4 -L \"x|y\" /dev/sda1"));

--- a/crates/goose/src/security/patterns.rs
+++ b/crates/goose/src/security/patterns.rs
@@ -69,7 +69,7 @@ pub const THREAT_PATTERNS: &[ThreatPattern] = &[
     },
     ThreatPattern {
         name: "format_drive",
-        pattern: r"(format|mkfs\.[a-z][a-z0-9]*)\s+[/\\]dev[/\\][sh]d[a-z]([0-9]+)?(\s|[;&|<>]|$)",
+        pattern: r"(format|mkfs\.[a-z][a-z0-9]*)\s+[/\\]dev[/\\][sh]d[a-z]([0-9]+)?(\s|[;&|<>)`]|$)",
         description: "Formatting system drives",
         risk_level: RiskLevel::Critical,
         category: ThreatCategory::FileSystemDestruction,
@@ -409,6 +409,8 @@ mod tests {
         assert!(matches(pat, "mkfs.ext4 /dev/hdb12 && reboot"));
         assert!(matches(pat, "mkfs.ext4 /dev/sda1>/tmp/mkfs.log"));
         assert!(matches(pat, "mkfs.ext4 /dev/sda</dev/null"));
+        assert!(matches(pat, "echo $(mkfs.ext4 /dev/sda1)"));
+        assert!(matches(pat, "echo `mkfs.ext4 /dev/sda`"));
         assert!(!matches(pat, "mkfs.ext4 /dev/sda-volume"));
         assert!(!matches(pat, "mkfs.ext4 /dev/sdaa"));
     }

--- a/crates/goose/src/security/patterns.rs
+++ b/crates/goose/src/security/patterns.rs
@@ -69,7 +69,7 @@ pub const THREAT_PATTERNS: &[ThreatPattern] = &[
     },
     ThreatPattern {
         name: "format_drive",
-        pattern: r#"(?:^|[\s;&|(`/"'])(?P<command>(?:[^\s;&|()`"']*[/\\])?(?:format|mkfs\.[a-z][a-z0-9]*))[ \t]+"#,
+        pattern: r#"(?:^|[\s;&|(`/"'])(?P<command>(?:[^\s;&|()`"']*[/\\])?(?:format|mkfs\.[a-z][a-z0-9]*))[ \t<>]+"#,
         description: "Formatting system drives",
         risk_level: RiskLevel::Critical,
         category: ThreatCategory::FileSystemDestruction,
@@ -475,7 +475,21 @@ fn format_option_value_flag(command: &str, flag: char) -> bool {
         ),
         "mkfs.f2fs" => matches!(
             flag,
-            'a' | 'c' | 'C' | 'd' | 'e' | 'E' | 'l' | 'o' | 'O' | 'R' | 's' | 't' | 'T' | 'w' | 'z'
+            'a' | 'c'
+                | 'C'
+                | 'd'
+                | 'e'
+                | 'E'
+                | 'g'
+                | 'l'
+                | 'o'
+                | 'O'
+                | 'R'
+                | 's'
+                | 't'
+                | 'T'
+                | 'w'
+                | 'z'
         ),
         "mkfs.xfs" => matches!(
             flag,
@@ -485,18 +499,15 @@ fn format_option_value_flag(command: &str, flag: char) -> bool {
     }
 }
 
-fn format_option_takes_next_value(command: &str, option: &str) -> bool {
-    let Some(short_options) = option
+fn format_option_next_value_flag(command: &str, option: &str) -> Option<char> {
+    let short_options = option
         .strip_prefix('-')
-        .filter(|options| !options.is_empty() && !options.starts_with('-'))
-    else {
-        return false;
-    };
+        .filter(|options| !options.is_empty() && !options.starts_with('-'))?;
 
     short_options
         .char_indices()
         .find(|(_, flag)| format_option_value_flag(command, *flag))
-        .is_some_and(|(index, flag)| index + flag.len_utf8() == short_options.len())
+        .and_then(|(index, flag)| (index + flag.len_utf8() == short_options.len()).then_some(flag))
 }
 
 fn is_non_writing_format_option(command: &str, option: &str) -> bool {
@@ -522,21 +533,25 @@ fn is_non_writing_format_option(command: &str, option: &str) -> bool {
         })
 }
 
-fn format_drive_target(words: &[ShellWord]) -> Option<&ShellWord> {
+fn format_drive_targets(words: &[ShellWord]) -> Vec<&ShellWord> {
     let command = words
-        .first()?
+        .first()
+        .expect("format command includes an executable")
         .value
         .rsplit(['/', '\\'])
-        .next()?
+        .next()
+        .expect("format command has a basename")
         .to_ascii_lowercase();
-    let mut target = None;
-    let mut skip_option_value = false;
+    let mut targets = Vec::new();
+    let mut pending_option_value = None;
     let mut options_ended = false;
     let mut non_writing = false;
 
     for word in &words[1..] {
-        if skip_option_value {
-            skip_option_value = false;
+        if let Some(option_flag) = pending_option_value.take() {
+            if command == "mkfs.f2fs" && option_flag == 'c' {
+                targets.push(word);
+            }
             continue;
         }
         if !options_ended && word.value == "--" {
@@ -545,24 +560,26 @@ fn format_drive_target(words: &[ShellWord]) -> Option<&ShellWord> {
         }
         if !options_ended && word.value.starts_with('-') {
             non_writing |= is_non_writing_format_option(&command, &word.value);
-            skip_option_value = format_option_takes_next_value(&command, &word.value);
+            pending_option_value = format_option_next_value_flag(&command, &word.value);
             continue;
         }
-        target.get_or_insert(word);
+        if targets.is_empty() || command == "mkfs.f2fs" {
+            targets.push(word);
+        }
     }
 
     if non_writing {
-        None
+        Vec::new()
     } else {
-        target
+        targets
     }
 }
 
-fn is_system_drive(word: &str) -> bool {
+fn contains_system_drive(word: &str) -> bool {
     static SYSTEM_DRIVE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(r"(?i)^[/\\]dev[/\\][sh]d[a-z](?:[0-9]+)?$").expect("valid system drive regex")
     });
-    SYSTEM_DRIVE.is_match(word)
+    word.split(',').any(|device| SYSTEM_DRIVE.is_match(device))
 }
 
 /// Pattern matcher for detecting security threats
@@ -591,12 +608,12 @@ impl PatternMatcher {
                             continue;
                         };
                         let words = shell_words_until_boundary(command_text);
-                        let Some(target) = format_drive_target(&words) else {
+                        let Some(target) = format_drive_targets(&words)
+                            .into_iter()
+                            .find(|target| contains_system_drive(&target.value))
+                        else {
                             continue;
                         };
-                        if !is_system_drive(&target.value) {
-                            continue;
-                        }
                         let end_pos = command_match.start() + target.end;
                         matches.push(PatternMatch {
                             threat: threat.clone(),
@@ -677,7 +694,11 @@ mod tests {
         assert!(matches(pat, "mkfs.ext4 /dev/sda"));
         assert!(matches(pat, "mkfs.f2fs /dev/sdc"));
         assert!(matches(pat, "mkfs.f2fs -l data /dev/sdc"));
+        assert!(matches(pat, "mkfs.f2fs -g android /dev/sdc"));
+        assert!(matches(pat, "mkfs.f2fs -c /dev/sdb /dev/loop0"));
+        assert!(matches(pat, "mkfs.f2fs -c /dev/sdb,/dev/loop0 /dev/loop1"));
         assert!(!matches(pat, "mkfs.f2fs -l /dev/sdc /tmp/image"));
+        assert!(!matches(pat, "mkfs.f2fs -c /tmp/image /dev/loop0"));
     }
 
     #[test]
@@ -694,6 +715,7 @@ mod tests {
         assert!(matches(pat, "mkfs.ext4 -F /dev/sda1"));
         assert!(matches(pat, "mkfs.ext4 -qL data /dev/sda1"));
         assert!(matches(pat, "mkfs.ext4 >/tmp/mkfs.log /dev/sda1"));
+        assert!(matches(pat, "mkfs.ext4>/tmp/mkfs.log -F /dev/sda1"));
         assert!(matches(pat, "mkfs.ext4 2>/tmp/mkfs.log /dev/sda1"));
         assert!(matches(pat, "mkfs.ext4 </dev/null /dev/sda1"));
         assert!(matches(pat, "mkfs.ext4 -F /dev/sda1 4096"));

--- a/crates/goose/src/security/patterns.rs
+++ b/crates/goose/src/security/patterns.rs
@@ -317,12 +317,16 @@ static COMPILED_PATTERNS: LazyLock<HashMap<&'static str, Regex>> = LazyLock::new
     patterns
 });
 
+fn trim_shell_delimiters(word: &str) -> &str {
+    word.trim_matches(|character: char| {
+        matches!(character, '\'' | '"' | '(' | ')' | '`' | ';' | '&' | '|')
+    })
+}
+
 fn is_non_writing_ext_format_match(matched_text: &str) -> bool {
     let mut words = matched_text.split_ascii_whitespace();
     let is_ext_command = words.any(|word| {
-        let word = word.trim_matches(|character: char| {
-            matches!(character, '\'' | '"' | '(' | ')' | '`' | ';' | '&' | '|')
-        });
+        let word = trim_shell_delimiters(word);
         let command = word
             .rsplit(|character| ['/', '\\'].contains(&character))
             .next()
@@ -331,21 +335,61 @@ fn is_non_writing_ext_format_match(matched_text: &str) -> bool {
         matches!(command.as_str(), "mkfs.ext2" | "mkfs.ext3" | "mkfs.ext4")
     });
 
-    is_ext_command
-        && words.any(|word| {
-            let flag = word.trim_matches(|character: char| {
-                matches!(character, '\'' | '"' | '(' | ')' | '`' | ';' | '&' | '|')
-            });
-            matches!(flag, "--help" | "--version")
-                || flag
-                    .strip_prefix('-')
-                    .filter(|short_flags| !short_flags.starts_with('-'))
-                    .is_some_and(|short_flags| {
-                        short_flags
-                            .chars()
-                            .any(|character| matches!(character, 'n' | 'V'))
-                    })
-        })
+    if !is_ext_command {
+        return false;
+    }
+
+    let mut skip_option_value = false;
+    words.any(|word| {
+        let flag = trim_shell_delimiters(word);
+        if skip_option_value {
+            skip_option_value = false;
+            return false;
+        }
+        if matches!(
+            flag,
+            "-b" | "-C"
+                | "-d"
+                | "-e"
+                | "-E"
+                | "-g"
+                | "-G"
+                | "-i"
+                | "-I"
+                | "-J"
+                | "-l"
+                | "-L"
+                | "-m"
+                | "-M"
+                | "-N"
+                | "-o"
+                | "-O"
+                | "-r"
+                | "-t"
+                | "-T"
+                | "-U"
+                | "-z"
+        ) {
+            skip_option_value = true;
+            return false;
+        }
+        if matches!(flag, "--help" | "--version") {
+            return true;
+        }
+
+        flag.strip_prefix('-')
+            .filter(|short_flags| !short_flags.is_empty() && !short_flags.starts_with('-'))
+            .is_some_and(|short_flags| {
+                short_flags.chars().all(|character| {
+                    matches!(
+                        character,
+                        'c' | 'D' | 'F' | 'j' | 'n' | 'q' | 'S' | 'v' | 'V'
+                    )
+                }) && short_flags
+                    .chars()
+                    .any(|character| matches!(character, 'n' | 'V'))
+            })
+    })
 }
 
 /// Pattern matcher for detecting security threats
@@ -476,6 +520,7 @@ mod tests {
         assert!(!matches(pat, "mkfs.ext4 -n /dev/sda1"));
         assert!(!matches(pat, "mkfs.ext4 -V /dev/sda1"));
         assert!(!matches(pat, "mkfs.ext4 -Fn /dev/sda1"));
+        assert!(matches(pat, "mkfs.ext4 -L -n /dev/sda1"));
         assert!(!matches(pat, "mkfs.ext4 --help\necho /dev/sda1"));
         assert!(!matches(pat, "echo $(mkfs.ext4 --help) /dev/sda"));
         assert!(!matches(pat, "stat --format '%n %s' /dev/sda"));

--- a/crates/goose/src/security/patterns.rs
+++ b/crates/goose/src/security/patterns.rs
@@ -69,7 +69,7 @@ pub const THREAT_PATTERNS: &[ThreatPattern] = &[
     },
     ThreatPattern {
         name: "format_drive",
-        pattern: r#"(?:^|\s|[;&|(`/\"'])(?:format\s+|mkfs\.[a-z][a-z0-9]*\s+[^;&|#\n]*?)[/\\]dev[/\\][sh]d[a-z](?:[0-9]+)?(?:\s|[;&|<>)`\"']|$)"#,
+        pattern: r#"(?:^|\s|[;&|(`/"'])(?:format\s+|mkfs\.[a-z][a-z0-9]*\s+(?:[^;&|#\n'"\\]|\\[^\n]|'[^'\n]*'|"(?:\\[^\n]|[^"\\\n])*")*?)[/\\]dev[/\\][sh]d[a-z](?:[0-9]+)?(?:\s|[;&|<>)`"']|$)"#,
         description: "Formatting system drives",
         risk_level: RiskLevel::Critical,
         category: ThreatCategory::FileSystemDestruction,
@@ -415,6 +415,10 @@ mod tests {
         assert!(matches(pat, "sh -c 'mkfs.ext4 /dev/sda1'"));
         assert!(matches(pat, "mkfs.ext4 -F /dev/sda1"));
         assert!(matches(pat, "mkfs.ext4 -q -L data /dev/sda1"));
+        assert!(matches(pat, "mkfs.ext4 -L 'x;y' /dev/sda1"));
+        assert!(matches(pat, "mkfs.ext4 -L \"x|y\" /dev/sda1"));
+        assert!(matches(pat, r"mkfs.ext4 -L x\;y /dev/sda1"));
+        assert!(matches(pat, "mkfs.ext4 -L '#data' /dev/sda1"));
         assert!(matches(pat, "/sbin/mkfs.ext4 -F /dev/sda1"));
         assert!(!matches(pat, "mkfs.ext4 /dev/sda-volume"));
         assert!(!matches(pat, "mkfs.ext4 /dev/sdaa"));

--- a/crates/goose/src/security/patterns.rs
+++ b/crates/goose/src/security/patterns.rs
@@ -69,7 +69,7 @@ pub const THREAT_PATTERNS: &[ThreatPattern] = &[
     },
     ThreatPattern {
         name: "format_drive",
-        pattern: r"(format|mkfs\.[a-z]+)\s+[/\\]dev[/\\][sh]d[a-z]",
+        pattern: r"(format|mkfs\.[a-z][a-z0-9]*)\s+[/\\]dev[/\\][sh]d[a-z]",
         description: "Formatting system drives",
         risk_level: RiskLevel::Critical,
         category: ThreatCategory::FileSystemDestruction,
@@ -391,6 +391,31 @@ mod tests {
             .scan_for_patterns(input)
             .iter()
             .any(|m| m.threat.name == pattern_name)
+    }
+
+    #[test]
+    fn format_drive_matches_digit_bearing_filesystem_types() {
+        let pat = "format_drive";
+        assert!(matches(pat, "mkfs.ext2 /dev/hda"));
+        assert!(matches(pat, "mkfs.ext3 /dev/sdb"));
+        assert!(matches(pat, "mkfs.ext4 /dev/sda"));
+        assert!(matches(pat, "mkfs.f2fs /dev/sdc"));
+    }
+
+    #[test]
+    fn format_drive_preserves_letter_only_types() {
+        let pat = "format_drive";
+        assert!(matches(pat, "mkfs.xfs /dev/sda"));
+        assert!(matches(pat, "MKFS.EXT4 /dev/sda"));
+    }
+
+    #[test]
+    fn format_drive_ignores_non_drive_targets_and_similar_tools() {
+        let pat = "format_drive";
+        assert!(!matches(pat, "mkfs.ext4 ./disk.img"));
+        assert!(!matches(pat, "mkfs.ext4 /tmp/disk.img"));
+        assert!(!matches(pat, "mkfs.ext4 /dev/null"));
+        assert!(!matches(pat, "mkfs.ext4-image /dev/sda"));
     }
 
     #[test]

--- a/crates/goose/src/security/patterns.rs
+++ b/crates/goose/src/security/patterns.rs
@@ -69,7 +69,7 @@ pub const THREAT_PATTERNS: &[ThreatPattern] = &[
     },
     ThreatPattern {
         name: "format_drive",
-        pattern: r#"(?:^|[\s;&|(`/"'])(?P<command>(?:[^\s;&|()`"']*[/\\])?(?:format|mkfs\.[a-z][a-z0-9]*))(?:[ \t<>]|\\\r?\n)+"#,
+        pattern: r#"(?:^|[\s;&|(`/"'])(?P<command>(?:[^\s;&|()`"']*[/\\])?(?:format|mkfs\.[a-z][a-z0-9]*))(?:[ \t<>'"]|&>>?|\\\r?\n)+"#,
         description: "Formatting system drives",
         risk_level: RiskLevel::Critical,
         category: ThreatCategory::FileSystemDestruction,
@@ -404,6 +404,26 @@ fn shell_words_until_boundary(text: &str) -> Vec<ShellWord> {
             continue;
         }
 
+        if character == '&' && characters.peek().is_some_and(|(_, next)| *next == '>') {
+            characters.next();
+            if characters.peek().is_some_and(|(_, next)| *next == '>') {
+                characters.next();
+            }
+            if start.take().is_some() {
+                if !discard_word {
+                    words.push(ShellWord {
+                        value: std::mem::take(&mut value),
+                        end: index,
+                    });
+                } else {
+                    value.clear();
+                }
+            }
+            discard_word = false;
+            awaiting_redirection_target = true;
+            continue;
+        }
+
         if awaiting_redirection_target && character == '&' {
             start = Some(index);
             discard_word = true;
@@ -542,7 +562,7 @@ fn is_non_writing_format_option(command: &str, option: &str) -> bool {
         .take_while(|flag| !format_option_value_flag(command, *flag))
         .any(|flag| match command {
             "mkfs.ext2" | "mkfs.ext3" | "mkfs.ext4" => matches!(flag, 'n' | 'V'),
-            "mkfs.f2fs" => flag == 'V',
+            "mkfs.f2fs" => matches!(flag, 'h' | 'V'),
             "mkfs.xfs" => matches!(flag, 'N' | 'V'),
             _ => false,
         })
@@ -654,7 +674,18 @@ impl PatternMatcher {
                         let Some(command_match) = captures.name("command") else {
                             continue;
                         };
-                        let Some(command_text) = text.get(command_match.start()..) else {
+                        let quoted_command =
+                            command_match
+                                .start()
+                                .checked_sub(1)
+                                .and_then(|quote_index| {
+                                    let quote = *text.as_bytes().get(quote_index)?;
+                                    (matches!(quote, b'\'' | b'"')
+                                        && text.as_bytes().get(command_match.end()) == Some(&quote))
+                                    .then_some(quote_index)
+                                });
+                        let command_start = quoted_command.unwrap_or(command_match.start());
+                        let Some(command_text) = text.get(command_start..) else {
                             continue;
                         };
                         let words = shell_words_until_boundary(command_text);
@@ -664,14 +695,14 @@ impl PatternMatcher {
                         else {
                             continue;
                         };
-                        let end_pos = command_match.start() + target.word.end;
+                        let end_pos = command_start + target.word.end;
                         matches.push(PatternMatch {
                             threat: threat.clone(),
                             matched_text: text
-                                .get(command_match.start()..end_pos)
+                                .get(command_start..end_pos)
                                 .unwrap_or_default()
                                 .to_string(),
-                            start_pos: command_match.start(),
+                            start_pos: command_start,
                             end_pos,
                         });
                     }
@@ -766,10 +797,17 @@ mod tests {
         assert!(matches(pat, "echo `mkfs.ext4 /dev/sda`"));
         assert!(matches(pat, "sh -c \"mkfs.ext4 /dev/sda1\""));
         assert!(matches(pat, "sh -c 'mkfs.ext4 /dev/sda1'"));
+        assert!(matches(pat, "'mkfs.ext4' -F /dev/sda1"));
+        assert!(matches(pat, "\"mkfs.ext4\" -F /dev/sda1"));
+        assert!(matches(pat, "sh -c \"'mkfs.ext4' -F /dev/sda1\""));
+        assert!(matches(pat, "'/sbin/mkfs.ext4' -F /dev/sda1"));
         assert!(matches(pat, "mkfs.ext4 -F /dev/sda1"));
         assert!(matches(pat, "mkfs.ext4 -qL data /dev/sda1"));
         assert!(matches(pat, "mkfs.ext4 >/tmp/mkfs.log /dev/sda1"));
         assert!(matches(pat, "mkfs.ext4>/tmp/mkfs.log -F /dev/sda1"));
+        assert!(matches(pat, "mkfs.ext4 &>/tmp/mkfs.log /dev/sda1"));
+        assert!(matches(pat, "mkfs.ext4&>/tmp/mkfs.log -F /dev/sda1"));
+        assert!(matches(pat, "mkfs.ext4 &>>/tmp/mkfs.log /dev/sda1"));
         assert!(matches(pat, "mkfs.ext4 \\\r\n /dev/sda1"));
         assert!(matches(pat, "mkfs.ext4 \\\n /dev/sda1"));
         assert!(matches(pat, "mkfs.ext4 2>/tmp/mkfs.log /dev/sda1"));
@@ -823,6 +861,7 @@ mod tests {
         assert!(matches(pat, "mkfs.xfs -L data /dev/sda"));
         assert!(!matches(pat, "mkfs.xfs -L /dev/sda /tmp/image"));
         assert!(!matches(pat, "mkfs.xfs -N /dev/sda"));
+        assert!(!matches(pat, "mkfs.f2fs -h /dev/sda"));
         assert!(!matches(pat, "mkfs.f2fs -V /dev/sda"));
         assert!(matches(pat, "MKFS.EXT4 /dev/sda"));
     }

--- a/crates/goose/src/security/patterns.rs
+++ b/crates/goose/src/security/patterns.rs
@@ -69,7 +69,7 @@ pub const THREAT_PATTERNS: &[ThreatPattern] = &[
     },
     ThreatPattern {
         name: "format_drive",
-        pattern: r"(format|mkfs\.[a-z][a-z0-9]*)\s+[/\\]dev[/\\][sh]d[a-z]([0-9]+)?(\s|[;&|<>)`]|$)",
+        pattern: r#"(format|mkfs\.[a-z][a-z0-9]*)\s+[/\\]dev[/\\][sh]d[a-z]([0-9]+)?(\s|[;&|<>)`'"]|$)"#,
         description: "Formatting system drives",
         risk_level: RiskLevel::Critical,
         category: ThreatCategory::FileSystemDestruction,
@@ -411,6 +411,8 @@ mod tests {
         assert!(matches(pat, "mkfs.ext4 /dev/sda</dev/null"));
         assert!(matches(pat, "echo $(mkfs.ext4 /dev/sda1)"));
         assert!(matches(pat, "echo `mkfs.ext4 /dev/sda`"));
+        assert!(matches(pat, "sh -c \"mkfs.ext4 /dev/sda1\""));
+        assert!(matches(pat, "sh -c 'mkfs.ext4 /dev/sda1'"));
         assert!(!matches(pat, "mkfs.ext4 /dev/sda-volume"));
         assert!(!matches(pat, "mkfs.ext4 /dev/sdaa"));
     }

--- a/crates/goose/src/security/patterns.rs
+++ b/crates/goose/src/security/patterns.rs
@@ -69,7 +69,7 @@ pub const THREAT_PATTERNS: &[ThreatPattern] = &[
     },
     ThreatPattern {
         name: "format_drive",
-        pattern: r"(format|mkfs\.[a-z][a-z0-9]*)\s+[/\\]dev[/\\][sh]d[a-z]",
+        pattern: r"(format|mkfs\.[a-z][a-z0-9]*)\s+[/\\]dev[/\\][sh]d[a-z]([0-9]+)?(\s|[;&|]|$)",
         description: "Formatting system drives",
         risk_level: RiskLevel::Critical,
         category: ThreatCategory::FileSystemDestruction,
@@ -400,6 +400,15 @@ mod tests {
         assert!(matches(pat, "mkfs.ext3 /dev/sdb"));
         assert!(matches(pat, "mkfs.ext4 /dev/sda"));
         assert!(matches(pat, "mkfs.f2fs /dev/sdc"));
+    }
+
+    #[test]
+    fn format_drive_matches_partitions_without_matching_device_prefixes() {
+        let pat = "format_drive";
+        assert!(matches(pat, "mkfs.ext4 /dev/sda1"));
+        assert!(matches(pat, "mkfs.ext4 /dev/hdb12 && reboot"));
+        assert!(!matches(pat, "mkfs.ext4 /dev/sda-volume"));
+        assert!(!matches(pat, "mkfs.ext4 /dev/sdaa"));
     }
 
     #[test]

--- a/crates/goose/src/security/patterns.rs
+++ b/crates/goose/src/security/patterns.rs
@@ -69,7 +69,7 @@ pub const THREAT_PATTERNS: &[ThreatPattern] = &[
     },
     ThreatPattern {
         name: "format_drive",
-        pattern: r#"(?:^|\s|[;&|(`/"'])(?:format\s+|mkfs\.[a-z][a-z0-9]*\s+(?:(?:[^;&|\s#'"\\]|\\[^\n])(?:[^;&|\s'"\\]|\\[^\n])*|'[^'\n]*'|"(?:\\[^\n]|[^"\\\n])*"|\s+)*?)(?:[/\\]dev[/\\][sh]d[a-z](?:[0-9]+)?(?:\s|[;&|<>)`"']|$)|'[/\\]dev[/\\][sh]d[a-z](?:[0-9]+)?'(?:\s|[;&|<>)`"']|$)|"[/\\]dev[/\\][sh]d[a-z](?:[0-9]+)?"(?:\s|[;&|<>)`"']|$))"#,
+        pattern: r#"(?:^|\s|[;&|(`/"'])(?:format[ \t]+|mkfs\.[a-z][a-z0-9]*[ \t]+(?:(?:[^;&|)`\s#'"\\]|\\[^\n])(?:[^;&|)`\s'"\\]|\\[^\n])*|'[^'\n]*'|"(?:\\[^\n]|[^"\\\n])*"|[ \t]+)*?)(?:[/\\]dev[/\\][sh]d[a-z](?:[0-9]+)?(?:\s|[;&|<>)`"']|$)|'[/\\]dev[/\\][sh]d[a-z](?:[0-9]+)?'(?:\s|[;&|<>)`"']|$)|"[/\\]dev[/\\][sh]d[a-z](?:[0-9]+)?"(?:\s|[;&|<>)`"']|$))"#,
         description: "Formatting system drives",
         risk_level: RiskLevel::Critical,
         category: ThreatCategory::FileSystemDestruction,
@@ -429,6 +429,8 @@ mod tests {
         assert!(!matches(pat, "mkfs.ext4 # /dev/sda1"));
         assert!(!matches(pat, "mkfs.ext4 -L data # /dev/sda1"));
         assert!(!matches(pat, "mkfs.ext4 -L '/dev/sda not-a-target'"));
+        assert!(!matches(pat, "mkfs.ext4 --help\necho /dev/sda1"));
+        assert!(!matches(pat, "echo $(mkfs.ext4 --help) /dev/sda"));
         assert!(!matches(pat, "stat --format '%n %s' /dev/sda"));
     }
 

--- a/crates/goose/src/security/patterns.rs
+++ b/crates/goose/src/security/patterns.rs
@@ -400,47 +400,76 @@ fn shell_words_until_boundary(text: &str) -> Vec<ShellWord> {
     words
 }
 
-fn ext_option_takes_value(option: &str) -> bool {
-    matches!(
-        option,
-        "-b" | "-C"
-            | "-d"
-            | "-e"
-            | "-E"
-            | "-g"
-            | "-G"
-            | "-i"
-            | "-I"
-            | "-J"
-            | "-l"
-            | "-L"
-            | "-m"
-            | "-M"
-            | "-N"
-            | "-o"
-            | "-O"
-            | "-r"
-            | "-t"
-            | "-T"
-            | "-U"
-            | "-z"
-    )
+fn format_option_takes_value(command: &str, option: &str) -> bool {
+    match command {
+        "mkfs.ext2" | "mkfs.ext3" | "mkfs.ext4" => matches!(
+            option,
+            "-b" | "-C"
+                | "-d"
+                | "-e"
+                | "-E"
+                | "-g"
+                | "-G"
+                | "-i"
+                | "-I"
+                | "-J"
+                | "-l"
+                | "-L"
+                | "-m"
+                | "-M"
+                | "-N"
+                | "-o"
+                | "-O"
+                | "-r"
+                | "-t"
+                | "-T"
+                | "-U"
+                | "-z"
+        ),
+        "mkfs.f2fs" => matches!(
+            option,
+            "-a" | "-c"
+                | "-C"
+                | "-d"
+                | "-e"
+                | "-E"
+                | "-l"
+                | "-o"
+                | "-O"
+                | "-R"
+                | "-s"
+                | "-t"
+                | "-T"
+                | "-w"
+                | "-z"
+        ),
+        "mkfs.xfs" => matches!(
+            option,
+            "-b" | "-c" | "-d" | "-i" | "-l" | "-L" | "-m" | "-n" | "-p" | "-r" | "-s"
+        ),
+        _ => false,
+    }
 }
 
-fn is_non_writing_ext_option(option: &str) -> bool {
+fn is_non_writing_format_option(command: &str, option: &str) -> bool {
     if matches!(option, "--help" | "--version") {
         return true;
     }
 
-    option
-        .strip_prefix('-')
-        .filter(|flags| !flags.is_empty() && !flags.starts_with('-'))
-        .is_some_and(|flags| {
-            flags
-                .chars()
-                .all(|flag| matches!(flag, 'c' | 'D' | 'F' | 'j' | 'n' | 'q' | 'S' | 'v' | 'V'))
-                && flags.chars().any(|flag| matches!(flag, 'n' | 'V'))
-        })
+    match command {
+        "mkfs.ext2" | "mkfs.ext3" | "mkfs.ext4" => option
+            .strip_prefix('-')
+            .filter(|flags| !flags.is_empty() && !flags.starts_with('-'))
+            .is_some_and(|flags| {
+                flags
+                    .chars()
+                    .all(|flag| matches!(flag, 'c' | 'D' | 'F' | 'j' | 'n' | 'q' | 'S' | 'v' | 'V'))
+                    && flags.chars().any(|flag| matches!(flag, 'n' | 'V'))
+            }),
+        "mkfs.f2fs" => option == "-V",
+        "mkfs.xfs" => matches!(option, "-N" | "-V"),
+        _ => false,
+    }
 }
 
 fn format_drive_target(words: &[ShellWord]) -> Option<&ShellWord> {
@@ -450,7 +479,6 @@ fn format_drive_target(words: &[ShellWord]) -> Option<&ShellWord> {
         .rsplit(['/', '\\'])
         .next()?
         .to_ascii_lowercase();
-    let is_ext = matches!(command.as_str(), "mkfs.ext2" | "mkfs.ext3" | "mkfs.ext4");
     let mut target = None;
     let mut skip_option_value = false;
     let mut options_ended = false;
@@ -466,10 +494,8 @@ fn format_drive_target(words: &[ShellWord]) -> Option<&ShellWord> {
             continue;
         }
         if !options_ended && word.value.starts_with('-') {
-            if is_ext {
-                non_writing |= is_non_writing_ext_option(&word.value);
-                skip_option_value = ext_option_takes_value(&word.value);
-            }
+            non_writing |= is_non_writing_format_option(&command, &word.value);
+            skip_option_value = format_option_takes_value(&command, &word.value);
             continue;
         }
         target.get_or_insert(word);
@@ -600,6 +626,8 @@ mod tests {
         assert!(matches(pat, "mkfs.ext3 /dev/sdb"));
         assert!(matches(pat, "mkfs.ext4 /dev/sda"));
         assert!(matches(pat, "mkfs.f2fs /dev/sdc"));
+        assert!(matches(pat, "mkfs.f2fs -l data /dev/sdc"));
+        assert!(!matches(pat, "mkfs.f2fs -l /dev/sdc /tmp/image"));
     }
 
     #[test]
@@ -652,6 +680,10 @@ mod tests {
     fn format_drive_preserves_letter_only_types() {
         let pat = "format_drive";
         assert!(matches(pat, "mkfs.xfs /dev/sda"));
+        assert!(matches(pat, "mkfs.xfs -L data /dev/sda"));
+        assert!(!matches(pat, "mkfs.xfs -L /dev/sda /tmp/image"));
+        assert!(!matches(pat, "mkfs.xfs -N /dev/sda"));
+        assert!(!matches(pat, "mkfs.f2fs -V /dev/sda"));
         assert!(matches(pat, "MKFS.EXT4 /dev/sda"));
     }
 

--- a/crates/goose/src/security/patterns.rs
+++ b/crates/goose/src/security/patterns.rs
@@ -330,9 +330,48 @@ fn shell_words_until_boundary(text: &str) -> Vec<ShellWord> {
     let mut quote = None;
     let mut discard_word = false;
     let mut awaiting_redirection_target = false;
+    let mut substitution_depth = 0;
+    let mut substitution_quote = None;
+    let mut backtick_substitution = false;
     let mut characters = text.char_indices().peekable();
 
     while let Some((index, character)) = characters.next() {
+        if substitution_depth > 0 {
+            value.push(character);
+            if let Some(active_quote) = substitution_quote {
+                if character == active_quote {
+                    substitution_quote = None;
+                } else if character == '\\' && active_quote == '"' {
+                    if let Some((_, escaped)) = characters.next() {
+                        value.push(escaped);
+                    }
+                }
+            } else if character == '\\' {
+                if let Some((_, escaped)) = characters.next() {
+                    value.push(escaped);
+                }
+            } else if matches!(character, '\'' | '"') {
+                substitution_quote = Some(character);
+            } else if character == '(' {
+                substitution_depth += 1;
+            } else if character == ')' {
+                substitution_depth -= 1;
+            }
+            continue;
+        }
+
+        if backtick_substitution {
+            value.push(character);
+            if character == '\\' {
+                if let Some((_, escaped)) = characters.next() {
+                    value.push(escaped);
+                }
+            } else if character == '`' {
+                backtick_substitution = false;
+            }
+            continue;
+        }
+
         if let Some(active_quote) = quote {
             if character == active_quote {
                 quote = None;
@@ -347,6 +386,35 @@ fn shell_words_until_boundary(text: &str) -> Vec<ShellWord> {
             } else {
                 value.push(character);
             }
+            continue;
+        }
+
+        if character == '$' && characters.peek().is_some_and(|(_, next)| *next == '(') {
+            if start.is_none() {
+                start = Some(index);
+                discard_word = awaiting_redirection_target;
+                awaiting_redirection_target = false;
+            }
+            value.push(character);
+            if let Some((_, open_parenthesis)) = characters.next() {
+                value.push(open_parenthesis);
+            }
+            substitution_depth = 1;
+            continue;
+        }
+
+        if character == '`'
+            && text
+                .get(index + character.len_utf8()..)
+                .is_some_and(|remainder| remainder.contains('`'))
+        {
+            if start.is_none() {
+                start = Some(index);
+                discard_word = awaiting_redirection_target;
+                awaiting_redirection_target = false;
+            }
+            value.push(character);
+            backtick_substitution = true;
             continue;
         }
 
@@ -568,10 +636,27 @@ fn is_non_writing_format_option(command: &str, option: &str) -> bool {
         })
 }
 
+#[derive(Clone, Copy)]
+enum FormatDriveTargetKind {
+    Operand,
+    F2fsDeviceList,
+    XfsLogSuboptions,
+    XfsRealtimeSuboptions,
+}
+
 struct FormatDriveTarget<'a> {
     word: &'a ShellWord,
     value: &'a str,
-    allows_f2fs_alias: bool,
+    kind: FormatDriveTargetKind,
+}
+
+fn format_option_target_kind(command: &str, flag: char) -> Option<FormatDriveTargetKind> {
+    match (command, flag) {
+        ("mkfs.f2fs", 'c') => Some(FormatDriveTargetKind::F2fsDeviceList),
+        ("mkfs.xfs", 'l') => Some(FormatDriveTargetKind::XfsLogSuboptions),
+        ("mkfs.xfs", 'r') => Some(FormatDriveTargetKind::XfsRealtimeSuboptions),
+        _ => None,
+    }
 }
 
 fn format_drive_targets(words: &[ShellWord]) -> Vec<FormatDriveTarget<'_>> {
@@ -590,11 +675,11 @@ fn format_drive_targets(words: &[ShellWord]) -> Vec<FormatDriveTarget<'_>> {
 
     for word in &words[1..] {
         if let Some(option_flag) = pending_option_value.take() {
-            if command == "mkfs.f2fs" && option_flag == 'c' {
+            if let Some(kind) = format_option_target_kind(&command, option_flag) {
                 targets.push(FormatDriveTarget {
                     word,
                     value: &word.value,
-                    allows_f2fs_alias: true,
+                    kind,
                 });
             }
             continue;
@@ -607,14 +692,11 @@ fn format_drive_targets(words: &[ShellWord]) -> Vec<FormatDriveTarget<'_>> {
             non_writing |= is_non_writing_format_option(&command, &word.value);
             if let Some((option_flag, attached_value)) = format_option_value(&command, &word.value)
             {
-                if command == "mkfs.f2fs" && option_flag == 'c' {
-                    if let Some(value) = attached_value {
-                        targets.push(FormatDriveTarget {
-                            word,
-                            value,
-                            allows_f2fs_alias: true,
-                        });
-                    }
+                if let (Some(kind), Some(value)) = (
+                    format_option_target_kind(&command, option_flag),
+                    attached_value,
+                ) {
+                    targets.push(FormatDriveTarget { word, value, kind });
                 }
                 if attached_value.is_none() {
                     pending_option_value = Some(option_flag);
@@ -626,7 +708,7 @@ fn format_drive_targets(words: &[ShellWord]) -> Vec<FormatDriveTarget<'_>> {
             targets.push(FormatDriveTarget {
                 word,
                 value: &word.value,
-                allows_f2fs_alias: false,
+                kind: FormatDriveTargetKind::Operand,
             });
         }
     }
@@ -642,13 +724,26 @@ fn contains_system_drive(target: &FormatDriveTarget<'_>) -> bool {
     static SYSTEM_DRIVE: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(r"(?i)^[/\\]dev[/\\][sh]d[a-z](?:[0-9]+)?$").expect("valid system drive regex")
     });
-    target.value.split(',').any(|device| {
-        let device = if target.allows_f2fs_alias {
-            device.split_once('@').map_or(device, |(name, _)| name)
-        } else {
-            device
-        };
-        SYSTEM_DRIVE.is_match(device)
+    match target.kind {
+        FormatDriveTargetKind::Operand => SYSTEM_DRIVE.is_match(target.value),
+        FormatDriveTargetKind::F2fsDeviceList => target.value.split(',').any(|device| {
+            let device = device.split_once('@').map_or(device, |(name, _)| name);
+            SYSTEM_DRIVE.is_match(device)
+        }),
+        FormatDriveTargetKind::XfsLogSuboptions => {
+            contains_xfs_device_suboption(target.value, "logdev", &SYSTEM_DRIVE)
+        }
+        FormatDriveTargetKind::XfsRealtimeSuboptions => {
+            contains_xfs_device_suboption(target.value, "rtdev", &SYSTEM_DRIVE)
+        }
+    }
+}
+
+fn contains_xfs_device_suboption(value: &str, name: &str, system_drive: &Regex) -> bool {
+    value.split(',').any(|suboption| {
+        suboption
+            .split_once('=')
+            .is_some_and(|(key, device)| key == name && system_drive.is_match(device))
     })
 }
 
@@ -823,6 +918,10 @@ mod tests {
         assert!(matches(pat, r"mkfs.ext4 -L x\;y /dev/sda1"));
         assert!(matches(pat, "mkfs.ext4 -L '#data' /dev/sda1"));
         assert!(matches(pat, "mkfs.ext4 -L data#1 /dev/sda1"));
+        assert!(matches(pat, "mkfs.ext4 -L $(hostname) /dev/sda1"));
+        assert!(matches(pat, "mkfs.ext4 -L $(printf '%s' data) /dev/sda1"));
+        assert!(matches(pat, "mkfs.ext4 -L $((1 + 2)) /dev/sda1"));
+        assert!(matches(pat, "mkfs.ext4 -L `hostname` /dev/sda1"));
         assert!(matches(pat, "mkfs.ext4 -F '/dev/sda1'"));
         assert!(matches(pat, "mkfs.ext4 \"/dev/sda\""));
         assert!(matches(pat, "/sbin/mkfs.ext4 -F /dev/sda1"));
@@ -859,7 +958,16 @@ mod tests {
         let pat = "format_drive";
         assert!(matches(pat, "mkfs.xfs /dev/sda"));
         assert!(matches(pat, "mkfs.xfs -L data /dev/sda"));
+        assert!(matches(
+            pat,
+            "mkfs.xfs -l logdev=/dev/sdb1,size=32m /dev/loop0"
+        ));
+        assert!(matches(pat, "mkfs.xfs -llogdev=/dev/sdb1 /dev/loop0"));
+        assert!(matches(pat, "mkfs.xfs -r rtdev=/dev/sdc /dev/loop0"));
+        assert!(matches(pat, "mkfs.xfs -rrtdev=/dev/sdc /dev/loop0"));
         assert!(!matches(pat, "mkfs.xfs -L /dev/sda /tmp/image"));
+        assert!(!matches(pat, "mkfs.xfs -l rtdev=/dev/sdb1 /dev/loop0"));
+        assert!(!matches(pat, "mkfs.xfs -L logdev=/dev/sda /tmp/image"));
         assert!(!matches(pat, "mkfs.xfs -N /dev/sda"));
         assert!(!matches(pat, "mkfs.f2fs -h /dev/sda"));
         assert!(!matches(pat, "mkfs.f2fs -V /dev/sda"));

--- a/crates/goose/src/security/patterns.rs
+++ b/crates/goose/src/security/patterns.rs
@@ -69,7 +69,7 @@ pub const THREAT_PATTERNS: &[ThreatPattern] = &[
     },
     ThreatPattern {
         name: "format_drive",
-        pattern: r#"(format|mkfs\.[a-z][a-z0-9]*)\s+[/\\]dev[/\\][sh]d[a-z]([0-9]+)?(\s|[;&|<>)`'"]|$)"#,
+        pattern: r#"(format|mkfs\.[a-z][a-z0-9]*)\s+[^;&|\n]*?[/\\]dev[/\\][sh]d[a-z]([0-9]+)?(\s|[;&|<>)`'"]|$)"#,
         description: "Formatting system drives",
         risk_level: RiskLevel::Critical,
         category: ThreatCategory::FileSystemDestruction,
@@ -413,8 +413,11 @@ mod tests {
         assert!(matches(pat, "echo `mkfs.ext4 /dev/sda`"));
         assert!(matches(pat, "sh -c \"mkfs.ext4 /dev/sda1\""));
         assert!(matches(pat, "sh -c 'mkfs.ext4 /dev/sda1'"));
+        assert!(matches(pat, "mkfs.ext4 -F /dev/sda1"));
+        assert!(matches(pat, "mkfs.ext4 -q -L data /dev/sda1"));
         assert!(!matches(pat, "mkfs.ext4 /dev/sda-volume"));
         assert!(!matches(pat, "mkfs.ext4 /dev/sdaa"));
+        assert!(!matches(pat, "mkfs.ext4 --help; echo /dev/sda1"));
     }
 
     #[test]

--- a/crates/goose/src/security/patterns.rs
+++ b/crates/goose/src/security/patterns.rs
@@ -493,9 +493,10 @@ fn format_option_takes_next_value(command: &str, option: &str) -> bool {
         return false;
     };
 
-    short_options.char_indices().any(|(index, flag)| {
-        format_option_value_flag(command, flag) && index + flag.len_utf8() == short_options.len()
-    })
+    short_options
+        .char_indices()
+        .find(|(_, flag)| format_option_value_flag(command, *flag))
+        .is_some_and(|(index, flag)| index + flag.len_utf8() == short_options.len())
 }
 
 fn is_non_writing_format_option(command: &str, option: &str) -> bool {
@@ -503,20 +504,22 @@ fn is_non_writing_format_option(command: &str, option: &str) -> bool {
         return true;
     }
 
-    match command {
-        "mkfs.ext2" | "mkfs.ext3" | "mkfs.ext4" => option
-            .strip_prefix('-')
-            .filter(|flags| !flags.is_empty() && !flags.starts_with('-'))
-            .is_some_and(|flags| {
-                flags
-                    .chars()
-                    .all(|flag| matches!(flag, 'c' | 'D' | 'F' | 'j' | 'n' | 'q' | 'S' | 'v' | 'V'))
-                    && flags.chars().any(|flag| matches!(flag, 'n' | 'V'))
-            }),
-        "mkfs.f2fs" => option == "-V",
-        "mkfs.xfs" => matches!(option, "-N" | "-V"),
-        _ => false,
-    }
+    let Some(short_options) = option
+        .strip_prefix('-')
+        .filter(|options| !options.is_empty() && !options.starts_with('-'))
+    else {
+        return false;
+    };
+
+    short_options
+        .chars()
+        .take_while(|flag| !format_option_value_flag(command, *flag))
+        .any(|flag| match command {
+            "mkfs.ext2" | "mkfs.ext3" | "mkfs.ext4" => matches!(flag, 'n' | 'V'),
+            "mkfs.f2fs" => flag == 'V',
+            "mkfs.xfs" => matches!(flag, 'N' | 'V'),
+            _ => false,
+        })
 }
 
 fn format_drive_target(words: &[ShellWord]) -> Option<&ShellWord> {
@@ -719,7 +722,10 @@ mod tests {
         assert!(!matches(pat, "mkfs.ext4 -n /dev/sda1"));
         assert!(!matches(pat, "mkfs.ext4 -V /dev/sda1"));
         assert!(!matches(pat, "mkfs.ext4 -Fn /dev/sda1"));
+        assert!(!matches(pat, "mkfs.ext4 -nL data /dev/sda1"));
         assert!(matches(pat, "mkfs.ext4 -L -n /dev/sda1"));
+        assert!(matches(pat, "mkfs.ext4 -L-n /dev/sda1"));
+        assert!(matches(pat, "mkfs.ext4 -LxN /dev/sda1"));
         assert!(matches(pat, r"mkfs.ext4 -L foo\ -n /dev/sda1"));
         assert!(!matches(pat, "mkfs.ext4 /tmp/image -L /dev/sda"));
         assert!(!matches(pat, "mkfs.ext4 >/dev/sda1 /tmp/image"));

--- a/crates/goose/src/security/patterns.rs
+++ b/crates/goose/src/security/patterns.rs
@@ -317,6 +317,37 @@ static COMPILED_PATTERNS: LazyLock<HashMap<&'static str, Regex>> = LazyLock::new
     patterns
 });
 
+fn is_non_writing_ext_format_match(matched_text: &str) -> bool {
+    let mut words = matched_text.split_ascii_whitespace();
+    let is_ext_command = words.any(|word| {
+        let word = word.trim_matches(|character: char| {
+            matches!(character, '\'' | '"' | '(' | ')' | '`' | ';' | '&' | '|')
+        });
+        let command = word
+            .rsplit(|character| ['/', '\\'].contains(&character))
+            .next()
+            .unwrap_or(word)
+            .to_ascii_lowercase();
+        matches!(command.as_str(), "mkfs.ext2" | "mkfs.ext3" | "mkfs.ext4")
+    });
+
+    is_ext_command
+        && words.any(|word| {
+            let flag = word.trim_matches(|character: char| {
+                matches!(character, '\'' | '"' | '(' | ')' | '`' | ';' | '&' | '|')
+            });
+            matches!(flag, "--help" | "--version")
+                || flag
+                    .strip_prefix('-')
+                    .filter(|short_flags| !short_flags.starts_with('-'))
+                    .is_some_and(|short_flags| {
+                        short_flags
+                            .chars()
+                            .any(|character| matches!(character, 'n' | 'V'))
+                    })
+        })
+}
+
 /// Pattern matcher for detecting security threats
 pub struct PatternMatcher {
     patterns: &'static HashMap<&'static str, Regex>,
@@ -337,6 +368,11 @@ impl PatternMatcher {
                 if regex.is_match(text) {
                     // Find all matches to get position information
                     for regex_match in regex.find_iter(text) {
+                        if threat.name == "format_drive"
+                            && is_non_writing_ext_format_match(regex_match.as_str())
+                        {
+                            continue;
+                        }
                         matches.push(PatternMatch {
                             threat: threat.clone(),
                             matched_text: regex_match.as_str().to_string(),
@@ -437,6 +473,9 @@ mod tests {
         assert!(!matches(pat, "mkfs.ext4 -F -L /dev/sda /tmp/image"));
         assert!(!matches(pat, "mkfs.ext4 -F -L '/dev/sda' /tmp/image"));
         assert!(!matches(pat, "mkfs.ext4 -F -L \"/dev/sda\" /tmp/image"));
+        assert!(!matches(pat, "mkfs.ext4 -n /dev/sda1"));
+        assert!(!matches(pat, "mkfs.ext4 -V /dev/sda1"));
+        assert!(!matches(pat, "mkfs.ext4 -Fn /dev/sda1"));
         assert!(!matches(pat, "mkfs.ext4 --help\necho /dev/sda1"));
         assert!(!matches(pat, "echo $(mkfs.ext4 --help) /dev/sda"));
         assert!(!matches(pat, "stat --format '%n %s' /dev/sda"));

--- a/crates/goose/src/security/patterns.rs
+++ b/crates/goose/src/security/patterns.rs
@@ -69,7 +69,7 @@ pub const THREAT_PATTERNS: &[ThreatPattern] = &[
     },
     ThreatPattern {
         name: "format_drive",
-        pattern: r#"(?:^|\s|[;&|(`/"'])(?:format[ \t]+|mkfs\.[a-z][a-z0-9]*[ \t]+(?:(?:[^;&|)`\s#'"\\]|\\[^\n])(?:[^;&|)`\s'"\\]|\\[^\n])*|'[^'\n]*'|"(?:\\[^\n]|[^"\\\n])*"|[ \t]+)*?)(?:[/\\]dev[/\\][sh]d[a-z](?:[0-9]+)?(?:[ \t]+[0-9]+)?[ \t]*(?:\n|[;&|<>)`"'#]|$)|'[/\\]dev[/\\][sh]d[a-z](?:[0-9]+)?'(?:[ \t]+[0-9]+)?[ \t]*(?:\n|[;&|<>)`"'#]|$)|"[/\\]dev[/\\][sh]d[a-z](?:[0-9]+)?"(?:[ \t]+[0-9]+)?[ \t]*(?:\n|[;&|<>)`"'#]|$))"#,
+        pattern: r#"(?:^|\s|[;&|(`/"'])(?:format[ \t]+|mkfs\.[a-z][a-z0-9]*[ \t]+(?:(?:[^;&|)`\s#'"\\]|\\[^\n])(?:[^;&|)`\s'"\\]|\\[^\n])*|'[^'\n]*'|"(?:\\[^\n]|[^"\\\n])*"|[ \t]+)*?)(?:[/\\]dev[/\\][sh]d[a-z](?:[0-9]+)?(?:[ \t]+(?:[0-9]+|-[^ \t\n;&|<>)`"'#]+))*[ \t]*(?:\n|[;&|<>)`"'#]|$)|'[/\\]dev[/\\][sh]d[a-z](?:[0-9]+)?'(?:[ \t]+(?:[0-9]+|-[^ \t\n;&|<>)`"'#]+))*[ \t]*(?:\n|[;&|<>)`"'#]|$)|"[/\\]dev[/\\][sh]d[a-z](?:[0-9]+)?"(?:[ \t]+(?:[0-9]+|-[^ \t\n;&|<>)`"'#]+))*[ \t]*(?:\n|[;&|<>)`"'#]|$))"#,
         description: "Formatting system drives",
         risk_level: RiskLevel::Critical,
         category: ThreatCategory::FileSystemDestruction,
@@ -415,6 +415,8 @@ mod tests {
         assert!(matches(pat, "sh -c 'mkfs.ext4 /dev/sda1'"));
         assert!(matches(pat, "mkfs.ext4 -F /dev/sda1"));
         assert!(matches(pat, "mkfs.ext4 -F /dev/sda1 4096"));
+        assert!(matches(pat, "mkfs.ext4 /dev/sda1 -F"));
+        assert!(matches(pat, "mkfs.ext4 /dev/sda1 -F -q"));
         assert!(matches(pat, "mkfs.ext4 -q -L data /dev/sda1"));
         assert!(matches(pat, "mkfs.ext4 -L 'x;y' /dev/sda1"));
         assert!(matches(pat, "mkfs.ext4 -L \"x|y\" /dev/sda1"));

--- a/crates/goose/src/security/patterns.rs
+++ b/crates/goose/src/security/patterns.rs
@@ -69,7 +69,7 @@ pub const THREAT_PATTERNS: &[ThreatPattern] = &[
     },
     ThreatPattern {
         name: "format_drive",
-        pattern: r#"(?:^|\s|[;&|(`/"'])(?:format\s+|mkfs\.[a-z][a-z0-9]*\s+(?:[^;&|#\n'"\\]|\\[^\n]|'[^'\n]*'|"(?:\\[^\n]|[^"\\\n])*")*?)[/\\]dev[/\\][sh]d[a-z](?:[0-9]+)?(?:\s|[;&|<>)`"']|$)"#,
+        pattern: r#"(?:^|\s|[;&|(`/"'])(?:format\s+|mkfs\.[a-z][a-z0-9]*\s+(?:(?:[^;&|\s#'"\\]|\\[^\n])(?:[^;&|\s'"\\]|\\[^\n])*|'[^'\n]*'|"(?:\\[^\n]|[^"\\\n])*"|\s+)*?)(?:[/\\]dev[/\\][sh]d[a-z](?:[0-9]+)?(?:\s|[;&|<>)`"']|$)|'[/\\]dev[/\\][sh]d[a-z](?:[0-9]+)?'(?:\s|[;&|<>)`"']|$)|"[/\\]dev[/\\][sh]d[a-z](?:[0-9]+)?"(?:\s|[;&|<>)`"']|$))"#,
         description: "Formatting system drives",
         risk_level: RiskLevel::Critical,
         category: ThreatCategory::FileSystemDestruction,
@@ -419,11 +419,16 @@ mod tests {
         assert!(matches(pat, "mkfs.ext4 -L \"x|y\" /dev/sda1"));
         assert!(matches(pat, r"mkfs.ext4 -L x\;y /dev/sda1"));
         assert!(matches(pat, "mkfs.ext4 -L '#data' /dev/sda1"));
+        assert!(matches(pat, "mkfs.ext4 -L data#1 /dev/sda1"));
+        assert!(matches(pat, "mkfs.ext4 -F '/dev/sda1'"));
+        assert!(matches(pat, "mkfs.ext4 \"/dev/sda\""));
         assert!(matches(pat, "/sbin/mkfs.ext4 -F /dev/sda1"));
         assert!(!matches(pat, "mkfs.ext4 /dev/sda-volume"));
         assert!(!matches(pat, "mkfs.ext4 /dev/sdaa"));
         assert!(!matches(pat, "mkfs.ext4 --help; echo /dev/sda1"));
         assert!(!matches(pat, "mkfs.ext4 # /dev/sda1"));
+        assert!(!matches(pat, "mkfs.ext4 -L data # /dev/sda1"));
+        assert!(!matches(pat, "mkfs.ext4 -L '/dev/sda not-a-target'"));
         assert!(!matches(pat, "stat --format '%n %s' /dev/sda"));
     }
 

--- a/crates/goose/src/security/patterns.rs
+++ b/crates/goose/src/security/patterns.rs
@@ -69,7 +69,7 @@ pub const THREAT_PATTERNS: &[ThreatPattern] = &[
     },
     ThreatPattern {
         name: "format_drive",
-        pattern: r#"(?:^|\s|[;&|(`/"'])(?:format[ \t]+|mkfs\.[a-z][a-z0-9]*[ \t]+(?:(?:[^;&|)`\s#'"\\]|\\[^\n])(?:[^;&|)`\s'"\\]|\\[^\n])*|'[^'\n]*'|"(?:\\[^\n]|[^"\\\n])*"|[ \t]+)*?)(?:[/\\]dev[/\\][sh]d[a-z](?:[0-9]+)?(?:(?:[ \t]+[0-9]+)|(?:[ \t]+-[^ \t\n;&|<>)`"'#]+(?:[ \t]+(?:(?:[^;&|)`\s#'"\\]|\\[^\n])(?:[^;&|)`\s'"\\]|\\[^\n])*|'[^'\n]*'|"(?:\\[^\n]|[^"\\\n])*"))?))*[ \t]*(?:\n|[;&|<>)`"'#]|$)|'[/\\]dev[/\\][sh]d[a-z](?:[0-9]+)?'(?:(?:[ \t]+[0-9]+)|(?:[ \t]+-[^ \t\n;&|<>)`"'#]+(?:[ \t]+(?:(?:[^;&|)`\s#'"\\]|\\[^\n])(?:[^;&|)`\s'"\\]|\\[^\n])*|'[^'\n]*'|"(?:\\[^\n]|[^"\\\n])*"))?))*[ \t]*(?:\n|[;&|<>)`"'#]|$)|"[/\\]dev[/\\][sh]d[a-z](?:[0-9]+)?"(?:(?:[ \t]+[0-9]+)|(?:[ \t]+-[^ \t\n;&|<>)`"'#]+(?:[ \t]+(?:(?:[^;&|)`\s#'"\\]|\\[^\n])(?:[^;&|)`\s'"\\]|\\[^\n])*|'[^'\n]*'|"(?:\\[^\n]|[^"\\\n])*"))?))*[ \t]*(?:\n|[;&|<>)`"'#]|$))"#,
+        pattern: r#"(?:^|[\s;&|(`/"'])(?P<command>(?:[^\s;&|()`"']*[/\\])?(?:format|mkfs\.[a-z][a-z0-9]*))[ \t]+"#,
         description: "Formatting system drives",
         risk_level: RiskLevel::Critical,
         category: ThreatCategory::FileSystemDestruction,
@@ -317,79 +317,176 @@ static COMPILED_PATTERNS: LazyLock<HashMap<&'static str, Regex>> = LazyLock::new
     patterns
 });
 
-fn trim_shell_delimiters(word: &str) -> &str {
-    word.trim_matches(|character: char| {
-        matches!(character, '\'' | '"' | '(' | ')' | '`' | ';' | '&' | '|')
-    })
+#[derive(Debug)]
+struct ShellWord {
+    value: String,
+    end: usize,
 }
 
-fn is_non_writing_ext_format_match(matched_text: &str) -> bool {
-    let mut words = matched_text.split_ascii_whitespace();
-    let is_ext_command = words.any(|word| {
-        let word = trim_shell_delimiters(word);
-        let command = word
-            .rsplit(|character| ['/', '\\'].contains(&character))
-            .next()
-            .unwrap_or(word)
-            .to_ascii_lowercase();
-        matches!(command.as_str(), "mkfs.ext2" | "mkfs.ext3" | "mkfs.ext4")
-    });
+fn shell_words_until_boundary(text: &str) -> Vec<ShellWord> {
+    let mut words = Vec::new();
+    let mut value = String::new();
+    let mut start = None;
+    let mut quote = None;
+    let mut characters = text.char_indices().peekable();
 
-    if !is_ext_command {
-        return false;
+    while let Some((index, character)) = characters.next() {
+        if let Some(active_quote) = quote {
+            if character == active_quote {
+                quote = None;
+            } else if character == '\\' && active_quote == '"' {
+                if let Some((_, escaped)) = characters.next() {
+                    value.push(escaped);
+                }
+            } else {
+                value.push(character);
+            }
+            continue;
+        }
+
+        if character == '\\' {
+            start.get_or_insert(index);
+            if let Some((_, escaped)) = characters.next() {
+                value.push(escaped);
+            }
+            continue;
+        }
+
+        if matches!(character, '\'' | '"') {
+            let remainder = text.get(index + character.len_utf8()..).unwrap_or_default();
+            if start.is_some() && !remainder.contains(character) {
+                break;
+            }
+            start.get_or_insert(index);
+            quote = Some(character);
+            continue;
+        }
+
+        if character == '\n' || matches!(character, ';' | '&' | '|' | '<' | '>' | ')' | '`') {
+            if start.take().is_some() {
+                words.push(ShellWord {
+                    value: std::mem::take(&mut value),
+                    end: index,
+                });
+            }
+            break;
+        }
+
+        if character == '#' && start.is_none() {
+            break;
+        }
+
+        if character.is_ascii_whitespace() {
+            if start.take().is_some() {
+                words.push(ShellWord {
+                    value: std::mem::take(&mut value),
+                    end: index,
+                });
+            }
+            continue;
+        }
+
+        start.get_or_insert(index);
+        value.push(character);
     }
 
+    if start.is_some() {
+        words.push(ShellWord {
+            value,
+            end: text.len(),
+        });
+    }
+
+    words
+}
+
+fn ext_option_takes_value(option: &str) -> bool {
+    matches!(
+        option,
+        "-b" | "-C"
+            | "-d"
+            | "-e"
+            | "-E"
+            | "-g"
+            | "-G"
+            | "-i"
+            | "-I"
+            | "-J"
+            | "-l"
+            | "-L"
+            | "-m"
+            | "-M"
+            | "-N"
+            | "-o"
+            | "-O"
+            | "-r"
+            | "-t"
+            | "-T"
+            | "-U"
+            | "-z"
+    )
+}
+
+fn is_non_writing_ext_option(option: &str) -> bool {
+    if matches!(option, "--help" | "--version") {
+        return true;
+    }
+
+    option
+        .strip_prefix('-')
+        .filter(|flags| !flags.is_empty() && !flags.starts_with('-'))
+        .is_some_and(|flags| {
+            flags
+                .chars()
+                .all(|flag| matches!(flag, 'c' | 'D' | 'F' | 'j' | 'n' | 'q' | 'S' | 'v' | 'V'))
+                && flags.chars().any(|flag| matches!(flag, 'n' | 'V'))
+        })
+}
+
+fn format_drive_target(words: &[ShellWord]) -> Option<&ShellWord> {
+    let command = words
+        .first()?
+        .value
+        .rsplit(['/', '\\'])
+        .next()?
+        .to_ascii_lowercase();
+    let is_ext = matches!(command.as_str(), "mkfs.ext2" | "mkfs.ext3" | "mkfs.ext4");
+    let mut target = None;
     let mut skip_option_value = false;
-    words.any(|word| {
-        let flag = trim_shell_delimiters(word);
+    let mut options_ended = false;
+    let mut non_writing = false;
+
+    for word in &words[1..] {
         if skip_option_value {
             skip_option_value = false;
-            return false;
+            continue;
         }
-        if matches!(
-            flag,
-            "-b" | "-C"
-                | "-d"
-                | "-e"
-                | "-E"
-                | "-g"
-                | "-G"
-                | "-i"
-                | "-I"
-                | "-J"
-                | "-l"
-                | "-L"
-                | "-m"
-                | "-M"
-                | "-N"
-                | "-o"
-                | "-O"
-                | "-r"
-                | "-t"
-                | "-T"
-                | "-U"
-                | "-z"
-        ) {
-            skip_option_value = true;
-            return false;
+        if !options_ended && word.value == "--" {
+            options_ended = true;
+            continue;
         }
-        if matches!(flag, "--help" | "--version") {
-            return true;
+        if !options_ended && word.value.starts_with('-') {
+            if is_ext {
+                non_writing |= is_non_writing_ext_option(&word.value);
+                skip_option_value = ext_option_takes_value(&word.value);
+            }
+            continue;
         }
+        target.get_or_insert(word);
+    }
 
-        flag.strip_prefix('-')
-            .filter(|short_flags| !short_flags.is_empty() && !short_flags.starts_with('-'))
-            .is_some_and(|short_flags| {
-                short_flags.chars().all(|character| {
-                    matches!(
-                        character,
-                        'c' | 'D' | 'F' | 'j' | 'n' | 'q' | 'S' | 'v' | 'V'
-                    )
-                }) && short_flags
-                    .chars()
-                    .any(|character| matches!(character, 'n' | 'V'))
-            })
-    })
+    if non_writing {
+        None
+    } else {
+        target
+    }
+}
+
+fn is_system_drive(word: &str) -> bool {
+    static SYSTEM_DRIVE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"(?i)^[/\\]dev[/\\][sh]d[a-z](?:[0-9]+)?$").expect("valid system drive regex")
+    });
+    SYSTEM_DRIVE.is_match(word)
 }
 
 /// Pattern matcher for detecting security threats
@@ -409,14 +506,37 @@ impl PatternMatcher {
 
         for threat in THREAT_PATTERNS {
             if let Some(regex) = self.patterns.get(threat.name) {
+                if threat.name == "format_drive" {
+                    for captures in regex.captures_iter(text) {
+                        let Some(command_match) = captures.name("command") else {
+                            continue;
+                        };
+                        let Some(command_text) = text.get(command_match.start()..) else {
+                            continue;
+                        };
+                        let words = shell_words_until_boundary(command_text);
+                        let Some(target) = format_drive_target(&words) else {
+                            continue;
+                        };
+                        if !is_system_drive(&target.value) {
+                            continue;
+                        }
+                        let end_pos = command_match.start() + target.end;
+                        matches.push(PatternMatch {
+                            threat: threat.clone(),
+                            matched_text: text
+                                .get(command_match.start()..end_pos)
+                                .unwrap_or_default()
+                                .to_string(),
+                            start_pos: command_match.start(),
+                            end_pos,
+                        });
+                    }
+                    continue;
+                }
                 if regex.is_match(text) {
                     // Find all matches to get position information
                     for regex_match in regex.find_iter(text) {
-                        if threat.name == "format_drive"
-                            && is_non_writing_ext_format_match(regex_match.as_str())
-                        {
-                            continue;
-                        }
                         matches.push(PatternMatch {
                             threat: threat.clone(),
                             matched_text: regex_match.as_str().to_string(),
@@ -521,6 +641,8 @@ mod tests {
         assert!(!matches(pat, "mkfs.ext4 -V /dev/sda1"));
         assert!(!matches(pat, "mkfs.ext4 -Fn /dev/sda1"));
         assert!(matches(pat, "mkfs.ext4 -L -n /dev/sda1"));
+        assert!(matches(pat, r"mkfs.ext4 -L foo\ -n /dev/sda1"));
+        assert!(!matches(pat, "mkfs.ext4 /tmp/image -L /dev/sda"));
         assert!(!matches(pat, "mkfs.ext4 --help\necho /dev/sda1"));
         assert!(!matches(pat, "echo $(mkfs.ext4 --help) /dev/sda"));
         assert!(!matches(pat, "stat --format '%n %s' /dev/sda"));

--- a/crates/goose/src/security/patterns.rs
+++ b/crates/goose/src/security/patterns.rs
@@ -69,7 +69,7 @@ pub const THREAT_PATTERNS: &[ThreatPattern] = &[
     },
     ThreatPattern {
         name: "format_drive",
-        pattern: r#"(format|mkfs\.[a-z][a-z0-9]*)\s+[^;&|\n]*?[/\\]dev[/\\][sh]d[a-z]([0-9]+)?(\s|[;&|<>)`'"]|$)"#,
+        pattern: r#"(?:^|\s|[;&|(`/\"'])(?:format\s+|mkfs\.[a-z][a-z0-9]*\s+[^;&|#\n]*?)[/\\]dev[/\\][sh]d[a-z](?:[0-9]+)?(?:\s|[;&|<>)`\"']|$)"#,
         description: "Formatting system drives",
         risk_level: RiskLevel::Critical,
         category: ThreatCategory::FileSystemDestruction,
@@ -415,9 +415,12 @@ mod tests {
         assert!(matches(pat, "sh -c 'mkfs.ext4 /dev/sda1'"));
         assert!(matches(pat, "mkfs.ext4 -F /dev/sda1"));
         assert!(matches(pat, "mkfs.ext4 -q -L data /dev/sda1"));
+        assert!(matches(pat, "/sbin/mkfs.ext4 -F /dev/sda1"));
         assert!(!matches(pat, "mkfs.ext4 /dev/sda-volume"));
         assert!(!matches(pat, "mkfs.ext4 /dev/sdaa"));
         assert!(!matches(pat, "mkfs.ext4 --help; echo /dev/sda1"));
+        assert!(!matches(pat, "mkfs.ext4 # /dev/sda1"));
+        assert!(!matches(pat, "stat --format '%n %s' /dev/sda"));
     }
 
     #[test]

--- a/crates/goose/src/security/patterns.rs
+++ b/crates/goose/src/security/patterns.rs
@@ -328,6 +328,8 @@ fn shell_words_until_boundary(text: &str) -> Vec<ShellWord> {
     let mut value = String::new();
     let mut start = None;
     let mut quote = None;
+    let mut discard_word = false;
+    let mut awaiting_redirection_target = false;
     let mut characters = text.char_indices().peekable();
 
     while let Some((index, character)) = characters.next() {
@@ -345,7 +347,11 @@ fn shell_words_until_boundary(text: &str) -> Vec<ShellWord> {
         }
 
         if character == '\\' {
-            start.get_or_insert(index);
+            if start.is_none() {
+                start = Some(index);
+                discard_word = awaiting_redirection_target;
+                awaiting_redirection_target = false;
+            }
             if let Some((_, escaped)) = characters.next() {
                 value.push(escaped);
             }
@@ -357,13 +363,45 @@ fn shell_words_until_boundary(text: &str) -> Vec<ShellWord> {
             if start.is_some() && !remainder.contains(character) {
                 break;
             }
-            start.get_or_insert(index);
+            if start.is_none() {
+                start = Some(index);
+                discard_word = awaiting_redirection_target;
+                awaiting_redirection_target = false;
+            }
             quote = Some(character);
             continue;
         }
 
-        if character == '\n' || matches!(character, ';' | '&' | '|' | '<' | '>' | ')' | '`') {
+        if matches!(character, '<' | '>') {
             if start.take().is_some() {
+                if !discard_word
+                    && !value
+                        .chars()
+                        .all(|value_character| value_character.is_ascii_digit())
+                {
+                    words.push(ShellWord {
+                        value: std::mem::take(&mut value),
+                        end: index,
+                    });
+                } else {
+                    value.clear();
+                }
+            }
+            discard_word = false;
+            awaiting_redirection_target = true;
+            continue;
+        }
+
+        if awaiting_redirection_target && character == '&' {
+            start = Some(index);
+            discard_word = true;
+            awaiting_redirection_target = false;
+            value.push(character);
+            continue;
+        }
+
+        if character == '\n' || matches!(character, ';' | '&' | '|' | ')' | '`') {
+            if start.take().is_some() && !discard_word {
                 words.push(ShellWord {
                     value: std::mem::take(&mut value),
                     end: index,
@@ -372,25 +410,34 @@ fn shell_words_until_boundary(text: &str) -> Vec<ShellWord> {
             break;
         }
 
-        if character == '#' && start.is_none() {
+        if character == '#' && start.is_none() && !awaiting_redirection_target {
             break;
         }
 
         if character.is_ascii_whitespace() {
             if start.take().is_some() {
-                words.push(ShellWord {
-                    value: std::mem::take(&mut value),
-                    end: index,
-                });
+                if !discard_word {
+                    words.push(ShellWord {
+                        value: std::mem::take(&mut value),
+                        end: index,
+                    });
+                } else {
+                    value.clear();
+                }
+                discard_word = false;
             }
             continue;
         }
 
-        start.get_or_insert(index);
+        if start.is_none() {
+            start = Some(index);
+            discard_word = awaiting_redirection_target;
+            awaiting_redirection_target = false;
+        }
         value.push(character);
     }
 
-    if start.is_some() {
+    if start.is_some() && !discard_word {
         words.push(ShellWord {
             value,
             end: text.len(),
@@ -400,55 +447,55 @@ fn shell_words_until_boundary(text: &str) -> Vec<ShellWord> {
     words
 }
 
-fn format_option_takes_value(command: &str, option: &str) -> bool {
+fn format_option_value_flag(command: &str, flag: char) -> bool {
     match command {
         "mkfs.ext2" | "mkfs.ext3" | "mkfs.ext4" => matches!(
-            option,
-            "-b" | "-C"
-                | "-d"
-                | "-e"
-                | "-E"
-                | "-g"
-                | "-G"
-                | "-i"
-                | "-I"
-                | "-J"
-                | "-l"
-                | "-L"
-                | "-m"
-                | "-M"
-                | "-N"
-                | "-o"
-                | "-O"
-                | "-r"
-                | "-t"
-                | "-T"
-                | "-U"
-                | "-z"
+            flag,
+            'b' | 'C'
+                | 'd'
+                | 'e'
+                | 'E'
+                | 'g'
+                | 'G'
+                | 'i'
+                | 'I'
+                | 'J'
+                | 'l'
+                | 'L'
+                | 'm'
+                | 'M'
+                | 'N'
+                | 'o'
+                | 'O'
+                | 'r'
+                | 't'
+                | 'T'
+                | 'U'
+                | 'z'
         ),
         "mkfs.f2fs" => matches!(
-            option,
-            "-a" | "-c"
-                | "-C"
-                | "-d"
-                | "-e"
-                | "-E"
-                | "-l"
-                | "-o"
-                | "-O"
-                | "-R"
-                | "-s"
-                | "-t"
-                | "-T"
-                | "-w"
-                | "-z"
+            flag,
+            'a' | 'c' | 'C' | 'd' | 'e' | 'E' | 'l' | 'o' | 'O' | 'R' | 's' | 't' | 'T' | 'w' | 'z'
         ),
         "mkfs.xfs" => matches!(
-            option,
-            "-b" | "-c" | "-d" | "-i" | "-l" | "-L" | "-m" | "-n" | "-p" | "-r" | "-s"
+            flag,
+            'b' | 'c' | 'd' | 'i' | 'l' | 'L' | 'm' | 'n' | 'p' | 'r' | 's'
         ),
         _ => false,
     }
+}
+
+fn format_option_takes_next_value(command: &str, option: &str) -> bool {
+    let Some(short_options) = option
+        .strip_prefix('-')
+        .filter(|options| !options.is_empty() && !options.starts_with('-'))
+    else {
+        return false;
+    };
+
+    short_options.char_indices().any(|(index, flag)| {
+        format_option_value_flag(command, flag) && index + flag.len_utf8() == short_options.len()
+    })
 }
 
 fn is_non_writing_format_option(command: &str, option: &str) -> bool {
@@ -495,7 +542,7 @@ fn format_drive_target(words: &[ShellWord]) -> Option<&ShellWord> {
         }
         if !options_ended && word.value.starts_with('-') {
             non_writing |= is_non_writing_format_option(&command, &word.value);
-            skip_option_value = format_option_takes_value(&command, &word.value);
+            skip_option_value = format_option_takes_next_value(&command, &word.value);
             continue;
         }
         target.get_or_insert(word);
@@ -642,6 +689,10 @@ mod tests {
         assert!(matches(pat, "sh -c \"mkfs.ext4 /dev/sda1\""));
         assert!(matches(pat, "sh -c 'mkfs.ext4 /dev/sda1'"));
         assert!(matches(pat, "mkfs.ext4 -F /dev/sda1"));
+        assert!(matches(pat, "mkfs.ext4 -qL data /dev/sda1"));
+        assert!(matches(pat, "mkfs.ext4 >/tmp/mkfs.log /dev/sda1"));
+        assert!(matches(pat, "mkfs.ext4 2>/tmp/mkfs.log /dev/sda1"));
+        assert!(matches(pat, "mkfs.ext4 </dev/null /dev/sda1"));
         assert!(matches(pat, "mkfs.ext4 -F /dev/sda1 4096"));
         assert!(matches(pat, "mkfs.ext4 /dev/sda1 -F"));
         assert!(matches(pat, "mkfs.ext4 /dev/sda1 -F -q"));
@@ -671,6 +722,7 @@ mod tests {
         assert!(matches(pat, "mkfs.ext4 -L -n /dev/sda1"));
         assert!(matches(pat, r"mkfs.ext4 -L foo\ -n /dev/sda1"));
         assert!(!matches(pat, "mkfs.ext4 /tmp/image -L /dev/sda"));
+        assert!(!matches(pat, "mkfs.ext4 >/dev/sda1 /tmp/image"));
         assert!(!matches(pat, "mkfs.ext4 --help\necho /dev/sda1"));
         assert!(!matches(pat, "echo $(mkfs.ext4 --help) /dev/sda"));
         assert!(!matches(pat, "stat --format '%n %s' /dev/sda"));


### PR DESCRIPTION
## Summary

- detect `mkfs` filesystem suffixes that begin with a letter and contain digits, including `ext2`, `ext3`, `ext4`, and `f2fs`
- preserve existing letter-only and case-insensitive matching
- add nearby negative coverage for files, non-drive device paths, and similar tool names

## Audit issue

- Addresses [project-loupe/audit-goose#98](https://github.com/project-loupe/audit-goose/issues/98)

## Verification

- `cargo fmt --all`
- `cargo test -p goose security::patterns::tests::format_drive` (3 passed)
- `cargo build -p goose`
- `cargo clippy -p goose --all-targets -- -D warnings`
- `git diff --check`

_This finding was discovered by [Project Loupe](https://github.com/project-loupe/loupe)._
