### PR TITLE
fix: disable stack-intensive TLS hybrid KX

### DIFF
--- a/crates/goose-cli/src/main.rs
+++ b/crates/goose-cli/src/main.rs
@@ -35,6 +35,8 @@ fn main() -> Result<()> {
     #[cfg(windows)]
     enable_windows_vt_processing();
 
+    goose::crypto::install_default_tls_provider();
+
     let handle = std::thread::Builder::new()
         .name("goose-cli-main".to_string())
         .stack_size(8 * 1024 * 1024)

--- a/crates/goose/src/acp/transport/tls.rs
+++ b/crates/goose/src/acp/transport/tls.rs
@@ -64,7 +64,7 @@ pub async fn from_pem_files(cert_path: &Path, key_path: &Path) -> Result<TlsSetu
 
     #[cfg(feature = "rustls-tls")]
     let config = {
-        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+        crate::crypto::install_default_tls_provider();
         axum_server::tls_rustls::RustlsConfig::from_pem(cert_pem, key_pem.clone()).await?
     };
 
@@ -144,7 +144,7 @@ fn try_save_tls_to_cache(cert_pem: &str, key_pem: &str) {
 
 pub async fn self_signed_config() -> Result<TlsSetup> {
     #[cfg(feature = "rustls-tls")]
-    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+    crate::crypto::install_default_tls_provider();
 
     if let Some(cached) = load_cached_tls().await {
         println!("GOOSED_CERT_FINGERPRINT={}", cached.fingerprint);

--- a/crates/goose/src/crypto.rs
+++ b/crates/goose/src/crypto.rs
@@ -1,0 +1,37 @@
+#[cfg(feature = "rustls-tls")]
+fn default_tls_provider() -> rustls::crypto::CryptoProvider {
+    let mut provider = rustls::crypto::aws_lc_rs::default_provider();
+    provider
+        .kx_groups
+        .retain(|group| group.name() != rustls::NamedGroup::X25519MLKEM768);
+    provider
+}
+
+/// Installs Goose's process-wide Rustls provider before any TLS configuration is built.
+#[cfg(feature = "rustls-tls")]
+pub fn install_default_tls_provider() {
+    let _ = default_tls_provider().install_default();
+}
+
+/// No-op when Goose is built with the native TLS backend.
+#[cfg(not(feature = "rustls-tls"))]
+pub fn install_default_tls_provider() {}
+
+#[cfg(all(test, feature = "rustls-tls"))]
+mod tests {
+    use super::default_tls_provider;
+
+    #[test]
+    fn default_provider_excludes_mlkem_hybrid_group() {
+        let provider = default_tls_provider();
+
+        assert!(provider
+            .kx_groups
+            .iter()
+            .all(|group| group.name() != rustls::NamedGroup::X25519MLKEM768));
+        assert!(provider
+            .kx_groups
+            .iter()
+            .any(|group| group.name() == rustls::NamedGroup::X25519));
+    }
+}

--- a/crates/goose/src/lib.rs
+++ b/crates/goose/src/lib.rs
@@ -11,6 +11,7 @@ pub mod builtin_extension;
 pub mod checks;
 pub mod config;
 pub mod context_mgmt;
+pub mod crypto;
 pub mod conversation {
     pub use goose_providers::conversation::*;
 }

--- a/crates/goose/src/session/nostr_share.rs
+++ b/crates/goose/src/session/nostr_share.rs
@@ -48,7 +48,7 @@ pub struct LiveNostrClient;
 #[async_trait]
 impl NostrPublisher for LiveNostrClient {
     async fn publish(&self, event: Event, relays: &[String]) -> Result<()> {
-        install_rustls_crypto_provider();
+        crate::crypto::install_default_tls_provider();
         let client = Client::default();
         for relay in relays {
             client
@@ -78,7 +78,7 @@ impl NostrPublisher for LiveNostrClient {
 #[async_trait]
 impl NostrFetcher for LiveNostrClient {
     async fn fetch(&self, event_id: EventId, relays: &[String]) -> Result<Event> {
-        install_rustls_crypto_provider();
+        crate::crypto::install_default_tls_provider();
         let client = Client::default();
         for relay in relays {
             client
@@ -108,14 +108,6 @@ impl NostrFetcher for LiveNostrClient {
             .ok_or_else(|| anyhow!("Shared session event not found"))
     }
 }
-
-#[cfg(feature = "rustls-tls")]
-fn install_rustls_crypto_provider() {
-    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
-}
-
-#[cfg(not(feature = "rustls-tls"))]
-fn install_rustls_crypto_provider() {}
 
 pub fn default_relays() -> Vec<String> {
     DEFAULT_RELAYS


### PR DESCRIPTION
## Summary

Disables the `X25519MLKEM768` hybrid key-exchange group in Goose's process-wide Rustls provider while retaining X25519.

This avoids the AWS-LC ML-KEM stack overflow that terminates the Desktop ACP backend during TLS handshakes. The shared provider is installed before CLI runtime startup and used by ACP and Nostr TLS paths.

## Validation

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets --exclude v8 -- -D warnings`
- `cargo test -p goose --no-default-features --features rustls-tls,code-mode` (passes when live providers are absent, matching CI)
- `cargo test -p goose --no-default-features --features native-tls,code-mode` (1,477 tests passed; local keychain-dependent OAuth cache test fails before this change)
- Release build and focused TLS regression test