### PR TITLE
fix(providers): add reasoning effort support for Ollama Cloud

### DIFF
--- a/crates/goose-provider-types/src/base.rs
+++ b/crates/goose-provider-types/src/base.rs
@@ -44,6 +44,10 @@ pub struct ProviderMetadata {
     /// compaction). When set, fast-path callers prefer this model over the main model.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub fast_model: Option<String>,
+    /// The catalog provider ID (e.g. "ollama_cloud") used for canonical model
+    /// lookups when the provider `name` is a custom alias.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub catalog_provider_id: Option<String>,
 }
 
 impl ProviderMetadata {
@@ -70,6 +74,7 @@ impl ProviderMetadata {
             setup_steps: vec![],
             model_selection_hint: None,
             fast_model: None,
+            catalog_provider_id: None,
         }
     }
 
@@ -93,6 +98,7 @@ impl ProviderMetadata {
             setup_steps: vec![],
             model_selection_hint: None,
             fast_model: None,
+            catalog_provider_id: None,
         }
     }
 
@@ -108,6 +114,7 @@ impl ProviderMetadata {
             setup_steps: vec![],
             model_selection_hint: None,
             fast_model: None,
+            catalog_provider_id: None,
         }
     }
 

--- a/crates/goose-provider-types/src/model.rs
+++ b/crates/goose-provider-types/src/model.rs
@@ -92,7 +92,23 @@ impl ModelConfig {
         config
     }
 
-    pub fn with_canonical_limits(mut self, provider_name: &str) -> Self {
+    pub fn with_canonical_limits(self, provider_name: &str) -> Self {
+        self.with_canonical_limits_inner(provider_name, None)
+    }
+
+    pub fn with_canonical_limits_and_catalog_id(
+        self,
+        provider_name: &str,
+        catalog_provider_id: Option<&str>,
+    ) -> Self {
+        self.with_canonical_limits_inner(provider_name, catalog_provider_id)
+    }
+
+    fn with_canonical_limits_inner(
+        mut self,
+        provider_name: &str,
+        catalog_provider_id: Option<&str>,
+    ) -> Self {
         // Try canonical lookup with the full model name first, then fall back
         // to the name with reasoning-effort suffixes stripped (e.g.
         // "databricks-gpt-5.4-high" → "databricks-gpt-5.4").
@@ -107,6 +123,24 @@ impl ModelConfig {
                     }
                 },
             );
+
+        // If the provider name is a custom alias (e.g. "my-ollama"), try the
+        // catalog_provider_id (e.g. "ollama_cloud") so reasoning metadata and
+        // context limits from the canonical registry are resolved.
+        let canonical = canonical.or_else(|| {
+            let catalog_id = catalog_provider_id?;
+            let by_catalog =
+                crate::canonical::maybe_get_canonical_model(catalog_id, &self.model_name);
+            if by_catalog.is_some() {
+                return by_catalog;
+            }
+            let (base, _effort) = extract_reasoning_effort(&self.model_name);
+            if base != self.model_name {
+                crate::canonical::maybe_get_canonical_model(catalog_id, &base)
+            } else {
+                None
+            }
+        });
 
         if let Some(canonical) = canonical {
             if self.context_limit.is_none() {
@@ -643,8 +677,6 @@ mod tests {
                 ("GOOSE_MAX_TOKENS", None::<&str>),
                 ("GOOSE_CONTEXT_LIMIT", None::<&str>),
             ]);
-
-            // "databricks-gpt-5.4-high" should resolve via "databricks-gpt-5.4"
             let config =
                 ModelConfig::new("databricks-gpt-5.4-high").with_canonical_limits("databricks");
             assert_eq!(config.context_limit, Some(1_050_000));
@@ -670,6 +702,26 @@ mod tests {
             // "gpt-5.4-nano-low" should resolve via "gpt-5.4-nano"
             let config = ModelConfig::new("gpt-5.4-nano-low").with_canonical_limits("openai");
             assert_eq!(config.context_limit, Some(400_000));
+        }
+
+        #[test]
+        fn catalog_provider_id_resolves_reasoning_for_custom_name() {
+            let _guard = env_lock::lock_env([
+                ("GOOSE_MAX_TOKENS", None::<&str>),
+                ("GOOSE_CONTEXT_LIMIT", None::<&str>),
+            ]);
+
+            // A custom-named provider (e.g. "my-ollama") cannot resolve
+            // canonical metadata via its name alone. The catalog_provider_id
+            // ("ollama_cloud") should be used as a fallback so reasoning
+            // metadata is correctly resolved.
+            let config = ModelConfig::new("gemma4:31b")
+                .with_canonical_limits_and_catalog_id("my-custom-ollama", Some("ollama_cloud"));
+            assert_eq!(config.reasoning, Some(true));
+
+            // Without the catalog_provider_id, the same lookup fails.
+            let config = ModelConfig::new("gemma4:31b").with_canonical_limits("my-custom-ollama");
+            assert_eq!(config.reasoning, None);
         }
     }
 

