### PR TITLE
feat(desktop): archive sessions + per-chat sidebar actions

### DIFF
--- a/crates/goose/src/acp/server/list_sessions.rs
+++ b/crates/goose/src/acp/server/list_sessions.rs
@@ -1,6 +1,6 @@
 use super::{build_session_info, meta_string, GooseAcpAgent, ResultExt};
 use crate::session::session_manager::{
-    SessionListCursor, SessionListFilters, SessionListPageQuery, SessionType,
+    ArchivedFilter, SessionListCursor, SessionListFilters, SessionListPageQuery, SessionType,
 };
 use agent_client_protocol::schema::v1::{
     ListSessionsRequest, ListSessionsResponse, Meta, SessionInfo,
@@ -30,6 +30,7 @@ struct SessionListCursorFilters {
     session_types: Vec<String>,
     keyword: Option<String>,
     only_sessions_with_messages: bool,
+    archived: &'static str,
 }
 
 fn invalid_session_list_cursor(message: &'static str) -> agent_client_protocol::Error {
@@ -73,6 +74,34 @@ fn session_types_from_meta(
     }
 }
 
+/// Stable identifier for an archived filter, used when binding cursors to filters.
+fn archived_filter_key(archived: ArchivedFilter) -> &'static str {
+    match archived {
+        ArchivedFilter::Active => "active",
+        ArchivedFilter::Archived => "archived",
+        ArchivedFilter::All => "all",
+    }
+}
+
+// Archived sessions are hidden by default; clients opt in via `_meta.archived`.
+fn archived_filter_from_meta(
+    meta: Option<&Meta>,
+) -> Result<ArchivedFilter, agent_client_protocol::Error> {
+    let Some(value) = meta.and_then(|meta| meta.get("archived")) else {
+        return Ok(ArchivedFilter::Active);
+    };
+    if value.is_null() {
+        return Ok(ArchivedFilter::Active);
+    }
+    match value.as_str() {
+        Some("active") => Ok(ArchivedFilter::Active),
+        Some("archived") => Ok(ArchivedFilter::Archived),
+        Some("all") => Ok(ArchivedFilter::All),
+        _ => Err(agent_client_protocol::Error::invalid_params()
+            .data("archived must be one of \"active\", \"archived\", or \"all\"")),
+    }
+}
+
 fn include_last_message_snippet_from_meta(
     meta: Option<&Meta>,
 ) -> Result<bool, agent_client_protocol::Error> {
@@ -104,6 +133,7 @@ fn session_list_filter_hash(
     cwd: Option<&std::path::Path>,
     session_types: &[SessionType],
     keyword: Option<&str>,
+    archived: ArchivedFilter,
 ) -> Result<String, agent_client_protocol::Error> {
     let mut session_type_names = session_types
         .iter()
@@ -115,6 +145,7 @@ fn session_list_filter_hash(
         session_types: session_type_names,
         keyword: keyword.map(ToString::to_string),
         only_sessions_with_messages: true,
+        archived: archived_filter_key(archived),
     };
     let bytes =
         serde_json::to_vec(&filters).internal_err_ctx("Failed to encode session list filters")?;
@@ -126,6 +157,7 @@ fn decode_session_list_cursor(
     cwd: Option<&std::path::Path>,
     session_types: &[SessionType],
     keyword: Option<&str>,
+    archived: ArchivedFilter,
 ) -> Result<Option<SessionListCursor>, agent_client_protocol::Error> {
     let Some(cursor) = cursor else {
         return Ok(None);
@@ -141,7 +173,7 @@ fn decode_session_list_cursor(
         return Err(invalid_session_list_cursor("malformed session list cursor"));
     }
 
-    let expected_filter_hash = session_list_filter_hash(cwd, session_types, keyword)?;
+    let expected_filter_hash = session_list_filter_hash(cwd, session_types, keyword, archived)?;
     if token.filter_hash != expected_filter_hash {
         return Err(invalid_session_list_cursor(
             "session list cursor does not match filters",
@@ -159,11 +191,12 @@ fn encode_session_list_cursor(
     cwd: Option<&std::path::Path>,
     session_types: &[SessionType],
     keyword: Option<&str>,
+    archived: ArchivedFilter,
 ) -> Result<String, agent_client_protocol::Error> {
     let token = SessionListCursorToken {
         sort_at: cursor.sort_at,
         session_id: cursor.session_id.clone(),
-        filter_hash: session_list_filter_hash(cwd, session_types, keyword)?,
+        filter_hash: session_list_filter_hash(cwd, session_types, keyword, archived)?,
     };
     let bytes =
         serde_json::to_vec(&token).internal_err_ctx("Failed to encode session list cursor")?;
@@ -185,6 +218,7 @@ impl GooseAcpAgent {
         let cwd = req.cwd.as_deref();
         let keyword = session_keyword_from_meta(req.meta.as_ref())?;
         let session_types = session_types_from_meta(req.meta.as_ref())?;
+        let archived = archived_filter_from_meta(req.meta.as_ref())?;
         let include_last_message_snippet =
             include_last_message_snippet_from_meta(req.meta.as_ref())?;
         let cursor = decode_session_list_cursor(
@@ -192,6 +226,7 @@ impl GooseAcpAgent {
             cwd,
             &session_types,
             keyword.as_deref(),
+            archived,
         )?;
 
         // ACP clients see their own (Acp) sessions plus legacy User/Scheduled ones.
@@ -203,6 +238,7 @@ impl GooseAcpAgent {
                     working_dir: cwd,
                     keyword: keyword.as_deref(),
                     only_sessions_with_messages: true,
+                    archived,
                 },
                 cursor: cursor.as_ref(),
                 page_size: SESSION_LIST_PAGE_SIZE,
@@ -217,7 +253,13 @@ impl GooseAcpAgent {
             .next_cursor
             .as_ref()
             .map(|cursor| {
-                encode_session_list_cursor(cursor, cwd, &session_types, keyword.as_deref())
+                encode_session_list_cursor(
+                    cursor,
+                    cwd,
+                    &session_types,
+                    keyword.as_deref(),
+                    archived,
+                )
             })
             .transpose()?;
         Ok(ListSessionsResponse::new(session_infos).next_cursor(next_cursor))

--- a/crates/goose/src/acp/server/list_sessions.rs
+++ b/crates/goose/src/acp/server/list_sessions.rs
@@ -74,6 +74,14 @@ fn session_types_from_meta(
     }
 }
 
+// Empty sessions are normally hidden so freshly created chats stay out of
+// listings and search, but an archived session must remain reachable for
+// restore even before its first message (e.g. a new chat archived from the
+// sidebar), so the explicit Archived listing includes empty sessions.
+fn only_sessions_with_messages(archived: ArchivedFilter) -> bool {
+    !matches!(archived, ArchivedFilter::Archived)
+}
+
 /// Stable identifier for an archived filter, used when binding cursors to filters.
 fn archived_filter_key(archived: ArchivedFilter) -> &'static str {
     match archived {
@@ -144,7 +152,7 @@ fn session_list_filter_hash(
         cwd: cwd.map(|path| path.to_string_lossy().to_string()),
         session_types: session_type_names,
         keyword: keyword.map(ToString::to_string),
-        only_sessions_with_messages: true,
+        only_sessions_with_messages: only_sessions_with_messages(archived),
         archived: archived_filter_key(archived),
     };
     let bytes =
@@ -237,7 +245,7 @@ impl GooseAcpAgent {
                     types: Some(&session_types),
                     working_dir: cwd,
                     keyword: keyword.as_deref(),
-                    only_sessions_with_messages: true,
+                    only_sessions_with_messages: only_sessions_with_messages(archived),
                     archived,
                 },
                 cursor: cursor.as_ref(),

--- a/crates/goose/src/acp/server/manage_sessions.rs
+++ b/crates/goose/src/acp/server/manage_sessions.rs
@@ -99,6 +99,18 @@ impl GooseAcpAgent {
         &self,
         req: DeleteSessionRequest,
     ) -> Result<EmptyResponse, agent_client_protocol::Error> {
+        // Deleting removes the loaded agent, so an in-flight prompt run would
+        // resume against a missing session. Client-side gating cannot see runs
+        // owned by other windows sharing this server, so refuse here too.
+        if self
+            .active_prompt_runs
+            .lock()
+            .await
+            .contains_key(&req.session_id)
+        {
+            return Err(agent_client_protocol::Error::invalid_params()
+                .data("cannot delete a session while it has an active prompt run"));
+        }
         self.session_manager
             .delete_session(&req.session_id)
             .await

--- a/crates/goose/src/acp/server/manage_sessions.rs
+++ b/crates/goose/src/acp/server/manage_sessions.rs
@@ -254,6 +254,18 @@ impl GooseAcpAgent {
         &self,
         req: ArchiveSessionRequest,
     ) -> Result<EmptyResponse, agent_client_protocol::Error> {
+        // Archiving removes the loaded agent, so an in-flight prompt run would
+        // resume against a missing session. Client-side gating cannot see runs
+        // owned by other windows sharing this server, so refuse here too.
+        if self
+            .active_prompt_runs
+            .lock()
+            .await
+            .contains_key(&req.session_id)
+        {
+            return Err(agent_client_protocol::Error::invalid_params()
+                .data("cannot archive a session while it has an active prompt run"));
+        }
         self.session_manager
             .update(&req.session_id)
             .archived_at(Some(chrono::Utc::now()))

--- a/crates/goose/src/session/session_manager.rs
+++ b/crates/goose/src/session/session_manager.rs
@@ -328,12 +328,25 @@ pub(crate) struct SessionListPage {
     pub(crate) next_cursor: Option<SessionListCursor>,
 }
 
+/// Controls whether archived sessions are included when listing.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ArchivedFilter {
+    /// Only sessions that have not been archived (`archived_at IS NULL`).
+    Active,
+    /// Only archived sessions (`archived_at IS NOT NULL`).
+    Archived,
+    /// Both active and archived sessions (no filtering).
+    #[default]
+    All,
+}
+
 #[derive(Debug, Default, Clone)]
 pub(crate) struct SessionListFilters<'a> {
     pub(crate) types: Option<&'a [SessionType]>,
     pub(crate) working_dir: Option<&'a Path>,
     pub(crate) keyword: Option<&'a str>,
     pub(crate) only_sessions_with_messages: bool,
+    pub(crate) archived: ArchivedFilter,
 }
 
 #[derive(Debug, Clone)]
@@ -1963,6 +1976,11 @@ impl SessionStorage {
         }
         if filters.working_dir.is_some() {
             where_clauses.push("s.working_dir = ?".to_string());
+        }
+        match filters.archived {
+            ArchivedFilter::Active => where_clauses.push("s.archived_at IS NULL".to_string()),
+            ArchivedFilter::Archived => where_clauses.push("s.archived_at IS NOT NULL".to_string()),
+            ArchivedFilter::All => {}
         }
         if !keywords.is_empty() {
             where_clauses.push(message_keyword_clause(keywords.len()));
@@ -3806,6 +3824,59 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_session_list_paged_archived_filter() {
+        let temp_dir = TempDir::new().unwrap();
+        let sm = SessionManager::new(temp_dir.path().to_path_buf());
+        let active =
+            create_session_for_list_with_message(&sm, "/tmp/session-list", "active session").await;
+        let archived =
+            create_session_for_list_with_message(&sm, "/tmp/session-list", "archived session")
+                .await;
+        sm.update(&archived)
+            .archived_at(Some(chrono::Utc::now()))
+            .apply()
+            .await
+            .unwrap();
+
+        async fn list_ids(sm: &SessionManager, archived: ArchivedFilter) -> Vec<String> {
+            let types = [SessionType::User];
+            let page = sm
+                .list_sessions_paged(SessionListPageQuery {
+                    filters: SessionListFilters {
+                        types: Some(&types),
+                        only_sessions_with_messages: true,
+                        archived,
+                        ..Default::default()
+                    },
+                    cursor: None,
+                    page_size: 10,
+                    include_last_message_snippet: false,
+                })
+                .await
+                .unwrap();
+            page.sessions
+                .into_iter()
+                .map(|session| session.id)
+                .collect::<Vec<_>>()
+        }
+
+        assert_eq!(
+            list_ids(&sm, ArchivedFilter::Active).await,
+            vec![active.clone()]
+        );
+        assert_eq!(
+            list_ids(&sm, ArchivedFilter::Archived).await,
+            vec![archived.clone()]
+        );
+
+        let mut all = list_ids(&sm, ArchivedFilter::All).await;
+        all.sort();
+        let mut expected = vec![active, archived];
+        expected.sort();
+        assert_eq!(all, expected);
+    }
+
+    #[tokio::test]
     async fn test_session_list_paged_keyword_treats_like_wildcards_as_literals() {
         let temp_dir = TempDir::new().unwrap();
         let sm = SessionManager::new(temp_dir.path().to_path_buf());
@@ -3885,6 +3956,7 @@ mod tests {
             working_dir: Some(Path::new("/tmp/session-list/a")),
             keyword: Some("postgres"),
             only_sessions_with_messages: true,
+            ..Default::default()
         };
         let cursor = sm
             .list_sessions_paged(SessionListPageQuery {

--- a/crates/goose/src/session/session_manager.rs
+++ b/crates/goose/src/session/session_manager.rs
@@ -332,11 +332,15 @@ pub(crate) struct SessionListPage {
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ArchivedFilter {
     /// Only sessions that have not been archived (`archived_at IS NULL`).
+    ///
+    /// This is the default so callers using `SessionListFilters::default()`
+    /// (the orchestrator `list_sessions` tool, scheduler listings, etc.) hide
+    /// archived chats just like the UI does; opt in to archived rows explicitly.
+    #[default]
     Active,
     /// Only archived sessions (`archived_at IS NOT NULL`).
     Archived,
     /// Both active and archived sessions (no filtering).
-    #[default]
     All,
 }
 

--- a/crates/goose/src/session/session_manager.rs
+++ b/crates/goose/src/session/session_manager.rs
@@ -2072,9 +2072,19 @@ impl SessionStorage {
     }
 
     async fn list_sessions_by_types(&self, types: Option<&[SessionType]>) -> Result<Vec<Session>> {
+        // `types: None` is the explicit all-sessions path (`list_all_sessions`), which
+        // `goose session remove --name` relies on to find a session by name — it must
+        // include archived rows. Type-scoped queries keep the Active default so archived
+        // chats stay hidden from the orchestrator/scheduler listings.
+        let archived = if types.is_none() {
+            ArchivedFilter::All
+        } else {
+            ArchivedFilter::Active
+        };
         self.list_sessions_matching(SessionListQuery {
             filters: SessionListFilters {
                 types,
+                archived,
                 ..Default::default()
             },
             ..Default::default()
@@ -3878,6 +3888,46 @@ mod tests {
         let mut expected = vec![active, archived];
         expected.sort();
         assert_eq!(all, expected);
+    }
+
+    #[tokio::test]
+    async fn test_list_all_sessions_includes_archived() {
+        let temp_dir = TempDir::new().unwrap();
+        let sm = SessionManager::new(temp_dir.path().to_path_buf());
+        let active =
+            create_session_for_list_with_message(&sm, "/tmp/session-list", "active session").await;
+        let archived =
+            create_session_for_list_with_message(&sm, "/tmp/session-list", "archived session")
+                .await;
+        sm.update(&archived)
+            .archived_at(Some(chrono::Utc::now()))
+            .apply()
+            .await
+            .unwrap();
+
+        // The explicit all-sessions path (used by `goose session remove --name`) must
+        // still surface archived sessions.
+        let mut all = sm
+            .list_all_sessions()
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|session| session.id)
+            .collect::<Vec<_>>();
+        all.sort();
+        let mut expected = vec![active.clone(), archived.clone()];
+        expected.sort();
+        assert_eq!(all, expected);
+
+        // Type-scoped listings hide archived sessions by default.
+        let active_only = sm
+            .list_sessions_by_types(&[SessionType::User])
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|session| session.id)
+            .collect::<Vec<_>>();
+        assert_eq!(active_only, vec![active]);
     }
 
     #[tokio::test]

--- a/crates/goose/tests/acp_server_test.rs
+++ b/crates/goose/tests/acp_server_test.rs
@@ -316,6 +316,62 @@ fn test_list_sessions_pagination() {
 }
 
 #[test]
+fn test_list_sessions_archived_includes_empty_sessions() {
+    run_test(async {
+        let data_root = tempfile::tempdir().unwrap();
+        let cwd = Path::new("/tmp/acp-session-list-archived-empty");
+        let session_manager = SessionManager::new(data_root.path().to_path_buf());
+        let archived_empty = session_manager
+            .create_session(
+                cwd.to_path_buf(),
+                "Archived before first message".to_string(),
+                SessionType::Acp,
+                GooseMode::default(),
+            )
+            .await
+            .unwrap();
+        session_manager
+            .update(&archived_empty.id)
+            .archived_at(Some(chrono::Utc::now()))
+            .apply()
+            .await
+            .unwrap();
+        session_manager
+            .create_session(
+                cwd.to_path_buf(),
+                "Active empty".to_string(),
+                SessionType::Acp,
+                GooseMode::default(),
+            )
+            .await
+            .unwrap();
+        let conn = new_connection(data_root.path()).await;
+
+        // An archived session must stay restorable even when it has no messages,
+        // so the explicit Archived listing includes empty sessions.
+        let mut meta = serde_json::Map::new();
+        meta.insert(
+            "archived".to_string(),
+            serde_json::Value::String("archived".to_string()),
+        );
+        let response = list_sessions_request(&conn, ListSessionsRequest::new().meta(meta))
+            .await
+            .unwrap();
+        assert_eq!(response.sessions.len(), 1);
+        assert_eq!(
+            response.sessions[0].session_id.0.as_ref(),
+            archived_empty.id.as_str()
+        );
+
+        // The default (active) listing keeps hiding empty sessions.
+        let response = list_sessions_request(&conn, ListSessionsRequest::new())
+            .await
+            .unwrap();
+        assert!(response.sessions.is_empty());
+    });
+}
+
+#[test]
 fn test_list_sessions_query_filters_results() {
     run_test(async {
         let data_root = tempfile::tempdir().unwrap();

--- a/ui/desktop/src/App.tsx
+++ b/ui/desktop/src/App.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState, useRef } from 'react';
 import { IpcRendererEvent } from 'electron';
 import { HashRouter, Routes, Route, useNavigate, useLocation, useSearchParams } from 'react-router';
 import { importNostrSessionFromDeepLink } from './sessionLinks';
+import { initSessionLifecycleBridge } from './sessionLifecycleBridge';
 import { ErrorUI } from './components/ErrorBoundary';
 import { ExtensionInstallModal } from './components/ExtensionInstallModal';
 import RecipeParamsModalContainer from './components/RecipeParamsModalContainer';
@@ -411,6 +412,10 @@ export function AppInner() {
 
       leaveRouteIfCurrent(sessionId);
     };
+
+    // Re-dispatch archive/delete events relayed from other windows so this
+    // window's handlers below run for them too.
+    initSessionLifecycleBridge();
 
     window.addEventListener(AppEvents.ADD_ACTIVE_SESSION, handleAddActiveSession);
     window.addEventListener(AppEvents.CLEAR_INITIAL_MESSAGE, handleClearInitialMessage);

--- a/ui/desktop/src/App.tsx
+++ b/ui/desktop/src/App.tsx
@@ -369,12 +369,27 @@ export function AppInner() {
       });
     };
 
+    // Removing a session (delete or archive) only filters activeSessions; if the
+    // removed chat is the one open at /pair?resumeSessionId=..., the URL still carries
+    // it so PairRouteWrapper re-adds and ChatSessionsContainer re-renders it against a
+    // now-gone server session. Leave the route when that session is the current one.
+    const leaveRouteIfCurrent = (sessionId: string) => {
+      const hash = window.location.hash;
+      const queryIndex = hash.indexOf('?');
+      const currentSessionId =
+        queryIndex >= 0
+          ? new URLSearchParams(hash.slice(queryIndex + 1)).get('resumeSessionId')
+          : null;
+      if (currentSessionId === sessionId) {
+        navigate('/');
+      }
+    };
+
     const handleSessionDeleted = (event: Event) => {
       const { sessionId } = (event as CustomEvent<{ sessionId: string }>).detail;
 
-      setActiveSessions((prev) => {
-        return prev.filter((session) => session.sessionId !== sessionId);
-      });
+      setActiveSessions((prev) => prev.filter((session) => session.sessionId !== sessionId));
+      leaveRouteIfCurrent(sessionId);
     };
 
     // Archiving removes the loaded agent on the server, so unmount the chat
@@ -394,18 +409,7 @@ export function AppInner() {
       cancelAcpElicitationRequestsForSession(sessionId);
       acpChatSessionActions.deleteSnapshot(sessionId);
 
-      // If the archived chat is the one currently open, filtering activeSessions is
-      // not enough: the resumeSessionId still in the URL makes PairRouteWrapper
-      // re-add it and ChatSessionsContainer re-render it. Leave the route entirely.
-      const hash = window.location.hash;
-      const queryIndex = hash.indexOf('?');
-      const currentSessionId =
-        queryIndex >= 0
-          ? new URLSearchParams(hash.slice(queryIndex + 1)).get('resumeSessionId')
-          : null;
-      if (currentSessionId === sessionId) {
-        navigate('/');
-      }
+      leaveRouteIfCurrent(sessionId);
     };
 
     window.addEventListener(AppEvents.ADD_ACTIVE_SESSION, handleAddActiveSession);

--- a/ui/desktop/src/App.tsx
+++ b/ui/desktop/src/App.tsx
@@ -13,7 +13,7 @@ import TelemetryConsentPrompt from './components/TelemetryConsentPrompt';
 import OnboardingGuard from './components/onboarding/OnboardingGuard';
 import { createSession } from './sessions';
 import { acpListSessions, acpDeleteSession } from './acp/sessions';
-import { acpChatSessionActions } from './acp/chatSessionStore';
+import { acpChatSessionActions, acpChatSessionStore } from './acp/chatSessionStore';
 import { cancelAcpPermissionRequestsForSession } from './acp/permissionRequests';
 import { cancelAcpElicitationRequestsForSession } from './acp/elicitationRequests';
 
@@ -406,7 +406,17 @@ export function AppInner() {
       const { sessionId, archived } = (
         event as CustomEvent<{ sessionId: string; archived?: boolean }>
       ).detail;
-      if (archived === false) return;
+      if (archived === false) {
+        // A restore from the History card or another window bypasses the mounted
+        // chat's updateSession, and loadSession short-circuits on a cached
+        // snapshot, so clear the stale archived flag on the session metadata —
+        // otherwise revisiting the chat keeps showing the archived banner.
+        const session = acpChatSessionStore.getSnapshot(sessionId)?.session;
+        if (session?.archived_at) {
+          acpChatSessionActions.setSessionMetadata(sessionId, { ...session, archived_at: null });
+        }
+        return;
+      }
 
       setActiveSessions((prev) => prev.filter((session) => session.sessionId !== sessionId));
 

--- a/ui/desktop/src/App.tsx
+++ b/ui/desktop/src/App.tsx
@@ -383,6 +383,19 @@ export function AppInner() {
       if (archived === false) return;
 
       setActiveSessions((prev) => prev.filter((session) => session.sessionId !== sessionId));
+
+      // If the archived chat is the one currently open, filtering activeSessions is
+      // not enough: the resumeSessionId still in the URL makes PairRouteWrapper
+      // re-add it and ChatSessionsContainer re-render it. Leave the route entirely.
+      const hash = window.location.hash;
+      const queryIndex = hash.indexOf('?');
+      const currentSessionId =
+        queryIndex >= 0
+          ? new URLSearchParams(hash.slice(queryIndex + 1)).get('resumeSessionId')
+          : null;
+      if (currentSessionId === sessionId) {
+        navigate('/');
+      }
     };
 
     window.addEventListener(AppEvents.ADD_ACTIVE_SESSION, handleAddActiveSession);
@@ -395,7 +408,7 @@ export function AppInner() {
       window.removeEventListener(AppEvents.SESSION_DELETED, handleSessionDeleted);
       window.removeEventListener(AppEvents.SESSION_ARCHIVED, handleSessionArchived);
     };
-  }, []);
+  }, [navigate]);
 
   const { addExtension } = useConfig();
 

--- a/ui/desktop/src/App.tsx
+++ b/ui/desktop/src/App.tsx
@@ -390,6 +390,13 @@ export function AppInner() {
       const { sessionId } = (event as CustomEvent<{ sessionId: string }>).detail;
 
       setActiveSessions((prev) => prev.filter((session) => session.sessionId !== sessionId));
+
+      // Centralized here so relayed deletes from other windows clear their ACP
+      // state too, not just the window that initiated the delete.
+      cancelAcpPermissionRequestsForSession(sessionId);
+      cancelAcpElicitationRequestsForSession(sessionId);
+      acpChatSessionActions.deleteSnapshot(sessionId);
+
       leaveRouteIfCurrent(sessionId);
     };
 

--- a/ui/desktop/src/App.tsx
+++ b/ui/desktop/src/App.tsx
@@ -374,13 +374,26 @@ export function AppInner() {
       });
     };
 
+    // Archiving removes the loaded agent on the server, so unmount the chat
+    // like a delete does; otherwise the open tab keeps talking to a hidden session.
+    const handleSessionArchived = (event: Event) => {
+      const { sessionId, archived } = (
+        event as CustomEvent<{ sessionId: string; archived?: boolean }>
+      ).detail;
+      if (archived === false) return;
+
+      setActiveSessions((prev) => prev.filter((session) => session.sessionId !== sessionId));
+    };
+
     window.addEventListener(AppEvents.ADD_ACTIVE_SESSION, handleAddActiveSession);
     window.addEventListener(AppEvents.CLEAR_INITIAL_MESSAGE, handleClearInitialMessage);
     window.addEventListener(AppEvents.SESSION_DELETED, handleSessionDeleted);
+    window.addEventListener(AppEvents.SESSION_ARCHIVED, handleSessionArchived);
     return () => {
       window.removeEventListener(AppEvents.ADD_ACTIVE_SESSION, handleAddActiveSession);
       window.removeEventListener(AppEvents.CLEAR_INITIAL_MESSAGE, handleClearInitialMessage);
       window.removeEventListener(AppEvents.SESSION_DELETED, handleSessionDeleted);
+      window.removeEventListener(AppEvents.SESSION_ARCHIVED, handleSessionArchived);
     };
   }, []);
 

--- a/ui/desktop/src/App.tsx
+++ b/ui/desktop/src/App.tsx
@@ -12,6 +12,9 @@ import TelemetryConsentPrompt from './components/TelemetryConsentPrompt';
 import OnboardingGuard from './components/onboarding/OnboardingGuard';
 import { createSession } from './sessions';
 import { acpListSessions, acpDeleteSession } from './acp/sessions';
+import { acpChatSessionActions } from './acp/chatSessionStore';
+import { cancelAcpPermissionRequestsForSession } from './acp/permissionRequests';
+import { cancelAcpElicitationRequestsForSession } from './acp/elicitationRequests';
 
 import { ChatType } from './types/chat';
 import Hub from './components/Hub';
@@ -383,6 +386,13 @@ export function AppInner() {
       if (archived === false) return;
 
       setActiveSessions((prev) => prev.filter((session) => session.sessionId !== sessionId));
+
+      // The archive server path drops the loaded agent, and loadSession short-circuits
+      // on a cached snapshot, so clear the session-scoped ACP state like delete does —
+      // otherwise reopening a restored chat reuses stale pending/waiting state.
+      cancelAcpPermissionRequestsForSession(sessionId);
+      cancelAcpElicitationRequestsForSession(sessionId);
+      acpChatSessionActions.deleteSnapshot(sessionId);
 
       // If the archived chat is the one currently open, filtering activeSessions is
       // not enough: the resumeSessionId still in the URL makes PairRouteWrapper

--- a/ui/desktop/src/acp/chatSessionStore.ts
+++ b/ui/desktop/src/acp/chatSessionStore.ts
@@ -567,6 +567,13 @@ interface AcpChatSessionSnapshotState {
   snapshot: AcpChatSessionSnapshot | undefined;
 }
 
+export function subscribeToAcpChatSession(
+  sessionId: string,
+  listener: (snapshot: AcpChatSessionSnapshot) => void
+): () => void {
+  return acpChatSessionStoreInternal.subscribe(sessionId, listener);
+}
+
 export function useAcpChatSessionSnapshot(sessionId: string): AcpChatSessionSnapshot | undefined {
   const [snapshotState, setSnapshotState] = useState<AcpChatSessionSnapshotState>(() => ({
     sessionId,

--- a/ui/desktop/src/acp/sessions.ts
+++ b/ui/desktop/src/acp/sessions.ts
@@ -130,8 +130,17 @@ function sessionInfoToListItem(s: SessionInfo): SessionListItem {
   };
 }
 
+/**
+ * Which archived state to include when listing sessions.
+ * - `active` (default): only sessions that have not been archived.
+ * - `archived`: only archived sessions.
+ * - `all`: both — used so archived sessions still surface in keyword search.
+ */
+export type ArchivedFilter = 'active' | 'archived' | 'all';
+
 export interface SessionListFilter {
   keyword?: string;
+  archived?: ArchivedFilter;
 }
 
 const SESSION_LIST_TYPES = ['user', 'scheduled'] as const;
@@ -150,6 +159,9 @@ export async function acpListSessions(
   if (keyword) {
     meta.query = keyword;
   }
+  if (filter?.archived) {
+    meta.archived = filter.archived;
+  }
   request._meta = meta;
   const response = await client.listSessions(request);
   return {
@@ -164,7 +176,9 @@ export async function acpListRecentSessions(maxSessions: number): Promise<Sessio
   }
 
   const client = await getAcpClient();
-  const response = await client.listSessions({ _meta: { types: SESSION_LIST_TYPES } });
+  const response = await client.listSessions({
+    _meta: { types: SESSION_LIST_TYPES, archived: 'active' },
+  });
   return response.sessions.slice(0, maxSessions).map(sessionInfoToListItem);
 }
 
@@ -269,6 +283,16 @@ export async function acpCloseSession(sessionId: string): Promise<void> {
 export async function acpRenameSession(sessionId: string, title: string): Promise<void> {
   const client = await getAcpClient();
   await client.goose.sessionRename_unstable({ sessionId, title });
+}
+
+export async function acpArchiveSession(sessionId: string): Promise<void> {
+  const client = await getAcpClient();
+  await client.goose.sessionArchive_unstable({ sessionId });
+}
+
+export async function acpUnarchiveSession(sessionId: string): Promise<void> {
+  const client = await getAcpClient();
+  await client.goose.sessionUnarchive_unstable({ sessionId });
 }
 
 export async function acpUpdateWorkingDir(sessionId: string, workingDir: string): Promise<void> {

--- a/ui/desktop/src/components/BaseChat.tsx
+++ b/ui/desktop/src/components/BaseChat.tsx
@@ -206,6 +206,9 @@ export default function BaseChat({
         },
       })
     );
+    // Other desktop windows run their own backends and cannot see this run;
+    // relay the status through the main process so their archive guards can.
+    window.electron?.broadcastSessionStatus?.({ sessionId, streamState });
   }, [sessionId, chatState, messages.length, sessionLoadError]);
 
   // Generate command history from user messages (most recent first)

--- a/ui/desktop/src/components/BaseChat.tsx
+++ b/ui/desktop/src/components/BaseChat.tsx
@@ -16,7 +16,10 @@ import { useIsMobile } from '../hooks/use-mobile';
 import { useNavigationContextSafe } from './Layout/NavigationContext';
 import { cn } from '../utils';
 import { useChatSession } from '../hooks/useChatSession';
-import { acpDeleteSession, acpUpdateWorkingDir } from '../acp/sessions';
+import { acpDeleteSession, acpUnarchiveSession, acpUpdateWorkingDir } from '../acp/sessions';
+import { errorMessage } from '../utils/conversionUtils';
+import { toast } from 'react-toastify';
+import { ArchiveRestore } from 'lucide-react';
 import { useNavigation } from '../hooks/useNavigation';
 import { RecipeHeader } from './RecipeHeader';
 import { RecipeWarningModal } from './ui/RecipeWarningModal';
@@ -48,6 +51,22 @@ const i18n = defineMessages({
   reconnecting: {
     id: 'baseChat.reconnecting',
     defaultMessage: 'Connection lost. Reconnecting…',
+  },
+  archivedNotice: {
+    id: 'baseChat.archivedNotice',
+    defaultMessage: 'This chat is archived and hidden from your recent chats.',
+  },
+  archivedRestore: {
+    id: 'baseChat.archivedRestore',
+    defaultMessage: 'Restore',
+  },
+  archivedRestored: {
+    id: 'baseChat.archivedRestored',
+    defaultMessage: 'Session restored',
+  },
+  archivedRestoreFailed: {
+    id: 'baseChat.archivedRestoreFailed',
+    defaultMessage: 'Failed to restore session: {error}',
   },
 });
 
@@ -206,6 +225,29 @@ export default function BaseChat({
     }
     handleSubmit(input);
   };
+
+  const isArchived = !!session?.archived_at;
+  const [isUnarchiving, setIsUnarchiving] = useState(false);
+  const handleUnarchive = useCallback(async () => {
+    if (!session) return;
+    setIsUnarchiving(true);
+    try {
+      await acpUnarchiveSession(session.id);
+      updateSession((current) => ({ ...current, archived_at: null }));
+      window.dispatchEvent(
+        new CustomEvent(AppEvents.SESSION_ARCHIVED, {
+          detail: { sessionId: session.id, archived: false },
+        })
+      );
+      toast.success(intl.formatMessage(i18n.archivedRestored));
+    } catch (error) {
+      toast.error(
+        intl.formatMessage(i18n.archivedRestoreFailed, { error: errorMessage(error, 'Unknown error') })
+      );
+    } finally {
+      setIsUnarchiving(false);
+    }
+  }, [session, updateSession, intl]);
 
   const sessionModel = session?.model_config?.model_name ?? null;
   const sessionProvider = session?.provider_name ?? null;
@@ -429,6 +471,21 @@ export default function BaseChat({
           </div>
 
           <SessionActionsHeader session={session} onSessionChange={updateSession} />
+
+          {isArchived && (
+            <div className="no-drag flex items-center gap-2 px-6 py-1.5 text-xs text-text-secondary bg-background-secondary/60 border-b border-border-secondary">
+              <ArchiveRestore className="size-3.5 flex-shrink-0" />
+              <span className="flex-1 truncate">{intl.formatMessage(i18n.archivedNotice)}</span>
+              <button
+                type="button"
+                onClick={() => void handleUnarchive()}
+                disabled={isUnarchiving}
+                className="flex-shrink-0 font-medium text-text-primary hover:underline disabled:opacity-60 disabled:cursor-wait"
+              >
+                {intl.formatMessage(i18n.archivedRestore)}
+              </button>
+            </div>
+          )}
 
           <ScrollArea
             ref={scrollRef}

--- a/ui/desktop/src/components/BaseChat.tsx
+++ b/ui/desktop/src/components/BaseChat.tsx
@@ -1,5 +1,11 @@
 import { AppEvents } from '../constants/events';
 import { dispatchSessionLifecycleEvent } from '../sessionLifecycleBridge';
+import {
+  beginSessionStatusReporting,
+  endSessionStatusReporting,
+  reportSessionStatus,
+  sessionStreamStateFor,
+} from '../sessionStatusBroadcast';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { defineMessages, useIntl } from '../i18n';
 import { useLocation, useNavigate } from 'react-router';
@@ -180,23 +186,15 @@ export default function BaseChat({
     handleSubmit,
   });
 
+  // Hand reporting back to the ACP store when this chat unmounts mid-run, so a
+  // session evicted while busy still reports idle once its run finishes.
   useEffect(() => {
-    let streamState: 'idle' | 'loading' | 'streaming' | 'waiting' | 'error' = 'idle';
-    if (chatState === ChatState.LoadingConversation) {
-      streamState = 'loading';
-    } else if (
-      chatState === ChatState.Streaming ||
-      chatState === ChatState.Thinking ||
-      chatState === ChatState.Compacting
-    ) {
-      streamState = 'streaming';
-    } else if (chatState === ChatState.WaitingForUserInput) {
-      // A prompt paused on a permission/elicitation request still has an
-      // active server run, so it must not report as idle.
-      streamState = 'waiting';
-    } else if (sessionLoadError) {
-      streamState = 'error';
-    }
+    beginSessionStatusReporting(sessionId);
+    return () => endSessionStatusReporting(sessionId);
+  }, [sessionId]);
+
+  useEffect(() => {
+    const streamState = sessionStreamStateFor(chatState, sessionLoadError);
 
     window.dispatchEvent(
       new CustomEvent(AppEvents.SESSION_STATUS_UPDATE, {
@@ -207,9 +205,7 @@ export default function BaseChat({
         },
       })
     );
-    // Other desktop windows run their own backends and cannot see this run;
-    // relay the status through the main process so their archive guards can.
-    window.electron?.broadcastSessionStatus?.({ sessionId, streamState });
+    reportSessionStatus(sessionId, streamState);
   }, [sessionId, chatState, messages.length, sessionLoadError]);
 
   // Generate command history from user messages (most recent first)

--- a/ui/desktop/src/components/BaseChat.tsx
+++ b/ui/desktop/src/components/BaseChat.tsx
@@ -180,7 +180,7 @@ export default function BaseChat({
   });
 
   useEffect(() => {
-    let streamState: 'idle' | 'loading' | 'streaming' | 'error' = 'idle';
+    let streamState: 'idle' | 'loading' | 'streaming' | 'waiting' | 'error' = 'idle';
     if (chatState === ChatState.LoadingConversation) {
       streamState = 'loading';
     } else if (
@@ -189,6 +189,10 @@ export default function BaseChat({
       chatState === ChatState.Compacting
     ) {
       streamState = 'streaming';
+    } else if (chatState === ChatState.WaitingForUserInput) {
+      // A prompt paused on a permission/elicitation request still has an
+      // active server run, so it must not report as idle.
+      streamState = 'waiting';
     } else if (sessionLoadError) {
       streamState = 'error';
     }

--- a/ui/desktop/src/components/BaseChat.tsx
+++ b/ui/desktop/src/components/BaseChat.tsx
@@ -1,4 +1,5 @@
 import { AppEvents } from '../constants/events';
+import { dispatchSessionLifecycleEvent } from '../sessionLifecycleBridge';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { defineMessages, useIntl } from '../i18n';
 import { useLocation, useNavigate } from 'react-router';
@@ -241,11 +242,10 @@ export default function BaseChat({
     try {
       await acpUnarchiveSession(session.id);
       updateSession((current) => ({ ...current, archived_at: null }));
-      window.dispatchEvent(
-        new CustomEvent(AppEvents.SESSION_ARCHIVED, {
-          detail: { sessionId: session.id, archived: false },
-        })
-      );
+      dispatchSessionLifecycleEvent(AppEvents.SESSION_ARCHIVED, {
+        sessionId: session.id,
+        archived: false,
+      });
       toast.success(intl.formatMessage(i18n.archivedRestored));
     } catch (error) {
       toast.error(

--- a/ui/desktop/src/components/Layout/NavigationPanel.tsx
+++ b/ui/desktop/src/components/Layout/NavigationPanel.tsx
@@ -6,6 +6,7 @@ import { toast } from 'react-toastify';
 import { useNavigationContext } from './NavigationContext';
 import { useConfig } from '../ConfigContext';
 import { useNavigationSessions } from '../../hooks/useNavigationSessions';
+import { useSessionBusyElsewhere } from '../../hooks/useSessionBusyElsewhere';
 import {
   NAV_ITEMS,
   SETTINGS_NAV_ITEM,
@@ -247,9 +248,14 @@ const SessionRow: React.FC<SessionRowProps> = ({
   const isStreaming = status?.streamState === 'streaming';
   // Archiving must not race an active run: mid-load the server can re-register
   // the agent after archive removed it, and streaming or waiting-on-user-input
-  // prompts would resume into a removed session, so gate all three states.
+  // prompts would resume into a removed session, so gate all three states —
+  // including runs owned by other desktop windows.
+  const busyElsewhere = useSessionBusyElsewhere(session.id);
   const isArchiveBlocked =
-    isStreaming || status?.streamState === 'loading' || status?.streamState === 'waiting';
+    isStreaming ||
+    status?.streamState === 'loading' ||
+    status?.streamState === 'waiting' ||
+    busyElsewhere;
   const hasError = status?.streamState === 'error';
   const hasUnread = status?.hasUnreadActivity ?? false;
 

--- a/ui/desktop/src/components/Layout/NavigationPanel.tsx
+++ b/ui/desktop/src/components/Layout/NavigationPanel.tsx
@@ -1,7 +1,8 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useLocation } from 'react-router';
-import { ChevronDown, ChevronRight } from 'lucide-react';
+import { Archive, ChevronDown, ChevronRight, MoreHorizontal, Pencil, Trash2 } from 'lucide-react';
 import { motion } from 'framer-motion';
+import { toast } from 'react-toastify';
 import { useNavigationContext } from './NavigationContext';
 import { useConfig } from '../ConfigContext';
 import { useNavigationSessions } from '../../hooks/useNavigationSessions';
@@ -14,9 +15,23 @@ import {
 import { AppEvents } from '../../constants/events';
 import { InlineEditText } from '../common/InlineEditText';
 import { SessionIndicators } from '../SessionIndicators';
-import { acpRenameSession, type SessionListItem } from '../../acp/sessions';
+import {
+  acpArchiveSession,
+  acpDeleteSession,
+  acpRenameSession,
+  type SessionListItem,
+} from '../../acp/sessions';
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/Tooltip';
 import { formatMessageTimestamp } from '../../utils/timeUtils';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '../ui/dropdown-menu';
+import { ConfirmationModal } from '../ui/ConfirmationModal';
+import { errorMessage } from '../../utils/conversionUtils';
 import { cn } from '../../utils';
 import type { ProjectGroup } from '../../utils/projectSessions';
 import { defineMessages, useIntl } from '../../i18n';
@@ -77,6 +92,54 @@ const i18n = defineMessages({
     id: 'navigationPanel.statusIdle',
     defaultMessage: 'Idle',
   },
+  sessionActions: {
+    id: 'navigationPanel.sessionActions',
+    defaultMessage: 'Session actions',
+  },
+  rename: {
+    id: 'navigationPanel.rename',
+    defaultMessage: 'Rename',
+  },
+  archive: {
+    id: 'navigationPanel.archive',
+    defaultMessage: 'Archive',
+  },
+  delete: {
+    id: 'navigationPanel.delete',
+    defaultMessage: 'Delete',
+  },
+  archiveSuccess: {
+    id: 'navigationPanel.archiveSuccess',
+    defaultMessage: 'Archived “{name}”',
+  },
+  archiveFailed: {
+    id: 'navigationPanel.archiveFailed',
+    defaultMessage: 'Failed to archive session: {error}',
+  },
+  deleteTitle: {
+    id: 'navigationPanel.deleteTitle',
+    defaultMessage: 'Delete chat',
+  },
+  deleteMessage: {
+    id: 'navigationPanel.deleteMessage',
+    defaultMessage: 'Are you sure you want to delete “{name}”? This cannot be undone.',
+  },
+  deleteConfirm: {
+    id: 'navigationPanel.deleteConfirm',
+    defaultMessage: 'Delete',
+  },
+  deleteCancel: {
+    id: 'navigationPanel.deleteCancel',
+    defaultMessage: 'Cancel',
+  },
+  deleteSuccess: {
+    id: 'navigationPanel.deleteSuccess',
+    defaultMessage: 'Chat deleted',
+  },
+  deleteFailed: {
+    id: 'navigationPanel.deleteFailed',
+    defaultMessage: 'Failed to delete session: {error}',
+  },
 });
 
 const navItemClass = (active: boolean) =>
@@ -114,6 +177,7 @@ interface SessionRowProps {
   status: SessionStatus | undefined;
   onClick: () => void;
   onRenamed: () => void;
+  onRequestDelete: (session: SessionListItem) => void;
 }
 
 const formatTimestamp = (value?: string): string | null => {
@@ -163,10 +227,20 @@ const SessionTooltipContent: React.FC<SessionTooltipContentProps> = ({ session, 
   );
 };
 
-const SessionRow: React.FC<SessionRowProps> = ({ session, active, status, onClick, onRenamed }) => {
+const SessionRow: React.FC<SessionRowProps> = ({
+  session,
+  active,
+  status,
+  onClick,
+  onRenamed,
+  onRequestDelete,
+}) => {
   const intl = useIntl();
   const [isEditing, setIsEditing] = useState(false);
   const [tooltipOpen, setTooltipOpen] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [editSignal, setEditSignal] = useState(0);
+  const renameRequested = useRef(false);
   const isStreaming = status?.streamState === 'streaming';
   const hasError = status?.streamState === 'error';
   const hasUnread = status?.hasUnreadActivity ?? false;
@@ -179,13 +253,37 @@ const SessionRow: React.FC<SessionRowProps> = ({ session, active, status, onClic
         ? intl.formatMessage(i18n.statusUnread)
         : intl.formatMessage(i18n.statusIdle);
 
+  const handleArchive = useCallback(async () => {
+    try {
+      await acpArchiveSession(session.id);
+      window.dispatchEvent(
+        new CustomEvent(AppEvents.SESSION_ARCHIVED, {
+          detail: { sessionId: session.id, archived: true },
+        })
+      );
+      toast.success(intl.formatMessage(i18n.archiveSuccess, { name: session.name }));
+    } catch (error) {
+      toast.error(
+        intl.formatMessage(i18n.archiveFailed, { error: errorMessage(error, 'Unknown error') })
+      );
+    }
+  }, [session.id, session.name, intl]);
+
   return (
-    <Tooltip open={tooltipOpen && !isEditing} onOpenChange={setTooltipOpen} delayDuration={400}>
+    <Tooltip
+      open={tooltipOpen && !isEditing && !menuOpen}
+      onOpenChange={setTooltipOpen}
+      delayDuration={400}
+    >
       <TooltipTrigger asChild>
         <div
           onClick={() => !isEditing && onClick()}
+          onContextMenu={(e) => {
+            e.preventDefault();
+            setMenuOpen(true);
+          }}
           className={cn(
-            'flex items-center gap-2 px-3 py-1.5 rounded-full cursor-pointer text-sm',
+            'group flex items-center gap-2 px-3 py-1.5 rounded-full cursor-pointer text-sm',
             'hover:bg-background-tertiary/60 transition-colors',
             active && 'bg-background-tertiary'
           )}
@@ -204,12 +302,60 @@ const SessionRow: React.FC<SessionRowProps> = ({ session, active, status, onClic
             placeholder={intl.formatMessage(i18n.untitledSession)}
             disabled={isStreaming}
             singleClickEdit={false}
+            editRequestSignal={editSignal}
             className="truncate text-text-primary flex-1 !px-0 !py-0 hover:bg-transparent"
             editClassName="!text-sm"
             onEditStart={() => setIsEditing(true)}
             onEditEnd={() => setIsEditing(false)}
           />
           <SessionIndicators isStreaming={isStreaming} hasUnread={hasUnread} hasError={hasError} />
+          <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
+            <DropdownMenuTrigger asChild>
+              <button
+                type="button"
+                aria-label={intl.formatMessage(i18n.sessionActions)}
+                onClick={(e) => e.stopPropagation()}
+                className={cn(
+                  'flex-shrink-0 rounded p-0.5 text-text-secondary hover:text-text-primary hover:bg-background-tertiary transition-opacity',
+                  'opacity-0 group-hover:opacity-100 focus:opacity-100 data-[state=open]:opacity-100'
+                )}
+              >
+                <MoreHorizontal className="w-4 h-4" />
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent
+              align="end"
+              onClick={(e) => e.stopPropagation()}
+              onCloseAutoFocus={(e) => {
+                // Keep focus on the rename input we are about to reveal instead of
+                // letting Radix return focus to the trigger.
+                if (renameRequested.current) {
+                  e.preventDefault();
+                  renameRequested.current = false;
+                }
+              }}
+            >
+              <DropdownMenuItem
+                disabled={isStreaming}
+                onSelect={() => {
+                  renameRequested.current = true;
+                  setEditSignal((v) => v + 1);
+                }}
+              >
+                <Pencil className="w-4 h-4" />
+                {intl.formatMessage(i18n.rename)}
+              </DropdownMenuItem>
+              <DropdownMenuItem onSelect={() => void handleArchive()}>
+                <Archive className="w-4 h-4" />
+                {intl.formatMessage(i18n.archive)}
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem variant="destructive" onSelect={() => onRequestDelete(session)}>
+                <Trash2 className="w-4 h-4" />
+                {intl.formatMessage(i18n.delete)}
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
         </div>
       </TooltipTrigger>
       <TooltipContent side="right" align="start" className="max-w-xs text-left">
@@ -302,6 +448,32 @@ export const Navigation: React.FC<{ className?: string }> = ({ className }) => {
     });
   }, []);
 
+  const [sessionPendingDelete, setSessionPendingDelete] = useState<SessionListItem | null>(null);
+
+  const handleRequestDelete = useCallback((session: SessionListItem) => {
+    setSessionPendingDelete(session);
+  }, []);
+
+  const handleConfirmDelete = useCallback(async () => {
+    if (!sessionPendingDelete) return;
+    const { id, name } = sessionPendingDelete;
+    setSessionPendingDelete(null);
+    try {
+      await acpDeleteSession(id);
+      window.dispatchEvent(
+        new CustomEvent(AppEvents.SESSION_DELETED, { detail: { sessionId: id } })
+      );
+      toast.success(intl.formatMessage(i18n.deleteSuccess));
+    } catch (error) {
+      toast.error(
+        intl.formatMessage(i18n.deleteFailed, {
+          name,
+          error: errorMessage(error, 'Unknown error'),
+        })
+      );
+    }
+  }, [sessionPendingDelete, intl]);
+
   if (!isNavExpanded) return null;
 
   return (
@@ -375,6 +547,7 @@ export const Navigation: React.FC<{ className?: string }> = ({ className }) => {
                             handleSessionClick(session.id);
                           }}
                           onRenamed={fetchSessions}
+                          onRequestDelete={handleRequestDelete}
                         />
                       ))}
                   </React.Fragment>
@@ -392,6 +565,7 @@ export const Navigation: React.FC<{ className?: string }> = ({ className }) => {
                     handleSessionClick(session.id);
                   }}
                   onRenamed={fetchSessions}
+                  onRequestDelete={handleRequestDelete}
                 />
               ))
             )}
@@ -406,6 +580,17 @@ export const Navigation: React.FC<{ className?: string }> = ({ className }) => {
           onClick={() => handleNavClick(SETTINGS_NAV_ITEM.path)}
         />
       </div>
+
+      <ConfirmationModal
+        isOpen={sessionPendingDelete !== null}
+        title={intl.formatMessage(i18n.deleteTitle)}
+        message={intl.formatMessage(i18n.deleteMessage, { name: sessionPendingDelete?.name ?? '' })}
+        confirmLabel={intl.formatMessage(i18n.deleteConfirm)}
+        cancelLabel={intl.formatMessage(i18n.deleteCancel)}
+        confirmVariant="destructive"
+        onConfirm={handleConfirmDelete}
+        onCancel={() => setSessionPendingDelete(null)}
+      />
     </motion.div>
   );
 };

--- a/ui/desktop/src/components/Layout/NavigationPanel.tsx
+++ b/ui/desktop/src/components/Layout/NavigationPanel.tsx
@@ -31,6 +31,9 @@ import {
   DropdownMenuTrigger,
 } from '../ui/dropdown-menu';
 import { ConfirmationModal } from '../ui/ConfirmationModal';
+import { acpChatSessionActions } from '../../acp/chatSessionStore';
+import { cancelAcpPermissionRequestsForSession } from '../../acp/permissionRequests';
+import { cancelAcpElicitationRequestsForSession } from '../../acp/elicitationRequests';
 import { errorMessage } from '../../utils/conversionUtils';
 import { cn } from '../../utils';
 import type { ProjectGroup } from '../../utils/projectSessions';
@@ -463,6 +466,9 @@ export const Navigation: React.FC<{ className?: string }> = ({ className }) => {
       window.dispatchEvent(
         new CustomEvent(AppEvents.SESSION_DELETED, { detail: { sessionId: id } })
       );
+      cancelAcpPermissionRequestsForSession(id);
+      cancelAcpElicitationRequestsForSession(id);
+      acpChatSessionActions.deleteSnapshot(id);
       toast.success(intl.formatMessage(i18n.deleteSuccess));
     } catch (error) {
       toast.error(

--- a/ui/desktop/src/components/Layout/NavigationPanel.tsx
+++ b/ui/desktop/src/components/Layout/NavigationPanel.tsx
@@ -245,6 +245,9 @@ const SessionRow: React.FC<SessionRowProps> = ({
   const [editSignal, setEditSignal] = useState(0);
   const renameRequested = useRef(false);
   const isStreaming = status?.streamState === 'streaming';
+  // Archiving a session that is still resuming races the load: the server can
+  // re-register the agent after archive removed it, so gate on loading too.
+  const isArchiveBlocked = isStreaming || status?.streamState === 'loading';
   const hasError = status?.streamState === 'error';
   const hasUnread = status?.hasUnreadActivity ?? false;
 
@@ -348,7 +351,7 @@ const SessionRow: React.FC<SessionRowProps> = ({
                 <Pencil className="w-4 h-4" />
                 {intl.formatMessage(i18n.rename)}
               </DropdownMenuItem>
-              <DropdownMenuItem disabled={isStreaming} onSelect={() => void handleArchive()}>
+              <DropdownMenuItem disabled={isArchiveBlocked} onSelect={() => void handleArchive()}>
                 <Archive className="w-4 h-4" />
                 {intl.formatMessage(i18n.archive)}
               </DropdownMenuItem>

--- a/ui/desktop/src/components/Layout/NavigationPanel.tsx
+++ b/ui/desktop/src/components/Layout/NavigationPanel.tsx
@@ -39,7 +39,7 @@ import { cn } from '../../utils';
 import type { ProjectGroup } from '../../utils/projectSessions';
 import { defineMessages, useIntl } from '../../i18n';
 
-type StreamState = 'idle' | 'loading' | 'streaming' | 'error';
+type StreamState = 'idle' | 'loading' | 'streaming' | 'waiting' | 'error';
 
 interface SessionStatus {
   streamState: StreamState;
@@ -245,9 +245,11 @@ const SessionRow: React.FC<SessionRowProps> = ({
   const [editSignal, setEditSignal] = useState(0);
   const renameRequested = useRef(false);
   const isStreaming = status?.streamState === 'streaming';
-  // Archiving a session that is still resuming races the load: the server can
-  // re-register the agent after archive removed it, so gate on loading too.
-  const isArchiveBlocked = isStreaming || status?.streamState === 'loading';
+  // Archiving must not race an active run: mid-load the server can re-register
+  // the agent after archive removed it, and streaming or waiting-on-user-input
+  // prompts would resume into a removed session, so gate all three states.
+  const isArchiveBlocked =
+    isStreaming || status?.streamState === 'loading' || status?.streamState === 'waiting';
   const hasError = status?.streamState === 'error';
   const hasUnread = status?.hasUnreadActivity ?? false;
 
@@ -404,7 +406,9 @@ export const Navigation: React.FC<{ className?: string }> = ({ className }) => {
       const { sessionId, streamState } = (event as CustomEvent).detail;
       setSessionStatuses((prev) => {
         const existing = prev.get(sessionId);
-        const shouldMarkUnread = existing?.streamState === 'streaming' && streamState === 'idle';
+        const shouldMarkUnread =
+          (existing?.streamState === 'streaming' || existing?.streamState === 'waiting') &&
+          streamState === 'idle';
         const next = new Map(prev);
         next.set(sessionId, {
           streamState,

--- a/ui/desktop/src/components/Layout/NavigationPanel.tsx
+++ b/ui/desktop/src/components/Layout/NavigationPanel.tsx
@@ -244,12 +244,12 @@ const SessionRow: React.FC<SessionRowProps> = ({
   const [editSignal, setEditSignal] = useState(0);
   const renameRequested = useRef(false);
   const isStreaming = status?.streamState === 'streaming';
-  // Archiving must not race an active run: mid-load the server can re-register
-  // the agent after archive removed it, and streaming or waiting-on-user-input
-  // prompts would resume into a removed session, so gate all three states —
-  // including runs owned by other desktop windows.
+  // Archive and delete both drop the loaded agent without cancelling an active
+  // run: mid-load the server can re-register the agent afterwards, and
+  // streaming or waiting-on-user-input prompts would resume into a session that
+  // is gone. Gate all three states — including runs owned by other windows.
   const busyElsewhere = useSessionBusyElsewhere(session.id);
-  const isArchiveBlocked =
+  const isBusy =
     isStreaming ||
     status?.streamState === 'loading' ||
     status?.streamState === 'waiting' ||
@@ -356,12 +356,16 @@ const SessionRow: React.FC<SessionRowProps> = ({
                 <Pencil className="w-4 h-4" />
                 {intl.formatMessage(i18n.rename)}
               </DropdownMenuItem>
-              <DropdownMenuItem disabled={isArchiveBlocked} onSelect={() => void handleArchive()}>
+              <DropdownMenuItem disabled={isBusy} onSelect={() => void handleArchive()}>
                 <Archive className="w-4 h-4" />
                 {intl.formatMessage(i18n.archive)}
               </DropdownMenuItem>
               <DropdownMenuSeparator />
-              <DropdownMenuItem variant="destructive" onSelect={() => onRequestDelete(session)}>
+              <DropdownMenuItem
+                variant="destructive"
+                disabled={isBusy}
+                onSelect={() => onRequestDelete(session)}
+              >
                 <Trash2 className="w-4 h-4" />
                 {intl.formatMessage(i18n.delete)}
               </DropdownMenuItem>

--- a/ui/desktop/src/components/Layout/NavigationPanel.tsx
+++ b/ui/desktop/src/components/Layout/NavigationPanel.tsx
@@ -348,7 +348,7 @@ const SessionRow: React.FC<SessionRowProps> = ({
                 <Pencil className="w-4 h-4" />
                 {intl.formatMessage(i18n.rename)}
               </DropdownMenuItem>
-              <DropdownMenuItem onSelect={() => void handleArchive()}>
+              <DropdownMenuItem disabled={isStreaming} onSelect={() => void handleArchive()}>
                 <Archive className="w-4 h-4" />
                 {intl.formatMessage(i18n.archive)}
               </DropdownMenuItem>

--- a/ui/desktop/src/components/Layout/NavigationPanel.tsx
+++ b/ui/desktop/src/components/Layout/NavigationPanel.tsx
@@ -33,9 +33,6 @@ import {
   DropdownMenuTrigger,
 } from '../ui/dropdown-menu';
 import { ConfirmationModal } from '../ui/ConfirmationModal';
-import { acpChatSessionActions } from '../../acp/chatSessionStore';
-import { cancelAcpPermissionRequestsForSession } from '../../acp/permissionRequests';
-import { cancelAcpElicitationRequestsForSession } from '../../acp/elicitationRequests';
 import { errorMessage } from '../../utils/conversionUtils';
 import { cn } from '../../utils';
 import type { ProjectGroup } from '../../utils/projectSessions';
@@ -476,10 +473,8 @@ export const Navigation: React.FC<{ className?: string }> = ({ className }) => {
     setSessionPendingDelete(null);
     try {
       await acpDeleteSession(id);
+      // App's SESSION_DELETED handler runs the ACP cleanup for every window.
       dispatchSessionLifecycleEvent(AppEvents.SESSION_DELETED, { sessionId: id });
-      cancelAcpPermissionRequestsForSession(id);
-      cancelAcpElicitationRequestsForSession(id);
-      acpChatSessionActions.deleteSnapshot(id);
       toast.success(intl.formatMessage(i18n.deleteSuccess));
     } catch (error) {
       toast.error(

--- a/ui/desktop/src/components/Layout/NavigationPanel.tsx
+++ b/ui/desktop/src/components/Layout/NavigationPanel.tsx
@@ -7,6 +7,7 @@ import { useNavigationContext } from './NavigationContext';
 import { useConfig } from '../ConfigContext';
 import { useNavigationSessions } from '../../hooks/useNavigationSessions';
 import { useSessionBusyElsewhere } from '../../hooks/useSessionBusyElsewhere';
+import { dispatchSessionLifecycleEvent } from '../../sessionLifecycleBridge';
 import {
   NAV_ITEMS,
   SETTINGS_NAV_ITEM,
@@ -270,11 +271,10 @@ const SessionRow: React.FC<SessionRowProps> = ({
   const handleArchive = useCallback(async () => {
     try {
       await acpArchiveSession(session.id);
-      window.dispatchEvent(
-        new CustomEvent(AppEvents.SESSION_ARCHIVED, {
-          detail: { sessionId: session.id, archived: true },
-        })
-      );
+      dispatchSessionLifecycleEvent(AppEvents.SESSION_ARCHIVED, {
+        sessionId: session.id,
+        archived: true,
+      });
       toast.success(intl.formatMessage(i18n.archiveSuccess, { name: session.name }));
     } catch (error) {
       toast.error(
@@ -476,9 +476,7 @@ export const Navigation: React.FC<{ className?: string }> = ({ className }) => {
     setSessionPendingDelete(null);
     try {
       await acpDeleteSession(id);
-      window.dispatchEvent(
-        new CustomEvent(AppEvents.SESSION_DELETED, { detail: { sessionId: id } })
-      );
+      dispatchSessionLifecycleEvent(AppEvents.SESSION_DELETED, { sessionId: id });
       cancelAcpPermissionRequestsForSession(id);
       cancelAcpElicitationRequestsForSession(id);
       acpChatSessionActions.deleteSnapshot(id);

--- a/ui/desktop/src/components/Layout/NavigationPanel.tsx
+++ b/ui/desktop/src/components/Layout/NavigationPanel.tsx
@@ -6,7 +6,11 @@ import { toast } from 'react-toastify';
 import { useNavigationContext } from './NavigationContext';
 import { useConfig } from '../ConfigContext';
 import { useNavigationSessions } from '../../hooks/useNavigationSessions';
-import { useSessionBusyElsewhere } from '../../hooks/useSessionBusyElsewhere';
+import {
+  isSessionBusy,
+  useSessionBusy,
+  useSessionBusyElsewhere,
+} from '../../hooks/useSessionBusyElsewhere';
 import { dispatchSessionLifecycleEvent } from '../../sessionLifecycleBridge';
 import {
   NAV_ITEMS,
@@ -471,9 +475,14 @@ export const Navigation: React.FC<{ className?: string }> = ({ className }) => {
     setSessionPendingDelete(session);
   }, []);
 
+  // The dialog can sit open while the session starts a run elsewhere, so
+  // re-check instead of trusting the state the menu item was disabled on.
+  const pendingDeleteBusy = useSessionBusy(sessionPendingDelete?.id ?? '');
+
   const handleConfirmDelete = useCallback(async () => {
     if (!sessionPendingDelete) return;
     const { id, name } = sessionPendingDelete;
+    if (isSessionBusy(id)) return;
     setSessionPendingDelete(null);
     try {
       await acpDeleteSession(id);
@@ -604,6 +613,7 @@ export const Navigation: React.FC<{ className?: string }> = ({ className }) => {
         confirmLabel={intl.formatMessage(i18n.deleteConfirm)}
         cancelLabel={intl.formatMessage(i18n.deleteCancel)}
         confirmVariant="destructive"
+        confirmDisabled={pendingDeleteBusy}
         onConfirm={handleConfirmDelete}
         onCancel={() => setSessionPendingDelete(null)}
       />

--- a/ui/desktop/src/components/common/InlineEditText.tsx
+++ b/ui/desktop/src/components/common/InlineEditText.tsx
@@ -34,6 +34,12 @@ interface InlineEditTextProps {
   onEditEnd?: () => void;
   allowEmpty?: boolean;
   singleClickEdit?: boolean;
+  /**
+   * Monotonically increasing signal used to start editing programmatically
+   * (e.g. from a context-menu "Rename" action). Editing begins whenever this
+   * value changes to a new number.
+   */
+  editRequestSignal?: number;
 }
 
 export const InlineEditText: React.FC<InlineEditTextProps> = ({
@@ -48,6 +54,7 @@ export const InlineEditText: React.FC<InlineEditTextProps> = ({
   onEditEnd,
   allowEmpty = false,
   singleClickEdit = true,
+  editRequestSignal,
 }) => {
   const intl = useIntl();
   const resolvedPlaceholder = placeholder ?? intl.formatMessage(i18n.enterText);
@@ -77,6 +84,14 @@ export const InlineEditText: React.FC<InlineEditTextProps> = ({
     setEditValue(value);
     onEditStart?.();
   }, [disabled, isSaving, value, onEditStart]);
+
+  const lastEditSignal = useRef(editRequestSignal);
+  useEffect(() => {
+    if (editRequestSignal !== undefined && editRequestSignal !== lastEditSignal.current) {
+      lastEditSignal.current = editRequestSignal;
+      handleStartEdit();
+    }
+  }, [editRequestSignal, handleStartEdit]);
 
   const handleCancel = useCallback(() => {
     setIsEditing(false);

--- a/ui/desktop/src/components/sessions/SessionListView.tsx
+++ b/ui/desktop/src/components/sessions/SessionListView.tsx
@@ -801,9 +801,9 @@ const SessionListView: React.FC<SessionListViewProps> = React.memo(({ onSelectSe
       onToggleArchive: (session: SessionListItem) => void;
     isSharing: boolean;
   }) {
-      // Archiving removes the loaded agent without cancelling an active prompt
-      // run, and archiving mid-load races the server re-registering the agent,
-      // so gate the action unless the session is idle (like the sidebar does).
+      // Archive and delete remove the loaded agent without cancelling an active
+      // prompt run, and doing so mid-load races the server re-registering the
+      // agent, so gate both unless the session is idle (like the sidebar does).
       // Anything non-idle — streaming, thinking, compacting, loading, waiting
       // on a permission/elicitation, restarting — still has server-side work
       // that would resume into a removed session. The local snapshot cannot see
@@ -811,8 +811,7 @@ const SessionListView: React.FC<SessionListViewProps> = React.memo(({ onSelectSe
       // busy registry.
       const chatState = useAcpChatSessionSnapshot(session.id)?.chatState;
       const busyElsewhere = useSessionBusyElsewhere(session.id);
-      const isArchiveBlocked =
-        (chatState !== undefined && chatState !== ChatState.Idle) || busyElsewhere;
+      const isBusy = (chatState !== undefined && chatState !== ChatState.Idle) || busyElsewhere;
 
     const handleEditClick = useCallback(
       (e: React.MouseEvent) => {
@@ -923,14 +922,15 @@ const SessionListView: React.FC<SessionListViewProps> = React.memo(({ onSelectSe
           </button>
           <button
             onClick={handleDeleteClick}
-            className="p-2 rounded hover:bg-red-50 dark:hover:bg-red-900/20 cursor-pointer transition-colors"
+              disabled={isBusy}
+              className="p-2 rounded hover:bg-red-50 dark:hover:bg-red-900/20 cursor-pointer transition-colors disabled:cursor-not-allowed disabled:opacity-60"
             title={intl.formatMessage(i18n.deleteSession)}
           >
             <Trash2 className="w-3 h-3 text-red-500 hover:text-red-600" />
           </button>
           <button
             onClick={handleArchiveClick}
-              disabled={isArchiveBlocked}
+              disabled={isBusy}
               className="p-2 rounded hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer disabled:cursor-not-allowed disabled:opacity-60"
             title={intl.formatMessage(
               session.archivedAt ? i18n.unarchiveSession : i18n.archiveSession

--- a/ui/desktop/src/components/sessions/SessionListView.tsx
+++ b/ui/desktop/src/components/sessions/SessionListView.tsx
@@ -57,12 +57,10 @@ import {
   type SessionListItem,
 } from '../../acp/sessions';
 import type { SessionExportFormat } from '@aaif/goose-sdk';
-import { acpChatSessionActions, useAcpChatSessionSnapshot } from '../../acp/chatSessionStore';
+import { useAcpChatSessionSnapshot } from '../../acp/chatSessionStore';
 import { useSessionBusyElsewhere } from '../../hooks/useSessionBusyElsewhere';
 import { dispatchSessionLifecycleEvent } from '../../sessionLifecycleBridge';
 import { ChatState } from '../../types/chatState';
-import { cancelAcpPermissionRequestsForSession } from '../../acp/permissionRequests';
-import { cancelAcpElicitationRequestsForSession } from '../../acp/elicitationRequests';
 import { getSearchShortcutText } from '../../utils/keyboardShortcuts';
 
 // In the Active view a keyword search still surfaces archived matches so a
@@ -632,9 +630,6 @@ const SessionListView: React.FC<SessionListViewProps> = React.memo(({ onSelectSe
         dispatchSessionLifecycleEvent(AppEvents.SESSION_DELETED, {
           sessionId: sessionToDeleteId,
         });
-      cancelAcpPermissionRequestsForSession(sessionToDeleteId);
-      cancelAcpElicitationRequestsForSession(sessionToDeleteId);
-      acpChatSessionActions.deleteSnapshot(sessionToDeleteId);
     } catch (error) {
       console.error('Error deleting session:', error);
       toast.error(

--- a/ui/desktop/src/components/sessions/SessionListView.tsx
+++ b/ui/desktop/src/components/sessions/SessionListView.tsx
@@ -807,14 +807,12 @@ const SessionListView: React.FC<SessionListViewProps> = React.memo(({ onSelectSe
   }) {
       // Archiving removes the loaded agent without cancelling an active prompt
       // run, and archiving mid-load races the server re-registering the agent,
-      // so gate the action while the session is streaming or still loading
-      // (like the sidebar does).
+      // so gate the action unless the session is idle (like the sidebar does).
+      // Anything non-idle — streaming, thinking, compacting, loading, waiting
+      // on a permission/elicitation, restarting — still has server-side work
+      // that would resume into a removed session.
       const chatState = useAcpChatSessionSnapshot(session.id)?.chatState;
-      const isArchiveBlocked =
-        chatState === ChatState.Streaming ||
-        chatState === ChatState.Thinking ||
-        chatState === ChatState.Compacting ||
-        chatState === ChatState.LoadingConversation;
+      const isArchiveBlocked = chatState !== undefined && chatState !== ChatState.Idle;
 
     const handleEditClick = useCallback(
       (e: React.MouseEvent) => {

--- a/ui/desktop/src/components/sessions/SessionListView.tsx
+++ b/ui/desktop/src/components/sessions/SessionListView.tsx
@@ -58,6 +58,7 @@ import {
 } from '../../acp/sessions';
 import type { SessionExportFormat } from '@aaif/goose-sdk';
 import { acpChatSessionActions, useAcpChatSessionSnapshot } from '../../acp/chatSessionStore';
+import { useSessionBusyElsewhere } from '../../hooks/useSessionBusyElsewhere';
 import { ChatState } from '../../types/chatState';
 import { cancelAcpPermissionRequestsForSession } from '../../acp/permissionRequests';
 import { cancelAcpElicitationRequestsForSession } from '../../acp/elicitationRequests';
@@ -810,9 +811,13 @@ const SessionListView: React.FC<SessionListViewProps> = React.memo(({ onSelectSe
       // so gate the action unless the session is idle (like the sidebar does).
       // Anything non-idle — streaming, thinking, compacting, loading, waiting
       // on a permission/elicitation, restarting — still has server-side work
-      // that would resume into a removed session.
+      // that would resume into a removed session. The local snapshot cannot see
+      // runs owned by other desktop windows, so also consult the cross-window
+      // busy registry.
       const chatState = useAcpChatSessionSnapshot(session.id)?.chatState;
-      const isArchiveBlocked = chatState !== undefined && chatState !== ChatState.Idle;
+      const busyElsewhere = useSessionBusyElsewhere(session.id);
+      const isArchiveBlocked =
+        (chatState !== undefined && chatState !== ChatState.Idle) || busyElsewhere;
 
     const handleEditClick = useCallback(
       (e: React.MouseEvent) => {

--- a/ui/desktop/src/components/sessions/SessionListView.tsx
+++ b/ui/desktop/src/components/sessions/SessionListView.tsx
@@ -57,10 +57,8 @@ import {
   type SessionListItem,
 } from '../../acp/sessions';
 import type { SessionExportFormat } from '@aaif/goose-sdk';
-import { useAcpChatSessionSnapshot } from '../../acp/chatSessionStore';
-import { useSessionBusyElsewhere } from '../../hooks/useSessionBusyElsewhere';
+import { isSessionBusy, useSessionBusy } from '../../hooks/useSessionBusyElsewhere';
 import { dispatchSessionLifecycleEvent } from '../../sessionLifecycleBridge';
-import { ChatState } from '../../types/chatState';
 import { getSearchShortcutText } from '../../utils/keyboardShortcuts';
 
 // In the Active view a keyword search still surfaces archived matches so a
@@ -616,8 +614,13 @@ const SessionListView: React.FC<SessionListViewProps> = React.memo(({ onSelectSe
       [intl, loadSessions]
     );
 
+    // The dialog can sit open while the session starts a run elsewhere, so
+    // re-check instead of trusting the state the button was disabled on.
+    const pendingDeleteBusy = useSessionBusy(sessionToDelete?.id ?? '');
+
   const handleConfirmDelete = useCallback(async () => {
     if (!sessionToDelete) return;
+      if (isSessionBusy(sessionToDelete.id)) return;
 
     setShowDeleteConfirmation(false);
     const sessionToDeleteId = sessionToDelete.id;
@@ -809,9 +812,7 @@ const SessionListView: React.FC<SessionListViewProps> = React.memo(({ onSelectSe
       // that would resume into a removed session. The local snapshot cannot see
       // runs owned by other desktop windows, so also consult the cross-window
       // busy registry.
-      const chatState = useAcpChatSessionSnapshot(session.id)?.chatState;
-      const busyElsewhere = useSessionBusyElsewhere(session.id);
-      const isBusy = (chatState !== undefined && chatState !== ChatState.Idle) || busyElsewhere;
+      const isBusy = useSessionBusy(session.id);
 
     const handleEditClick = useCallback(
       (e: React.MouseEvent) => {
@@ -1332,6 +1333,7 @@ const SessionListView: React.FC<SessionListViewProps> = React.memo(({ onSelectSe
         confirmLabel={intl.formatMessage(i18n.deleteTitle)}
         cancelLabel={intl.formatMessage(i18n.cancel)}
         confirmVariant="destructive"
+          confirmDisabled={pendingDeleteBusy}
         onConfirm={handleConfirmDelete}
         onCancel={handleCancelDelete}
       />

--- a/ui/desktop/src/components/sessions/SessionListView.tsx
+++ b/ui/desktop/src/components/sessions/SessionListView.tsx
@@ -581,8 +581,16 @@ const SessionListView: React.FC<SessionListViewProps> = React.memo(({ onSelectSe
     const handleToggleArchive = useCallback(
       async (session: SessionListItem) => {
         const isArchived = !!session.archivedAt;
-        // Optimistically drop the row: it leaves the current view either way.
-        setSessions((prev) => prev.filter((s) => s.id !== session.id));
+        const nextArchivedAt = isArchived ? undefined : new Date().toISOString();
+        // The `all` filter (Active tab with a search) shows both states, so the row
+        // still matches after toggling — update it in place. In the scoped `active`
+        // or `archived` views the toggled row leaves the filter, so drop it.
+        const staysInView = archivedFilterRef.current === 'all';
+        setSessions((prev) =>
+          staysInView
+            ? prev.map((s) => (s.id === session.id ? { ...s, archivedAt: nextArchivedAt } : s))
+            : prev.filter((s) => s.id !== session.id)
+        );
         try {
           if (isArchived) {
             await acpUnarchiveSession(session.id);

--- a/ui/desktop/src/components/sessions/SessionListView.tsx
+++ b/ui/desktop/src/components/sessions/SessionListView.tsx
@@ -488,6 +488,48 @@ const SessionListView: React.FC<SessionListViewProps> = React.memo(({ onSelectSe
     };
     }, [loadSessions, debouncedSearchTerm, archivedView]);
 
+    // Sessions can be archived, restored, or deleted from the sidebar menu or
+    // another window while this view stays mounted, so consume the lifecycle
+    // events to keep the list current. A row leaving the current filter is
+    // dropped in place; an event that can surface a new row refetches under the
+    // current keyword/filter.
+    useEffect(() => {
+      const handleSessionDeleted = (event: Event) => {
+        const { sessionId } = (event as CustomEvent<{ sessionId: string }>).detail;
+        setSessions((prev) => prev.filter((s) => s.id !== sessionId));
+      };
+
+      const handleSessionArchived = (event: Event) => {
+        const { sessionId, archived } = (
+          event as CustomEvent<{ sessionId: string; archived?: boolean }>
+        ).detail;
+        const filter = archivedFilterRef.current;
+        if (filter === 'all') {
+          setSessions((prev) =>
+            prev.map((s) =>
+              s.id === sessionId
+                ? { ...s, archivedAt: archived ? new Date().toISOString() : undefined }
+                : s
+            )
+          );
+          return;
+        }
+        const leavesView = archived ? filter === 'active' : filter === 'archived';
+        if (leavesView) {
+          setSessions((prev) => prev.filter((s) => s.id !== sessionId));
+        } else {
+          void loadSessions();
+        }
+      };
+
+      window.addEventListener(AppEvents.SESSION_DELETED, handleSessionDeleted);
+      window.addEventListener(AppEvents.SESSION_ARCHIVED, handleSessionArchived);
+      return () => {
+        window.removeEventListener(AppEvents.SESSION_DELETED, handleSessionDeleted);
+        window.removeEventListener(AppEvents.SESSION_ARCHIVED, handleSessionArchived);
+      };
+    }, [loadSessions]);
+
   // Hide Nostr sharing when explicitly disabled via env var (restricted/enterprise bundles)
   useEffect(() => {
     const config = window.electron.getConfig();

--- a/ui/desktop/src/components/sessions/SessionListView.tsx
+++ b/ui/desktop/src/components/sessions/SessionListView.tsx
@@ -66,7 +66,9 @@ import { getSearchShortcutText } from '../../utils/keyboardShortcuts';
 // deliberately hidden session remains findable; the Archived view is scoped.
 function archivedFilterFor(keyword: string, archivedView: boolean): ArchivedFilter {
   if (archivedView) return 'archived';
-  return keyword ? 'all' : 'active';
+  // Match acpListSessions, which trims the keyword and omits an empty query — a
+  // whitespace-only term must not widen the Active view to archived sessions.
+  return keyword.trim() ? 'all' : 'active';
 }
 
 const i18n = defineMessages({

--- a/ui/desktop/src/components/sessions/SessionListView.tsx
+++ b/ui/desktop/src/components/sessions/SessionListView.tsx
@@ -14,6 +14,8 @@ import {
   LoaderCircle,
   ExternalLink,
   Copy,
+  Archive,
+  ArchiveRestore,
 } from 'lucide-react';
 import { Card } from '../ui/card';
 import { Button } from '../ui/button';
@@ -23,6 +25,7 @@ import { SearchView } from '../conversation/SearchView';
 import { MainPanelLayout } from '../Layout/MainPanelLayout';
 import { groupSessionsByDate, sessionActivityAt, type DateGroup } from '../../utils/dateUtils';
 import { errorMessage } from '../../utils/conversionUtils';
+import { cn } from '../../utils';
 import { Skeleton } from '../ui/skeleton';
 import { toast } from 'react-toastify';
 import { ConfirmationModal } from '../ui/ConfirmationModal';
@@ -41,6 +44,7 @@ import {
   DropdownMenuTrigger,
 } from '../ui/dropdown-menu';
 import {
+  acpArchiveSession,
   acpDeleteSession,
   acpExportSession,
   acpForkSession,
@@ -48,6 +52,8 @@ import {
   acpListSessions,
   acpRenameSession,
   acpShareSessionNostr,
+  acpUnarchiveSession,
+  type ArchivedFilter,
   type SessionListItem,
 } from '../../acp/sessions';
 import type { SessionExportFormat } from '@aaif/goose-sdk';
@@ -55,6 +61,13 @@ import { acpChatSessionActions } from '../../acp/chatSessionStore';
 import { cancelAcpPermissionRequestsForSession } from '../../acp/permissionRequests';
 import { cancelAcpElicitationRequestsForSession } from '../../acp/elicitationRequests';
 import { getSearchShortcutText } from '../../utils/keyboardShortcuts';
+
+// In the Active view a keyword search still surfaces archived matches so a
+// deliberately hidden session remains findable; the Archived view is scoped.
+function archivedFilterFor(keyword: string, archivedView: boolean): ArchivedFilter {
+  if (archivedView) return 'archived';
+  return keyword ? 'all' : 'active';
+}
 
 const i18n = defineMessages({
   editSessionTitle: { id: 'sessions.edit.title', defaultMessage: 'Edit Session Description' },
@@ -162,6 +175,16 @@ const i18n = defineMessages({
     defaultMessage:
       'Anyone with this link can fetch and decrypt the session. Treat it like a secret.',
   },
+  archiveSession: { id: 'sessions.action.archive', defaultMessage: 'Archive session' },
+  unarchiveSession: { id: 'sessions.action.unarchive', defaultMessage: 'Restore from archive' },
+  archiveSuccess: { id: 'sessions.toast.archived', defaultMessage: 'Session archived' },
+  archiveFailed: { id: 'sessions.toast.archiveFailed', defaultMessage: 'Failed to archive session: {error}' },
+  unarchiveSuccess: { id: 'sessions.toast.unarchived', defaultMessage: 'Session restored' },
+  unarchiveFailed: { id: 'sessions.toast.unarchiveFailed', defaultMessage: 'Failed to restore session: {error}' },
+  activeTab: { id: 'sessions.tab.active', defaultMessage: 'Active' },
+  archivedTab: { id: 'sessions.tab.archived', defaultMessage: 'Archived' },
+  noArchived: { id: 'sessions.noArchived', defaultMessage: 'No archived sessions' },
+  noArchivedDesc: { id: 'sessions.noArchivedDesc', defaultMessage: 'Sessions you archive will appear here.' },
   close: { id: 'sessions.close', defaultMessage: 'Close' },
 });
 
@@ -337,6 +360,9 @@ const SessionListView: React.FC<SessionListViewProps> = React.memo(({ onSelectSe
   const debouncedSearchTermRef = useRef(debouncedSearchTerm);
   debouncedSearchTermRef.current = debouncedSearchTerm;
 
+    const [archivedView, setArchivedView] = useState(false);
+    const archivedFilterRef = useRef<ArchivedFilter>('active');
+
   const containerRef = useRef<HTMLDivElement>(null);
   const loadGenerationRef = useRef(0);
   const hasLoadedRef = useRef(false);
@@ -361,13 +387,18 @@ const SessionListView: React.FC<SessionListViewProps> = React.memo(({ onSelectSe
   }, [debouncedSearchTerm, dateGroups.length]);
 
   const loadRemainingSessionPages = useCallback(
-    async (initialCursor: string, loadId: number, keyword?: string) => {
+      async (
+        initialCursor: string,
+        loadId: number,
+        keyword?: string,
+        archived: ArchivedFilter = archivedFilterRef.current
+      ) => {
       let cursor: string | null = initialCursor;
       setIsPrefetchingSessions(true);
 
       try {
         while (cursor && loadGenerationRef.current === loadId) {
-          const resp = await acpListSessions(cursor, { keyword });
+            const resp = await acpListSessions(cursor, { keyword, archived });
           if (loadGenerationRef.current !== loadId) return;
 
           cursor = resp.nextCursor;
@@ -390,7 +421,11 @@ const SessionListView: React.FC<SessionListViewProps> = React.memo(({ onSelectSe
   );
 
   const loadSessions = useCallback(
-    async (keyword: string = debouncedSearchTermRef.current) => {
+      async (
+        keyword: string = debouncedSearchTermRef.current,
+        archived: ArchivedFilter = archivedFilterRef.current
+      ) => {
+        archivedFilterRef.current = archived;
       const loadId = loadGenerationRef.current + 1;
       loadGenerationRef.current = loadId;
       // Only show the skeleton on the first load; subsequent loads (e.g. typing a
@@ -404,7 +439,7 @@ const SessionListView: React.FC<SessionListViewProps> = React.memo(({ onSelectSe
         setShowContent(false);
       }
       try {
-        const resp = await acpListSessions(undefined, { keyword });
+          const resp = await acpListSessions(undefined, { keyword, archived });
         if (loadGenerationRef.current !== loadId) return;
         hasLoadedRef.current = true;
 
@@ -413,7 +448,7 @@ const SessionListView: React.FC<SessionListViewProps> = React.memo(({ onSelectSe
         });
 
         if (resp.nextCursor) {
-          void loadRemainingSessionPages(resp.nextCursor, loadId, keyword);
+            void loadRemainingSessionPages(resp.nextCursor, loadId, keyword, archived);
         }
       } catch (err) {
         if (loadGenerationRef.current !== loadId) return;
@@ -445,12 +480,12 @@ const SessionListView: React.FC<SessionListViewProps> = React.memo(({ onSelectSe
   );
 
   useEffect(() => {
-    loadSessions(debouncedSearchTerm);
+      loadSessions(debouncedSearchTerm, archivedFilterFor(debouncedSearchTerm, archivedView));
     return () => {
       // Bump the generation so any in-flight load for the previous keyword is discarded.
       loadGenerationRef.current += 1;
     };
-  }, [loadSessions, debouncedSearchTerm]);
+    }, [loadSessions, debouncedSearchTerm, archivedView]);
 
   // Hide Nostr sharing when explicitly disabled via env var (restricted/enterprise bundles)
   useEffect(() => {
@@ -540,6 +575,36 @@ const SessionListView: React.FC<SessionListViewProps> = React.memo(({ onSelectSe
     },
     [loadSessions, intl]
   );
+
+    const handleToggleArchive = useCallback(
+      async (session: SessionListItem) => {
+        const isArchived = !!session.archivedAt;
+        // Optimistically drop the row: it leaves the current view either way.
+        setSessions((prev) => prev.filter((s) => s.id !== session.id));
+        try {
+          if (isArchived) {
+            await acpUnarchiveSession(session.id);
+            toast.success(intl.formatMessage(i18n.unarchiveSuccess));
+          } else {
+            await acpArchiveSession(session.id);
+            toast.success(intl.formatMessage(i18n.archiveSuccess));
+          }
+          window.dispatchEvent(
+            new CustomEvent(AppEvents.SESSION_ARCHIVED, {
+              detail: { sessionId: session.id, archived: !isArchived },
+            })
+          );
+        } catch (error) {
+          toast.error(
+            intl.formatMessage(isArchived ? i18n.unarchiveFailed : i18n.archiveFailed, {
+              error: errorMessage(error, 'Unknown error'),
+            })
+          );
+          await loadSessions();
+        }
+      },
+      [intl, loadSessions]
+    );
 
   const handleConfirmDelete = useCallback(async () => {
     if (!sessionToDelete) return;
@@ -716,6 +781,7 @@ const SessionListView: React.FC<SessionListViewProps> = React.memo(({ onSelectSe
     onExportClick,
     onShareClick,
     onOpenInNewWindow,
+      onToggleArchive,
     isSharing,
   }: {
     session: SessionListItem;
@@ -725,6 +791,7 @@ const SessionListView: React.FC<SessionListViewProps> = React.memo(({ onSelectSe
     onExportClick: (session: SessionListItem, format: SessionExportFormat) => void;
     onShareClick: (session: SessionListItem, e: React.MouseEvent) => void;
     onOpenInNewWindow: (session: SessionListItem, e: React.MouseEvent) => void;
+      onToggleArchive: (session: SessionListItem) => void;
     isSharing: boolean;
   }) {
     const handleEditClick = useCallback(
@@ -750,6 +817,14 @@ const SessionListView: React.FC<SessionListViewProps> = React.memo(({ onSelectSe
       },
       [onDeleteClick, session]
     );
+
+      const handleArchiveClick = useCallback(
+        (e: React.MouseEvent) => {
+          e.stopPropagation();
+          onToggleArchive(session);
+        },
+        [onToggleArchive, session]
+      );
 
     const handleCardClick = useCallback(() => {
       onSelectSession(session.id);
@@ -832,6 +907,19 @@ const SessionListView: React.FC<SessionListViewProps> = React.memo(({ onSelectSe
             title={intl.formatMessage(i18n.deleteSession)}
           >
             <Trash2 className="w-3 h-3 text-red-500 hover:text-red-600" />
+          </button>
+          <button
+            onClick={handleArchiveClick}
+            className="p-2 rounded hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer"
+            title={intl.formatMessage(
+              session.archivedAt ? i18n.unarchiveSession : i18n.archiveSession
+            )}
+          >
+            {session.archivedAt ? (
+              <ArchiveRestore className="w-3 h-3 text-text-secondary hover:text-text-primary" />
+            ) : (
+              <Archive className="w-3 h-3 text-text-secondary hover:text-text-primary" />
+            )}
           </button>
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
@@ -941,8 +1029,12 @@ const SessionListView: React.FC<SessionListViewProps> = React.memo(({ onSelectSe
       return (
         <div className="flex flex-col justify-center h-full text-text-secondary">
           <MessageSquareText className="h-12 w-12 mb-4" />
-          <p className="text-lg mb-2">{intl.formatMessage(i18n.noSessions)}</p>
-          <p className="text-sm">{intl.formatMessage(i18n.noSessionsDesc)}</p>
+            <p className="text-lg mb-2">
+              {intl.formatMessage(archivedView ? i18n.noArchived : i18n.noSessions)}
+            </p>
+            <p className="text-sm">
+              {intl.formatMessage(archivedView ? i18n.noArchivedDesc : i18n.noSessionsDesc)}
+            </p>
         </div>
       );
     }
@@ -965,6 +1057,7 @@ const SessionListView: React.FC<SessionListViewProps> = React.memo(({ onSelectSe
                   onExportClick={handleExportSession}
                   onShareClick={handleShareSessionNostr}
                   onOpenInNewWindow={handleOpenInNewWindow}
+                    onToggleArchive={handleToggleArchive}
                   isSharing={sharingSessionId === session.id}
                 />
               ))}
@@ -1018,6 +1111,32 @@ const SessionListView: React.FC<SessionListViewProps> = React.memo(({ onSelectSe
               <p className="text-sm text-text-secondary mb-4">
                 {intl.formatMessage(i18n.chatHistoryDesc, { shortcut: getSearchShortcutText() })}
               </p>
+                <div className="inline-flex items-center gap-1 rounded-full bg-background-secondary p-0.5 self-start">
+                  <button
+                    type="button"
+                    onClick={() => setArchivedView(false)}
+                    className={cn(
+                      'rounded-full px-3 py-1 text-sm transition-colors',
+                      archivedView
+                        ? 'text-text-secondary hover:text-text-primary'
+                        : 'bg-background-primary text-text-primary shadow-sm'
+                    )}
+                  >
+                    {intl.formatMessage(i18n.activeTab)}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setArchivedView(true)}
+                    className={cn(
+                      'rounded-full px-3 py-1 text-sm transition-colors',
+                      archivedView
+                        ? 'bg-background-primary text-text-primary shadow-sm'
+                        : 'text-text-secondary hover:text-text-primary'
+                    )}
+                  >
+                    {intl.formatMessage(i18n.archivedTab)}
+                  </button>
+                </div>
             </div>
           </div>
 

--- a/ui/desktop/src/components/sessions/SessionListView.tsx
+++ b/ui/desktop/src/components/sessions/SessionListView.tsx
@@ -806,13 +806,15 @@ const SessionListView: React.FC<SessionListViewProps> = React.memo(({ onSelectSe
     isSharing: boolean;
   }) {
       // Archiving removes the loaded agent without cancelling an active prompt
-      // run, so gate the action while the session is streaming (like the
-      // sidebar does).
+      // run, and archiving mid-load races the server re-registering the agent,
+      // so gate the action while the session is streaming or still loading
+      // (like the sidebar does).
       const chatState = useAcpChatSessionSnapshot(session.id)?.chatState;
-      const isStreaming =
+      const isArchiveBlocked =
         chatState === ChatState.Streaming ||
         chatState === ChatState.Thinking ||
-        chatState === ChatState.Compacting;
+        chatState === ChatState.Compacting ||
+        chatState === ChatState.LoadingConversation;
 
     const handleEditClick = useCallback(
       (e: React.MouseEvent) => {
@@ -930,7 +932,7 @@ const SessionListView: React.FC<SessionListViewProps> = React.memo(({ onSelectSe
           </button>
           <button
             onClick={handleArchiveClick}
-              disabled={isStreaming}
+              disabled={isArchiveBlocked}
               className="p-2 rounded hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer disabled:cursor-not-allowed disabled:opacity-60"
             title={intl.formatMessage(
               session.archivedAt ? i18n.unarchiveSession : i18n.archiveSession

--- a/ui/desktop/src/components/sessions/SessionListView.tsx
+++ b/ui/desktop/src/components/sessions/SessionListView.tsx
@@ -522,11 +522,26 @@ const SessionListView: React.FC<SessionListViewProps> = React.memo(({ onSelectSe
         }
       };
 
+      const handleSessionRenamed = (event: Event) => {
+        const { sessionId, newName, userInitiated } = (
+          event as CustomEvent<{ sessionId: string; newName: string; userInitiated?: boolean }>
+        ).detail;
+        setSessions((prev) =>
+          prev.map((s) =>
+            s.id === sessionId
+              ? { ...s, name: newName, ...(userInitiated && { userSetName: true }) }
+              : s
+          )
+        );
+      };
+
       window.addEventListener(AppEvents.SESSION_DELETED, handleSessionDeleted);
       window.addEventListener(AppEvents.SESSION_ARCHIVED, handleSessionArchived);
+      window.addEventListener(AppEvents.SESSION_RENAMED, handleSessionRenamed);
       return () => {
         window.removeEventListener(AppEvents.SESSION_DELETED, handleSessionDeleted);
         window.removeEventListener(AppEvents.SESSION_ARCHIVED, handleSessionArchived);
+        window.removeEventListener(AppEvents.SESSION_RENAMED, handleSessionRenamed);
       };
     }, [loadSessions]);
 
@@ -582,7 +597,7 @@ const SessionListView: React.FC<SessionListViewProps> = React.memo(({ onSelectSe
     // Update state immediately for optimistic UI
     setSessions((prevSessions) =>
       prevSessions.map((s) =>
-        s.id === sessionId ? { ...s, name: newDescription, user_set_name: true } : s
+          s.id === sessionId ? { ...s, name: newDescription, userSetName: true } : s
       )
     );
     window.dispatchEvent(

--- a/ui/desktop/src/components/sessions/SessionListView.tsx
+++ b/ui/desktop/src/components/sessions/SessionListView.tsx
@@ -59,6 +59,7 @@ import {
 import type { SessionExportFormat } from '@aaif/goose-sdk';
 import { acpChatSessionActions, useAcpChatSessionSnapshot } from '../../acp/chatSessionStore';
 import { useSessionBusyElsewhere } from '../../hooks/useSessionBusyElsewhere';
+import { dispatchSessionLifecycleEvent } from '../../sessionLifecycleBridge';
 import { ChatState } from '../../types/chatState';
 import { cancelAcpPermissionRequestsForSession } from '../../acp/permissionRequests';
 import { cancelAcpElicitationRequestsForSession } from '../../acp/elicitationRequests';
@@ -601,11 +602,10 @@ const SessionListView: React.FC<SessionListViewProps> = React.memo(({ onSelectSe
             await acpArchiveSession(session.id);
             toast.success(intl.formatMessage(i18n.archiveSuccess));
           }
-          window.dispatchEvent(
-            new CustomEvent(AppEvents.SESSION_ARCHIVED, {
-              detail: { sessionId: session.id, archived: !isArchived },
-            })
-          );
+          dispatchSessionLifecycleEvent(AppEvents.SESSION_ARCHIVED, {
+            sessionId: session.id,
+            archived: !isArchived,
+          });
         } catch (error) {
           toast.error(
             intl.formatMessage(isArchived ? i18n.unarchiveFailed : i18n.archiveFailed, {
@@ -629,9 +629,9 @@ const SessionListView: React.FC<SessionListViewProps> = React.memo(({ onSelectSe
     try {
       await acpDeleteSession(sessionToDeleteId);
       toast.success(intl.formatMessage(i18n.deleteSuccess));
-      window.dispatchEvent(
-        new CustomEvent(AppEvents.SESSION_DELETED, { detail: { sessionId: sessionToDeleteId } })
-      );
+        dispatchSessionLifecycleEvent(AppEvents.SESSION_DELETED, {
+          sessionId: sessionToDeleteId,
+        });
       cancelAcpPermissionRequestsForSession(sessionToDeleteId);
       cancelAcpElicitationRequestsForSession(sessionToDeleteId);
       acpChatSessionActions.deleteSnapshot(sessionToDeleteId);

--- a/ui/desktop/src/components/sessions/SessionListView.tsx
+++ b/ui/desktop/src/components/sessions/SessionListView.tsx
@@ -57,7 +57,8 @@ import {
   type SessionListItem,
 } from '../../acp/sessions';
 import type { SessionExportFormat } from '@aaif/goose-sdk';
-import { acpChatSessionActions } from '../../acp/chatSessionStore';
+import { acpChatSessionActions, useAcpChatSessionSnapshot } from '../../acp/chatSessionStore';
+import { ChatState } from '../../types/chatState';
 import { cancelAcpPermissionRequestsForSession } from '../../acp/permissionRequests';
 import { cancelAcpElicitationRequestsForSession } from '../../acp/elicitationRequests';
 import { getSearchShortcutText } from '../../utils/keyboardShortcuts';
@@ -804,6 +805,15 @@ const SessionListView: React.FC<SessionListViewProps> = React.memo(({ onSelectSe
       onToggleArchive: (session: SessionListItem) => void;
     isSharing: boolean;
   }) {
+      // Archiving removes the loaded agent without cancelling an active prompt
+      // run, so gate the action while the session is streaming (like the
+      // sidebar does).
+      const chatState = useAcpChatSessionSnapshot(session.id)?.chatState;
+      const isStreaming =
+        chatState === ChatState.Streaming ||
+        chatState === ChatState.Thinking ||
+        chatState === ChatState.Compacting;
+
     const handleEditClick = useCallback(
       (e: React.MouseEvent) => {
         e.stopPropagation();
@@ -920,7 +930,8 @@ const SessionListView: React.FC<SessionListViewProps> = React.memo(({ onSelectSe
           </button>
           <button
             onClick={handleArchiveClick}
-            className="p-2 rounded hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer"
+              disabled={isStreaming}
+              className="p-2 rounded hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer disabled:cursor-not-allowed disabled:opacity-60"
             title={intl.formatMessage(
               session.archivedAt ? i18n.unarchiveSession : i18n.archiveSession
             )}

--- a/ui/desktop/src/components/ui/ConfirmationModal.tsx
+++ b/ui/desktop/src/components/ui/ConfirmationModal.tsx
@@ -35,6 +35,7 @@ export function ConfirmationModal({
   confirmLabel,
   cancelLabel,
   isSubmitting = false,
+  confirmDisabled = false,
   confirmVariant = 'default',
 }: {
   isOpen: boolean;
@@ -46,6 +47,7 @@ export function ConfirmationModal({
   confirmLabel?: string;
   cancelLabel?: string;
   isSubmitting?: boolean; // To handle debounce state
+  confirmDisabled?: boolean;
   confirmVariant?: 'default' | 'destructive' | 'outline' | 'secondary' | 'ghost' | 'link';
 }) {
   const intl = useIntl();
@@ -74,7 +76,7 @@ export function ConfirmationModal({
           <Button
             variant={confirmVariant}
             onClick={onConfirm}
-            disabled={isSubmitting}
+            disabled={isSubmitting || confirmDisabled}
             className="focus-visible:ring-2 focus-visible:ring-background-accent focus-visible:ring-offset-2 focus-visible:ring-offset-background-default"
           >
             {isSubmitting ? intl.formatMessage(i18n.processing) : (confirmLabel || intl.formatMessage(i18n.defaultConfirm))}

--- a/ui/desktop/src/constants/events.ts
+++ b/ui/desktop/src/constants/events.ts
@@ -5,6 +5,7 @@ export enum AppEvents {
   SESSION_CREATED = 'session-created',
   SESSION_EXTENSIONS_LOADED = 'session-extensions-loaded',
   SESSION_DELETED = 'session-deleted',
+  SESSION_ARCHIVED = 'session-archived',
   SESSION_RENAMED = 'session-renamed',
   SESSION_FORKED = 'session-forked',
   SESSION_STATUS_UPDATE = 'session-status-update',

--- a/ui/desktop/src/hooks/useNavigationSessions.ts
+++ b/ui/desktop/src/hooks/useNavigationSessions.ts
@@ -87,6 +87,9 @@ export function useNavigationSessions() {
 
     acpGetSessionListItem(activeSessionId)
       .then((item) => {
+        // Viewing an archived chat must not resurface it in the sidebar; it stays
+        // hidden until the user explicitly restores it.
+        if (item.archivedAt) return;
         setRecentSessions((prev) => prependUnique(prev, item));
       })
       .catch((error) => {

--- a/ui/desktop/src/hooks/useNavigationSessions.ts
+++ b/ui/desktop/src/hooks/useNavigationSessions.ts
@@ -75,7 +75,9 @@ export function useNavigationSessions() {
   const fetchSessions = useCallback(async () => {
     try {
       const sessions = await acpListRecentSessions(MAX_RECENT_SESSIONS);
-      setRecentSessions(sessions);
+      // Active listings omit message-less sessions, so a refresh would drop a
+      // freshly created or just-restored empty chat; keep those locals.
+      setRecentSessions((prev) => mergeWithEmptyLocals(prev, sessions));
     } catch (error) {
       console.error('Failed to fetch sessions:', error);
     }
@@ -157,7 +159,9 @@ export function useNavigationSessions() {
       acpListRecentSessions(MAX_RECENT_SESSIONS)
         .then((sessions) => {
           if (version !== fetchVersion) return;
-          setRecentSessions(sessions.filter((session) => session.id !== sessionId));
+          setRecentSessions((prev) =>
+            mergeWithEmptyLocals(prev, sessions).filter((session) => session.id !== sessionId)
+          );
         })
         .catch((error) => console.error('Failed to fetch sessions:', error));
     };
@@ -181,7 +185,7 @@ export function useNavigationSessions() {
           })
           .then((sessions) => {
             if (version !== fetchVersion) return;
-            setRecentSessions(sessions);
+            setRecentSessions((prev) => mergeWithEmptyLocals(prev, sessions));
           })
           .catch((error) => console.error('Failed to fetch sessions:', error));
         return;

--- a/ui/desktop/src/hooks/useNavigationSessions.ts
+++ b/ui/desktop/src/hooks/useNavigationSessions.ts
@@ -172,6 +172,13 @@ export function useNavigationSessions() {
       if (archived === false) {
         const version = ++fetchVersion;
         acpListRecentSessions(MAX_RECENT_SESSIONS)
+          .then(async (sessions) => {
+            // Active listings hide empty sessions, so a restored empty chat is
+            // missing from the refetch; fetch it directly to keep it reachable.
+            if (sessions.some((s) => s.id === sessionId)) return sessions;
+            const restored = await acpGetSessionListItem(sessionId);
+            return prependUnique(sessions, restored);
+          })
           .then((sessions) => {
             if (version !== fetchVersion) return;
             setRecentSessions(sessions);

--- a/ui/desktop/src/hooks/useNavigationSessions.ts
+++ b/ui/desktop/src/hooks/useNavigationSessions.ts
@@ -159,6 +159,30 @@ export function useNavigationSessions() {
         .catch((error) => console.error('Failed to fetch sessions:', error));
     };
 
+    const handleSessionArchived = (event: Event) => {
+      const { sessionId, archived } = (
+        event as CustomEvent<{ sessionId: string; archived?: boolean }>
+      ).detail;
+
+      // Archiving hides a session from the sidebar; unarchiving may bring a
+      // recent one back, so refetch to reflect the current active set.
+      if (archived === false) {
+        const version = ++fetchVersion;
+        acpListRecentSessions(MAX_RECENT_SESSIONS)
+          .then((sessions) => {
+            if (version !== fetchVersion) return;
+            setRecentSessions(sessions);
+          })
+          .catch((error) => console.error('Failed to fetch sessions:', error));
+        return;
+      }
+
+      setRecentSessions((prev) => prev.filter((session) => session.id !== sessionId));
+      if (lastSessionIdRef.current === sessionId) {
+        lastSessionIdRef.current = null;
+      }
+    };
+
     const handleSessionRenamed = (event: Event) => {
       const { sessionId, newName, userInitiated } = (
         event as CustomEvent<{ sessionId: string; newName: string; userInitiated?: boolean }>
@@ -174,10 +198,12 @@ export function useNavigationSessions() {
     };
 
     window.addEventListener(AppEvents.SESSION_DELETED, handleSessionDeleted);
+    window.addEventListener(AppEvents.SESSION_ARCHIVED, handleSessionArchived);
     window.addEventListener(AppEvents.SESSION_RENAMED, handleSessionRenamed);
 
     return () => {
       window.removeEventListener(AppEvents.SESSION_DELETED, handleSessionDeleted);
+      window.removeEventListener(AppEvents.SESSION_ARCHIVED, handleSessionArchived);
       window.removeEventListener(AppEvents.SESSION_RENAMED, handleSessionRenamed);
     };
   }, []);

--- a/ui/desktop/src/hooks/useSessionBusyElsewhere.ts
+++ b/ui/desktop/src/hooks/useSessionBusyElsewhere.ts
@@ -1,4 +1,6 @@
 import { useSyncExternalStore } from 'react';
+import { acpChatSessionStore, useAcpChatSessionSnapshot } from '../acp/chatSessionStore';
+import { ChatState } from '../types/chatState';
 
 // Local backends are per-window, so neither the server nor this renderer's ACP
 // snapshot can see a prompt run owned by another desktop window. The main
@@ -75,4 +77,20 @@ export function isSessionBusyElsewhere(sessionId: string): boolean {
 
 export function useSessionBusyElsewhere(sessionId: string): boolean {
   return useSyncExternalStore(subscribe, () => isSessionBusyElsewhere(sessionId));
+}
+
+// A session is busy when it has server-side work that archive/delete would rip
+// out from under it: any non-idle chat state in this window, or a run reported
+// by another window (whose backend this one cannot see).
+export function isSessionBusy(sessionId: string): boolean {
+  const chatState = acpChatSessionStore.getSnapshot(sessionId)?.chatState;
+  return (
+    (chatState !== undefined && chatState !== ChatState.Idle) || isSessionBusyElsewhere(sessionId)
+  );
+}
+
+export function useSessionBusy(sessionId: string): boolean {
+  const chatState = useAcpChatSessionSnapshot(sessionId)?.chatState;
+  const busyElsewhere = useSessionBusyElsewhere(sessionId);
+  return (chatState !== undefined && chatState !== ChatState.Idle) || busyElsewhere;
 }

--- a/ui/desktop/src/hooks/useSessionBusyElsewhere.ts
+++ b/ui/desktop/src/hooks/useSessionBusyElsewhere.ts
@@ -1,0 +1,70 @@
+import { useSyncExternalStore } from 'react';
+
+// Local backends are per-window, so neither the server nor this renderer's ACP
+// snapshot can see a prompt run owned by another desktop window. The main
+// process relays each window's per-session stream status ('broadcast-session-
+// status' -> 'remote-session-status-update') and tells us to drop a window's
+// statuses when it closes or reloads ('remote-session-status-cleared'). Archive
+// guards consult this registry so a session busy in another window still counts
+// as busy here.
+
+const BUSY_STREAM_STATES = new Set(['loading', 'streaming', 'waiting']);
+
+const busyByWindow = new Map<number, Map<string, string>>();
+const listeners = new Set<() => void>();
+let subscribedToIpc = false;
+
+function notify() {
+  listeners.forEach((listener) => listener());
+}
+
+function handleRemoteStatus(_event: unknown, payload: unknown) {
+  const { windowId, sessionId, streamState } = (payload ?? {}) as {
+    windowId?: number;
+    sessionId?: string;
+    streamState?: string;
+  };
+  if (typeof windowId !== 'number' || typeof sessionId !== 'string') return;
+
+  let byWindow = busyByWindow.get(windowId);
+  if (streamState !== undefined && BUSY_STREAM_STATES.has(streamState)) {
+    if (!byWindow) {
+      byWindow = new Map();
+      busyByWindow.set(windowId, byWindow);
+    }
+    byWindow.set(sessionId, streamState);
+  } else {
+    if (!byWindow?.delete(sessionId)) return;
+  }
+  notify();
+}
+
+function handleRemoteCleared(_event: unknown, payload: unknown) {
+  const { windowId } = (payload ?? {}) as { windowId?: number };
+  if (typeof windowId !== 'number') return;
+  if (busyByWindow.delete(windowId)) notify();
+}
+
+function ensureIpcSubscription() {
+  if (subscribedToIpc || !window.electron?.on) return;
+  subscribedToIpc = true;
+  window.electron.on('remote-session-status-update', handleRemoteStatus);
+  window.electron.on('remote-session-status-cleared', handleRemoteCleared);
+}
+
+function subscribe(listener: () => void): () => void {
+  ensureIpcSubscription();
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+export function isSessionBusyElsewhere(sessionId: string): boolean {
+  for (const byWindow of busyByWindow.values()) {
+    if (byWindow.has(sessionId)) return true;
+  }
+  return false;
+}
+
+export function useSessionBusyElsewhere(sessionId: string): boolean {
+  return useSyncExternalStore(subscribe, () => isSessionBusyElsewhere(sessionId));
+}

--- a/ui/desktop/src/hooks/useSessionBusyElsewhere.ts
+++ b/ui/desktop/src/hooks/useSessionBusyElsewhere.ts
@@ -50,6 +50,14 @@ function ensureIpcSubscription() {
   subscribedToIpc = true;
   window.electron.on('remote-session-status-update', handleRemoteStatus);
   window.electron.on('remote-session-status-cleared', handleRemoteCleared);
+  // The main process only forwards live transitions; seed from its cached busy
+  // map so runs that started before this window subscribed still count.
+  window.electron
+    .getRemoteSessionStatuses?.()
+    .then((statuses) => {
+      statuses.forEach((status) => handleRemoteStatus(undefined, status));
+    })
+    .catch((error) => console.error('Failed to seed remote session statuses:', error));
 }
 
 function subscribe(listener: () => void): () => void {

--- a/ui/desktop/src/i18n/messages/de.json
+++ b/ui/desktop/src/i18n/messages/de.json
@@ -125,6 +125,18 @@
   "backButton.back": {
     "defaultMessage": "Zurück"
   },
+  "baseChat.archivedNotice": {
+    "defaultMessage": "Dieser Chat ist archiviert und in Ihren letzten Chats ausgeblendet."
+  },
+  "baseChat.archivedRestore": {
+    "defaultMessage": "Wiederherstellen"
+  },
+  "baseChat.archivedRestoreFailed": {
+    "defaultMessage": "Sitzung konnte nicht wiederhergestellt werden: {error}"
+  },
+  "baseChat.archivedRestored": {
+    "defaultMessage": "Sitzung wiederhergestellt"
+  },
   "baseChat.failedToLoadSession": {
     "defaultMessage": "Sitzung konnte nicht geladen werden"
   },

--- a/ui/desktop/src/i18n/messages/de.json
+++ b/ui/desktop/src/i18n/messages/de.json
@@ -2366,8 +2366,38 @@
   "navigation.itemSkills": {
     "defaultMessage": "Skills"
   },
+  "navigationPanel.archive": {
+    "defaultMessage": "Archivieren"
+  },
+  "navigationPanel.archiveFailed": {
+    "defaultMessage": "Sitzung konnte nicht archiviert werden: {error}"
+  },
+  "navigationPanel.archiveSuccess": {
+    "defaultMessage": "„{name}“ archiviert"
+  },
   "navigationPanel.chats": {
     "defaultMessage": "Chats"
+  },
+  "navigationPanel.delete": {
+    "defaultMessage": "Löschen"
+  },
+  "navigationPanel.deleteCancel": {
+    "defaultMessage": "Abbrechen"
+  },
+  "navigationPanel.deleteConfirm": {
+    "defaultMessage": "Löschen"
+  },
+  "navigationPanel.deleteFailed": {
+    "defaultMessage": "Sitzung konnte nicht gelöscht werden: {error}"
+  },
+  "navigationPanel.deleteMessage": {
+    "defaultMessage": "Möchten Sie „{name}“ wirklich löschen? Dies kann nicht rückgängig gemacht werden."
+  },
+  "navigationPanel.deleteSuccess": {
+    "defaultMessage": "Chat gelöscht"
+  },
+  "navigationPanel.deleteTitle": {
+    "defaultMessage": "Chat löschen"
   },
   "navigationPanel.metaCreated": {
     "defaultMessage": "Erstellt"
@@ -2386,6 +2416,12 @@
   },
   "navigationPanel.noChats": {
     "defaultMessage": "Keine aktuellen Chats"
+  },
+  "navigationPanel.rename": {
+    "defaultMessage": "Umbenennen"
+  },
+  "navigationPanel.sessionActions": {
+    "defaultMessage": "Sitzungsaktionen"
   },
   "navigationPanel.statusError": {
     "defaultMessage": "Fehler"
@@ -3767,6 +3803,9 @@
   "sessionIndicators.streaming": {
     "defaultMessage": "Streaming"
   },
+  "sessions.action.archive": {
+    "defaultMessage": "Sitzung archivieren"
+  },
   "sessions.action.delete": {
     "defaultMessage": "Sitzung löschen"
   },
@@ -3790,6 +3829,9 @@
   },
   "sessions.action.shareNostr": {
     "defaultMessage": "Verschlüsselten Nostr-Link teilen"
+  },
+  "sessions.action.unarchive": {
+    "defaultMessage": "Aus Archiv wiederherstellen"
   },
   "sessions.cancel": {
     "defaultMessage": "Abbrechen"
@@ -3848,6 +3890,12 @@
   "sessions.loadingMore": {
     "defaultMessage": "Weitere Sitzungen werden geladen..."
   },
+  "sessions.noArchived": {
+    "defaultMessage": "Keine archivierten Sitzungen"
+  },
+  "sessions.noArchivedDesc": {
+    "defaultMessage": "Von Ihnen archivierte Sitzungen werden hier angezeigt."
+  },
   "sessions.save": {
     "defaultMessage": "Speichern"
   },
@@ -3868,6 +3916,18 @@
   },
   "sessions.shareNostr.title": {
     "defaultMessage": "Verschlüsselter Nostr-Freigabelink"
+  },
+  "sessions.tab.active": {
+    "defaultMessage": "Aktiv"
+  },
+  "sessions.tab.archived": {
+    "defaultMessage": "Archiviert"
+  },
+  "sessions.toast.archiveFailed": {
+    "defaultMessage": "Sitzung konnte nicht archiviert werden: {error}"
+  },
+  "sessions.toast.archived": {
+    "defaultMessage": "Sitzung archiviert"
   },
   "sessions.toast.copied": {
     "defaultMessage": "In die Zwischenablage kopiert"
@@ -3901,6 +3961,12 @@
   },
   "sessions.toast.shareNostrFailed": {
     "defaultMessage": "Nostr-Freigabelink konnte nicht erstellt werden: {error}"
+  },
+  "sessions.toast.unarchiveFailed": {
+    "defaultMessage": "Sitzung konnte nicht wiederhergestellt werden: {error}"
+  },
+  "sessions.toast.unarchived": {
+    "defaultMessage": "Sitzung wiederhergestellt"
   },
   "sessions.toast.updateFailed": {
     "defaultMessage": "Sitzungsbeschreibung konnte nicht aktualisiert werden: {error}"

--- a/ui/desktop/src/i18n/messages/en.json
+++ b/ui/desktop/src/i18n/messages/en.json
@@ -125,6 +125,18 @@
   "backButton.back": {
     "defaultMessage": "Back"
   },
+  "baseChat.archivedNotice": {
+    "defaultMessage": "This chat is archived and hidden from your recent chats."
+  },
+  "baseChat.archivedRestore": {
+    "defaultMessage": "Restore"
+  },
+  "baseChat.archivedRestoreFailed": {
+    "defaultMessage": "Failed to restore session: {error}"
+  },
+  "baseChat.archivedRestored": {
+    "defaultMessage": "Session restored"
+  },
   "baseChat.failedToLoadSession": {
     "defaultMessage": "Failed to Load Session"
   },

--- a/ui/desktop/src/i18n/messages/en.json
+++ b/ui/desktop/src/i18n/messages/en.json
@@ -2369,8 +2369,38 @@
   "navigation.itemSkills": {
     "defaultMessage": "Skills"
   },
+  "navigationPanel.archive": {
+    "defaultMessage": "Archive"
+  },
+  "navigationPanel.archiveFailed": {
+    "defaultMessage": "Failed to archive session: {error}"
+  },
+  "navigationPanel.archiveSuccess": {
+    "defaultMessage": "Archived “{name}”"
+  },
   "navigationPanel.chats": {
     "defaultMessage": "Chats"
+  },
+  "navigationPanel.delete": {
+    "defaultMessage": "Delete"
+  },
+  "navigationPanel.deleteCancel": {
+    "defaultMessage": "Cancel"
+  },
+  "navigationPanel.deleteConfirm": {
+    "defaultMessage": "Delete"
+  },
+  "navigationPanel.deleteFailed": {
+    "defaultMessage": "Failed to delete session: {error}"
+  },
+  "navigationPanel.deleteMessage": {
+    "defaultMessage": "Are you sure you want to delete “{name}”? This cannot be undone."
+  },
+  "navigationPanel.deleteSuccess": {
+    "defaultMessage": "Chat deleted"
+  },
+  "navigationPanel.deleteTitle": {
+    "defaultMessage": "Delete chat"
   },
   "navigationPanel.metaCreated": {
     "defaultMessage": "Created"
@@ -2389,6 +2419,12 @@
   },
   "navigationPanel.noChats": {
     "defaultMessage": "No recent chats"
+  },
+  "navigationPanel.rename": {
+    "defaultMessage": "Rename"
+  },
+  "navigationPanel.sessionActions": {
+    "defaultMessage": "Session actions"
   },
   "navigationPanel.statusError": {
     "defaultMessage": "Error"
@@ -3770,6 +3806,9 @@
   "sessionIndicators.streaming": {
     "defaultMessage": "Streaming"
   },
+  "sessions.action.archive": {
+    "defaultMessage": "Archive session"
+  },
   "sessions.action.delete": {
     "defaultMessage": "Delete session"
   },
@@ -3793,6 +3832,9 @@
   },
   "sessions.action.shareNostr": {
     "defaultMessage": "Share encrypted Nostr link"
+  },
+  "sessions.action.unarchive": {
+    "defaultMessage": "Restore from archive"
   },
   "sessions.cancel": {
     "defaultMessage": "Cancel"
@@ -3851,6 +3893,12 @@
   "sessions.loadingMore": {
     "defaultMessage": "Loading more sessions..."
   },
+  "sessions.noArchived": {
+    "defaultMessage": "No archived sessions"
+  },
+  "sessions.noArchivedDesc": {
+    "defaultMessage": "Sessions you archive will appear here."
+  },
   "sessions.save": {
     "defaultMessage": "Save"
   },
@@ -3871,6 +3919,18 @@
   },
   "sessions.shareNostr.title": {
     "defaultMessage": "Encrypted Nostr Share Link"
+  },
+  "sessions.tab.active": {
+    "defaultMessage": "Active"
+  },
+  "sessions.tab.archived": {
+    "defaultMessage": "Archived"
+  },
+  "sessions.toast.archiveFailed": {
+    "defaultMessage": "Failed to archive session: {error}"
+  },
+  "sessions.toast.archived": {
+    "defaultMessage": "Session archived"
   },
   "sessions.toast.copied": {
     "defaultMessage": "Copied to clipboard"
@@ -3904,6 +3964,12 @@
   },
   "sessions.toast.shareNostrFailed": {
     "defaultMessage": "Failed to create Nostr share link: {error}"
+  },
+  "sessions.toast.unarchiveFailed": {
+    "defaultMessage": "Failed to restore session: {error}"
+  },
+  "sessions.toast.unarchived": {
+    "defaultMessage": "Session restored"
   },
   "sessions.toast.updateFailed": {
     "defaultMessage": "Failed to update session description: {error}"

--- a/ui/desktop/src/i18n/messages/es.json
+++ b/ui/desktop/src/i18n/messages/es.json
@@ -2366,8 +2366,38 @@
   "navigation.itemSkills": {
     "defaultMessage": "Skills"
   },
+  "navigationPanel.archive": {
+    "defaultMessage": "Archivar"
+  },
+  "navigationPanel.archiveFailed": {
+    "defaultMessage": "No se pudo archivar la sesión: {error}"
+  },
+  "navigationPanel.archiveSuccess": {
+    "defaultMessage": "“{name}” archivada"
+  },
   "navigationPanel.chats": {
     "defaultMessage": "Chats"
+  },
+  "navigationPanel.delete": {
+    "defaultMessage": "Eliminar"
+  },
+  "navigationPanel.deleteCancel": {
+    "defaultMessage": "Cancelar"
+  },
+  "navigationPanel.deleteConfirm": {
+    "defaultMessage": "Eliminar"
+  },
+  "navigationPanel.deleteFailed": {
+    "defaultMessage": "No se pudo eliminar la sesión: {error}"
+  },
+  "navigationPanel.deleteMessage": {
+    "defaultMessage": "¿Seguro que quieres eliminar “{name}”? Esta acción no se puede deshacer."
+  },
+  "navigationPanel.deleteSuccess": {
+    "defaultMessage": "Chat eliminado"
+  },
+  "navigationPanel.deleteTitle": {
+    "defaultMessage": "Eliminar chat"
   },
   "navigationPanel.metaCreated": {
     "defaultMessage": "Creado"
@@ -2386,6 +2416,12 @@
   },
   "navigationPanel.noChats": {
     "defaultMessage": "No hay chats recientes"
+  },
+  "navigationPanel.rename": {
+    "defaultMessage": "Cambiar nombre"
+  },
+  "navigationPanel.sessionActions": {
+    "defaultMessage": "Acciones de sesión"
   },
   "navigationPanel.statusError": {
     "defaultMessage": "Error"
@@ -3767,6 +3803,9 @@
   "sessionIndicators.streaming": {
     "defaultMessage": "Streaming"
   },
+  "sessions.action.archive": {
+    "defaultMessage": "Archivar sesión"
+  },
   "sessions.action.delete": {
     "defaultMessage": "Eliminar sesión"
   },
@@ -3790,6 +3829,9 @@
   },
   "sessions.action.shareNostr": {
     "defaultMessage": "Compartir enlace cifrado de Nostr"
+  },
+  "sessions.action.unarchive": {
+    "defaultMessage": "Restaurar del archivo"
   },
   "sessions.cancel": {
     "defaultMessage": "Cancelar"
@@ -3848,6 +3890,12 @@
   "sessions.loadingMore": {
     "defaultMessage": "Cargando más sesiones..."
   },
+  "sessions.noArchived": {
+    "defaultMessage": "No hay sesiones archivadas"
+  },
+  "sessions.noArchivedDesc": {
+    "defaultMessage": "Las sesiones que archives aparecerán aquí."
+  },
   "sessions.save": {
     "defaultMessage": "Guardar"
   },
@@ -3868,6 +3916,18 @@
   },
   "sessions.shareNostr.title": {
     "defaultMessage": "Enlace cifrado de Nostr para compartir"
+  },
+  "sessions.tab.active": {
+    "defaultMessage": "Activas"
+  },
+  "sessions.tab.archived": {
+    "defaultMessage": "Archivadas"
+  },
+  "sessions.toast.archiveFailed": {
+    "defaultMessage": "No se pudo archivar la sesión: {error}"
+  },
+  "sessions.toast.archived": {
+    "defaultMessage": "Sesión archivada"
   },
   "sessions.toast.copied": {
     "defaultMessage": "Copiado al portapapeles"
@@ -3901,6 +3961,12 @@
   },
   "sessions.toast.shareNostrFailed": {
     "defaultMessage": "No se pudo crear el enlace de Nostr para compartir: {error}"
+  },
+  "sessions.toast.unarchiveFailed": {
+    "defaultMessage": "No se pudo restaurar la sesión: {error}"
+  },
+  "sessions.toast.unarchived": {
+    "defaultMessage": "Sesión restaurada"
   },
   "sessions.toast.updateFailed": {
     "defaultMessage": "No se pudo actualizar la descripción de la sesión: {error}"

--- a/ui/desktop/src/i18n/messages/es.json
+++ b/ui/desktop/src/i18n/messages/es.json
@@ -125,6 +125,18 @@
   "backButton.back": {
     "defaultMessage": "Atrás"
   },
+  "baseChat.archivedNotice": {
+    "defaultMessage": "Este chat está archivado y oculto de tus chats recientes."
+  },
+  "baseChat.archivedRestore": {
+    "defaultMessage": "Restaurar"
+  },
+  "baseChat.archivedRestoreFailed": {
+    "defaultMessage": "No se pudo restaurar la sesión: {error}"
+  },
+  "baseChat.archivedRestored": {
+    "defaultMessage": "Sesión restaurada"
+  },
   "baseChat.failedToLoadSession": {
     "defaultMessage": "No se pudo cargar la sesión"
   },

--- a/ui/desktop/src/i18n/messages/fr.json
+++ b/ui/desktop/src/i18n/messages/fr.json
@@ -2366,8 +2366,38 @@
   "navigation.itemSkills": {
     "defaultMessage": "Compétences"
   },
+  "navigationPanel.archive": {
+    "defaultMessage": "Archiver"
+  },
+  "navigationPanel.archiveFailed": {
+    "defaultMessage": "Échec de l’archivage de la session : {error}"
+  },
+  "navigationPanel.archiveSuccess": {
+    "defaultMessage": "“{name}” archivée"
+  },
   "navigationPanel.chats": {
     "defaultMessage": "Discussions"
+  },
+  "navigationPanel.delete": {
+    "defaultMessage": "Supprimer"
+  },
+  "navigationPanel.deleteCancel": {
+    "defaultMessage": "Annuler"
+  },
+  "navigationPanel.deleteConfirm": {
+    "defaultMessage": "Supprimer"
+  },
+  "navigationPanel.deleteFailed": {
+    "defaultMessage": "Échec de la suppression de la session : {error}"
+  },
+  "navigationPanel.deleteMessage": {
+    "defaultMessage": "Voulez-vous vraiment supprimer “{name}” ? Cette action est irréversible."
+  },
+  "navigationPanel.deleteSuccess": {
+    "defaultMessage": "Conversation supprimée"
+  },
+  "navigationPanel.deleteTitle": {
+    "defaultMessage": "Supprimer la conversation"
   },
   "navigationPanel.metaCreated": {
     "defaultMessage": "Créé"
@@ -2386,6 +2416,12 @@
   },
   "navigationPanel.noChats": {
     "defaultMessage": "Aucune discussion récente"
+  },
+  "navigationPanel.rename": {
+    "defaultMessage": "Renommer"
+  },
+  "navigationPanel.sessionActions": {
+    "defaultMessage": "Actions de session"
   },
   "navigationPanel.statusError": {
     "defaultMessage": "Erreur"
@@ -3767,6 +3803,9 @@
   "sessionIndicators.streaming": {
     "defaultMessage": "Diffusion en cours"
   },
+  "sessions.action.archive": {
+    "defaultMessage": "Archiver la session"
+  },
   "sessions.action.delete": {
     "defaultMessage": "Supprimer la session"
   },
@@ -3790,6 +3829,9 @@
   },
   "sessions.action.shareNostr": {
     "defaultMessage": "Partager un lien Nostr chiffré"
+  },
+  "sessions.action.unarchive": {
+    "defaultMessage": "Restaurer depuis l’archive"
   },
   "sessions.cancel": {
     "defaultMessage": "Annuler"
@@ -3848,6 +3890,12 @@
   "sessions.loadingMore": {
     "defaultMessage": "Chargement de sessions supplémentaires..."
   },
+  "sessions.noArchived": {
+    "defaultMessage": "Aucune session archivée"
+  },
+  "sessions.noArchivedDesc": {
+    "defaultMessage": "Les sessions que vous archivez apparaîtront ici."
+  },
   "sessions.save": {
     "defaultMessage": "Enregistrer"
   },
@@ -3868,6 +3916,18 @@
   },
   "sessions.shareNostr.title": {
     "defaultMessage": "Lien de partage Nostr chiffré"
+  },
+  "sessions.tab.active": {
+    "defaultMessage": "Actives"
+  },
+  "sessions.tab.archived": {
+    "defaultMessage": "Archivées"
+  },
+  "sessions.toast.archiveFailed": {
+    "defaultMessage": "Échec de l’archivage de la session : {error}"
+  },
+  "sessions.toast.archived": {
+    "defaultMessage": "Session archivée"
   },
   "sessions.toast.copied": {
     "defaultMessage": "Copié dans le presse-papiers"
@@ -3901,6 +3961,12 @@
   },
   "sessions.toast.shareNostrFailed": {
     "defaultMessage": "Échec de la création du lien de partage Nostr : {error}"
+  },
+  "sessions.toast.unarchiveFailed": {
+    "defaultMessage": "Échec de la restauration de la session : {error}"
+  },
+  "sessions.toast.unarchived": {
+    "defaultMessage": "Session restaurée"
   },
   "sessions.toast.updateFailed": {
     "defaultMessage": "Échec de la mise à jour de la description de la session : {error}"

--- a/ui/desktop/src/i18n/messages/fr.json
+++ b/ui/desktop/src/i18n/messages/fr.json
@@ -125,6 +125,18 @@
   "backButton.back": {
     "defaultMessage": "Retour"
   },
+  "baseChat.archivedNotice": {
+    "defaultMessage": "Cette conversation est archivée et masquée de vos conversations récentes."
+  },
+  "baseChat.archivedRestore": {
+    "defaultMessage": "Restaurer"
+  },
+  "baseChat.archivedRestoreFailed": {
+    "defaultMessage": "Échec de la restauration de la session : {error}"
+  },
+  "baseChat.archivedRestored": {
+    "defaultMessage": "Session restaurée"
+  },
   "baseChat.failedToLoadSession": {
     "defaultMessage": "Échec du chargement de la session"
   },

--- a/ui/desktop/src/i18n/messages/hi.json
+++ b/ui/desktop/src/i18n/messages/hi.json
@@ -125,6 +125,18 @@
   "backButton.back": {
     "defaultMessage": "वापस"
   },
+  "baseChat.archivedNotice": {
+    "defaultMessage": "यह चैट संग्रहित है और आपकी हाल की चैट से छिपी हुई है।"
+  },
+  "baseChat.archivedRestore": {
+    "defaultMessage": "पुनर्स्थापित करें"
+  },
+  "baseChat.archivedRestoreFailed": {
+    "defaultMessage": "सत्र पुनर्स्थापित नहीं किया जा सका: {error}"
+  },
+  "baseChat.archivedRestored": {
+    "defaultMessage": "सत्र पुनर्स्थापित किया गया"
+  },
   "baseChat.failedToLoadSession": {
     "defaultMessage": "सत्र लोड करने में विफल"
   },

--- a/ui/desktop/src/i18n/messages/hi.json
+++ b/ui/desktop/src/i18n/messages/hi.json
@@ -2366,8 +2366,38 @@
   "navigation.itemSkills": {
     "defaultMessage": "कौशल"
   },
+  "navigationPanel.archive": {
+    "defaultMessage": "संग्रहित करें"
+  },
+  "navigationPanel.archiveFailed": {
+    "defaultMessage": "सत्र संग्रहित नहीं किया जा सका: {error}"
+  },
+  "navigationPanel.archiveSuccess": {
+    "defaultMessage": "“{name}” संग्रहित किया गया"
+  },
   "navigationPanel.chats": {
     "defaultMessage": "चैट"
+  },
+  "navigationPanel.delete": {
+    "defaultMessage": "हटाएँ"
+  },
+  "navigationPanel.deleteCancel": {
+    "defaultMessage": "रद्द करें"
+  },
+  "navigationPanel.deleteConfirm": {
+    "defaultMessage": "हटाएँ"
+  },
+  "navigationPanel.deleteFailed": {
+    "defaultMessage": "सत्र हटाया नहीं जा सका: {error}"
+  },
+  "navigationPanel.deleteMessage": {
+    "defaultMessage": "क्या आप वाकई “{name}” को हटाना चाहते हैं? इसे पूर्ववत नहीं किया जा सकता।"
+  },
+  "navigationPanel.deleteSuccess": {
+    "defaultMessage": "चैट हटाई गई"
+  },
+  "navigationPanel.deleteTitle": {
+    "defaultMessage": "चैट हटाएँ"
   },
   "navigationPanel.metaCreated": {
     "defaultMessage": "बनाया गया"
@@ -2386,6 +2416,12 @@
   },
   "navigationPanel.noChats": {
     "defaultMessage": "कोई हालिया चैट नहीं"
+  },
+  "navigationPanel.rename": {
+    "defaultMessage": "नाम बदलें"
+  },
+  "navigationPanel.sessionActions": {
+    "defaultMessage": "सत्र क्रियाएँ"
   },
   "navigationPanel.statusError": {
     "defaultMessage": "त्रुटि"
@@ -3767,6 +3803,9 @@
   "sessionIndicators.streaming": {
     "defaultMessage": "स्ट्रीमिंग"
   },
+  "sessions.action.archive": {
+    "defaultMessage": "सत्र संग्रहित करें"
+  },
   "sessions.action.delete": {
     "defaultMessage": "सत्र हटाएँ"
   },
@@ -3790,6 +3829,9 @@
   },
   "sessions.action.shareNostr": {
     "defaultMessage": "एन्क्रिप्टेड नोस्ट्र लिंक साझा करें"
+  },
+  "sessions.action.unarchive": {
+    "defaultMessage": "संग्रह से पुनर्स्थापित करें"
   },
   "sessions.cancel": {
     "defaultMessage": "रद्द करें"
@@ -3848,6 +3890,12 @@
   "sessions.loadingMore": {
     "defaultMessage": "अधिक सत्र लोड हो रहे हैं..."
   },
+  "sessions.noArchived": {
+    "defaultMessage": "कोई संग्रहित सत्र नहीं"
+  },
+  "sessions.noArchivedDesc": {
+    "defaultMessage": "आपके द्वारा संग्रहित किए गए सत्र यहाँ दिखाई देंगे।"
+  },
   "sessions.save": {
     "defaultMessage": "सहेजें"
   },
@@ -3868,6 +3916,18 @@
   },
   "sessions.shareNostr.title": {
     "defaultMessage": "एन्क्रिप्टेड नोस्ट्र शेयर लिंक"
+  },
+  "sessions.tab.active": {
+    "defaultMessage": "सक्रिय"
+  },
+  "sessions.tab.archived": {
+    "defaultMessage": "संग्रहित"
+  },
+  "sessions.toast.archiveFailed": {
+    "defaultMessage": "सत्र संग्रहित नहीं किया जा सका: {error}"
+  },
+  "sessions.toast.archived": {
+    "defaultMessage": "सत्र संग्रहित किया गया"
   },
   "sessions.toast.copied": {
     "defaultMessage": "क्लिपबोर्ड पर कॉपी किया गया"
@@ -3901,6 +3961,12 @@
   },
   "sessions.toast.shareNostrFailed": {
     "defaultMessage": "Nostr शेयर लिंक बनाने में विफल: {error}"
+  },
+  "sessions.toast.unarchiveFailed": {
+    "defaultMessage": "सत्र पुनर्स्थापित नहीं किया जा सका: {error}"
+  },
+  "sessions.toast.unarchived": {
+    "defaultMessage": "सत्र पुनर्स्थापित किया गया"
   },
   "sessions.toast.updateFailed": {
     "defaultMessage": "सत्र विवरण अद्यतन करने में विफल: {error}"

--- a/ui/desktop/src/i18n/messages/id.json
+++ b/ui/desktop/src/i18n/messages/id.json
@@ -2366,8 +2366,38 @@
   "navigation.itemSkills": {
     "defaultMessage": "Keterampilan"
   },
+  "navigationPanel.archive": {
+    "defaultMessage": "Arsipkan"
+  },
+  "navigationPanel.archiveFailed": {
+    "defaultMessage": "Gagal mengarsipkan sesi: {error}"
+  },
+  "navigationPanel.archiveSuccess": {
+    "defaultMessage": "“{name}” diarsipkan"
+  },
   "navigationPanel.chats": {
     "defaultMessage": "Obrolan"
+  },
+  "navigationPanel.delete": {
+    "defaultMessage": "Hapus"
+  },
+  "navigationPanel.deleteCancel": {
+    "defaultMessage": "Batal"
+  },
+  "navigationPanel.deleteConfirm": {
+    "defaultMessage": "Hapus"
+  },
+  "navigationPanel.deleteFailed": {
+    "defaultMessage": "Gagal menghapus sesi: {error}"
+  },
+  "navigationPanel.deleteMessage": {
+    "defaultMessage": "Yakin ingin menghapus “{name}”? Tindakan ini tidak dapat dibatalkan."
+  },
+  "navigationPanel.deleteSuccess": {
+    "defaultMessage": "Obrolan dihapus"
+  },
+  "navigationPanel.deleteTitle": {
+    "defaultMessage": "Hapus obrolan"
   },
   "navigationPanel.metaCreated": {
     "defaultMessage": "Dibuat"
@@ -2386,6 +2416,12 @@
   },
   "navigationPanel.noChats": {
     "defaultMessage": "Tidak ada obrolan terbaru"
+  },
+  "navigationPanel.rename": {
+    "defaultMessage": "Ganti nama"
+  },
+  "navigationPanel.sessionActions": {
+    "defaultMessage": "Tindakan sesi"
   },
   "navigationPanel.statusError": {
     "defaultMessage": "Kesalahan"
@@ -3767,6 +3803,9 @@
   "sessionIndicators.streaming": {
     "defaultMessage": "Streaming"
   },
+  "sessions.action.archive": {
+    "defaultMessage": "Arsipkan sesi"
+  },
   "sessions.action.delete": {
     "defaultMessage": "Hapus sesi"
   },
@@ -3790,6 +3829,9 @@
   },
   "sessions.action.shareNostr": {
     "defaultMessage": "Bagikan tautan Nostr terenkripsi"
+  },
+  "sessions.action.unarchive": {
+    "defaultMessage": "Pulihkan dari arsip"
   },
   "sessions.cancel": {
     "defaultMessage": "Batal"
@@ -3848,6 +3890,12 @@
   "sessions.loadingMore": {
     "defaultMessage": "Memuat lebih banyak sesi..."
   },
+  "sessions.noArchived": {
+    "defaultMessage": "Tidak ada sesi terarsip"
+  },
+  "sessions.noArchivedDesc": {
+    "defaultMessage": "Sesi yang Anda arsipkan akan muncul di sini."
+  },
   "sessions.save": {
     "defaultMessage": "Simpan"
   },
@@ -3868,6 +3916,18 @@
   },
   "sessions.shareNostr.title": {
     "defaultMessage": "Tautan Berbagi Nostr Terenkripsi"
+  },
+  "sessions.tab.active": {
+    "defaultMessage": "Aktif"
+  },
+  "sessions.tab.archived": {
+    "defaultMessage": "Terarsip"
+  },
+  "sessions.toast.archiveFailed": {
+    "defaultMessage": "Gagal mengarsipkan sesi: {error}"
+  },
+  "sessions.toast.archived": {
+    "defaultMessage": "Sesi diarsipkan"
   },
   "sessions.toast.copied": {
     "defaultMessage": "Disalin ke papan klip"
@@ -3901,6 +3961,12 @@
   },
   "sessions.toast.shareNostrFailed": {
     "defaultMessage": "Gagal membuat tautan berbagi Nostr: {error}"
+  },
+  "sessions.toast.unarchiveFailed": {
+    "defaultMessage": "Gagal memulihkan sesi: {error}"
+  },
+  "sessions.toast.unarchived": {
+    "defaultMessage": "Sesi dipulihkan"
   },
   "sessions.toast.updateFailed": {
     "defaultMessage": "Gagal memperbarui deskripsi sesi: {error}"

--- a/ui/desktop/src/i18n/messages/id.json
+++ b/ui/desktop/src/i18n/messages/id.json
@@ -125,6 +125,18 @@
   "backButton.back": {
     "defaultMessage": "Kembali"
   },
+  "baseChat.archivedNotice": {
+    "defaultMessage": "Obrolan ini diarsipkan dan disembunyikan dari obrolan terbaru Anda."
+  },
+  "baseChat.archivedRestore": {
+    "defaultMessage": "Pulihkan"
+  },
+  "baseChat.archivedRestoreFailed": {
+    "defaultMessage": "Gagal memulihkan sesi: {error}"
+  },
+  "baseChat.archivedRestored": {
+    "defaultMessage": "Sesi dipulihkan"
+  },
   "baseChat.failedToLoadSession": {
     "defaultMessage": "Gagal Memuat Sesi"
   },

--- a/ui/desktop/src/i18n/messages/it.json
+++ b/ui/desktop/src/i18n/messages/it.json
@@ -2366,8 +2366,38 @@
   "navigation.itemSkills": {
     "defaultMessage": "Competenze"
   },
+  "navigationPanel.archive": {
+    "defaultMessage": "Archivia"
+  },
+  "navigationPanel.archiveFailed": {
+    "defaultMessage": "Impossibile archiviare la sessione: {error}"
+  },
+  "navigationPanel.archiveSuccess": {
+    "defaultMessage": "“{name}” archiviata"
+  },
   "navigationPanel.chats": {
     "defaultMessage": "Chat"
+  },
+  "navigationPanel.delete": {
+    "defaultMessage": "Elimina"
+  },
+  "navigationPanel.deleteCancel": {
+    "defaultMessage": "Annulla"
+  },
+  "navigationPanel.deleteConfirm": {
+    "defaultMessage": "Elimina"
+  },
+  "navigationPanel.deleteFailed": {
+    "defaultMessage": "Impossibile eliminare la sessione: {error}"
+  },
+  "navigationPanel.deleteMessage": {
+    "defaultMessage": "Vuoi davvero eliminare “{name}”? L’operazione non può essere annullata."
+  },
+  "navigationPanel.deleteSuccess": {
+    "defaultMessage": "Chat eliminata"
+  },
+  "navigationPanel.deleteTitle": {
+    "defaultMessage": "Elimina chat"
   },
   "navigationPanel.metaCreated": {
     "defaultMessage": "Creato"
@@ -2386,6 +2416,12 @@
   },
   "navigationPanel.noChats": {
     "defaultMessage": "Nessuna chat recente"
+  },
+  "navigationPanel.rename": {
+    "defaultMessage": "Rinomina"
+  },
+  "navigationPanel.sessionActions": {
+    "defaultMessage": "Azioni sessione"
   },
   "navigationPanel.statusError": {
     "defaultMessage": "Errore"
@@ -3767,6 +3803,9 @@
   "sessionIndicators.streaming": {
     "defaultMessage": "Streaming"
   },
+  "sessions.action.archive": {
+    "defaultMessage": "Archivia sessione"
+  },
   "sessions.action.delete": {
     "defaultMessage": "Elimina sessione"
   },
@@ -3790,6 +3829,9 @@
   },
   "sessions.action.shareNostr": {
     "defaultMessage": "Condividi link Nostr crittografato"
+  },
+  "sessions.action.unarchive": {
+    "defaultMessage": "Ripristina dall’archivio"
   },
   "sessions.cancel": {
     "defaultMessage": "Annulla"
@@ -3848,6 +3890,12 @@
   "sessions.loadingMore": {
     "defaultMessage": "Caricamento di altre sessioni..."
   },
+  "sessions.noArchived": {
+    "defaultMessage": "Nessuna sessione archiviata"
+  },
+  "sessions.noArchivedDesc": {
+    "defaultMessage": "Le sessioni che archivi appariranno qui."
+  },
   "sessions.save": {
     "defaultMessage": "Salva"
   },
@@ -3868,6 +3916,18 @@
   },
   "sessions.shareNostr.title": {
     "defaultMessage": "Link di condivisione Nostr crittografato"
+  },
+  "sessions.tab.active": {
+    "defaultMessage": "Attive"
+  },
+  "sessions.tab.archived": {
+    "defaultMessage": "Archiviate"
+  },
+  "sessions.toast.archiveFailed": {
+    "defaultMessage": "Impossibile archiviare la sessione: {error}"
+  },
+  "sessions.toast.archived": {
+    "defaultMessage": "Sessione archiviata"
   },
   "sessions.toast.copied": {
     "defaultMessage": "Copiato negli appunti"
@@ -3901,6 +3961,12 @@
   },
   "sessions.toast.shareNostrFailed": {
     "defaultMessage": "Impossibile creare il link di condivisione Nostr: {error}"
+  },
+  "sessions.toast.unarchiveFailed": {
+    "defaultMessage": "Impossibile ripristinare la sessione: {error}"
+  },
+  "sessions.toast.unarchived": {
+    "defaultMessage": "Sessione ripristinata"
   },
   "sessions.toast.updateFailed": {
     "defaultMessage": "Impossibile aggiornare la descrizione della sessione: {error}"

--- a/ui/desktop/src/i18n/messages/it.json
+++ b/ui/desktop/src/i18n/messages/it.json
@@ -125,6 +125,18 @@
   "backButton.back": {
     "defaultMessage": "Indietro"
   },
+  "baseChat.archivedNotice": {
+    "defaultMessage": "Questa chat è archiviata e nascosta dalle chat recenti."
+  },
+  "baseChat.archivedRestore": {
+    "defaultMessage": "Ripristina"
+  },
+  "baseChat.archivedRestoreFailed": {
+    "defaultMessage": "Impossibile ripristinare la sessione: {error}"
+  },
+  "baseChat.archivedRestored": {
+    "defaultMessage": "Sessione ripristinata"
+  },
   "baseChat.failedToLoadSession": {
     "defaultMessage": "Impossibile caricare la sessione"
   },

--- a/ui/desktop/src/i18n/messages/ja.json
+++ b/ui/desktop/src/i18n/messages/ja.json
@@ -2366,8 +2366,38 @@
   "navigation.itemSkills": {
     "defaultMessage": "スキル"
   },
+  "navigationPanel.archive": {
+    "defaultMessage": "アーカイブ"
+  },
+  "navigationPanel.archiveFailed": {
+    "defaultMessage": "セッションをアーカイブできませんでした: {error}"
+  },
+  "navigationPanel.archiveSuccess": {
+    "defaultMessage": "「{name}」をアーカイブしました"
+  },
   "navigationPanel.chats": {
     "defaultMessage": "チャット"
+  },
+  "navigationPanel.delete": {
+    "defaultMessage": "削除"
+  },
+  "navigationPanel.deleteCancel": {
+    "defaultMessage": "キャンセル"
+  },
+  "navigationPanel.deleteConfirm": {
+    "defaultMessage": "削除"
+  },
+  "navigationPanel.deleteFailed": {
+    "defaultMessage": "セッションを削除できませんでした: {error}"
+  },
+  "navigationPanel.deleteMessage": {
+    "defaultMessage": "「{name}」を削除してもよろしいですか？この操作は取り消せません。"
+  },
+  "navigationPanel.deleteSuccess": {
+    "defaultMessage": "チャットを削除しました"
+  },
+  "navigationPanel.deleteTitle": {
+    "defaultMessage": "チャットを削除"
   },
   "navigationPanel.metaCreated": {
     "defaultMessage": "作成"
@@ -2386,6 +2416,12 @@
   },
   "navigationPanel.noChats": {
     "defaultMessage": "最近のチャットはありません"
+  },
+  "navigationPanel.rename": {
+    "defaultMessage": "名前を変更"
+  },
+  "navigationPanel.sessionActions": {
+    "defaultMessage": "セッションの操作"
   },
   "navigationPanel.statusError": {
     "defaultMessage": "エラー"
@@ -3767,6 +3803,9 @@
   "sessionIndicators.streaming": {
     "defaultMessage": "ストリーミング中"
   },
+  "sessions.action.archive": {
+    "defaultMessage": "セッションをアーカイブ"
+  },
   "sessions.action.delete": {
     "defaultMessage": "セッションを削除"
   },
@@ -3790,6 +3829,9 @@
   },
   "sessions.action.shareNostr": {
     "defaultMessage": "暗号化Nostrリンクを共有"
+  },
+  "sessions.action.unarchive": {
+    "defaultMessage": "アーカイブから復元"
   },
   "sessions.cancel": {
     "defaultMessage": "キャンセル"
@@ -3848,6 +3890,12 @@
   "sessions.loadingMore": {
     "defaultMessage": "さらにセッションを読み込み中..."
   },
+  "sessions.noArchived": {
+    "defaultMessage": "アーカイブされたセッションはありません"
+  },
+  "sessions.noArchivedDesc": {
+    "defaultMessage": "アーカイブしたセッションがここに表示されます。"
+  },
   "sessions.save": {
     "defaultMessage": "保存"
   },
@@ -3868,6 +3916,18 @@
   },
   "sessions.shareNostr.title": {
     "defaultMessage": "暗号化Nostr共有リンク"
+  },
+  "sessions.tab.active": {
+    "defaultMessage": "アクティブ"
+  },
+  "sessions.tab.archived": {
+    "defaultMessage": "アーカイブ済み"
+  },
+  "sessions.toast.archiveFailed": {
+    "defaultMessage": "セッションをアーカイブできませんでした: {error}"
+  },
+  "sessions.toast.archived": {
+    "defaultMessage": "セッションをアーカイブしました"
   },
   "sessions.toast.copied": {
     "defaultMessage": "クリップボードにコピーしました"
@@ -3901,6 +3961,12 @@
   },
   "sessions.toast.shareNostrFailed": {
     "defaultMessage": "Nostr共有リンクを作成できませんでした: {error}"
+  },
+  "sessions.toast.unarchiveFailed": {
+    "defaultMessage": "セッションを復元できませんでした: {error}"
+  },
+  "sessions.toast.unarchived": {
+    "defaultMessage": "セッションを復元しました"
   },
   "sessions.toast.updateFailed": {
     "defaultMessage": "セッションの説明を更新できませんでした: {error}"

--- a/ui/desktop/src/i18n/messages/ja.json
+++ b/ui/desktop/src/i18n/messages/ja.json
@@ -125,6 +125,18 @@
   "backButton.back": {
     "defaultMessage": "戻る"
   },
+  "baseChat.archivedNotice": {
+    "defaultMessage": "このチャットはアーカイブされ、最近のチャットには表示されません。"
+  },
+  "baseChat.archivedRestore": {
+    "defaultMessage": "復元"
+  },
+  "baseChat.archivedRestoreFailed": {
+    "defaultMessage": "セッションを復元できませんでした: {error}"
+  },
+  "baseChat.archivedRestored": {
+    "defaultMessage": "セッションを復元しました"
+  },
   "baseChat.failedToLoadSession": {
     "defaultMessage": "セッションの読み込みに失敗しました"
   },

--- a/ui/desktop/src/i18n/messages/ko.json
+++ b/ui/desktop/src/i18n/messages/ko.json
@@ -2366,8 +2366,38 @@
   "navigation.itemSkills": {
     "defaultMessage": "스킬"
   },
+  "navigationPanel.archive": {
+    "defaultMessage": "보관"
+  },
+  "navigationPanel.archiveFailed": {
+    "defaultMessage": "세션을 보관하지 못했습니다: {error}"
+  },
+  "navigationPanel.archiveSuccess": {
+    "defaultMessage": "“{name}” 보관됨"
+  },
   "navigationPanel.chats": {
     "defaultMessage": "채팅"
+  },
+  "navigationPanel.delete": {
+    "defaultMessage": "삭제"
+  },
+  "navigationPanel.deleteCancel": {
+    "defaultMessage": "취소"
+  },
+  "navigationPanel.deleteConfirm": {
+    "defaultMessage": "삭제"
+  },
+  "navigationPanel.deleteFailed": {
+    "defaultMessage": "세션을 삭제하지 못했습니다: {error}"
+  },
+  "navigationPanel.deleteMessage": {
+    "defaultMessage": "“{name}”을(를) 삭제하시겠습니까? 이 작업은 취소할 수 없습니다."
+  },
+  "navigationPanel.deleteSuccess": {
+    "defaultMessage": "채팅이 삭제됨"
+  },
+  "navigationPanel.deleteTitle": {
+    "defaultMessage": "채팅 삭제"
   },
   "navigationPanel.metaCreated": {
     "defaultMessage": "생성됨"
@@ -2386,6 +2416,12 @@
   },
   "navigationPanel.noChats": {
     "defaultMessage": "최근 채팅 없음"
+  },
+  "navigationPanel.rename": {
+    "defaultMessage": "이름 변경"
+  },
+  "navigationPanel.sessionActions": {
+    "defaultMessage": "세션 작업"
   },
   "navigationPanel.statusError": {
     "defaultMessage": "오류"
@@ -3767,6 +3803,9 @@
   "sessionIndicators.streaming": {
     "defaultMessage": "스트리밍"
   },
+  "sessions.action.archive": {
+    "defaultMessage": "세션 보관"
+  },
   "sessions.action.delete": {
     "defaultMessage": "세션 삭제"
   },
@@ -3790,6 +3829,9 @@
   },
   "sessions.action.shareNostr": {
     "defaultMessage": "암호화된 Nostr 링크 공유"
+  },
+  "sessions.action.unarchive": {
+    "defaultMessage": "보관함에서 복원"
   },
   "sessions.cancel": {
     "defaultMessage": "취소"
@@ -3848,6 +3890,12 @@
   "sessions.loadingMore": {
     "defaultMessage": "추가 세션 로드 중..."
   },
+  "sessions.noArchived": {
+    "defaultMessage": "보관된 세션 없음"
+  },
+  "sessions.noArchivedDesc": {
+    "defaultMessage": "보관한 세션이 여기에 표시됩니다."
+  },
   "sessions.save": {
     "defaultMessage": "저장"
   },
@@ -3868,6 +3916,18 @@
   },
   "sessions.shareNostr.title": {
     "defaultMessage": "암호화된 Nostr 공유 링크"
+  },
+  "sessions.tab.active": {
+    "defaultMessage": "활성"
+  },
+  "sessions.tab.archived": {
+    "defaultMessage": "보관됨"
+  },
+  "sessions.toast.archiveFailed": {
+    "defaultMessage": "세션을 보관하지 못했습니다: {error}"
+  },
+  "sessions.toast.archived": {
+    "defaultMessage": "세션이 보관됨"
   },
   "sessions.toast.copied": {
     "defaultMessage": "클립보드에 복사됨"
@@ -3901,6 +3961,12 @@
   },
   "sessions.toast.shareNostrFailed": {
     "defaultMessage": "Nostr 공유 링크 생성 실패: {error}"
+  },
+  "sessions.toast.unarchiveFailed": {
+    "defaultMessage": "세션을 복원하지 못했습니다: {error}"
+  },
+  "sessions.toast.unarchived": {
+    "defaultMessage": "세션이 복원됨"
   },
   "sessions.toast.updateFailed": {
     "defaultMessage": "세션 설명 업데이트 실패: {error}"

--- a/ui/desktop/src/i18n/messages/ko.json
+++ b/ui/desktop/src/i18n/messages/ko.json
@@ -125,6 +125,18 @@
   "backButton.back": {
     "defaultMessage": "뒤로"
   },
+  "baseChat.archivedNotice": {
+    "defaultMessage": "이 채팅은 보관되어 최근 채팅에서 숨겨져 있습니다."
+  },
+  "baseChat.archivedRestore": {
+    "defaultMessage": "복원"
+  },
+  "baseChat.archivedRestoreFailed": {
+    "defaultMessage": "세션을 복원하지 못했습니다: {error}"
+  },
+  "baseChat.archivedRestored": {
+    "defaultMessage": "세션이 복원됨"
+  },
   "baseChat.failedToLoadSession": {
     "defaultMessage": "세션을 로드하지 못했습니다."
   },

--- a/ui/desktop/src/i18n/messages/ms.json
+++ b/ui/desktop/src/i18n/messages/ms.json
@@ -2366,8 +2366,38 @@
   "navigation.itemSkills": {
     "defaultMessage": "Kemahiran"
   },
+  "navigationPanel.archive": {
+    "defaultMessage": "Arkibkan"
+  },
+  "navigationPanel.archiveFailed": {
+    "defaultMessage": "Gagal mengarkibkan sesi: {error}"
+  },
+  "navigationPanel.archiveSuccess": {
+    "defaultMessage": "“{name}” diarkibkan"
+  },
   "navigationPanel.chats": {
     "defaultMessage": "Sembang"
+  },
+  "navigationPanel.delete": {
+    "defaultMessage": "Padam"
+  },
+  "navigationPanel.deleteCancel": {
+    "defaultMessage": "Batal"
+  },
+  "navigationPanel.deleteConfirm": {
+    "defaultMessage": "Padam"
+  },
+  "navigationPanel.deleteFailed": {
+    "defaultMessage": "Gagal memadam sesi: {error}"
+  },
+  "navigationPanel.deleteMessage": {
+    "defaultMessage": "Adakah anda pasti mahu memadam “{name}”? Tindakan ini tidak boleh dibuat asal."
+  },
+  "navigationPanel.deleteSuccess": {
+    "defaultMessage": "Sembang dipadam"
+  },
+  "navigationPanel.deleteTitle": {
+    "defaultMessage": "Padam sembang"
   },
   "navigationPanel.metaCreated": {
     "defaultMessage": "Dicipta"
@@ -2386,6 +2416,12 @@
   },
   "navigationPanel.noChats": {
     "defaultMessage": "Tiada sembang terkini"
+  },
+  "navigationPanel.rename": {
+    "defaultMessage": "Namakan semula"
+  },
+  "navigationPanel.sessionActions": {
+    "defaultMessage": "Tindakan sesi"
   },
   "navigationPanel.statusError": {
     "defaultMessage": "Ralat"
@@ -3767,6 +3803,9 @@
   "sessionIndicators.streaming": {
     "defaultMessage": "Penstriman"
   },
+  "sessions.action.archive": {
+    "defaultMessage": "Arkibkan sesi"
+  },
   "sessions.action.delete": {
     "defaultMessage": "Padam sesi"
   },
@@ -3790,6 +3829,9 @@
   },
   "sessions.action.shareNostr": {
     "defaultMessage": "Kongsi pautan Nostr tersulit"
+  },
+  "sessions.action.unarchive": {
+    "defaultMessage": "Pulihkan daripada arkib"
   },
   "sessions.cancel": {
     "defaultMessage": "Batal"
@@ -3848,6 +3890,12 @@
   "sessions.loadingMore": {
     "defaultMessage": "Memuatkan lebih banyak sesi..."
   },
+  "sessions.noArchived": {
+    "defaultMessage": "Tiada sesi diarkibkan"
+  },
+  "sessions.noArchivedDesc": {
+    "defaultMessage": "Sesi yang anda arkibkan akan dipaparkan di sini."
+  },
   "sessions.save": {
     "defaultMessage": "Simpan"
   },
@@ -3868,6 +3916,18 @@
   },
   "sessions.shareNostr.title": {
     "defaultMessage": "Pautan Kongsi Nostr Tersulit"
+  },
+  "sessions.tab.active": {
+    "defaultMessage": "Aktif"
+  },
+  "sessions.tab.archived": {
+    "defaultMessage": "Diarkibkan"
+  },
+  "sessions.toast.archiveFailed": {
+    "defaultMessage": "Gagal mengarkibkan sesi: {error}"
+  },
+  "sessions.toast.archived": {
+    "defaultMessage": "Sesi diarkibkan"
   },
   "sessions.toast.copied": {
     "defaultMessage": "Disalin ke papan keratan"
@@ -3901,6 +3961,12 @@
   },
   "sessions.toast.shareNostrFailed": {
     "defaultMessage": "Gagal mencipta pautan kongsi Nostr: {error}"
+  },
+  "sessions.toast.unarchiveFailed": {
+    "defaultMessage": "Gagal memulihkan sesi: {error}"
+  },
+  "sessions.toast.unarchived": {
+    "defaultMessage": "Sesi dipulihkan"
   },
   "sessions.toast.updateFailed": {
     "defaultMessage": "Gagal mengemas kini penerangan sesi: {error}"

--- a/ui/desktop/src/i18n/messages/ms.json
+++ b/ui/desktop/src/i18n/messages/ms.json
@@ -125,6 +125,18 @@
   "backButton.back": {
     "defaultMessage": "Kembali"
   },
+  "baseChat.archivedNotice": {
+    "defaultMessage": "Sembang ini diarkibkan dan disembunyikan daripada sembang terkini anda."
+  },
+  "baseChat.archivedRestore": {
+    "defaultMessage": "Pulihkan"
+  },
+  "baseChat.archivedRestoreFailed": {
+    "defaultMessage": "Gagal memulihkan sesi: {error}"
+  },
+  "baseChat.archivedRestored": {
+    "defaultMessage": "Sesi dipulihkan"
+  },
   "baseChat.failedToLoadSession": {
     "defaultMessage": "Gagal Memuatkan Sesi"
   },

--- a/ui/desktop/src/i18n/messages/pt.json
+++ b/ui/desktop/src/i18n/messages/pt.json
@@ -125,6 +125,18 @@
   "backButton.back": {
     "defaultMessage": "Voltar"
   },
+  "baseChat.archivedNotice": {
+    "defaultMessage": "Esta conversa está arquivada e oculta das suas conversas recentes."
+  },
+  "baseChat.archivedRestore": {
+    "defaultMessage": "Restaurar"
+  },
+  "baseChat.archivedRestoreFailed": {
+    "defaultMessage": "Falha ao restaurar a sessão: {error}"
+  },
+  "baseChat.archivedRestored": {
+    "defaultMessage": "Sessão restaurada"
+  },
   "baseChat.failedToLoadSession": {
     "defaultMessage": "Falha ao carregar a sessão"
   },

--- a/ui/desktop/src/i18n/messages/pt.json
+++ b/ui/desktop/src/i18n/messages/pt.json
@@ -2366,8 +2366,38 @@
   "navigation.itemSkills": {
     "defaultMessage": "Competências"
   },
+  "navigationPanel.archive": {
+    "defaultMessage": "Arquivar"
+  },
+  "navigationPanel.archiveFailed": {
+    "defaultMessage": "Falha ao arquivar a sessão: {error}"
+  },
+  "navigationPanel.archiveSuccess": {
+    "defaultMessage": "“{name}” arquivada"
+  },
   "navigationPanel.chats": {
     "defaultMessage": "Conversas"
+  },
+  "navigationPanel.delete": {
+    "defaultMessage": "Eliminar"
+  },
+  "navigationPanel.deleteCancel": {
+    "defaultMessage": "Cancelar"
+  },
+  "navigationPanel.deleteConfirm": {
+    "defaultMessage": "Eliminar"
+  },
+  "navigationPanel.deleteFailed": {
+    "defaultMessage": "Falha ao eliminar a sessão: {error}"
+  },
+  "navigationPanel.deleteMessage": {
+    "defaultMessage": "Tem a certeza de que pretende eliminar “{name}”? Esta ação não pode ser anulada."
+  },
+  "navigationPanel.deleteSuccess": {
+    "defaultMessage": "Conversa eliminada"
+  },
+  "navigationPanel.deleteTitle": {
+    "defaultMessage": "Eliminar conversa"
   },
   "navigationPanel.metaCreated": {
     "defaultMessage": "Criado"
@@ -2386,6 +2416,12 @@
   },
   "navigationPanel.noChats": {
     "defaultMessage": "Sem conversas recentes"
+  },
+  "navigationPanel.rename": {
+    "defaultMessage": "Mudar o nome"
+  },
+  "navigationPanel.sessionActions": {
+    "defaultMessage": "Ações da sessão"
   },
   "navigationPanel.statusError": {
     "defaultMessage": "Erro"
@@ -3767,6 +3803,9 @@
   "sessionIndicators.streaming": {
     "defaultMessage": "Em transmissão"
   },
+  "sessions.action.archive": {
+    "defaultMessage": "Arquivar sessão"
+  },
   "sessions.action.delete": {
     "defaultMessage": "Eliminar sessão"
   },
@@ -3790,6 +3829,9 @@
   },
   "sessions.action.shareNostr": {
     "defaultMessage": "Partilhar ligação Nostr encriptada"
+  },
+  "sessions.action.unarchive": {
+    "defaultMessage": "Restaurar do arquivo"
   },
   "sessions.cancel": {
     "defaultMessage": "Cancelar"
@@ -3848,6 +3890,12 @@
   "sessions.loadingMore": {
     "defaultMessage": "A carregar mais sessões..."
   },
+  "sessions.noArchived": {
+    "defaultMessage": "Sem sessões arquivadas"
+  },
+  "sessions.noArchivedDesc": {
+    "defaultMessage": "As sessões que arquivar aparecerão aqui."
+  },
   "sessions.save": {
     "defaultMessage": "Guardar"
   },
@@ -3868,6 +3916,18 @@
   },
   "sessions.shareNostr.title": {
     "defaultMessage": "Link de Partilha Nostr Criptografado"
+  },
+  "sessions.tab.active": {
+    "defaultMessage": "Ativas"
+  },
+  "sessions.tab.archived": {
+    "defaultMessage": "Arquivadas"
+  },
+  "sessions.toast.archiveFailed": {
+    "defaultMessage": "Falha ao arquivar a sessão: {error}"
+  },
+  "sessions.toast.archived": {
+    "defaultMessage": "Sessão arquivada"
   },
   "sessions.toast.copied": {
     "defaultMessage": "Copiado para a área de transferência"
@@ -3901,6 +3961,12 @@
   },
   "sessions.toast.shareNostrFailed": {
     "defaultMessage": "Falha ao criar o link de partilha Nostr: {error}"
+  },
+  "sessions.toast.unarchiveFailed": {
+    "defaultMessage": "Falha ao restaurar a sessão: {error}"
+  },
+  "sessions.toast.unarchived": {
+    "defaultMessage": "Sessão restaurada"
   },
   "sessions.toast.updateFailed": {
     "defaultMessage": "Falha ao atualizar a descrição da sessão: {error}"

--- a/ui/desktop/src/i18n/messages/ru.json
+++ b/ui/desktop/src/i18n/messages/ru.json
@@ -125,6 +125,18 @@
   "backButton.back": {
     "defaultMessage": "Назад"
   },
+  "baseChat.archivedNotice": {
+    "defaultMessage": "Этот чат архивирован и скрыт из недавних чатов."
+  },
+  "baseChat.archivedRestore": {
+    "defaultMessage": "Восстановить"
+  },
+  "baseChat.archivedRestoreFailed": {
+    "defaultMessage": "Не удалось восстановить сеанс: {error}"
+  },
+  "baseChat.archivedRestored": {
+    "defaultMessage": "Сеанс восстановлен"
+  },
   "baseChat.failedToLoadSession": {
     "defaultMessage": "Не удалось загрузить сеанс"
   },

--- a/ui/desktop/src/i18n/messages/ru.json
+++ b/ui/desktop/src/i18n/messages/ru.json
@@ -2366,8 +2366,38 @@
   "navigation.itemSkills": {
     "defaultMessage": "Навыки"
   },
+  "navigationPanel.archive": {
+    "defaultMessage": "Архивировать"
+  },
+  "navigationPanel.archiveFailed": {
+    "defaultMessage": "Не удалось архивировать сеанс: {error}"
+  },
+  "navigationPanel.archiveSuccess": {
+    "defaultMessage": "«{name}» архивирован"
+  },
   "navigationPanel.chats": {
     "defaultMessage": "Чаты"
+  },
+  "navigationPanel.delete": {
+    "defaultMessage": "Удалить"
+  },
+  "navigationPanel.deleteCancel": {
+    "defaultMessage": "Отмена"
+  },
+  "navigationPanel.deleteConfirm": {
+    "defaultMessage": "Удалить"
+  },
+  "navigationPanel.deleteFailed": {
+    "defaultMessage": "Не удалось удалить сеанс: {error}"
+  },
+  "navigationPanel.deleteMessage": {
+    "defaultMessage": "Вы уверены, что хотите удалить «{name}»? Это действие нельзя отменить."
+  },
+  "navigationPanel.deleteSuccess": {
+    "defaultMessage": "Чат удалён"
+  },
+  "navigationPanel.deleteTitle": {
+    "defaultMessage": "Удалить чат"
   },
   "navigationPanel.metaCreated": {
     "defaultMessage": "Создано"
@@ -2386,6 +2416,12 @@
   },
   "navigationPanel.noChats": {
     "defaultMessage": "Нет недавних чатов"
+  },
+  "navigationPanel.rename": {
+    "defaultMessage": "Переименовать"
+  },
+  "navigationPanel.sessionActions": {
+    "defaultMessage": "Действия с сеансом"
   },
   "navigationPanel.statusError": {
     "defaultMessage": "Ошибка"
@@ -3767,6 +3803,9 @@
   "sessionIndicators.streaming": {
     "defaultMessage": "Потоковая передача"
   },
+  "sessions.action.archive": {
+    "defaultMessage": "Архивировать сеанс"
+  },
   "sessions.action.delete": {
     "defaultMessage": "Удалить сеанс"
   },
@@ -3790,6 +3829,9 @@
   },
   "sessions.action.shareNostr": {
     "defaultMessage": "Поделиться зашифрованной ссылкой Nostr"
+  },
+  "sessions.action.unarchive": {
+    "defaultMessage": "Восстановить из архива"
   },
   "sessions.cancel": {
     "defaultMessage": "Отмена"
@@ -3848,6 +3890,12 @@
   "sessions.loadingMore": {
     "defaultMessage": "Загрузка дополнительных сеансов..."
   },
+  "sessions.noArchived": {
+    "defaultMessage": "Нет архивированных сеансов"
+  },
+  "sessions.noArchivedDesc": {
+    "defaultMessage": "Здесь будут отображаться архивированные вами сеансы."
+  },
   "sessions.save": {
     "defaultMessage": "Сохранить"
   },
@@ -3868,6 +3916,18 @@
   },
   "sessions.shareNostr.title": {
     "defaultMessage": "Зашифрованная ссылка общего доступа Nostr"
+  },
+  "sessions.tab.active": {
+    "defaultMessage": "Активные"
+  },
+  "sessions.tab.archived": {
+    "defaultMessage": "Архивированные"
+  },
+  "sessions.toast.archiveFailed": {
+    "defaultMessage": "Не удалось архивировать сеанс: {error}"
+  },
+  "sessions.toast.archived": {
+    "defaultMessage": "Сеанс архивирован"
   },
   "sessions.toast.copied": {
     "defaultMessage": "Скопировано в буфер обмена"
@@ -3901,6 +3961,12 @@
   },
   "sessions.toast.shareNostrFailed": {
     "defaultMessage": "Не удалось создать ссылку Nostr: {error}"
+  },
+  "sessions.toast.unarchiveFailed": {
+    "defaultMessage": "Не удалось восстановить сеанс: {error}"
+  },
+  "sessions.toast.unarchived": {
+    "defaultMessage": "Сеанс восстановлен"
   },
   "sessions.toast.updateFailed": {
     "defaultMessage": "Не удалось обновить описание сеанса: {error}"

--- a/ui/desktop/src/i18n/messages/tr.json
+++ b/ui/desktop/src/i18n/messages/tr.json
@@ -2366,8 +2366,38 @@
   "navigation.itemSkills": {
     "defaultMessage": "Beceriler"
   },
+  "navigationPanel.archive": {
+    "defaultMessage": "Arşivle"
+  },
+  "navigationPanel.archiveFailed": {
+    "defaultMessage": "Oturum arşivlenemedi: {error}"
+  },
+  "navigationPanel.archiveSuccess": {
+    "defaultMessage": "“{name}” arşivlendi"
+  },
   "navigationPanel.chats": {
     "defaultMessage": "Sohbetler"
+  },
+  "navigationPanel.delete": {
+    "defaultMessage": "Sil"
+  },
+  "navigationPanel.deleteCancel": {
+    "defaultMessage": "İptal"
+  },
+  "navigationPanel.deleteConfirm": {
+    "defaultMessage": "Sil"
+  },
+  "navigationPanel.deleteFailed": {
+    "defaultMessage": "Oturum silinemedi: {error}"
+  },
+  "navigationPanel.deleteMessage": {
+    "defaultMessage": "“{name}” sohbetini silmek istediğinizden emin misiniz? Bu işlem geri alınamaz."
+  },
+  "navigationPanel.deleteSuccess": {
+    "defaultMessage": "Sohbet silindi"
+  },
+  "navigationPanel.deleteTitle": {
+    "defaultMessage": "Sohbeti sil"
   },
   "navigationPanel.metaCreated": {
     "defaultMessage": "Oluşturuldu"
@@ -2386,6 +2416,12 @@
   },
   "navigationPanel.noChats": {
     "defaultMessage": "Son sohbet yok"
+  },
+  "navigationPanel.rename": {
+    "defaultMessage": "Yeniden adlandır"
+  },
+  "navigationPanel.sessionActions": {
+    "defaultMessage": "Oturum işlemleri"
   },
   "navigationPanel.statusError": {
     "defaultMessage": "Hata"
@@ -3767,6 +3803,9 @@
   "sessionIndicators.streaming": {
     "defaultMessage": "Akış"
   },
+  "sessions.action.archive": {
+    "defaultMessage": "Oturumu arşivle"
+  },
   "sessions.action.delete": {
     "defaultMessage": "Oturumu sil"
   },
@@ -3790,6 +3829,9 @@
   },
   "sessions.action.shareNostr": {
     "defaultMessage": "Şifrelenmiş Nostr bağlantısını paylaşın"
+  },
+  "sessions.action.unarchive": {
+    "defaultMessage": "Arşivden geri yükle"
   },
   "sessions.cancel": {
     "defaultMessage": "İptal"
@@ -3848,6 +3890,12 @@
   "sessions.loadingMore": {
     "defaultMessage": "Daha fazla oturum yükleniyor..."
   },
+  "sessions.noArchived": {
+    "defaultMessage": "Arşivlenmiş oturum yok"
+  },
+  "sessions.noArchivedDesc": {
+    "defaultMessage": "Arşivlediğiniz oturumlar burada görünecek."
+  },
   "sessions.save": {
     "defaultMessage": "Kaydet"
   },
@@ -3868,6 +3916,18 @@
   },
   "sessions.shareNostr.title": {
     "defaultMessage": "Şifreli Nostr Paylaşım Bağlantısı"
+  },
+  "sessions.tab.active": {
+    "defaultMessage": "Etkin"
+  },
+  "sessions.tab.archived": {
+    "defaultMessage": "Arşivlenmiş"
+  },
+  "sessions.toast.archiveFailed": {
+    "defaultMessage": "Oturum arşivlenemedi: {error}"
+  },
+  "sessions.toast.archived": {
+    "defaultMessage": "Oturum arşivlendi"
   },
   "sessions.toast.copied": {
     "defaultMessage": "Panoya kopyalandı"
@@ -3901,6 +3961,12 @@
   },
   "sessions.toast.shareNostrFailed": {
     "defaultMessage": "Nostr paylaşım bağlantısı oluşturulamadı: {error}"
+  },
+  "sessions.toast.unarchiveFailed": {
+    "defaultMessage": "Oturum geri yüklenemedi: {error}"
+  },
+  "sessions.toast.unarchived": {
+    "defaultMessage": "Oturum geri yüklendi"
   },
   "sessions.toast.updateFailed": {
     "defaultMessage": "Oturum açıklaması güncellenemedi: {error}"

--- a/ui/desktop/src/i18n/messages/tr.json
+++ b/ui/desktop/src/i18n/messages/tr.json
@@ -125,6 +125,18 @@
   "backButton.back": {
     "defaultMessage": "Geri"
   },
+  "baseChat.archivedNotice": {
+    "defaultMessage": "Bu sohbet arşivlendi ve son sohbetlerinizden gizlendi."
+  },
+  "baseChat.archivedRestore": {
+    "defaultMessage": "Geri yükle"
+  },
+  "baseChat.archivedRestoreFailed": {
+    "defaultMessage": "Oturum geri yüklenemedi: {error}"
+  },
+  "baseChat.archivedRestored": {
+    "defaultMessage": "Oturum geri yüklendi"
+  },
   "baseChat.failedToLoadSession": {
     "defaultMessage": "Oturum Yüklenemedi"
   },

--- a/ui/desktop/src/i18n/messages/vi.json
+++ b/ui/desktop/src/i18n/messages/vi.json
@@ -125,6 +125,18 @@
   "backButton.back": {
     "defaultMessage": "Quay lại"
   },
+  "baseChat.archivedNotice": {
+    "defaultMessage": "Cuộc trò chuyện này đã được lưu trữ và ẩn khỏi các cuộc trò chuyện gần đây."
+  },
+  "baseChat.archivedRestore": {
+    "defaultMessage": "Khôi phục"
+  },
+  "baseChat.archivedRestoreFailed": {
+    "defaultMessage": "Không thể khôi phục phiên: {error}"
+  },
+  "baseChat.archivedRestored": {
+    "defaultMessage": "Đã khôi phục phiên"
+  },
   "baseChat.failedToLoadSession": {
     "defaultMessage": "Không thể tải phiên"
   },

--- a/ui/desktop/src/i18n/messages/vi.json
+++ b/ui/desktop/src/i18n/messages/vi.json
@@ -2366,8 +2366,38 @@
   "navigation.itemSkills": {
     "defaultMessage": "Kỹ năng"
   },
+  "navigationPanel.archive": {
+    "defaultMessage": "Lưu trữ"
+  },
+  "navigationPanel.archiveFailed": {
+    "defaultMessage": "Không thể lưu trữ phiên: {error}"
+  },
+  "navigationPanel.archiveSuccess": {
+    "defaultMessage": "Đã lưu trữ “{name}”"
+  },
   "navigationPanel.chats": {
     "defaultMessage": "Cuộc trò chuyện"
+  },
+  "navigationPanel.delete": {
+    "defaultMessage": "Xóa"
+  },
+  "navigationPanel.deleteCancel": {
+    "defaultMessage": "Hủy"
+  },
+  "navigationPanel.deleteConfirm": {
+    "defaultMessage": "Xóa"
+  },
+  "navigationPanel.deleteFailed": {
+    "defaultMessage": "Không thể xóa phiên: {error}"
+  },
+  "navigationPanel.deleteMessage": {
+    "defaultMessage": "Bạn có chắc muốn xóa “{name}”? Hành động này không thể hoàn tác."
+  },
+  "navigationPanel.deleteSuccess": {
+    "defaultMessage": "Đã xóa cuộc trò chuyện"
+  },
+  "navigationPanel.deleteTitle": {
+    "defaultMessage": "Xóa cuộc trò chuyện"
   },
   "navigationPanel.metaCreated": {
     "defaultMessage": "Đã tạo"
@@ -2386,6 +2416,12 @@
   },
   "navigationPanel.noChats": {
     "defaultMessage": "Không có cuộc trò chuyện gần đây"
+  },
+  "navigationPanel.rename": {
+    "defaultMessage": "Đổi tên"
+  },
+  "navigationPanel.sessionActions": {
+    "defaultMessage": "Tác vụ phiên"
   },
   "navigationPanel.statusError": {
     "defaultMessage": "Lỗi"
@@ -3767,6 +3803,9 @@
   "sessionIndicators.streaming": {
     "defaultMessage": "Đang truyền phát"
   },
+  "sessions.action.archive": {
+    "defaultMessage": "Lưu trữ phiên"
+  },
   "sessions.action.delete": {
     "defaultMessage": "Xóa phiên"
   },
@@ -3790,6 +3829,9 @@
   },
   "sessions.action.shareNostr": {
     "defaultMessage": "Chia sẻ liên kết Nostr được mã hóa"
+  },
+  "sessions.action.unarchive": {
+    "defaultMessage": "Khôi phục từ kho lưu trữ"
   },
   "sessions.cancel": {
     "defaultMessage": "Hủy"
@@ -3848,6 +3890,12 @@
   "sessions.loadingMore": {
     "defaultMessage": "Đang tải thêm phiên..."
   },
+  "sessions.noArchived": {
+    "defaultMessage": "Không có phiên đã lưu trữ"
+  },
+  "sessions.noArchivedDesc": {
+    "defaultMessage": "Các phiên bạn lưu trữ sẽ xuất hiện ở đây."
+  },
   "sessions.save": {
     "defaultMessage": "Lưu"
   },
@@ -3868,6 +3916,18 @@
   },
   "sessions.shareNostr.title": {
     "defaultMessage": "Liên kết chia sẻ Nostr được mã hóa"
+  },
+  "sessions.tab.active": {
+    "defaultMessage": "Đang hoạt động"
+  },
+  "sessions.tab.archived": {
+    "defaultMessage": "Đã lưu trữ"
+  },
+  "sessions.toast.archiveFailed": {
+    "defaultMessage": "Không thể lưu trữ phiên: {error}"
+  },
+  "sessions.toast.archived": {
+    "defaultMessage": "Đã lưu trữ phiên"
   },
   "sessions.toast.copied": {
     "defaultMessage": "Đã sao chép vào bộ nhớ tạm"
@@ -3901,6 +3961,12 @@
   },
   "sessions.toast.shareNostrFailed": {
     "defaultMessage": "Không thể tạo liên kết chia sẻ Nostr: {error}"
+  },
+  "sessions.toast.unarchiveFailed": {
+    "defaultMessage": "Không thể khôi phục phiên: {error}"
+  },
+  "sessions.toast.unarchived": {
+    "defaultMessage": "Đã khôi phục phiên"
   },
   "sessions.toast.updateFailed": {
     "defaultMessage": "Không thể cập nhật mô tả phiên làm việc: {error}"

--- a/ui/desktop/src/i18n/messages/zh-CN.json
+++ b/ui/desktop/src/i18n/messages/zh-CN.json
@@ -125,6 +125,18 @@
   "backButton.back": {
     "defaultMessage": "返回"
   },
+  "baseChat.archivedNotice": {
+    "defaultMessage": "此聊天已归档，并从最近的聊天中隐藏。"
+  },
+  "baseChat.archivedRestore": {
+    "defaultMessage": "恢复"
+  },
+  "baseChat.archivedRestoreFailed": {
+    "defaultMessage": "恢复会话失败：{error}"
+  },
+  "baseChat.archivedRestored": {
+    "defaultMessage": "会话已恢复"
+  },
   "baseChat.failedToLoadSession": {
     "defaultMessage": "加载会话失败"
   },

--- a/ui/desktop/src/i18n/messages/zh-CN.json
+++ b/ui/desktop/src/i18n/messages/zh-CN.json
@@ -2366,8 +2366,38 @@
   "navigation.itemSkills": {
     "defaultMessage": "技能"
   },
+  "navigationPanel.archive": {
+    "defaultMessage": "归档"
+  },
+  "navigationPanel.archiveFailed": {
+    "defaultMessage": "归档会话失败：{error}"
+  },
+  "navigationPanel.archiveSuccess": {
+    "defaultMessage": "已归档“{name}”"
+  },
   "navigationPanel.chats": {
     "defaultMessage": "聊天"
+  },
+  "navigationPanel.delete": {
+    "defaultMessage": "删除"
+  },
+  "navigationPanel.deleteCancel": {
+    "defaultMessage": "取消"
+  },
+  "navigationPanel.deleteConfirm": {
+    "defaultMessage": "删除"
+  },
+  "navigationPanel.deleteFailed": {
+    "defaultMessage": "删除会话失败：{error}"
+  },
+  "navigationPanel.deleteMessage": {
+    "defaultMessage": "确定要删除“{name}”吗？此操作无法撤消。"
+  },
+  "navigationPanel.deleteSuccess": {
+    "defaultMessage": "聊天已删除"
+  },
+  "navigationPanel.deleteTitle": {
+    "defaultMessage": "删除聊天"
   },
   "navigationPanel.metaCreated": {
     "defaultMessage": "创建时间"
@@ -2386,6 +2416,12 @@
   },
   "navigationPanel.noChats": {
     "defaultMessage": "没有最近的聊天"
+  },
+  "navigationPanel.rename": {
+    "defaultMessage": "重命名"
+  },
+  "navigationPanel.sessionActions": {
+    "defaultMessage": "会话操作"
   },
   "navigationPanel.statusError": {
     "defaultMessage": "错误"
@@ -3767,6 +3803,9 @@
   "sessionIndicators.streaming": {
     "defaultMessage": "流式传输中"
   },
+  "sessions.action.archive": {
+    "defaultMessage": "归档会话"
+  },
   "sessions.action.delete": {
     "defaultMessage": "删除会话"
   },
@@ -3790,6 +3829,9 @@
   },
   "sessions.action.shareNostr": {
     "defaultMessage": "分享加密的 Nostr 链接"
+  },
+  "sessions.action.unarchive": {
+    "defaultMessage": "从归档恢复"
   },
   "sessions.cancel": {
     "defaultMessage": "取消"
@@ -3848,6 +3890,12 @@
   "sessions.loadingMore": {
     "defaultMessage": "正在加载更多会话…"
   },
+  "sessions.noArchived": {
+    "defaultMessage": "没有已归档的会话"
+  },
+  "sessions.noArchivedDesc": {
+    "defaultMessage": "您归档的会话将显示在此处。"
+  },
   "sessions.save": {
     "defaultMessage": "保存"
   },
@@ -3868,6 +3916,18 @@
   },
   "sessions.shareNostr.title": {
     "defaultMessage": "加密的 Nostr 分享链接"
+  },
+  "sessions.tab.active": {
+    "defaultMessage": "活跃"
+  },
+  "sessions.tab.archived": {
+    "defaultMessage": "已归档"
+  },
+  "sessions.toast.archiveFailed": {
+    "defaultMessage": "归档会话失败：{error}"
+  },
+  "sessions.toast.archived": {
+    "defaultMessage": "会话已归档"
   },
   "sessions.toast.copied": {
     "defaultMessage": "已复制到剪贴板"
@@ -3901,6 +3961,12 @@
   },
   "sessions.toast.shareNostrFailed": {
     "defaultMessage": "创建 Nostr 分享链接失败：{error}"
+  },
+  "sessions.toast.unarchiveFailed": {
+    "defaultMessage": "恢复会话失败：{error}"
+  },
+  "sessions.toast.unarchived": {
+    "defaultMessage": "会话已恢复"
   },
   "sessions.toast.updateFailed": {
     "defaultMessage": "更新会话描述失败：{error}"

--- a/ui/desktop/src/i18n/messages/zh-TW.json
+++ b/ui/desktop/src/i18n/messages/zh-TW.json
@@ -2366,8 +2366,38 @@
   "navigation.itemSkills": {
     "defaultMessage": "技能"
   },
+  "navigationPanel.archive": {
+    "defaultMessage": "封存"
+  },
+  "navigationPanel.archiveFailed": {
+    "defaultMessage": "封存工作階段失敗：{error}"
+  },
+  "navigationPanel.archiveSuccess": {
+    "defaultMessage": "已封存「{name}」"
+  },
   "navigationPanel.chats": {
     "defaultMessage": "交談"
+  },
+  "navigationPanel.delete": {
+    "defaultMessage": "刪除"
+  },
+  "navigationPanel.deleteCancel": {
+    "defaultMessage": "取消"
+  },
+  "navigationPanel.deleteConfirm": {
+    "defaultMessage": "刪除"
+  },
+  "navigationPanel.deleteFailed": {
+    "defaultMessage": "刪除工作階段失敗：{error}"
+  },
+  "navigationPanel.deleteMessage": {
+    "defaultMessage": "確定要刪除「{name}」嗎？此操作無法復原。"
+  },
+  "navigationPanel.deleteSuccess": {
+    "defaultMessage": "已刪除聊天"
+  },
+  "navigationPanel.deleteTitle": {
+    "defaultMessage": "刪除聊天"
   },
   "navigationPanel.metaCreated": {
     "defaultMessage": "建立時間"
@@ -2386,6 +2416,12 @@
   },
   "navigationPanel.noChats": {
     "defaultMessage": "沒有最近的交談"
+  },
+  "navigationPanel.rename": {
+    "defaultMessage": "重新命名"
+  },
+  "navigationPanel.sessionActions": {
+    "defaultMessage": "工作階段動作"
   },
   "navigationPanel.statusError": {
     "defaultMessage": "錯誤"
@@ -3767,6 +3803,9 @@
   "sessionIndicators.streaming": {
     "defaultMessage": "串流中"
   },
+  "sessions.action.archive": {
+    "defaultMessage": "封存工作階段"
+  },
   "sessions.action.delete": {
     "defaultMessage": "刪除工作階段"
   },
@@ -3790,6 +3829,9 @@
   },
   "sessions.action.shareNostr": {
     "defaultMessage": "分享加密的 Nostr 連結"
+  },
+  "sessions.action.unarchive": {
+    "defaultMessage": "從封存還原"
   },
   "sessions.cancel": {
     "defaultMessage": "取消"
@@ -3848,6 +3890,12 @@
   "sessions.loadingMore": {
     "defaultMessage": "正在載入更多工作階段…"
   },
+  "sessions.noArchived": {
+    "defaultMessage": "沒有已封存的工作階段"
+  },
+  "sessions.noArchivedDesc": {
+    "defaultMessage": "您封存的工作階段將顯示在此處。"
+  },
   "sessions.save": {
     "defaultMessage": "儲存"
   },
@@ -3868,6 +3916,18 @@
   },
   "sessions.shareNostr.title": {
     "defaultMessage": "加密的 Nostr 分享連結"
+  },
+  "sessions.tab.active": {
+    "defaultMessage": "使用中"
+  },
+  "sessions.tab.archived": {
+    "defaultMessage": "已封存"
+  },
+  "sessions.toast.archiveFailed": {
+    "defaultMessage": "封存工作階段失敗：{error}"
+  },
+  "sessions.toast.archived": {
+    "defaultMessage": "工作階段已封存"
   },
   "sessions.toast.copied": {
     "defaultMessage": "已複製到剪貼簿"
@@ -3901,6 +3961,12 @@
   },
   "sessions.toast.shareNostrFailed": {
     "defaultMessage": "無法建立 Nostr 分享連結：{error}"
+  },
+  "sessions.toast.unarchiveFailed": {
+    "defaultMessage": "還原工作階段失敗：{error}"
+  },
+  "sessions.toast.unarchived": {
+    "defaultMessage": "工作階段已還原"
   },
   "sessions.toast.updateFailed": {
     "defaultMessage": "無法更新工作階段描述：{error}"

--- a/ui/desktop/src/i18n/messages/zh-TW.json
+++ b/ui/desktop/src/i18n/messages/zh-TW.json
@@ -125,6 +125,18 @@
   "backButton.back": {
     "defaultMessage": "返回"
   },
+  "baseChat.archivedNotice": {
+    "defaultMessage": "此聊天已封存，並從最近的聊天中隱藏。"
+  },
+  "baseChat.archivedRestore": {
+    "defaultMessage": "還原"
+  },
+  "baseChat.archivedRestoreFailed": {
+    "defaultMessage": "還原工作階段失敗：{error}"
+  },
+  "baseChat.archivedRestored": {
+    "defaultMessage": "工作階段已還原"
+  },
   "baseChat.failedToLoadSession": {
     "defaultMessage": "無法載入工作階段"
   },

--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -2951,6 +2951,10 @@ async function appMain() {
   // to drop its statuses — otherwise a window closed mid-stream would leave its
   // sessions marked busy forever.
   const sessionStatusWiredIds = new Set<number>();
+  // Latest busy statuses per reporting window, so windows and views that start
+  // listening after a run began can seed their state instead of missing it.
+  const sessionStatusesByWindow = new Map<number, Map<string, string>>();
+  const busySessionStreamStates = new Set(['loading', 'streaming', 'waiting']);
   ipcMain.on('broadcast-session-status', (event, status) => {
     const senderWindow = BrowserWindow.fromWebContents(event.sender);
     if (!senderWindow) {
@@ -2958,9 +2962,27 @@ async function appMain() {
     }
     const senderId = senderWindow.id;
 
+    const { sessionId, streamState } = (status ?? {}) as {
+      sessionId?: string;
+      streamState?: string;
+    };
+    if (typeof sessionId === 'string') {
+      if (typeof streamState === 'string' && busySessionStreamStates.has(streamState)) {
+        let byWindow = sessionStatusesByWindow.get(senderId);
+        if (!byWindow) {
+          byWindow = new Map();
+          sessionStatusesByWindow.set(senderId, byWindow);
+        }
+        byWindow.set(sessionId, streamState);
+      } else {
+        sessionStatusesByWindow.get(senderId)?.delete(sessionId);
+      }
+    }
+
     if (!sessionStatusWiredIds.has(senderId)) {
       sessionStatusWiredIds.add(senderId);
       const clearReporter = () => {
+        sessionStatusesByWindow.delete(senderId);
         BrowserWindow.getAllWindows().forEach((window) => {
           if (window.id !== senderId && !window.webContents.isDestroyed()) {
             window.webContents.send('remote-session-status-cleared', { windowId: senderId });
@@ -2982,6 +3004,31 @@ async function appMain() {
     BrowserWindow.getAllWindows().forEach((window) => {
       if (window.id !== senderId) {
         window.webContents.send('remote-session-status-update', { windowId: senderId, ...status });
+      }
+    });
+  });
+
+  ipcMain.handle('get-remote-session-statuses', (event) => {
+    const senderId = BrowserWindow.fromWebContents(event.sender)?.id;
+    const statuses: Array<{ windowId: number; sessionId: string; streamState: string }> = [];
+    sessionStatusesByWindow.forEach((byWindow, windowId) => {
+      if (windowId === senderId) {
+        return;
+      }
+      byWindow.forEach((streamState, sessionId) => {
+        statuses.push({ windowId, sessionId, streamState });
+      });
+    });
+    return statuses;
+  });
+
+  // Archive/delete change what other windows may safely show; relay the
+  // renderer lifecycle events so each window runs its own cleanup/navigation.
+  ipcMain.on('broadcast-session-lifecycle', (event, lifecycleEvent) => {
+    const senderWindow = BrowserWindow.fromWebContents(event.sender);
+    BrowserWindow.getAllWindows().forEach((window) => {
+      if (window.id !== senderWindow?.id) {
+        window.webContents.send('remote-session-lifecycle', lifecycleEvent);
       }
     });
   });

--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -2945,6 +2945,47 @@ async function appMain() {
     });
   });
 
+  // Relay per-session stream status between windows so archive/delete guards
+  // can see runs owned by other windows (local backends are per-window, so the
+  // server cannot). When a reporting window closes or reloads, tell the others
+  // to drop its statuses — otherwise a window closed mid-stream would leave its
+  // sessions marked busy forever.
+  const sessionStatusWiredIds = new Set<number>();
+  ipcMain.on('broadcast-session-status', (event, status) => {
+    const senderWindow = BrowserWindow.fromWebContents(event.sender);
+    if (!senderWindow) {
+      return;
+    }
+    const senderId = senderWindow.id;
+
+    if (!sessionStatusWiredIds.has(senderId)) {
+      sessionStatusWiredIds.add(senderId);
+      const clearReporter = () => {
+        BrowserWindow.getAllWindows().forEach((window) => {
+          if (window.id !== senderId && !window.webContents.isDestroyed()) {
+            window.webContents.send('remote-session-status-cleared', { windowId: senderId });
+          }
+        });
+      };
+      senderWindow.once('closed', () => {
+        sessionStatusWiredIds.delete(senderId);
+        clearReporter();
+      });
+      // A reload drops the renderer's streaming state without firing 'closed'.
+      senderWindow.webContents.on('did-start-navigation', (navigationEvent) => {
+        if (!navigationEvent.isSameDocument) {
+          clearReporter();
+        }
+      });
+    }
+
+    BrowserWindow.getAllWindows().forEach((window) => {
+      if (window.id !== senderId) {
+        window.webContents.send('remote-session-status-update', { windowId: senderId, ...status });
+      }
+    });
+  });
+
   ipcMain.on('reload-app', (event) => {
     // Get the window that sent the event
     const window = BrowserWindow.fromWebContents(event.sender);

--- a/ui/desktop/src/preload.ts
+++ b/ui/desktop/src/preload.ts
@@ -156,6 +156,7 @@ type ElectronAPI = {
     theme: string;
     tokensUpdated?: boolean;
   }) => void;
+  broadcastSessionStatus: (status: { sessionId: string; streamState: string }) => void;
   openExternal: (url: string) => Promise<void>;
   // Update-related functions
   getVersion: () => string;
@@ -292,6 +293,9 @@ const electronAPI: ElectronAPI = {
     tokensUpdated?: boolean;
   }) => {
     ipcRenderer.send('broadcast-theme-change', themeData);
+  },
+  broadcastSessionStatus: (status: { sessionId: string; streamState: string }) => {
+    ipcRenderer.send('broadcast-session-status', status);
   },
   openExternal: (url: string): Promise<void> => {
     return ipcRenderer.invoke('open-external', url);

--- a/ui/desktop/src/preload.ts
+++ b/ui/desktop/src/preload.ts
@@ -157,6 +157,10 @@ type ElectronAPI = {
     tokensUpdated?: boolean;
   }) => void;
   broadcastSessionStatus: (status: { sessionId: string; streamState: string }) => void;
+  getRemoteSessionStatuses: () => Promise<
+    Array<{ windowId: number; sessionId: string; streamState: string }>
+  >;
+  broadcastSessionLifecycle: (event: { name: string; detail: unknown }) => void;
   openExternal: (url: string) => Promise<void>;
   // Update-related functions
   getVersion: () => string;
@@ -296,6 +300,10 @@ const electronAPI: ElectronAPI = {
   },
   broadcastSessionStatus: (status: { sessionId: string; streamState: string }) => {
     ipcRenderer.send('broadcast-session-status', status);
+  },
+  getRemoteSessionStatuses: () => ipcRenderer.invoke('get-remote-session-statuses'),
+  broadcastSessionLifecycle: (event: { name: string; detail: unknown }) => {
+    ipcRenderer.send('broadcast-session-lifecycle', event);
   },
   openExternal: (url: string): Promise<void> => {
     return ipcRenderer.invoke('open-external', url);

--- a/ui/desktop/src/sessionLifecycleBridge.ts
+++ b/ui/desktop/src/sessionLifecycleBridge.ts
@@ -1,0 +1,32 @@
+import { AppEvents } from './constants/events';
+
+// Archive/delete mutate the shared session store, but window.dispatchEvent only
+// reaches the current renderer — another desktop window with the same chat open
+// would keep talking to a session that is now archived or gone. Relay these
+// lifecycle events through the main process so every window runs its normal
+// App/sidebar cleanup. Remote re-dispatches go through window.dispatchEvent
+// directly (not dispatchSessionLifecycleEvent), so they are not re-broadcast.
+
+const RELAYED_EVENTS: ReadonlySet<string> = new Set([
+  AppEvents.SESSION_ARCHIVED,
+  AppEvents.SESSION_DELETED,
+]);
+
+let subscribed = false;
+
+export function dispatchSessionLifecycleEvent(name: string, detail: unknown): void {
+  window.dispatchEvent(new CustomEvent(name, { detail }));
+  if (RELAYED_EVENTS.has(name)) {
+    window.electron?.broadcastSessionLifecycle?.({ name, detail });
+  }
+}
+
+export function initSessionLifecycleBridge(): void {
+  if (subscribed || !window.electron?.on) return;
+  subscribed = true;
+  window.electron.on('remote-session-lifecycle', (_event, payload) => {
+    const { name, detail } = (payload ?? {}) as { name?: string; detail?: unknown };
+    if (typeof name !== 'string' || !RELAYED_EVENTS.has(name)) return;
+    window.dispatchEvent(new CustomEvent(name, { detail }));
+  });
+}

--- a/ui/desktop/src/sessionStatusBroadcast.ts
+++ b/ui/desktop/src/sessionStatusBroadcast.ts
@@ -1,0 +1,79 @@
+import { acpChatSessionStore, subscribeToAcpChatSession } from './acp/chatSessionStore';
+import { AppEvents } from './constants/events';
+import { ChatState } from './types/chatState';
+
+export type SessionStreamState = 'idle' | 'loading' | 'streaming' | 'waiting' | 'error';
+
+const BUSY_STREAM_STATES: ReadonlySet<SessionStreamState> = new Set<SessionStreamState>([
+  'loading',
+  'streaming',
+  'waiting',
+]);
+
+export function sessionStreamStateFor(
+  chatState: ChatState | undefined,
+  sessionLoadError: string | undefined
+): SessionStreamState {
+  if (chatState === ChatState.LoadingConversation) return 'loading';
+  if (
+    chatState === ChatState.Streaming ||
+    chatState === ChatState.Thinking ||
+    chatState === ChatState.Compacting
+  ) {
+    return 'streaming';
+  }
+  // A prompt paused on a permission/elicitation request still has an active
+  // server run, so it must not report as idle.
+  if (chatState === ChatState.WaitingForUserInput) return 'waiting';
+  if (sessionLoadError) return 'error';
+  return 'idle';
+}
+
+// Other desktop windows run their own backends and cannot see this window's
+// runs; relay status through the main process so their archive/delete guards
+// can. A chat component can unmount mid-run (session eviction), so reporting
+// falls back to the ACP store, which outlives the component — otherwise the
+// session would stay cached as busy until this window reloads.
+export function reportSessionStatus(sessionId: string, streamState: SessionStreamState): void {
+  window.electron?.broadcastSessionStatus?.({ sessionId, streamState });
+}
+
+// This window's own sidebar tracks status from SESSION_STATUS_UPDATE, which
+// only BaseChat emits, so an unmounted chat leaves it stale here too.
+function reportSessionStatusLocally(sessionId: string, streamState: SessionStreamState): void {
+  window.dispatchEvent(
+    new CustomEvent(AppEvents.SESSION_STATUS_UPDATE, { detail: { sessionId, streamState } })
+  );
+  reportSessionStatus(sessionId, streamState);
+}
+
+const watchers = new Map<string, () => void>();
+
+function stopWatching(sessionId: string): void {
+  watchers.get(sessionId)?.();
+  watchers.delete(sessionId);
+}
+
+export function beginSessionStatusReporting(sessionId: string): void {
+  stopWatching(sessionId);
+}
+
+export function endSessionStatusReporting(sessionId: string): void {
+  stopWatching(sessionId);
+
+  const snapshot = acpChatSessionStore.getSnapshot(sessionId);
+  const streamState = sessionStreamStateFor(snapshot?.chatState, snapshot?.sessionLoadError);
+  if (!BUSY_STREAM_STATES.has(streamState)) {
+    reportSessionStatusLocally(sessionId, 'idle');
+    return;
+  }
+
+  const unsubscribe = subscribeToAcpChatSession(sessionId, (next) => {
+    const nextStreamState = sessionStreamStateFor(next.chatState, next.sessionLoadError);
+    reportSessionStatusLocally(sessionId, nextStreamState);
+    if (!BUSY_STREAM_STATES.has(nextStreamState)) {
+      stopWatching(sessionId);
+    }
+  });
+  watchers.set(sessionId, unsubscribe);
+}


### PR DESCRIPTION
Closes #10277. Pin/Star is split out as a distinct follow-up: #10636.

## What

Adds a per-chat **⋯ menu** (hover or right-click) to each session in the sidebar `CHATS` list, exposing **Rename**, **Archive**, and **Delete** — no more detour to Session History for these high-frequency actions.

**Archive** is the net-new capability: a non-destructive hide. Archiving removes a chat from the active sidebar and the Active history list while preserving the record. It stays findable — a keyword search in Session History still surfaces archived matches — and a dedicated **Archived** tab lets you browse and restore.

## Why

Session management was split across two surfaces: the sidebar had only double-click rename, and the only way to declutter it was permanent deletion or waiting for sessions to age out. Archive gives a safe middle ground, and surfacing rename/archive/delete in the sidebar closes a UX gap versus comparable tools.

## How

- **Backend (`crates/goose`)**: new `ArchivedFilter` (`Active`/`Archived`/`All`) added to the session-list query as a SQL `WHERE` clause on the existing `archived_at` column, wired through the ACP `listSessions` `_meta.archived` param and folded into the pagination cursor's filter hash so cursors can't cross filters. Unit test `test_session_list_paged_archived_filter`.
- **Sidebar (`NavigationPanel`)**: reuses the existing Radix `DropdownMenu`; delete goes through the shared `ConfirmationModal`. `useNavigationSessions` listens for `SESSION_ARCHIVED` to drop/refetch rows live.
- **Rename**: `InlineEditText` gains an `editRequestSignal` so the menu can start inline editing programmatically.
- **Session History (`SessionListView`)**: Active/Archived tabs + an archive/restore toggle per card. Active view lists with `archived=all` when a keyword is present so archived sessions remain searchable. The view consumes `SESSION_ARCHIVED`/`SESSION_DELETED`/`SESSION_RENAMED` lifecycle events so it stays in sync with actions taken from the sidebar or other windows.
- **Cross-window consistency (`sessionLifecycleBridge`, `sessionStatusBroadcast`)**: archive/delete events relay through the main process so every window unmounts the affected chat and clears its ACP snapshot; a cross-window busy registry (`useSessionBusyElsewhere`) gates archive/delete on sessions with active runs anywhere, not just the current window.

Sidebar and recent-session lists request `archived=active`, so archived chats are hidden by default everywhere except the Archived tab and keyword search.

## Scope

**Pin/Star is intentionally out of scope** for this PR — it's the only piece of #10277 that needs a new DB column + migration + ACP method, and it's tracked as a follow-up in #10636. This PR delivers the declutter-without-losing capability, which is the core of the request.

## Testing

- `tsc --noEmit` (ui/desktop) — clean
- `cargo test -p goose … test_session_list_paged_archived_filter` — passes
- `cargo fmt --check`, `cargo clippy -p goose --all-targets` — clean


