### PR TITLE
feat(dictation): add LOCAL_WHISPER_LANGUAGE for multilingual local transcription

### DIFF
--- a/crates/goose/src/dictation/whisper.rs
+++ b/crates/goose/src/dictation/whisper.rs
@@ -11,6 +11,7 @@ use crate::config::paths::Paths;
 pub const LOCAL_WHISPER_MODEL_CONFIG_KEY: &str = "LOCAL_WHISPER_MODEL";
 pub const LOCAL_WHISPER_LANGUAGE_CONFIG_KEY: &str = "LOCAL_WHISPER_LANGUAGE";
 const ENGLISH_LANGUAGE_TOKEN: u32 = 50259;
+const LANGUAGE_TOKEN_COUNT: u32 = 99;
 use anyhow::{Context, Result};
 use candle_core::{Device, IndexOp, Tensor};
 use candle_nn::ops::log_softmax;
@@ -314,6 +315,8 @@ impl WhisperTranscriber {
             tracing::debug!("empty audio data received");
             return Ok(String::new());
         }
+
+        self.language_token = Self::resolve_language_token(&self.tokenizer);
 
         let (mel_tensor, actual_content_frames) = self.prepare_audio_input(audio_data)?;
         let (_, _, padded_frames) = mel_tensor.dims3()?;
