### PR TITLE
fix(acp): preserve read lines and reload tool output

### DIFF
--- a/crates/goose/src/acp/fs.rs
+++ b/crates/goose/src/acp/fs.rs
@@ -143,7 +143,7 @@ impl AcpTools {
             ctx,
             ToolCallUpdateFields::new()
                 .kind(ToolKind::Read)
-                .locations(vec![ToolCallLocation::new(&path)]),
+                .locations(vec![ToolCallLocation::new(&path).line(params.line)]),
         );
         match acp_read_text_file(&self.cx, &self.session_id, &path, params.line, params.limit).await
         {

--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -1186,7 +1186,7 @@ impl GooseAcpAgent {
         session_id: &SessionId,
         cx: &ConnectionTo<Client>,
     ) -> Result<(), agent_client_protocol::Error> {
-        let fields = tool_call_update_fields_from_response(tool_response, tool_request);
+        let fields = tool_call_update_fields_from_response(tool_response, tool_request, false);
 
         let update = ToolCallUpdate::new(ToolCallId::new(tool_response.id.clone()), fields)
             .meta(trusted_update_meta(tool_response));

--- a/crates/goose/src/acp/server/load_session.rs
+++ b/crates/goose/src/acp/server/load_session.rs
@@ -157,6 +157,7 @@ fn replay_conversation_to_client(
                     let fields = tool_call_update_fields_from_response(
                         tool_response,
                         replay_tool_requests.get(&tool_response.id),
+                        true,
                     );
 
                     let update =

--- a/crates/goose/src/acp/server/tool_calls/conversion.rs
+++ b/crates/goose/src/acp/server/tool_calls/conversion.rs
@@ -266,6 +266,7 @@ fn extract_tool_raw_output(tool_result: &ToolResult<CallToolResult>) -> Option<s
 pub(crate) fn tool_call_update_fields_from_response(
     tool_response: &ToolResponse,
     tool_request: Option<&ToolRequest>,
+    include_content_for_acp_aware_tools: bool,
 ) -> ToolCallUpdateFields {
     let is_failed = match &tool_response.tool_result {
         Ok(result) => result.is_error == Some(true),
@@ -285,7 +286,7 @@ pub(crate) fn tool_call_update_fields_from_response(
         .tool_result
         .as_ref()
         .is_ok_and(|result| result.is_acp_aware());
-    let include_content = is_failed || !is_acp_aware;
+    let include_content = include_content_for_acp_aware_tools || is_failed || !is_acp_aware;
     let include_locations = !is_acp_aware;
 
     if include_content {
@@ -719,7 +720,7 @@ mod tests {
             let response = response_from_tool_result(Ok(result));
             let request = write_request("/tmp/request.txt");
 
-            let fields = tool_call_update_fields_from_response(&response, Some(&request));
+            let fields = tool_call_update_fields_from_response(&response, Some(&request), false);
 
             assert_eq!(fields.status, Some(ToolCallStatus::Completed));
             assert_eq!(fields.raw_output, Some(raw_output));
@@ -737,7 +738,7 @@ mod tests {
                     "write failed",
                 )])));
 
-            let fields = tool_call_update_fields_from_response(&response, None);
+            let fields = tool_call_update_fields_from_response(&response, None, false);
 
             assert_eq!(fields.status, Some(ToolCallStatus::Failed));
             assert_eq!(first_tool_call_text(&fields), Some("write failed"));
@@ -752,12 +753,24 @@ mod tests {
             let response = response_from_tool_result(Ok(result.with_acp_aware_meta()));
             let request = write_request("/tmp/request.txt");
 
-            let fields = tool_call_update_fields_from_response(&response, Some(&request));
+            let fields = tool_call_update_fields_from_response(&response, Some(&request), false);
 
             assert_eq!(fields.status, Some(ToolCallStatus::Completed));
             assert_eq!(fields.raw_output, Some(raw_output));
             assert!(fields.content.is_none());
             assert!(fields.locations.is_none());
+        }
+
+        #[test]
+        fn includes_acp_aware_success_content_when_requested() {
+            let result = CallToolResult::success(vec![RmcpContent::text("write completed")])
+                .with_acp_aware_meta();
+            let response = response_from_tool_result(Ok(result));
+
+            let fields = tool_call_update_fields_from_response(&response, None, true);
+
+            assert_eq!(fields.status, Some(ToolCallStatus::Completed));
+            assert_eq!(first_tool_call_text(&fields), Some("write completed"));
         }
 
         #[test]
@@ -767,7 +780,7 @@ mod tests {
             })));
             let request = write_request("/tmp/request.txt");
 
-            let fields = tool_call_update_fields_from_response(&response, Some(&request));
+            let fields = tool_call_update_fields_from_response(&response, Some(&request), false);
 
             let locations = fields.locations.as_deref().expect("expected location");
             assert_eq!(locations.len(), 1);
@@ -782,7 +795,7 @@ mod tests {
             let response = response_from_tool_result(Ok(result));
             let request = write_request("/tmp/request.txt");
 
-            let fields = tool_call_update_fields_from_response(&response, Some(&request));
+            let fields = tool_call_update_fields_from_response(&response, Some(&request), false);
 
             assert_eq!(fields.status, Some(ToolCallStatus::Failed));
             assert_eq!(first_tool_call_text(&fields), Some("write failed"));
@@ -797,7 +810,7 @@ mod tests {
                 None,
             )));
 
-            let fields = tool_call_update_fields_from_response(&response, None);
+            let fields = tool_call_update_fields_from_response(&response, None, false);
 
             assert_eq!(fields.status, Some(ToolCallStatus::Failed));
             assert_eq!(first_tool_call_text(&fields), Some("transport failed"));


### PR DESCRIPTION
## Summary

Following the tool-call consistency work in #10574, this addresses two remaining gaps seen in ACP clients such as Zed:

- Shows saved output for read, write, edit, and shell tool calls after reload session. Live behavior remains unchanged to avoid duplicate output.

- Includes the requested line in ACP read locations.

## Testing
Unit test and Manual


### Screenshots/Demos (for UX changes)
Before: (no expand arrow in the tool call) 
<img width="640" height="829" alt="replay_tool_call_zed_issue" src="https://github.com/user-attachments/assets/327849dc-2bf7-485a-bf19-bae856d080b0" />

After (expand arrow with tool call info)

<img width="502" height="373" alt="Screenshot 2026-07-24 at 11 09 29 am" src="https://github.com/user-attachments/assets/ce37c5e6-9a9f-422c-a7c3-d2047226de4d" />
