### PR TITLE
fix(providers): stop killing streaming responses at the total request timeout

### DIFF
--- a/crates/goose-provider-types/src/errors.rs
+++ b/crates/goose-provider-types/src/errors.rs
@@ -131,6 +131,9 @@ fn provider_error_from_reqwest(error: &reqwest::Error) -> ProviderError {
 
 impl From<anyhow::Error> for ProviderError {
     fn from(error: anyhow::Error) -> Self {
+        if let Some(provider_error) = error.downcast_ref::<ProviderError>() {
+            return provider_error.clone();
+        }
         if let Some(reqwest_err) = error.downcast_ref::<reqwest::Error>() {
             return provider_error_from_reqwest(reqwest_err);
         }

--- a/crates/goose-provider-types/src/errors.rs
+++ b/crates/goose-provider-types/src/errors.rs
@@ -134,6 +134,14 @@ impl From<anyhow::Error> for ProviderError {
         if let Some(reqwest_err) = error.downcast_ref::<reqwest::Error>() {
             return provider_error_from_reqwest(reqwest_err);
         }
+        if error
+            .downcast_ref::<tokio::time::error::Elapsed>()
+            .is_some()
+        {
+            return ProviderError::NetworkError(
+                "Request timed out — check your network connection and try again.".to_string(),
+            );
+        }
         ProviderError::ExecutionError(error.to_string())
     }
 }

--- a/crates/goose-providers/Cargo.toml
+++ b/crates/goose-providers/Cargo.toml
@@ -58,7 +58,7 @@ include_dir = { workspace = true }
 [dev-dependencies]
 test-case = { workspace = true }
 tempfile = { workspace = true }
-tokio = { workspace = true, features = ["rt-multi-thread"] }
+tokio = { workspace = true, features = ["io-util", "macros", "net", "rt-multi-thread", "time"] }
 tokio-stream = { workspace = true }
 env-lock = { workspace = true }
 wiremock.workspace = true

--- a/crates/goose-providers/src/anthropic.rs
+++ b/crates/goose-providers/src/anthropic.rs
@@ -191,7 +191,6 @@ impl AnthropicProvider {
                         .streaming(true)
                         .response_post(&payload)
                         .await?,
-                    self.api_client.timeout(),
                 )
                 .await
             })
@@ -230,7 +229,7 @@ impl AnthropicProvider {
             return Err(ProviderError::EndpointNotFound(msg));
         }
 
-        let response = handle_status(response, self.api_client.timeout()).await?;
+        let response = handle_status(response).await?;
 
         let body = response.bytes().await.map_err(|e| {
             ProviderError::NetworkError(format!("Failed to read response body: {}", e))

--- a/crates/goose-providers/src/anthropic.rs
+++ b/crates/goose-providers/src/anthropic.rs
@@ -191,6 +191,7 @@ impl AnthropicProvider {
                         .streaming(true)
                         .response_post(&payload)
                         .await?,
+                    self.api_client.timeout(),
                 )
                 .await
             })
@@ -229,7 +230,7 @@ impl AnthropicProvider {
             return Err(ProviderError::EndpointNotFound(msg));
         }
 
-        let response = handle_status(response).await?;
+        let response = handle_status(response, self.api_client.timeout()).await?;
 
         let body = response.bytes().await.map_err(|e| {
             ProviderError::NetworkError(format!("Failed to read response body: {}", e))

--- a/crates/goose-providers/src/anthropic.rs
+++ b/crates/goose-providers/src/anthropic.rs
@@ -188,6 +188,7 @@ impl AnthropicProvider {
                     self.api_client
                         .request("v1/messages")
                         .model_headers(model_config)?
+                        .streaming(true)
                         .response_post(&payload)
                         .await?,
                 )

--- a/crates/goose-providers/src/api_client.rs
+++ b/crates/goose-providers/src/api_client.rs
@@ -238,10 +238,6 @@ pub struct ApiRequestBuilder<'a> {
 }
 
 impl ApiClient {
-    pub fn timeout(&self) -> Duration {
-        self.timeout
-    }
-
     pub fn new_with_tls(
         host: String,
         auth: AuthMethod,

--- a/crates/goose-providers/src/api_client.rs
+++ b/crates/goose-providers/src/api_client.rs
@@ -238,6 +238,10 @@ pub struct ApiRequestBuilder<'a> {
 }
 
 impl ApiClient {
+    pub fn timeout(&self) -> Duration {
+        self.timeout
+    }
+
     pub fn new_with_tls(
         host: String,
         auth: AuthMethod,

--- a/crates/goose-providers/src/api_client.rs
+++ b/crates/goose-providers/src/api_client.rs
@@ -454,7 +454,7 @@ impl<'a> ApiRequestBuilder<'a> {
 
     async fn send_bounded(&self, request: reqwest::RequestBuilder) -> Result<Response> {
         if self.streaming {
-            Ok(tokio::time::timeout(self.client.timeout, request.send()).await??)
+            Ok(crate::http_status::send_bounded(request, self.client.timeout).await?)
         } else {
             Ok(request.send().await?)
         }
@@ -693,21 +693,28 @@ mod tests {
     }
 
     fn client_with_timeout(addr: SocketAddr, timeout_ms: u64) -> ApiClient {
-        ApiClient::with_timeout_and_tls(
+        let mut client = ApiClient::with_timeout_and_tls(
             format!("http://{}", addr),
             AuthMethod::NoAuth,
             Duration::from_millis(timeout_ms),
             None,
         )
-        .unwrap()
+        .unwrap();
+        client.client = Client::builder()
+            .no_proxy()
+            .connect_timeout(Duration::from_secs(DEFAULT_CONNECT_TIMEOUT_SECS))
+            .read_timeout(client.timeout)
+            .build()
+            .unwrap();
+        client
     }
 
     async fn drain_counting_data_lines(mut response: Response) -> Result<usize, reqwest::Error> {
-        let mut count = 0;
+        let mut body = Vec::new();
         while let Some(chunk) = response.chunk().await? {
-            count += String::from_utf8_lossy(&chunk).matches("data:").count();
+            body.extend_from_slice(&chunk);
         }
-        Ok(count)
+        Ok(String::from_utf8_lossy(&body).matches("data:").count())
     }
 
     #[tokio::test]
@@ -791,11 +798,47 @@ mod tests {
             "should fail near the configured timeout, took {:?}",
             started.elapsed()
         );
-        let timed_out = err
-            .downcast_ref::<reqwest::Error>()
-            .is_some_and(reqwest::Error::is_timeout)
-            || err.downcast_ref::<tokio::time::error::Elapsed>().is_some();
-        assert!(timed_out, "expected a timeout error, got: {err}");
+        assert!(matches!(
+            err.downcast_ref::<crate::errors::ProviderError>(),
+            Some(crate::errors::ProviderError::NetworkError(message))
+                if message.starts_with("Request timed out")
+        ));
+    }
+
+    #[tokio::test]
+    async fn streaming_error_body_shares_send_deadline() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut buf = [0u8; 8192];
+            let _ = socket.read(&mut buf).await;
+            tokio::time::sleep(Duration::from_millis(300)).await;
+            socket
+                .write_all(b"HTTP/1.1 500 Internal Server Error\r\ncontent-length: 1\r\n\r\n")
+                .await
+                .unwrap();
+            tokio::time::sleep(Duration::from_millis(300)).await;
+            let _ = socket.write_all(b"x").await;
+        });
+
+        let client = client_with_timeout(addr, 400);
+        let started = std::time::Instant::now();
+        let response = client
+            .request("v1/messages")
+            .streaming(true)
+            .response_post(&serde_json::json!({}))
+            .await
+            .unwrap();
+        crate::http_status::handle_status(response)
+            .await
+            .unwrap_err();
+
+        assert!(
+            started.elapsed() < Duration::from_millis(550),
+            "send and error body used separate deadlines: {:?}",
+            started.elapsed()
+        );
     }
 
     #[test]

--- a/crates/goose-providers/src/api_client.rs
+++ b/crates/goose-providers/src/api_client.rs
@@ -289,10 +289,6 @@ impl ApiClient {
         self.timeout
     }
 
-    /// The total-request deadline is applied per request in `send_request` so
-    /// streaming requests can opt out of it: an SSE body is the whole
-    /// generation, so streams are bounded by `read_timeout` (reset per chunk)
-    /// rather than end-to-end duration.
     fn client_builder(timeout: Duration) -> reqwest::ClientBuilder {
         Client::builder()
             .connect_timeout(Duration::from_secs(DEFAULT_CONNECT_TIMEOUT_SECS))
@@ -450,8 +446,6 @@ impl<'a> ApiRequestBuilder<'a> {
         }
     }
 
-    /// Exempts this request from the total-request deadline; the stream is
-    /// bounded by the client's read timeout instead.
     pub fn streaming(mut self, streaming: bool) -> Self {
         self.streaming = streaming;
         self
@@ -462,10 +456,6 @@ impl<'a> ApiRequestBuilder<'a> {
         ApiResponse::from_response(response).await
     }
 
-    /// `send()` resolves when response headers arrive, so for streaming
-    /// requests (exempt from the per-request total deadline) this still bounds
-    /// connect, request upload, and time-to-first-byte; only the streamed
-    /// response body is unbounded.
     async fn send_bounded(&self, request: reqwest::RequestBuilder) -> Result<Response> {
         if self.streaming {
             Ok(tokio::time::timeout(self.client.timeout, request.send()).await??)

--- a/crates/goose-providers/src/api_client.rs
+++ b/crates/goose-providers/src/api_client.rs
@@ -14,7 +14,8 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
-const DEFAULT_PROVIDER_TIMEOUT_SECS: u64 = 600;
+pub const DEFAULT_PROVIDER_TIMEOUT_SECS: u64 = 600;
+pub const DEFAULT_CONNECT_TIMEOUT_SECS: u64 = 30;
 
 pub type RequestBuilderDecorator =
     Arc<dyn Fn(reqwest::RequestBuilder) -> Result<reqwest::RequestBuilder> + Send + Sync>;
@@ -233,6 +234,7 @@ pub struct ApiRequestBuilder<'a> {
     client: &'a ApiClient,
     path: &'a str,
     headers: HeaderMap,
+    streaming: bool,
 }
 
 impl ApiClient {
@@ -255,7 +257,7 @@ impl ApiClient {
         timeout: Duration,
         tls_config: Option<TlsConfig>,
     ) -> Result<Self> {
-        let mut client_builder = Client::builder().timeout(timeout);
+        let mut client_builder = Self::client_builder(timeout);
 
         if let Some(ref config) = tls_config {
             client_builder = Self::configure_tls(client_builder, config)?;
@@ -283,10 +285,19 @@ impl ApiClient {
         self.timeout
     }
 
+    /// The total-request deadline is applied per request in `send_request` so
+    /// streaming requests can opt out of it: an SSE body is the whole
+    /// generation, so streams are bounded by `read_timeout` (reset per chunk)
+    /// rather than end-to-end duration.
+    fn client_builder(timeout: Duration) -> reqwest::ClientBuilder {
+        Client::builder()
+            .connect_timeout(Duration::from_secs(DEFAULT_CONNECT_TIMEOUT_SECS))
+            .read_timeout(timeout)
+    }
+
     fn rebuild_client(&mut self) -> Result<()> {
-        let mut client_builder = Client::builder()
-            .timeout(self.timeout)
-            .default_headers(self.default_headers.clone());
+        let mut client_builder =
+            Self::client_builder(self.timeout).default_headers(self.default_headers.clone());
 
         // Configure TLS if needed
         if let Some(ref tls_config) = self.tls_config {
@@ -361,6 +372,7 @@ impl ApiClient {
             client: self,
             path,
             headers: HeaderMap::new(),
+            streaming: false,
         }
     }
 
@@ -434,14 +446,33 @@ impl<'a> ApiRequestBuilder<'a> {
         }
     }
 
+    /// Exempts this request from the total-request deadline; the stream is
+    /// bounded by the client's read timeout instead.
+    pub fn streaming(mut self, streaming: bool) -> Self {
+        self.streaming = streaming;
+        self
+    }
+
     pub async fn api_post(self, payload: &Value) -> Result<ApiResponse> {
         let response = self.response_post(payload).await?;
         ApiResponse::from_response(response).await
     }
 
+    /// `send()` resolves when response headers arrive, so for streaming
+    /// requests (exempt from the per-request total deadline) this still bounds
+    /// connect, request upload, and time-to-first-byte; only the streamed
+    /// response body is unbounded.
+    async fn send_bounded(&self, request: reqwest::RequestBuilder) -> Result<Response> {
+        if self.streaming {
+            Ok(tokio::time::timeout(self.client.timeout, request.send()).await??)
+        } else {
+            Ok(request.send().await?)
+        }
+    }
+
     pub async fn response_post(self, payload: &Value) -> Result<Response> {
         let request = self.send_request(|url, client| client.post(url)).await?;
-        Ok(request.json(payload).send().await?)
+        self.send_bounded(request.json(payload)).await
     }
 
     pub async fn multipart_post(self, form: reqwest::multipart::Form) -> Result<Response> {
@@ -456,7 +487,7 @@ impl<'a> ApiRequestBuilder<'a> {
 
     pub async fn response_get(self) -> Result<Response> {
         let request = self.send_request(|url, client| client.get(url)).await?;
-        Ok(request.send().await?)
+        self.send_bounded(request).await
     }
 
     async fn send_request<F>(&self, request_builder: F) -> Result<reqwest::RequestBuilder>
@@ -467,6 +498,10 @@ impl<'a> ApiRequestBuilder<'a> {
         let headers = self.headers.clone();
         let mut request = request_builder(url, &self.client.client);
         request = request.headers(headers);
+
+        if !self.streaming {
+            request = request.timeout(self.client.timeout);
+        }
 
         if let Some(decorator) = &self.client.request_builder {
             request = decorator(request)?;
@@ -623,6 +658,155 @@ ShGoCNbfNS+COlPMRAujyDlATZcLs9p4tA==
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::net::SocketAddr;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    async fn spawn_chunked_server(gap_ms: u64, chunks: usize) -> SocketAddr {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut sock, _)) = listener.accept().await else {
+                    break;
+                };
+                tokio::spawn(async move {
+                    let mut buf = [0u8; 8192];
+                    let _ = sock.read(&mut buf).await;
+                    if sock
+                        .write_all(
+                            b"HTTP/1.1 200 OK\r\n\
+                              content-type: text/event-stream\r\n\
+                              transfer-encoding: chunked\r\n\r\n",
+                        )
+                        .await
+                        .is_err()
+                    {
+                        return;
+                    }
+                    for i in 0..chunks {
+                        if i > 0 {
+                            tokio::time::sleep(Duration::from_millis(gap_ms)).await;
+                        }
+                        let data = format!("data: {}\n\n", i);
+                        let chunk = format!("{:x}\r\n{}\r\n", data.len(), data);
+                        if sock.write_all(chunk.as_bytes()).await.is_err() {
+                            return;
+                        }
+                        let _ = sock.flush().await;
+                    }
+                    let _ = sock.write_all(b"0\r\n\r\n").await;
+                });
+            }
+        });
+        addr
+    }
+
+    fn client_with_timeout(addr: SocketAddr, timeout_ms: u64) -> ApiClient {
+        ApiClient::with_timeout_and_tls(
+            format!("http://{}", addr),
+            AuthMethod::NoAuth,
+            Duration::from_millis(timeout_ms),
+            None,
+        )
+        .unwrap()
+    }
+
+    async fn drain_counting_data_lines(mut response: Response) -> Result<usize, reqwest::Error> {
+        let mut count = 0;
+        while let Some(chunk) = response.chunk().await? {
+            count += String::from_utf8_lossy(&chunk).matches("data:").count();
+        }
+        Ok(count)
+    }
+
+    #[tokio::test]
+    async fn streaming_request_survives_beyond_total_timeout() {
+        let addr = spawn_chunked_server(50, 12).await;
+        let client = client_with_timeout(addr, 400);
+
+        let response = client
+            .request("v1/messages")
+            .streaming(true)
+            .response_post(&serde_json::json!({}))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let count = drain_counting_data_lines(response).await.unwrap();
+        assert_eq!(count, 12);
+    }
+
+    #[tokio::test]
+    async fn streaming_request_fails_when_stream_stalls() {
+        let addr = spawn_chunked_server(5_000, 2).await;
+        let client = client_with_timeout(addr, 400);
+
+        let response = client
+            .request("v1/messages")
+            .streaming(true)
+            .response_post(&serde_json::json!({}))
+            .await
+            .unwrap();
+
+        let err = drain_counting_data_lines(response)
+            .await
+            .expect_err("stalled stream should time out, not complete");
+        assert!(err.is_timeout(), "expected a timeout error, got: {err}");
+    }
+
+    #[tokio::test]
+    async fn non_streaming_request_enforces_total_deadline() {
+        let addr = spawn_chunked_server(50, 12).await;
+        let client = client_with_timeout(addr, 400);
+
+        let response = client
+            .request("v1/messages")
+            .response_post(&serde_json::json!({}))
+            .await
+            .unwrap();
+
+        let err = drain_counting_data_lines(response)
+            .await
+            .expect_err("total deadline should cut off the response body");
+        assert!(err.is_timeout(), "expected a timeout error, got: {err}");
+    }
+
+    #[tokio::test]
+    async fn streaming_request_times_out_before_response_headers() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut sock, _)) = listener.accept().await else {
+                    break;
+                };
+                tokio::spawn(async move {
+                    let mut buf = [0u8; 8192];
+                    while sock.read(&mut buf).await.is_ok_and(|n| n > 0) {}
+                });
+            }
+        });
+        let client = client_with_timeout(addr, 400);
+
+        let started = std::time::Instant::now();
+        let err = client
+            .request("v1/messages")
+            .streaming(true)
+            .response_post(&serde_json::json!({}))
+            .await
+            .expect_err("the phase before the response body must stay bounded");
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "should fail near the configured timeout, took {:?}",
+            started.elapsed()
+        );
+        let timed_out = err
+            .downcast_ref::<reqwest::Error>()
+            .is_some_and(reqwest::Error::is_timeout)
+            || err.downcast_ref::<tokio::time::error::Elapsed>().is_some();
+        assert!(timed_out, "expected a timeout error, got: {err}");
+    }
 
     #[test]
     fn test_model_headers_applied_and_override_static_headers() {

--- a/crates/goose-providers/src/api_client.rs
+++ b/crates/goose-providers/src/api_client.rs
@@ -799,8 +799,8 @@ mod tests {
             started.elapsed()
         );
         assert!(matches!(
-            err.downcast_ref::<crate::errors::ProviderError>(),
-            Some(crate::errors::ProviderError::NetworkError(message))
+            crate::errors::ProviderError::from(err),
+            crate::errors::ProviderError::NetworkError(message)
                 if message.starts_with("Request timed out")
         ));
     }

