### PR TITLE
Hot-reload provider/model from config file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4375,6 +4375,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "fslock"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4974,6 +4983,7 @@ dependencies = [
  "nanoid",
  "nostr",
  "nostr-sdk",
+ "notify",
  "oauth2",
  "once_cell",
  "openssl",
@@ -6089,6 +6099,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "153be1941a183ec9ccd095ddbe17a8b8d435ef6c76e9e02451b933c3999af2c8"
+dependencies = [
+ "bitflags 2.13.0",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c033f80b2c113cdf91ab7a33faa9cbc014726dcad99880c8609af2a370edf37d"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6418,6 +6448,26 @@ name = "konst_proc_macros"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e037a2e1d8d5fdbd49b16a4ea09d5d6401c1f29eca5ff29d03d3824dba16256a"
+
+[[package]]
+name = "kqueue"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "273c0752728918e0ac4976f2b275b6fefb9ecd400585dec929419f3844cd87b5"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
+dependencies = [
+ "bitflags 2.13.0",
+ "libc",
+]
 
 [[package]]
 name = "lazy-regex"
@@ -6835,6 +6885,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
+ "log",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
 ]
@@ -7099,6 +7150,33 @@ dependencies = [
  "nostr-relay-pool",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags 2.13.0",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags 2.13.0",
 ]
 
 [[package]]

--- a/crates/goose/Cargo.toml
+++ b/crates/goose/Cargo.toml
@@ -227,6 +227,7 @@ icu_locale = { version = "=2.1.1", default-features = false }
 image = { version = "0.24.9", default-features = false, features = ["png", "jpeg", "gif", "webp"] }
 subtle = { version = "2.5", default-features = false, features = ["std"] }
 gethostname = "1.1.0"
+notify = "8.2.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { workspace = true, features = ["accctrl", "aclapi", "fileapi", "handleapi", "minwinbase", "sddl", "securitybaseapi", "winbase", "winerror"] }

--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -174,6 +174,10 @@ const PROVIDER_CONFIG_STATUS_CHECK_CONCURRENCY: usize = 16;
 /// below is keyed by session ID.
 struct GooseAcpSession {
     agent: Arc<Agent>,
+    /// Hot-reloads the provider/model when the config file changes. `None` if
+    /// the watcher could not be started. Dropping the session stops the watch.
+    #[allow(dead_code)]
+    config_watcher: Option<crate::config::watcher::ConfigWatcher>,
 }
 
 struct ActivePromptRun {
@@ -946,7 +950,12 @@ impl GooseAcpAgent {
     }
 
     async fn register_acp_session(&self, session_id: String, agent: Arc<Agent>) {
-        let acp_session = GooseAcpSession { agent };
+        let config_watcher =
+            crate::config::watcher::ConfigWatcher::start(agent.clone(), session_id.clone()).ok();
+        let acp_session = GooseAcpSession {
+            agent,
+            config_watcher,
+        };
         self.sessions.lock().await.insert(session_id, acp_session);
     }
 

--- a/crates/goose/src/config/mod.rs
+++ b/crates/goose/src/config/mod.rs
@@ -10,6 +10,7 @@ pub mod search_path;
 pub mod signup_openrouter;
 pub mod signup_tetrate;
 pub mod tls;
+pub mod watcher;
 
 pub use crate::agents::ExtensionConfig;
 pub use base::{merge_config_values, Config, ConfigError};

--- a/crates/goose/src/config/watcher.rs
+++ b/crates/goose/src/config/watcher.rs
@@ -1,0 +1,243 @@
+//! Hot-reload of the active provider/model from the goose config file.
+//!
+//! [`ConfigWatcher`] watches the config directory and, when the active provider
+//! or its model changes on disk, rebuilds the provider and swaps it into a
+//! running [`Agent`] via [`Agent::update_provider`], without restarting the
+//! session.
+//!
+//! Precedence: `GOOSE_PROVIDER`/`GOOSE_MODEL` env vars still win over the file
+//! (see [`crate::config::providers::get_active_provider`]); a file edit is a
+//! no-op while they are set and unchanged. The config file is persisted
+//! atomically (temp-file + rename), so the parent directory is watched rather
+//! than the file itself.
+//!
+//! Dropping the [`ConfigWatcher`] guard stops watching and releases the
+//! `Arc<Agent>` it holds: the guard owns the event sender, so its drop closes
+//! the receiver and the reload task exits.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use futures::future::BoxFuture;
+use notify::{Event, RecommendedWatcher, RecursiveMode, Watcher};
+use tokio::sync::{mpsc, Mutex};
+use tracing::{debug, info, warn};
+
+use crate::agents::Agent;
+use crate::config::base::CONFIG_YAML_NAME;
+use crate::config::paths::Paths;
+use crate::config::providers::{get_active_model, get_active_provider};
+use crate::config::Config;
+use crate::model_config::model_config_from_user_config;
+use crate::providers::base::Provider;
+use crate::providers::create;
+
+/// Coalesce a burst of filesystem events (atomic temp + rename, editor saves)
+/// into a single reload.
+const DEBOUNCE: Duration = Duration::from_millis(300);
+
+type BuildProvider =
+    Arc<dyn Fn(&str) -> BoxFuture<'static, Result<Arc<dyn Provider>>> + Send + Sync>;
+type ApplyProvider =
+    Arc<dyn Fn(Arc<dyn Provider>, String, String) -> BoxFuture<'static, Result<()>> + Send + Sync>;
+
+pub struct ConfigWatcher {
+    _watcher: RecommendedWatcher,
+}
+
+impl ConfigWatcher {
+    /// Watch the default config file and hot-swap `agent`'s provider on change.
+    pub fn start(agent: Arc<Agent>, session_id: String) -> Result<Self> {
+        let factory: BuildProvider = Arc::new(|name: &str| {
+            let name = name.to_string();
+            Box::pin(async move { create(&name, Vec::new()).await })
+        });
+        let apply: ApplyProvider = Arc::new({
+            let agent = agent.clone();
+            let session_id = session_id.clone();
+            move |provider, provider_name, model| {
+                let agent = agent.clone();
+                let session_id = session_id.clone();
+                Box::pin(async move {
+                    let model_config = model_config_from_user_config(&provider_name, &model)?;
+                    agent
+                        .update_provider(provider, model_config, &session_id)
+                        .await
+                })
+            }
+        });
+        Self::start_impl(factory, apply)
+    }
+
+    fn start_impl(factory: BuildProvider, apply: ApplyProvider) -> Result<Self> {
+        let dir = Paths::config_dir();
+        let target: PathBuf = dir.join(CONFIG_YAML_NAME);
+
+        let (tx, mut rx) = mpsc::channel::<()>(16);
+        let watch_target = target.clone();
+        let mut watcher = notify::recommended_watcher(move |res: notify::Result<Event>| {
+            if let Ok(ev) = res {
+                if ev.paths.contains(&watch_target) {
+                    let _ = tx.blocking_send(());
+                }
+            }
+        })
+        .context("initialize config file watcher")?;
+
+        if let Err(e) = watcher.watch(&dir, RecursiveMode::NonRecursive) {
+            // A missing config dir on a fresh install means there is nothing to
+            // watch yet; reload begins working once the file is created.
+            debug!(error = %e, "could not watch config dir; hot-reload inactive until it exists");
+        }
+
+        let last = Arc::new(Mutex::new(resolve_selection()));
+        tokio::spawn(async move {
+            loop {
+                if rx.recv().await.is_none() {
+                    break;
+                }
+                // Drain the burst, then reload once it has been quiet for DEBOUNCE.
+                loop {
+                    tokio::select! {
+                        _ = rx.recv() => continue,
+                        _ = tokio::time::sleep(DEBOUNCE) => break,
+                    }
+                }
+                Config::global().invalidate_secrets_cache();
+                let selection = resolve_selection();
+                let mut guard = last.lock().await;
+                match reload(&mut guard, selection, &factory, &apply).await {
+                    Ok(true) => {}
+                    Ok(false) => debug!("config changed but active selection unchanged"),
+                    Err(e) => warn!(error = %e, "config hot-reload failed"),
+                }
+            }
+            debug!("config watcher task exited");
+        });
+
+        Ok(Self { _watcher: watcher })
+    }
+}
+
+/// Resolves the active (provider, model) from the process config. Env wins.
+fn resolve_selection() -> Option<(String, String)> {
+    let config = Config::global();
+    let provider = get_active_provider(config)?;
+    let model = get_active_model(config).unwrap_or_default();
+    Some((provider, model))
+}
+
+/// Builds and applies the provider when `selection` differs from `last`.
+/// Returns `Ok(true)` if a swap happened, `Ok(false)` on a no-op.
+async fn reload(
+    last: &mut Option<(String, String)>,
+    selection: Option<(String, String)>,
+    factory: &BuildProvider,
+    apply: &ApplyProvider,
+) -> Result<bool> {
+    let selection = match selection {
+        Some(s) => s,
+        None => return Ok(false),
+    };
+    if *last == Some(selection.clone()) {
+        return Ok(false);
+    }
+    let (name, model) = selection;
+    let provider = factory(&name).await?;
+    apply(provider, name.clone(), model.clone()).await?;
+    let applied_model = model.clone();
+    *last = Some((name, model));
+    info!(model = %applied_model, "hot-reloaded provider from config change");
+    Ok(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use goose_providers::errors::ProviderError;
+    use goose_providers::model::ModelConfig;
+
+    struct StubProvider {
+        name: String,
+    }
+
+    #[async_trait::async_trait]
+    impl Provider for StubProvider {
+        fn get_name(&self) -> &str {
+            &self.name
+        }
+        async fn stream(
+            &self,
+            _model_config: &ModelConfig,
+            _system: &str,
+            _messages: &[crate::conversation::message::Message],
+            _tools: &[rmcp::model::Tool],
+        ) -> std::result::Result<crate::providers::base::MessageStream, ProviderError> {
+            unimplemented!()
+        }
+        async fn fetch_recommended_models(
+            &self,
+            _toolshim: bool,
+        ) -> std::result::Result<Vec<String>, ProviderError> {
+            Ok(vec![])
+        }
+    }
+
+    fn mocks() -> (BuildProvider, ApplyProvider, Arc<Mutex<Vec<String>>>) {
+        let calls = Arc::new(Mutex::new(Vec::<String>::new()));
+        let calls_c = calls.clone();
+        let factory: BuildProvider = Arc::new(move |name: &str| {
+            let name = name.to_string();
+            let calls = calls_c.clone();
+            Box::pin(async move {
+                calls.lock().await.push(format!("build:{name}"));
+                Ok(Arc::new(StubProvider { name }) as Arc<dyn Provider>)
+            })
+        });
+        let calls_c2 = calls.clone();
+        let apply: ApplyProvider = Arc::new(move |_provider, name, model| {
+            let calls = calls_c2.clone();
+            Box::pin(async move {
+                calls.lock().await.push(format!("apply:{name}/{model}"));
+                Ok(())
+            })
+        });
+        (factory, apply, calls)
+    }
+
+    #[tokio::test]
+    async fn reload_swaps_when_selection_changes() {
+        let (factory, apply, calls) = mocks();
+        let mut last = Some(("a".to_string(), "a-model".to_string()));
+
+        // Same selection: no-op.
+        assert!(!reload(
+            &mut last,
+            Some(("a".into(), "a-model".into())),
+            &factory,
+            &apply
+        )
+        .await
+        .unwrap());
+        assert!(calls.lock().await.is_empty());
+
+        // Different selection: swap.
+        assert!(reload(
+            &mut last,
+            Some(("b".into(), "b-model".into())),
+            &factory,
+            &apply
+        )
+        .await
+        .unwrap());
+        let recorded = calls.lock().await.clone();
+        assert!(recorded.iter().any(|c| c == "build:b"));
+        assert!(recorded.iter().any(|c| c == "apply:b/b-model"));
+        assert_eq!(last, Some(("b".to_string(), "b-model".to_string())));
+
+        // No active provider configured: no-op.
+        assert!(!reload(&mut last, None, &factory, &apply).await.unwrap());
+    }
+}


### PR DESCRIPTION
Issue: #11056 — filed for this PR per the contribution workflow in `AGENTS.md`; not yet triaged to **Ready**, so this PR is a proposal attached to it rather than agreed work.

Rebased onto `main`.

**Verification after rebase**
- Conflict resolved by hand: `main` dropped the tool-chain fields from `GooseAcpSession`, so the rebased struct is `main`'s minimal version plus `config_watcher` only.
- `cargo test -p goose --lib config::watcher` — passed.
- `cargo check -p goose --lib` and `cargo clippy -p goose --lib --tests -- -D warnings` — clean.

---

## Summary
- Add `ConfigWatcher`: a debounced watcher on `config.yaml` that rebuilds the provider and swaps it into the running agent via `Agent::update_provider`, so a provider/model change takes effect without restarting the session.
- Watch the config directory (config is written via atomic temp + rename), coalesce event bursts, and only reload when the active provider or model actually changes.
- `GOOSE_PROVIDER`/`GOOSE_MODEL` env vars still win over the file; the secrets cache is invalidated before each resolve so a changed key takes effect.
- Wire into ACP sessions, which keep the agent as `Arc<Agent>`. The watcher is a RAII guard stored on the session: dropping the session drops the event sender, ending the reload task and releasing the `Arc<Agent>`.

## Test plan
- [x] `cargo fmt -p goose -- --check`
- [x] `cargo clippy -p goose --all-targets -- -D warnings`
- [x] `cargo test -p goose --lib config::` — 124 passed, incl. `config::watcher::tests::reload_swaps_when_selection_changes`
- [ ] Manual: edit `~/.config/goose/config.yaml` `active_provider`/model while an ACP session is running and confirm the agent switches without restart.

Follow-up: desktop/`goose-server` wiring (SSE picker refresh) is not in this PR — `goose-server` is not on `main`; this lands the reusable capability plus ACP-session hot-reload.

