### PR TITLE
fix(providers): refresh Moonshot model list with current Kimi lineup

### DIFF
--- a/crates/goose-providers/src/declarative/definitions/moonshot.json
+++ b/crates/goose-providers/src/declarative/definitions/moonshot.json
@@ -15,12 +15,16 @@
     }
   ],
   "models": [
-    {"name": "kimi-latest", "context_limit": 131072},
-    {"name": "kimi-thinking-preview", "context_limit": 131072},
-    {"name": "kimi-k2-0711", "context_limit": 131072},
-    {"name": "kimi-k2", "context_limit": 262144},
-    {"name": "moonshot-v1-8k", "context_limit": 8192},
-    {"name": "moonshot-v1-32k", "context_limit": 32768}
+    {"name": "kimi-k2-0711-preview", "context_limit": 131072},
+    {"name": "kimi-k2-0905-preview", "context_limit": 262144},
+    {"name": "kimi-k2-thinking", "context_limit": 262144},
+    {"name": "kimi-k2-thinking-turbo", "context_limit": 262144},
+    {"name": "kimi-k2-turbo-preview", "context_limit": 262144},
+    {"name": "kimi-k2.5", "context_limit": 262144},
+    {"name": "kimi-k2.6", "context_limit": 262144},
+    {"name": "kimi-k2.7-code", "context_limit": 262144},
+    {"name": "kimi-k2.7-code-highspeed", "context_limit": 262144},
+    {"name": "kimi-k3", "context_limit": 1048576}
   ],
   "preserves_thinking": true,
   "supports_streaming": true


### PR DESCRIPTION
## Summary
- The `moonshot` declarative provider shipped a stale static model list from #7304 (`kimi-latest`, `kimi-k2-0711`, `moonshot-v1-8k/32k`, ...), none of which the API serves anymore
- When `/v1/models` discovery is unavailable, goose falls back to this list — so current models like `kimi-k3` were not selectable
- Replaced with the current lineup from the canonical registry (#10695): `kimi-k2-0711/0905/turbo-preview`, `kimi-k2-thinking(-turbo)`, `kimi-k2.5`, `kimi-k2.6`, `kimi-k2.7-code(-highspeed)`, `kimi-k3` (1M context)

## Test plan
- [ ] CI passes
- [x] `cargo test -p goose-providers` (86 pass)
- [x] `cargo clippy -p goose-providers --all-targets -- -D warnings`
- [x] Context limits match `canonical_models.json` (`moonshotai/*` entries)