### PR TITLE
fix(acp): surface tool call output in CLI and Desktop

### DIFF
--- a/crates/goose/src/acp/provider.rs
+++ b/crates/goose/src/acp/provider.rs
@@ -2502,7 +2502,7 @@ mod tests {
             None,
         );
 
-        assert_eq!(out.len(), 4, "all four block kinds should produce output");
+        assert_eq!(out.len(), 3, "terminal blocks produce no output");
         let serialized: Vec<String> = out
             .iter()
             .map(|c| serde_json::to_string(c).unwrap())
@@ -2520,13 +2520,24 @@ mod tests {
             "diff body lost: {serialized:?}"
         );
         assert!(
-            serialized[2].contains("term-7"),
-            "terminal id lost: {serialized:?}"
-        );
-        assert!(
-            serialized[3].contains("base64data"),
+            serialized[2].contains("base64data"),
             "image data lost: {serialized:?}"
         );
+    }
+
+    #[test]
+    fn acp_tool_call_terminal_falls_back_to_raw_output() {
+        use agent_client_protocol::schema::v1::{Terminal, TerminalId};
+
+        let terminal_block = ToolCallContent::Terminal(Terminal::new(TerminalId::new("term-1")));
+        let raw_output = serde_json::Value::String("hello from shell".to_string());
+
+        let out = acp_tool_call_content_to_rmcp(Some(vec![terminal_block]), Some(raw_output));
+
+        assert_eq!(out.len(), 1);
+        let text = out[0].as_text().unwrap();
+        assert_eq!(text.text, "hello from shell");
+        assert_eq!(out[0].priority(), Some(0.0));
     }
 
     #[test]

--- a/crates/goose/src/acp/provider.rs
+++ b/crates/goose/src/acp/provider.rs
@@ -1509,12 +1509,7 @@ fn acp_tool_call_content_to_rmcp(
                     };
                     out.push(RmcpContent::text(body));
                 }
-                ToolCallContent::Terminal(terminal) => {
-                    out.push(RmcpContent::text(format!(
-                        "[terminal {}]",
-                        terminal.terminal_id.0
-                    )));
-                }
+                ToolCallContent::Terminal(_) => {}
                 _ => {}
             }
         }
@@ -1525,7 +1520,13 @@ fn acp_tool_call_content_to_rmcp(
                 serde_json::Value::String(s) => s,
                 other => other.to_string(),
             };
-            out.push(RmcpContent::text(text));
+            out.push(RmcpContent::text(text).with_priority(0.0));
+        }
+    } else {
+        for item in &mut out {
+            if item.priority().is_none() {
+                *item = item.clone().with_priority(0.0);
+            }
         }
     }
     out


### PR DESCRIPTION
Fixes #10642

## Summary

When using ACP providers like claude-acp, tool call output was never shown, Two bugs: Terminal content blocks were pushing a useless [terminal <id>] stub that blocked the real raw_output from being used, and content had no priority set so the CLI filter silently dropped it. Fixed both in acp_tool_call_content_to_rmcp

### Testing
manual 

