### PR TITLE
docs: add BountyVerdict extension

### DIFF
--- a/documentation/docs/mcp/bountyverdict-mcp.md
+++ b/documentation/docs/mcp/bountyverdict-mcp.md
@@ -29,9 +29,9 @@ BountyVerdict is an account-free, read-only MCP server that helps agents decide 
 
 The server exposes six tools:
 
-- `check_bounty` checks one public GitHub bounty for assignment, claim competition, repository policy, reward provenance, and linked work.
-- `rank_bounties` compares two to five bounties and returns the best eligible candidate.
-- `audit_repository_instructions` checks repository agent instructions for risky or contradictory behavior.
+- `check_github_bounty` checks one public GitHub bounty for assignment, claim competition, repository policy, reward provenance, and linked work.
+- `rank_github_bounties` compares two to ten bounties and returns the best eligible candidate.
+- `audit_agent_harness` checks repository agent instructions for risky or contradictory behavior.
 - `diagnose_github_actions_run` identifies evidence-backed failure causes in a public Actions run.
 - `classify_github_actions_flake` decides whether one failed job should be retried or fixed.
 - `check_mcp_tool_drift` compares MCP tool catalogs for breaking changes.

--- a/documentation/docs/mcp/bountyverdict-mcp.md
+++ b/documentation/docs/mcp/bountyverdict-mcp.md
@@ -13,7 +13,7 @@ BountyVerdict is an account-free, read-only MCP server that helps agents decide 
 :::tip Quick Install
 <Tabs groupId="interface">
   <TabItem value="ui" label="goose Desktop" default>
