### PR TITLE
fix(acp): interrupt the agent on cancel instead of hanging the session

### DIFF
--- a/crates/goose-provider-types/src/base.rs
+++ b/crates/goose-provider-types/src/base.rs
@@ -629,6 +629,13 @@ pub trait Provider: Send + Sync {
     /// default is a no-op, appropriate for providers whose turn ends as soon
     /// as goose stops polling the response stream.
     async fn cancel(&self, _session_id: &str) {}
+
+    /// Discard any cancellation state latched by [`cancel`](Self::cancel).
+    ///
+    /// Called when a new reply begins, before that reply's own cancellation
+    /// can fire, so a cancel recorded during a previous reply cannot suppress
+    /// the new reply's work. The default is a no-op.
+    fn clear_pending_cancel(&self) {}
 }
 
 #[cfg(test)]

--- a/crates/goose-provider-types/src/base.rs
+++ b/crates/goose-provider-types/src/base.rs
@@ -621,21 +621,29 @@ pub trait Provider: Send + Sync {
         false
     }
 
+    /// Open a cancellation scope for the reply that is about to begin and
+    /// return its identifier.
+    ///
+    /// Called at reply setup, before that reply's own cancellation can fire.
+    /// The returned scope is passed back through [`cancel`](Self::cancel) so
+    /// the provider can tell which reply a (possibly late-firing) cancel
+    /// belongs to. The default returns 0, matching the no-op `cancel`.
+    fn begin_cancel_scope(&self) -> u64 {
+        0
+    }
+
     /// Cancel the in-flight turn for the given session.
+    ///
+    /// `scope` is the value [`begin_cancel_scope`](Self::begin_cancel_scope)
+    /// returned when the cancelled reply began, so a cancel that fires after
+    /// a newer reply has already started cannot be misattributed to it.
     ///
     /// Providers that drive a turn on a remote backend (e.g. ACP agents)
     /// override this to forward an out-of-band cancellation so the backend
     /// stops promptly instead of running the whole turn to completion. The
     /// default is a no-op, appropriate for providers whose turn ends as soon
     /// as goose stops polling the response stream.
-    async fn cancel(&self, _session_id: &str) {}
-
-    /// Discard any cancellation state latched by [`cancel`](Self::cancel).
-    ///
-    /// Called when a new reply begins, before that reply's own cancellation
-    /// can fire, so a cancel recorded during a previous reply cannot suppress
-    /// the new reply's work. The default is a no-op.
-    fn clear_pending_cancel(&self) {}
+    async fn cancel(&self, _session_id: &str, _scope: u64) {}
 }
 
 #[cfg(test)]

--- a/crates/goose-provider-types/src/base.rs
+++ b/crates/goose-provider-types/src/base.rs
@@ -620,6 +620,15 @@ pub trait Provider: Send + Sync {
     ) -> bool {
         false
     }
+
+    /// Cancel the in-flight turn for the given session.
+    ///
+    /// Providers that drive a turn on a remote backend (e.g. ACP agents)
+    /// override this to forward an out-of-band cancellation so the backend
+    /// stops promptly instead of running the whole turn to completion. The
+    /// default is a no-op, appropriate for providers whose turn ends as soon
+    /// as goose stops polling the response stream.
+    async fn cancel(&self, _session_id: &str) {}
 }
 
 #[cfg(test)]

