### PR TITLE
fix overlong function names in provider requests

### DIFF
--- a/crates/goose-provider-types/src/formats/openai.rs
+++ b/crates/goose-provider-types/src/formats/openai.rs
@@ -1591,7 +1591,7 @@ pub fn sanitize_function_name(name: &str) -> String {
 pub fn is_valid_function_name(name: &str) -> bool {
     static RE: OnceLock<Regex> = OnceLock::new();
     let re = RE.get_or_init(|| Regex::new(r"^[a-zA-Z0-9_-]+$").unwrap());
-    name.len() <= MAX_FUNCTION_NAME_LENGTH && re.is_match(name)
+    re.is_match(name)
 }
 
 #[cfg(test)]
@@ -4180,13 +4180,10 @@ data: [DONE]"#;
         assert!(is_valid_function_name("hello-world"));
         assert!(is_valid_function_name("hello_world"));
         assert!(is_valid_function_name(
-            &"a".repeat(MAX_FUNCTION_NAME_LENGTH)
+            &"a".repeat(MAX_FUNCTION_NAME_LENGTH + 1)
         ));
         assert!(!is_valid_function_name("hello world"));
         assert!(!is_valid_function_name("hello@world"));
-        assert!(!is_valid_function_name(
-            &"a".repeat(MAX_FUNCTION_NAME_LENGTH + 1)
-        ));
     }
 
     #[test]

--- a/crates/goose-provider-types/src/formats/openai.rs
+++ b/crates/goose-provider-types/src/formats/openai.rs
@@ -1577,16 +1577,21 @@ pub(crate) fn openai_reasoning_efforts_for_model(model_name: &str) -> &'static [
     }
 }
 
+const MAX_FUNCTION_NAME_LENGTH: usize = 128;
+
 pub fn sanitize_function_name(name: &str) -> String {
     static RE: OnceLock<Regex> = OnceLock::new();
     let re = RE.get_or_init(|| Regex::new(r"[^a-zA-Z0-9_-]").unwrap());
-    re.replace_all(name, "_").to_string()
+    re.replace_all(name, "_")
+        .chars()
+        .take(MAX_FUNCTION_NAME_LENGTH)
+        .collect()
 }
 
 pub fn is_valid_function_name(name: &str) -> bool {
     static RE: OnceLock<Regex> = OnceLock::new();
     let re = RE.get_or_init(|| Regex::new(r"^[a-zA-Z0-9_-]+$").unwrap());
-    re.is_match(name)
+    name.len() <= MAX_FUNCTION_NAME_LENGTH && re.is_match(name)
 }
 
 #[cfg(test)]
@@ -4160,14 +4165,28 @@ data: [DONE]"#;
         assert_eq!(sanitize_function_name("hello-world"), "hello-world");
         assert_eq!(sanitize_function_name("hello world"), "hello_world");
         assert_eq!(sanitize_function_name("hello@world"), "hello_world");
+        assert_eq!(
+            sanitize_function_name(&"a".repeat(MAX_FUNCTION_NAME_LENGTH)),
+            "a".repeat(MAX_FUNCTION_NAME_LENGTH)
+        );
+        assert_eq!(
+            sanitize_function_name(&"a".repeat(MAX_FUNCTION_NAME_LENGTH + 32)),
+            "a".repeat(MAX_FUNCTION_NAME_LENGTH)
+        );
     }
 
     #[test]
     fn test_is_valid_function_name() {
         assert!(is_valid_function_name("hello-world"));
         assert!(is_valid_function_name("hello_world"));
+        assert!(is_valid_function_name(
+            &"a".repeat(MAX_FUNCTION_NAME_LENGTH)
+        ));
         assert!(!is_valid_function_name("hello world"));
         assert!(!is_valid_function_name("hello@world"));
+        assert!(!is_valid_function_name(
+            &"a".repeat(MAX_FUNCTION_NAME_LENGTH + 1)
+        ));
     }
 
     #[test]

--- a/crates/goose-provider-types/src/formats/openai_responses.rs
+++ b/crates/goose-provider-types/src/formats/openai_responses.rs
@@ -2158,6 +2158,32 @@ mod tests {
     }
 
     #[test]
+    fn test_responses_request_limits_replayed_function_call_names() {
+        use crate::conversation::message::Message;
+
+        let messages = vec![Message::assistant().with_tool_request(
+            "call_long_name",
+            Ok(CallToolRequestParams::new("a".repeat(160))),
+        )];
+        let model_config = ModelConfig {
+            model_name: "gpt-5.5".to_string(),
+            context_limit: None,
+            temperature: None,
+            max_tokens: None,
+            toolshim: false,
+            toolshim_model: None,
+            request_params: None,
+            reasoning: None,
+            request_headers: None,
+        };
+
+        let result = create_responses_request(&model_config, "", &messages, &[]).unwrap();
+        let name = result["input"][0]["name"].as_str().unwrap();
+
+        assert_eq!(name.len(), 128);
+    }
+
+    #[test]
     fn test_tool_request_error_emits_function_call_output() {
         use crate::conversation::message::Message;
         use rmcp::model::{ErrorCode, ErrorData};


### PR DESCRIPTION
**Category:** fix
**User Impact:** Sessions no longer become permanently stuck when OpenAI replays an overlong function name from conversation history.

**Problem:** ACP harness activity can leave human-readable tool titles in conversation history. When one of those persisted names exceeds OpenAI's 128-character limit, every Responses API request that replays the history fails with a 400, so retrying or switching back to an OpenAI-backed provider cannot recover the session.

**Solution:** Enforce OpenAI's 128-character limit in the outbound function-name sanitizer used when serializing conversation history. This repairs affected history at request time while preserving the provider-neutral inbound validator used by other providers.

**Scope:** This PR fixes the confirmed permanent OpenAI 400 loop. It does not address whether prior conversation context is successfully handed to a newly selected ACP harness; that is a separate provider-switch path that still needs an end-to-end reproduction before changing it.

<details>
<summary>File changes</summary>

**crates/goose-provider-types/src/formats/openai.rs**
Caps sanitized outbound function names at 128 characters while keeping inbound character validation provider-neutral. Adds boundary coverage for both behaviors.

**crates/goose-provider-types/src/formats/openai_responses.rs**
Adds a request-level regression test proving a persisted 160-character tool-call name is serialized within OpenAI's limit.

</details>

Tests:
- `cargo fmt --all -- --check`
- `cargo test -p goose-provider-types`
- `cargo clippy -p goose-provider-types --tests -- -D warnings`
