### PR TITLE
fix(providers): enable inventory refresh for claude-code, codex, and cursor-agent

### DIFF
--- a/crates/goose/src/providers/init.rs
+++ b/crates/goose/src/providers/init.rs
@@ -81,7 +81,10 @@ async fn init_registry() -> RwLock<ProviderRegistry> {
             false,
             Some(registrations::claude_acp_inventory()),
         );
-        registry.register::<ClaudeCodeProvider>(true);
+        registry.register_with_inventory::<ClaudeCodeProvider>(
+            true,
+            Some(registrations::refresh_only()),
+        );
         registry.register_with_inventory::<CodexAcpProvider>(
             false,
             Some(registrations::codex_acp_inventory()),
@@ -90,8 +93,14 @@ async fn init_registry() -> RwLock<ProviderRegistry> {
             false,
             Some(registrations::copilot_acp_inventory()),
         );
-        registry.register::<CodexProvider>(true);
-        registry.register::<CursorAgentProvider>(false);
+        registry.register_with_inventory::<CodexProvider>(
+            true,
+            Some(registrations::refresh_only()),
+        );
+        registry.register_with_inventory::<CursorAgentProvider>(
+            false,
+            Some(registrations::refresh_only()),
+        );
         registry.register_with_inventory::<DatabricksProviderDef>(
             true,
             Some(registrations::refresh_only()),
@@ -477,6 +486,21 @@ mod tests {
         assert_eq!(inf_config.context_limit(), 1_000_000);
 
         std::env::remove_var("GOOSE_PATH_ROOT");
+    }
+
+    // Named to sort after the env-sensitive tests above: the first test to touch
+    // the global registry/config wins, so registry-only tests must run later.
+    #[tokio::test]
+    async fn test_inventory_refresh_supported_for_cli_providers() {
+        for provider in ["claude-code", "codex", "cursor-agent"] {
+            let entry = get_from_registry(provider)
+                .await
+                .unwrap_or_else(|_| panic!("{provider} should be registered"));
+            assert!(
+                entry.supports_inventory_refresh(),
+                "{provider} must support inventory refresh so the model picker calls fetch_supported_models"
+            );
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

Selecting the **Claude Code CLI** provider in Goose Desktop shows an empty model dropdown — only "Enter a model not listed..." — even though `ClaudeCodeProvider::fetch_supported_models` successfully fetches the model list from the CLI (verified against claude CLI 2.1.214: the `initialize` control response returns `default`, `opus[1m]`, `claude-fable-5[1m]`, `sonnet`, ...).

**Root cause:** `registry.register::<ClaudeCodeProvider>(true)` registers the provider without an `InventoryRegistration`, and `InventoryResolvers::for_metadata` defaults that to `supports_refresh: false`. The provider inventory therefore never plans a refresh job (`DoesNotSupportRefresh`), never calls `fetch_supported_models`, and `providersList_unstable` serves the static metadata list — which is intentionally `vec![]` for this provider ("fetched dynamically via fetch_supported_models").

## Fix

Register `claude-code`, `codex`, and `cursor-agent` with `registrations::refresh_only()` so the inventory refresh path reaches `fetch_supported_models`.

Notes:
- `CLAUDE_CODE_COMMAND`/`CODEX_COMMAND`/`CURSOR_AGENT_COMMAND` all have defaults, so the default configured-resolver passes and refresh isn't skipped as `NotConfigured`.
- Canonical filtering in `fetch_recommended_models` can't drop the CLI aliases: there is no canonical mapping for these providers, so zero models map and the code falls back to the full fetched list.
- For codex/cursor-agent, `fetch_supported_models` currently returns the static known list, so this is a consistency/refresh-affordance improvement there; making cursor-agent fetch from its CLI is tracked separately in #10367.

## Test

Added `test_inventory_refresh_supported_for_cli_providers`, mirroring the existing `test_litellm_supports_inventory_refresh` (added after #10641 fixed the same gap for OpenRouter/LiteLLM). The test is named to sort after the env-sensitive tests in the module, since the first test to touch the global registry/config wins (a pre-existing ordering constraint the litellm tests also rely on).

`cargo test -p goose --lib providers::init -- --test-threads=1` → 8 passed.

Fixes #10691
Related: #10260, #10309, #10367
