### PR TITLE
fix(oauth): preserve RFC 9207 iss from MCP OAuth callback

### DIFF
--- a/crates/goose/src/agents/extension_manager.rs
+++ b/crates/goose/src/agents/extension_manager.rs
@@ -793,7 +793,13 @@ async fn create_streamable_http_client(
                 )
                 .await
             }
-            Err(_) => Ok(Box::new(client_res?)),
+            Err(e) => {
+                warn!(
+                    "[OAuth:{}] Browser authorization flow failed: {:#}",
+                    name, e
+                );
+                Ok(Box::new(client_res?))
+            }
         }
     } else {
         Ok(Box::new(client_res?))

--- a/crates/goose/src/oauth/mod.rs
+++ b/crates/goose/src/oauth/mod.rs
@@ -31,6 +31,7 @@ struct AppState {
 struct CallbackParams {
     code: String,
     state: String,
+    iss: Option<String>,
 }
 
 fn resolve_oauth_callback_timeout(value: Option<&str>) -> Duration {
@@ -174,8 +175,11 @@ pub async fn oauth_flow(
     let CallbackParams {
         code: auth_code,
         state: csrf_token,
+        iss,
     } = callback_params?;
-    oauth_state.handle_callback(&auth_code, &csrf_token).await?;
+    oauth_state
+        .handle_callback_with_issuer(&auth_code, &csrf_token, iss.as_deref())
+        .await?;
 
     let (client_id, token_response) = oauth_state.get_credentials().await?;
 
@@ -243,6 +247,7 @@ mod tests {
             .send(CallbackParams {
                 code: "auth-code".to_string(),
                 state: "csrf-state".to_string(),
+                iss: Some("https://auth.example".to_string()),
             })
             .unwrap();
 
@@ -257,6 +262,31 @@ mod tests {
 
         assert_eq!(params.code, "auth-code");
         assert_eq!(params.state, "csrf-state");
+        assert_eq!(params.iss.as_deref(), Some("https://auth.example"));
+    }
+
+    #[test]
+    fn callback_params_capture_rfc_9207_issuer() {
+        let uri: axum::http::Uri =
+            "http://127.0.0.1/oauth_callback?code=auth-code&state=csrf-state&iss=https%3A%2F%2Fauth.example%2Fidp"
+                .parse()
+                .unwrap();
+
+        let Query(params) = Query::<CallbackParams>::try_from_uri(&uri).unwrap();
+
+        assert_eq!(params.iss.as_deref(), Some("https://auth.example/idp"));
+    }
+
+    #[test]
+    fn callback_params_accept_missing_issuer() {
+        let uri: axum::http::Uri =
+            "http://127.0.0.1/oauth_callback?code=auth-code&state=csrf-state"
+                .parse()
+                .unwrap();
+
+        let Query(params) = Query::<CallbackParams>::try_from_uri(&uri).unwrap();
+
+        assert_eq!(params.iss, None);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

MCP extensions could never complete OAuth against an authorization server that
advertises `authorization_response_iss_parameter_supported: true`. The `iss` query
parameter from the authorization redirect was dropped by `CallbackParams`, so
`handle_callback` passed `None` to rmcp, which requires the issuer in that case and
fails the exchange with `AuthorizationServerMissingIssuer`.

This captures `iss` from the callback and forwards it via
`handle_callback_with_issuer`.

It also stops the OAuth fallback in `create_streamable_http_client` from discarding
the flow error: previously any failure after the browser redirect was swallowed and
the earlier unauthenticated 401 was surfaced instead, so the user saw
`Auth required` with nothing logged about the browser flow having failed.

### Testing

- New unit tests cover that `iss` is captured from the callback query string and
  that its absence is still accepted (servers that don't implement RFC 9207).
- `cargo test -p goose --lib oauth::tests`, `cargo clippy -p goose --all-targets`,
  `cargo fmt`.
- Manually verified against a live `node-oidc-provider` IdP with
  `authorization_response_iss_parameter_supported: true`: before the change the flow
  failed with `AuthorizationServerMissingIssuer` after consent; after it the token
  exchange succeeds and the client proceeds to the authorized `initialize` request.

### Related Issues

Fixes #10677
