### PR TITLE
docs(rendex): refresh tutorial — fix Free-tier pricing + add extract/artifact/Watch tools

### DIFF
--- a/documentation/docs/mcp/rendex-mcp.md
+++ b/documentation/docs/mcp/rendex-mcp.md
@@ -1,6 +1,6 @@
 ---
 title: Rendex Extension
-description: Add Rendex MCP Server as a goose Extension for Screenshots, PDFs, and HTML-to-Image Rendering
+description: Add Rendex MCP Server as a goose Extension to screenshot, render, extract, and monitor any webpage
 ---
 
 import Tabs from '@theme/Tabs';
@@ -8,14 +8,14 @@ import TabItem from '@theme/TabItem';
 import GooseDesktopInstaller from '@site/src/components/GooseDesktopInstaller';
 import CLIExtensionInstructions from '@site/src/components/CLIExtensionInstructions';
 
-This tutorial covers how to add the [Rendex MCP Server](https://github.com/copperline-labs/rendex-mcp) as a goose extension to capture screenshots, generate PDFs, and render HTML to images from any webpage or raw HTML — useful for archiving UIs, generating invoices and reports, producing OG images, and giving goose a reliable "see the web" capability without spinning up a full browser automation stack.
+This tutorial covers how to add the [Rendex MCP Server](https://github.com/copperline-labs/rendex-mcp) as a goose extension. Rendex gives goose one rendering platform for the web: capture screenshots and PDFs of any URL or raw HTML, render HTML/Markdown into branded PDF + PNG artifacts with a hosted share link, extract clean reader-mode text from a page, and monitor a URL on a schedule for visual or text changes — useful for archiving UIs, generating invoices and reports, producing OG images, giving goose a reliable "see the web" capability, and watching a page for changes without spinning up a full browser automation stack.
 
 ## Configuration
 
 :::tip Quick Install
 <Tabs groupId="interface">
   <TabItem value="ui" label="goose Desktop" default>
-  [Launch the installer](goose://extension?type=streamable_http&url=https%3A%2F%2Fmcp.rendex.dev%2Fmcp&id=rendex-mcp&name=Rendex&description=Capture%20screenshots%2C%20generate%20PDFs%2C%20and%20render%20HTML%20to%20images%20via%20AI%20agents&header=Authorization%3DBearer%20YOUR_RENDEX_API_KEY)
+  [Launch the installer](goose://extension?type=streamable_http&url=https%3A%2F%2Fmcp.rendex.dev%2Fmcp&id=rendex-mcp&name=Rendex&description=Screenshot%2C%20render%2C%20extract%2C%20and%20monitor%20any%20webpage%20via%20AI%20agents&header=Authorization%3DBearer%20YOUR_RENDEX_API_KEY)
   </TabItem>
   <TabItem value="cli" label="goose CLI">
   Add a `Remote Extension (Streamable HTTP)` extension type with:
@@ -38,7 +38,7 @@ This tutorial covers how to add the [Rendex MCP Server](https://github.com/coppe
     <GooseDesktopInstaller
       extensionId="rendex-mcp"
       extensionName="Rendex"
-      description="Capture screenshots, generate PDFs, and render HTML to images via AI agents"
+      description="Screenshot, render, extract, and monitor any webpage via AI agents"
       type="http"
       url="https://mcp.rendex.dev/mcp"
       envVars={[
@@ -52,7 +52,7 @@ This tutorial covers how to add the [Rendex MCP Server](https://github.com/coppe
   <TabItem value="cli" label="goose CLI">
     <CLIExtensionInstructions
       name="Rendex"
-      description="Capture screenshots, generate PDFs, and render HTML to images via AI agents"
+      description="Screenshot, render, extract, and monitor any webpage via AI agents"
       type="http"
       url="https://mcp.rendex.dev/mcp"
       timeout={300}
@@ -61,12 +61,25 @@ This tutorial covers how to add the [Rendex MCP Server](https://github.com/coppe
       ]}
       infoNote={
         <>
-          Obtain your <a href="https://rendex.dev/dashboard/keys" target="_blank" rel="noopener noreferrer">Rendex API key</a> and paste it in as the <code>Bearer</code> token. Free tier includes 500 calls/month, no credit card required.
+          Obtain your <a href="https://rendex.dev/dashboard/keys" target="_blank" rel="noopener noreferrer">Rendex API key</a> and paste it in as the <code>Bearer</code> token. Free tier includes 100 renders/month, no credit card required.
         </>
       }
     />
   </TabItem>
 </Tabs>
+
+## Available tools
+
+The Rendex extension exposes 13 tools:
+
+| Tool | What it does |
+|---|---|
+| `rendex_screenshot` | Screenshot or PDF of any URL or raw HTML — full-page, dark mode, custom viewport, CSS/JS injection |
+| `rendex_render_link` | Render a URL or HTML to a reusable hosted image URL (og:image / share image) |
+| `rendex_extract` | Extract a page to clean reader-mode Markdown, JSON, or HTML |
+| `render_artifact` | Turn Markdown or HTML into a branded PDF + PNG with a hosted share page in one call |
+| `rendex_account` | Read your plan and this month's usage (read-only, costs no credits) |
+| `watch_create`, `watch_test`, `watch_list`, `watch_get`, `watch_run`, `watch_runs`, `watch_update`, `watch_delete` | **Rendex Watch** — monitor a URL on a schedule and get notified on visual or text changes (full CRUD + run/test) |
 
 ## Example Usage
 
@@ -112,13 +125,29 @@ Both renders completed. You have:
   2. Dark-mode full-page screenshot of Hacker News (PNG, 847KB) — base64 in result 2
 ```
 
+### Monitoring a page for changes
+
+Rendex Watch lets goose keep an eye on a page and tell you when it changes.
+
+```
+Watch https://news.ycombinator.com for visual changes every 3 hours and
+alert my webhook at https://example.com/hooks/hn when the front page changes.
+```
+
+```
+[watch_create: url=https://news.ycombinator.com, diffMode=visual, intervalMinutes=180,
+               webhookUrl=https://example.com/hooks/hn]
+✓ Watch created (baseline captured now)
+  id: wat_7f3a…  status: active  nextRun: 2026-04-15T15:34:56Z
+```
+
 ## Pricing
 
 Rendex is free to try — no credit card required for the free tier.
 
-| Plan | Calls/Month | Rate limit |
+| Plan | Renders/Month | Rate limit |
 |---|---|---|
-| Free | 500 | 10/min |
+| Free | 100 | 3/min |
 | Starter | 10,000 | 60/min |
 | Pro | 100,000 | 300/min |
 | Enterprise | Custom | 1,000/min |


### PR DESCRIPTION
## Summary

Refreshes the existing **Rendex** extension tutorial (`documentation/docs/mcp/rendex-mcp.md`). The page had drifted from the current Rendex MCP server (`@copperline/rendex-mcp` v1.8.2):

- **Corrects the Free-tier pricing** — was `500 calls/month @ 10/min`, now `100 renders/month @ 3/min` (matches current rendex.dev pricing). Starter/Pro/Enterprise unchanged.
- **Broadens the intro & descriptions** beyond screenshots/PDF to reflect the full platform (render, extract, monitor).
- **Adds an "Available tools" table** listing all 13 tools, including `rendex_extract`, `render_artifact`, and the 8 **Rendex Watch** tools that shipped since the original tutorial.
- **Adds a Watch usage example** (`watch_create`) so users see the change-monitoring capability.

No structural/component changes — same `GooseDesktopInstaller` / `CLIExtensionInstructions` usage and install flow.

## Type of change

- [x] Documentation

## How Has This Been Tested?

Content-only Markdown/MDX edit; existing install links and component props are unchanged. Facts verified against the published package (`@copperline/rendex-mcp` v1.8.2) and rendex.dev pricing.
