### PR TITLE
fix(ui): Refine dark theme message surfaces for consistent, compliant dark mode UX.

### DIFF
--- a/ui/desktop/src/components/GooseMessage.tsx
+++ b/ui/desktop/src/components/GooseMessage.tsx
@@ -137,7 +137,7 @@ export default function GooseMessage({
         {(displayText.trim() || imagePaths.length > 0) && (
           <div className="flex flex-col group">
             {displayText.trim() && (
-              <div ref={contentRef} className="w-full">
+              <div ref={contentRef} className="agent-message-bubble w-full">
                 <MarkdownContent content={displayText} />
               </div>
             )}

--- a/ui/desktop/src/components/UserMessage.tsx
+++ b/ui/desktop/src/components/UserMessage.tsx
@@ -260,7 +260,7 @@ export default function UserMessage({ message, onMessageUpdate }: UserMessagePro
             <div className="flex-col max-w-[85%] w-fit">
               <div className="flex flex-col group">
                 {textContent.trim() && (
-                  <div className="flex bg-text-primary text-background-primary rounded-xl py-2.5 px-4">
+                  <div className="user-message-bubble flex bg-text-primary text-background-primary rounded-xl py-2.5 px-4">
                     <div ref={contentRef}>
                       <MarkdownContent
                         content={textContent}

--- a/ui/desktop/src/styles/main.css
+++ b/ui/desktop/src/styles/main.css
@@ -585,6 +585,37 @@ pre:has(> code.bg-inline-code) {
   margin-bottom: 0 !important;
 }
 
+.dark .user-message-bubble {
+  background-color: #171d30;
+  color: #d2dae6;
+}
+
+.dark .user-message :is(h1, h2, h3, h4, h5, h6, strong) {
+  color: #e7ebf2 !important;
+}
+
+.dark .user-message li {
+  color: #c4cfde !important;
+}
+
+.dark .user-message li::marker {
+  color: #8798b0;
+}
+
+.dark .user-message a {
+  color: #aecfe3 !important;
+}
+
+.dark .user-message em {
+  color: #c6d9df !important;
+}
+
+.dark .agent-message-bubble {
+  background-color: #1f2126;
+  border-radius: 0.75rem;
+  padding: 0.625rem 1rem;
+}
+
 .scrollbar-thin {
   scrollbar-width: thin;
 }


### PR DESCRIPTION
## Summary

- replace the bright user prompt background with a muted slate-blue palette
- add harmonious Markdown accent colors within user messages
- add a subtle darker background to agent responses
- leave the light theme and tool rendering unchanged

## Testing

- manually built and tested on Windows 11

### Screenshots/Demos (for UX changes)

Before:  
<img width="2524" height="584" alt="image" src="https://github.com/user-attachments/assets/5273670b-be65-4e7e-b5df-21a4cd23391e" />


After:   
<img width="2415" height="816" alt="image" src="https://github.com/user-attachments/assets/5df9fdfd-3246-46df-b5d8-6ba1d450e8fa" />