@@ -736,15 +739,21 @@ impl WhisperTranscriber {
 /// Whisper tokenizers expose one `<|xx|>` token per supported language, so the code is looked up
 /// in the tokenizer rather than mapped through a table that would drift from the model.
 /// Unset or unrecognized codes fall back to English.
+///
+/// The result is bounded to the language block because the tokenizer also contains task and
+/// control tokens such as `<|translate|>`, which would otherwise resolve here and produce an
+/// invalid decoder prompt.
 fn language_token(tokenizer: &Tokenizer, code: Option<&str>) -> u32 {
     let Some(code) = code else {
         return ENGLISH_LANGUAGE_TOKEN;
     };
 
     let code = code.trim().to_lowercase();
+    let languages = ENGLISH_LANGUAGE_TOKEN..ENGLISH_LANGUAGE_TOKEN + LANGUAGE_TOKEN_COUNT;
+
     match tokenizer.token_to_id(&format!("<|{}|>", code)) {
-        Some(token) => token,
-        None => {
+        Some(token) if languages.contains(&token) => token,
+        _ => {
             tracing::warn!(
                 language = %code,
                 "unsupported LOCAL_WHISPER_LANGUAGE, transcribing as English"
@@ -1145,6 +1154,10 @@ mod tests {
     #[test_case(Some("ru"), 50263 ; "russian")]
     #[test_case(Some("DE"), 50261 ; "uppercase code is normalized")]
     #[test_case(Some("klingon"), ENGLISH_LANGUAGE_TOKEN ; "unsupported falls back to english")]
+    #[test_case(Some("su"), 50357 ; "last language in the block")]
+    #[test_case(Some("translate"), ENGLISH_LANGUAGE_TOKEN ; "task token is not a language")]
+    #[test_case(Some("notimestamps"), ENGLISH_LANGUAGE_TOKEN ; "control token is not a language")]
+    #[test_case(Some("startoftranscript"), ENGLISH_LANGUAGE_TOKEN ; "sot token is not a language")]
     fn test_language_token(code: Option<&str>, expected: u32) {
         let tokenizer =
             Tokenizer::from_bytes(include_bytes!("whisper_data/tokens.json")).expect("tokenizer");

--- a/crates/goose/src/dictation/whisper.rs
+++ b/crates/goose/src/dictation/whisper.rs
@@ -9,6 +9,8 @@
 use crate::config::paths::Paths;
 
 pub const LOCAL_WHISPER_MODEL_CONFIG_KEY: &str = "LOCAL_WHISPER_MODEL";
+pub const LOCAL_WHISPER_LANGUAGE_CONFIG_KEY: &str = "LOCAL_WHISPER_LANGUAGE";
+const ENGLISH_LANGUAGE_TOKEN: u32 = 50259;
 use anyhow::{Context, Result};
 use candle_core::{Device, IndexOp, Tensor};
 use candle_nn::ops::log_softmax;
@@ -255,6 +257,8 @@ impl WhisperTranscriber {
         let tokenizer = Self::load_tokenizer(model_path_ref, Some(bundled_tokenizer))?;
         tracing::debug!("tokenizer loaded successfully");
 
+        let language_token = Self::resolve_language_token(&tokenizer);
+
         Ok(Self {
             model,
             config,
@@ -263,9 +267,18 @@ impl WhisperTranscriber {
             tokenizer,
             eot_token: 50257,
             no_timestamps_token: 50363,
-            language_token: 50259,
+            language_token,
             max_initial_timestamp_index: 50,
         })
+    }
+
+    fn resolve_language_token(tokenizer: &Tokenizer) -> u32 {
+        let configured = crate::config::Config::global()
+            .get(LOCAL_WHISPER_LANGUAGE_CONFIG_KEY, false)
+            .ok()
+            .and_then(|v| v.as_str().map(|s| s.to_string()));
+
+        language_token(tokenizer, configured.as_deref())
     }
 
     fn load_tokenizer(model_dir: &Path, bundled_tokenizer: Option<&str>) -> Result<Tokenizer> {
@@ -718,6 +731,29 @@ impl WhisperTranscriber {
     }
 }
 
+/// Resolve an ISO 639-1 language code to its Whisper language token.
+///
+/// Whisper tokenizers expose one `<|xx|>` token per supported language, so the code is looked up
+/// in the tokenizer rather than mapped through a table that would drift from the model.
+/// Unset or unrecognized codes fall back to English.
+fn language_token(tokenizer: &Tokenizer, code: Option<&str>) -> u32 {
+    let Some(code) = code else {
+        return ENGLISH_LANGUAGE_TOKEN;
+    };
+
+    let code = code.trim().to_lowercase();
+    match tokenizer.token_to_id(&format!("<|{}|>", code)) {
+        Some(token) => token,
+        None => {
+            tracing::warn!(
+                language = %code,
+                "unsupported LOCAL_WHISPER_LANGUAGE, transcribing as English"
+            );
+            ENGLISH_LANGUAGE_TOKEN
+        }
+    }
+}
+
 /// Remove repeated phrases from transcribed text.
 ///
 /// Whisper models (especially smaller/quantized ones) tend to loop, producing output like
@@ -1102,6 +1138,19 @@ mod tests {
     use test_case::test_case;
 
     const TS: u32 = 50364; // A timestamp token for tests
+
+    #[test_case(None, ENGLISH_LANGUAGE_TOKEN ; "unset falls back to english")]
+    #[test_case(Some("en"), ENGLISH_LANGUAGE_TOKEN ; "english")]
+    #[test_case(Some("de"), 50261 ; "german")]
+    #[test_case(Some("ru"), 50263 ; "russian")]
+    #[test_case(Some("DE"), 50261 ; "uppercase code is normalized")]
+    #[test_case(Some("klingon"), ENGLISH_LANGUAGE_TOKEN ; "unsupported falls back to english")]
+    fn test_language_token(code: Option<&str>, expected: u32) {
+        let tokenizer =
+            Tokenizer::from_bytes(include_bytes!("whisper_data/tokens.json")).expect("tokenizer");
+
+        assert_eq!(language_token(&tokenizer, code), expected);
+    }
 
     // detect_repetition_impl tests
     // sample_begin=3 means tokens[0..3] are SOT, language, transcribe


### PR DESCRIPTION
## Problem

Local Whisper dictation hardcodes the English language token, so speech in any other language is transcribed as though it were English:

https://github.com/aaif-goose/goose/blob/main/crates/goose/src/dictation/whisper.rs#L266

Closes #10580

## Change

Adds an optional `LOCAL_WHISPER_LANGUAGE` config key, alongside the existing `LOCAL_WHISPER_MODEL`:

```yaml
LOCAL_WHISPER_MODEL: small
LOCAL_WHISPER_LANGUAGE: de   # new, optional
```

When unset or set to a code the model doesn't support, behavior is unchanged — English, with a warning logged in the latter case. No UI changes.

## A note on the approach

The issue suggested a static `LANGUAGE_TOKENS` table mapping ISO codes to token IDs. I went a different way: the bundled tokenizer already contains all 99 `<|xx|>` language tokens, so the code is resolved with `tokenizer.token_to_id()` instead.

This avoids a hand-maintained table that would drift from the model, and covers every language the model supports rather than a transcribed subset. Happy to switch to the table if you'd prefer it for explicitness.

## Testing

`language_token()` is separated from the config read so it can be tested without touching global config. Six cases cover English, German, Russian, uppercase normalization, unset, and an unsupported code.

- `cargo fmt --check` — pass
- `cargo check -p goose --features local-inference` — pass, no warnings
- `cargo test -p goose --features local-inference --lib dictation` — 33 passed, 0 failed
- `cargo clippy --all-targets -- -D warnings` — pass

Not covered: end-to-end transcription of non-English audio, which needs a downloaded model and real speech. The token IDs are asserted against the bundled tokenizer instead.