### PR TITLE
Add Cursor composer-2.5 models to known list

### DIFF
--- a/crates/goose/src/providers/cursor_agent.rs
+++ b/crates/goose/src/providers/cursor_agent.rs
@@ -23,7 +23,13 @@ use rmcp::model::Tool;
 
 const CURSOR_AGENT_PROVIDER_NAME: &str = "cursor-agent";
 pub const CURSOR_AGENT_DEFAULT_MODEL: &str = "auto";
-pub const CURSOR_AGENT_KNOWN_MODELS: &[&str] = &["auto", "composer-2", "composer-2-fast"];
+pub const CURSOR_AGENT_KNOWN_MODELS: &[&str] = &[
+    "auto",
+    "composer-2",
+    "composer-2-fast",
+    "composer-2.5",
+    "composer-2.5-fast",
+];
 
 pub const CURSOR_AGENT_DOC_URL: &str = "https://docs.cursor.com/en/cli/overview";
 


### PR DESCRIPTION
Resolves #10575

- Add 'composer-2.5' and 'composer-2.5-fast' to CURSOR_AGENT_KNOWN_MODELS
- These models are now available in the latest Cursor release and should be recognized by Goose