### PR TITLE
Add Glif to servers directory

### DIFF
--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -324,6 +324,18 @@
     "environmentVariables": []
   },
   {
+    "id": "glif",
+    "name": "Glif",
+    "description": "Generate images, video, and audio with Glif's media-generation agent",
+    "url": "https://glif.app/api/mcp",
+    "link": "https://glif.app/mcp",
+    "installation_notes": "Hosted remote server. Sign in with your Glif account via OAuth on first connect.",
+    "is_builtin": false,
+    "endorsed": false,
+    "environmentVariables": [],
+    "type": "streamable-http"
+  },
+  {
     "id": "github-mcp",
     "name": "GitHub",
     "description": "GitHub repository management and operations",


### PR DESCRIPTION
Adds Glif — hosted media-generation MCP server (images, video, audio). Remote streamable-http at `https://glif.app/api/mcp`, OAuth on first connect. Official, maintained by the Glif team.