--- a/crates/goose-providers/src/declarative/definitions/ollama_cloud.json
+++ b/crates/goose-providers/src/declarative/definitions/ollama_cloud.json
@@ -9,5 +9,6 @@
   "dynamic_models": true,
   "headers": null,
   "timeout_seconds": null,
-  "supports_streaming": true
+  "supports_streaming": true,
+  "catalog_provider_id": "ollama_cloud"
 }

--- a/crates/goose-providers/src/openai.rs
+++ b/crates/goose-providers/src/openai.rs
@@ -354,7 +354,7 @@ impl OpenAiProvider {
     /// matched by [`is_openai_responses_model`] (which only recognises
     /// OpenAI's own `o*`/`gpt-5*` model names). These need the unified
     /// [`ThinkingEffort`] mapped onto the request explicitly.
-    const PROVIDERS_NEEDING_REASONING_EFFORT_MAPPING: &[&str] = &["meta"];
+    const PROVIDERS_NEEDING_REASONING_EFFORT_MAPPING: &[&str] = &["meta", "ollama_cloud"];
 
     /// Maps the unified thinking effort onto Meta's Muse Spark
     /// `reasoning_effort` levels: `low`, `medium`, `high`, `xhigh`.
@@ -368,6 +368,29 @@ impl OpenAiProvider {
             ThinkingEffort::Medium => "medium",
             ThinkingEffort::High => "high",
             ThinkingEffort::Max => "xhigh",
+        }
+    }
+
+    /// Maps the unified thinking effort onto Ollama Cloud's OpenAI-compatible
+    /// `reasoning_effort` levels.
+    ///
+    /// Returns `None` for `Off` so the field is omitted rather than sending
+    /// unsupported `"none"`. Supported values are passed through 1:1.
+    fn ollama_cloud_reasoning_effort(effort: ThinkingEffort) -> Option<&'static str> {
+        match effort {
+            ThinkingEffort::Off => None,
+            ThinkingEffort::Low => Some("low"),
+            ThinkingEffort::Medium => Some("medium"),
+            ThinkingEffort::High => Some("high"),
+            ThinkingEffort::Max => Some("max"),
+        }
+    }
+
+    fn map_reasoning_effort_for_provider(&self, effort: ThinkingEffort) -> Option<&'static str> {
+        match self.name.as_str() {
+            "meta" => Some(Self::meta_reasoning_effort(effort)),
+            "ollama_cloud" => Self::ollama_cloud_reasoning_effort(effort),
+            _ => None,
         }
     }
 
