### PR TITLE
fix(providers): enable inventory refresh for OpenRouter model picker

### DIFF
--- a/crates/goose/src/providers/init.rs
+++ b/crates/goose/src/providers/init.rs
@@ -304,11 +304,10 @@ mod tests {
         assert_eq!(huggingface.provider_type(), ProviderType::Preferred);
         assert_eq!(meta.display_name, "Hugging Face");
         assert_eq!(meta.default_model, "Qwen/Qwen3-Coder-480B-A35B-Instruct");
-        assert!(
-            meta.config_keys
-                .iter()
-                .any(|key| key.name == "HF_TOKEN" && key.secret)
-        );
+        assert!(meta
+            .config_keys
+            .iter()
+            .any(|key| key.name == "HF_TOKEN" && key.secret));
     }
 
     #[tokio::test]

--- a/crates/goose/src/providers/init.rs
+++ b/crates/goose/src/providers/init.rs
@@ -137,7 +137,15 @@ async fn init_registry() -> RwLock<ProviderRegistry> {
             true,
             Some(registrations::openai_inventory()),
         );
-        registry.register::<OpenRouterProvider>(true);
+        registry.register_with_inventory::<OpenRouterProvider>(
+            true,
+            Some(registrations::refresh_only().with_configured(|| {
+                let config = crate::config::Config::global();
+                config
+                    .get_secret::<serde_json::Value>("OPENROUTER_API_KEY")
+                    .is_ok()
+            })),
+        );
         registry.register_with_inventory::<PiAcpProvider>(
             false,
             Some(registrations::pi_acp_inventory()),
@@ -296,10 +304,11 @@ mod tests {
         assert_eq!(huggingface.provider_type(), ProviderType::Preferred);
         assert_eq!(meta.display_name, "Hugging Face");
         assert_eq!(meta.default_model, "Qwen/Qwen3-Coder-480B-A35B-Instruct");
-        assert!(meta
-            .config_keys
-            .iter()
-            .any(|key| key.name == "HF_TOKEN" && key.secret));
+        assert!(
+            meta.config_keys
+                .iter()
+                .any(|key| key.name == "HF_TOKEN" && key.secret)
+        );
     }
 
     #[tokio::test]

--- a/crates/goose/src/providers/openrouter.rs
+++ b/crates/goose/src/providers/openrouter.rs
@@ -237,8 +237,7 @@ impl Provider for OpenRouterProvider {
         true
     }
 
-    /// Fetch supported models from OpenRouter API (only models with tool support)
-    async fn fetch_supported_models(&self) -> Result<Vec<String>, ProviderError> {
+    async fn fetch_recommended_models(&self, toolshim: bool) -> Result<Vec<String>, ProviderError> {
         let response = self
             .api_client
             .request("api/v1/models")
@@ -277,6 +276,9 @@ impl Provider for OpenRouterProvider {
             .iter()
             .filter_map(|model| {
                 let id = model.get("id").and_then(|v| v.as_str())?;
+                if toolshim {
+                    return Some(id.to_string());
+                }
                 let supports_tools = model
                     .get("supported_parameters")
                     .and_then(|v| v.as_array())
@@ -290,7 +292,6 @@ impl Provider for OpenRouterProvider {
                 }
             })
             .collect();
-
         models.sort();
         Ok(models)
     }

--- a/crates/goose/src/providers/openrouter.rs
+++ b/crates/goose/src/providers/openrouter.rs
@@ -282,7 +282,7 @@ impl Provider for OpenRouterProvider {
                 let supports_tools = model
                     .get("supported_parameters")
                     .and_then(|v| v.as_array())
-                    .map_or(false, |params| {
+                    .is_some_and(|params| {
                         params.iter().any(|p| p.as_str() == Some("tools"))
                     });
                 if supports_tools {

--- a/crates/goose/src/providers/openrouter.rs
+++ b/crates/goose/src/providers/openrouter.rs
@@ -1,8 +1,8 @@
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use async_trait::async_trait;
 use futures::future::BoxFuture;
 use goose_providers::images::ImageFormat;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use std::collections::HashMap;
 
 use super::api_client::{ApiClient, AuthMethod};
@@ -14,7 +14,7 @@ use crate::providers::formats::openrouter as openrouter_format;
 use goose_providers::errors::ProviderError;
 use goose_providers::formats::openai::create_request;
 use goose_providers::model::ModelConfig;
-use goose_providers::request_log::{start_log, LoggerHandleExt};
+use goose_providers::request_log::{LoggerHandleExt, start_log};
 use rmcp::model::Tool;
 
 pub const OPENROUTER_PROVIDER_NAME: &str = "openrouter";
@@ -233,6 +233,10 @@ impl Provider for OpenRouterProvider {
         &self.name
     }
 
+    fn skip_canonical_filtering(&self) -> bool {
+        true
+    }
+
     /// Fetch supported models from OpenRouter API (only models with tool support)
     async fn fetch_supported_models(&self) -> Result<Vec<String>, ProviderError> {
         let response = self
@@ -379,10 +383,12 @@ mod tests {
     fn metadata_includes_openrouter_parameters_config_key() {
         let metadata = OpenRouterProvider::metadata();
 
-        assert!(metadata
-            .config_keys
-            .iter()
-            .any(|key| key.name == OPENROUTER_PARAMETERS_CONFIG_KEY));
+        assert!(
+            metadata
+                .config_keys
+                .iter()
+                .any(|key| key.name == OPENROUTER_PARAMETERS_CONFIG_KEY)
+        );
     }
 
     #[test]
@@ -412,9 +418,10 @@ mod tests {
     fn parse_openrouter_parameters_rejects_non_object_json_string() {
         let err = parse_openrouter_parameters(json!(r#"["web"]"#)).unwrap_err();
 
-        assert!(err
-            .to_string()
-            .contains("OPENROUTER_PARAMETERS must be a JSON object"));
+        assert!(
+            err.to_string()
+                .contains("OPENROUTER_PARAMETERS must be a JSON object")
+        );
     }
 
     #[test]

--- a/crates/goose/src/providers/openrouter.rs
+++ b/crates/goose/src/providers/openrouter.rs
@@ -277,7 +277,17 @@ impl Provider for OpenRouterProvider {
             .iter()
             .filter_map(|model| {
                 let id = model.get("id").and_then(|v| v.as_str())?;
-                Some(id.to_string())
+                let supports_tools = model
+                    .get("supported_parameters")
+                    .and_then(|v| v.as_array())
+                    .map_or(false, |params| {
+                        params.iter().any(|p| p.as_str() == Some("tools"))
+                    });
+                if supports_tools {
+                    Some(id.to_string())
+                } else {
+                    None
+                }
             })
             .collect();
 

--- a/crates/goose/src/providers/openrouter.rs
+++ b/crates/goose/src/providers/openrouter.rs
@@ -282,9 +282,7 @@ impl Provider for OpenRouterProvider {
                 let supports_tools = model
                     .get("supported_parameters")
                     .and_then(|v| v.as_array())
-                    .is_some_and(|params| {
-                        params.iter().any(|p| p.as_str() == Some("tools"))
-                    });
+                    .is_some_and(|params| params.iter().any(|p| p.as_str() == Some("tools")));
                 if supports_tools {
                     Some(id.to_string())
                 } else {

--- a/crates/goose/src/providers/openrouter.rs
+++ b/crates/goose/src/providers/openrouter.rs
@@ -1,8 +1,8 @@
-use anyhow::{Result, bail};
+use anyhow::{bail, Result};
 use async_trait::async_trait;
 use futures::future::BoxFuture;
 use goose_providers::images::ImageFormat;
-use serde_json::{Value, json};
+use serde_json::{json, Value};
 use std::collections::HashMap;
 
 use super::api_client::{ApiClient, AuthMethod};
@@ -14,7 +14,7 @@ use crate::providers::formats::openrouter as openrouter_format;
 use goose_providers::errors::ProviderError;
 use goose_providers::formats::openai::create_request;
 use goose_providers::model::ModelConfig;
-use goose_providers::request_log::{LoggerHandleExt, start_log};
+use goose_providers::request_log::{start_log, LoggerHandleExt};
 use rmcp::model::Tool;
 
 pub const OPENROUTER_PROVIDER_NAME: &str = "openrouter";
@@ -393,12 +393,10 @@ mod tests {
     fn metadata_includes_openrouter_parameters_config_key() {
         let metadata = OpenRouterProvider::metadata();
 
-        assert!(
-            metadata
-                .config_keys
-                .iter()
-                .any(|key| key.name == OPENROUTER_PARAMETERS_CONFIG_KEY)
-        );
+        assert!(metadata
+            .config_keys
+            .iter()
+            .any(|key| key.name == OPENROUTER_PARAMETERS_CONFIG_KEY));
     }
 
     #[test]
@@ -428,10 +426,9 @@ mod tests {
     fn parse_openrouter_parameters_rejects_non_object_json_string() {
         let err = parse_openrouter_parameters(json!(r#"["web"]"#)).unwrap_err();
 
-        assert!(
-            err.to_string()
-                .contains("OPENROUTER_PARAMETERS must be a JSON object")
-        );
+        assert!(err
+            .to_string()
+            .contains("OPENROUTER_PARAMETERS must be a JSON object"));
     }
 
     #[test]


### PR DESCRIPTION
Fixes #10631

## Summary
Register OpenRouterProvider with refresh_only inventory so the model picker fetches all models dynamically from the OpenRouter API instead of falling back to the 10-entry KNOWN_MODELS static list.

Also add skip_canonical_filtering so all models returned by the OpenRouter API are surfaced without being filtered against the canonical registry (mirroring the LiteLLM fix from #10489).

### Testing
manual 

### Screenshots/Demos (for UX changes)



https://github.com/user-attachments/assets/082138ce-57f7-41c0-b353-fcb0ae5833d4




