### PR TITLE
Add pngmeta to extension directory

### DIFF
--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -555,6 +555,17 @@
     "environmentVariables": []
   },
   {
+    "id": "pngmeta",
+    "name": "PNG Metadata",
+    "description": "Read and write PNG metadata (tEXt, iTXt, zTXt chunks and XMP)",
+    "command": "uvx --from pngmeta[mcp] pngmeta-mcp",
+    "link": "https://github.com/james-see/pngmeta",
+    "installation_notes": "Install using uvx. Requires pngmeta[mcp] extra.",
+    "is_builtin": false,
+    "endorsed": false,
+    "environmentVariables": []
+  },
+  {
     "id": "playwright",
     "name": "Playwright",
     "description": "Interact with web pages through structured accessibility snapshots using Playwright",


### PR DESCRIPTION
## Summary

Adds pngmeta to the goose extension directory (servers.json) so it appears in the Extension Manager's discoverable list.

## About pngmeta

pngmeta is a Python library for reading and writing PNG metadata (tEXt, iTXt, zTXt chunks and XMP). It ships as an MCP server via the [mcp] optional dependency.

- PyPI: https://pypi.org/project/pngmeta/0.2.0/
- Source: https://github.com/james-see/pngmeta
- Install: `uvx --from pngmeta[mcp] pngmeta-mcp`
- No API key required (reads/writes local PNG files)
- 6 MCP tools: read_metadata, write_metadata, write_metadata_batch, get_xmp, set_xmp, remove_metadata

## Changes

- 1 file changed, 11 insertions to `documentation/static/servers.json`
- Inserted alphabetically (between 'pieces' and 'playwright')
- No other entries modified