@@ -404,15 +427,27 @@ impl OpenAiProvider {
 
             if Self::PROVIDERS_NEEDING_REASONING_EFFORT_MAPPING.contains(&self.name.as_str()) {
                 match model_config.thinking_effort() {
-                    Some(effort) => {
-                        obj.insert(
-                            "reasoning_effort".to_string(),
-                            json!(Self::meta_reasoning_effort(effort)),
-                        );
-                    }
-                    None => {
+                    Some(effort) => match self.map_reasoning_effort_for_provider(effort) {
+                        Some(mapped) => {
+                            obj.insert("reasoning_effort".to_string(), json!(mapped));
+                        }
+                        // Ollama does not accept reasoning_effort=none; omit the
+                        // field when the user explicitly selects Off.
+                        None if self.name == "ollama_cloud"
+                            && matches!(effort, ThinkingEffort::Off) =>
+                        {
+                            obj.remove("reasoning_effort");
+                        }
+                        None => {}
+                    },
+                    // Meta has no request_params-based reasoning_effort path and
+                    // always wants an explicit mapped value or omission. Ollama
+                    // Cloud callers may set provider-native reasoning_effort via
+                    // request_params without unified thinking_effort; preserve it.
+                    None if self.name == "meta" => {
                         obj.remove("reasoning_effort");
                     }
+                    None => {}
                 }
             }
         }

--- a/crates/goose-providers/src/openai.rs
+++ b/crates/goose-providers/src/openai.rs
@@ -145,6 +145,8 @@ pub struct OpenAiProvider {
     skip_canonical_filtering: bool,
     preserve_thinking_context: bool,
     #[serde(skip)]
+    catalog_provider_id: Option<String>,
+    #[serde(skip)]
     n_ctx_cache: Arc<Mutex<HashMap<String, Option<usize>>>>,
 }
 
@@ -165,6 +167,7 @@ pub struct OpenAiProviderBuilder {
     dynamic_models: Option<bool>,
     skip_canonical_filtering: bool,
     preserve_thinking_context: bool,
+    catalog_provider_id: Option<String>,
 }
 
 impl OpenAiProviderBuilder {
@@ -181,6 +184,7 @@ impl OpenAiProviderBuilder {
             dynamic_models: None,
             skip_canonical_filtering: false,
             preserve_thinking_context: false,
+            catalog_provider_id: None,
         }
     }
 
@@ -252,6 +256,11 @@ impl OpenAiProviderBuilder {
         self
     }
 
+    pub fn catalog_provider_id(mut self, catalog_provider_id: Option<String>) -> Self {
+        self.catalog_provider_id = catalog_provider_id;
+        self
+    }
+
     pub fn build(self) -> OpenAiProvider {
         OpenAiProvider {
             api_client: self.api_client,
@@ -265,6 +274,7 @@ impl OpenAiProviderBuilder {
             dynamic_models: self.dynamic_models,
             skip_canonical_filtering: self.skip_canonical_filtering,
             preserve_thinking_context: self.preserve_thinking_context,
+            catalog_provider_id: self.catalog_provider_id,
             n_ctx_cache: Arc::new(Mutex::new(HashMap::new())),
         }
     }
@@ -285,6 +295,7 @@ impl OpenAiProvider {
             dynamic_models: None,
             skip_canonical_filtering: false,
             preserve_thinking_context: false,
+            catalog_provider_id: None,
             n_ctx_cache: Arc::new(Mutex::new(HashMap::new())),
         }
     }
@@ -349,13 +360,6 @@ impl OpenAiProvider {
 
     const PROVIDERS_NEEDING_STANDARD_CHAT_PARAMS: &[&str] = &["nearai"];
 
-    /// Providers whose reasoning models accept an OpenAI-style
-    /// `reasoning_effort` field on chat-completions requests but aren't
-    /// matched by [`is_openai_responses_model`] (which only recognises
-    /// OpenAI's own `o*`/`gpt-5*` model names). These need the unified
-    /// [`ThinkingEffort`] mapped onto the request explicitly.
-    const PROVIDERS_NEEDING_REASONING_EFFORT_MAPPING: &[&str] = &["meta", "ollama_cloud"];
-
     /// Maps the unified thinking effort onto Meta's Muse Spark
     /// `reasoning_effort` levels: `low`, `medium`, `high`, `xhigh`.
     ///
@@ -374,11 +378,12 @@ impl OpenAiProvider {
     /// Maps the unified thinking effort onto Ollama Cloud's OpenAI-compatible
     /// `reasoning_effort` levels.
     ///
-    /// Returns `None` for `Off` so the field is omitted rather than sending
-    /// unsupported `"none"`. Supported values are passed through 1:1.
+    /// Ollama's server whitelists {high, medium, low, max, none} and maps
+    /// `"none"` to `think: false`. Since thinking is on by default, omitting
+    /// the field makes `Off` a no-op, so `Off` must be sent as `"none"`.
     fn ollama_cloud_reasoning_effort(effort: ThinkingEffort) -> Option<&'static str> {
         match effort {
-            ThinkingEffort::Off => None,
+            ThinkingEffort::Off => Some("none"),
             ThinkingEffort::Low => Some("low"),
             ThinkingEffort::Medium => Some("medium"),
             ThinkingEffort::High => Some("high"),
@@ -387,11 +392,21 @@ impl OpenAiProvider {
     }
 
     fn map_reasoning_effort_for_provider(&self, effort: ThinkingEffort) -> Option<&'static str> {
-        match self.name.as_str() {
-            "meta" => Some(Self::meta_reasoning_effort(effort)),
-            "ollama_cloud" => Self::ollama_cloud_reasoning_effort(effort),
-            _ => None,
+        if self.is_meta() {
+            Some(Self::meta_reasoning_effort(effort))
+        } else if self.is_ollama_cloud() {
+            Self::ollama_cloud_reasoning_effort(effort)
+        } else {
+            None
         }
+    }
+
+    fn is_meta(&self) -> bool {
+        self.name == "meta" || self.catalog_provider_id.as_deref() == Some("meta")
+    }
+
+    fn is_ollama_cloud(&self) -> bool {
+        self.name == "ollama_cloud" || self.catalog_provider_id.as_deref() == Some("ollama_cloud")
     }
 
     fn sanitize_request_for_compat(
@@ -425,26 +440,27 @@ impl OpenAiProvider {
                 }
             }
 
-            if Self::PROVIDERS_NEEDING_REASONING_EFFORT_MAPPING.contains(&self.name.as_str()) {
+            if self.is_meta() || self.is_ollama_cloud() {
+                // Meta (Muse Spark) always reasons and has no "disable reasoning"
+                // level, so its mapping must not be gated on is_reasoning_model().
+                let should_map = self.is_meta() || model_config.is_reasoning_model();
                 match model_config.thinking_effort() {
-                    Some(effort) => match self.map_reasoning_effort_for_provider(effort) {
-                        Some(mapped) => {
+                    Some(effort) if should_map => {
+                        if let Some(mapped) = self.map_reasoning_effort_for_provider(effort) {
                             obj.insert("reasoning_effort".to_string(), json!(mapped));
                         }
-                        // Ollama does not accept reasoning_effort=none; omit the
-                        // field when the user explicitly selects Off.
-                        None if self.name == "ollama_cloud"
-                            && matches!(effort, ThinkingEffort::Off) =>
-                        {
-                            obj.remove("reasoning_effort");
-                        }
-                        None => {}
-                    },
+                    }
+                    // Non-reasoning model with thinking_effort set: strip
+                    // reasoning_effort entirely (including request_params-provided
+                    // values) to avoid 400 errors from providers that reject it.
+                    Some(_) => {
+                        obj.remove("reasoning_effort");
+                    }
                     // Meta has no request_params-based reasoning_effort path and
                     // always wants an explicit mapped value or omission. Ollama
                     // Cloud callers may set provider-native reasoning_effort via
                     // request_params without unified thinking_effort; preserve it.
-                    None if self.name == "meta" => {
+                    None if self.is_meta() => {
                         obj.remove("reasoning_effort");
                     }
                     None => {}
@@ -883,7 +899,8 @@ pub fn from_declarative_config(
         .custom_models(custom_models)
         .dynamic_models(config.dynamic_models)
         .skip_canonical_filtering(config.skip_canonical_filtering)
-        .preserve_thinking_context(config.preserves_thinking))
+        .preserve_thinking_context(config.preserves_thinking)
+        .catalog_provider_id(config.catalog_provider_id.clone()))
 }
 
 pub fn parse_custom_headers(s: String) -> HashMap<String, String> {
@@ -941,6 +958,7 @@ mod tests {
             dynamic_models: None,
             skip_canonical_filtering: false,
             preserve_thinking_context: false,
+            catalog_provider_id: None,
             n_ctx_cache: Arc::new(Mutex::new(HashMap::new())),
         }
     }
@@ -1142,6 +1160,116 @@ mod tests {
         let obj = result.as_object().unwrap();
 
         assert!(!obj.contains_key("reasoning_effort"));
+    }
+
+    fn make_ollama_cloud_provider() -> OpenAiProvider {
+        let mut provider = make_provider("ollama_cloud");
+        provider.catalog_provider_id = Some("ollama_cloud".to_string());
+        provider
+    }
+
+    fn reasoning_model_config(name: &str, effort: ThinkingEffort) -> ModelConfig {
+        let mut config = ModelConfig::new(name).with_thinking_effort(effort);
+        config.reasoning = Some(true);
+        config
+    }
+
+    fn non_reasoning_model_config(name: &str, effort: ThinkingEffort) -> ModelConfig {
+        let mut config = ModelConfig::new(name).with_thinking_effort(effort);
+        config.reasoning = Some(false);
+        config
+    }
+
+    #[test]
+    fn sanitize_ollama_cloud_maps_reasoning_effort() {
+        let provider = make_ollama_cloud_provider();
+        let payload = json!({ "model": "qwen3-coder:480b-cloud", "messages": [] });
+
+        let result = provider.sanitize_request_for_compat(
+            payload.clone(),
+            &reasoning_model_config("qwen3-coder:480b-cloud", ThinkingEffort::High),
+        );
+        assert_eq!(
+            result.as_object().unwrap().get("reasoning_effort"),
+            Some(&json!("high"))
+        );
+
+        let result = provider.sanitize_request_for_compat(
+            payload.clone(),
+            &reasoning_model_config("qwen3-coder:480b-cloud", ThinkingEffort::Max),
+        );
+        assert_eq!(
+            result.as_object().unwrap().get("reasoning_effort"),
+            Some(&json!("max"))
+        );
+
+        let result = provider.sanitize_request_for_compat(
+            payload,
+            &reasoning_model_config("qwen3-coder:480b-cloud", ThinkingEffort::Off),
+        );
+        assert_eq!(
+            result.as_object().unwrap().get("reasoning_effort"),
+            Some(&json!("none"))
+        );
+    }
+
+    #[test]
+    fn sanitize_ollama_cloud_skips_reasoning_effort_for_non_reasoning_model() {
+        let provider = make_ollama_cloud_provider();
+
+        let payload = json!({ "model": "mistral-large-3:675b", "messages": [] });
+        let result = provider.sanitize_request_for_compat(
+            payload,
+            &non_reasoning_model_config("mistral-large-3:675b", ThinkingEffort::High),
+        );
+        assert!(
+            !result.as_object().unwrap().contains_key("reasoning_effort"),
+            "non-reasoning model should not get reasoning_effort"
+        );
+
+        let payload = json!({
+            "model": "mistral-large-3:675b",
+            "messages": [],
+            "reasoning_effort": "high"
+        });
+        let result = provider.sanitize_request_for_compat(
+            payload,
+            &non_reasoning_model_config("mistral-large-3:675b", ThinkingEffort::Off),
+        );
+        assert!(
+            !result.as_object().unwrap().contains_key("reasoning_effort"),
+            "non-reasoning model with Off should not have reasoning_effort"
+        );
+    }
+
+    #[test]
+    fn sanitize_ollama_cloud_preserves_request_params_reasoning_effort_when_thinking_unset() {
+        let provider = make_ollama_cloud_provider();
+        let payload = json!({
+            "model": "qwen3-coder:480b-cloud",
+            "messages": [],
+            "reasoning_effort": "low"
+        });
+        let mut model_config = ModelConfig::new("qwen3-coder:480b-cloud");
+        model_config.reasoning = Some(true);
+
+        let result = provider.sanitize_request_for_compat(payload, &model_config);
+        let obj = result.as_object().unwrap();
+
+        assert_eq!(obj.get("reasoning_effort"), Some(&json!("low")));
+    }
+
+    #[test]
+    fn sanitize_ollama_cloud_works_with_custom_name_via_catalog_provider_id() {
+        let mut provider = make_provider("my-custom-ollama");
+        provider.catalog_provider_id = Some("ollama_cloud".to_string());
+        let payload = json!({ "model": "qwen3-coder:480b-cloud", "messages": [] });
+        let model_config = reasoning_model_config("qwen3-coder:480b-cloud", ThinkingEffort::Medium);
+
+        let result = provider.sanitize_request_for_compat(payload, &model_config);
+        let obj = result.as_object().unwrap();
+
+        assert_eq!(obj.get("reasoning_effort"), Some(&json!("medium")));
     }
 
     #[test]

--- a/crates/goose/src/model_config.rs
+++ b/crates/goose/src/model_config.rs
@@ -36,8 +36,16 @@ pub fn model_config_from_user_config_with_session_settings(
 }
 
 pub fn materialize_model_config(provider_name: &str, model: ModelConfig) -> Result<ModelConfig> {
+    materialize_model_config_with_catalog(provider_name, None, model)
+}
+
+pub fn materialize_model_config_with_catalog(
+    provider_name: &str,
+    catalog_provider_id: Option<&str>,
+    model: ModelConfig,
+) -> Result<ModelConfig> {
     let model = materialize_model_config_inner(model, provider_name, true)?;
-    Ok(model.with_canonical_limits(provider_name))
+    Ok(model.with_canonical_limits_and_catalog_id(provider_name, catalog_provider_id))
 }
 
 fn materialize_model_config_inner(

--- a/crates/goose/src/providers/init.rs
+++ b/crates/goose/src/providers/init.rs
@@ -480,6 +480,57 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_custom_provider_reasoning_flag_from_known_models() {
+        let _guard = env_lock::lock_env([
+            ("GOOSE_PATH_ROOT", None::<&str>),
+            ("GOOSE_MAX_TOKENS", None::<&str>),
+            ("GOOSE_CONTEXT_LIMIT", None::<&str>),
+            ("GOOSE_TEMPERATURE", None::<&str>),
+            ("GOOSE_TOOLSHIM", None::<&str>),
+            ("GOOSE_TOOLSHIM_OLLAMA_MODEL", None::<&str>),
+            ("GOOSE_THINKING_EFFORT", None::<&str>),
+        ]);
+        let temp_dir = tempfile::tempdir().expect("tempdir should be created");
+        std::env::set_var("GOOSE_PATH_ROOT", temp_dir.path());
+
+        let custom_dir = Paths::config_dir().join("custom_providers");
+        fs::create_dir_all(&custom_dir).expect("custom providers dir should be created");
+
+        let custom_reasoning = r#"{
+  "name": "custom_reasoning",
+  "engine": "openai",
+  "display_name": "Custom Reasoning",
+  "description": "test provider",
+  "api_key_env": "",
+  "base_url": "https://example.invalid/v1/chat/completions",
+  "models": [
+    {"name": "my-uncatalogued-model", "context_limit": 200000, "reasoning": true}
+  ],
+  "requires_auth": false
+}"#;
+        fs::write(custom_dir.join("custom_reasoning.json"), custom_reasoning)
+            .expect("custom_reasoning.json should be written");
+
+        refresh_custom_providers()
+            .await
+            .expect("custom providers should refresh");
+
+        let entry = get_from_registry("custom_reasoning")
+            .await
+            .expect("custom_reasoning entry should exist");
+        let config = entry
+            .normalize_model_config(ModelConfig::new("my-uncatalogued-model"))
+            .expect("model config should normalize");
+        assert_eq!(
+            config.reasoning,
+            Some(true),
+            "reasoning flag should be propagated from known_models"
+        );
+
+        std::env::remove_var("GOOSE_PATH_ROOT");
+    }
+
+    #[tokio::test]
     async fn test_litellm_supports_inventory_refresh() {
         let entry = get_from_registry("litellm")
             .await

--- a/crates/goose/src/providers/provider_registry.rs
+++ b/crates/goose/src/providers/provider_registry.rs
@@ -60,7 +60,11 @@ impl ProviderEntry {
     /// the agent/session layer to resolve effective limits (e.g. for custom
     /// providers that declare explicit context limits in their config).
     pub fn normalize_model_config(&self, mut model: ModelConfig) -> Result<ModelConfig> {
-        model = crate::model_config::materialize_model_config(&self.metadata.name, model)?;
+        model = crate::model_config::materialize_model_config_with_catalog(
+            &self.metadata.name,
+            self.metadata.catalog_provider_id.as_deref(),
+            model,
+        )?;
 
         if model.context_limit.is_none() {
             if let Some(info) = self
@@ -298,6 +302,7 @@ impl ProviderRegistry {
             setup_steps: config.setup_steps.clone(),
             model_selection_hint: None,
             fast_model: config.fast_model.clone(),
+            catalog_provider_id: config.catalog_provider_id.clone(),
         };
         let inventory_config_keys = custom_metadata.config_keys.clone();
         let default_inventory_configured = Arc::new(move || {

--- a/crates/goose/src/providers/provider_registry.rs
+++ b/crates/goose/src/providers/provider_registry.rs
@@ -66,14 +66,17 @@ impl ProviderEntry {
             model,
         )?;
 
-        if model.context_limit.is_none() {
-            if let Some(info) = self
-                .metadata
-                .known_models
-                .iter()
-                .find(|m| m.name.eq_ignore_ascii_case(&model.model_name) && m.context_limit > 0)
-            {
+        if let Some(info) = self
+            .metadata
+            .known_models
+            .iter()
+            .find(|m| m.name.eq_ignore_ascii_case(&model.model_name))
+        {
+            if model.context_limit.is_none() && info.context_limit > 0 {
                 model.context_limit = Some(info.context_limit);
+            }
+            if model.reasoning.is_none() && info.reasoning {
+                model.reasoning = Some(true);
             }
         }
 

--- a/crates/goose/tests/agent.rs
+++ b/crates/goose/tests/agent.rs
@@ -524,6 +524,7 @@ mod tests {
                     setup_steps: vec![],
                     model_selection_hint: None,
                     fast_model: None,
+                    catalog_provider_id: None,
                 }
             }
         }
@@ -696,6 +697,7 @@ mod tests {
                     setup_steps: vec![],
                     model_selection_hint: None,
                     fast_model: None,
+                    catalog_provider_id: None,
                 }
             }
         }
@@ -877,6 +879,7 @@ mod tests {
                     setup_steps: vec![],
                     model_selection_hint: None,
                     fast_model: None,
+                    catalog_provider_id: None,
                 }
             }
         }
@@ -1237,6 +1240,7 @@ mod tests {
                     setup_steps: vec![],
                     model_selection_hint: None,
                     fast_model: None,
+                    catalog_provider_id: None,
                 }
             }
         }
@@ -1508,6 +1512,7 @@ mod tests {
                     setup_steps: vec![],
                     model_selection_hint: None,
                     fast_model: None,
+                    catalog_provider_id: None,
                 }
             }
         }
@@ -1708,6 +1713,7 @@ mod tests {
                     setup_steps: vec![],
                     model_selection_hint: None,
                     fast_model: None,
+                    catalog_provider_id: None,
                 }
             }
         }
@@ -1859,6 +1865,7 @@ mod tests {
                     setup_steps: vec![],
                     model_selection_hint: None,
                     fast_model: None,
+                    catalog_provider_id: None,
                 }
             }
         }
@@ -2163,6 +2170,7 @@ mod tests {
                     setup_steps: vec![],
                     model_selection_hint: None,
                     fast_model: None,
+                    catalog_provider_id: None,
                 }
             }
         }