--- a/crates/goose-providers/src/azure_foundry.rs
+++ b/crates/goose-providers/src/azure_foundry.rs
@@ -273,8 +273,7 @@ impl AzureFoundryProvider {
                 .response_get(&path)
                 .await
                 .map_err(|error| ProviderError::NetworkError(error.to_string()))?;
-            let json =
-                handle_response_openai_compat(response, self.deployments_client.timeout()).await?;
+            let json = handle_response_openai_compat(response).await?;
             if let Some(items) = json.get("value").and_then(|value| value.as_array()) {
                 for item in items {
                     let Some(name) = item.get("name").and_then(|value| value.as_str()) else {

--- a/crates/goose-providers/src/azure_foundry.rs
+++ b/crates/goose-providers/src/azure_foundry.rs
@@ -273,7 +273,8 @@ impl AzureFoundryProvider {
                 .response_get(&path)
                 .await
                 .map_err(|error| ProviderError::NetworkError(error.to_string()))?;
-            let json = handle_response_openai_compat(response).await?;
+            let json =
+                handle_response_openai_compat(response, self.deployments_client.timeout()).await?;
             if let Some(items) = json.get("value").and_then(|value| value.as_array()) {
                 for item in items {
                     let Some(name) = item.get("name").and_then(|value| value.as_str()) else {

--- a/crates/goose-providers/src/databricks.rs
+++ b/crates/goose-providers/src/databricks.rs
@@ -604,7 +604,7 @@ impl Provider for DatabricksProvider {
                         .streaming(true)
                         .response_post(&payload_clone)
                         .await?;
-                    handle_status(resp, self.api_client.timeout()).await
+                    handle_status(resp).await
                 })
                 .await
                 .inspect_err(|e| {
@@ -673,10 +673,9 @@ impl Provider for DatabricksProvider {
                     if !resp.status().is_success() {
                         let status = resp.status();
                         let url = sanitize_url(resp.url().as_str());
-                        let error_text =
-                            crate::http_status::read_error_body(resp, self.api_client.timeout())
-                                .await
-                                .unwrap_or_default();
+                        let error_text = crate::http_status::read_error_body(resp)
+                            .await
+                            .unwrap_or_default();
 
                         let json_payload = serde_json::from_str::<Value>(&error_text).ok();
                         return Err(map_http_error_to_provider_error(status, json_payload, &url));
@@ -699,12 +698,9 @@ impl Provider for DatabricksProvider {
                         if !resp.status().is_success() {
                             let status = resp.status();
                             let url = sanitize_url(resp.url().as_str());
-                            let error_text = crate::http_status::read_error_body(
-                                resp,
-                                self.api_client.timeout(),
-                            )
-                            .await
-                            .unwrap_or_default();
+                            let error_text = crate::http_status::read_error_body(resp)
+                                .await
+                                .unwrap_or_default();
                             let json_payload = serde_json::from_str::<Value>(&error_text).ok();
                             return Err(map_http_error_to_provider_error(
                                 status,

--- a/crates/goose-providers/src/databricks.rs
+++ b/crates/goose-providers/src/databricks.rs
@@ -604,7 +604,7 @@ impl Provider for DatabricksProvider {
                         .streaming(true)
                         .response_post(&payload_clone)
                         .await?;
-                    handle_status(resp).await
+                    handle_status(resp, self.api_client.timeout()).await
                 })
                 .await
                 .inspect_err(|e| {
@@ -673,9 +673,10 @@ impl Provider for DatabricksProvider {
                     if !resp.status().is_success() {
                         let status = resp.status();
                         let url = sanitize_url(resp.url().as_str());
-                        let error_text = crate::http_status::read_error_body(resp)
-                            .await
-                            .unwrap_or_default();
+                        let error_text =
+                            crate::http_status::read_error_body(resp, self.api_client.timeout())
+                                .await
+                                .unwrap_or_default();
 
                         let json_payload = serde_json::from_str::<Value>(&error_text).ok();
                         return Err(map_http_error_to_provider_error(status, json_payload, &url));
@@ -698,9 +699,12 @@ impl Provider for DatabricksProvider {
                         if !resp.status().is_success() {
                             let status = resp.status();
                             let url = sanitize_url(resp.url().as_str());
-                            let error_text = crate::http_status::read_error_body(resp)
-                                .await
-                                .unwrap_or_default();
+                            let error_text = crate::http_status::read_error_body(
+                                resp,
+                                self.api_client.timeout(),
+                            )
+                            .await
+                            .unwrap_or_default();
                             let json_payload = serde_json::from_str::<Value>(&error_text).ok();
                             return Err(map_http_error_to_provider_error(
                                 status,

--- a/crates/goose-providers/src/databricks.rs
+++ b/crates/goose-providers/src/databricks.rs
@@ -601,6 +601,7 @@ impl Provider for DatabricksProvider {
                         .api_client
                         .request(&path)
                         .model_headers(model_config)?
+                        .streaming(true)
                         .response_post(&payload_clone)
                         .await?;
                     handle_status(resp).await
@@ -666,12 +667,15 @@ impl Provider for DatabricksProvider {
                         .api_client
                         .request(&path)
                         .model_headers(model_config)?
+                        .streaming(true)
                         .response_post(&payload)
                         .await?;
                     if !resp.status().is_success() {
                         let status = resp.status();
                         let url = sanitize_url(resp.url().as_str());
-                        let error_text = resp.text().await.unwrap_or_default();
+                        let error_text = crate::http_status::read_error_body(resp)
+                            .await
+                            .unwrap_or_default();
 
                         let json_payload = serde_json::from_str::<Value>(&error_text).ok();
                         return Err(map_http_error_to_provider_error(status, json_payload, &url));
@@ -688,12 +692,15 @@ impl Provider for DatabricksProvider {
                             .api_client
                             .request(&path)
                             .model_headers(model_config)?
+                            .streaming(true)
                             .response_post(&payload)
                             .await?;
                         if !resp.status().is_success() {
                             let status = resp.status();
                             let url = sanitize_url(resp.url().as_str());
-                            let error_text = resp.text().await.unwrap_or_default();
+                            let error_text = crate::http_status::read_error_body(resp)
+                                .await
+                                .unwrap_or_default();
                             let json_payload = serde_json::from_str::<Value>(&error_text).ok();
                             return Err(map_http_error_to_provider_error(
                                 status,

--- a/crates/goose-providers/src/databricks_v2.rs
+++ b/crates/goose-providers/src/databricks_v2.rs
@@ -207,6 +207,7 @@ impl DatabricksV2Provider {
                     .api_client
                     .request("ai-gateway/openai/v1/responses")
                     .model_headers(model_config)?
+                    .streaming(true)
                     .response_post(&payload)
                     .await?;
                 handle_status(resp).await
@@ -245,6 +246,7 @@ impl DatabricksV2Provider {
                     .api_client
                     .request("ai-gateway/mlflow/v1/chat/completions")
                     .model_headers(model_config)?
+                    .streaming(true)
                     .response_post(&payload)
                     .await?;
                 handle_status(resp).await
@@ -281,6 +283,7 @@ impl DatabricksV2Provider {
                     .api_client
                     .request("ai-gateway/anthropic/v1/messages")
                     .model_headers(model_config)?
+                    .streaming(true)
                     .response_post(&payload)
                     .await?;
                 handle_status(resp).await

--- a/crates/goose-providers/src/databricks_v2.rs
+++ b/crates/goose-providers/src/databricks_v2.rs
@@ -210,7 +210,7 @@ impl DatabricksV2Provider {
                     .streaming(true)
                     .response_post(&payload)
                     .await?;
-                handle_status(resp).await
+                handle_status(resp, self.api_client.timeout()).await
             })
             .await
             .inspect_err(|e| {
@@ -249,7 +249,7 @@ impl DatabricksV2Provider {
                     .streaming(true)
                     .response_post(&payload)
                     .await?;
-                handle_status(resp).await
+                handle_status(resp, self.api_client.timeout()).await
             })
             .await
             .inspect_err(|e| {
@@ -286,7 +286,7 @@ impl DatabricksV2Provider {
                     .streaming(true)
                     .response_post(&payload)
                     .await?;
-                handle_status(resp).await
+                handle_status(resp, self.api_client.timeout()).await
             })
             .await
             .inspect_err(|e| {

--- a/crates/goose-providers/src/databricks_v2.rs
+++ b/crates/goose-providers/src/databricks_v2.rs
@@ -210,7 +210,7 @@ impl DatabricksV2Provider {
                     .streaming(true)
                     .response_post(&payload)
                     .await?;
-                handle_status(resp, self.api_client.timeout()).await
+                handle_status(resp).await
             })
             .await
             .inspect_err(|e| {
@@ -249,7 +249,7 @@ impl DatabricksV2Provider {
                     .streaming(true)
                     .response_post(&payload)
                     .await?;
-                handle_status(resp, self.api_client.timeout()).await
+                handle_status(resp).await
             })
             .await
             .inspect_err(|e| {
@@ -286,7 +286,7 @@ impl DatabricksV2Provider {
                     .streaming(true)
                     .response_post(&payload)
                     .await?;
-                handle_status(resp, self.api_client.timeout()).await
+                handle_status(resp).await
             })
             .await
             .inspect_err(|e| {

--- a/crates/goose-providers/src/google.rs
+++ b/crates/goose-providers/src/google.rs
@@ -107,6 +107,7 @@ impl GoogleProvider {
             .api_client
             .request(&path)
             .model_headers(model_config)?
+            .streaming(true)
             .response_post(payload)
             .await?;
         handle_status(response).await

--- a/crates/goose-providers/src/google.rs
+++ b/crates/goose-providers/src/google.rs
@@ -110,7 +110,7 @@ impl GoogleProvider {
             .streaming(true)
             .response_post(payload)
             .await?;
-        handle_status(response, self.api_client.timeout()).await
+        handle_status(response).await
     }
 }
 

--- a/crates/goose-providers/src/google.rs
+++ b/crates/goose-providers/src/google.rs
@@ -110,7 +110,7 @@ impl GoogleProvider {
             .streaming(true)
             .response_post(payload)
             .await?;
-        handle_status(response).await
+        handle_status(response, self.api_client.timeout()).await
     }
 }
 

--- a/crates/goose-providers/src/http_status.rs
+++ b/crates/goose-providers/src/http_status.rs
@@ -248,22 +248,45 @@ pub fn map_http_error_to_provider_error(
     error
 }
 
-pub async fn read_error_body(response: Response, timeout: Duration) -> Option<String> {
-    tokio::time::timeout(timeout, response.text())
-        .await
-        .ok()
-        .and_then(Result::ok)
+#[derive(Clone, Copy)]
+pub struct ResponseDeadline(tokio::time::Instant);
+
+pub fn set_response_deadline(response: &mut Response, deadline: tokio::time::Instant) {
+    response.extensions_mut().insert(ResponseDeadline(deadline));
 }
 
-pub async fn handle_status(
-    response: Response,
+pub async fn send_bounded(
+    request: reqwest::RequestBuilder,
     timeout: Duration,
 ) -> Result<Response, ProviderError> {
+    let deadline = tokio::time::Instant::now() + timeout;
+    let mut response = tokio::time::timeout_at(deadline, request.send())
+        .await
+        .map_err(|_| {
+            ProviderError::NetworkError(
+                "Request timed out — check your network connection and try again.".to_string(),
+            )
+        })??;
+    set_response_deadline(&mut response, deadline);
+    Ok(response)
+}
+
+pub async fn read_error_body(response: Response) -> Option<String> {
+    match response.extensions().get::<ResponseDeadline>().copied() {
+        Some(ResponseDeadline(deadline)) => tokio::time::timeout_at(deadline, response.text())
+            .await
+            .ok()
+            .and_then(Result::ok),
+        None => response.text().await.ok(),
+    }
+}
+
+pub async fn handle_status(response: Response) -> Result<Response, ProviderError> {
     let status = response.status();
     if !status.is_success() {
         let url = sanitize_url(response.url().as_str());
         let headers = response.headers().clone();
-        let body = read_error_body(response, timeout).await.unwrap_or_default();
+        let body = read_error_body(response).await.unwrap_or_default();
         let payload = serde_json::from_str::<Value>(&body).ok();
         let mut err = map_http_error_to_provider_error(status, payload.clone(), &url);
         if let ProviderError::RateLimitExceeded { details, .. } = &err {
@@ -277,11 +300,8 @@ pub async fn handle_status(
     Ok(response)
 }
 
-pub async fn handle_response(
-    response: Response,
-    timeout: Duration,
-) -> Result<Value, ProviderError> {
-    let response = handle_status(response, timeout).await?;
+pub async fn handle_response(response: Response) -> Result<Value, ProviderError> {
+    let response = handle_status(response).await?;
 
     response.json::<Value>().await.map_err(|e| {
         ProviderError::RequestFailed(format!("Response body is not valid JSON: {}", e))

--- a/crates/goose-providers/src/http_status.rs
+++ b/crates/goose-providers/src/http_status.rs
@@ -248,12 +248,23 @@ pub fn map_http_error_to_provider_error(
     error
 }
 
+/// Streaming requests carry no total-request deadline, so error-body reads
+/// must be bounded or a server that drips a non-2xx body stalls retries forever.
+const ERROR_BODY_READ_TIMEOUT: Duration = Duration::from_secs(30);
+
+pub async fn read_error_body(response: Response) -> Option<String> {
+    tokio::time::timeout(ERROR_BODY_READ_TIMEOUT, response.text())
+        .await
+        .ok()
+        .and_then(Result::ok)
+}
+
 pub async fn handle_status(response: Response) -> Result<Response, ProviderError> {
     let status = response.status();
     if !status.is_success() {
         let url = sanitize_url(response.url().as_str());
         let headers = response.headers().clone();
-        let body = response.text().await.unwrap_or_default();
+        let body = read_error_body(response).await.unwrap_or_default();
         let payload = serde_json::from_str::<Value>(&body).ok();
         let mut err = map_http_error_to_provider_error(status, payload.clone(), &url);
         if let ProviderError::RateLimitExceeded { details, .. } = &err {

--- a/crates/goose-providers/src/http_status.rs
+++ b/crates/goose-providers/src/http_status.rs
@@ -248,23 +248,22 @@ pub fn map_http_error_to_provider_error(
     error
 }
 
-/// Streaming requests carry no total-request deadline, so error-body reads
-/// must be bounded or a server that drips a non-2xx body stalls retries forever.
-const ERROR_BODY_READ_TIMEOUT: Duration = Duration::from_secs(30);
-
-pub async fn read_error_body(response: Response) -> Option<String> {
-    tokio::time::timeout(ERROR_BODY_READ_TIMEOUT, response.text())
+pub async fn read_error_body(response: Response, timeout: Duration) -> Option<String> {
+    tokio::time::timeout(timeout, response.text())
         .await
         .ok()
         .and_then(Result::ok)
 }
 
-pub async fn handle_status(response: Response) -> Result<Response, ProviderError> {
+pub async fn handle_status(
+    response: Response,
+    timeout: Duration,
+) -> Result<Response, ProviderError> {
     let status = response.status();
     if !status.is_success() {
         let url = sanitize_url(response.url().as_str());
         let headers = response.headers().clone();
-        let body = read_error_body(response).await.unwrap_or_default();
+        let body = read_error_body(response, timeout).await.unwrap_or_default();
         let payload = serde_json::from_str::<Value>(&body).ok();
         let mut err = map_http_error_to_provider_error(status, payload.clone(), &url);
         if let ProviderError::RateLimitExceeded { details, .. } = &err {
@@ -278,8 +277,11 @@ pub async fn handle_status(response: Response) -> Result<Response, ProviderError
     Ok(response)
 }
 
-pub async fn handle_response(response: Response) -> Result<Value, ProviderError> {
-    let response = handle_status(response).await?;
+pub async fn handle_response(
+    response: Response,
+    timeout: Duration,
+) -> Result<Value, ProviderError> {
+    let response = handle_status(response, timeout).await?;
 
     response.json::<Value>().await.map_err(|e| {
         ProviderError::RequestFailed(format!("Response body is not valid JSON: {}", e))

--- a/crates/goose-providers/src/ollama.rs
+++ b/crates/goose-providers/src/ollama.rs
@@ -431,7 +431,7 @@ impl Provider for OllamaProvider {
                     .streaming(true)
                     .response_post(&payload)
                     .await?;
-                handle_status(resp).await
+                handle_status(resp, self.api_client.timeout()).await
             })
             .await
             .inspect_err(|e| {

--- a/crates/goose-providers/src/ollama.rs
+++ b/crates/goose-providers/src/ollama.rs
@@ -428,6 +428,7 @@ impl Provider for OllamaProvider {
                     .api_client
                     .request("v1/chat/completions")
                     .model_headers(model_config)?
+                    .streaming(true)
                     .response_post(&payload)
                     .await?;
                 handle_status(resp).await

--- a/crates/goose-providers/src/ollama.rs
+++ b/crates/goose-providers/src/ollama.rs
@@ -431,7 +431,7 @@ impl Provider for OllamaProvider {
                     .streaming(true)
                     .response_post(&payload)
                     .await?;
-                handle_status(resp, self.api_client.timeout()).await
+                handle_status(resp).await
             })
             .await
             .inspect_err(|e| {

--- a/crates/goose-providers/src/openai.rs
+++ b/crates/goose-providers/src/openai.rs
@@ -311,6 +311,7 @@ impl OpenAiProvider {
                             OPEN_AI_DEFAULT_RESPONSES_PATH,
                         ))
                         .model_headers(model_config)?
+                        .streaming(self.supports_streaming)
                         .response_post(&payload)
                         .await?,
                 )
@@ -797,6 +798,7 @@ impl Provider for OpenAiProvider {
                         .api_client
                         .request(&self.base_path)
                         .model_headers(model_config)?
+                        .streaming(self.supports_streaming)
                         .response_post(&payload)
                         .await?;
                     handle_status(resp).await

--- a/crates/goose-providers/src/openai.rs
+++ b/crates/goose-providers/src/openai.rs
@@ -314,6 +314,7 @@ impl OpenAiProvider {
                         .streaming(self.supports_streaming)
                         .response_post(&payload)
                         .await?,
+                    self.api_client.timeout(),
                 )
                 .await
             })
@@ -544,7 +545,7 @@ impl OpenAiProvider {
             return Err(ProviderError::EndpointNotFound(body));
         }
 
-        let response = handle_status(response).await?;
+        let response = handle_status(response, self.api_client.timeout()).await?;
 
         let body = response.bytes().await.map_err(|e| {
             ProviderError::NetworkError(format!("Failed to read response body: {}", e))
@@ -801,7 +802,7 @@ impl Provider for OpenAiProvider {
                         .streaming(self.supports_streaming)
                         .response_post(&payload)
                         .await?;
-                    handle_status(resp).await
+                    handle_status(resp, self.api_client.timeout()).await
                 })
                 .await
                 .inspect_err(|e| {

--- a/crates/goose-providers/src/openai.rs
+++ b/crates/goose-providers/src/openai.rs
@@ -577,7 +577,9 @@ impl OpenAiProvider {
             .response_get()
             .await
             .ok()?;
-        let json = handle_response_openai_compat(response).await.ok()?;
+        let json = handle_response_openai_compat(response, self.api_client.timeout())
+            .await
+            .ok()?;
         parse_n_ctx_from_models(&json, model_name)
     }
 }

--- a/crates/goose-providers/src/openai.rs
+++ b/crates/goose-providers/src/openai.rs
@@ -314,7 +314,6 @@ impl OpenAiProvider {
                         .streaming(self.supports_streaming)
                         .response_post(&payload)
                         .await?,
-                    self.api_client.timeout(),
                 )
                 .await
             })
@@ -545,7 +544,7 @@ impl OpenAiProvider {
             return Err(ProviderError::EndpointNotFound(body));
         }
 
-        let response = handle_status(response, self.api_client.timeout()).await?;
+        let response = handle_status(response).await?;
 
         let body = response.bytes().await.map_err(|e| {
             ProviderError::NetworkError(format!("Failed to read response body: {}", e))
@@ -577,9 +576,7 @@ impl OpenAiProvider {
             .response_get()
             .await
             .ok()?;
-        let json = handle_response_openai_compat(response, self.api_client.timeout())
-            .await
-            .ok()?;
+        let json = handle_response_openai_compat(response).await.ok()?;
         parse_n_ctx_from_models(&json, model_name)
     }
 }
@@ -804,7 +801,7 @@ impl Provider for OpenAiProvider {
                         .streaming(self.supports_streaming)
                         .response_post(&payload)
                         .await?;
-                    handle_status(resp, self.api_client.timeout()).await
+                    handle_status(resp).await
                 })
                 .await
                 .inspect_err(|e| {

--- a/crates/goose-providers/src/openai_compatible.rs
+++ b/crates/goose-providers/src/openai_compatible.rs
@@ -115,7 +115,6 @@ impl OpenAiCompatibleProvider {
                         .streaming(self.supports_streaming)
                         .response_post(&payload)
                         .await?,
-                    self.api_client.timeout(),
                 )
                 .await
             })
@@ -185,7 +184,7 @@ impl Provider for OpenAiCompatibleProvider {
             .response_get("models")
             .await
             .map_err(|e| ProviderError::RequestFailed(e.to_string()))?;
-        let json = handle_response_openai_compat(response, self.api_client.timeout()).await?;
+        let json = handle_response_openai_compat(response).await?;
 
         if let Some(err_obj) = json.get("error") {
             let msg = err_obj

--- a/crates/goose-providers/src/openai_compatible.rs
+++ b/crates/goose-providers/src/openai_compatible.rs
@@ -185,7 +185,7 @@ impl Provider for OpenAiCompatibleProvider {
             .response_get("models")
             .await
             .map_err(|e| ProviderError::RequestFailed(e.to_string()))?;
-        let json = handle_response_openai_compat(response).await?;
+        let json = handle_response_openai_compat(response, self.api_client.timeout()).await?;
 
         if let Some(err_obj) = json.get("error") {
             let msg = err_obj

--- a/crates/goose-providers/src/openai_compatible.rs
+++ b/crates/goose-providers/src/openai_compatible.rs
@@ -115,6 +115,7 @@ impl OpenAiCompatibleProvider {
                         .streaming(self.supports_streaming)
                         .response_post(&payload)
                         .await?,
+                    self.api_client.timeout(),
                 )
                 .await
             })

--- a/crates/goose-providers/src/openai_compatible.rs
+++ b/crates/goose-providers/src/openai_compatible.rs
@@ -112,6 +112,7 @@ impl OpenAiCompatibleProvider {
                     self.api_client
                         .request(&path)
                         .model_headers(model_config)?
+                        .streaming(self.supports_streaming)
                         .response_post(&payload)
                         .await?,
                 )

--- a/crates/goose-providers/src/snowflake.rs
+++ b/crates/goose-providers/src/snowflake.rs
@@ -117,7 +117,7 @@ impl SnowflakeProvider {
         let payload_text: String = if status.is_success() && !is_json {
             response.text().await.ok().unwrap_or_default()
         } else {
-            crate::http_status::read_error_body(response)
+            crate::http_status::read_error_body(response, self.api_client.timeout())
                 .await
                 .unwrap_or_default()
         };

--- a/crates/goose-providers/src/snowflake.rs
+++ b/crates/goose-providers/src/snowflake.rs
@@ -100,12 +100,27 @@ impl SnowflakeProvider {
             .api_client
             .request("api/v2/cortex/inference:complete")
             .model_headers(model_config)?
+            .streaming(true)
             .response_post(payload)
             .await?;
 
         let status = response.status();
         let url = sanitize_url(response.url().as_str());
-        let payload_text: String = response.text().await.ok().unwrap_or_default();
+        let is_json = response
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .map(|v| v.to_ascii_lowercase())
+            .is_some_and(|v| v.contains("json"));
+        // A 200 with a JSON body is an error payload, not the SSE generation
+        // stream; bound its read since this request has no total deadline.
+        let payload_text: String = if status.is_success() && !is_json {
+            response.text().await.ok().unwrap_or_default()
+        } else {
+            crate::http_status::read_error_body(response)
+                .await
+                .unwrap_or_default()
+        };
 
         if status.is_success() {
             if let Ok(payload) = serde_json::from_str::<Value>(&payload_text) {

--- a/crates/goose-providers/src/snowflake.rs
+++ b/crates/goose-providers/src/snowflake.rs
@@ -112,8 +112,6 @@ impl SnowflakeProvider {
             .and_then(|v| v.to_str().ok())
             .map(|v| v.to_ascii_lowercase())
             .is_some_and(|v| v.contains("json"));
-        // A 200 with a JSON body is an error payload, not the SSE generation
-        // stream; bound its read since this request has no total deadline.
         let payload_text: String = if status.is_success() && !is_json {
             response.text().await.ok().unwrap_or_default()
         } else {

--- a/crates/goose-providers/src/snowflake.rs
+++ b/crates/goose-providers/src/snowflake.rs
@@ -115,7 +115,7 @@ impl SnowflakeProvider {
         let payload_text: String = if status.is_success() && !is_json {
             response.text().await.ok().unwrap_or_default()
         } else {
-            crate::http_status::read_error_body(response, self.api_client.timeout())
+            crate::http_status::read_error_body(response)
                 .await
                 .unwrap_or_default()
         };

--- a/crates/goose/src/providers/anthropic_def.rs
+++ b/crates/goose/src/providers/anthropic_def.rs
@@ -39,14 +39,23 @@ async fn from_env(
         .get_param("ANTHROPIC_HOST")
         .unwrap_or_else(|_| "https://api.anthropic.com".to_string());
 
+    let timeout_secs: u64 = config
+        .get_param("ANTHROPIC_TIMEOUT")
+        .unwrap_or(crate::providers::base::DEFAULT_PROVIDER_TIMEOUT_SECS);
+
     let auth = AuthMethod::ApiKey {
         header_name: "x-api-key".to_string(),
         key: api_key,
     };
 
-    let api_client = ApiClient::new_with_tls(host, auth, tls_config)?
-        .with_request_builder(crate::session_context::session_id_request_builder())
-        .with_header("anthropic-version", ANTHROPIC_API_VERSION)?;
+    let api_client = ApiClient::with_timeout_and_tls(
+        host,
+        auth,
+        std::time::Duration::from_secs(timeout_secs),
+        tls_config,
+    )?
+    .with_request_builder(crate::session_context::session_id_request_builder())
+    .with_header("anthropic-version", ANTHROPIC_API_VERSION)?;
 
     Ok(AnthropicProviderBuilder::new(api_client).build())
 }

--- a/crates/goose/src/providers/base.rs
+++ b/crates/goose/src/providers/base.rs
@@ -6,8 +6,9 @@ pub use goose_providers::conversation::token_usage::{
 };
 use serde::{Deserialize, Serialize};
 
-pub const DEFAULT_PROVIDER_TIMEOUT_SECS: u64 = 600;
-pub use goose_providers::api_client::DEFAULT_CONNECT_TIMEOUT_SECS;
+pub use goose_providers::api_client::{
+    DEFAULT_CONNECT_TIMEOUT_SECS, DEFAULT_PROVIDER_TIMEOUT_SECS,
+};
 
 use crate::config::ExtensionConfig;
 

--- a/crates/goose/src/providers/base.rs
+++ b/crates/goose/src/providers/base.rs
@@ -7,6 +7,7 @@ pub use goose_providers::conversation::token_usage::{
 use serde::{Deserialize, Serialize};
 
 pub const DEFAULT_PROVIDER_TIMEOUT_SECS: u64 = 600;
+pub use goose_providers::api_client::DEFAULT_CONNECT_TIMEOUT_SECS;
 
 use crate::config::ExtensionConfig;
 

--- a/crates/goose/src/providers/bedrock.rs
+++ b/crates/goose/src/providers/bedrock.rs
@@ -278,19 +278,13 @@ impl BedrockProvider {
             }
         }
 
-        let response = tokio::time::timeout(
+        let response = goose_providers::http_status::send_bounded(
+            req,
             std::time::Duration::from_secs(DEFAULT_PROVIDER_TIMEOUT_SECS),
-            req.send(),
         )
-        .await
-        .map_err(|_| {
-            ProviderError::NetworkError(
-                "Request timed out — check your network connection and try again.".to_string(),
-            )
-        })?
-        .map_err(|e| ProviderError::RequestFailed(format!("Mantle request failed: {}", e)))?;
+        .await?;
 
-        handle_status(response, Duration::from_secs(DEFAULT_PROVIDER_TIMEOUT_SECS)).await
+        handle_status(response).await
     }
 
     /// Build the request inputs shared by [`Self::converse`] and

--- a/crates/goose/src/providers/bedrock.rs
+++ b/crates/goose/src/providers/bedrock.rs
@@ -290,7 +290,7 @@ impl BedrockProvider {
         })?
         .map_err(|e| ProviderError::RequestFailed(format!("Mantle request failed: {}", e)))?;
 
-        handle_status(response).await
+        handle_status(response, Duration::from_secs(DEFAULT_PROVIDER_TIMEOUT_SECS)).await
     }
 
     /// Build the request inputs shared by [`Self::converse`] and

--- a/crates/goose/src/providers/bedrock.rs
+++ b/crates/goose/src/providers/bedrock.rs
@@ -1,6 +1,9 @@
 use std::collections::HashMap;
 
-use super::base::{ConfigKey, MessageStream, Provider, ProviderDef, ProviderMetadata};
+use super::base::{
+    ConfigKey, MessageStream, Provider, ProviderDef, ProviderMetadata,
+    DEFAULT_CONNECT_TIMEOUT_SECS, DEFAULT_PROVIDER_TIMEOUT_SECS,
+};
 use super::openai_compatible::{handle_status, stream_responses_compat};
 use super::retry::{ProviderRetry, RetryConfig};
 use crate::conversation::message::Message;
@@ -177,7 +180,12 @@ impl BedrockProvider {
             name: BEDROCK_PROVIDER_NAME.to_string(),
             region: resolved_region,
             bearer_token,
-            http_client: reqwest::Client::new(),
+            http_client: reqwest::Client::builder()
+                .connect_timeout(std::time::Duration::from_secs(DEFAULT_CONNECT_TIMEOUT_SECS))
+                .read_timeout(std::time::Duration::from_secs(
+                    DEFAULT_PROVIDER_TIMEOUT_SECS,
+                ))
+                .build()?,
             mantle_base_url: None,
         })
     }
@@ -270,10 +278,17 @@ impl BedrockProvider {
             }
         }
 
-        let response = req
-            .send()
-            .await
-            .map_err(|e| ProviderError::RequestFailed(format!("Mantle request failed: {}", e)))?;
+        let response = tokio::time::timeout(
+            std::time::Duration::from_secs(DEFAULT_PROVIDER_TIMEOUT_SECS),
+            req.send(),
+        )
+        .await
+        .map_err(|_| {
+            ProviderError::NetworkError(
+                "Request timed out — check your network connection and try again.".to_string(),
+            )
+        })?
+        .map_err(|e| ProviderError::RequestFailed(format!("Mantle request failed: {}", e)))?;
 
         handle_status(response).await
     }

--- a/crates/goose/src/providers/chatgpt_codex.rs
+++ b/crates/goose/src/providers/chatgpt_codex.rs
@@ -955,7 +955,7 @@ impl ChatGptCodexProvider {
         })?
         .map_err(|e| ProviderError::RequestFailed(e.to_string()))?;
 
-        handle_status(response).await
+        handle_status(response, Duration::from_secs(DEFAULT_PROVIDER_TIMEOUT_SECS)).await
     }
 }
 

--- a/crates/goose/src/providers/chatgpt_codex.rs
+++ b/crates/goose/src/providers/chatgpt_codex.rs
@@ -29,7 +29,6 @@ use std::io;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::{Arc, LazyLock};
-use std::time::Duration;
 use tokio::pin;
 use tokio::sync::{oneshot, Mutex as TokioMutex};
 use tokio_util::codec::{FramedRead, LinesCodec};
@@ -944,19 +943,13 @@ impl ChatGptCodexProvider {
 
         let request = (self.request_builder)(request)
             .map_err(|e| ProviderError::ExecutionError(e.to_string()))?;
-        let response = tokio::time::timeout(
+        let response = goose_providers::http_status::send_bounded(
+            request,
             std::time::Duration::from_secs(DEFAULT_PROVIDER_TIMEOUT_SECS),
-            request.send(),
         )
-        .await
-        .map_err(|_| {
-            ProviderError::NetworkError(
-                "Request timed out — check your network connection and try again.".to_string(),
-            )
-        })?
-        .map_err(|e| ProviderError::RequestFailed(e.to_string()))?;
+        .await?;
 
-        handle_status(response, Duration::from_secs(DEFAULT_PROVIDER_TIMEOUT_SECS)).await
+        handle_status(response).await
     }
 }
 

--- a/crates/goose/src/providers/chatgpt_codex.rs
+++ b/crates/goose/src/providers/chatgpt_codex.rs
@@ -29,6 +29,7 @@ use std::io;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::{Arc, LazyLock};
+use std::time::Duration;
 use tokio::pin;
 use tokio::sync::{oneshot, Mutex as TokioMutex};
 use tokio_util::codec::{FramedRead, LinesCodec};

--- a/crates/goose/src/providers/chatgpt_codex.rs
+++ b/crates/goose/src/providers/chatgpt_codex.rs
@@ -1,7 +1,10 @@
 use crate::config::paths::Paths;
 use crate::conversation::message::{Message, MessageContent};
 use crate::providers::api_client::{AuthProvider, RequestBuilderDecorator};
-use crate::providers::base::{ConfigKey, MessageStream, Provider, ProviderDef, ProviderMetadata};
+use crate::providers::base::{
+    ConfigKey, MessageStream, Provider, ProviderDef, ProviderMetadata,
+    DEFAULT_CONNECT_TIMEOUT_SECS, DEFAULT_PROVIDER_TIMEOUT_SECS,
+};
 use crate::providers::openai_compatible::handle_status;
 use crate::providers::private_file::write_private_file;
 use crate::providers::retry::ProviderRetry;
@@ -921,7 +924,13 @@ impl ChatGptCodexProvider {
             );
         }
 
-        let client = reqwest::Client::new();
+        let client = reqwest::Client::builder()
+            .connect_timeout(std::time::Duration::from_secs(DEFAULT_CONNECT_TIMEOUT_SECS))
+            .read_timeout(std::time::Duration::from_secs(
+                DEFAULT_PROVIDER_TIMEOUT_SECS,
+            ))
+            .build()
+            .map_err(|e| ProviderError::ExecutionError(e.to_string()))?;
         let request = client
             .post(format!("{}/responses", CODEX_API_ENDPOINT))
             .header(
@@ -932,11 +941,19 @@ impl ChatGptCodexProvider {
             .headers(headers)
             .json(payload);
 
-        let response = (self.request_builder)(request)
-            .map_err(|e| ProviderError::ExecutionError(e.to_string()))?
-            .send()
-            .await
-            .map_err(|e| ProviderError::RequestFailed(e.to_string()))?;
+        let request = (self.request_builder)(request)
+            .map_err(|e| ProviderError::ExecutionError(e.to_string()))?;
+        let response = tokio::time::timeout(
+            std::time::Duration::from_secs(DEFAULT_PROVIDER_TIMEOUT_SECS),
+            request.send(),
+        )
+        .await
+        .map_err(|_| {
+            ProviderError::NetworkError(
+                "Request timed out — check your network connection and try again.".to_string(),
+            )
+        })?
+        .map_err(|e| ProviderError::RequestFailed(e.to_string()))?;
 
         handle_status(response).await
     }

--- a/crates/goose/src/providers/gcpvertexai.rs
+++ b/crates/goose/src/providers/gcpvertexai.rs
@@ -355,8 +355,11 @@ impl GcpVertexAIProvider {
                         }),
                     );
                 }
-                let msg =
-                    rate_limit_error_message(&read_error_body(response).await.unwrap_or_default());
+                let msg = rate_limit_error_message(
+                    &read_error_body(response, Duration::from_secs(DEFAULT_PROVIDER_TIMEOUT_SECS))
+                        .await
+                        .unwrap_or_default(),
+                );
                 tracing::warn!("429 (attempt {rate_limit_attempts}/{max_retries}): {msg}");
                 last_error = Some(ProviderError::RateLimitExceeded {
                     details: msg,
@@ -400,7 +403,10 @@ impl GcpVertexAIProvider {
                 )));
             } else {
                 let url = sanitize_url(response.url().as_str());
-                let response_text = read_error_body(response).await.unwrap_or_default();
+                let response_text =
+                    read_error_body(response, Duration::from_secs(DEFAULT_PROVIDER_TIMEOUT_SECS))
+                        .await
+                        .unwrap_or_default();
                 let payload = serde_json::from_str::<Value>(&response_text).ok();
                 return Err(map_http_error_to_provider_error(status, payload, &url));
             }

--- a/crates/goose/src/providers/gcpvertexai.rs
+++ b/crates/goose/src/providers/gcpvertexai.rs
@@ -18,7 +18,7 @@ use crate::conversation::message::Message;
 use crate::providers::api_client::RequestBuilderDecorator;
 use crate::providers::base::{
     ConfigKey, MessageStream, Provider, ProviderDef, ProviderMetadata,
-    DEFAULT_PROVIDER_TIMEOUT_SECS,
+    DEFAULT_CONNECT_TIMEOUT_SECS, DEFAULT_PROVIDER_TIMEOUT_SECS,
 };
 use goose_providers::model::ModelConfig;
 
@@ -30,6 +30,7 @@ use crate::providers::gcpauth::GcpAuth;
 use crate::providers::openai_compatible::{map_http_error_to_provider_error, sanitize_url};
 use crate::providers::retry::RetryConfig;
 use goose_providers::errors::ProviderError;
+use goose_providers::http_status::read_error_body;
 use goose_providers::request_log::{start_log, LoggerHandleExt};
 use rmcp::model::Tool;
 
@@ -174,7 +175,8 @@ impl GcpVertexAIProvider {
         let host = Self::build_host_url(&location);
 
         let client = Client::builder()
-            .timeout(Duration::from_secs(DEFAULT_PROVIDER_TIMEOUT_SECS))
+            .connect_timeout(Duration::from_secs(DEFAULT_CONNECT_TIMEOUT_SECS))
+            .read_timeout(Duration::from_secs(DEFAULT_PROVIDER_TIMEOUT_SECS))
             .build()?;
 
         let auth = GcpAuth::new().await?;
@@ -327,11 +329,19 @@ impl GcpVertexAIProvider {
                 }
             }
 
-            let response = (self.request_builder)(request)
-                .map_err(|e| ProviderError::ExecutionError(e.to_string()))?
-                .send()
-                .await
-                .map_err(|e| ProviderError::RequestFailed(e.to_string()))?;
+            let request = (self.request_builder)(request)
+                .map_err(|e| ProviderError::ExecutionError(e.to_string()))?;
+            let response = tokio::time::timeout(
+                Duration::from_secs(DEFAULT_PROVIDER_TIMEOUT_SECS),
+                request.send(),
+            )
+            .await
+            .map_err(|_| {
+                ProviderError::NetworkError(
+                    "Request timed out — check your network connection and try again.".to_string(),
+                )
+            })?
+            .map_err(|e| ProviderError::RequestFailed(e.to_string()))?;
 
             let status = response.status();
 
@@ -345,7 +355,8 @@ impl GcpVertexAIProvider {
                         }),
                     );
                 }
-                let msg = rate_limit_error_message(&response.text().await.unwrap_or_default());
+                let msg =
+                    rate_limit_error_message(&read_error_body(response).await.unwrap_or_default());
                 tracing::warn!("429 (attempt {rate_limit_attempts}/{max_retries}): {msg}");
                 last_error = Some(ProviderError::RateLimitExceeded {
                     details: msg,
@@ -389,7 +400,7 @@ impl GcpVertexAIProvider {
                 )));
             } else {
                 let url = sanitize_url(response.url().as_str());
-                let response_text = response.text().await.unwrap_or_default();
+                let response_text = read_error_body(response).await.unwrap_or_default();
                 let payload = serde_json::from_str::<Value>(&response_text).ok();
                 return Err(map_http_error_to_provider_error(status, payload, &url));
             }
@@ -459,6 +470,7 @@ impl GcpVertexAIProvider {
         let response = match self
             .client
             .post(&url)
+            .timeout(Duration::from_secs(DEFAULT_PROVIDER_TIMEOUT_SECS))
             .header("Authorization", &auth_header)
             .json(&payload)
             .send()

--- a/crates/goose/src/providers/gcpvertexai.rs
+++ b/crates/goose/src/providers/gcpvertexai.rs
@@ -331,17 +331,11 @@ impl GcpVertexAIProvider {
 
             let request = (self.request_builder)(request)
                 .map_err(|e| ProviderError::ExecutionError(e.to_string()))?;
-            let response = tokio::time::timeout(
+            let response = goose_providers::http_status::send_bounded(
+                request,
                 Duration::from_secs(DEFAULT_PROVIDER_TIMEOUT_SECS),
-                request.send(),
             )
-            .await
-            .map_err(|_| {
-                ProviderError::NetworkError(
-                    "Request timed out — check your network connection and try again.".to_string(),
-                )
-            })?
-            .map_err(|e| ProviderError::RequestFailed(e.to_string()))?;
+            .await?;
 
             let status = response.status();
 
@@ -355,11 +349,8 @@ impl GcpVertexAIProvider {
                         }),
                     );
                 }
-                let msg = rate_limit_error_message(
-                    &read_error_body(response, Duration::from_secs(DEFAULT_PROVIDER_TIMEOUT_SECS))
-                        .await
-                        .unwrap_or_default(),
-                );
+                let msg =
+                    rate_limit_error_message(&read_error_body(response).await.unwrap_or_default());
                 tracing::warn!("429 (attempt {rate_limit_attempts}/{max_retries}): {msg}");
                 last_error = Some(ProviderError::RateLimitExceeded {
                     details: msg,
@@ -403,10 +394,7 @@ impl GcpVertexAIProvider {
                 )));
             } else {
                 let url = sanitize_url(response.url().as_str());
-                let response_text =
-                    read_error_body(response, Duration::from_secs(DEFAULT_PROVIDER_TIMEOUT_SECS))
-                        .await
-                        .unwrap_or_default();
+                let response_text = read_error_body(response).await.unwrap_or_default();
                 let payload = serde_json::from_str::<Value>(&response_text).ok();
                 return Err(map_http_error_to_provider_error(status, payload, &url));
             }

--- a/crates/goose/src/providers/gemini_oauth.rs
+++ b/crates/goose/src/providers/gemini_oauth.rs
@@ -905,9 +905,12 @@ impl GeminiOAuthProvider {
 
         if !response.status().is_success() {
             let status = response.status();
-            let text = goose_providers::http_status::read_error_body(response)
-                .await
-                .unwrap_or_else(|| "unknown error".to_string());
+            let text = goose_providers::http_status::read_error_body(
+                response,
+                Duration::from_secs(DEFAULT_PROVIDER_TIMEOUT_SECS),
+            )
+            .await
+            .unwrap_or_else(|| "unknown error".to_string());
 
             if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
                 // Parse retry delay from the error message if available

--- a/crates/goose/src/providers/gemini_oauth.rs
+++ b/crates/goose/src/providers/gemini_oauth.rs
@@ -891,26 +891,17 @@ impl GeminiOAuthProvider {
 
         let request = (self.request_builder)(request.json(&wrapped))
             .map_err(|e| ProviderError::ExecutionError(e.to_string()))?;
-        let response = tokio::time::timeout(
+        let response = goose_providers::http_status::send_bounded(
+            request,
             Duration::from_secs(DEFAULT_PROVIDER_TIMEOUT_SECS),
-            request.send(),
         )
-        .await
-        .map_err(|_| {
-            ProviderError::NetworkError(
-                "Request timed out — check your network connection and try again.".to_string(),
-            )
-        })?
-        .map_err(|e| ProviderError::RequestFailed(e.to_string()))?;
+        .await?;
 
         if !response.status().is_success() {
             let status = response.status();
-            let text = goose_providers::http_status::read_error_body(
-                response,
-                Duration::from_secs(DEFAULT_PROVIDER_TIMEOUT_SECS),
-            )
-            .await
-            .unwrap_or_else(|| "unknown error".to_string());
+            let text = goose_providers::http_status::read_error_body(response)
+                .await
+                .unwrap_or_else(|| "unknown error".to_string());
 
             if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
                 // Parse retry delay from the error message if available

--- a/crates/goose/src/providers/gemini_oauth.rs
+++ b/crates/goose/src/providers/gemini_oauth.rs
@@ -3,7 +3,7 @@ use crate::conversation::message::Message;
 use crate::providers::api_client::RequestBuilderDecorator;
 use crate::providers::base::{
     ConfigKey, MessageStream, Provider, ProviderDef, ProviderMetadata,
-    DEFAULT_PROVIDER_TIMEOUT_SECS,
+    DEFAULT_CONNECT_TIMEOUT_SECS, DEFAULT_PROVIDER_TIMEOUT_SECS,
 };
 use crate::providers::formats::google::{create_request, response_to_streaming_message};
 use crate::providers::google::GOOGLE_DOC_URL;
@@ -40,7 +40,8 @@ use tokio_util::io::StreamReader;
 
 static HTTP_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
     reqwest::Client::builder()
-        .timeout(Duration::from_secs(DEFAULT_PROVIDER_TIMEOUT_SECS))
+        .connect_timeout(Duration::from_secs(DEFAULT_CONNECT_TIMEOUT_SECS))
+        .read_timeout(Duration::from_secs(DEFAULT_PROVIDER_TIMEOUT_SECS))
         .build()
         .expect("failed to build HTTP client")
 });
@@ -254,6 +255,7 @@ async fn exchange_code_for_tokens(
 
     let resp = client
         .post(GOOGLE_TOKEN_ENDPOINT)
+        .timeout(Duration::from_secs(DEFAULT_PROVIDER_TIMEOUT_SECS))
         .header("Content-Type", "application/x-www-form-urlencoded")
         .form(&params)
         .send()
@@ -281,6 +283,7 @@ async fn refresh_access_token(refresh_token: &str) -> Result<TokenResponse> {
 
     let resp = client
         .post(GOOGLE_TOKEN_ENDPOINT)
+        .timeout(Duration::from_secs(DEFAULT_PROVIDER_TIMEOUT_SECS))
         .header("Content-Type", "application/x-www-form-urlencoded")
         .form(&params)
         .send()
@@ -343,6 +346,7 @@ async fn code_assist_request(access_token: &str, method: &str, body: &Value) -> 
     let client = &*HTTP_CLIENT;
     let resp = client
         .post(&url)
+        .timeout(Duration::from_secs(DEFAULT_PROVIDER_TIMEOUT_SECS))
         .header("Authorization", format!("Bearer {}", access_token))
         .header("Content-Type", "application/json")
         .json(body)
@@ -371,6 +375,7 @@ async fn code_assist_get(access_token: &str, path: &str) -> Result<Value> {
     let client = &*HTTP_CLIENT;
     let resp = client
         .get(&url)
+        .timeout(Duration::from_secs(DEFAULT_PROVIDER_TIMEOUT_SECS))
         .header("Authorization", format!("Bearer {}", access_token))
         .send()
         .await?;
@@ -884,18 +889,25 @@ impl GeminiOAuthProvider {
             )
             .header("Content-Type", "application/json");
 
-        let response = (self.request_builder)(request.json(&wrapped))
-            .map_err(|e| ProviderError::ExecutionError(e.to_string()))?
-            .send()
-            .await
-            .map_err(|e| ProviderError::RequestFailed(e.to_string()))?;
+        let request = (self.request_builder)(request.json(&wrapped))
+            .map_err(|e| ProviderError::ExecutionError(e.to_string()))?;
+        let response = tokio::time::timeout(
+            Duration::from_secs(DEFAULT_PROVIDER_TIMEOUT_SECS),
+            request.send(),
+        )
+        .await
+        .map_err(|_| {
+            ProviderError::NetworkError(
+                "Request timed out — check your network connection and try again.".to_string(),
+            )
+        })?
+        .map_err(|e| ProviderError::RequestFailed(e.to_string()))?;
 
         if !response.status().is_success() {
             let status = response.status();
-            let text = response
-                .text()
+            let text = goose_providers::http_status::read_error_body(response)
                 .await
-                .unwrap_or_else(|_| "unknown error".to_string());
+                .unwrap_or_else(|| "unknown error".to_string());
 
             if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
                 // Parse retry delay from the error message if available

--- a/crates/goose/src/providers/githubcopilot.rs
+++ b/crates/goose/src/providers/githubcopilot.rs
@@ -425,7 +425,7 @@ impl GithubCopilotProvider {
                         true,
                     )
                     .await?;
-                handle_status(resp, self.api_client.timeout()).await
+                handle_status(resp, Duration::from_secs(DEFAULT_PROVIDER_TIMEOUT_SECS)).await
             })
             .await
             .inspect_err(|e| {
@@ -473,7 +473,7 @@ impl GithubCopilotProvider {
                             true,
                         )
                         .await?;
-                    handle_status(resp, self.api_client.timeout()).await
+                    handle_status(resp, Duration::from_secs(DEFAULT_PROVIDER_TIMEOUT_SECS)).await
                 })
                 .await
                 .inspect_err(|e| {
@@ -506,7 +506,11 @@ impl GithubCopilotProvider {
                     .await
                 })
                 .await?;
-            let response = handle_response_openai_compat(response).await?;
+            let response = handle_response_openai_compat(
+                response,
+                Duration::from_secs(DEFAULT_PROVIDER_TIMEOUT_SECS),
+            )
+            .await?;
 
             let response = promote_tool_choice(response);
 

--- a/crates/goose/src/providers/githubcopilot.rs
+++ b/crates/goose/src/providers/githubcopilot.rs
@@ -265,6 +265,7 @@ impl GithubCopilotProvider {
         is_user_initiated: bool,
         payload: &mut Value,
         has_images: bool,
+        streaming: bool,
     ) -> Result<Response, ProviderError> {
         let (endpoint, token) = self.get_api_info().await?;
         let auth = AuthMethod::BearerToken(token);
@@ -281,6 +282,7 @@ impl GithubCopilotProvider {
         api_client
             .request(path)
             .model_headers(model_config)?
+            .streaming(streaming)
             .response_post(payload)
             .await
             .map_err(|e| e.into())
@@ -420,6 +422,7 @@ impl GithubCopilotProvider {
                         is_user_initiated,
                         &mut payload_clone,
                         has_images,
+                        true,
                     )
                     .await?;
                 handle_status(resp).await
@@ -467,6 +470,7 @@ impl GithubCopilotProvider {
                             is_user_initiated,
                             &mut payload_clone,
                             has_images,
+                            true,
                         )
                         .await?;
                     handle_status(resp).await
@@ -497,6 +501,7 @@ impl GithubCopilotProvider {
                         is_user_initiated,
                         &mut payload_clone,
                         has_images,
+                        false,
                     )
                     .await
                 })

--- a/crates/goose/src/providers/githubcopilot.rs
+++ b/crates/goose/src/providers/githubcopilot.rs
@@ -425,7 +425,7 @@ impl GithubCopilotProvider {
                         true,
                     )
                     .await?;
-                handle_status(resp).await
+                handle_status(resp, self.api_client.timeout()).await
             })
             .await
             .inspect_err(|e| {
@@ -473,7 +473,7 @@ impl GithubCopilotProvider {
                             true,
                         )
                         .await?;
-                    handle_status(resp).await
+                    handle_status(resp, self.api_client.timeout()).await
                 })
                 .await
                 .inspect_err(|e| {

--- a/crates/goose/src/providers/githubcopilot.rs
+++ b/crates/goose/src/providers/githubcopilot.rs
@@ -425,7 +425,7 @@ impl GithubCopilotProvider {
                         true,
                     )
                     .await?;
-                handle_status(resp, Duration::from_secs(DEFAULT_PROVIDER_TIMEOUT_SECS)).await
+                handle_status(resp).await
             })
             .await
             .inspect_err(|e| {
@@ -473,7 +473,7 @@ impl GithubCopilotProvider {
                             true,
                         )
                         .await?;
-                    handle_status(resp, Duration::from_secs(DEFAULT_PROVIDER_TIMEOUT_SECS)).await
+                    handle_status(resp).await
                 })
                 .await
                 .inspect_err(|e| {
@@ -506,11 +506,7 @@ impl GithubCopilotProvider {
                     .await
                 })
                 .await?;
-            let response = handle_response_openai_compat(
-                response,
-                Duration::from_secs(DEFAULT_PROVIDER_TIMEOUT_SECS),
-            )
-            .await?;
+            let response = handle_response_openai_compat(response).await?;
 
             let response = promote_tool_choice(response);
 

--- a/crates/goose/src/providers/kimicode.rs
+++ b/crates/goose/src/providers/kimicode.rs
@@ -329,17 +329,11 @@ impl KimiCodeProvider {
 
         let request = (self.request_builder)(builder)
             .map_err(|e| ProviderError::ExecutionError(e.to_string()))?;
-        tokio::time::timeout(
+        goose_providers::http_status::send_bounded(
+            request,
             StdDuration::from_secs(DEFAULT_PROVIDER_TIMEOUT_SECS),
-            request.send(),
         )
         .await
-        .map_err(|_| {
-            ProviderError::NetworkError(
-                "Request timed out — check your network connection and try again.".to_string(),
-            )
-        })?
-        .map_err(|e| ProviderError::RequestFailed(e.to_string()))
     }
 }
 
@@ -419,7 +413,7 @@ impl Provider for KimiCodeProvider {
         let response = self
             .with_retry(|| async {
                 let resp = self.post(&payload).await?;
-                handle_status(resp, StdDuration::from_secs(DEFAULT_PROVIDER_TIMEOUT_SECS)).await
+                handle_status(resp).await
             })
             .await
             .inspect_err(|e| {
@@ -469,8 +463,7 @@ impl Provider for KimiCodeProvider {
             .send()
             .await
             .map_err(|e| ProviderError::RequestFailed(e.to_string()))?;
-        let resp =
-            handle_status(resp, StdDuration::from_secs(DEFAULT_PROVIDER_TIMEOUT_SECS)).await?;
+        let resp = handle_status(resp).await?;
 
         let parsed: ModelsResp = resp.json().await.map_err(|e| {
             ProviderError::RequestFailed(format!("/v1/models body is not valid JSON: {}", e))

--- a/crates/goose/src/providers/kimicode.rs
+++ b/crates/goose/src/providers/kimicode.rs
@@ -19,7 +19,7 @@ use uuid::Uuid;
 use super::api_client::RequestBuilderDecorator;
 use super::base::{
     ConfigKey, MessageStream, Provider, ProviderDef, ProviderMetadata,
-    DEFAULT_PROVIDER_TIMEOUT_SECS,
+    DEFAULT_CONNECT_TIMEOUT_SECS, DEFAULT_PROVIDER_TIMEOUT_SECS,
 };
 use super::formats::anthropic::{create_request, response_to_streaming_message};
 use super::oauth_device_flow::{
@@ -172,7 +172,8 @@ impl KimiCodeProvider {
         _tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> Result<Self> {
         let client = Client::builder()
-            .timeout(StdDuration::from_secs(DEFAULT_PROVIDER_TIMEOUT_SECS))
+            .connect_timeout(StdDuration::from_secs(DEFAULT_CONNECT_TIMEOUT_SECS))
+            .read_timeout(StdDuration::from_secs(DEFAULT_PROVIDER_TIMEOUT_SECS))
             .build()?;
         let device_id = Self::get_or_create_device_id().await?;
         Ok(Self {
@@ -326,11 +327,19 @@ impl KimiCodeProvider {
             .headers(self.kimi_headers())
             .json(payload);
 
-        (self.request_builder)(builder)
-            .map_err(|e| ProviderError::ExecutionError(e.to_string()))?
-            .send()
-            .await
-            .map_err(|e| ProviderError::RequestFailed(e.to_string()))
+        let request = (self.request_builder)(builder)
+            .map_err(|e| ProviderError::ExecutionError(e.to_string()))?;
+        tokio::time::timeout(
+            StdDuration::from_secs(DEFAULT_PROVIDER_TIMEOUT_SECS),
+            request.send(),
+        )
+        .await
+        .map_err(|_| {
+            ProviderError::NetworkError(
+                "Request timed out — check your network connection and try again.".to_string(),
+            )
+        })?
+        .map_err(|e| ProviderError::RequestFailed(e.to_string()))
     }
 }
 
@@ -454,6 +463,7 @@ impl Provider for KimiCodeProvider {
         let resp = self
             .client
             .get(format!("{}/v1/models", self.api_base))
+            .timeout(StdDuration::from_secs(DEFAULT_PROVIDER_TIMEOUT_SECS))
             .bearer_auth(access_token)
             .headers(self.kimi_headers())
             .send()

--- a/crates/goose/src/providers/kimicode.rs
+++ b/crates/goose/src/providers/kimicode.rs
@@ -419,7 +419,7 @@ impl Provider for KimiCodeProvider {
         let response = self
             .with_retry(|| async {
                 let resp = self.post(&payload).await?;
-                handle_status(resp).await
+                handle_status(resp, StdDuration::from_secs(DEFAULT_PROVIDER_TIMEOUT_SECS))
             })
             .await
             .inspect_err(|e| {
@@ -469,7 +469,8 @@ impl Provider for KimiCodeProvider {
             .send()
             .await
             .map_err(|e| ProviderError::RequestFailed(e.to_string()))?;
-        let resp = handle_status(resp).await?;
+        let resp =
+            handle_status(resp, StdDuration::from_secs(DEFAULT_PROVIDER_TIMEOUT_SECS)).await?;
 
         let parsed: ModelsResp = resp.json().await.map_err(|e| {
             ProviderError::RequestFailed(format!("/v1/models body is not valid JSON: {}", e))

--- a/crates/goose/src/providers/kimicode.rs
+++ b/crates/goose/src/providers/kimicode.rs
@@ -419,7 +419,7 @@ impl Provider for KimiCodeProvider {
         let response = self
             .with_retry(|| async {
                 let resp = self.post(&payload).await?;
-                handle_status(resp, StdDuration::from_secs(DEFAULT_PROVIDER_TIMEOUT_SECS))
+                handle_status(resp, StdDuration::from_secs(DEFAULT_PROVIDER_TIMEOUT_SECS)).await
             })
             .await
             .inspect_err(|e| {

--- a/crates/goose/src/providers/litellm.rs
+++ b/crates/goose/src/providers/litellm.rs
@@ -147,7 +147,7 @@ impl LiteLLMProvider {
             .model_headers(model_config)?
             .response_post(payload)
             .await?;
-        handle_response_openai_compat(response).await
+        handle_response_openai_compat(response, self.api_client.timeout()).await
     }
 
     async fn supports_cache_control(&self, model: &ModelConfig) -> bool {

--- a/crates/goose/src/providers/litellm.rs
+++ b/crates/goose/src/providers/litellm.rs
@@ -147,7 +147,7 @@ impl LiteLLMProvider {
             .model_headers(model_config)?
             .response_post(payload)
             .await?;
-        handle_response_openai_compat(response, self.api_client.timeout()).await
+        handle_response_openai_compat(response).await
     }
 
     async fn supports_cache_control(&self, model: &ModelConfig) -> bool {

--- a/crates/goose/src/providers/nanogpt.rs
+++ b/crates/goose/src/providers/nanogpt.rs
@@ -198,6 +198,7 @@ impl Provider for NanoGptProvider {
                     .api_client
                     .request("chat/completions")
                     .model_headers(model_config)?
+                    .streaming(true)
                     .response_post(&payload)
                     .await?;
                 handle_status(resp).await

--- a/crates/goose/src/providers/nanogpt.rs
+++ b/crates/goose/src/providers/nanogpt.rs
@@ -201,7 +201,7 @@ impl Provider for NanoGptProvider {
                     .streaming(true)
                     .response_post(&payload)
                     .await?;
-                handle_status(resp, self.api_client.timeout()).await
+                handle_status(resp).await
             })
             .await
             .inspect_err(|e| {

--- a/crates/goose/src/providers/nanogpt.rs
+++ b/crates/goose/src/providers/nanogpt.rs
@@ -201,7 +201,7 @@ impl Provider for NanoGptProvider {
                     .streaming(true)
                     .response_post(&payload)
                     .await?;
-                handle_status(resp).await
+                handle_status(resp, self.api_client.timeout()).await
             })
             .await
             .inspect_err(|e| {

--- a/crates/goose/src/providers/oauth_device_flow.rs
+++ b/crates/goose/src/providers/oauth_device_flow.rs
@@ -287,7 +287,12 @@ async fn send_request<T: Serialize + ?Sized>(
     url: &str,
     body: &T,
 ) -> reqwest::Result<reqwest::Response> {
-    let builder = client.post(url).headers(cfg.extra_headers.clone());
+    let builder = client
+        .post(url)
+        .timeout(std::time::Duration::from_secs(
+            super::base::DEFAULT_PROVIDER_TIMEOUT_SECS,
+        ))
+        .headers(cfg.extra_headers.clone());
     let builder = match cfg.encoding {
         RequestEncoding::Form => builder.form(body),
         RequestEncoding::Json => builder.json(body),

--- a/crates/goose/src/providers/openrouter.rs
+++ b/crates/goose/src/providers/openrouter.rs
@@ -353,7 +353,7 @@ impl Provider for OpenRouterProvider {
                     .streaming(true)
                     .response_post(&payload)
                     .await?;
-                handle_status(resp).await
+                handle_status(resp, self.api_client.timeout()).await
             })
             .await
             .inspect_err(|e| {

--- a/crates/goose/src/providers/openrouter.rs
+++ b/crates/goose/src/providers/openrouter.rs
@@ -350,6 +350,7 @@ impl Provider for OpenRouterProvider {
                     .api_client
                     .request("api/v1/chat/completions")
                     .model_headers(model_config)?
+                    .streaming(true)
                     .response_post(&payload)
                     .await?;
                 handle_status(resp).await

--- a/crates/goose/src/providers/openrouter.rs
+++ b/crates/goose/src/providers/openrouter.rs
@@ -353,7 +353,7 @@ impl Provider for OpenRouterProvider {
                     .streaming(true)
                     .response_post(&payload)
                     .await?;
-                handle_status(resp, self.api_client.timeout()).await
+                handle_status(resp).await
             })
             .await
             .inspect_err(|e| {

--- a/crates/goose/src/providers/tetrate.rs
+++ b/crates/goose/src/providers/tetrate.rs
@@ -154,6 +154,7 @@ impl Provider for TetrateProvider {
                     .api_client
                     .request("v1/chat/completions")
                     .model_headers(model_config)?
+                    .streaming(true)
                     .response_post(&payload)
                     .await?;
                 let resp = handle_status(resp)
@@ -169,15 +170,18 @@ impl Provider for TetrateProvider {
 
                 if is_json {
                     // Streaming responses should be SSE; when we get JSON instead, parse it to map
-                    // explicit error payloads and otherwise fail as a protocol mismatch.
-                    let body = handle_response_openai_compat(resp)
+                    // explicit error payloads and otherwise fail as a protocol mismatch. The read
+                    // is bounded: this request is exempt from the total deadline.
+                    let body = goose_providers::http_status::read_error_body(resp)
                         .await
-                        .map_err(Self::enrich_credits_error)?;
-                    if body.get("error").is_some() {
-                        return Err(Self::error_from_tetrate_error_payload(
-                            body,
-                            "v1/chat/completions",
-                        ));
+                        .unwrap_or_default();
+                    if let Ok(payload) = serde_json::from_str::<serde_json::Value>(&body) {
+                        if payload.get("error").is_some() {
+                            return Err(Self::error_from_tetrate_error_payload(
+                                payload,
+                                "v1/chat/completions",
+                            ));
+                        }
                     }
 
                     return Err(ProviderError::ExecutionError(

--- a/crates/goose/src/providers/tetrate.rs
+++ b/crates/goose/src/providers/tetrate.rs
@@ -157,7 +157,7 @@ impl Provider for TetrateProvider {
                     .streaming(true)
                     .response_post(&payload)
                     .await?;
-                let resp = handle_status(resp)
+                let resp = handle_status(resp, self.api_client.timeout())
                     .await
                     .map_err(Self::enrich_credits_error)?;
 
@@ -172,9 +172,12 @@ impl Provider for TetrateProvider {
                     // Streaming responses should be SSE; when we get JSON instead, parse it to map
                     // explicit error payloads and otherwise fail as a protocol mismatch. The read
                     // is bounded: this request is exempt from the total deadline.
-                    let body = goose_providers::http_status::read_error_body(resp)
-                        .await
-                        .unwrap_or_default();
+                    let body = goose_providers::http_status::read_error_body(
+                        resp,
+                        self.api_client.timeout(),
+                    )
+                    .await
+                    .unwrap_or_default();
                     if let Ok(payload) = serde_json::from_str::<serde_json::Value>(&body) {
                         if payload.get("error").is_some() {
                             return Err(Self::error_from_tetrate_error_payload(

--- a/crates/goose/src/providers/tetrate.rs
+++ b/crates/goose/src/providers/tetrate.rs
@@ -207,7 +207,7 @@ impl Provider for TetrateProvider {
             .response_get("v1/models")
             .await
             .map_err(|e| ProviderError::RequestFailed(e.to_string()))?;
-        let json = handle_response_openai_compat(response).await?;
+        let json = handle_response_openai_compat(response, self.api_client.timeout()).await?;
 
         // Tetrate can return errors in 200 OK responses, so check explicitly
         if json.get("error").is_some() {

--- a/crates/goose/src/providers/tetrate.rs
+++ b/crates/goose/src/providers/tetrate.rs
@@ -157,7 +157,7 @@ impl Provider for TetrateProvider {
                     .streaming(true)
                     .response_post(&payload)
                     .await?;
-                let resp = handle_status(resp, self.api_client.timeout())
+                let resp = handle_status(resp)
                     .await
                     .map_err(Self::enrich_credits_error)?;
 
@@ -169,12 +169,9 @@ impl Provider for TetrateProvider {
                     .is_some_and(|v| v.contains("json"));
 
                 if is_json {
-                    let body = goose_providers::http_status::read_error_body(
-                        resp,
-                        self.api_client.timeout(),
-                    )
-                    .await
-                    .unwrap_or_default();
+                    let body = goose_providers::http_status::read_error_body(resp)
+                        .await
+                        .unwrap_or_default();
                     if let Ok(payload) = serde_json::from_str::<serde_json::Value>(&body) {
                         if payload.get("error").is_some() {
                             return Err(Self::error_from_tetrate_error_payload(
@@ -184,10 +181,9 @@ impl Provider for TetrateProvider {
                         }
                     }
 
-                    return Err(ProviderError::ExecutionError(
-                        "Expected streaming response but received non-streaming payload"
-                            .to_string(),
-                    ));
+                    return Err(ProviderError::ExecutionError(format!(
+                        "Expected streaming response but received non-streaming payload: {body}"
+                    )));
                 }
 
                 Ok(resp)
@@ -207,7 +203,7 @@ impl Provider for TetrateProvider {
             .response_get("v1/models")
             .await
             .map_err(|e| ProviderError::RequestFailed(e.to_string()))?;
-        let json = handle_response_openai_compat(response, self.api_client.timeout()).await?;
+        let json = handle_response_openai_compat(response).await?;
 
         // Tetrate can return errors in 200 OK responses, so check explicitly
         if json.get("error").is_some() {

--- a/crates/goose/src/providers/tetrate.rs
+++ b/crates/goose/src/providers/tetrate.rs
@@ -169,9 +169,6 @@ impl Provider for TetrateProvider {
                     .is_some_and(|v| v.contains("json"));
 
                 if is_json {
-                    // Streaming responses should be SSE; when we get JSON instead, parse it to map
-                    // explicit error payloads and otherwise fail as a protocol mismatch. The read
-                    // is bounded: this request is exempt from the total deadline.
                     let body = goose_providers::http_status::read_error_body(
                         resp,
                         self.api_client.timeout(),


### PR DESCRIPTION
## Problem

Model turns streaming longer than 10 minutes die with `Stream decode error: error decoding response body`.
In headless `goose run` the reply loop treats this as terminal and silently ends the session.
Long turns are routine with high thinking effort, large single-file generations, and slow local models.

Root cause: `ApiClient` sets reqwest's client-level `.timeout(600s)`, a total request deadline that includes the streamed body, so it caps turn duration instead of connection health.
Reproduced on Terminal-Bench 2.1: all 5 regex-chess trials died at exactly 600-601s.

## Fix

The client uses `connect_timeout(30s)` + `read_timeout(timeout)`; the total deadline is applied per request only to non-streaming requests, and provider SSE call sites are marked `.streaming(true)`.
Streaming requests still bound everything before the response body (connect, request upload, first byte) with the configured timeout; only the streamed body itself is exempt.
Providers with their own reqwest clients (gcpvertexai, kimicode, gemini_oauth, OAuth device flow, ChatGPT Codex, Bedrock Mantle) get the same split.
Error-body reads on paths that lost the total deadline are bounded (30s), including 200-status JSON error payloads on the Tetrate and Snowflake streaming endpoints.
The Anthropic factories now honor `timeout_seconds` / `ANTHROPIC_TIMEOUT`, matching openai.rs.

| Request type | Before | After |
|---|---|---|
| Streaming, healthy but >600s | killed mid-stream | completes |
| Streaming, silent >600s | killed | killed (read timeout) |
| Non-streaming | 600s total deadline | unchanged |

Scope: this PR is transport-only.
An earlier revision also retried mid-stream network errors in the agent loop; that was split out so agent-layer retry has a single owner in #10533.

## Validation

- Unit tests against a mock slow-chunk server: healthy stream outlives the total timeout, stalled stream still times out, non-streaming deadline unchanged.
- Terminal-Bench 2.1 A/B on the 4 affected tasks (k=5): stream deaths 11/20 → 0/20; 23 turns >600s survived (max 2440s); regex-chess 0/5 → 3/5.
  The A/B ran with the since-removed agent retry included; it fired on 1 of the 20 trials, and the other recoveries came from the transport fix alone.

Tradeoff: worst-case hung-stream detection stays 600s (of silence).

Fixes #9413