### PR TITLE
fix(kimi-code): update known models metadata with current platform lineup

### DIFF
--- a/crates/goose/src/providers/kimicode.rs
+++ b/crates/goose/src/providers/kimicode.rs
@@ -38,9 +38,14 @@ const KIMI_CODE_PROVIDER_NAME: &str = "kimi_code";
 pub const KIMI_CODE_DEFAULT_MODEL: &str = "kimi-for-coding";
 /// Known models for the provider metadata registration. The live catalogue is
 /// fetched from `/v1/models` at request time; this constant is only used for
-/// `ProviderMetadata`. As of 2025-10 Kimi Code exposes a single model,
-/// `kimi-for-coding`, and silently routes any other model name to it.
-pub const KIMI_CODE_KNOWN_MODELS: &[&str] = &["kimi-for-coding"];
+/// `ProviderMetadata`, e.g. when the catalogue fetch fails. As of 2026-07 the
+/// platform serves these ids verbatim (`k3`, not `kimi-k3`).
+pub const KIMI_CODE_KNOWN_MODELS: &[&str] = &[
+    "kimi-for-coding",
+    "kimi-for-coding-highspeed",
+    "k3",
+    "k3-256k",
+];
 
 const KIMI_CODE_DOC_URL: &str = "https://www.kimi.com/code/docs/en/";
 const KIMI_CODE_CLIENT_ID: &str = "17e5f671-d194-4dfb-9706-5516cb48c098";


### PR DESCRIPTION
## Summary
- `kimi_code`'s `/v1/models` catalogue now serves `kimi-for-coding`, `kimi-for-coding-highspeed`, `k3`, and `k3-256k` (verified live against `api.kimi.com/coding/v1/models`)
- `KIMI_CODE_KNOWN_MODELS` still listed only `kimi-for-coding`; it's the fallback shown when the live fetch fails (e.g. expired token), so k3 was hidden from the model picker
- Updated the metadata list to match the live catalogue. Note the platform ids are `k3`/`k3-256k`, not `kimi-k3`

## Test plan
- [ ] CI passes
- [x] `cargo test -p goose --lib kimicode` (12 pass)
- [x] `cargo clippy -p goose --lib -- -D warnings`