@@ -3015,6 +3023,7 @@ mod tests {
                     setup_steps: vec![],
                     model_selection_hint: None,
                     fast_model: None,
+                    catalog_provider_id: None,
                 }
             }
         }
@@ -3089,6 +3098,7 @@ mod tests {
                     setup_steps: vec![],
                     model_selection_hint: None,
                     fast_model: None,
+                    catalog_provider_id: None,
                 }
             }
         }

--- a/crates/goose/tests/compaction.rs
+++ b/crates/goose/tests/compaction.rs
@@ -187,6 +187,7 @@ impl goose::providers::base::ProviderDescriptor for MockCompactionProvider {
             setup_steps: vec![],
             model_selection_hint: None,
             fast_model: None,
+            catalog_provider_id: None,
         }
     }
 }

--- a/goose-self-test.yaml
+++ b/goose-self-test.yaml
@@ -375,7 +375,7 @@ prompt: |
   ### Provider Feature Smoke Check
   Confirm Ollama Cloud reasoning wiring is present in source:
   1. `ollama_cloud.json` has `catalog_provider_id: "ollama_cloud"`
-  2. `openai.rs` maps Ollama Cloud thinking effort via `PROVIDERS_NEEDING_REASONING_EFFORT_MAPPING`
+  2. `openai.rs` maps Ollama Cloud thinking effort via `is_ollama_cloud()` and `map_reasoning_effort_for_provider()`
 
   Log results to: {{ workspace_dir }}/phase4_advanced.md
   {% endif %}

