### PR TITLE
fix(desktop): use shell working directory on initial launch

### DIFF
--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -837,6 +837,13 @@ const parseArgs = () => {
     }
   }
 
+  if (!dirPath && process.stdin.isTTY) {
+    const cwd = process.cwd();
+    if (path.parse(cwd).root !== cwd) {
+      dirPath = cwd;
+    }
+  }
+
   return { dirPath };
 };
 

--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -838,9 +838,13 @@ const parseArgs = () => {
   }
 
   if (!dirPath && process.stdin.isTTY) {
-    const cwd = process.cwd();
-    if (path.parse(cwd).root !== cwd) {
-      dirPath = cwd;
+    try {
+      const cwd = process.cwd();
+      if (path.parse(cwd).root !== cwd) {
+        dirPath = cwd;
+      }
+    } catch {
+      // cwd unavailable; fall through to recentDirs
     }
   }
 


### PR DESCRIPTION
Fixes : #10603

## Summary
When Goose Desktop is launched from a terminal without --dir, the session now opens in the shell's working directory instead of always falling back to the most recent directory or os.homedir().

Root paths (e.g. / on macOS Dock launch, C:\ on Windows Start Menu) are excluded so GUI launches are unaffected. Subsequent "New Window" actions from the Dock menu or menu bar continue to use the most recent directory.

### Testing
manual but would appreciate win user testing it