--- a/crates/goose/src/acp/provider.rs
+++ b/crates/goose/src/acp/provider.rs
@@ -165,6 +165,13 @@ pub struct AcpProvider {
     /// redundant `SetConfigOption` calls.
     applied_model: Arc<Mutex<Option<String>>>,
 
+    /// Set by `cancel()` and cleared at the start of each reply. The client
+    /// loop checks it around sending `session/prompt` so a cancel that fired
+    /// before the prompt reached the wire — where the backend would ignore it
+    /// as targeting no active run — suppresses the prompt (or is re-sent after
+    /// it) instead of being lost.
+    cancel_requested: Arc<AtomicBool>,
+
     tx: Option<mpsc::Sender<ClientRequest>>,
     loop_thread: Option<JoinHandle<()>>,
 
@@ -253,12 +260,14 @@ impl AcpProvider {
             Arc::new(Mutex::new(HashMap::new()));
         let context_size = Arc::new(AtomicU64::new(0));
         let agent_cx: Arc<OnceLock<ConnectionTo<Agent>>> = Arc::new(OnceLock::new());
+        let cancel_requested = Arc::new(AtomicBool::new(false));
         let client_loop = AcpClientLoop::new(
             config,
             goose_mode_shared.clone(),
             pending_tool_updates.clone(),
             context_size.clone(),
             agent_cx.clone(),
+            cancel_requested.clone(),
         );
         let loop_thread = spawn_client_loop(run(client_loop, rx, init_tx));
 
@@ -293,6 +302,7 @@ impl AcpProvider {
             context_size,
             model_config_option_id,
             applied_model: Arc::new(Mutex::new(applied_model)),
+            cancel_requested,
             tx: Some(tx),
             loop_thread: Some(loop_thread),
             agent_cx,
@@ -470,12 +480,21 @@ impl Provider for AcpProvider {
     }
 
     async fn cancel(&self, _session_id: &str) {
+        // Latch first: if the prompt has not reached the wire yet, the
+        // notification below targets no active run and the backend ignores
+        // it, so the client loop must observe the latch around the prompt
+        // send to suppress or re-cancel the turn.
+        self.cancel_requested.store(true, Ordering::SeqCst);
         let Some(cx) = self.agent_cx.get() else {
             return;
         };
         if let Err(e) = cx.send_notification(CancelNotification::new(self.acp_session_id())) {
             tracing::warn!(error = %e, "failed to send ACP session/cancel");
         }
+    }
+
+    fn clear_pending_cancel(&self) {
+        self.cancel_requested.store(false, Ordering::SeqCst);
     }
 
     async fn handle_permission_confirmation(
@@ -718,6 +737,7 @@ struct AcpClientLoop {
     pending_tool_updates: Arc<Mutex<HashMap<String, AccumulatedToolCall>>>,
     context_size: Arc<AtomicU64>,
     agent_cx: Arc<OnceLock<ConnectionTo<Agent>>>,
+    cancel_requested: Arc<AtomicBool>,
 }
 
 impl AcpClientLoop {
@@ -727,6 +747,7 @@ impl AcpClientLoop {
         pending_tool_updates: Arc<Mutex<HashMap<String, AccumulatedToolCall>>>,
         context_size: Arc<AtomicU64>,
         agent_cx: Arc<OnceLock<ConnectionTo<Agent>>>,
+        cancel_requested: Arc<AtomicBool>,
     ) -> Self {
         Self {
             config,
@@ -735,6 +756,7 @@ impl AcpClientLoop {
             pending_tool_updates,
             context_size,
             agent_cx,
+            cancel_requested,
         }
     }
 
@@ -790,6 +812,7 @@ impl AcpClientLoop {
             pending_tool_updates,
             context_size,
             agent_cx,
+            cancel_requested,
         } = self;
         let notification_callback = config.notification_callback.clone();
         let reverse_modes = reverse_mode_mapping(&config.mode_mapping);
@@ -998,7 +1021,16 @@ impl AcpClientLoop {
             )
             .connect_with(transport, async move |cx: ConnectionTo<Agent>| {
                 let _ = agent_cx.set(cx.clone());
-                handle_requests(config, goose_mode, cx, rx, prompt_response_tx, init_tx).await
+                handle_requests(
+                    config,
+                    goose_mode,
+                    cx,
+                    rx,
+                    prompt_response_tx,
+                    cancel_requested,
+                    init_tx,
+                )
+                .await
             })
             .await?;
 
@@ -1082,6 +1114,7 @@ async fn handle_requests(
     cx: ConnectionTo<Agent>,
     rx: &mut mpsc::Receiver<ClientRequest>,
     prompt_response_tx: Arc<Mutex<Option<mpsc::Sender<AcpUpdate>>>>,
+    cancel_requested: Arc<AtomicBool>,
     init_tx: oneshot::Sender<Result<InitializeResponse>>,
 ) -> Result<(), agent_client_protocol::Error> {
     let mut init_tx = Some(init_tx);
@@ -1178,12 +1211,29 @@ async fn handle_requests(
                 content,
                 response_tx,
             } => {
+                // The turn's cancel already fired; a prompt sent now would be
+                // its backend's only run and nothing would ever cancel it.
+                if cancel_requested.load(Ordering::SeqCst) {
+                    log_undelivered(
+                        response_tx.try_send(AcpUpdate::Complete(StopReason::Cancelled, None)),
+                        AGENT_METHOD_NAMES.session_prompt,
+                    );
+                    continue;
+                }
+
                 *prompt_response_tx.lock().unwrap() = Some(response_tx.clone());
 
-                let response: Result<PromptResponse, _> = cx
-                    .send_request(PromptRequest::new(session_id, content))
-                    .block_task()
-                    .await;
+                let request = cx.send_request(PromptRequest::new(session_id.clone(), content));
+                // send_request queues the message before returning, so a
+                // cancel observed here raced the enqueue and its notification
+                // may sit ahead of the prompt on the wire, where the backend
+                // ignores it. Re-send it so one lands after the prompt.
+                if cancel_requested.load(Ordering::SeqCst) {
+                    if let Err(e) = cx.send_notification(CancelNotification::new(session_id)) {
+                        tracing::warn!(error = %e, "failed to re-send ACP session/cancel");
+                    }
+                }
+                let response: Result<PromptResponse, _> = request.block_task().await;
 
                 match response {
                     Ok(r) => {
@@ -1728,6 +1778,7 @@ mod tests {
                 context_size: Arc::new(AtomicU64::new(0)),
                 model_config_option_id: None,
                 applied_model: Arc::new(Mutex::new(None)),
+                cancel_requested: Arc::new(AtomicBool::new(false)),
                 tx,
                 loop_thread: None,
                 agent_cx: Arc::new(OnceLock::new()),
@@ -2131,6 +2182,102 @@ mod tests {
             mode_mapping,
             notification_callback: None,
         }
+    }
+
+    /// In-process ACP agent that records prompts and cancels it receives.
+    struct FakeAcpAgent {
+        prompts: Arc<Mutex<u32>>,
+        cancels: Arc<Mutex<u32>>,
+    }
+
+    impl agent_client_protocol::ConnectTo<Client> for FakeAcpAgent {
+        async fn connect_to(
+            self,
+            client: impl agent_client_protocol::ConnectTo<Agent>,
+        ) -> std::result::Result<(), agent_client_protocol::Error> {
+            let prompts = self.prompts;
+            let cancels = self.cancels;
+            Agent
+                .builder()
+                .on_receive_request(
+                    async move |_req: InitializeRequest, responder, _cx| {
+                        responder.respond(InitializeResponse::new(ProtocolVersion::LATEST))
+                    },
+                    agent_client_protocol::on_receive_request!(),
+                )
+                .on_receive_request(
+                    async move |_req: NewSessionRequest, responder, _cx| {
+                        responder.respond(NewSessionResponse::new("fake-session"))
+                    },
+                    agent_client_protocol::on_receive_request!(),
+                )
+                .on_receive_request(
+                    {
+                        let prompts = prompts.clone();
+                        async move |_req: PromptRequest, responder, _cx| {
+                            *prompts.lock().unwrap() += 1;
+                            responder.respond(PromptResponse::new(StopReason::EndTurn))
+                        }
+                    },
+                    agent_client_protocol::on_receive_request!(),
+                )
+                .on_receive_notification(
+                    {
+                        let cancels = cancels.clone();
+                        async move |_n: CancelNotification, _cx| {
+                            *cancels.lock().unwrap() += 1;
+                            Ok(())
+                        }
+                    },
+                    agent_client_protocol::on_receive_notification!(),
+                )
+                .connect_to(client)
+                .await
+        }
+    }
+
+    #[tokio::test]
+    async fn cancel_before_prompt_send_suppresses_prompt_until_cleared() {
+        use futures::StreamExt;
+
+        let prompts = Arc::new(Mutex::new(0));
+        let cancels = Arc::new(Mutex::new(0));
+        let provider = AcpProvider::connect_with_transport(
+            "acp-test".to_string(),
+            GooseMode::Auto,
+            test_acp_config(HashMap::new(), None),
+            FakeAcpAgent {
+                prompts: prompts.clone(),
+                cancels: cancels.clone(),
+            },
+        )
+        .await
+        .unwrap();
+        let model = ModelConfig::new("test-model");
+        let messages = vec![Message::user().with_text("hello")];
+
+        // Cancel fires before the prompt reaches the wire: the backend would
+        // ignore the notification (no active run), so the prompt must be
+        // suppressed instead of starting a turn nothing can cancel.
+        provider.cancel("goose-session").await;
+        let mut stream = provider.stream(&model, "", &messages, &[]).await.unwrap();
+        assert!(stream.next().await.is_none());
+        assert_eq!(
+            *prompts.lock().unwrap(),
+            0,
+            "prompt must not start after its only cancel already fired"
+        );
+        assert_eq!(*cancels.lock().unwrap(), 1);
+
+        // A new reply clears the latch, so prompting works again.
+        provider.clear_pending_cancel();
+        let mut stream = provider.stream(&model, "", &messages, &[]).await.unwrap();
+        while stream.next().await.is_some() {}
+        assert_eq!(
+            *prompts.lock().unwrap(),
+            1,
+            "prompt after clear_pending_cancel must reach the backend"
+        );
     }
 
     #[test_case(GooseMode::Auto)]

--- a/crates/goose/src/acp/provider.rs
+++ b/crates/goose/src/acp/provider.rs
@@ -87,6 +87,10 @@ enum ClientRequest {
         /// loop suppresses the prompt if a cancel has since been recorded for
         /// this epoch, even when it is handled after a newer reply started.
         cancel_epoch: u64,
+        /// Whether this prompt claimed the one-shot handoff context. If the
+        /// client loop suppresses the prompt, it rolls the claim back so the
+        /// next prompt still carries the context the backend never received.
+        claimed_handoff: bool,
         response_tx: mpsc::Sender<AcpUpdate>,
     },
 }
@@ -156,7 +160,9 @@ pub struct AcpProvider {
     pending_confirmations:
         Arc<TokioMutex<HashMap<String, oneshot::Sender<PermissionConfirmation>>>>,
     pending_tool_updates: Arc<Mutex<HashMap<String, AccumulatedToolCall>>>,
-    handoff_context_sent: AtomicBool,
+    /// Shared with the client loop so a suppressed (cancelled-before-send)
+    /// first prompt can roll back the handoff-context claim it made.
+    handoff_context_sent: Arc<AtomicBool>,
     /// Latest `size` reported by the ACP server in a `session/update` →
     /// `usage_update` notification. 0 means no real update has arrived yet,
     /// in which case `get_context_limit()` falls back to the supplied model
@@ -181,6 +187,12 @@ pub struct AcpProvider {
     /// by epoch keeps a stale queued prompt cancelled even when it is handled
     /// after a newer reply has already begun.
     cancelled_epoch: Arc<AtomicU64>,
+    /// Epoch of the prompt currently in flight on the backend (0 = none).
+    /// The client loop sets it around `session/prompt`; `cancel()` only sends
+    /// the wire notification when the in-flight prompt belongs to the scope
+    /// being cancelled, so a stale forwarder from a finished reply can never
+    /// cancel a newer reply's active run.
+    active_prompt_epoch: Arc<AtomicU64>,
 
     tx: Option<mpsc::Sender<ClientRequest>>,
     loop_thread: Option<JoinHandle<()>>,
@@ -271,6 +283,8 @@ impl AcpProvider {
         let context_size = Arc::new(AtomicU64::new(0));
         let agent_cx: Arc<OnceLock<ConnectionTo<Agent>>> = Arc::new(OnceLock::new());
         let cancelled_epoch = Arc::new(AtomicU64::new(0));
+        let active_prompt_epoch = Arc::new(AtomicU64::new(0));
+        let handoff_context_sent = Arc::new(AtomicBool::new(false));
         let client_loop = AcpClientLoop::new(
             config,
             goose_mode_shared.clone(),
@@ -278,6 +292,8 @@ impl AcpProvider {
             context_size.clone(),
             agent_cx.clone(),
             cancelled_epoch.clone(),
+            active_prompt_epoch.clone(),
+            handoff_context_sent.clone(),
         );
         let loop_thread = spawn_client_loop(run(client_loop, rx, init_tx));
 
@@ -308,12 +324,13 @@ impl AcpProvider {
             session,
             pending_confirmations: Arc::new(TokioMutex::new(HashMap::new())),
             pending_tool_updates,
-            handoff_context_sent: AtomicBool::new(false),
+            handoff_context_sent,
             context_size,
             model_config_option_id,
             applied_model: Arc::new(Mutex::new(applied_model)),
             cancel_epoch: Arc::new(AtomicU64::new(1)),
             cancelled_epoch,
+            active_prompt_epoch,
             tx: Some(tx),
             loop_thread: Some(loop_thread),
             agent_cx,
@@ -399,6 +416,7 @@ impl AcpProvider {
         &self,
         session_id: SessionId,
         content: Vec<ContentBlock>,
+        claimed_handoff: bool,
     ) -> Result<mpsc::Receiver<AcpUpdate>> {
         let (response_tx, response_rx) = mpsc::channel(64);
         self.tx
@@ -408,6 +426,7 @@ impl AcpProvider {
                 session_id,
                 content,
                 cancel_epoch: self.cancel_epoch.load(Ordering::SeqCst),
+                claimed_handoff,
                 response_tx,
             })
             .await
@@ -501,6 +520,16 @@ impl Provider for AcpProvider {
         // reply's prompts. fetch_max keeps a late stale cancel from lowering
         // the latch.
         self.cancelled_epoch.fetch_max(scope, Ordering::SeqCst);
+        // Only notify the backend when the prompt currently in flight belongs
+        // to the scope being cancelled. A stale forwarder from a finished
+        // reply must not cancel a newer reply's active run, and with nothing
+        // in flight the notification targets no active run anyway — the latch
+        // above keeps that scope's prompt suppressed (or re-cancelled) by the
+        // client loop.
+        let active = self.active_prompt_epoch.load(Ordering::SeqCst);
+        if active == 0 || active > scope {
+            return;
+        }
         let Some(cx) = self.agent_cx.get() else {
             return;
         };
@@ -561,7 +590,10 @@ impl Provider for AcpProvider {
         if let Ok(mut buffer) = self.pending_tool_updates.lock() {
             buffer.clear();
         }
-        let mut rx = match self.prompt(session_id, prompt_blocks).await {
+        let mut rx = match self
+            .prompt(session_id, prompt_blocks, claim.first_prompt)
+            .await
+        {
             Ok(rx) => rx,
             Err(e) => {
                 if claim.first_prompt {
@@ -758,9 +790,12 @@ struct AcpClientLoop {
     context_size: Arc<AtomicU64>,
     agent_cx: Arc<OnceLock<ConnectionTo<Agent>>>,
     cancelled_epoch: Arc<AtomicU64>,
+    active_prompt_epoch: Arc<AtomicU64>,
+    handoff_context_sent: Arc<AtomicBool>,
 }
 
 impl AcpClientLoop {
+    #[allow(clippy::too_many_arguments)]
     fn new(
         config: AcpProviderConfig,
         goose_mode: Arc<Mutex<GooseMode>>,
@@ -768,6 +803,8 @@ impl AcpClientLoop {
         context_size: Arc<AtomicU64>,
         agent_cx: Arc<OnceLock<ConnectionTo<Agent>>>,
         cancelled_epoch: Arc<AtomicU64>,
+        active_prompt_epoch: Arc<AtomicU64>,
+        handoff_context_sent: Arc<AtomicBool>,
     ) -> Self {
         Self {
             config,
@@ -777,6 +814,8 @@ impl AcpClientLoop {
             context_size,
             agent_cx,
             cancelled_epoch,
+            active_prompt_epoch,
+            handoff_context_sent,
         }
     }
 
@@ -833,6 +872,8 @@ impl AcpClientLoop {
             context_size,
             agent_cx,
             cancelled_epoch,
+            active_prompt_epoch,
+            handoff_context_sent,
         } = self;
         let notification_callback = config.notification_callback.clone();
         let reverse_modes = reverse_mode_mapping(&config.mode_mapping);
@@ -1048,6 +1089,8 @@ impl AcpClientLoop {
                     rx,
                     prompt_response_tx,
                     cancelled_epoch,
+                    active_prompt_epoch,
+                    handoff_context_sent,
                     init_tx,
                 )
                 .await
@@ -1128,6 +1171,7 @@ fn log_undelivered<E: std::fmt::Debug>(result: Result<(), E>, method: &str) {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn handle_requests(
     config: AcpProviderConfig,
     goose_mode: Arc<Mutex<GooseMode>>,
@@ -1135,6 +1179,8 @@ async fn handle_requests(
     rx: &mut mpsc::Receiver<ClientRequest>,
     prompt_response_tx: Arc<Mutex<Option<mpsc::Sender<AcpUpdate>>>>,
     cancelled_epoch: Arc<AtomicU64>,
+    active_prompt_epoch: Arc<AtomicU64>,
+    handoff_context_sent: Arc<AtomicBool>,
     init_tx: oneshot::Sender<Result<InitializeResponse>>,
 ) -> Result<(), agent_client_protocol::Error> {
     let mut init_tx = Some(init_tx);
@@ -1230,11 +1276,17 @@ async fn handle_requests(
                 session_id,
                 content,
                 cancel_epoch,
+                claimed_handoff,
                 response_tx,
             } => {
                 // The turn's cancel already fired; a prompt sent now would be
                 // its backend's only run and nothing would ever cancel it.
                 if cancelled_epoch.load(Ordering::SeqCst) >= cancel_epoch {
+                    // The backend never received this prompt, so give the
+                    // one-shot handoff-context claim back to the next prompt.
+                    if claimed_handoff {
+                        handoff_context_sent.store(false, Ordering::Release);
+                    }
                     log_undelivered(
                         response_tx.try_send(AcpUpdate::Complete(StopReason::Cancelled, None)),
                         AGENT_METHOD_NAMES.session_prompt,
@@ -1244,6 +1296,10 @@ async fn handle_requests(
 
                 *prompt_response_tx.lock().unwrap() = Some(response_tx.clone());
 
+                // Mark this epoch's prompt as the active run before it can
+                // reach the wire, so `cancel()` for this scope notifies the
+                // backend while a stale scope's cancel does not.
+                active_prompt_epoch.store(cancel_epoch, Ordering::SeqCst);
                 let request = cx.send_request(PromptRequest::new(session_id.clone(), content));
                 // send_request queues the message before returning, so a
                 // cancel observed here raced the enqueue and its notification
@@ -1255,6 +1311,7 @@ async fn handle_requests(
                     }
                 }
                 let response: Result<PromptResponse, _> = request.block_task().await;
+                active_prompt_epoch.store(0, Ordering::SeqCst);
 
                 match response {
                     Ok(r) => {
@@ -1795,12 +1852,13 @@ mod tests {
                 },
                 pending_confirmations: Arc::new(TokioMutex::new(HashMap::new())),
                 pending_tool_updates: Arc::new(Mutex::new(HashMap::new())),
-                handoff_context_sent: AtomicBool::new(false),
+                handoff_context_sent: Arc::new(AtomicBool::new(false)),
                 context_size: Arc::new(AtomicU64::new(0)),
                 model_config_option_id: None,
                 applied_model: Arc::new(Mutex::new(None)),
                 cancel_epoch: Arc::new(AtomicU64::new(1)),
                 cancelled_epoch: Arc::new(AtomicU64::new(0)),
+                active_prompt_epoch: Arc::new(AtomicU64::new(0)),
                 tx,
                 loop_thread: None,
                 agent_cx: Arc::new(OnceLock::new()),
@@ -2208,7 +2266,7 @@ mod tests {
 
     /// In-process ACP agent that records prompts and cancels it receives.
     struct FakeAcpAgent {
-        prompts: Arc<Mutex<u32>>,
+        prompts: Arc<Mutex<Vec<String>>>,
         cancels: Arc<Mutex<u32>>,
     }
 
@@ -2236,8 +2294,17 @@ mod tests {
                 .on_receive_request(
                     {
                         let prompts = prompts.clone();
-                        async move |_req: PromptRequest, responder, _cx| {
-                            *prompts.lock().unwrap() += 1;
+                        async move |req: PromptRequest, responder, _cx| {
+                            let text = req
+                                .prompt
+                                .iter()
+                                .filter_map(|block| match block {
+                                    ContentBlock::Text(text) => Some(text.text.as_str()),
+                                    _ => None,
+                                })
+                                .collect::<Vec<_>>()
+                                .join("\n");
+                            prompts.lock().unwrap().push(text);
                             responder.respond(PromptResponse::new(StopReason::EndTurn))
                         }
                     },
@@ -2258,8 +2325,8 @@ mod tests {
         }
     }
 
-    async fn fake_connected_provider() -> (AcpProvider, Arc<Mutex<u32>>, Arc<Mutex<u32>>) {
-        let prompts = Arc::new(Mutex::new(0));
+    async fn fake_connected_provider() -> (AcpProvider, Arc<Mutex<Vec<String>>>, Arc<Mutex<u32>>) {
+        let prompts = Arc::new(Mutex::new(Vec::new()));
         let cancels = Arc::new(Mutex::new(0));
         let provider = AcpProvider::connect_with_transport(
             "acp-test".to_string(),
@@ -2283,28 +2350,33 @@ mod tests {
         let model = ModelConfig::new("test-model");
         let messages = vec![Message::user().with_text("hello")];
 
-        // Cancel fires before the prompt reaches the wire: the backend would
-        // ignore the notification (no active run), so the prompt must be
-        // suppressed instead of starting a turn nothing can cancel.
+        // Cancel fires before the prompt reaches the wire: with no active run
+        // the backend would ignore a notification (and none is sent), so the
+        // prompt must be suppressed instead of starting a turn nothing can
+        // cancel.
         let scope = provider.begin_cancel_scope();
         provider.cancel("goose-session", scope).await;
         let mut stream = provider.stream(&model, "", &messages, &[]).await.unwrap();
         assert!(stream.next().await.is_none());
         assert_eq!(
-            *prompts.lock().unwrap(),
+            prompts.lock().unwrap().len(),
             0,
             "prompt must not start after its only cancel already fired"
         );
-        assert_eq!(*cancels.lock().unwrap(), 1);
 
         // A new reply opens a fresh scope, so prompting works again.
         provider.begin_cancel_scope();
         let mut stream = provider.stream(&model, "", &messages, &[]).await.unwrap();
         while stream.next().await.is_some() {}
         assert_eq!(
-            *prompts.lock().unwrap(),
+            prompts.lock().unwrap().len(),
             1,
             "prompt in a fresh cancel scope must reach the backend"
+        );
+        assert_eq!(
+            *cancels.lock().unwrap(),
+            0,
+            "no session/cancel should reach the backend when nothing was in flight"
         );
     }
 
@@ -2325,9 +2397,87 @@ mod tests {
         let mut stream = provider.stream(&model, "", &messages, &[]).await.unwrap();
         while stream.next().await.is_some() {}
         assert_eq!(
-            *prompts.lock().unwrap(),
+            prompts.lock().unwrap().len(),
             1,
             "a stale cancel must not suppress the newer reply's prompt"
+        );
+    }
+
+    #[tokio::test]
+    async fn stale_cancel_notification_is_not_sent_while_newer_prompt_active() {
+        use futures::StreamExt;
+
+        let (provider, prompts, cancels) = fake_connected_provider().await;
+        let model = ModelConfig::new("test-model");
+        let messages = vec![Message::user().with_text("hello")];
+
+        // Turn N's forwarder fires while turn N+1's prompt is the active run:
+        // the latch records N, but no session/cancel may reach the backend.
+        let stale_scope = provider.begin_cancel_scope();
+        let fresh_scope = provider.begin_cancel_scope();
+        provider
+            .active_prompt_epoch
+            .store(fresh_scope, Ordering::SeqCst);
+        provider.cancel("goose-session", stale_scope).await;
+        provider.active_prompt_epoch.store(0, Ordering::SeqCst);
+
+        // Round-trip a prompt so any (wrongly) sent notification would have
+        // been processed by the fake agent before the count is checked.
+        provider.begin_cancel_scope();
+        let mut stream = provider.stream(&model, "", &messages, &[]).await.unwrap();
+        while stream.next().await.is_some() {}
+        assert_eq!(prompts.lock().unwrap().len(), 1);
+        assert_eq!(
+            *cancels.lock().unwrap(),
+            0,
+            "a stale cancel must not cancel the newer reply's active run"
+        );
+
+        // A cancel matching the in-flight prompt's scope still notifies.
+        let scope = provider.begin_cancel_scope();
+        provider.active_prompt_epoch.store(scope, Ordering::SeqCst);
+        provider.cancel("goose-session", scope).await;
+        provider.active_prompt_epoch.store(0, Ordering::SeqCst);
+        provider.begin_cancel_scope();
+        let mut stream = provider.stream(&model, "", &messages, &[]).await.unwrap();
+        while stream.next().await.is_some() {}
+        assert_eq!(
+            *cancels.lock().unwrap(),
+            1,
+            "a cancel for the active prompt's own scope must reach the backend"
+        );
+    }
+
+    #[tokio::test]
+    async fn suppressed_first_prompt_rolls_back_handoff_claim() {
+        use futures::StreamExt;
+
+        let (provider, prompts, _cancels) = fake_connected_provider().await;
+        let model = ModelConfig::new("test-model");
+        let messages = vec![
+            Message::assistant().with_text("prior answer"),
+            Message::user().with_text("current request"),
+        ];
+
+        // The first prompt claims the one-shot handoff context, but its
+        // cancel fires before the client loop sends it: the backend never
+        // sees the context, so the claim must be rolled back.
+        let scope = provider.begin_cancel_scope();
+        provider.cancel("goose-session", scope).await;
+        let mut stream = provider.stream(&model, "", &messages, &[]).await.unwrap();
+        assert!(stream.next().await.is_none());
+        assert_eq!(prompts.lock().unwrap().len(), 0);
+
+        // The next reply's prompt must carry the handoff context.
+        provider.begin_cancel_scope();
+        let mut stream = provider.stream(&model, "", &messages, &[]).await.unwrap();
+        while stream.next().await.is_some() {}
+        let prompts = prompts.lock().unwrap();
+        assert_eq!(prompts.len(), 1);
+        assert!(
+            prompts[0].contains("Conversation context from goose"),
+            "prompt after a suppressed first prompt must include the handoff memo, got: {}",
+            prompts[0]
         );
     }
 

--- a/crates/goose/src/acp/provider.rs
+++ b/crates/goose/src/acp/provider.rs
@@ -174,10 +174,10 @@ pub struct AcpProvider {
     /// Model currently applied via `model_config_option_id`, used to avoid
     /// redundant `SetConfigOption` calls.
     applied_model: Arc<Mutex<Option<String>>>,
-    /// Set while a cancel-abandoned model setup is still in flight; the next
-    /// selection waits for it so the backend is not left on the abandoned
-    /// model while a later prompt runs.
-    abandoned_model_setup: Arc<AbandonedModelSetup>,
+    /// Model setups the client loop has sent but not yet seen answered; the
+    /// next prompt waits for them so the backend is not left on a
+    /// cancel-abandoned model while that prompt runs.
+    model_setups_in_flight: Arc<ModelSetupsInFlight>,
 
     /// Current cancel epoch, bumped by `begin_cancel_scope()` when a new
     /// reply begins. Prompts capture it at enqueue time; each reply's cancel
@@ -290,7 +290,7 @@ impl AcpProvider {
                     .map(|(_, value)| value.clone())
             },
         )));
-        let abandoned_model_setup: Arc<AbandonedModelSetup> = Arc::default();
+        let model_setups_in_flight: Arc<ModelSetupsInFlight> = Arc::default();
         let goose_mode_shared = Arc::new(Mutex::new(goose_mode));
         let pending_tool_updates: Arc<Mutex<HashMap<String, AccumulatedToolCall>>> =
             Arc::new(Mutex::new(HashMap::new()));
@@ -309,7 +309,7 @@ impl AcpProvider {
             active_prompt_epoch.clone(),
             cancel_notify.clone(),
             applied_model.clone(),
-            abandoned_model_setup.clone(),
+            model_setups_in_flight.clone(),
         );
         let loop_thread = spawn_client_loop(run(client_loop, rx, init_tx));
 
@@ -343,7 +343,7 @@ impl AcpProvider {
             context_size,
             model_config_option_id,
             applied_model,
-            abandoned_model_setup,
+            model_setups_in_flight,
             cancel_epoch: Arc::new(AtomicU64::new(1)),
             cancelled_scopes,
             active_prompt_epoch,
@@ -415,10 +415,6 @@ impl AcpProvider {
         let Some(config_id) = self.model_config_option_id.clone() else {
             return Ok(());
         };
-        if model_name == ACP_CURRENT_MODEL {
-            return Ok(());
-        }
-
         // A setup abandoned by an earlier cancel is still on the wire, and the
         // ACP server applies config options in spawned tasks, so it could land
         // after this selection and leave the backend on the abandoned model
@@ -426,13 +422,21 @@ impl AcpProvider {
         // memo below as it does — so the selection this prompt runs under is
         // applied last. The wait is on the calling reply, not the serial
         // client loop, and ends early if that reply is itself cancelled.
+        //
+        // This precedes the sentinel return below: a prompt that keeps the
+        // backend's current model is just as exposed to an abandoned setup
+        // landing mid-turn, and has no selection of its own to overwrite it.
         let scope = self.cancel_epoch.load(Ordering::SeqCst);
         tokio::select! {
             biased;
             () = await_cancelled_scope(&self.cancel_notify, &self.cancelled_scopes, scope) => {
                 return Err(anyhow::anyhow!("reply cancelled"));
             }
-            () = self.abandoned_model_setup.await_settled() => {}
+            () = self.model_setups_in_flight.await_settled() => {}
+        }
+
+        if model_name == ACP_CURRENT_MODEL {
+            return Ok(());
         }
 
         {
@@ -841,7 +845,7 @@ struct AcpClientLoop {
     cancel_notify: Arc<tokio::sync::Notify>,
     handoff_context_sent: Arc<AtomicBool>,
     applied_model: Arc<Mutex<Option<String>>>,
-    abandoned_model_setup: Arc<AbandonedModelSetup>,
+    model_setups_in_flight: Arc<ModelSetupsInFlight>,
 }
 
 impl AcpClientLoop {
@@ -856,7 +860,7 @@ impl AcpClientLoop {
         active_prompt_epoch: Arc<AtomicU64>,
         cancel_notify: Arc<tokio::sync::Notify>,
         applied_model: Arc<Mutex<Option<String>>>,
-        abandoned_model_setup: Arc<AbandonedModelSetup>,
+        model_setups_in_flight: Arc<ModelSetupsInFlight>,
     ) -> Self {
         Self {
             config,
@@ -870,7 +874,7 @@ impl AcpClientLoop {
             cancel_notify,
             handoff_context_sent: Arc::new(AtomicBool::new(false)),
             applied_model,
-            abandoned_model_setup,
+            model_setups_in_flight,
         }
     }
 
@@ -931,7 +935,7 @@ impl AcpClientLoop {
             cancel_notify,
             handoff_context_sent,
             applied_model,
-            abandoned_model_setup,
+            model_setups_in_flight,
         } = self;
         let notification_callback = config.notification_callback.clone();
         let reverse_modes = reverse_mode_mapping(&config.mode_mapping);
@@ -1151,7 +1155,7 @@ impl AcpClientLoop {
                     cancel_notify,
                     handoff_context_sent,
                     applied_model,
-                    abandoned_model_setup,
+                    model_setups_in_flight,
                     init_tx,
                 )
                 .await
@@ -1226,33 +1230,42 @@ async fn spawn_acp_process(config: &AcpProviderConfig) -> Result<Child> {
     cmd.spawn().context("failed to spawn ACP process")
 }
 
-/// A reply-scoped model setup that a cancel abandoned. ACP has no way to
-/// retract the request, so it stays on the wire and the backend may apply it
-/// at any point; until it settles, no later selection can be known to be the
-/// one the backend ends up on.
+/// Model setups the client loop has taken off its queue. ACP has no way to
+/// retract a request, so one a cancel abandons stays on the wire and the
+/// backend may apply it at any point; until every setup has settled, no later
+/// selection can be known to be the one the backend ends up on.
+///
+/// A setup is counted from the moment the loop picks it up rather than from
+/// the moment the loop notices its reply was cancelled. The reply is released
+/// by observing the cancel itself, on a task of its own, so it can race ahead
+/// of the loop: counting at cancel time would leave the next selection seeing
+/// nothing in flight while an abandoned request was already on the wire.
+/// Anything not yet counted has not reached the backend either — the loop
+/// drops a request whose scope is already cancelled before sending it.
 #[derive(Default)]
-struct AbandonedModelSetup {
-    outstanding: AtomicBool,
+struct ModelSetupsInFlight {
+    count: AtomicU64,
     settled: tokio::sync::Notify,
 }
 
-impl AbandonedModelSetup {
-    fn mark_outstanding(&self) {
-        self.outstanding.store(true, Ordering::SeqCst);
+impl ModelSetupsInFlight {
+    fn enter(&self) {
+        self.count.fetch_add(1, Ordering::SeqCst);
     }
 
-    fn mark_settled(&self) {
-        self.outstanding.store(false, Ordering::SeqCst);
-        self.settled.notify_waiters();
+    fn leave(&self) {
+        if self.count.fetch_sub(1, Ordering::SeqCst) == 1 {
+            self.settled.notify_waiters();
+        }
     }
 
-    /// Resolves once no abandoned setup is outstanding. Registering with
-    /// `Notify` before re-reading the flag keeps a settlement that lands
-    /// between the two from being missed.
+    /// Resolves once no setup is in flight. Registering with `Notify` before
+    /// re-reading the count keeps a settlement that lands between the two from
+    /// being missed.
     async fn await_settled(&self) {
         loop {
             let settled = self.settled.notified();
-            if !self.outstanding.load(Ordering::SeqCst) {
+            if self.count.load(Ordering::SeqCst) == 0 {
                 return;
             }
             settled.await;
@@ -1302,7 +1315,7 @@ async fn handle_requests(
     cancel_notify: Arc<tokio::sync::Notify>,
     handoff_context_sent: Arc<AtomicBool>,
     applied_model: Arc<Mutex<Option<String>>>,
-    abandoned_model_setup: Arc<AbandonedModelSetup>,
+    model_setups_in_flight: Arc<ModelSetupsInFlight>,
     init_tx: oneshot::Sender<Result<InitializeResponse>>,
 ) -> Result<(), agent_client_protocol::Error> {
     let mut init_tx = Some(init_tx);
@@ -1382,8 +1395,13 @@ async fn handle_requests(
                 cancel_epoch,
                 response_tx,
             } => {
+                // Counted before the scope check so that every request this
+                // arm can put on the wire is already in flight by the time it
+                // is sent, even if its reply is released by a cancel first.
+                model_setups_in_flight.enter();
                 let cancelled = |epoch| scope_cancelled(&cancelled_scopes, epoch);
                 if cancel_epoch.is_some_and(cancelled) {
+                    model_setups_in_flight.leave();
                     log_undelivered(
                         response_tx.send(Err(anyhow::anyhow!("reply cancelled"))),
                         AGENT_METHOD_NAMES.session_set_config_option,
@@ -1407,22 +1425,24 @@ async fn handle_requests(
                     None => Some(request.as_mut().await),
                 };
                 let result: Result<()> = match settled {
-                    Some(response) => response.map(|_| ()).map_err(anyhow::Error::from),
+                    Some(response) => {
+                        model_setups_in_flight.leave();
+                        response.map(|_| ()).map_err(anyhow::Error::from)
+                    }
                     None => {
                         // An abandoned option can still reach the backend after
                         // a later one has been applied, so keep watching it off
                         // the serial loop: the next selection waits for it to
                         // settle, and its settlement marks the applied model
                         // unknown so that selection is re-sent afterwards.
-                        abandoned_model_setup.mark_outstanding();
                         let applied_model = applied_model.clone();
-                        let abandoned_model_setup = abandoned_model_setup.clone();
+                        let model_setups_in_flight = model_setups_in_flight.clone();
                         tokio::spawn(async move {
                             let _ = request.await;
                             if let Ok(mut applied) = applied_model.lock() {
                                 *applied = None;
                             }
-                            abandoned_model_setup.mark_settled();
+                            model_setups_in_flight.leave();
                         });
                         Err(anyhow::anyhow!("reply cancelled"))
                     }
@@ -2030,7 +2050,7 @@ mod tests {
                 context_size: Arc::new(AtomicU64::new(0)),
                 model_config_option_id: None,
                 applied_model: Arc::new(Mutex::new(None)),
-                abandoned_model_setup: Arc::default(),
+                model_setups_in_flight: Arc::default(),
                 cancel_epoch: Arc::new(AtomicU64::new(1)),
                 cancelled_scopes: Arc::new(Mutex::new(HashSet::new())),
                 active_prompt_epoch: Arc::new(AtomicU64::new(0)),
@@ -2801,6 +2821,86 @@ mod tests {
             config_options.lock().unwrap().as_slice(),
             ["model-a", "model-b"],
             "the new selection must be applied after the abandoned setup settled"
+        );
+        assert_eq!(prompts.lock().unwrap().len(), 1);
+    }
+
+    /// A turn that keeps the backend's current model sends no selection of its
+    /// own, so an abandoned setup landing mid-turn would decide the model it
+    /// runs under. It has to wait for that request to settle just the same.
+    #[tokio::test]
+    async fn a_current_model_prompt_waits_for_an_abandoned_model_setup_to_settle() {
+        use futures::StreamExt;
+
+        let gate = Arc::new(tokio::sync::Notify::new());
+        let prompts = Arc::new(Mutex::new(Vec::new()));
+        let mut config = test_acp_config(HashMap::new(), None);
+        config.model_config_option_id = Some("model".to_string());
+        let provider = AcpProvider::connect_with_transport(
+            "acp-test".to_string(),
+            GooseMode::Auto,
+            config,
+            FakeAcpAgent {
+                prompts: prompts.clone(),
+                cancels: Arc::new(Mutex::new(0)),
+                config_options: Arc::new(Mutex::new(Vec::new())),
+                config_option_gate: Some(gate.clone()),
+            },
+        )
+        .await
+        .unwrap();
+        let messages = vec![Message::user().with_text("hello")];
+
+        let scope = provider.begin_cancel_scope();
+        let model_a = ModelConfig::new("model-a");
+        let cancelled = provider.stream(&model_a, "", &messages, &[]);
+        let cancel = async {
+            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+            provider.cancel("goose-session", scope).await;
+        };
+        let (result, ()) = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            futures::future::join(cancelled, cancel),
+        )
+        .await
+        .expect("client loop stayed blocked on the cancelled reply's config option");
+        assert!(matches!(result, Err(ProviderError::RequestFailed(_))));
+
+        provider.begin_cancel_scope();
+        let current = ModelConfig::new(ACP_CURRENT_MODEL);
+        let mut pending = Box::pin(provider.stream(&current, "", &messages, &[]));
+        let proceeded_early = tokio::select! {
+            _ = &mut pending => true,
+            () = tokio::time::sleep(std::time::Duration::from_millis(300)) => false,
+        };
+        let prompted_while_outstanding = prompts.lock().unwrap().len();
+
+        // Release the backend before asserting so a failure reports cleanly
+        // instead of deadlocking the provider's drop on the client loop.
+        let _releaser = tokio::spawn({
+            let gate = gate.clone();
+            async move {
+                loop {
+                    gate.notify_one();
+                    tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+                }
+            }
+        });
+        if !proceeded_early {
+            let mut stream = tokio::time::timeout(std::time::Duration::from_secs(5), pending)
+                .await
+                .expect("the current-model prompt never proceeded after the setup settled")
+                .unwrap();
+            while stream.next().await.is_some() {}
+        }
+
+        assert!(
+            !proceeded_early,
+            "a current-model prompt went out before the abandoned setup settled"
+        );
+        assert_eq!(
+            prompted_while_outstanding, 0,
+            "no prompt may be sent while an abandoned model setup is outstanding"
         );
         assert_eq!(prompts.lock().unwrap().len(), 1);
     }

--- a/crates/goose/src/acp/provider.rs
+++ b/crates/goose/src/acp/provider.rs
@@ -551,13 +551,15 @@ impl Provider for AcpProvider {
         self.cancelled_epoch.fetch_max(scope, Ordering::SeqCst);
         self.cancel_notify.notify_waiters();
         // Only notify the backend when the prompt currently in flight belongs
-        // to the scope being cancelled. A stale forwarder from a finished
-        // reply must not cancel a newer reply's active run, and with nothing
-        // in flight the notification targets no active run anyway — the latch
-        // above keeps that scope's prompt suppressed (or re-cancelled) by the
-        // client loop.
-        let active = self.active_prompt_epoch.load(Ordering::SeqCst);
-        if active == 0 || active > scope {
+        // to the scope being cancelled: `session/cancel` is session-scoped, so
+        // sending it for any other scope would abort a run the caller did not
+        // cancel — a stale forwarder from a finished reply hitting a newer
+        // reply's prompt, or a newer reply cancelled while its own prompt is
+        // still queued behind an older one. With nothing in flight the
+        // notification targets no active run anyway. In every one of those
+        // cases the latch above is what suppresses (or re-cancels) that
+        // scope's prompt in the client loop.
+        if self.active_prompt_epoch.load(Ordering::SeqCst) != scope {
             return;
         }
         let Some(cx) = self.agent_cx.get() else {
@@ -2713,6 +2715,41 @@ mod tests {
             *cancels.lock().unwrap(),
             1,
             "a cancel for the active prompt's own scope must reach the backend"
+        );
+    }
+
+    /// `session/cancel` is session-scoped, so cancelling a newer reply whose
+    /// prompt is still queued behind an older in-flight one must not reach the
+    /// backend: it would abort the older run. The latch alone covers the
+    /// queued prompt.
+    #[tokio::test]
+    async fn cancelling_a_queued_reply_does_not_abort_the_active_prompt() {
+        use futures::StreamExt;
+
+        let (provider, prompts, cancels) = fake_connected_provider().await;
+        let model = ModelConfig::new("test-model");
+        let messages = vec![Message::user().with_text("hello")];
+
+        // Turn N is the active run while turn N+1 is cancelled before its own
+        // prompt reaches the wire.
+        let active_scope = provider.begin_cancel_scope();
+        let queued_scope = provider.begin_cancel_scope();
+        provider
+            .active_prompt_epoch
+            .store(active_scope, Ordering::SeqCst);
+        provider.cancel("goose-session", queued_scope).await;
+        provider.active_prompt_epoch.store(0, Ordering::SeqCst);
+
+        // Round-trip a prompt so any (wrongly) sent notification would have
+        // been processed by the fake agent before the count is checked.
+        provider.begin_cancel_scope();
+        let mut stream = provider.stream(&model, "", &messages, &[]).await.unwrap();
+        while stream.next().await.is_some() {}
+        assert_eq!(prompts.lock().unwrap().len(), 1);
+        assert_eq!(
+            *cancels.lock().unwrap(),
+            0,
+            "cancelling a queued reply must not cancel the older active run"
         );
     }
 

--- a/crates/goose/src/acp/provider.rs
+++ b/crates/goose/src/acp/provider.rs
@@ -174,6 +174,10 @@ pub struct AcpProvider {
     /// Model currently applied via `model_config_option_id`, used to avoid
     /// redundant `SetConfigOption` calls.
     applied_model: Arc<Mutex<Option<String>>>,
+    /// Set while a cancel-abandoned model setup is still in flight; the next
+    /// selection waits for it so the backend is not left on the abandoned
+    /// model while a later prompt runs.
+    abandoned_model_setup: Arc<AbandonedModelSetup>,
 
     /// Current cancel epoch, bumped by `begin_cancel_scope()` when a new
     /// reply begins. Prompts capture it at enqueue time; each reply's cancel
@@ -286,6 +290,7 @@ impl AcpProvider {
                     .map(|(_, value)| value.clone())
             },
         )));
+        let abandoned_model_setup: Arc<AbandonedModelSetup> = Arc::default();
         let goose_mode_shared = Arc::new(Mutex::new(goose_mode));
         let pending_tool_updates: Arc<Mutex<HashMap<String, AccumulatedToolCall>>> =
             Arc::new(Mutex::new(HashMap::new()));
@@ -304,6 +309,7 @@ impl AcpProvider {
             active_prompt_epoch.clone(),
             cancel_notify.clone(),
             applied_model.clone(),
+            abandoned_model_setup.clone(),
         );
         let loop_thread = spawn_client_loop(run(client_loop, rx, init_tx));
 
@@ -337,6 +343,7 @@ impl AcpProvider {
             context_size,
             model_config_option_id,
             applied_model,
+            abandoned_model_setup,
             cancel_epoch: Arc::new(AtomicU64::new(1)),
             cancelled_scopes,
             active_prompt_epoch,
@@ -410,6 +417,22 @@ impl AcpProvider {
         };
         if model_name == ACP_CURRENT_MODEL {
             return Ok(());
+        }
+
+        // A setup abandoned by an earlier cancel is still on the wire, and the
+        // ACP server applies config options in spawned tasks, so it could land
+        // after this selection and leave the backend on the abandoned model
+        // while this reply prompts. Let it settle first — it invalidates the
+        // memo below as it does — so the selection this prompt runs under is
+        // applied last. The wait is on the calling reply, not the serial
+        // client loop, and ends early if that reply is itself cancelled.
+        let scope = self.cancel_epoch.load(Ordering::SeqCst);
+        tokio::select! {
+            biased;
+            () = await_cancelled_scope(&self.cancel_notify, &self.cancelled_scopes, scope) => {
+                return Err(anyhow::anyhow!("reply cancelled"));
+            }
+            () = self.abandoned_model_setup.await_settled() => {}
         }
 
         {
@@ -818,6 +841,7 @@ struct AcpClientLoop {
     cancel_notify: Arc<tokio::sync::Notify>,
     handoff_context_sent: Arc<AtomicBool>,
     applied_model: Arc<Mutex<Option<String>>>,
+    abandoned_model_setup: Arc<AbandonedModelSetup>,
 }
 
 impl AcpClientLoop {
@@ -832,6 +856,7 @@ impl AcpClientLoop {
         active_prompt_epoch: Arc<AtomicU64>,
         cancel_notify: Arc<tokio::sync::Notify>,
         applied_model: Arc<Mutex<Option<String>>>,
+        abandoned_model_setup: Arc<AbandonedModelSetup>,
     ) -> Self {
         Self {
             config,
@@ -845,6 +870,7 @@ impl AcpClientLoop {
             cancel_notify,
             handoff_context_sent: Arc::new(AtomicBool::new(false)),
             applied_model,
+            abandoned_model_setup,
         }
     }
 
@@ -905,6 +931,7 @@ impl AcpClientLoop {
             cancel_notify,
             handoff_context_sent,
             applied_model,
+            abandoned_model_setup,
         } = self;
         let notification_callback = config.notification_callback.clone();
         let reverse_modes = reverse_mode_mapping(&config.mode_mapping);
@@ -1124,6 +1151,7 @@ impl AcpClientLoop {
                     cancel_notify,
                     handoff_context_sent,
                     applied_model,
+                    abandoned_model_setup,
                     init_tx,
                 )
                 .await
@@ -1198,6 +1226,40 @@ async fn spawn_acp_process(config: &AcpProviderConfig) -> Result<Child> {
     cmd.spawn().context("failed to spawn ACP process")
 }
 
+/// A reply-scoped model setup that a cancel abandoned. ACP has no way to
+/// retract the request, so it stays on the wire and the backend may apply it
+/// at any point; until it settles, no later selection can be known to be the
+/// one the backend ends up on.
+#[derive(Default)]
+struct AbandonedModelSetup {
+    outstanding: AtomicBool,
+    settled: tokio::sync::Notify,
+}
+
+impl AbandonedModelSetup {
+    fn mark_outstanding(&self) {
+        self.outstanding.store(true, Ordering::SeqCst);
+    }
+
+    fn mark_settled(&self) {
+        self.outstanding.store(false, Ordering::SeqCst);
+        self.settled.notify_waiters();
+    }
+
+    /// Resolves once no abandoned setup is outstanding. Registering with
+    /// `Notify` before re-reading the flag keeps a settlement that lands
+    /// between the two from being missed.
+    async fn await_settled(&self) {
+        loop {
+            let settled = self.settled.notified();
+            if !self.outstanding.load(Ordering::SeqCst) {
+                return;
+            }
+            settled.await;
+        }
+    }
+}
+
 /// Whether `cancel()` has fired for this exact scope.
 fn scope_cancelled(cancelled_scopes: &Mutex<HashSet<u64>>, scope: u64) -> bool {
     cancelled_scopes
@@ -1240,6 +1302,7 @@ async fn handle_requests(
     cancel_notify: Arc<tokio::sync::Notify>,
     handoff_context_sent: Arc<AtomicBool>,
     applied_model: Arc<Mutex<Option<String>>>,
+    abandoned_model_setup: Arc<AbandonedModelSetup>,
     init_tx: oneshot::Sender<Result<InitializeResponse>>,
 ) -> Result<(), agent_client_protocol::Error> {
     let mut init_tx = Some(init_tx);
@@ -1348,16 +1411,18 @@ async fn handle_requests(
                     None => {
                         // An abandoned option can still reach the backend after
                         // a later one has been applied, so keep watching it off
-                        // the serial loop and mark the applied model unknown
-                        // once it settles. The next reply then re-applies its
-                        // model instead of trusting a value this request may
-                        // have overwritten.
+                        // the serial loop: the next selection waits for it to
+                        // settle, and its settlement marks the applied model
+                        // unknown so that selection is re-sent afterwards.
+                        abandoned_model_setup.mark_outstanding();
                         let applied_model = applied_model.clone();
+                        let abandoned_model_setup = abandoned_model_setup.clone();
                         tokio::spawn(async move {
                             let _ = request.await;
                             if let Ok(mut applied) = applied_model.lock() {
                                 *applied = None;
                             }
+                            abandoned_model_setup.mark_settled();
                         });
                         Err(anyhow::anyhow!("reply cancelled"))
                     }
@@ -1965,6 +2030,7 @@ mod tests {
                 context_size: Arc::new(AtomicU64::new(0)),
                 model_config_option_id: None,
                 applied_model: Arc::new(Mutex::new(None)),
+                abandoned_model_setup: Arc::default(),
                 cancel_epoch: Arc::new(AtomicU64::new(1)),
                 cancelled_scopes: Arc::new(Mutex::new(HashSet::new())),
                 active_prompt_epoch: Arc::new(AtomicU64::new(0)),
@@ -2426,10 +2492,14 @@ mod tests {
         }
     }
 
-    /// In-process ACP agent that records prompts and cancels it receives.
+    /// In-process ACP agent that records prompts, config options and cancels
+    /// it receives.
     struct FakeAcpAgent {
         prompts: Arc<Mutex<Vec<String>>>,
         cancels: Arc<Mutex<u32>>,
+        /// Config option values in the order the requests arrived, recorded
+        /// before `config_option_gate` is awaited.
+        config_options: Arc<Mutex<Vec<String>>>,
         /// When set, `session/set_config_option` waits on this gate instead of
         /// answering, mimicking a backend that hangs applying an option.
         config_option_gate: Option<Arc<tokio::sync::Notify>>,
@@ -2442,19 +2512,31 @@ mod tests {
         ) -> std::result::Result<(), agent_client_protocol::Error> {
             let prompts = self.prompts;
             let cancels = self.cancels;
+            let config_options = self.config_options;
             let config_option_gate = self.config_option_gate;
             Agent
                 .builder()
                 .on_receive_request(
-                    async move |_req: SetSessionConfigOptionRequest, responder, _cx| {
-                        if let Some(gate) = config_option_gate.as_ref() {
-                            gate.notified().await;
+                    async move |req: SetSessionConfigOptionRequest, responder, cx| {
+                        if let Some(value) = req.value.as_value_id() {
+                            config_options.lock().unwrap().push(value.0.to_string());
                         }
-                        responder.respond(
-                            agent_client_protocol::schema::v1::SetSessionConfigOptionResponse::new(
-                                vec![],
-                            ),
-                        )
+                        // Mirror the real server, which applies config options
+                        // in spawned tasks: dispatch keeps serving requests
+                        // while one is still being applied.
+                        let gate = config_option_gate.clone();
+                        cx.spawn(async move {
+                            if let Some(gate) = gate.as_ref() {
+                                gate.notified().await;
+                            }
+                            responder.respond(
+                                agent_client_protocol::schema::v1::SetSessionConfigOptionResponse::new(
+                                    vec![],
+                                ),
+                            )?;
+                            Ok(())
+                        })?;
+                        Ok(())
                     },
                     agent_client_protocol::on_receive_request!(),
                 )
@@ -2514,6 +2596,7 @@ mod tests {
             FakeAcpAgent {
                 prompts: prompts.clone(),
                 cancels: cancels.clone(),
+                config_options: Arc::new(Mutex::new(Vec::new())),
                 config_option_gate: None,
             },
         )
@@ -2538,6 +2621,7 @@ mod tests {
             FakeAcpAgent {
                 prompts: Arc::new(Mutex::new(Vec::new())),
                 cancels: Arc::new(Mutex::new(0)),
+                config_options: Arc::new(Mutex::new(Vec::new())),
                 config_option_gate: Some(gate.clone()),
             },
         )
@@ -2585,6 +2669,7 @@ mod tests {
             FakeAcpAgent {
                 prompts: Arc::new(Mutex::new(Vec::new())),
                 cancels: Arc::new(Mutex::new(0)),
+                config_options: Arc::new(Mutex::new(Vec::new())),
                 config_option_gate: Some(gate.clone()),
             },
         )
@@ -2620,6 +2705,104 @@ mod tests {
         })
         .await
         .expect("a settled abandoned model setup must invalidate the applied model");
+    }
+
+    /// The abandoned setup can still be applied by the backend at any time, so
+    /// a later reply must not select its model — or prompt — until that
+    /// request has settled, or the backend could flip back under the prompt.
+    #[tokio::test]
+    async fn a_new_selection_waits_for_an_abandoned_model_setup_to_settle() {
+        use futures::StreamExt;
+
+        let gate = Arc::new(tokio::sync::Notify::new());
+        let prompts = Arc::new(Mutex::new(Vec::new()));
+        let config_options = Arc::new(Mutex::new(Vec::new()));
+        let mut config = test_acp_config(HashMap::new(), None);
+        config.model_config_option_id = Some("model".to_string());
+        let provider = AcpProvider::connect_with_transport(
+            "acp-test".to_string(),
+            GooseMode::Auto,
+            config,
+            FakeAcpAgent {
+                prompts: prompts.clone(),
+                cancels: Arc::new(Mutex::new(0)),
+                config_options: config_options.clone(),
+                config_option_gate: Some(gate.clone()),
+            },
+        )
+        .await
+        .unwrap();
+        let messages = vec![Message::user().with_text("hello")];
+
+        // Model A's setup is abandoned mid-request and stays on the wire.
+        let model_a = ModelConfig::new("model-a");
+        let model_b = ModelConfig::new("model-b");
+        let scope = provider.begin_cancel_scope();
+        let cancelled = provider.stream(&model_a, "", &messages, &[]);
+        let cancel = async {
+            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+            provider.cancel("goose-session", scope).await;
+        };
+        let (result, ()) = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            futures::future::join(cancelled, cancel),
+        )
+        .await
+        .expect("client loop stayed blocked on the cancelled reply's config option");
+        assert!(matches!(result, Err(ProviderError::RequestFailed(_))));
+
+        // The next reply selects model B while A is still outstanding: it must
+        // wait rather than prompt under a backend A could still flip.
+        provider.begin_cancel_scope();
+        let mut pending = Box::pin(provider.stream(&model_b, "", &messages, &[]));
+        let proceeded_early = tokio::select! {
+            _ = &mut pending => true,
+            () = tokio::time::sleep(std::time::Duration::from_millis(300)) => false,
+        };
+        let selected_while_outstanding = config_options.lock().unwrap().clone();
+        let prompted_while_outstanding = prompts.lock().unwrap().len();
+
+        // Release the backend before asserting so a failure reports cleanly
+        // instead of deadlocking the provider's drop on the client loop. The
+        // abandoned request settles here, after which the new selection is
+        // applied and its prompt goes out.
+        let _releaser = tokio::spawn({
+            let gate = gate.clone();
+            async move {
+                loop {
+                    gate.notify_one();
+                    tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+                }
+            }
+        });
+        if !proceeded_early {
+            let mut stream = tokio::time::timeout(std::time::Duration::from_secs(5), pending)
+                .await
+                .expect("the new selection never proceeded after the abandoned setup settled")
+                .unwrap();
+            while stream.next().await.is_some() {}
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+        assert!(
+            !proceeded_early,
+            "model-b was applied before the abandoned setup settled"
+        );
+        assert_eq!(
+            selected_while_outstanding.as_slice(),
+            ["model-a"],
+            "model-b must not be selected while the abandoned setup is outstanding"
+        );
+        assert_eq!(
+            prompted_while_outstanding, 0,
+            "no prompt may be sent while an abandoned model setup is outstanding"
+        );
+        assert_eq!(
+            config_options.lock().unwrap().as_slice(),
+            ["model-a", "model-b"],
+            "the new selection must be applied after the abandoned setup settled"
+        );
+        assert_eq!(prompts.lock().unwrap().len(), 1);
     }
 
     #[tokio::test]

--- a/crates/goose/src/acp/provider.rs
+++ b/crates/goose/src/acp/provider.rs
@@ -1,8 +1,8 @@
 use agent_client_protocol::schema::v1::{
-    Annotations as AcpAnnotations, ClientCapabilities, CloseSessionRequest, ContentBlock,
-    ContentChunk, EnvVariable, HttpHeader, ImageContent, InitializeRequest, InitializeResponse,
-    McpCapabilities, McpServer, McpServerHttp, McpServerStdio, NewSessionRequest,
-    NewSessionResponse, PromptRequest, PromptResponse, RequestPermissionOutcome,
+    Annotations as AcpAnnotations, CancelNotification, ClientCapabilities, CloseSessionRequest,
+    ContentBlock, ContentChunk, EnvVariable, HttpHeader, ImageContent, InitializeRequest,
+    InitializeResponse, McpCapabilities, McpServer, McpServerHttp, McpServerStdio,
+    NewSessionRequest, NewSessionResponse, PromptRequest, PromptResponse, RequestPermissionOutcome,
     RequestPermissionRequest, RequestPermissionResponse, Role as AcpRole, SessionConfigKind,
     SessionConfigOption, SessionConfigOptionCategory, SessionConfigSelectOptions, SessionId,
     SessionModeState, SessionNotification, SessionUpdate, SetSessionConfigOptionRequest,
@@ -24,7 +24,7 @@ use std::path::PathBuf;
 use std::process::Stdio;
 use std::sync::{
     atomic::{AtomicBool, AtomicU64, Ordering},
-    Arc, Mutex,
+    Arc, Mutex, OnceLock,
 };
 use std::thread::JoinHandle;
 use tokio::io::AsyncReadExt;
@@ -167,6 +167,13 @@ pub struct AcpProvider {
 
     tx: Option<mpsc::Sender<ClientRequest>>,
     loop_thread: Option<JoinHandle<()>>,
+
+    /// Connection handle to the ACP agent, populated once the client loop has
+    /// connected. Used to send `session/cancel` out-of-band — the serial
+    /// request loop is blocked awaiting the in-flight prompt response, so a
+    /// cancel routed through `tx` could not be delivered until the turn it is
+    /// meant to interrupt has already finished.
+    agent_cx: Arc<OnceLock<ConnectionTo<Agent>>>,
 }
 
 impl std::fmt::Debug for AcpProvider {
@@ -245,11 +252,13 @@ impl AcpProvider {
         let pending_tool_updates: Arc<Mutex<HashMap<String, AccumulatedToolCall>>> =
             Arc::new(Mutex::new(HashMap::new()));
         let context_size = Arc::new(AtomicU64::new(0));
+        let agent_cx: Arc<OnceLock<ConnectionTo<Agent>>> = Arc::new(OnceLock::new());
         let client_loop = AcpClientLoop::new(
             config,
             goose_mode_shared.clone(),
             pending_tool_updates.clone(),
             context_size.clone(),
+            agent_cx.clone(),
         );
         let loop_thread = spawn_client_loop(run(client_loop, rx, init_tx));
 
@@ -286,6 +295,7 @@ impl AcpProvider {
             applied_model: Arc::new(Mutex::new(applied_model)),
             tx: Some(tx),
             loop_thread: Some(loop_thread),
+            agent_cx,
         })
     }
 
@@ -457,6 +467,15 @@ impl Provider for AcpProvider {
 
     fn manages_own_context(&self) -> bool {
         true
+    }
+
+    async fn cancel(&self, _session_id: &str) {
+        let Some(cx) = self.agent_cx.get() else {
+            return;
+        };
+        if let Err(e) = cx.send_notification(CancelNotification::new(self.acp_session_id())) {
+            tracing::warn!(error = %e, "failed to send ACP session/cancel");
+        }
     }
 
     async fn handle_permission_confirmation(
@@ -698,6 +717,7 @@ struct AcpClientLoop {
     prompt_response_tx: Arc<Mutex<Option<mpsc::Sender<AcpUpdate>>>>,
     pending_tool_updates: Arc<Mutex<HashMap<String, AccumulatedToolCall>>>,
     context_size: Arc<AtomicU64>,
+    agent_cx: Arc<OnceLock<ConnectionTo<Agent>>>,
 }
 
 impl AcpClientLoop {
@@ -706,6 +726,7 @@ impl AcpClientLoop {
         goose_mode: Arc<Mutex<GooseMode>>,
         pending_tool_updates: Arc<Mutex<HashMap<String, AccumulatedToolCall>>>,
         context_size: Arc<AtomicU64>,
+        agent_cx: Arc<OnceLock<ConnectionTo<Agent>>>,
     ) -> Self {
         Self {
             config,
@@ -713,6 +734,7 @@ impl AcpClientLoop {
             prompt_response_tx: Arc::new(Mutex::new(None)),
             pending_tool_updates,
             context_size,
+            agent_cx,
         }
     }
 
@@ -767,6 +789,7 @@ impl AcpClientLoop {
             prompt_response_tx,
             pending_tool_updates,
             context_size,
+            agent_cx,
         } = self;
         let notification_callback = config.notification_callback.clone();
         let reverse_modes = reverse_mode_mapping(&config.mode_mapping);
@@ -974,6 +997,7 @@ impl AcpClientLoop {
                 agent_client_protocol::on_receive_request!(),
             )
             .connect_with(transport, async move |cx: ConnectionTo<Agent>| {
+                let _ = agent_cx.set(cx.clone());
                 handle_requests(config, goose_mode, cx, rx, prompt_response_tx, init_tx).await
             })
             .await?;
@@ -1706,6 +1730,7 @@ mod tests {
                 applied_model: Arc::new(Mutex::new(None)),
                 tx,
                 loop_thread: None,
+                agent_cx: Arc::new(OnceLock::new()),
             },
             ModelConfig::new("test-model"),
         )

--- a/crates/goose/src/acp/provider.rs
+++ b/crates/goose/src/acp/provider.rs
@@ -87,10 +87,11 @@ enum ClientRequest {
         /// loop suppresses the prompt if a cancel has since been recorded for
         /// this epoch, even when it is handled after a newer reply started.
         cancel_epoch: u64,
-        /// Whether this prompt claimed the one-shot handoff context. If the
-        /// client loop suppresses the prompt, it rolls the claim back so the
-        /// next prompt still carries the context the backend never received.
-        claimed_handoff: bool,
+        /// Handoff-context memo to prepend if this turns out to be the first
+        /// prompt the client loop actually sends. Claiming at send time (rather
+        /// than when the prompt is built) keeps a prompt that is never sent
+        /// from spending the one-shot context.
+        handoff_prefix: Option<Box<ContentBlock>>,
         response_tx: mpsc::Sender<AcpUpdate>,
     },
 }
@@ -145,11 +146,6 @@ struct AcpSession {
     response: NewSessionResponse,
 }
 
-struct HandoffContextClaim {
-    first_prompt: bool,
-    include_context: bool,
-}
-
 pub struct AcpProvider {
     name: String,
     goose_mode: Arc<Mutex<GooseMode>>,
@@ -160,9 +156,6 @@ pub struct AcpProvider {
     pending_confirmations:
         Arc<TokioMutex<HashMap<String, oneshot::Sender<PermissionConfirmation>>>>,
     pending_tool_updates: Arc<Mutex<HashMap<String, AccumulatedToolCall>>>,
-    /// Shared with the client loop so a suppressed (cancelled-before-send)
-    /// first prompt can roll back the handoff-context claim it made.
-    handoff_context_sent: Arc<AtomicBool>,
     /// Latest `size` reported by the ACP server in a `session/update` →
     /// `usage_update` notification. 0 means no real update has arrived yet,
     /// in which case `get_context_limit()` falls back to the supplied model
@@ -284,7 +277,6 @@ impl AcpProvider {
         let agent_cx: Arc<OnceLock<ConnectionTo<Agent>>> = Arc::new(OnceLock::new());
         let cancelled_epoch = Arc::new(AtomicU64::new(0));
         let active_prompt_epoch = Arc::new(AtomicU64::new(0));
-        let handoff_context_sent = Arc::new(AtomicBool::new(false));
         let client_loop = AcpClientLoop::new(
             config,
             goose_mode_shared.clone(),
@@ -293,7 +285,6 @@ impl AcpProvider {
             agent_cx.clone(),
             cancelled_epoch.clone(),
             active_prompt_epoch.clone(),
-            handoff_context_sent.clone(),
         );
         let loop_thread = spawn_client_loop(run(client_loop, rx, init_tx));
 
@@ -324,7 +315,6 @@ impl AcpProvider {
             session,
             pending_confirmations: Arc::new(TokioMutex::new(HashMap::new())),
             pending_tool_updates,
-            handoff_context_sent,
             context_size,
             model_config_option_id,
             applied_model: Arc::new(Mutex::new(applied_model)),
@@ -416,7 +406,7 @@ impl AcpProvider {
         &self,
         session_id: SessionId,
         content: Vec<ContentBlock>,
-        claimed_handoff: bool,
+        handoff_prefix: Option<Box<ContentBlock>>,
     ) -> Result<mpsc::Receiver<AcpUpdate>> {
         let (response_tx, response_rx) = mpsc::channel(64);
         self.tx
@@ -426,7 +416,7 @@ impl AcpProvider {
                 session_id,
                 content,
                 cancel_epoch: self.cancel_epoch.load(Ordering::SeqCst),
-                claimed_handoff,
+                handoff_prefix,
                 response_tx,
             })
             .await
@@ -440,14 +430,6 @@ impl AcpProvider {
             .config_options
             .as_ref()
             .is_some_and(|opts| opts.iter().any(|o| o.category.as_ref() == Some(&category)))
-    }
-
-    fn claim_handoff_context(&self, messages: &[Message]) -> HandoffContextClaim {
-        let first_prompt = !self.handoff_context_sent.swap(true, Ordering::AcqRel);
-        HandoffContextClaim {
-            first_prompt,
-            include_context: first_prompt && has_handoff_context(messages),
-        }
     }
 }
 
@@ -574,36 +556,25 @@ impl Provider for AcpProvider {
                 ProviderError::RequestFailed(format!("Failed to set ACP model option: {e}"))
             })?;
 
-        let current_prompt_blocks = messages_to_prompt(messages, false);
-        if current_prompt_blocks.is_empty() {
+        let prompt_blocks = messages_to_prompt(messages);
+        if prompt_blocks.is_empty() {
             return Ok(Box::pin(futures::stream::empty()));
         }
 
-        let claim = self.claim_handoff_context(messages);
-        let prompt_blocks = if claim.include_context {
-            messages_to_prompt(messages, true)
-        } else {
-            current_prompt_blocks
-        };
+        // The handoff memo travels alongside the prompt rather than baked into
+        // it: the client loop claims the one-shot context when it actually
+        // sends, so a prompt that is never sent (cancelled or failed) neither
+        // spends the claim nor leaves a later prompt without the context.
+        let handoff_prefix = handoff_context_block(messages);
         // Drop any tool-call buffer state left over from a prior prompt
         // (e.g. cancelled or interrupted before its terminal status arrived).
         if let Ok(mut buffer) = self.pending_tool_updates.lock() {
             buffer.clear();
         }
-        let mut rx = match self
-            .prompt(session_id, prompt_blocks, claim.first_prompt)
+        let mut rx = self
+            .prompt(session_id, prompt_blocks, handoff_prefix)
             .await
-        {
-            Ok(rx) => rx,
-            Err(e) => {
-                if claim.first_prompt {
-                    self.handoff_context_sent.store(false, Ordering::Release);
-                }
-                return Err(ProviderError::RequestFailed(format!(
-                    "Failed to send ACP prompt: {e}"
-                )));
-            }
-        };
+            .map_err(|e| ProviderError::RequestFailed(format!("Failed to send ACP prompt: {e}")))?;
 
         let pending_confirmations = self.pending_confirmations.clone();
         let goose_mode = *self
@@ -804,7 +775,6 @@ impl AcpClientLoop {
         agent_cx: Arc<OnceLock<ConnectionTo<Agent>>>,
         cancelled_epoch: Arc<AtomicU64>,
         active_prompt_epoch: Arc<AtomicU64>,
-        handoff_context_sent: Arc<AtomicBool>,
     ) -> Self {
         Self {
             config,
@@ -815,7 +785,7 @@ impl AcpClientLoop {
             agent_cx,
             cancelled_epoch,
             active_prompt_epoch,
-            handoff_context_sent,
+            handoff_context_sent: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -1276,22 +1246,30 @@ async fn handle_requests(
                 session_id,
                 content,
                 cancel_epoch,
-                claimed_handoff,
+                handoff_prefix,
                 response_tx,
             } => {
                 // The turn's cancel already fired; a prompt sent now would be
                 // its backend's only run and nothing would ever cancel it.
+                // Nothing reached the backend, so the one-shot handoff context
+                // is still unclaimed and the next prompt carries it.
                 if cancelled_epoch.load(Ordering::SeqCst) >= cancel_epoch {
-                    // The backend never received this prompt, so give the
-                    // one-shot handoff-context claim back to the next prompt.
-                    if claimed_handoff {
-                        handoff_context_sent.store(false, Ordering::Release);
-                    }
                     log_undelivered(
                         response_tx.try_send(AcpUpdate::Complete(StopReason::Cancelled, None)),
                         AGENT_METHOD_NAMES.session_prompt,
                     );
                     continue;
+                }
+
+                // This prompt is going to the backend, so it claims the
+                // one-shot handoff context. The claim happens here, on the
+                // serial loop, so exactly one sent prompt carries the memo and
+                // it is the first one actually delivered.
+                let mut content = content;
+                if !handoff_context_sent.swap(true, Ordering::AcqRel) {
+                    if let Some(prefix) = handoff_prefix {
+                        content.insert(0, *prefix);
+                    }
                 }
 
                 *prompt_response_tx.lock().unwrap() = Some(response_tx.clone());
@@ -1515,7 +1493,7 @@ fn filter_supported_servers(
         .collect()
 }
 
-fn messages_to_prompt(messages: &[Message], include_handoff_context: bool) -> Vec<ContentBlock> {
+fn messages_to_prompt(messages: &[Message]) -> Vec<ContentBlock> {
     let Some(last_user_index) = last_user_message_index(messages) else {
         return Vec::new();
     };
@@ -1537,30 +1515,23 @@ fn messages_to_prompt(messages: &[Message], include_handoff_context: bool) -> Ve
         }
     }
 
-    if current_prompt_blocks.is_empty() || !include_handoff_context {
-        return current_prompt_blocks;
-    }
+    current_prompt_blocks
+}
 
-    let mut content_blocks = Vec::new();
-    if let Some(memo) = build_handoff_context_memo(&messages[..last_user_index]) {
-        content_blocks.push(ContentBlock::Text(TextContent::new(memo)));
-    }
-    content_blocks.extend(current_prompt_blocks);
-    content_blocks
+/// The handoff-context memo block to prepend to the prompt, if this
+/// conversation has agent-visible history predating the ACP session. Built
+/// separately from the prompt body so the client loop can decide at send time
+/// whether this prompt is the one that carries it.
+fn handoff_context_block(messages: &[Message]) -> Option<Box<ContentBlock>> {
+    let last_user_index = last_user_message_index(messages)?;
+    let memo = build_handoff_context_memo(&messages[..last_user_index])?;
+    Some(Box::new(ContentBlock::Text(TextContent::new(memo))))
 }
 
 fn last_user_message_index(messages: &[Message]) -> Option<usize> {
     messages
         .iter()
         .rposition(|m| m.role == Role::User && m.is_agent_visible())
-}
-
-fn has_handoff_context(messages: &[Message]) -> bool {
-    last_user_message_index(messages).is_some_and(|last_user_index| {
-        messages[..last_user_index]
-            .iter()
-            .any(Message::is_agent_visible)
-    })
 }
 
 fn build_handoff_context_memo(prior_messages: &[Message]) -> Option<String> {
@@ -1827,6 +1798,20 @@ mod tests {
 
     use test_case::test_case;
 
+    /// The blocks a first-sent prompt carries: the handoff memo (when the
+    /// conversation has prior history) followed by the current prompt body.
+    fn prompt_with_handoff(messages: &[Message]) -> Vec<ContentBlock> {
+        let current = messages_to_prompt(messages);
+        if current.is_empty() {
+            return current;
+        }
+        handoff_context_block(messages)
+            .map(|block| *block)
+            .into_iter()
+            .chain(current)
+            .collect()
+    }
+
     fn prompt_text(block: &ContentBlock) -> &str {
         match block {
             ContentBlock::Text(text) => &text.text,
@@ -1852,7 +1837,6 @@ mod tests {
                 },
                 pending_confirmations: Arc::new(TokioMutex::new(HashMap::new())),
                 pending_tool_updates: Arc::new(Mutex::new(HashMap::new())),
-                handoff_context_sent: Arc::new(AtomicBool::new(false)),
                 context_size: Arc::new(AtomicU64::new(0)),
                 model_config_option_id: None,
                 applied_model: Arc::new(Mutex::new(None)),
@@ -1871,7 +1855,7 @@ mod tests {
     fn messages_to_prompt_without_prior_history_preserves_current_prompt() {
         let messages = vec![Message::user().with_text("current request")];
 
-        let blocks = messages_to_prompt(&messages, true);
+        let blocks = prompt_with_handoff(&messages);
 
         assert_eq!(blocks.len(), 1);
         assert_eq!(prompt_text(&blocks[0]), "current request");
@@ -1893,7 +1877,7 @@ mod tests {
             Message::user().with_text("continue from there"),
         ];
 
-        let blocks = messages_to_prompt(&messages, true);
+        let blocks = prompt_with_handoff(&messages);
 
         assert_eq!(blocks.len(), 2);
         let memo = prompt_text(&blocks[0]);
@@ -1918,7 +1902,7 @@ mod tests {
             Message::user().with_text("current request"),
         ];
 
-        let blocks = messages_to_prompt(&messages, true);
+        let blocks = prompt_with_handoff(&messages);
 
         assert_eq!(blocks.len(), 2);
         let memo = prompt_text(&blocks[0]);
@@ -1937,7 +1921,7 @@ mod tests {
                 .with_text("describe this"),
         ];
 
-        let blocks = messages_to_prompt(&messages, true);
+        let blocks = prompt_with_handoff(&messages);
 
         assert_eq!(blocks.len(), 3);
         assert!(prompt_text(&blocks[0]).contains("[assistant]: prior answer"));
@@ -1971,7 +1955,7 @@ mod tests {
                 .with_content(user_only_text("SECRET_CURRENT")),
         ];
 
-        let rendered = messages_to_prompt(&messages, true)
+        let rendered = prompt_with_handoff(&messages)
             .iter()
             .filter_map(|block| match block {
                 ContentBlock::Text(text) => Some(text.text.as_str()),
@@ -1999,11 +1983,11 @@ mod tests {
             Message::user().with_content(current),
         ];
 
-        assert!(messages_to_prompt(&messages, true).is_empty());
+        assert!(prompt_with_handoff(&messages).is_empty());
     }
 
     #[tokio::test]
-    async fn stream_skips_user_only_prompt_without_claiming_handoff_context() {
+    async fn stream_skips_user_only_prompt_without_enqueueing_a_prompt() {
         use futures::StreamExt;
         use rmcp::model::{Annotations, TextContent};
 
@@ -2022,7 +2006,6 @@ mod tests {
 
         assert!(stream.next().await.is_none());
         assert!(rx.try_recv().is_err());
-        assert!(!provider.handoff_context_sent.load(Ordering::Acquire));
     }
 
     #[tokio::test]
@@ -2112,39 +2095,51 @@ mod tests {
         assert!(!audience.contains(&Role::User));
     }
 
-    #[test]
-    fn handoff_context_is_sent_only_on_first_provider_prompt() {
-        let (provider, _) = test_provider();
+    #[tokio::test]
+    async fn handoff_context_is_sent_only_on_first_provider_prompt() {
+        use futures::StreamExt;
+
+        let (provider, prompts, _cancels) = fake_connected_provider().await;
+        let model = ModelConfig::new("test-model");
         let messages = vec![
             Message::assistant().with_text("prior answer"),
             Message::user().with_text("current request"),
         ];
 
-        let first_claim = provider.claim_handoff_context(&messages);
-        assert!(first_claim.first_prompt);
-        assert!(first_claim.include_context);
+        for _ in 0..2 {
+            let mut stream = provider.stream(&model, "", &messages, &[]).await.unwrap();
+            while stream.next().await.is_some() {}
+        }
 
-        let second_claim = provider.claim_handoff_context(&messages);
-        assert!(!second_claim.first_prompt);
-        assert!(!second_claim.include_context);
+        let prompts = prompts.lock().unwrap();
+        assert_eq!(prompts.len(), 2);
+        assert!(prompts[0].contains("Conversation context from goose"));
+        assert!(!prompts[1].contains("Conversation context from goose"));
     }
 
-    #[test]
-    fn first_prompt_without_history_still_marks_handoff_context_sent() {
-        let (provider, _) = test_provider();
+    #[tokio::test]
+    async fn first_prompt_without_history_still_marks_handoff_context_sent() {
+        use futures::StreamExt;
+
+        let (provider, prompts, _cancels) = fake_connected_provider().await;
+        let model = ModelConfig::new("test-model");
         let first_prompt = vec![Message::user().with_text("new conversation")];
         let later_prompt_with_history = vec![
             Message::assistant().with_text("prior answer"),
             Message::user().with_text("current request"),
         ];
 
-        let first_claim = provider.claim_handoff_context(&first_prompt);
-        assert!(first_claim.first_prompt);
-        assert!(!first_claim.include_context);
+        for messages in [&first_prompt, &later_prompt_with_history] {
+            let mut stream = provider.stream(&model, "", messages, &[]).await.unwrap();
+            while stream.next().await.is_some() {}
+        }
 
-        let later_claim = provider.claim_handoff_context(&later_prompt_with_history);
-        assert!(!later_claim.first_prompt);
-        assert!(!later_claim.include_context);
+        let prompts = prompts.lock().unwrap();
+        assert_eq!(prompts.len(), 2);
+        assert!(
+            !prompts[1].contains("Conversation context from goose"),
+            "a first prompt without history still spends the one-shot claim"
+        );
     }
 
     #[tokio::test]
@@ -2160,7 +2155,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn failed_first_prompt_send_rolls_back_handoff_context_claim() {
+    async fn failed_prompt_send_surfaces_a_request_failure() {
         let (tx, rx) = mpsc::channel(1);
         drop(rx);
         let (provider, model) = test_provider_with_tx(Some(tx));
@@ -2172,9 +2167,6 @@ mod tests {
         let result = provider.stream(&model, "", &messages, &[]).await;
 
         assert!(matches!(result, Err(ProviderError::RequestFailed(_))));
-        let next_claim = provider.claim_handoff_context(&messages);
-        assert!(next_claim.first_prompt);
-        assert!(next_claim.include_context);
     }
 
     fn test_provider_with_model_option(
@@ -2448,8 +2440,39 @@ mod tests {
         );
     }
 
+    /// Two prompts can be queued before the client loop handles either, so the
+    /// handoff memo must ride along with each rather than being baked into
+    /// whichever was built first: the prompt that is actually sent carries it.
     #[tokio::test]
-    async fn suppressed_first_prompt_rolls_back_handoff_claim() {
+    async fn queued_prompts_all_carry_the_handoff_memo_until_one_is_sent() {
+        let (tx, mut rx) = mpsc::channel(4);
+        let (provider, model) = test_provider_with_tx(Some(tx));
+        let messages = vec![
+            Message::assistant().with_text("prior answer"),
+            Message::user().with_text("current request"),
+        ];
+
+        // Reply N is cancelled while still queued, and reply N+1 builds its
+        // prompt before the client loop has handled either.
+        let scope_n = provider.begin_cancel_scope();
+        let _stream = provider.stream(&model, "", &messages, &[]).await.unwrap();
+        provider.cancel("goose-session", scope_n).await;
+        provider.begin_cancel_scope();
+        let _stream = provider.stream(&model, "", &messages, &[]).await.unwrap();
+
+        for expected in ["cancelled prompt", "next reply's prompt"] {
+            match rx.recv().await.expect("expected ACP prompt request") {
+                ClientRequest::Prompt { handoff_prefix, .. } => assert!(
+                    handoff_prefix.is_some(),
+                    "{expected} must still carry the handoff memo"
+                ),
+                _ => panic!("expected ACP prompt request"),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn suppressed_first_prompt_leaves_handoff_context_for_the_next_prompt() {
         use futures::StreamExt;
 
         let (provider, prompts, _cancels) = fake_connected_provider().await;
@@ -2696,7 +2719,7 @@ mod tests {
             Message::user().with_text("current request"),
         ];
 
-        let blocks = messages_to_prompt(&messages, true);
+        let blocks = prompt_with_handoff(&messages);
 
         assert_eq!(blocks.len(), 2);
         let memo = prompt_text(&blocks[0]);

--- a/crates/goose/src/acp/provider.rs
+++ b/crates/goose/src/acp/provider.rs
@@ -78,6 +78,13 @@ enum ClientRequest {
         session_id: SessionId,
         config_id: String,
         value: String,
+        /// `Some(epoch)` when this option is applied as part of a reply's
+        /// pre-prompt setup, so the client loop can skip it — or stop awaiting
+        /// it — once that reply is cancelled, instead of leaving the serial
+        /// loop blocked on a slow backend with later prompts queued behind it.
+        /// `None` for out-of-band updates (mode/config changes), which are not
+        /// tied to a reply and always run.
+        cancel_epoch: Option<u64>,
         response_tx: oneshot::Sender<Result<()>>,
     },
     Prompt {
@@ -186,6 +193,10 @@ pub struct AcpProvider {
     /// being cancelled, so a stale forwarder from a finished reply can never
     /// cancel a newer reply's active run.
     active_prompt_epoch: Arc<AtomicU64>,
+    /// Woken whenever `cancelled_epoch` advances, so the client loop can stop
+    /// awaiting an in-flight pre-prompt request the moment its reply is
+    /// cancelled rather than only noticing between requests.
+    cancel_notify: Arc<tokio::sync::Notify>,
 
     tx: Option<mpsc::Sender<ClientRequest>>,
     loop_thread: Option<JoinHandle<()>>,
@@ -277,6 +288,7 @@ impl AcpProvider {
         let agent_cx: Arc<OnceLock<ConnectionTo<Agent>>> = Arc::new(OnceLock::new());
         let cancelled_epoch = Arc::new(AtomicU64::new(0));
         let active_prompt_epoch = Arc::new(AtomicU64::new(0));
+        let cancel_notify = Arc::new(tokio::sync::Notify::new());
         let client_loop = AcpClientLoop::new(
             config,
             goose_mode_shared.clone(),
@@ -285,6 +297,7 @@ impl AcpProvider {
             agent_cx.clone(),
             cancelled_epoch.clone(),
             active_prompt_epoch.clone(),
+            cancel_notify.clone(),
         );
         let loop_thread = spawn_client_loop(run(client_loop, rx, init_tx));
 
@@ -321,6 +334,7 @@ impl AcpProvider {
             cancel_epoch: Arc::new(AtomicU64::new(1)),
             cancelled_epoch,
             active_prompt_epoch,
+            cancel_notify,
             tx: Some(tx),
             loop_thread: Some(loop_thread),
             agent_cx,
@@ -353,6 +367,16 @@ impl AcpProvider {
         config_id: String,
         value: String,
     ) -> Result<()> {
+        self.send_set_config_option_in_scope(config_id, value, None)
+            .await
+    }
+
+    async fn send_set_config_option_in_scope(
+        &self,
+        config_id: String,
+        value: String,
+        cancel_epoch: Option<u64>,
+    ) -> Result<()> {
         let session_id = self.acp_session_id();
         let (response_tx, response_rx) = oneshot::channel();
         self.tx
@@ -362,6 +386,7 @@ impl AcpProvider {
                 session_id,
                 config_id,
                 value,
+                cancel_epoch,
                 response_tx,
             })
             .await
@@ -391,8 +416,15 @@ impl AcpProvider {
             }
         }
 
-        self.send_set_config_option("", config_id, model_name.to_string())
-            .await?;
+        // Applied in this reply's cancel scope: a cancel that lands while the
+        // backend is still handling it frees the client loop instead of
+        // stalling the next prompt behind it.
+        self.send_set_config_option_in_scope(
+            config_id,
+            model_name.to_string(),
+            Some(self.cancel_epoch.load(Ordering::SeqCst)),
+        )
+        .await?;
 
         let mut applied = self
             .applied_model
@@ -502,6 +534,7 @@ impl Provider for AcpProvider {
         // reply's prompts. fetch_max keeps a late stale cancel from lowering
         // the latch.
         self.cancelled_epoch.fetch_max(scope, Ordering::SeqCst);
+        self.cancel_notify.notify_waiters();
         // Only notify the backend when the prompt currently in flight belongs
         // to the scope being cancelled. A stale forwarder from a finished
         // reply must not cancel a newer reply's active run, and with nothing
@@ -762,6 +795,7 @@ struct AcpClientLoop {
     agent_cx: Arc<OnceLock<ConnectionTo<Agent>>>,
     cancelled_epoch: Arc<AtomicU64>,
     active_prompt_epoch: Arc<AtomicU64>,
+    cancel_notify: Arc<tokio::sync::Notify>,
     handoff_context_sent: Arc<AtomicBool>,
 }
 
@@ -775,6 +809,7 @@ impl AcpClientLoop {
         agent_cx: Arc<OnceLock<ConnectionTo<Agent>>>,
         cancelled_epoch: Arc<AtomicU64>,
         active_prompt_epoch: Arc<AtomicU64>,
+        cancel_notify: Arc<tokio::sync::Notify>,
     ) -> Self {
         Self {
             config,
@@ -785,6 +820,7 @@ impl AcpClientLoop {
             agent_cx,
             cancelled_epoch,
             active_prompt_epoch,
+            cancel_notify,
             handoff_context_sent: Arc::new(AtomicBool::new(false)),
         }
     }
@@ -843,6 +879,7 @@ impl AcpClientLoop {
             agent_cx,
             cancelled_epoch,
             active_prompt_epoch,
+            cancel_notify,
             handoff_context_sent,
         } = self;
         let notification_callback = config.notification_callback.clone();
@@ -1060,6 +1097,7 @@ impl AcpClientLoop {
                     prompt_response_tx,
                     cancelled_epoch,
                     active_prompt_epoch,
+                    cancel_notify,
                     handoff_context_sent,
                     init_tx,
                 )
@@ -1135,6 +1173,23 @@ async fn spawn_acp_process(config: &AcpProviderConfig) -> Result<Child> {
     cmd.spawn().context("failed to spawn ACP process")
 }
 
+/// Resolves once a cancel has been recorded for `epoch` or any later one.
+/// Registering with `Notify` before re-reading the epoch keeps a cancel that
+/// lands between the two from being missed.
+async fn await_cancelled_epoch(
+    cancel_notify: &tokio::sync::Notify,
+    cancelled_epoch: &AtomicU64,
+    epoch: u64,
+) {
+    loop {
+        let notified = cancel_notify.notified();
+        if cancelled_epoch.load(Ordering::SeqCst) >= epoch {
+            return;
+        }
+        notified.await;
+    }
+}
+
 fn log_undelivered<E: std::fmt::Debug>(result: Result<(), E>, method: &str) {
     if let Err(e) = result {
         tracing::debug!(method, error = ?e, "response not delivered");
@@ -1150,6 +1205,7 @@ async fn handle_requests(
     prompt_response_tx: Arc<Mutex<Option<mpsc::Sender<AcpUpdate>>>>,
     cancelled_epoch: Arc<AtomicU64>,
     active_prompt_epoch: Arc<AtomicU64>,
+    cancel_notify: Arc<tokio::sync::Notify>,
     handoff_context_sent: Arc<AtomicBool>,
     init_tx: oneshot::Sender<Result<InitializeResponse>>,
 ) -> Result<(), agent_client_protocol::Error> {
@@ -1227,16 +1283,35 @@ async fn handle_requests(
                 session_id,
                 config_id,
                 value,
+                cancel_epoch,
                 response_tx,
             } => {
+                let cancelled = |epoch| cancelled_epoch.load(Ordering::SeqCst) >= epoch;
+                if cancel_epoch.is_some_and(cancelled) {
+                    log_undelivered(
+                        response_tx.send(Err(anyhow::anyhow!("reply cancelled"))),
+                        AGENT_METHOD_NAMES.session_set_config_option,
+                    );
+                    continue;
+                }
+
                 let value_id = agent_client_protocol::schema::v1::SessionConfigValueId::new(value);
                 let req = SetSessionConfigOptionRequest::new(session_id, config_id, value_id);
-                let result: Result<()> = cx
-                    .send_request(req)
-                    .block_task()
-                    .await
-                    .map(|_| ())
-                    .map_err(anyhow::Error::from);
+                let request = cx.send_request(req).block_task();
+                // Stop awaiting a cancelled reply's setup request so the next
+                // prompt is not queued behind a backend that may never answer.
+                // The request itself stays on the wire — ACP has no way to
+                // retract it — but the serial loop is free again.
+                let result: Result<()> = match cancel_epoch {
+                    Some(epoch) => tokio::select! {
+                        biased;
+                        () = await_cancelled_epoch(&cancel_notify, &cancelled_epoch, epoch) => {
+                            Err(anyhow::anyhow!("reply cancelled"))
+                        }
+                        response = request => response.map(|_| ()).map_err(anyhow::Error::from),
+                    },
+                    None => request.await.map(|_| ()).map_err(anyhow::Error::from),
+                };
                 log_undelivered(
                     response_tx.send(result),
                     AGENT_METHOD_NAMES.session_set_config_option,
@@ -1843,6 +1918,7 @@ mod tests {
                 cancel_epoch: Arc::new(AtomicU64::new(1)),
                 cancelled_epoch: Arc::new(AtomicU64::new(0)),
                 active_prompt_epoch: Arc::new(AtomicU64::new(0)),
+                cancel_notify: Arc::new(tokio::sync::Notify::new()),
                 tx,
                 loop_thread: None,
                 agent_cx: Arc::new(OnceLock::new()),
@@ -2260,6 +2336,9 @@ mod tests {
     struct FakeAcpAgent {
         prompts: Arc<Mutex<Vec<String>>>,
         cancels: Arc<Mutex<u32>>,
+        /// When set, `session/set_config_option` waits on this gate instead of
+        /// answering, mimicking a backend that hangs applying an option.
+        config_option_gate: Option<Arc<tokio::sync::Notify>>,
     }
 
     impl agent_client_protocol::ConnectTo<Client> for FakeAcpAgent {
@@ -2269,8 +2348,22 @@ mod tests {
         ) -> std::result::Result<(), agent_client_protocol::Error> {
             let prompts = self.prompts;
             let cancels = self.cancels;
+            let config_option_gate = self.config_option_gate;
             Agent
                 .builder()
+                .on_receive_request(
+                    async move |_req: SetSessionConfigOptionRequest, responder, _cx| {
+                        if let Some(gate) = config_option_gate.as_ref() {
+                            gate.notified().await;
+                        }
+                        responder.respond(
+                            agent_client_protocol::schema::v1::SetSessionConfigOptionResponse::new(
+                                vec![],
+                            ),
+                        )
+                    },
+                    agent_client_protocol::on_receive_request!(),
+                )
                 .on_receive_request(
                     async move |_req: InitializeRequest, responder, _cx| {
                         responder.respond(InitializeResponse::new(ProtocolVersion::LATEST))
@@ -2327,11 +2420,59 @@ mod tests {
             FakeAcpAgent {
                 prompts: prompts.clone(),
                 cancels: cancels.clone(),
+                config_option_gate: None,
             },
         )
         .await
         .unwrap();
         (provider, prompts, cancels)
+    }
+
+    /// A cancel landing while the backend is still applying a pre-prompt
+    /// config option must free the serial client loop: it stops awaiting the
+    /// request instead of leaving later prompts queued behind a backend that
+    /// may never answer.
+    #[tokio::test]
+    async fn cancel_during_pre_prompt_config_option_unblocks_the_client_loop() {
+        let gate = Arc::new(tokio::sync::Notify::new());
+        let mut config = test_acp_config(HashMap::new(), None);
+        config.model_config_option_id = Some("model".to_string());
+        let provider = AcpProvider::connect_with_transport(
+            "acp-test".to_string(),
+            GooseMode::Auto,
+            config,
+            FakeAcpAgent {
+                prompts: Arc::new(Mutex::new(Vec::new())),
+                cancels: Arc::new(Mutex::new(0)),
+                config_option_gate: Some(gate.clone()),
+            },
+        )
+        .await
+        .unwrap();
+        let model = ModelConfig::new("some-model");
+        let messages = vec![Message::user().with_text("hello")];
+
+        // The reply stalls in apply_model_if_changed with the client loop
+        // awaiting the backend. Cancelling it must end that await, which the
+        // caller observes as the request failing rather than hanging.
+        let scope = provider.begin_cancel_scope();
+        let stalled = provider.stream(&model, "", &messages, &[]);
+        let cancel = async {
+            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+            provider.cancel("goose-session", scope).await;
+        };
+        let joined = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            futures::future::join(stalled, cancel),
+        )
+        .await;
+        // Release the backend before asserting so a failure reports cleanly
+        // instead of deadlocking the provider's drop on the client loop.
+        gate.notify_one();
+
+        let (result, ()) =
+            joined.expect("client loop stayed blocked on the cancelled reply's config option");
+        assert!(matches!(result, Err(ProviderError::RequestFailed(_))));
     }
 
     #[tokio::test]

--- a/crates/goose/src/acp/provider.rs
+++ b/crates/goose/src/acp/provider.rs
@@ -83,6 +83,10 @@ enum ClientRequest {
     Prompt {
         session_id: SessionId,
         content: Vec<ContentBlock>,
+        /// Value of `cancel_epoch` when this prompt was enqueued. The client
+        /// loop suppresses the prompt if a cancel has since been recorded for
+        /// this epoch, even when it is handled after a newer reply started.
+        cancel_epoch: u64,
         response_tx: mpsc::Sender<AcpUpdate>,
     },
 }
@@ -165,12 +169,17 @@ pub struct AcpProvider {
     /// redundant `SetConfigOption` calls.
     applied_model: Arc<Mutex<Option<String>>>,
 
-    /// Set by `cancel()` and cleared at the start of each reply. The client
-    /// loop checks it around sending `session/prompt` so a cancel that fired
-    /// before the prompt reached the wire — where the backend would ignore it
-    /// as targeting no active run — suppresses the prompt (or is re-sent after
-    /// it) instead of being lost.
-    cancel_requested: Arc<AtomicBool>,
+    /// Current cancel epoch, bumped by `clear_pending_cancel()` when a new
+    /// reply begins. Prompts capture it at enqueue time.
+    cancel_epoch: Arc<AtomicU64>,
+    /// Highest epoch for which `cancel()` has fired (0 = none). The client
+    /// loop suppresses (or re-cancels) any prompt whose captured epoch is at
+    /// or below this: a cancel that fired before the prompt reached the wire
+    /// would otherwise be ignored by the backend as targeting no active run,
+    /// and the prompt would start with its only cancel already spent. Keying
+    /// by epoch keeps a stale queued prompt cancelled even when it is handled
+    /// after a newer reply has already begun.
+    cancelled_epoch: Arc<AtomicU64>,
 
     tx: Option<mpsc::Sender<ClientRequest>>,
     loop_thread: Option<JoinHandle<()>>,
@@ -260,14 +269,14 @@ impl AcpProvider {
             Arc::new(Mutex::new(HashMap::new()));
         let context_size = Arc::new(AtomicU64::new(0));
         let agent_cx: Arc<OnceLock<ConnectionTo<Agent>>> = Arc::new(OnceLock::new());
-        let cancel_requested = Arc::new(AtomicBool::new(false));
+        let cancelled_epoch = Arc::new(AtomicU64::new(0));
         let client_loop = AcpClientLoop::new(
             config,
             goose_mode_shared.clone(),
             pending_tool_updates.clone(),
             context_size.clone(),
             agent_cx.clone(),
-            cancel_requested.clone(),
+            cancelled_epoch.clone(),
         );
         let loop_thread = spawn_client_loop(run(client_loop, rx, init_tx));
 
@@ -302,7 +311,8 @@ impl AcpProvider {
             context_size,
             model_config_option_id,
             applied_model: Arc::new(Mutex::new(applied_model)),
-            cancel_requested,
+            cancel_epoch: Arc::new(AtomicU64::new(1)),
+            cancelled_epoch,
             tx: Some(tx),
             loop_thread: Some(loop_thread),
             agent_cx,
@@ -396,6 +406,7 @@ impl AcpProvider {
             .send(ClientRequest::Prompt {
                 session_id,
                 content,
+                cancel_epoch: self.cancel_epoch.load(Ordering::SeqCst),
                 response_tx,
             })
             .await
@@ -484,7 +495,8 @@ impl Provider for AcpProvider {
         // notification below targets no active run and the backend ignores
         // it, so the client loop must observe the latch around the prompt
         // send to suppress or re-cancel the turn.
-        self.cancel_requested.store(true, Ordering::SeqCst);
+        self.cancelled_epoch
+            .store(self.cancel_epoch.load(Ordering::SeqCst), Ordering::SeqCst);
         let Some(cx) = self.agent_cx.get() else {
             return;
         };
@@ -494,7 +506,11 @@ impl Provider for AcpProvider {
     }
 
     fn clear_pending_cancel(&self) {
-        self.cancel_requested.store(false, Ordering::SeqCst);
+        // Bump the epoch instead of clearing the latch: prompts from the
+        // cancelled reply may still sit in the client-loop queue and must
+        // stay cancelled, while the new reply's prompts capture the fresh
+        // epoch and are unaffected.
+        self.cancel_epoch.fetch_add(1, Ordering::SeqCst);
     }
 
     async fn handle_permission_confirmation(
@@ -737,7 +753,7 @@ struct AcpClientLoop {
     pending_tool_updates: Arc<Mutex<HashMap<String, AccumulatedToolCall>>>,
     context_size: Arc<AtomicU64>,
     agent_cx: Arc<OnceLock<ConnectionTo<Agent>>>,
-    cancel_requested: Arc<AtomicBool>,
+    cancelled_epoch: Arc<AtomicU64>,
 }
 
 impl AcpClientLoop {
@@ -747,7 +763,7 @@ impl AcpClientLoop {
         pending_tool_updates: Arc<Mutex<HashMap<String, AccumulatedToolCall>>>,
         context_size: Arc<AtomicU64>,
         agent_cx: Arc<OnceLock<ConnectionTo<Agent>>>,
-        cancel_requested: Arc<AtomicBool>,
+        cancelled_epoch: Arc<AtomicU64>,
     ) -> Self {
         Self {
             config,
@@ -756,7 +772,7 @@ impl AcpClientLoop {
             pending_tool_updates,
             context_size,
             agent_cx,
-            cancel_requested,
+            cancelled_epoch,
         }
     }
 
@@ -812,7 +828,7 @@ impl AcpClientLoop {
             pending_tool_updates,
             context_size,
             agent_cx,
-            cancel_requested,
+            cancelled_epoch,
         } = self;
         let notification_callback = config.notification_callback.clone();
         let reverse_modes = reverse_mode_mapping(&config.mode_mapping);
@@ -1027,7 +1043,7 @@ impl AcpClientLoop {
                     cx,
                     rx,
                     prompt_response_tx,
-                    cancel_requested,
+                    cancelled_epoch,
                     init_tx,
                 )
                 .await
@@ -1114,7 +1130,7 @@ async fn handle_requests(
     cx: ConnectionTo<Agent>,
     rx: &mut mpsc::Receiver<ClientRequest>,
     prompt_response_tx: Arc<Mutex<Option<mpsc::Sender<AcpUpdate>>>>,
-    cancel_requested: Arc<AtomicBool>,
+    cancelled_epoch: Arc<AtomicU64>,
     init_tx: oneshot::Sender<Result<InitializeResponse>>,
 ) -> Result<(), agent_client_protocol::Error> {
     let mut init_tx = Some(init_tx);
@@ -1209,11 +1225,12 @@ async fn handle_requests(
             ClientRequest::Prompt {
                 session_id,
                 content,
+                cancel_epoch,
                 response_tx,
             } => {
                 // The turn's cancel already fired; a prompt sent now would be
                 // its backend's only run and nothing would ever cancel it.
-                if cancel_requested.load(Ordering::SeqCst) {
+                if cancelled_epoch.load(Ordering::SeqCst) >= cancel_epoch {
                     log_undelivered(
                         response_tx.try_send(AcpUpdate::Complete(StopReason::Cancelled, None)),
                         AGENT_METHOD_NAMES.session_prompt,
@@ -1228,7 +1245,7 @@ async fn handle_requests(
                 // cancel observed here raced the enqueue and its notification
                 // may sit ahead of the prompt on the wire, where the backend
                 // ignores it. Re-send it so one lands after the prompt.
-                if cancel_requested.load(Ordering::SeqCst) {
+                if cancelled_epoch.load(Ordering::SeqCst) >= cancel_epoch {
                     if let Err(e) = cx.send_notification(CancelNotification::new(session_id)) {
                         tracing::warn!(error = %e, "failed to re-send ACP session/cancel");
                     }
@@ -1778,7 +1795,8 @@ mod tests {
                 context_size: Arc::new(AtomicU64::new(0)),
                 model_config_option_id: None,
                 applied_model: Arc::new(Mutex::new(None)),
-                cancel_requested: Arc::new(AtomicBool::new(false)),
+                cancel_epoch: Arc::new(AtomicU64::new(1)),
+                cancelled_epoch: Arc::new(AtomicU64::new(0)),
                 tx,
                 loop_thread: None,
                 agent_cx: Arc::new(OnceLock::new()),
@@ -2277,6 +2295,41 @@ mod tests {
             *prompts.lock().unwrap(),
             1,
             "prompt after clear_pending_cancel must reach the backend"
+        );
+    }
+
+    #[tokio::test]
+    async fn stale_queued_prompt_stays_cancelled_after_new_reply_starts() {
+        let (tx, mut rx) = mpsc::channel(4);
+        let (provider, model) = test_provider_with_tx(Some(tx));
+        let messages = vec![Message::user().with_text("hello")];
+
+        // Reply N enqueues its prompt; the client loop has not handled it yet.
+        let _stream = provider.stream(&model, "", &messages, &[]).await.unwrap();
+        let stale_epoch = match rx.recv().await.expect("expected ACP prompt request") {
+            ClientRequest::Prompt { cancel_epoch, .. } => cancel_epoch,
+            _ => panic!("expected ACP prompt request"),
+        };
+
+        // Reply N is cancelled, then reply N+1 begins.
+        provider.cancel("goose-session").await;
+        provider.clear_pending_cancel();
+        let _stream = provider.stream(&model, "", &messages, &[]).await.unwrap();
+        let fresh_epoch = match rx.recv().await.expect("expected ACP prompt request") {
+            ClientRequest::Prompt { cancel_epoch, .. } => cancel_epoch,
+            _ => panic!("expected ACP prompt request"),
+        };
+
+        // The stale prompt must still be seen as cancelled by the client
+        // loop, while the new reply's prompt must not be.
+        let cancelled = provider.cancelled_epoch.load(Ordering::SeqCst);
+        assert!(
+            cancelled >= stale_epoch,
+            "stale queued prompt must stay cancelled (cancelled={cancelled}, stale={stale_epoch})"
+        );
+        assert!(
+            cancelled < fresh_epoch,
+            "new reply's prompt must not be suppressed (cancelled={cancelled}, fresh={fresh_epoch})"
         );
     }
 

--- a/crates/goose/src/acp/provider.rs
+++ b/crates/goose/src/acp/provider.rs
@@ -274,13 +274,15 @@ impl AcpProvider {
         let (init_tx, init_rx) = oneshot::channel();
         let mode_mapping = config.mode_mapping.clone();
         let model_config_option_id = config.model_config_option_id.clone();
-        let applied_model = config.model_config_option_id.as_ref().and_then(|id| {
-            config
-                .session_config_options
-                .iter()
-                .find(|(opt_id, _)| opt_id == id)
-                .map(|(_, value)| value.clone())
-        });
+        let applied_model = Arc::new(Mutex::new(config.model_config_option_id.as_ref().and_then(
+            |id| {
+                config
+                    .session_config_options
+                    .iter()
+                    .find(|(opt_id, _)| opt_id == id)
+                    .map(|(_, value)| value.clone())
+            },
+        )));
         let goose_mode_shared = Arc::new(Mutex::new(goose_mode));
         let pending_tool_updates: Arc<Mutex<HashMap<String, AccumulatedToolCall>>> =
             Arc::new(Mutex::new(HashMap::new()));
@@ -298,6 +300,7 @@ impl AcpProvider {
             cancelled_epoch.clone(),
             active_prompt_epoch.clone(),
             cancel_notify.clone(),
+            applied_model.clone(),
         );
         let loop_thread = spawn_client_loop(run(client_loop, rx, init_tx));
 
@@ -330,7 +333,7 @@ impl AcpProvider {
             pending_tool_updates,
             context_size,
             model_config_option_id,
-            applied_model: Arc::new(Mutex::new(applied_model)),
+            applied_model,
             cancel_epoch: Arc::new(AtomicU64::new(1)),
             cancelled_epoch,
             active_prompt_epoch,
@@ -414,6 +417,18 @@ impl AcpProvider {
             if applied.as_deref() == Some(model_name) {
                 return Ok(());
             }
+        }
+
+        // The request reaches the backend before it is known to have settled,
+        // so no value is trustworthy until it answers: clear the memo first
+        // and only record the new model once it does. An attempt abandoned by
+        // a cancel therefore leaves the next reply re-applying its model.
+        {
+            let mut applied = self
+                .applied_model
+                .lock()
+                .map_err(|_| anyhow::anyhow!("applied_model lock poisoned"))?;
+            *applied = None;
         }
 
         // Applied in this reply's cancel scope: a cancel that lands while the
@@ -797,6 +812,7 @@ struct AcpClientLoop {
     active_prompt_epoch: Arc<AtomicU64>,
     cancel_notify: Arc<tokio::sync::Notify>,
     handoff_context_sent: Arc<AtomicBool>,
+    applied_model: Arc<Mutex<Option<String>>>,
 }
 
 impl AcpClientLoop {
@@ -810,6 +826,7 @@ impl AcpClientLoop {
         cancelled_epoch: Arc<AtomicU64>,
         active_prompt_epoch: Arc<AtomicU64>,
         cancel_notify: Arc<tokio::sync::Notify>,
+        applied_model: Arc<Mutex<Option<String>>>,
     ) -> Self {
         Self {
             config,
@@ -822,6 +839,7 @@ impl AcpClientLoop {
             active_prompt_epoch,
             cancel_notify,
             handoff_context_sent: Arc::new(AtomicBool::new(false)),
+            applied_model,
         }
     }
 
@@ -881,6 +899,7 @@ impl AcpClientLoop {
             active_prompt_epoch,
             cancel_notify,
             handoff_context_sent,
+            applied_model,
         } = self;
         let notification_callback = config.notification_callback.clone();
         let reverse_modes = reverse_mode_mapping(&config.mode_mapping);
@@ -1099,6 +1118,7 @@ impl AcpClientLoop {
                     active_prompt_epoch,
                     cancel_notify,
                     handoff_context_sent,
+                    applied_model,
                     init_tx,
                 )
                 .await
@@ -1207,6 +1227,7 @@ async fn handle_requests(
     active_prompt_epoch: Arc<AtomicU64>,
     cancel_notify: Arc<tokio::sync::Notify>,
     handoff_context_sent: Arc<AtomicBool>,
+    applied_model: Arc<Mutex<Option<String>>>,
     init_tx: oneshot::Sender<Result<InitializeResponse>>,
 ) -> Result<(), agent_client_protocol::Error> {
     let mut init_tx = Some(init_tx);
@@ -1297,20 +1318,37 @@ async fn handle_requests(
 
                 let value_id = agent_client_protocol::schema::v1::SessionConfigValueId::new(value);
                 let req = SetSessionConfigOptionRequest::new(session_id, config_id, value_id);
-                let request = cx.send_request(req).block_task();
+                let mut request = Box::pin(cx.send_request(req).block_task());
                 // Stop awaiting a cancelled reply's setup request so the next
                 // prompt is not queued behind a backend that may never answer.
                 // The request itself stays on the wire — ACP has no way to
                 // retract it — but the serial loop is free again.
-                let result: Result<()> = match cancel_epoch {
+                let settled = match cancel_epoch {
                     Some(epoch) => tokio::select! {
                         biased;
-                        () = await_cancelled_epoch(&cancel_notify, &cancelled_epoch, epoch) => {
-                            Err(anyhow::anyhow!("reply cancelled"))
-                        }
-                        response = request => response.map(|_| ()).map_err(anyhow::Error::from),
+                        () = await_cancelled_epoch(&cancel_notify, &cancelled_epoch, epoch) => None,
+                        response = &mut request => Some(response),
                     },
-                    None => request.await.map(|_| ()).map_err(anyhow::Error::from),
+                    None => Some(request.as_mut().await),
+                };
+                let result: Result<()> = match settled {
+                    Some(response) => response.map(|_| ()).map_err(anyhow::Error::from),
+                    None => {
+                        // An abandoned option can still reach the backend after
+                        // a later one has been applied, so keep watching it off
+                        // the serial loop and mark the applied model unknown
+                        // once it settles. The next reply then re-applies its
+                        // model instead of trusting a value this request may
+                        // have overwritten.
+                        let applied_model = applied_model.clone();
+                        tokio::spawn(async move {
+                            let _ = request.await;
+                            if let Ok(mut applied) = applied_model.lock() {
+                                *applied = None;
+                            }
+                        });
+                        Err(anyhow::anyhow!("reply cancelled"))
+                    }
                 };
                 log_undelivered(
                     response_tx.send(result),
@@ -2280,6 +2318,50 @@ mod tests {
         handle.await.unwrap().unwrap();
     }
 
+    /// A failed attempt — a cancel abandoning it, say — has already reached
+    /// the backend, so the previously applied model can no longer be trusted
+    /// and the next attempt must re-send even for that same model.
+    #[tokio::test]
+    async fn apply_model_if_changed_reapplies_after_a_failed_attempt() {
+        let (tx, mut rx) = mpsc::channel(1);
+        let provider = test_provider_with_model_option(tx, Some("old-model".to_string()));
+
+        let fail = async {
+            match rx.recv().await.expect("expected a SetConfigOption request") {
+                ClientRequest::SetConfigOption { response_tx, .. } => {
+                    let _ = response_tx.send(Err(anyhow::anyhow!("reply cancelled")));
+                }
+                _ => panic!("unexpected request kind"),
+            }
+        };
+        let (result, ()) =
+            futures::future::join(provider.apply_model_if_changed("new-model"), fail).await;
+        assert!(result.is_err());
+
+        let reapply = async {
+            match rx
+                .recv()
+                .await
+                .expect("expected a re-applied SetConfigOption")
+            {
+                ClientRequest::SetConfigOption {
+                    value, response_tx, ..
+                } => {
+                    assert_eq!(value, "old-model");
+                    let _ = response_tx.send(Ok(()));
+                }
+                _ => panic!("unexpected request kind"),
+            }
+        };
+        let (result, ()) = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            futures::future::join(provider.apply_model_if_changed("old-model"), reapply),
+        )
+        .await
+        .expect("a failed attempt must leave the applied model unknown");
+        result.unwrap();
+    }
+
     #[tokio::test]
     async fn apply_model_if_changed_skips_when_model_unchanged() {
         let (tx, mut rx) = mpsc::channel(1);
@@ -2473,6 +2555,59 @@ mod tests {
         let (result, ()) =
             joined.expect("client loop stayed blocked on the cancelled reply's config option");
         assert!(matches!(result, Err(ProviderError::RequestFailed(_))));
+    }
+
+    /// The abandoned request stays on the wire, so it can reach the backend
+    /// after a later reply has applied a different model. Once it settles, the
+    /// applied-model memo is dropped so the next reply re-applies its own
+    /// model instead of leaving the backend on the abandoned one.
+    #[tokio::test]
+    async fn settled_abandoned_model_setup_invalidates_the_applied_model() {
+        let gate = Arc::new(tokio::sync::Notify::new());
+        let mut config = test_acp_config(HashMap::new(), None);
+        config.model_config_option_id = Some("model".to_string());
+        let provider = AcpProvider::connect_with_transport(
+            "acp-test".to_string(),
+            GooseMode::Auto,
+            config,
+            FakeAcpAgent {
+                prompts: Arc::new(Mutex::new(Vec::new())),
+                cancels: Arc::new(Mutex::new(0)),
+                config_option_gate: Some(gate.clone()),
+            },
+        )
+        .await
+        .unwrap();
+        let model = ModelConfig::new("model-a");
+        let messages = vec![Message::user().with_text("hello")];
+
+        let scope = provider.begin_cancel_scope();
+        let stalled = provider.stream(&model, "", &messages, &[]);
+        let cancel = async {
+            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+            provider.cancel("goose-session", scope).await;
+        };
+        let (result, ()) = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            futures::future::join(stalled, cancel),
+        )
+        .await
+        .expect("client loop stayed blocked on the cancelled reply's config option");
+        assert!(matches!(result, Err(ProviderError::RequestFailed(_))));
+
+        // Stand in for a later reply having applied model B while the
+        // abandoned model-a request was still outstanding.
+        *provider.applied_model.lock().unwrap() = Some("model-b".to_string());
+
+        gate.notify_one();
+
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            while provider.applied_model.lock().unwrap().is_some() {
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("a settled abandoned model setup must invalidate the applied model");
     }
 
     #[tokio::test]

--- a/crates/goose/src/acp/provider.rs
+++ b/crates/goose/src/acp/provider.rs
@@ -179,21 +179,24 @@ pub struct AcpProvider {
     /// reply begins. Prompts capture it at enqueue time; each reply's cancel
     /// forwarder passes its own epoch back through `cancel()`.
     cancel_epoch: Arc<AtomicU64>,
-    /// Highest epoch for which `cancel()` has fired (0 = none). The client
-    /// loop suppresses (or re-cancels) any prompt whose captured epoch is at
-    /// or below this: a cancel that fired before the prompt reached the wire
-    /// would otherwise be ignored by the backend as targeting no active run,
-    /// and the prompt would start with its only cancel already spent. Keying
-    /// by epoch keeps a stale queued prompt cancelled even when it is handled
-    /// after a newer reply has already begun.
-    cancelled_epoch: Arc<AtomicU64>,
+    /// Epochs for which `cancel()` has fired. The client loop suppresses (or
+    /// re-cancels) any prompt whose captured epoch is in here: a cancel that
+    /// fired before the prompt reached the wire would otherwise be ignored by
+    /// the backend as targeting no active run, and the prompt would start with
+    /// its only cancel already spent. Keying by epoch keeps a stale queued
+    /// prompt cancelled even when it is handled after a newer reply has
+    /// already begun. Each epoch is recorded on its own rather than as a
+    /// high-water mark, because prompts from different replies can sit in the
+    /// queue together and cancelling a later one says nothing about an earlier
+    /// one that is still live.
+    cancelled_scopes: Arc<Mutex<HashSet<u64>>>,
     /// Epoch of the prompt currently in flight on the backend (0 = none).
     /// The client loop sets it around `session/prompt`; `cancel()` only sends
     /// the wire notification when the in-flight prompt belongs to the scope
     /// being cancelled, so a stale forwarder from a finished reply can never
     /// cancel a newer reply's active run.
     active_prompt_epoch: Arc<AtomicU64>,
-    /// Woken whenever `cancelled_epoch` advances, so the client loop can stop
+    /// Woken whenever a scope is cancelled, so the client loop can stop
     /// awaiting an in-flight pre-prompt request the moment its reply is
     /// cancelled rather than only noticing between requests.
     cancel_notify: Arc<tokio::sync::Notify>,
@@ -288,7 +291,7 @@ impl AcpProvider {
             Arc::new(Mutex::new(HashMap::new()));
         let context_size = Arc::new(AtomicU64::new(0));
         let agent_cx: Arc<OnceLock<ConnectionTo<Agent>>> = Arc::new(OnceLock::new());
-        let cancelled_epoch = Arc::new(AtomicU64::new(0));
+        let cancelled_scopes: Arc<Mutex<HashSet<u64>>> = Arc::new(Mutex::new(HashSet::new()));
         let active_prompt_epoch = Arc::new(AtomicU64::new(0));
         let cancel_notify = Arc::new(tokio::sync::Notify::new());
         let client_loop = AcpClientLoop::new(
@@ -297,7 +300,7 @@ impl AcpProvider {
             pending_tool_updates.clone(),
             context_size.clone(),
             agent_cx.clone(),
-            cancelled_epoch.clone(),
+            cancelled_scopes.clone(),
             active_prompt_epoch.clone(),
             cancel_notify.clone(),
             applied_model.clone(),
@@ -335,7 +338,7 @@ impl AcpProvider {
             model_config_option_id,
             applied_model,
             cancel_epoch: Arc::new(AtomicU64::new(1)),
-            cancelled_epoch,
+            cancelled_scopes,
             active_prompt_epoch,
             cancel_notify,
             tx: Some(tx),
@@ -540,15 +543,15 @@ impl Provider for AcpProvider {
     }
 
     async fn cancel(&self, _session_id: &str, scope: u64) {
-        // Latch first: if the prompt has not reached the wire yet, the
+        // Record first: if the prompt has not reached the wire yet, the
         // notification below targets no active run and the backend ignores
-        // it, so the client loop must observe the latch around the prompt
-        // send to suppress or re-cancel the turn. Latching the caller's
-        // scope — not the current epoch — keeps a forwarder that fires late,
-        // after a newer reply bumped the epoch, from suppressing that newer
-        // reply's prompts. fetch_max keeps a late stale cancel from lowering
-        // the latch.
-        self.cancelled_epoch.fetch_max(scope, Ordering::SeqCst);
+        // it, so the client loop must observe this around the prompt send to
+        // suppress or re-cancel the turn. Recording the caller's scope — not
+        // the current epoch — keeps a forwarder that fires late, after a newer
+        // reply bumped the epoch, from suppressing that newer reply's prompts.
+        if let Ok(mut scopes) = self.cancelled_scopes.lock() {
+            scopes.insert(scope);
+        }
         self.cancel_notify.notify_waiters();
         // Only notify the backend when the prompt currently in flight belongs
         // to the scope being cancelled: `session/cancel` is session-scoped, so
@@ -810,7 +813,7 @@ struct AcpClientLoop {
     pending_tool_updates: Arc<Mutex<HashMap<String, AccumulatedToolCall>>>,
     context_size: Arc<AtomicU64>,
     agent_cx: Arc<OnceLock<ConnectionTo<Agent>>>,
-    cancelled_epoch: Arc<AtomicU64>,
+    cancelled_scopes: Arc<Mutex<HashSet<u64>>>,
     active_prompt_epoch: Arc<AtomicU64>,
     cancel_notify: Arc<tokio::sync::Notify>,
     handoff_context_sent: Arc<AtomicBool>,
@@ -825,7 +828,7 @@ impl AcpClientLoop {
         pending_tool_updates: Arc<Mutex<HashMap<String, AccumulatedToolCall>>>,
         context_size: Arc<AtomicU64>,
         agent_cx: Arc<OnceLock<ConnectionTo<Agent>>>,
-        cancelled_epoch: Arc<AtomicU64>,
+        cancelled_scopes: Arc<Mutex<HashSet<u64>>>,
         active_prompt_epoch: Arc<AtomicU64>,
         cancel_notify: Arc<tokio::sync::Notify>,
         applied_model: Arc<Mutex<Option<String>>>,
@@ -837,7 +840,7 @@ impl AcpClientLoop {
             pending_tool_updates,
             context_size,
             agent_cx,
-            cancelled_epoch,
+            cancelled_scopes,
             active_prompt_epoch,
             cancel_notify,
             handoff_context_sent: Arc::new(AtomicBool::new(false)),
@@ -897,7 +900,7 @@ impl AcpClientLoop {
             pending_tool_updates,
             context_size,
             agent_cx,
-            cancelled_epoch,
+            cancelled_scopes,
             active_prompt_epoch,
             cancel_notify,
             handoff_context_sent,
@@ -1116,7 +1119,7 @@ impl AcpClientLoop {
                     cx,
                     rx,
                     prompt_response_tx,
-                    cancelled_epoch,
+                    cancelled_scopes,
                     active_prompt_epoch,
                     cancel_notify,
                     handoff_context_sent,
@@ -1195,17 +1198,24 @@ async fn spawn_acp_process(config: &AcpProviderConfig) -> Result<Child> {
     cmd.spawn().context("failed to spawn ACP process")
 }
 
-/// Resolves once a cancel has been recorded for `epoch` or any later one.
-/// Registering with `Notify` before re-reading the epoch keeps a cancel that
-/// lands between the two from being missed.
-async fn await_cancelled_epoch(
+/// Whether `cancel()` has fired for this exact scope.
+fn scope_cancelled(cancelled_scopes: &Mutex<HashSet<u64>>, scope: u64) -> bool {
+    cancelled_scopes
+        .lock()
+        .is_ok_and(|scopes| scopes.contains(&scope))
+}
+
+/// Resolves once a cancel has been recorded for `scope`. Registering with
+/// `Notify` before re-reading the set keeps a cancel that lands between the
+/// two from being missed.
+async fn await_cancelled_scope(
     cancel_notify: &tokio::sync::Notify,
-    cancelled_epoch: &AtomicU64,
-    epoch: u64,
+    cancelled_scopes: &Mutex<HashSet<u64>>,
+    scope: u64,
 ) {
     loop {
         let notified = cancel_notify.notified();
-        if cancelled_epoch.load(Ordering::SeqCst) >= epoch {
+        if scope_cancelled(cancelled_scopes, scope) {
             return;
         }
         notified.await;
@@ -1225,7 +1235,7 @@ async fn handle_requests(
     cx: ConnectionTo<Agent>,
     rx: &mut mpsc::Receiver<ClientRequest>,
     prompt_response_tx: Arc<Mutex<Option<mpsc::Sender<AcpUpdate>>>>,
-    cancelled_epoch: Arc<AtomicU64>,
+    cancelled_scopes: Arc<Mutex<HashSet<u64>>>,
     active_prompt_epoch: Arc<AtomicU64>,
     cancel_notify: Arc<tokio::sync::Notify>,
     handoff_context_sent: Arc<AtomicBool>,
@@ -1309,7 +1319,7 @@ async fn handle_requests(
                 cancel_epoch,
                 response_tx,
             } => {
-                let cancelled = |epoch| cancelled_epoch.load(Ordering::SeqCst) >= epoch;
+                let cancelled = |epoch| scope_cancelled(&cancelled_scopes, epoch);
                 if cancel_epoch.is_some_and(cancelled) {
                     log_undelivered(
                         response_tx.send(Err(anyhow::anyhow!("reply cancelled"))),
@@ -1328,7 +1338,7 @@ async fn handle_requests(
                 let settled = match cancel_epoch {
                     Some(epoch) => tokio::select! {
                         biased;
-                        () = await_cancelled_epoch(&cancel_notify, &cancelled_epoch, epoch) => None,
+                        () = await_cancelled_scope(&cancel_notify, &cancelled_scopes, epoch) => None,
                         response = &mut request => Some(response),
                     },
                     None => Some(request.as_mut().await),
@@ -1368,7 +1378,7 @@ async fn handle_requests(
                 // its backend's only run and nothing would ever cancel it.
                 // Nothing reached the backend, so the one-shot handoff context
                 // is still unclaimed and the next prompt carries it.
-                if cancelled_epoch.load(Ordering::SeqCst) >= cancel_epoch {
+                if scope_cancelled(&cancelled_scopes, cancel_epoch) {
                     log_undelivered(
                         response_tx.try_send(AcpUpdate::Complete(StopReason::Cancelled, None)),
                         AGENT_METHOD_NAMES.session_prompt,
@@ -1398,7 +1408,7 @@ async fn handle_requests(
                 // cancel observed here raced the enqueue and its notification
                 // may sit ahead of the prompt on the wire, where the backend
                 // ignores it. Re-send it so one lands after the prompt.
-                if cancelled_epoch.load(Ordering::SeqCst) >= cancel_epoch {
+                if scope_cancelled(&cancelled_scopes, cancel_epoch) {
                     if let Err(e) = cx.send_notification(CancelNotification::new(session_id)) {
                         tracing::warn!(error = %e, "failed to re-send ACP session/cancel");
                     }
@@ -1956,7 +1966,7 @@ mod tests {
                 model_config_option_id: None,
                 applied_model: Arc::new(Mutex::new(None)),
                 cancel_epoch: Arc::new(AtomicU64::new(1)),
-                cancelled_epoch: Arc::new(AtomicU64::new(0)),
+                cancelled_scopes: Arc::new(Mutex::new(HashSet::new())),
                 active_prompt_epoch: Arc::new(AtomicU64::new(0)),
                 cancel_notify: Arc::new(tokio::sync::Notify::new()),
                 tx,
@@ -2842,14 +2852,48 @@ mod tests {
 
         // The stale prompt must still be seen as cancelled by the client
         // loop, while the new reply's prompt must not be.
-        let cancelled = provider.cancelled_epoch.load(Ordering::SeqCst);
         assert!(
-            cancelled >= stale_epoch,
-            "stale queued prompt must stay cancelled (cancelled={cancelled}, stale={stale_epoch})"
+            scope_cancelled(&provider.cancelled_scopes, stale_epoch),
+            "stale queued prompt must stay cancelled (stale={stale_epoch})"
         );
         assert!(
-            cancelled < fresh_epoch,
-            "new reply's prompt must not be suppressed (cancelled={cancelled}, fresh={fresh_epoch})"
+            !scope_cancelled(&provider.cancelled_scopes, fresh_epoch),
+            "new reply's prompt must not be suppressed (fresh={fresh_epoch})"
+        );
+    }
+
+    /// Prompts from different replies can sit in the client-loop queue at the
+    /// same time, so cancelling a later reply must not suppress an earlier,
+    /// still-live one — a high-water mark would sweep it up.
+    #[tokio::test]
+    async fn cancelling_a_later_reply_leaves_an_earlier_queued_prompt_live() {
+        let (tx, mut rx) = mpsc::channel(4);
+        let (provider, model) = test_provider_with_tx(Some(tx));
+        let messages = vec![Message::user().with_text("hello")];
+
+        // Reply N's prompt is queued, then reply N+1 queues its own behind it.
+        provider.begin_cancel_scope();
+        let _stream = provider.stream(&model, "", &messages, &[]).await.unwrap();
+        let earlier_epoch = match rx.recv().await.expect("expected ACP prompt request") {
+            ClientRequest::Prompt { cancel_epoch, .. } => cancel_epoch,
+            _ => panic!("expected ACP prompt request"),
+        };
+        let scope_n_plus_1 = provider.begin_cancel_scope();
+        let _stream = provider.stream(&model, "", &messages, &[]).await.unwrap();
+        let later_epoch = match rx.recv().await.expect("expected ACP prompt request") {
+            ClientRequest::Prompt { cancel_epoch, .. } => cancel_epoch,
+            _ => panic!("expected ACP prompt request"),
+        };
+
+        provider.cancel("goose-session", scope_n_plus_1).await;
+
+        assert!(
+            scope_cancelled(&provider.cancelled_scopes, later_epoch),
+            "the cancelled reply's prompt must be suppressed (later={later_epoch})"
+        );
+        assert!(
+            !scope_cancelled(&provider.cancelled_scopes, earlier_epoch),
+            "an earlier reply that was not cancelled must still reach the backend (earlier={earlier_epoch})"
         );
     }
 

--- a/crates/goose/src/acp/provider.rs
+++ b/crates/goose/src/acp/provider.rs
@@ -169,8 +169,9 @@ pub struct AcpProvider {
     /// redundant `SetConfigOption` calls.
     applied_model: Arc<Mutex<Option<String>>>,
 
-    /// Current cancel epoch, bumped by `clear_pending_cancel()` when a new
-    /// reply begins. Prompts capture it at enqueue time.
+    /// Current cancel epoch, bumped by `begin_cancel_scope()` when a new
+    /// reply begins. Prompts capture it at enqueue time; each reply's cancel
+    /// forwarder passes its own epoch back through `cancel()`.
     cancel_epoch: Arc<AtomicU64>,
     /// Highest epoch for which `cancel()` has fired (0 = none). The client
     /// loop suppresses (or re-cancels) any prompt whose captured epoch is at
@@ -490,13 +491,16 @@ impl Provider for AcpProvider {
         true
     }
 
-    async fn cancel(&self, _session_id: &str) {
+    async fn cancel(&self, _session_id: &str, scope: u64) {
         // Latch first: if the prompt has not reached the wire yet, the
         // notification below targets no active run and the backend ignores
         // it, so the client loop must observe the latch around the prompt
-        // send to suppress or re-cancel the turn.
-        self.cancelled_epoch
-            .store(self.cancel_epoch.load(Ordering::SeqCst), Ordering::SeqCst);
+        // send to suppress or re-cancel the turn. Latching the caller's
+        // scope — not the current epoch — keeps a forwarder that fires late,
+        // after a newer reply bumped the epoch, from suppressing that newer
+        // reply's prompts. fetch_max keeps a late stale cancel from lowering
+        // the latch.
+        self.cancelled_epoch.fetch_max(scope, Ordering::SeqCst);
         let Some(cx) = self.agent_cx.get() else {
             return;
         };
@@ -505,12 +509,12 @@ impl Provider for AcpProvider {
         }
     }
 
-    fn clear_pending_cancel(&self) {
-        // Bump the epoch instead of clearing the latch: prompts from the
+    fn begin_cancel_scope(&self) -> u64 {
+        // Bump the epoch instead of clearing the latch: prompts from a
         // cancelled reply may still sit in the client-loop queue and must
         // stay cancelled, while the new reply's prompts capture the fresh
         // epoch and are unaffected.
-        self.cancel_epoch.fetch_add(1, Ordering::SeqCst);
+        self.cancel_epoch.fetch_add(1, Ordering::SeqCst) + 1
     }
 
     async fn handle_permission_confirmation(
@@ -2254,10 +2258,7 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn cancel_before_prompt_send_suppresses_prompt_until_cleared() {
-        use futures::StreamExt;
-
+    async fn fake_connected_provider() -> (AcpProvider, Arc<Mutex<u32>>, Arc<Mutex<u32>>) {
         let prompts = Arc::new(Mutex::new(0));
         let cancels = Arc::new(Mutex::new(0));
         let provider = AcpProvider::connect_with_transport(
@@ -2271,13 +2272,22 @@ mod tests {
         )
         .await
         .unwrap();
+        (provider, prompts, cancels)
+    }
+
+    #[tokio::test]
+    async fn cancel_before_prompt_send_suppresses_prompt_until_new_scope() {
+        use futures::StreamExt;
+
+        let (provider, prompts, cancels) = fake_connected_provider().await;
         let model = ModelConfig::new("test-model");
         let messages = vec![Message::user().with_text("hello")];
 
         // Cancel fires before the prompt reaches the wire: the backend would
         // ignore the notification (no active run), so the prompt must be
         // suppressed instead of starting a turn nothing can cancel.
-        provider.cancel("goose-session").await;
+        let scope = provider.begin_cancel_scope();
+        provider.cancel("goose-session", scope).await;
         let mut stream = provider.stream(&model, "", &messages, &[]).await.unwrap();
         assert!(stream.next().await.is_none());
         assert_eq!(
@@ -2287,14 +2297,37 @@ mod tests {
         );
         assert_eq!(*cancels.lock().unwrap(), 1);
 
-        // A new reply clears the latch, so prompting works again.
-        provider.clear_pending_cancel();
+        // A new reply opens a fresh scope, so prompting works again.
+        provider.begin_cancel_scope();
         let mut stream = provider.stream(&model, "", &messages, &[]).await.unwrap();
         while stream.next().await.is_some() {}
         assert_eq!(
             *prompts.lock().unwrap(),
             1,
-            "prompt after clear_pending_cancel must reach the backend"
+            "prompt in a fresh cancel scope must reach the backend"
+        );
+    }
+
+    #[tokio::test]
+    async fn late_cancel_from_previous_reply_does_not_suppress_new_prompt() {
+        use futures::StreamExt;
+
+        let (provider, prompts, _cancels) = fake_connected_provider().await;
+        let model = ModelConfig::new("test-model");
+        let messages = vec![Message::user().with_text("hello")];
+
+        // Reply N's forwarder fires only after reply N+1 already began: the
+        // cancel must be attributed to reply N's scope, not the current one.
+        let stale_scope = provider.begin_cancel_scope();
+        provider.begin_cancel_scope();
+        provider.cancel("goose-session", stale_scope).await;
+
+        let mut stream = provider.stream(&model, "", &messages, &[]).await.unwrap();
+        while stream.next().await.is_some() {}
+        assert_eq!(
+            *prompts.lock().unwrap(),
+            1,
+            "a stale cancel must not suppress the newer reply's prompt"
         );
     }
 
@@ -2305,6 +2338,7 @@ mod tests {
         let messages = vec![Message::user().with_text("hello")];
 
         // Reply N enqueues its prompt; the client loop has not handled it yet.
+        let scope_n = provider.begin_cancel_scope();
         let _stream = provider.stream(&model, "", &messages, &[]).await.unwrap();
         let stale_epoch = match rx.recv().await.expect("expected ACP prompt request") {
             ClientRequest::Prompt { cancel_epoch, .. } => cancel_epoch,
@@ -2312,8 +2346,8 @@ mod tests {
         };
 
         // Reply N is cancelled, then reply N+1 begins.
-        provider.cancel("goose-session").await;
-        provider.clear_pending_cancel();
+        provider.cancel("goose-session", scope_n).await;
+        provider.begin_cancel_scope();
         let _stream = provider.stream(&model, "", &messages, &[]).await.unwrap();
         let fresh_epoch = match rx.recv().await.expect("expected ACP prompt request") {
             ClientRequest::Prompt { cancel_epoch, .. } => cancel_epoch,

--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -1898,6 +1898,14 @@ impl GooseAcpAgent {
             return Err(error);
         }
 
+        // A cancel that lands while the provider stream is quiet ends the reply
+        // stream cleanly (EOF) rather than surfacing an event, so the in-loop
+        // check above never runs. Re-check the token so the turn is still
+        // reported as cancelled instead of a normal completion.
+        if cancel_token.is_cancelled() {
+            was_cancelled = true;
+        }
+
         let session = self
             .session_manager
             .get_session(&session_id, false)

--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -1887,6 +1887,15 @@ impl GooseAcpAgent {
             }
         }
 
+        // A cancel that lands while the provider stream is quiet ends the reply
+        // stream cleanly (EOF) rather than surfacing an event, so the in-loop
+        // check above never runs. Re-check the token before closing tool
+        // chains, so a cancelled EOF neither schedules chain-summary
+        // enrichment nor gets reported as a normal completion.
+        if cancel_token.is_cancelled() {
+            was_cancelled = true;
+        }
+
         if !was_cancelled && stream_error.is_none() {
             if let Some(chain) = chain_tracker.close_current_chain() {
                 self.spawn_ready_chain_summary(chain, &agent, &args.session_id, cx);
@@ -1896,14 +1905,6 @@ impl GooseAcpAgent {
         Self::send_active_run_update(cx, &args.session_id, None)?;
         if let Some(error) = stream_error {
             return Err(error);
-        }
-
-        // A cancel that lands while the provider stream is quiet ends the reply
-        // stream cleanly (EOF) rather than surfacing an event, so the in-loop
-        // check above never runs. Re-check the token so the turn is still
-        // reported as cancelled instead of a normal completion.
-        if cancel_token.is_cancelled() {
-            was_cancelled = true;
         }
 
         let session = self

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -76,6 +76,43 @@ async fn await_cancellation(cancel_token: &Option<CancellationToken>) {
     }
 }
 
+/// Forwards a cancellation to the provider from a detached task, so a
+/// remote-backed turn (e.g. an ACP agent) still receives `session/cancel` even
+/// when the reply-stream consumer drops the stream on cancel instead of polling
+/// it to completion (the CLI Ctrl-C path does exactly this). The task fires as
+/// soon as the token is cancelled, independent of stream lifecycle.
+///
+/// The guard lives inside the reply stream: dropping the stream aborts the
+/// forwarder unless cancellation is already in flight, so a turn that ends
+/// normally does not leave a task waiting on a token that never fires.
+struct CancelForwarder {
+    handle: tokio::task::JoinHandle<()>,
+    token: CancellationToken,
+}
+
+impl CancelForwarder {
+    fn spawn(
+        token: CancellationToken,
+        provider: Arc<dyn crate::providers::base::Provider>,
+        session_id: String,
+    ) -> Self {
+        let watch_token = token.clone();
+        let handle = tokio::spawn(async move {
+            watch_token.cancelled().await;
+            provider.cancel(&session_id).await;
+        });
+        Self { handle, token }
+    }
+}
+
+impl Drop for CancelForwarder {
+    fn drop(&mut self) {
+        if !self.token.is_cancelled() {
+            self.handle.abort();
+        }
+    }
+}
+
 const DEFAULT_MAX_TURNS: u32 = 1000;
 const DEFAULT_STOP_HOOK_BLOCK_CAP: u32 = 8;
 const COMPACTION_PROGRESS_TEXT: &str = "goose is compacting the conversation...";
@@ -2074,7 +2111,13 @@ impl Agent {
                 );
             }
         }
+        let cancel_forwarder = cancel_token.as_ref().map(|token| {
+            CancelForwarder::spawn(token.clone(), provider.clone(), session_config.id.clone())
+        });
         let inner = Box::pin(async_stream::try_stream! {
+            // Kept alive for the stream's lifetime; dropping the stream (e.g. a
+            // consumer that drops us on cancel) tears the forwarder down.
+            let _cancel_forwarder = cancel_forwarder;
             let mut turns_taken = 0u32;
             let max_turns = session_config.max_turns.unwrap_or_else(|| {
                 Config::global()
@@ -2254,16 +2297,12 @@ impl Agent {
                     // that drives a remote turn (ACP) may go silent for minutes
                     // mid-turn, so waiting on `stream.next()` alone would leave
                     // the reply future — and the UI — stuck until the backend
-                    // finishes on its own. On cancel, forward it to the provider
-                    // so the backend stops promptly, then break like end-of-stream.
+                    // finishes on its own. Stop polling promptly on cancel; the
+                    // detached `CancelForwarder` delivers `session/cancel` to the
+                    // provider so it runs regardless of who drops the stream.
                     let next = tokio::select! {
                         biased;
-                        () = await_cancellation(&cancel_token) => {
-                            if let Ok(provider) = self.provider().await {
-                                provider.cancel(&session_config.id).await;
-                            }
-                            break;
-                        }
+                        () = await_cancellation(&cancel_token) => break,
                         item = stream.next() => item,
                     };
                     let Some(next) = next else {
@@ -4330,9 +4369,11 @@ echo start >> "$PLUGIN_ROOT/hook.log"
     }
 
     /// Provider whose stream never yields and never ends, mimicking an ACP
-    /// backend that goes silent mid-turn. Records whether `cancel` was called.
+    /// backend that goes silent mid-turn. Signals when its stream is polled and
+    /// records `cancel` calls.
     struct HangingProvider {
         stream_entered: Arc<tokio::sync::Notify>,
+        cancel_called: Arc<tokio::sync::Notify>,
         cancel_calls: AtomicUsize,
         cancelled_session: std::sync::Mutex<Option<String>>,
     }
@@ -4341,6 +4382,7 @@ echo start >> "$PLUGIN_ROOT/hook.log"
         fn new() -> Self {
             Self {
                 stream_entered: Arc::new(tokio::sync::Notify::new()),
+                cancel_called: Arc::new(tokio::sync::Notify::new()),
                 cancel_calls: AtomicUsize::new(0),
                 cancelled_session: std::sync::Mutex::new(None),
             }
@@ -4369,7 +4411,32 @@ echo start >> "$PLUGIN_ROOT/hook.log"
         async fn cancel(&self, session_id: &str) {
             self.cancel_calls.fetch_add(1, Ordering::SeqCst);
             *self.cancelled_session.lock().unwrap() = Some(session_id.to_string());
+            self.cancel_called.notify_one();
         }
+    }
+
+    fn stalled_reply_session_config(session_id: &str) -> SessionConfig {
+        SessionConfig {
+            id: session_id.to_string(),
+            schedule_id: None,
+            max_turns: Some(10),
+            retry_config: None,
+        }
+    }
+
+    /// Cancels `token` once the provider stream has actually been polled, so
+    /// tests exercise the mid-stream cancel path rather than the top-of-loop
+    /// cancel check.
+    fn cancel_once_stream_is_stalled(
+        token: CancellationToken,
+        stream_entered: Arc<tokio::sync::Notify>,
+    ) -> tokio::task::JoinHandle<()> {
+        tokio::spawn(async move {
+            let _ =
+                tokio::time::timeout(std::time::Duration::from_secs(5), stream_entered.notified())
+                    .await;
+            token.cancel();
+        })
     }
 
     #[tokio::test]
@@ -4380,35 +4447,21 @@ echo start >> "$PLUGIN_ROOT/hook.log"
         let (agent, session_id) =
             create_test_agent(temp_dir.path().join("data"), hook_manager, provider.clone()).await?;
 
-        let session_config = SessionConfig {
-            id: session_id.clone(),
-            schedule_id: None,
-            max_turns: Some(10),
-            retry_config: None,
-        };
-
-        // Cancel only once the reply loop is actually parked on the stalled
-        // stream, so the test exercises the mid-stream cancel path rather than
-        // the top-of-loop cancel check.
         let cancel_token = CancellationToken::new();
-        let cancel_for_task = cancel_token.clone();
-        let stream_entered = provider.stream_entered.clone();
-        let canceller = tokio::spawn(async move {
-            let _ =
-                tokio::time::timeout(std::time::Duration::from_secs(5), stream_entered.notified())
-                    .await;
-            cancel_for_task.cancel();
-        });
+        let canceller =
+            cancel_once_stream_is_stalled(cancel_token.clone(), provider.stream_entered.clone());
 
         let reply_stream = agent
             .reply(
                 Message::user().with_text("hi"),
-                session_config,
+                stalled_reply_session_config(&session_id),
                 Some(cancel_token),
             )
             .await?;
         tokio::pin!(reply_stream);
 
+        // A consumer that polls to completion (e.g. the ACP server) must see the
+        // reply end promptly on cancel rather than blocking on the silent stream.
         tokio::time::timeout(std::time::Duration::from_secs(5), async {
             while let Some(event) = reply_stream.next().await {
                 let _ = event;
@@ -4419,16 +4472,64 @@ echo start >> "$PLUGIN_ROOT/hook.log"
 
         canceller.await.expect("canceller task panicked");
 
-        assert_eq!(
-            provider.cancel_calls.load(Ordering::SeqCst),
-            1,
-            "cancellation must be forwarded to the provider exactly once"
-        );
+        tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            provider.cancel_called.notified(),
+        )
+        .await
+        .expect("cancellation was not forwarded to the provider");
+        assert_eq!(provider.cancel_calls.load(Ordering::SeqCst), 1);
         assert_eq!(
             provider.cancelled_session.lock().unwrap().as_deref(),
             Some(session_id.as_str()),
             "provider cancel must receive the active session id"
         );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn cancellation_forwards_to_provider_even_when_stream_is_dropped() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let provider = Arc::new(HangingProvider::new());
+        let hook_manager = crate::hooks::HookManager::from_plugins_for_test(vec![]);
+        let (agent, session_id) =
+            create_test_agent(temp_dir.path().join("data"), hook_manager, provider.clone()).await?;
+
+        let cancel_token = CancellationToken::new();
+        let canceller =
+            cancel_once_stream_is_stalled(cancel_token.clone(), provider.stream_entered.clone());
+
+        let reply_stream = agent
+            .reply(
+                Message::user().with_text("hi"),
+                stalled_reply_session_config(&session_id),
+                Some(cancel_token.clone()),
+            )
+            .await?;
+
+        // Mimic the CLI Ctrl-C path: the consumer drops the reply stream on
+        // cancel instead of polling it to completion. The detached forwarder
+        // must still deliver the cancellation to the provider.
+        let mut reply_stream = reply_stream;
+        tokio::select! {
+            _ = cancel_token.cancelled() => {}
+            _ = async {
+                while let Some(event) = reply_stream.next().await {
+                    let _ = event;
+                }
+            } => {}
+        }
+        drop(reply_stream);
+
+        canceller.await.expect("canceller task panicked");
+
+        tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            provider.cancel_called.notified(),
+        )
+        .await
+        .expect("cancellation was not forwarded after the stream was dropped");
+        assert_eq!(provider.cancel_calls.load(Ordering::SeqCst), 1);
         Ok(())
     }
 

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -2130,8 +2130,11 @@ impl Agent {
         });
         let inner = Box::pin(async_stream::try_stream! {
             // Kept alive for the stream's lifetime; dropping the stream (e.g. a
-            // consumer that drops us on cancel) tears the forwarder down.
-            let _cancel_forwarder = cancel_forwarder;
+            // consumer that drops us on cancel) tears the forwarder down. It is
+            // rebound below whenever the session provider is swapped mid-reply,
+            // so it always points at the provider running the current turn.
+            let mut _cancel_forwarder = cancel_forwarder;
+            let mut forwarder_provider = provider.clone();
             let mut turns_taken = 0u32;
             let max_turns = session_config.max_turns.unwrap_or_else(|| {
                 Config::global()
@@ -2266,6 +2269,24 @@ impl Agent {
                 // and the cancel forwarder has no in-flight prompt to interrupt,
                 // so awaiting this alone would leave the reply (and the UI) stuck.
                 let turn_provider = self.provider().await?;
+                // The session provider can be swapped between turns (an ACP
+                // `set_config_option` provider change is handled without
+                // waiting for the active prompt). Rebind the cancel scope and
+                // forwarder to whichever provider streams this turn, or a
+                // cancel would be delivered to a provider that is no longer
+                // running while the new one keeps the session busy.
+                if !Arc::ptr_eq(&turn_provider, &forwarder_provider) {
+                    let turn_cancel_scope = turn_provider.begin_cancel_scope();
+                    _cancel_forwarder = cancel_token.as_ref().map(|token| {
+                        CancelForwarder::spawn(
+                            token.clone(),
+                            turn_provider.clone(),
+                            session_config.id.clone(),
+                            turn_cancel_scope,
+                        )
+                    });
+                    forwarder_provider = turn_provider.clone();
+                }
                 let stream = tokio::select! {
                     biased;
                     () = await_cancellation(&cancel_token) => break,
@@ -4619,6 +4640,118 @@ echo start >> "$PLUGIN_ROOT/hook.log"
         .await
         .expect("cancellation was not forwarded after the stream was dropped");
         assert_eq!(provider.cancel_calls.load(Ordering::SeqCst), 1);
+        Ok(())
+    }
+
+    /// Streams a single tool call so the reply loop takes another turn, giving
+    /// the test a suspension point at which to swap the session provider.
+    struct ToolCallProvider {
+        cancel_calls: AtomicUsize,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::providers::base::Provider for ToolCallProvider {
+        async fn stream(
+            &self,
+            _model_config: &goose_providers::model::ModelConfig,
+            _system_prompt: &str,
+            _messages: &[Message],
+            _tools: &[Tool],
+        ) -> Result<MessageStream, ProviderError> {
+            let message = Message::assistant().with_tool_request(
+                "call_1",
+                Ok(rmcp::model::CallToolRequestParams::new("missing__tool")),
+            );
+            Ok(Box::pin(futures::stream::once(async move {
+                Ok((Some(message), None))
+            })))
+        }
+
+        fn get_name(&self) -> &str {
+            "tool-call"
+        }
+
+        async fn cancel(&self, _session_id: &str, _scope: u64) {
+            self.cancel_calls.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    /// Swapping the session provider between turns of a live reply (an ACP
+    /// `set_config_option` provider change, which is handled without waiting for
+    /// the active prompt) must move the cancel forwarder onto the provider that
+    /// actually streams the next turn. Cancelling the replaced one would leave
+    /// the new backend running and the session stuck.
+    #[tokio::test]
+    async fn cancellation_follows_a_provider_swapped_mid_reply() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let original = Arc::new(ToolCallProvider {
+            cancel_calls: AtomicUsize::new(0),
+        });
+        let replacement = Arc::new(HangingProvider::new());
+        let hook_manager = crate::hooks::HookManager::from_plugins_for_test(vec![]);
+        let (agent, session_id) =
+            create_test_agent(temp_dir.path().join("data"), hook_manager, original.clone()).await?;
+
+        let cancel_token = CancellationToken::new();
+        let reply_stream = agent
+            .reply(
+                Message::user().with_text("hi"),
+                stalled_reply_session_config(&session_id),
+                Some(cancel_token.clone()),
+            )
+            .await?;
+        tokio::pin!(reply_stream);
+
+        // Drain up to the first turn's tool request. The reply stream is
+        // unbuffered, so the producer is parked on that yield and has not yet
+        // resolved the provider for the second turn.
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            while let Some(event) = reply_stream.next().await {
+                if let Ok(AgentEvent::Message(message)) = event {
+                    if message
+                        .content
+                        .iter()
+                        .any(|c| matches!(c, MessageContent::ToolRequest(_)))
+                    {
+                        break;
+                    }
+                }
+            }
+        })
+        .await
+        .expect("first turn did not produce a tool request");
+
+        agent
+            .update_provider(
+                replacement.clone(),
+                goose_providers::model::ModelConfig::new("mock-model"),
+                &session_id,
+            )
+            .await?;
+        let canceller =
+            cancel_once_stream_is_stalled(cancel_token, replacement.stream_entered.clone());
+
+        tokio::time::timeout(std::time::Duration::from_secs(10), async {
+            while let Some(event) = reply_stream.next().await {
+                let _ = event;
+            }
+        })
+        .await
+        .expect("reply did not stop promptly after cancellation");
+        canceller.await.expect("canceller task panicked");
+
+        tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            replacement.cancel_called.notified(),
+        )
+        .await
+        .expect("cancellation was not forwarded to the swapped-in provider");
+        assert_eq!(replacement.cancel_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            original.cancel_calls.load(Ordering::SeqCst),
+            0,
+            "the replaced provider no longer runs the turn and must not be cancelled"
+        );
         Ok(())
     }
 

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -2910,6 +2910,24 @@ impl Agent {
                         }
                     }
                 }
+                // Cancelled mid-turn: end the reply immediately, before any
+                // post-stream work runs. When cancellation wins the select!
+                // above, the inner loop breaks and falls through to recipe
+                // retry checks / on_failure shell commands, final-output and
+                // goal/grind handling, tool-pair summarization, message
+                // persistence, and the exit-path stop hooks — several of which
+                // spawn shell commands with their own timeouts and can mutate
+                // history. Guarding here, immediately after the provider-stream
+                // loop and before that handling, keeps a cancelled (e.g. quiet
+                // ACP) turn from blocking the UI on that work. Mirrors the outer
+                // loop's top-of-iteration cancel check, a turn earlier.
+                if is_token_cancelled(&cancel_token) {
+                    if let Some(ref task) = tool_pair_summarization_task {
+                        task.abort();
+                    }
+                    break;
+                }
+
                 can_drain_pending_steers = true;
 
                 if tools_updated {
@@ -3073,19 +3091,6 @@ impl Agent {
                             }
                         }
                     }
-                }
-
-                if is_token_cancelled(&cancel_token) {
-                    // Cancelled mid-turn: end the reply immediately instead of
-                    // running post-turn work — tool-pair summarization, final
-                    // output, message persistence, and (on exit) stop hooks,
-                    // which run shell commands with their own timeouts. The
-                    // outer loop's top-of-iteration cancel check would otherwise
-                    // only fire after all of that completes.
-                    if let Some(ref task) = tool_pair_summarization_task {
-                        task.abort();
-                    }
-                    break;
                 }
 
                 if let Some(task) = tool_pair_summarization_task {
@@ -4537,6 +4542,67 @@ echo start >> "$PLUGIN_ROOT/hook.log"
         .await
         .expect("cancellation was not forwarded after the stream was dropped");
         assert_eq!(provider.cancel_calls.load(Ordering::SeqCst), 1);
+        Ok(())
+    }
+
+    /// A cancel that lands while the provider stream is quiet must skip the
+    /// post-stream turn handling — including recipe retry success checks, which
+    /// run shell commands with their own timeouts. Regression guard for the
+    /// cancel-guard placement: the check sits immediately after the
+    /// provider-stream loop, before `handle_retry_logic`, so a cancelled turn
+    /// never executes the check. (Before the fix the guard sat after the retry
+    /// call, so the check ran during a cancelled turn.)
+    #[tokio::test]
+    async fn cancellation_skips_recipe_retry_success_checks() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let sentinel = temp_dir.path().join("retry_check_ran");
+        let provider = Arc::new(HangingProvider::new());
+        let hook_manager = crate::hooks::HookManager::from_plugins_for_test(vec![]);
+        let (agent, session_id) =
+            create_test_agent(temp_dir.path().join("data"), hook_manager, provider.clone()).await?;
+
+        // A recipe retry whose success check touches a sentinel file. If the
+        // cancelled turn reached handle_retry_logic, the file would appear.
+        let session_config = SessionConfig {
+            id: session_id.clone(),
+            schedule_id: None,
+            max_turns: Some(10),
+            retry_config: Some(crate::agents::types::RetryConfig {
+                max_retries: 3,
+                checks: vec![crate::agents::types::SuccessCheck::Shell {
+                    command: format!("touch '{}'", sentinel.display()),
+                }],
+                on_failure: None,
+                timeout_seconds: None,
+                on_failure_timeout_seconds: None,
+            }),
+        };
+
+        let cancel_token = CancellationToken::new();
+        let canceller =
+            cancel_once_stream_is_stalled(cancel_token.clone(), provider.stream_entered.clone());
+
+        let reply_stream = agent
+            .reply(
+                Message::user().with_text("hi"),
+                session_config,
+                Some(cancel_token),
+            )
+            .await?;
+        tokio::pin!(reply_stream);
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            while let Some(event) = reply_stream.next().await {
+                let _ = event;
+            }
+        })
+        .await
+        .expect("reply did not stop promptly after cancellation");
+        canceller.await.expect("canceller task panicked");
+
+        assert!(
+            !sentinel.exists(),
+            "recipe retry success check ran during a cancelled turn"
+        );
         Ok(())
     }
 

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -95,11 +95,15 @@ impl CancelForwarder {
         token: CancellationToken,
         provider: Arc<dyn crate::providers::base::Provider>,
         session_id: String,
+        cancel_scope: u64,
     ) -> Self {
         let watch_token = token.clone();
         let handle = tokio::spawn(async move {
             watch_token.cancelled().await;
-            provider.cancel(&session_id).await;
+            // The scope captured at spawn keeps a forwarder that fires late —
+            // after a newer reply has begun — from being attributed to that
+            // newer reply's prompts.
+            provider.cancel(&session_id, cancel_scope).await;
         });
         Self { handle, token }
     }
@@ -2112,11 +2116,17 @@ impl Agent {
             }
         }
         // A cancel latched by the provider during a previous reply must not
-        // suppress this reply's prompts; this reply's own cancel can only fire
-        // through the forwarder spawned below.
-        provider.clear_pending_cancel();
+        // suppress this reply's prompts; opening a fresh scope here, before
+        // this reply's forwarder exists, ties every cancel to the reply it
+        // was actually issued for.
+        let cancel_scope = provider.begin_cancel_scope();
         let cancel_forwarder = cancel_token.as_ref().map(|token| {
-            CancelForwarder::spawn(token.clone(), provider.clone(), session_config.id.clone())
+            CancelForwarder::spawn(
+                token.clone(),
+                provider.clone(),
+                session_config.id.clone(),
+                cancel_scope,
+            )
         });
         let inner = Box::pin(async_stream::try_stream! {
             // Kept alive for the stream's lifetime; dropping the stream (e.g. a
@@ -3220,7 +3230,10 @@ impl Agent {
             gen_ai_telemetry::record_usage(&tracing::Span::current(), &turn_total_usage);
             gen_ai_telemetry::record_usage(&reply_span, &turn_total_usage);
 
-            if !stop_hook_handled_for_exit {
+            // A cancelled turn skips Stop hooks: they mark the agent finishing
+            // a response, and their commands could otherwise block a cancelled
+            // (e.g. quiet ACP) turn until they finish or time out.
+            if !stop_hook_handled_for_exit && !is_token_cancelled(&cancel_token) {
                 self.emit_stop_hook(&session_config.id, &last_assistant_text, &session.working_dir.to_string_lossy()).await;
             }
         }.instrument(reply_stream_span));
@@ -4424,7 +4437,7 @@ echo start >> "$PLUGIN_ROOT/hook.log"
             "hanging"
         }
 
-        async fn cancel(&self, session_id: &str) {
+        async fn cancel(&self, session_id: &str, _scope: u64) {
             self.cancel_calls.fetch_add(1, Ordering::SeqCst);
             *self.cancelled_session.lock().unwrap() = Some(session_id.to_string());
             self.cancel_called.notify_one();
@@ -4606,6 +4619,49 @@ echo start >> "$PLUGIN_ROOT/hook.log"
         assert!(
             !sentinel.exists(),
             "recipe retry success check ran during a cancelled turn"
+        );
+        Ok(())
+    }
+
+    /// A cancelled turn must not run Stop hooks: they mark the agent finishing
+    /// a response, and their commands could otherwise block the cancelled
+    /// reply until they finish or time out.
+    #[tokio::test]
+    async fn cancellation_skips_stop_hooks() -> Result<()> {
+        const COUNT_STOP_SCRIPT: &str = r#"#!/bin/sh
+echo ran >> "$PLUGIN_ROOT/hook.log"
+exit 0
+"#;
+        let env = StopHookTestEnv::new(COUNT_STOP_SCRIPT)?;
+        let provider = Arc::new(HangingProvider::new());
+        let (agent, session_id) =
+            create_test_agent(env.data_dir(), env.hook_manager(), provider.clone()).await?;
+
+        let cancel_token = CancellationToken::new();
+        let canceller =
+            cancel_once_stream_is_stalled(cancel_token.clone(), provider.stream_entered.clone());
+
+        let reply_stream = agent
+            .reply(
+                Message::user().with_text("hi"),
+                stalled_reply_session_config(&session_id),
+                Some(cancel_token),
+            )
+            .await?;
+        tokio::pin!(reply_stream);
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            while let Some(event) = reply_stream.next().await {
+                let _ = event;
+            }
+        })
+        .await
+        .expect("reply did not stop promptly after cancellation");
+        canceller.await.expect("canceller task panicked");
+
+        assert_eq!(
+            env.hook_invocations(),
+            0,
+            "Stop hook ran during a cancelled turn"
         );
         Ok(())
     }

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -3076,9 +3076,16 @@ impl Agent {
                 }
 
                 if is_token_cancelled(&cancel_token) {
+                    // Cancelled mid-turn: end the reply immediately instead of
+                    // running post-turn work — tool-pair summarization, final
+                    // output, message persistence, and (on exit) stop hooks,
+                    // which run shell commands with their own timeouts. The
+                    // outer loop's top-of-iteration cancel check would otherwise
+                    // only fire after all of that completes.
                     if let Some(ref task) = tool_pair_summarization_task {
                         task.abort();
                     }
+                    break;
                 }
 
                 if let Some(task) = tool_pair_summarization_task {

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -2260,15 +2260,26 @@ impl Agent {
                 )
                 .await;
 
-                let mut stream = Self::stream_response_from_provider(
-                    self.provider().await?,
-                    model_config.clone(),
-                    &session_config.id,
-                    &system_prompt,
-                    conversation_with_moim.messages(),
-                    &tools,
-                    &toolshim_tools,
-                ).await?;
+                // Race cancellation against stream creation too: a provider that
+                // talks to a remote backend (ACP) can block here before the
+                // response stream exists — e.g. applying a model config option —
+                // and the cancel forwarder has no in-flight prompt to interrupt,
+                // so awaiting this alone would leave the reply (and the UI) stuck.
+                let turn_provider = self.provider().await?;
+                let stream = tokio::select! {
+                    biased;
+                    () = await_cancellation(&cancel_token) => break,
+                    stream = Self::stream_response_from_provider(
+                        turn_provider,
+                        model_config.clone(),
+                        &session_config.id,
+                        &system_prompt,
+                        conversation_with_moim.messages(),
+                        &tools,
+                        &toolshim_tools,
+                    ) => stream,
+                };
+                let mut stream = stream?;
                 last_assistant_text.clear();
 
                 let current_turn_tool_count = conversation.messages().iter()
@@ -4405,6 +4416,10 @@ echo start >> "$PLUGIN_ROOT/hook.log"
         cancel_called: Arc<tokio::sync::Notify>,
         cancel_calls: AtomicUsize,
         cancelled_session: std::sync::Mutex<Option<String>>,
+        /// Hang inside `stream()` instead of returning a silent stream,
+        /// mimicking an ACP backend stuck applying a session config option
+        /// before the prompt is established.
+        stall_before_stream: bool,
     }
 
     impl HangingProvider {
@@ -4414,6 +4429,14 @@ echo start >> "$PLUGIN_ROOT/hook.log"
                 cancel_called: Arc::new(tokio::sync::Notify::new()),
                 cancel_calls: AtomicUsize::new(0),
                 cancelled_session: std::sync::Mutex::new(None),
+                stall_before_stream: false,
+            }
+        }
+
+        fn stalling_before_stream() -> Self {
+            Self {
+                stall_before_stream: true,
+                ..Self::new()
             }
         }
     }
@@ -4428,6 +4451,9 @@ echo start >> "$PLUGIN_ROOT/hook.log"
             _tools: &[Tool],
         ) -> Result<MessageStream, ProviderError> {
             self.stream_entered.notify_one();
+            if self.stall_before_stream {
+                std::future::pending::<()>().await;
+            }
             Ok(Box::pin(futures::stream::pending::<
                 Result<(Option<Message>, Option<ProviderUsage>), ProviderError>,
             >()))
@@ -4513,6 +4539,40 @@ echo start >> "$PLUGIN_ROOT/hook.log"
             Some(session_id.as_str()),
             "provider cancel must receive the active session id"
         );
+        Ok(())
+    }
+
+    /// A cancel landing while the provider is still *creating* its stream (an
+    /// ACP agent stuck applying a model config option before the prompt exists)
+    /// must end the reply, not wait for the backend to return a stream.
+    #[tokio::test]
+    async fn cancellation_interrupts_provider_stream_creation() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let provider = Arc::new(HangingProvider::stalling_before_stream());
+        let hook_manager = crate::hooks::HookManager::from_plugins_for_test(vec![]);
+        let (agent, session_id) =
+            create_test_agent(temp_dir.path().join("data"), hook_manager, provider.clone()).await?;
+
+        let cancel_token = CancellationToken::new();
+        let canceller =
+            cancel_once_stream_is_stalled(cancel_token.clone(), provider.stream_entered.clone());
+
+        let reply_stream = agent
+            .reply(
+                Message::user().with_text("hi"),
+                stalled_reply_session_config(&session_id),
+                Some(cancel_token),
+            )
+            .await?;
+        tokio::pin!(reply_stream);
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            while let Some(event) = reply_stream.next().await {
+                let _ = event;
+            }
+        })
+        .await
+        .expect("reply did not stop promptly after cancellation during stream creation");
+        canceller.await.expect("canceller task panicked");
         Ok(())
     }
 

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -66,6 +66,16 @@ use tokio::sync::{mpsc, Mutex};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, instrument, warn};
 
+/// Resolves when the token is cancelled; stays pending forever when there is
+/// no token, so it can be raced against a stream in `tokio::select!` without
+/// affecting the no-token path.
+async fn await_cancellation(cancel_token: &Option<CancellationToken>) {
+    match cancel_token {
+        Some(token) => token.cancelled().await,
+        None => std::future::pending().await,
+    }
+}
+
 const DEFAULT_MAX_TURNS: u32 = 1000;
 const DEFAULT_STOP_HOOK_BLOCK_CAP: u32 = 8;
 const COMPACTION_PROGRESS_TEXT: &str = "goose is compacting the conversation...";
@@ -2239,7 +2249,26 @@ impl Agent {
                 // reasoning without hiding final-only non-streaming thoughts.
                 let mut surfaced_thinking_in_turn = false;
 
-                while let Some(next) = stream.next().await {
+                loop {
+                    // Race the provider stream against cancellation. A provider
+                    // that drives a remote turn (ACP) may go silent for minutes
+                    // mid-turn, so waiting on `stream.next()` alone would leave
+                    // the reply future — and the UI — stuck until the backend
+                    // finishes on its own. On cancel, forward it to the provider
+                    // so the backend stops promptly, then break like end-of-stream.
+                    let next = tokio::select! {
+                        biased;
+                        () = await_cancellation(&cancel_token) => {
+                            if let Ok(provider) = self.provider().await {
+                                provider.cancel(&session_config.id).await;
+                            }
+                            break;
+                        }
+                        item = stream.next() => item,
+                    };
+                    let Some(next) = next else {
+                        break;
+                    };
                     if is_token_cancelled(&cancel_token) || exit_chat {
                         break;
                     }
@@ -4297,6 +4326,109 @@ echo start >> "$PLUGIN_ROOT/hook.log"
         let emitted_refusal_id =
             emitted_refusal_id.expect("refusal message should be emitted with an ID");
         assert!(emitted_refusal_id.starts_with("msg_"));
+        Ok(())
+    }
+
+    /// Provider whose stream never yields and never ends, mimicking an ACP
+    /// backend that goes silent mid-turn. Records whether `cancel` was called.
+    struct HangingProvider {
+        stream_entered: Arc<tokio::sync::Notify>,
+        cancel_calls: AtomicUsize,
+        cancelled_session: std::sync::Mutex<Option<String>>,
+    }
+
+    impl HangingProvider {
+        fn new() -> Self {
+            Self {
+                stream_entered: Arc::new(tokio::sync::Notify::new()),
+                cancel_calls: AtomicUsize::new(0),
+                cancelled_session: std::sync::Mutex::new(None),
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl crate::providers::base::Provider for HangingProvider {
+        async fn stream(
+            &self,
+            _model_config: &goose_providers::model::ModelConfig,
+            _system_prompt: &str,
+            _messages: &[Message],
+            _tools: &[Tool],
+        ) -> Result<MessageStream, ProviderError> {
+            self.stream_entered.notify_one();
+            Ok(Box::pin(futures::stream::pending::<
+                Result<(Option<Message>, Option<ProviderUsage>), ProviderError>,
+            >()))
+        }
+
+        fn get_name(&self) -> &str {
+            "hanging"
+        }
+
+        async fn cancel(&self, session_id: &str) {
+            self.cancel_calls.fetch_add(1, Ordering::SeqCst);
+            *self.cancelled_session.lock().unwrap() = Some(session_id.to_string());
+        }
+    }
+
+    #[tokio::test]
+    async fn cancellation_interrupts_a_stalled_provider_stream() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let provider = Arc::new(HangingProvider::new());
+        let hook_manager = crate::hooks::HookManager::from_plugins_for_test(vec![]);
+        let (agent, session_id) =
+            create_test_agent(temp_dir.path().join("data"), hook_manager, provider.clone()).await?;
+
+        let session_config = SessionConfig {
+            id: session_id.clone(),
+            schedule_id: None,
+            max_turns: Some(10),
+            retry_config: None,
+        };
+
+        // Cancel only once the reply loop is actually parked on the stalled
+        // stream, so the test exercises the mid-stream cancel path rather than
+        // the top-of-loop cancel check.
+        let cancel_token = CancellationToken::new();
+        let cancel_for_task = cancel_token.clone();
+        let stream_entered = provider.stream_entered.clone();
+        let canceller = tokio::spawn(async move {
+            let _ =
+                tokio::time::timeout(std::time::Duration::from_secs(5), stream_entered.notified())
+                    .await;
+            cancel_for_task.cancel();
+        });
+
+        let reply_stream = agent
+            .reply(
+                Message::user().with_text("hi"),
+                session_config,
+                Some(cancel_token),
+            )
+            .await?;
+        tokio::pin!(reply_stream);
+
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            while let Some(event) = reply_stream.next().await {
+                let _ = event;
+            }
+        })
+        .await
+        .expect("reply did not stop promptly after cancellation");
+
+        canceller.await.expect("canceller task panicked");
+
+        assert_eq!(
+            provider.cancel_calls.load(Ordering::SeqCst),
+            1,
+            "cancellation must be forwarded to the provider exactly once"
+        );
+        assert_eq!(
+            provider.cancelled_session.lock().unwrap().as_deref(),
+            Some(session_id.as_str()),
+            "provider cancel must receive the active session id"
+        );
         Ok(())
     }
 

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -2111,6 +2111,10 @@ impl Agent {
                 );
             }
         }
+        // A cancel latched by the provider during a previous reply must not
+        // suppress this reply's prompts; this reply's own cancel can only fire
+        // through the forwarder spawned below.
+        provider.clear_pending_cancel();
         let cancel_forwarder = cancel_token.as_ref().map(|token| {
             CancelForwarder::spawn(token.clone(), provider.clone(), session_config.id.clone())
         });


### PR DESCRIPTION
## Problem

Fixes #10619. When goose uses an ACP agent as its provider (e.g. Claude Code), cancelling a prompt does not interrupt the agent. The session stays "running" — the send button stays disabled and the user cannot queue a message — until the agent finishes the whole turn on its own, often minutes later.

Two gaps combine:

1. **No `session/cancel` is ever sent to the agent.** The client→agent request channel has no cancel path, so cancelling sets goose's own token but the backend keeps running the entire turn.
2. **The reply loop's cancel check is cooperative and can't fire while the stream is blocked.** `agents/agent.rs` only checks the cancel token *after* `stream.next().await` yields. While an ACP backend is silent mid-turn, that await never returns, so the token is never observed, the reply future never completes, and the serial client-request loop stays blocked (so the next message can't be sent either).

## Fix

- Add a `Provider::cancel` hook (default no-op). `AcpProvider` overrides it to send a `session/cancel` notification **out-of-band** via a stored clone of the connection handle (`ConnectionTo<Agent>`). This matters: the serial request loop is parked awaiting the in-flight prompt response, so a cancel routed through that channel could not be delivered until the very turn it means to interrupt has already ended. `send_notification` enqueues on the connection's outbound writer, which the event loop services concurrently.
- Race `stream.next()` against the cancel token in the reply loop via `tokio::select!`, so goose tears down its own side promptly even if the backend is slow to acknowledge, forwarding the cancel to the provider before breaking. Once the agent receives `session/cancel` it returns `StopReason::Cancelled`, which unblocks the client-request loop for the next message.

## Test

Adds `cancellation_interrupts_a_stalled_provider_stream`, which drives a provider whose stream never yields (mimicking a silent backend), cancels once the loop is parked on it, and asserts the reply completes promptly and `cancel` is forwarded exactly once with the active session id. Without the loop change the reply hangs and the test's drain times out.

All 48 existing ACP integration tests and the agent module tests pass; `cargo fmt` and `cargo clippy --all-targets` are clean.