### PR TITLE
fix(desktop): clear stale validation error when reopening the schedule modal

### DIFF
--- a/ui/desktop/src/components/schedule/ScheduleModal.tsx
+++ b/ui/desktop/src/components/schedule/ScheduleModal.tsx
@@ -109,6 +109,7 @@ export const ScheduleModal: React.FC<ScheduleModalProps> = ({
 
   useEffect(() => {
     if (isOpen) {
+      setInternalValidationError(null);
       if (schedule) {
         setScheduleId(schedule.id);
         setCronExpression(schedule.cron);
@@ -119,7 +120,6 @@ export const ScheduleModal: React.FC<ScheduleModalProps> = ({
         setDeepLinkInput('');
         setParsedRecipe(null);
         setCronExpression('0 0 14 * * *');
-        setInternalValidationError(null);
         if (initialDeepLink) {
           setSourceType('deeplink');
           handleDeepLinkChange(initialDeepLink);

--- a/ui/desktop/src/components/schedule/__tests__/ScheduleModal.test.tsx
+++ b/ui/desktop/src/components/schedule/__tests__/ScheduleModal.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, type RenderOptions, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ScheduledJobDto } from '@aaif/goose-sdk';
+import { ScheduleModal } from '../ScheduleModal';
+import { IntlTestWrapper } from '../../../i18n/test-utils';
+
+const renderWithIntl = (ui: React.ReactElement, options?: RenderOptions) =>
+  render(ui, { wrapper: IntlTestWrapper, ...options });
+
+const existingSchedule = {
+  id: 'daily-summary-job',
+  cron: '0 0 14 * * *',
+} as ScheduledJobDto;
+
+const baseProps = {
+  onClose: vi.fn(),
+  onSubmit: vi.fn().mockResolvedValue(undefined),
+  isLoadingExternally: false,
+  apiErrorExternally: null,
+  initialDeepLink: null,
+};
+
+describe('ScheduleModal', () => {
+  it('clears a validation error from create mode when reopened to edit a schedule', async () => {
+    const user = userEvent.setup();
+    const { rerender } = renderWithIntl(<ScheduleModal {...baseProps} isOpen schedule={null} />);
+
+    await user.type(screen.getByLabelText(/name/i), 'my-job');
+    await user.click(screen.getByRole('button', { name: 'Create Schedule' }));
+    await waitFor(() => {
+      expect(screen.getByText('Please provide a valid recipe source.')).toBeInTheDocument();
+    });
+
+    rerender(<ScheduleModal {...baseProps} isOpen={false} schedule={null} />);
+    rerender(<ScheduleModal {...baseProps} isOpen schedule={existingSchedule} />);
+
+    expect(screen.getByText('Edit Schedule')).toBeInTheDocument();
+    expect(screen.queryByText('Please provide a valid recipe source.')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
A validation error raised while creating a schedule stays on screen when the modal is reopened to edit a different schedule.

`ScheduleModal` is rendered unconditionally by both `SchedulesView` and `ScheduleDetailView` — `if (!isOpen) return null` is an early return inside the component, so it never unmounts and its state survives close/reopen. The `isOpen` effect resets `internalValidationError` only in the create branch, so an error set during creation is still rendered afterwards. The error banner sits above the `!isEditMode` block, so it shows in edit mode too.

Steps: open Create Schedule, enter a name but no recipe source, submit ("Please provide a valid recipe source."), cancel, then click Edit on any schedule — the Edit dialog opens with the leftover error.

Fix: reset the validation error whenever the modal opens, before branching on create vs edit.

### Testing
Added `ScheduleModal.test.tsx` — the component needs no mocks on this path (`window.electron` is only touched by the file browser), so the test is just render + rerender under `IntlTestWrapper`. It fails on `main` and passes with the fix.

`pnpm run lint:check`, `pnpm run typecheck` and `pnpm run test:run` (583 passed) all pass.

### Related Issues
None — self-found.
