### PR TITLE
fix(acp): forward Claude Code model picker selection to the adapter

### DIFF
--- a/crates/goose/src/providers/claude_acp.rs
+++ b/crates/goose/src/providers/claude_acp.rs
@@ -82,7 +82,10 @@ impl ProviderDef for ClaudeAcpProvider {
                 mcp_servers: extension_configs_to_mcp_servers(&extensions),
                 session_mode_id: mode_mapping[&goose_mode].first().cloned(),
                 session_config_options: vec![],
-                model_config_option_id: None,
+                // claude-agent-acp advertises the model as a "model" select
+                // config option and applies session/set_config_option for it
+                // via query.setModel, so forward the picker's selection.
+                model_config_option_id: Some("model".to_string()),
                 mode_mapping,
                 notification_callback: None,
             };


### PR DESCRIPTION
## Problem

The **Claude Code (ACP)** provider's model picker was display-only. goose read the adapter-advertised Model config option to populate the dropdown, but whatever you selected never reached `claude-agent-acp` — it kept using whatever its own config dictated (env / `~/.claude/settings.json` / `/model`). The UI showed one model while a different one served the session.

## Root cause

`claude_acp.rs` built its `AcpProviderConfig` with `model_config_option_id: None`. The generic ACP provider only pushes a model choice to the agent (via `session/set_config_option`) when that id is `Some`; with `None`, `apply_model_if_changed` short-circuits and sends nothing.

## Fix

I verified against the installed adapter (`@agentclientprotocol/claude-agent-acp`) that it advertises the model as a select config option with id `"model"` (`MODEL_CONFIG_ID`), and its `setSessionConfigOption` handler applies the value via `query.setModel(...)` (with a `resolveModelPreference` fallback for non-exact values). So the adapter fully supports model changes over ACP.

Wire the picker's selection through by setting `model_config_option_id: Some("model")`, mirroring the Copilot provider — the only one that previously wired this up.

## Testing

`cargo check -p goose` passes. The `apply_model_if_changed` behavior is already covered by generic tests in `acp/provider.rs`; this is a one-line config change with no new branching to test (Copilot's identical config is likewise untested at the provider level).

Fixes #10669