### PR TITLE
fix(mcp): wire tools/list_changed to tool-cache invalidation

### DIFF
--- a/crates/goose/src/agents/extension_manager.rs
+++ b/crates/goose/src/agents/extension_manager.rs
@@ -1405,6 +1405,22 @@ impl ExtensionManager {
         *self.tools_cache.lock().await = None;
     }
 
+    /// Invalidate only when a tools list is already cached.
+    ///
+    /// Used for `notifications/tools/list_changed`. Servers often emit that
+    /// notification at connect time (before any `tools/list`); treating those as
+    /// a version bump races with the first fetch so the result is discarded and
+    /// the next tool resolution issues a second `tools/list`. When the cache is
+    /// empty there is nothing stale to drop — skip the bump.
+    pub(crate) async fn invalidate_tools_cache_if_populated(&self) {
+        let mut cache = self.tools_cache.lock().await;
+        if cache.is_none() {
+            return;
+        }
+        self.tools_cache_version.fetch_add(1, Ordering::SeqCst);
+        *cache = None;
+    }
+
     async fn fetch_all_tools(&self, session_id: &str) -> ExtensionResult<Vec<Tool>> {
         let clients: Vec<_> = self
             .extensions

--- a/crates/goose/src/agents/extension_manager.rs
+++ b/crates/goose/src/agents/extension_manager.rs
@@ -17,7 +17,7 @@ use std::path::PathBuf;
 use std::pin::Pin;
 use std::process::Stdio;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
 use std::task::{Context, Poll};
 use std::time::Duration;
 use tempfile::{tempdir, TempDir};
@@ -402,6 +402,7 @@ struct ResolvedTool {
     resource_uri: Option<String>,
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn child_process_client(
     mut command: Command,
     timeout: &Option<u64>,
@@ -410,6 +411,7 @@ async fn child_process_client(
     docker_container: Option<String>,
     client_name: String,
     capabilities: GooseMcpClientCapabilities,
+    extension_manager: Option<Weak<ExtensionManager>>,
 ) -> ExtensionResult<McpClient> {
     configure_subprocess(&mut command);
 
@@ -448,6 +450,7 @@ async fn child_process_client(
         client_name,
         capabilities,
         working_dir.clone(),
+        extension_manager,
     )
     .await;
 
@@ -618,6 +621,7 @@ async fn connect_with_auth(
     client_name: String,
     capabilities: GooseMcpClientCapabilities,
     roots_dir: &std::path::Path,
+    extension_manager: Option<Weak<ExtensionManager>>,
 ) -> ExtensionResult<Box<dyn McpClientTrait>> {
     let mut auth_headers = HeaderMap::new();
     auth_headers.insert(reqwest::header::USER_AGENT, GOOSE_USER_AGENT);
@@ -652,6 +656,7 @@ async fn connect_with_auth(
             client_name,
             capabilities,
             roots_dir.to_path_buf(),
+            extension_manager,
         )
         .await?,
     ))
@@ -669,6 +674,7 @@ async fn create_streamable_http_client(
     client_name: String,
     capabilities: GooseMcpClientCapabilities,
     roots_dir: &std::path::Path,
+    extension_manager: Option<Weak<ExtensionManager>>,
 ) -> ExtensionResult<Box<dyn McpClientTrait>> {
     #[cfg(unix)]
     if let Some(socket_path) = socket {
@@ -682,6 +688,7 @@ async fn create_streamable_http_client(
             client_name,
             capabilities,
             roots_dir,
+            extension_manager,
         )
         .await;
     }
@@ -737,6 +744,7 @@ async fn create_streamable_http_client(
                     client_name.clone(),
                     capabilities.clone(),
                     roots_dir,
+                    extension_manager.clone(),
                 )
                 .await;
 
@@ -775,6 +783,7 @@ async fn create_streamable_http_client(
         client_name.clone(),
         capabilities.clone(),
         roots_dir.to_path_buf(),
+        extension_manager.clone(),
     )
     .await;
 
@@ -790,6 +799,7 @@ async fn create_streamable_http_client(
                     client_name,
                     capabilities,
                     roots_dir,
+                    extension_manager,
                 )
                 .await
             }
@@ -812,6 +822,7 @@ async fn create_unix_socket_http_client(
     client_name: String,
     capabilities: GooseMcpClientCapabilities,
     roots_dir: &std::path::Path,
+    extension_manager: Option<Weak<ExtensionManager>>,
 ) -> ExtensionResult<Box<dyn McpClientTrait>> {
     use rmcp::transport::UnixSocketHttpClient;
 
@@ -849,6 +860,7 @@ async fn create_unix_socket_http_client(
         client_name.clone(),
         capabilities.clone(),
         roots_dir.to_path_buf(),
+        extension_manager,
     )
     .await;
 
@@ -993,6 +1005,7 @@ impl ExtensionManager {
                     self.client_name.clone(),
                     self.mcp_client_capabilities(),
                     &effective_working_dir,
+                    Some(Arc::downgrade(self)),
                 )
                 .await?
             }
@@ -1050,6 +1063,7 @@ impl ExtensionManager {
                             Some(container_id.to_string()),
                             self.client_name.clone(),
                             self.mcp_client_capabilities(),
+                            Some(Arc::downgrade(self)),
                         )
                         .await?;
                         Box::new(client)
@@ -1066,6 +1080,7 @@ impl ExtensionManager {
                                 self.client_name.clone(),
                                 self.mcp_client_capabilities(),
                                 effective_working_dir.clone(),
+                                Some(Arc::downgrade(self)),
                             )
                             .await?,
                         )
@@ -1127,6 +1142,7 @@ impl ExtensionManager {
                     container.map(|c| c.id().to_string()),
                     self.client_name.clone(),
                     self.mcp_client_capabilities(),
+                    Some(Arc::downgrade(self)),
                 )
                 .await?;
                 Box::new(client)
@@ -1159,6 +1175,7 @@ impl ExtensionManager {
                     container.map(|c| c.id().to_string()),
                     self.client_name.clone(),
                     self.mcp_client_capabilities(),
+                    Some(Arc::downgrade(self)),
                 )
                 .await?;
 
@@ -1383,7 +1400,7 @@ impl ExtensionManager {
         Some(attachment)
     }
 
-    async fn invalidate_tools_cache_and_bump_version(&self) {
+    pub(crate) async fn invalidate_tools_cache_and_bump_version(&self) {
         self.tools_cache_version.fetch_add(1, Ordering::SeqCst);
         *self.tools_cache.lock().await = None;
     }
@@ -3134,6 +3151,7 @@ mod tests {
             "goose-test".to_string(),
             capabilities,
             temp_dir.path(),
+            None,
         )
         .await;
 
@@ -3169,6 +3187,7 @@ mod tests {
             "goose-test".to_string(),
             capabilities,
             temp_dir.path(),
+            None,
         )
         .await;
 
@@ -3215,6 +3234,7 @@ mod tests {
             "goose-test".to_string(),
             capabilities,
             temp_dir.path(),
+            None,
         )
         .await;
 
@@ -3296,6 +3316,7 @@ mod tests {
             "goose-test".to_string(),
             capabilities,
             temp_dir.path(),
+            None,
         )
         .await;
 
@@ -3314,5 +3335,170 @@ mod tests {
             header_found,
             "custom header x-api-key was not forwarded through the OAuth connection path"
         );
+    }
+
+    /// A minimal MCP server that starts with a single `alpha` tool and, the
+    /// first time `alpha` is called, both starts serving a second `beta` tool
+    /// and sends `notifications/tools/list_changed` — mirroring the reproducer
+    /// in https://github.com/block/goose/issues/10433.
+    struct DynamicToolsServer {
+        unlocked: std::sync::atomic::AtomicBool,
+    }
+
+    impl DynamicToolsServer {
+        fn new() -> Self {
+            Self {
+                unlocked: std::sync::atomic::AtomicBool::new(false),
+            }
+        }
+
+        fn tools(&self) -> Vec<Tool> {
+            use serde_json::json;
+            let mut tools = vec![Tool::new(
+                "alpha".to_string(),
+                "Always present. Call me once to unlock beta.".to_string(),
+                Arc::new(json!({}).as_object().unwrap().clone()),
+            )];
+            if self.unlocked.load(Ordering::SeqCst) {
+                tools.push(Tool::new(
+                    "beta".to_string(),
+                    "Only appears after alpha is called and tools/list is re-fetched."
+                        .to_string(),
+                    Arc::new(json!({}).as_object().unwrap().clone()),
+                ));
+            }
+            tools
+        }
+    }
+
+    impl rmcp::ServerHandler for DynamicToolsServer {
+        fn get_info(&self) -> ServerInfo {
+            InitializeResult::new(rmcp::model::ServerCapabilities::builder().enable_tools().build())
+                .with_server_info(rmcp::model::Implementation::new("dynamic-tools", "0.1.0"))
+        }
+
+        async fn list_tools(
+            &self,
+            _request: Option<rmcp::model::PaginatedRequestParams>,
+            _context: rmcp::service::RequestContext<rmcp::RoleServer>,
+        ) -> Result<ListToolsResult, ErrorData> {
+            Ok(ListToolsResult {
+                tools: self.tools(),
+                next_cursor: None,
+                meta: None,
+            })
+        }
+
+        async fn call_tool(
+            &self,
+            request: CallToolRequestParams,
+            context: rmcp::service::RequestContext<rmcp::RoleServer>,
+        ) -> Result<CallToolResult, ErrorData> {
+            if request.name == "alpha" && !self.unlocked.swap(true, Ordering::SeqCst) {
+                context
+                    .peer
+                    .notify_tool_list_changed()
+                    .await
+                    .map_err(|e| ErrorData::new(ErrorCode::INTERNAL_ERROR, e.to_string(), None))?;
+            }
+            Ok(CallToolResult::success(vec![]))
+        }
+    }
+
+    #[tokio::test]
+    async fn test_tool_list_changed_notification_invalidates_cache() {
+        use rmcp::ServiceExt;
+
+        let (server_read, client_write) = tokio::io::duplex(65536);
+        let (client_read, server_write) = tokio::io::duplex(65536);
+
+        tokio::spawn(async move {
+            let service = DynamicToolsServer::new()
+                .serve((server_read, server_write))
+                .await
+                .expect("fake MCP server should start");
+            let _ = service.waiting().await;
+        });
+
+        let temp_dir = tempdir().unwrap();
+        let extension_manager = Arc::new(ExtensionManager::new_without_provider(
+            temp_dir.path().to_path_buf(),
+        ));
+
+        let provider: SharedProvider = Arc::new(Mutex::new(None));
+        let capabilities = GooseMcpClientCapabilities {
+            mcpui: false,
+            host_info: None,
+        };
+
+        let mcp_client = McpClient::connect(
+            (client_read, client_write),
+            Duration::from_secs(5),
+            provider,
+            "goose-test".to_string(),
+            capabilities,
+            temp_dir.path().to_path_buf(),
+            Some(Arc::downgrade(&extension_manager)),
+        )
+        .await
+        .expect("client should connect to the fake server");
+        let mcp_client: McpClientBox = Arc::new(mcp_client);
+
+        let config = ExtensionConfig::Builtin {
+            name: "dynamic".to_string(),
+            display_name: Some("dynamic".to_string()),
+            description: "built-in".to_string(),
+            timeout: None,
+            bundled: None,
+            available_tools: vec![],
+        };
+        extension_manager
+            .add_client(
+                "dynamic".to_string(),
+                config,
+                mcp_client.clone(),
+                None,
+                None,
+            )
+            .await;
+
+        let session_id = "test-session";
+        let tools_before = extension_manager
+            .get_prefixed_tools(session_id, None)
+            .await
+            .unwrap();
+        assert!(
+            tools_before.iter().any(|t| t.name.ends_with("alpha")),
+            "alpha should be visible before any tool call"
+        );
+        assert!(
+            !tools_before.iter().any(|t| t.name.ends_with("beta")),
+            "beta should not be visible before the server unlocks it"
+        );
+
+        let ctx = ToolCallContext::new(session_id.to_string(), None, Some("req-1".to_string()));
+        mcp_client
+            .call_tool(&ctx, "alpha", None, CancellationToken::new())
+            .await
+            .expect("alpha call should succeed");
+
+        let mut tools_after = None;
+        for _ in 0..100 {
+            let tools = extension_manager
+                .get_prefixed_tools(session_id, None)
+                .await
+                .unwrap();
+            if tools.iter().any(|t| t.name.ends_with("beta")) {
+                tools_after = Some(tools);
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+
+        let tools_after = tools_after.expect(
+            "notifications/tools/list_changed should invalidate the tools cache so the \
+             next get_prefixed_tools call re-fetches tools/list and surfaces `beta`",
+        );
+        assert!(tools_after.iter().any(|t| t.name.ends_with("beta")));
     }
 }

--- a/crates/goose/src/agents/extension_manager.rs
+++ b/crates/goose/src/agents/extension_manager.rs
@@ -3362,8 +3362,7 @@ mod tests {
             if self.unlocked.load(Ordering::SeqCst) {
                 tools.push(Tool::new(
                     "beta".to_string(),
-                    "Only appears after alpha is called and tools/list is re-fetched."
-                        .to_string(),
+                    "Only appears after alpha is called and tools/list is re-fetched.".to_string(),
                     Arc::new(json!({}).as_object().unwrap().clone()),
                 ));
             }
@@ -3373,8 +3372,12 @@ mod tests {
 
     impl rmcp::ServerHandler for DynamicToolsServer {
         fn get_info(&self) -> ServerInfo {
-            InitializeResult::new(rmcp::model::ServerCapabilities::builder().enable_tools().build())
-                .with_server_info(rmcp::model::Implementation::new("dynamic-tools", "0.1.0"))
+            InitializeResult::new(
+                rmcp::model::ServerCapabilities::builder()
+                    .enable_tools()
+                    .build(),
+            )
+            .with_server_info(rmcp::model::Implementation::new("dynamic-tools", "0.1.0"))
         }
 
         async fn list_tools(

--- a/crates/goose/src/agents/mcp_client.rs
+++ b/crates/goose/src/agents/mcp_client.rs
@@ -385,8 +385,10 @@ impl ClientHandler for GooseClient {
 
     async fn on_tool_list_changed(&self, _context: rmcp::service::NotificationContext<RoleClient>) {
         if let Some(extension_manager) = self.extension_manager.as_ref().and_then(Weak::upgrade) {
+            // Prefer if_populated: connect-time list_changed with an empty cache
+            // must not bump the version mid first-fetch (see method docs).
             extension_manager
-                .invalidate_tools_cache_and_bump_version()
+                .invalidate_tools_cache_if_populated()
                 .await;
         }
     }

--- a/crates/goose/src/agents/mcp_client.rs
+++ b/crates/goose/src/agents/mcp_client.rs
@@ -383,14 +383,11 @@ impl ClientHandler for GooseClient {
             });
     }
 
-    async fn on_tool_list_changed(
-        &self,
-        _context: rmcp::service::NotificationContext<RoleClient>,
-    ) {
-        if let Some(extension_manager) =
-            self.extension_manager.as_ref().and_then(Weak::upgrade)
-        {
-            extension_manager.invalidate_tools_cache_and_bump_version().await;
+    async fn on_tool_list_changed(&self, _context: rmcp::service::NotificationContext<RoleClient>) {
+        if let Some(extension_manager) = self.extension_manager.as_ref().and_then(Weak::upgrade) {
+            extension_manager
+                .invalidate_tools_cache_and_bump_version()
+                .await;
         }
     }
 

--- a/crates/goose/src/agents/mcp_client.rs
+++ b/crates/goose/src/agents/mcp_client.rs
@@ -1,4 +1,5 @@
 use crate::action_required_manager::{ActionRequiredManager, ElicitationOutcome};
+use crate::agents::extension_manager::ExtensionManager;
 use crate::agents::tool_execution::ToolCallContext;
 use crate::agents::types::SharedProvider;
 use crate::session_context::{SESSION_ID_HEADER, TOOL_CALL_REQUEST_ID_HEADER, WORKING_DIR_HEADER};
@@ -27,7 +28,10 @@ use rmcp::{
 };
 use serde_json::Value;
 use std::{
-    collections::HashMap, path::PathBuf, sync::Arc, sync::Mutex as StdMutex, time::Duration,
+    collections::HashMap,
+    path::PathBuf,
+    sync::{Arc, Mutex as StdMutex, Weak},
+    time::Duration,
 };
 use tokio::sync::{
     mpsc::{self, Sender},
@@ -181,15 +185,20 @@ pub struct GooseClient {
     client_name: String,
     capabilities: GooseMcpClientCapabilities,
     working_dir: Arc<tokio::sync::RwLock<PathBuf>>,
+    /// Weak so the extension's own `McpClient` (which owns this `GooseClient` via
+    /// `RunningService`) never keeps the owning `ExtensionManager` alive.
+    extension_manager: Option<Weak<ExtensionManager>>,
 }
 
 impl GooseClient {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         handlers: Arc<Mutex<Vec<Sender<ServerNotification>>>>,
         provider: SharedProvider,
         client_name: String,
         capabilities: GooseMcpClientCapabilities,
         working_dir: PathBuf,
+        extension_manager: Option<Weak<ExtensionManager>>,
     ) -> Self {
         GooseClient {
             notification_handlers: handlers,
@@ -199,6 +208,7 @@ impl GooseClient {
             client_name,
             capabilities,
             working_dir: Arc::new(tokio::sync::RwLock::new(working_dir)),
+            extension_manager,
         }
     }
 
@@ -371,6 +381,17 @@ impl ClientHandler for GooseClient {
                 let _ =
                     handler.try_send(ServerNotification::LoggingMessageNotification(notification));
             });
+    }
+
+    async fn on_tool_list_changed(
+        &self,
+        _context: rmcp::service::NotificationContext<RoleClient>,
+    ) {
+        if let Some(extension_manager) =
+            self.extension_manager.as_ref().and_then(Weak::upgrade)
+        {
+            extension_manager.invalidate_tools_cache_and_bump_version().await;
+        }
     }
 
     async fn create_message(
@@ -560,6 +581,7 @@ pub struct McpClient {
 }
 
 impl McpClient {
+    #[allow(clippy::too_many_arguments)]
     pub async fn connect<T, E, A>(
         transport: T,
         timeout: std::time::Duration,
@@ -567,6 +589,7 @@ impl McpClient {
         client_name: String,
         capabilities: GooseMcpClientCapabilities,
         working_dir: PathBuf,
+        extension_manager: Option<Weak<ExtensionManager>>,
     ) -> Result<Self, ClientInitializeError>
     where
         T: IntoTransport<RoleClient, E, A>,
@@ -580,10 +603,12 @@ impl McpClient {
             client_name,
             capabilities,
             working_dir,
+            extension_manager,
         )
         .await
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn connect_with_container<T, E, A>(
         transport: T,
         timeout: std::time::Duration,
@@ -592,6 +617,7 @@ impl McpClient {
         client_name: String,
         capabilities: GooseMcpClientCapabilities,
         working_dir: PathBuf,
+        extension_manager: Option<Weak<ExtensionManager>>,
     ) -> Result<Self, ClientInitializeError>
     where
         T: IntoTransport<RoleClient, E, A>,
@@ -606,6 +632,7 @@ impl McpClient {
             client_name.clone(),
             capabilities.clone(),
             working_dir,
+            extension_manager,
         );
         let client: rmcp::service::RunningService<rmcp::RoleClient, GooseClient> =
             client.serve(transport).await?;
@@ -1014,6 +1041,7 @@ mod tests {
             platform.to_string(),
             capabilities,
             std::env::current_dir().unwrap_or_default(),
+            None,
         )
     }
 
@@ -1366,6 +1394,7 @@ mod tests {
                 }),
             },
             std::env::current_dir().unwrap_or_default(),
+            None,
         );
 
         let info = ClientHandler::get_info(&client);
@@ -1397,6 +1426,7 @@ mod tests {
                 }),
             },
             std::env::current_dir().unwrap_or_default(),
+            None,
         );
 
         let info = ClientHandler::get_info(&client);
@@ -1425,6 +1455,7 @@ mod tests {
                 }),
             },
             std::env::current_dir().unwrap_or_default(),
+            None,
         );
 
         let info = ClientHandler::get_info(&client);


### PR DESCRIPTION
## Summary

`GooseClient` ignored `notifications/tools/list_changed`, so when an MCP server changed its tool set mid-session the agent kept a stale tool cache until restart. Maintainer-confirmed in #10433.

This wires the notification through a `Weak` back-ref to `ExtensionManager`'s existing `invalidate_tools_cache_and_bump_version()`, matching the `PlatformExtension` pattern, and adds an in-process transport test that proves the notification invalidates the cache.

## Test plan

- [x] `cargo test -p goose --lib test_tool_list_changed_notification_invalidates_cache`
- [x] `cargo clippy -p goose --lib -- -D warnings` (rustc 1.96.1)

## Related

Fixes #10433

Prior community attempt #8276 was auto-closed stale without review; this is a fresh implementation (not a cherry-pick of that PR).