--- a/goose-self-test.yaml
+++ b/goose-self-test.yaml
@@ -372,6 +372,11 @@ prompt: |
   3. Test with harmful Unicode characters
   4. Verify command injection prevention
 
+  ### Provider Feature Smoke Check
+  Confirm Ollama Cloud reasoning wiring is present in source:
+  1. `ollama_cloud.json` has `catalog_provider_id: "ollama_cloud"`
+  2. `openai.rs` maps Ollama Cloud thinking effort via `PROVIDERS_NEEDING_REASONING_EFFORT_MAPPING`
+
   Log results to: {{ workspace_dir }}/phase4_advanced.md
   {% endif %}
 


### PR DESCRIPTION
## Summary

Fixes two bugs that prevent Ollama Cloud reasoning effort from working consistently across CLI and Desktop:

1. **Desktop UI does not show the reasoning effort control** for Ollama Cloud reasoning models — `ollama_cloud.json` was missing `catalog_provider_id`, so canonical model lookup failed and `reasoning: true` was never resolved.
2. **Reasoning effort values are not sent to the Ollama Cloud API** — shared OpenAI request formatting only applied `reasoning_effort` to OpenAI responses models (`o1`, `o3`, `gpt-5`). Ollama Cloud models never received a mapped `reasoning_effort` value even when the user configured thinking effort.