-    [Launch the installer](goose://extension?type=streamable_http&url=https%3A%2F%2Fbountyverdict-agent-production.mimirslab.workers.dev%2Fmcp%3Fsource%3Dgoose-extensions&id=bountyverdict&name=BountyVerdict%20Agent%20Decision%20Tools&description=Remote%2C%20account-free%20MCP%20server%20for%20preflight%20decisions%20on%20public%20GitHub%20bounties%2C%20coding-agent%20repository%20instructions%2C%20GitHub%20Actions%20failures%2C%20flaky%20retries%2C%20and%20MCP%20tool-catalog%20changes.%20Six%20read-only%20tools%20return%20evidence-linked%20verdicts.%20A%20valid%20first%20unsigned%20call%20cannot%20charge%20and%20returns%20a%20structured%20selection%20preview%20plus%20the%20exact%20x402%20USDC%20quote.)
+    [Launch the installer](goose://extension?type=streamable_http&url=https%3A%2F%2Fbountyverdict-agent-production.mimirslab.workers.dev%2Fmcp%3Fsource%3Dgoose-extensions&id=bountyverdict&name=BountyVerdict%20Agent%20Decision%20Tools&description=Remote%2C%20account-free%20MCP%20server%20for%20preflight%20decisions%20on%20public%20GitHub%20bounties%2C%20coding-agent%20repository%20instructions%2C%20GitHub%20Actions%20failures%2C%20flaky%20retries%2C%20and%20MCP%20tool-catalog%20changes.%20One%20free%20deterministic%20selector%2C%20choose_github_agent_decision%2C%20routes%20requests%20to%20six%20paid%2C%20read-only%20tools%20that%20return%20evidence-linked%20verdicts.%20A%20valid%20unsigned%20paid-tool%20call%20cannot%20charge%20and%20returns%20a%20structured%20selection%20preview%2C%20exact%20x402%20v2%20Base%20USDC%20quote%2C%20and%20executable%20payment%20handoff.)
   </TabItem>
   <TabItem value="cli" label="goose CLI">
     Start a session with the remote extension:
@@ -27,8 +27,9 @@ BountyVerdict is an account-free, read-only MCP server that helps agents decide 
 
 ## What BountyVerdict provides
 
-The server exposes six tools:
+The server exposes one free selector and six paid tools:
 
+- `choose_github_agent_decision` deterministically routes a task to the matching paid decision tool without requiring payment.
 - `check_github_bounty` checks one public GitHub bounty for assignment, claim competition, repository policy, reward provenance, and linked work.
 - `rank_github_bounties` compares two to ten bounties and returns the best eligible candidate.
 - `audit_agent_harness` checks repository agent instructions for risky or contradictory behavior.
@@ -62,7 +63,7 @@ No BountyVerdict account, API key, or environment variable is required.
 
 ## Payment boundary
 
-Connecting and listing tools are free. A valid first tool call is also unsigned and cannot charge. It returns a structured selection preview and the exact x402 v2 Base USDC payment requirement.
+Connecting, listing tools, and calling `choose_github_agent_decision` are free. A valid unsigned paid-tool call cannot charge. It returns a structured selection preview, the exact x402 v2 Base USDC quote, and an executable payment handoff.
 
 The standard goose MCP connection does not authorize or settle x402 payments. Receiving the paid result requires a separately authorized x402-aware wallet client to validate the quote and replay the exact request with payment. Never paste a private key, seed phrase, or wallet secret into the extension configuration.
 

--- a/documentation/docs/mcp/bountyverdict-mcp.md
+++ b/documentation/docs/mcp/bountyverdict-mcp.md
@@ -1,0 +1,87 @@
+---
+title: BountyVerdict Extension
+description: Add BountyVerdict as a goose Extension for evidence-linked GitHub engineering decisions
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import CLIExtensionInstructions from '@site/src/components/CLIExtensionInstructions';
+import GooseDesktopInstaller from '@site/src/components/GooseDesktopInstaller';
+
+BountyVerdict is an account-free, read-only MCP server that helps agents decide whether to pursue public GitHub bounties, trust repository instructions, diagnose GitHub Actions failures, retry flaky jobs, or accept MCP tool-catalog changes.
+
+:::tip Quick Install
+<Tabs groupId="interface">
+  <TabItem value="ui" label="goose Desktop" default>
+    [Launch the installer](goose://extension?type=streamable_http&url=https%3A%2F%2Fbountyverdict-agent-production.mimirslab.workers.dev%2Fmcp%3Fsource%3Dgoose-extensions&id=bountyverdict&name=BountyVerdict%20Agent%20Decision%20Tools&description=Remote%2C%20account-free%20MCP%20server%20for%20preflight%20decisions%20on%20public%20GitHub%20bounties%2C%20coding-agent%20repository%20instructions%2C%20GitHub%20Actions%20failures%2C%20flaky%20retries%2C%20and%20MCP%20tool-catalog%20changes.%20Six%20read-only%20tools%20return%20evidence-linked%20verdicts.%20A%20valid%20first%20unsigned%20call%20cannot%20charge%20and%20returns%20a%20structured%20selection%20preview%20plus%20the%20exact%20x402%20USDC%20quote.)
+  </TabItem>
+  <TabItem value="cli" label="goose CLI">
+    Start a session with the remote extension:
+
+    ```sh
+    goose session --with-streamable-http-extension "https://bountyverdict-agent-production.mimirslab.workers.dev/mcp?source=goose-extensions"
+    ```
+  </TabItem>
+</Tabs>
+:::
+
+## What BountyVerdict provides
+
+The server exposes six tools:
+
+- `check_bounty` checks one public GitHub bounty for assignment, claim competition, repository policy, reward provenance, and linked work.
+- `rank_bounties` compares two to five bounties and returns the best eligible candidate.
+- `audit_repository_instructions` checks repository agent instructions for risky or contradictory behavior.
+- `diagnose_github_actions_run` identifies evidence-backed failure causes in a public Actions run.
+- `classify_github_actions_flake` decides whether one failed job should be retried or fixed.
+- `check_mcp_tool_drift` compares MCP tool catalogs for breaking changes.
+
+## Configuration
+
+No BountyVerdict account, API key, or environment variable is required.
+
+<Tabs groupId="interface">
+  <TabItem value="ui" label="goose Desktop" default>
+    <GooseDesktopInstaller
+      extensionId="bountyverdict"
+      extensionName="BountyVerdict Agent Decision Tools"
+      description="Evidence-linked preflight decisions for public GitHub engineering work"
+      type="http"
+      url="https://bountyverdict-agent-production.mimirslab.workers.dev/mcp?source=goose-extensions"
+    />
+  </TabItem>
+  <TabItem value="cli" label="goose CLI">
+    <CLIExtensionInstructions
+      name="BountyVerdict Agent Decision Tools"
+      description="Evidence-linked preflight decisions for public GitHub engineering work"
+      type="http"
+      url="https://bountyverdict-agent-production.mimirslab.workers.dev/mcp?source=goose-extensions"
+    />
+  </TabItem>
+</Tabs>
+
+## Payment boundary
+
+Connecting and listing tools are free. A valid first tool call is also unsigned and cannot charge. It returns a structured selection preview and the exact x402 v2 Base USDC payment requirement.
+
+The standard goose MCP connection does not authorize or settle x402 payments. Receiving the paid result requires a separately authorized x402-aware wallet client to validate the quote and replay the exact request with payment. Never paste a private key, seed phrase, or wallet secret into the extension configuration.
+
+## Example requests
+
+```text
+Which of these public GitHub bounties is safe to start, and is either already claimed?
+```
+
+```text
+Why did this public GitHub Actions run fail, and what evidence supports that diagnosis?
+```
+
+```text
+Will this MCP tools-list update break existing agents?
+```
+
+## Resources
+
+- [Source](https://github.com/Mimirs402/bountyverdict)
+- [Agent guide](https://mimirs402.github.io/bountyverdict/agents.html)
+- [Privacy and payment disclosures](https://mimirs402.github.io/bountyverdict/privacy.html)

--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -103,11 +103,11 @@
   {
     "id": "bountyverdict",
     "name": "BountyVerdict Agent Decision Tools",
-    "description": "Remote, account-free MCP server for preflight decisions on public GitHub bounties, coding-agent repository instructions, GitHub Actions failures, flaky retries, and MCP tool-catalog changes. Six read-only tools return evidence-linked verdicts. A valid first unsigned call cannot charge and returns a structured selection preview plus the exact x402 USDC quote.",
+    "description": "Remote, account-free MCP server for preflight decisions on public GitHub bounties, coding-agent repository instructions, GitHub Actions failures, flaky retries, and MCP tool-catalog changes. One free deterministic selector, choose_github_agent_decision, routes requests to six paid, read-only tools that return evidence-linked verdicts. A valid unsigned paid-tool call cannot charge and returns a structured selection preview, exact x402 v2 Base USDC quote, and executable payment handoff.",
     "type": "streamable-http",
     "url": "https://bountyverdict-agent-production.mimirslab.workers.dev/mcp?source=goose-extensions",
     "link": "https://github.com/Mimirs402/bountyverdict",
-    "installation_notes": "No BountyVerdict account or API key is required. Connecting and listing tools are free. A valid unsigned tool call returns an exact x402 v2 Base USDC payment requirement; the standard goose MCP connection does not itself authorize or settle the payment.",
+    "installation_notes": "No BountyVerdict account or API key is required. Connecting, listing tools, and calling choose_github_agent_decision are free. A valid unsigned paid-tool call cannot charge and returns an exact x402 v2 Base USDC executable payment handoff; the standard goose MCP connection does not itself authorize or settle the payment.",
     "is_builtin": false,
     "endorsed": false,
     "environmentVariables": []

--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -101,6 +101,18 @@
     "environmentVariables": []
   },
   {
+    "id": "bountyverdict",
+    "name": "BountyVerdict Agent Decision Tools",
+    "description": "Remote, account-free MCP server for preflight decisions on public GitHub bounties, coding-agent repository instructions, GitHub Actions failures, flaky retries, and MCP tool-catalog changes. Six read-only tools return evidence-linked verdicts. A valid first unsigned call cannot charge and returns a structured selection preview plus the exact x402 USDC quote.",
+    "type": "streamable-http",
+    "url": "https://bountyverdict-agent-production.mimirslab.workers.dev/mcp?source=goose-extensions",
+    "link": "https://github.com/Mimirs402/bountyverdict",
+    "installation_notes": "No BountyVerdict account or API key is required. Connecting and listing tools are free. A valid unsigned tool call returns an exact x402 v2 Base USDC payment requirement; the standard goose MCP connection does not itself authorize or settle the payment.",
+    "is_builtin": false,
+    "endorsed": false,
+    "environmentVariables": []
+  },
+  {
     "id": "browserbase-mcp",
     "name": "Browserbase",
     "description": "Browser automation and web scraping",


### PR DESCRIPTION
## Summary

- add BountyVerdict to the official goose Extensions catalog as a keyless Streamable HTTP MCP server
- add focused desktop and CLI setup guidance for its six read-only GitHub engineering decision tools
- state the x402 boundary explicitly: discovery and the unsigned selection preview are free, while standard goose does not itself authorize or settle payment

### Testing

- `jq empty documentation/static/servers.json`
- `npm test` (9 passed)
- `npm run build` (production Docusaurus build passed under the repository Hermit environment)
- confirmed the built `servers.json` contains exactly one BountyVerdict entry and the tutorial renders at `/docs/mcp/bountyverdict-mcp`

`npm run typecheck` still reports the current unrelated Docusaurus/JSX and recipe/prompt model errors; this PR changes only the catalog JSON and one Markdown tutorial.

### Related Issues

N/A

### Screenshots/Demos (for UX changes)

No UI code change. The catalog entry uses goose's existing Streamable HTTP install card and the tutorial uses the existing desktop/CLI installer components.
