### PR TITLE
fix(acp): skip permission mode negotiation for Pi

### DIFF
--- a/crates/goose/src/providers/pi_acp.rs
+++ b/crates/goose/src/providers/pi_acp.rs
@@ -72,13 +72,6 @@ impl ProviderDef for PiAcpProvider {
                 vec![("model".to_string(), model)]
             };
 
-            let mode_mapping = HashMap::from([
-                (GooseMode::Auto, vec!["auto".to_string()]),
-                (GooseMode::Approve, vec!["approve".to_string()]),
-                (GooseMode::SmartApprove, vec!["smart-approve".to_string()]),
-                (GooseMode::Chat, vec!["chat".to_string()]),
-            ]);
-
             let provider_config = AcpProviderConfig {
                 command: resolved_command,
                 args: vec![],
@@ -86,10 +79,11 @@ impl ProviderDef for PiAcpProvider {
                 env_remove: vec![],
                 work_dir: working_dir,
                 mcp_servers: extension_configs_to_mcp_servers(&extensions),
-                session_mode_id: mode_mapping[&goose_mode].first().cloned(),
+                session_mode_id: None,
                 session_config_options,
                 model_config_option_id: Some("model".to_string()),
-                mode_mapping,
+                // pi-acp exposes thinking levels as ACP modes, not permission modes.
+                mode_mapping: HashMap::new(),
                 notification_callback: None,
             };
 


### PR DESCRIPTION
## Summary

Stop mapping goose permission modes onto `pi-acp`'s ACP modes. `pi-acp` uses those IDs for thinking levels, so requesting `auto` prevented every current Pi ACP session from starting.

The Pi provider now leaves session mode negotiation disabled. goose still tracks its mode locally, while Pi's thinking level remains independent through the adapter's `thought_level` config option.

### How to review

1. Confirm Pi no longer supplies an initial ACP session mode or a permission-mode mapping.
2. Confirm the empty mapping uses the no-negotiation behavior added in #10320.
3. Note that exposing Pi's thinking-level selector in goose is deliberately out of scope.

### Testing

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- Workspace tests passed with three unrelated local-only exclusions:
  - `test_steer_session_adds_input_to_active_prompt` (passed when rerun alone; flaky in the full suite)
  - `test_codex_provider` and `test_claude_code_provider` (installed CLIs detected in the isolated test home without credentials)
- Existing no-mode-negotiation tests passed for all four goose modes.
- Manual end-to-end test with goose built from this branch, Pi CLI `0.82.1`, and `pi-acp@0.0.32` successfully created a session and returned `PI_ACP_OK`.

### Related Issues

Fixes #10699
Related to #10320

### Screenshots/Demos

Not applicable; provider initialization fix only.

### Review notes

No unresolved review findings.
