### PR TITLE
fix(acp): pass session working_dir to on_call_tool

### DIFF
--- a/crates/goose/src/acp/server/tools.rs
+++ b/crates/goose/src/acp/server/tools.rs
@@ -91,7 +91,20 @@ impl GooseAcpAgent {
             params
         };
 
-        let ctx = crate::agents::ToolCallContext::new(session_id.clone(), None, None);
+        let session = self
+            .session_manager
+            .get_session(session_id, false)
+            .await
+            .map_err(|_| {
+                agent_client_protocol::Error::resource_not_found(Some(session_id.to_string()))
+                    .data(format!("Session not found: {}", session_id))
+            })?;
+
+        let ctx = crate::agents::ToolCallContext::new(
+            session_id.clone(),
+            Some(session.working_dir),
+            None,
+        );
         let tool_result = agent
             .extension_manager
             .dispatch_tool_call(&ctx, tool_call, CancellationToken::new())


### PR DESCRIPTION
Fixes : #10680

## Summary
ACP goose/call_tool was constructing ToolCallContext with working_dir: None, so tools that require a session cwd (e.g. summarize) always failed with "working_dir is required". Load the session and pass its working_dir, matching the agent dispatch path.


### Testing
manual 