## Motivation

I wanted a consistent way to configure reasoning effort for Ollama Cloud models across both CLI and Desktop. Before this fix, two issues prevented this: the reasoning effort dropdown was invisible in Desktop (so users could not set it), and Ollama Cloud requests never mapped the configured thinking effort onto an API `reasoning_effort` field. After this fix, the reasoning effort dropdown is visible in Desktop for Ollama Cloud reasoning models, and the selected effort is included in the Ollama Cloud request payload.

## Changes

### 1. Add `catalog_provider_id` to `ollama_cloud.json`

```diff
+ "catalog_provider_id": "ollama_cloud"
```

This sets `provider_family` to `"ollama_cloud"` in `declarative_inventory_identity()`. `map_provider_name("ollama_cloud")` → `"ollama-cloud"` maps to the canonical registry, where most `ollama-cloud/` models have `reasoning: true`. This enables the Desktop UI to show the reasoning effort dropdown for reasoning models and hide it for non-reasoning models.

The value `"ollama_cloud"` (underscore) is intentionally chosen to match `OLLAMA_CLOUD_PROVIDER_NAME` used in `OllamaCloudProvider::matches_declarative_config()`, ensuring the provider is correctly routed to `OllamaCloudProvider` even when a custom provider name is used.

Ollama Cloud provides an [OpenAI-compatible API](https://docs.ollama.com/api/openai-compatibility), so the `reasoning_effort` parameter follows the same convention as OpenAI's chat completions API.

### 2. Map thinking effort in the Ollama Cloud provider sanitizer

Follow the existing Meta pattern in `OpenAiProvider::sanitize_request_for_compat()` instead of emitting `reasoning_effort` from the shared OpenAI formatter for all reasoning models.

```rust
const PROVIDERS_NEEDING_REASONING_EFFORT_MAPPING: &[&str] = &["meta", "ollama_cloud"];

fn ollama_cloud_reasoning_effort(effort: ThinkingEffort) -> Option<&'static str> {
    match effort {
        ThinkingEffort::Off => None,
        ThinkingEffort::Low => Some("low"),
        ThinkingEffort::Medium => Some("medium"),
        ThinkingEffort::High => Some("high"),
        ThinkingEffort::Max => Some("max"),
    }
}
```

- Scoped to the `ollama_cloud` provider only
- Pass `low` / `medium` / `high` / `max` through 1:1
- For `Off`, omit `reasoning_effort` instead of sending unsupported `"none"`
- When unified `thinking_effort` is unset, preserve any explicit `reasoning_effort` already present in the payload (for example via `request_params`)

### 3. Minimal self-test coverage

Add a short smoke check in the advanced phase of `goose-self-test.yaml` for the two source wires above.

## Flow

```mermaid
flowchart TD
    subgraph Fix1["Fix 1: catalog_provider_id → UI dropdown visibility"]
        A["User selects Ollama Cloud model"]
        B{"catalog_provider_id present?"}
        C["provider_family = openai fallback"]
        D["canonical lookup fails"]
        F["UI: no reasoning effort dropdown"]
        G["provider_family = ollama_cloud"]
        H["map_provider_name → ollama-cloud"]
        I["canonical lookup succeeds"]
        K["UI: reasoning effort dropdown shown"]

        A --> B
        B -->|"No before fix"| C --> D --> F
        B -->|"Yes: ollama_cloud after fix"| G --> H --> I --> K
    end

    subgraph Fix2["Fix 2: provider sanitizer → API payload"]
        L["User sends message"]
        M["create_request_with_options()"]
        N["payload may include request_params.reasoning_effort"]
        O["sanitize_request_for_compat()"]
        P{"provider name == ollama_cloud?"}
        Q{"thinking_effort set?"}
        R{"effort == Off?"}
        S["omit reasoning_effort"]
        T["map Low/Medium/High/Max → low/medium/high/max"]
        U["Ollama Cloud API receives mapped reasoning_effort"]
        V["preserve existing reasoning_effort if present"]
        W["other providers unchanged"]

        K --> L --> M --> N --> O --> P
        P -->|"No"| W
        P -->|"Yes"| Q
        Q -->|"Yes"| R
        R -->|"Yes"| S
        R -->|"No"| T --> U
        Q -->|"No"| V
    end
```

## Considerations

### #10039 — canonical_models.json is auto-generated

Per [this comment](https://github.com/aaif-goose/goose/pull/10039#issuecomment-4846954869), `canonical_models.json` is a generated file regenerated every release via `cargo run --bin build_canonical_models`. Hand-editing it would be silently discarded on the next regen.

**This PR does not touch `canonical_models.json`.** The `ollama-cloud/` entries already exist in the canonical registry from models.dev. Our fix works by adding `catalog_provider_id` to the *declarative provider config* (`ollama_cloud.json`), which is a source file — not a generated artifact. This connects the existing canonical data to the provider without modifying any auto-generated content.

### Impact on other providers

This change is scoped to the `ollama_cloud` provider path:

1. `catalog_provider_id` only affects Ollama Cloud inventory/canonical lookup
2. `reasoning_effort` mapping is added only to `PROVIDERS_NEEDING_REASONING_EFFORT_MAPPING` for `"ollama_cloud"`
3. Shared `create_request_with_options()` behavior for non-OpenAI models is unchanged
4. Meta keeps its existing behavior of omitting `reasoning_effort` when unified thinking effort is unset

Other OpenAI-compatible providers are unaffected.

## Testing

- `cargo test -p goose-providers sanitize_meta`
- `goose recipe validate goose-self-test.yaml`
- `cargo clippy -p goose-providers --all-targets -- -D warnings`
- `cargo fmt --check`

### Manual verification

- Set reasoning effort via CLI for an Ollama Cloud reasoning model → confirmed the same effort level appears in Desktop session
- Non-reasoning Ollama Cloud model (e.g. `mistral-large-3:675b`) → reasoning effort dropdown not shown

## Future Work

Currently this PR relies on the canonical registry to determine whether a model supports reasoning effort. Since the canonical registry is auto-generated from models.dev, newly added Ollama Cloud models won't have reasoning effort support detected until the next canonical update.

Ideally, a future enhancement would auto-detect reasoning capability directly from the provider's API:

1. **API-based capability discovery** — Query `/api/show` or `/v1/models` endpoints to dynamically determine whether a model supports reasoning and which effort levels (`low`, `medium`, `high`, `max`, etc.) are accepted.
2. **Supplement canonical registry** — For models not yet in the canonical registry, use API responses to determine reasoning support and reflect it in the UI.
3. **Provider-agnostic generalization** — Standardize the capability discovery mechanism so it applies to all OpenAI-compatible providers, not just Ollama Cloud.

This would allow the reasoning effort control to appear automatically for new models without waiting for canonical registry updates.

## Related

- #8189 — Initial Ollama Cloud declarative provider (added without `catalog_provider_id`)
- #10264 — OllamaCloudProvider with dynamic model discovery and context limits
- #10035 — Custom OpenAI providers ignoring `catalog_provider_id` (related issue)
- [#10039 (comment)](https://github.com/aaif-goose/goose/pull/10039#issuecomment-4846954869) — canonical_models.json is auto-generated; do not hand-edit
