### PR TITLE
feat: add Celeris provider

### DIFF
--- a/crates/goose-providers/src/declarative.rs
+++ b/crates/goose-providers/src/declarative.rs
@@ -15,6 +15,7 @@ pub(crate) mod declarative_providers {
     expose_declarative_providers!(
         alibaba,
         atomic_chat,
+        celeris,
         cerebras,
         deepseek,
         empiriolabs,

--- a/crates/goose-providers/src/declarative/definitions/celeris.json
+++ b/crates/goose-providers/src/declarative/definitions/celeris.json
@@ -1,0 +1,20 @@
+{
+  "name": "celeris",
+  "engine": "openai",
+  "display_name": "Celeris",
+  "description": "Diffusion-based language models over an OpenAI-compatible API, optimized for low latency on short responses. celeris-1 has an 8192 token context shared between the prompt and the completion, and the base URL pins the model in its path.",
+  "api_key_env": "CELERIS_API_KEY",
+  "base_url": "https://inference.celeris.ai/celeris-1/v1",
+  "models": [
+    { "name": "celeris-1", "context_limit": 8192 }
+  ],
+  "dynamic_models": false,
+  "skip_canonical_filtering": true,
+  "supports_streaming": true,
+  "model_doc_link": "https://docs.celeris.ai/api-reference",
+  "setup_steps": [
+    "Sign up at https://celeris.ai",
+    "Create an API key",
+    "Paste the key above as CELERIS_API_KEY"
+  ]
+}

--- a/crates/goose-providers/src/declarative/definitions/celeris.json
+++ b/crates/goose-providers/src/declarative/definitions/celeris.json
@@ -2,7 +2,7 @@
   "name": "celeris",
   "engine": "openai",
   "display_name": "Celeris",
-  "description": "Diffusion-based language models over an OpenAI-compatible API, optimized for low latency on short responses. celeris-1 has an 8192 token context shared between the prompt and the completion, and the base URL pins the model in its path.",
+  "description": "General-purpose diffusion language models over an OpenAI-compatible API. Tokens are generated in parallel blocks rather than one at a time, which makes them substantially faster than comparable autoregressive models. celeris-1 has an 8192 token context shared between the prompt and the completion, and the base URL pins the model in its path.",
   "api_key_env": "CELERIS_API_KEY",
   "base_url": "https://inference.celeris.ai/celeris-1/v1",
   "models": [


### PR DESCRIPTION
## Summary

Adds [Celeris](https://celeris.ai) as a declarative OpenAI-compatible provider — one JSON definition plus a line in the `expose_declarative_providers!` list, following the same shape as the Fireworks, EmpirioLabs and OrcaRouter additions.

Celeris serves diffusion-based language models over an OpenAI-compatible chat-completions API, aimed at low-latency short responses. `celeris-1` is the only model served today.

**Disclosure:** I work with Celeris — this is a vendor-submitted integration and I'll maintain it. Flagging that up front so you can weight the review accordingly. The definition was drafted with AI assistance and then verified by hand against the live API; I've read the contributing guide and kept this to the smallest change that does the job.

## A known limitation you should weigh before merging

I'd rather you hear this from me than find it later.

The Celeris API rejects any `max_tokens` that isn't `1` or a positive multiple of 256:

```
400 max_tokens must be 1 (warm ping) or a positive multiple of 256, got 100
```

The declarative provider format has no hook for transforming request parameters, so this constraint can't be enforced from the JSON definition. What that means in practice:

- **Default path is safe.** With no `max_tokens` configured, `ModelConfig::with_canonical_limits` fills it from the canonical catalog's `limit.output`. I've submitted the models.dev entry with `limit.output = 4096` — 256-aligned — precisely so this path stays valid ([anomalyco/models.dev#3757](https://github.com/anomalyco/models.dev/pull/3757)). Before that entry lands, `max_tokens` stays `None` and isn't sent at all, which is also fine.
- **User override is not safe.** If someone sets a custom `max_tokens` that isn't 256-aligned, every request to Celeris returns a 400, and nothing in the current architecture catches it.

The clean general fix is a `max_tokens_multiple` field on the declarative definition applied in `sanitize_request_for_compat`, which would serve any provider with a quantized limit rather than just this one. That touches shared code, so I didn't want to bundle it into a first contribution unasked. Happy to open an issue or send it as a follow-up if you think it's worth having — equally happy for you to tell me the sharp edge is acceptable for now.

## Other constraints worth knowing

- **`context_limit` is 8192 and it's shared** between prompt and completion — not 8K in plus 8K out. A 7,169-token prompt with `max_tokens: 1024` returns a 400. That makes this a poor fit as a primary coding model and a reasonable one for short, fast turns.
- **No `response_format`** — no JSON mode or JSON-schema output. Structured output has to route through tool calling, which does work.
- `skip_canonical_filtering` is set because Celeris serves exactly one model per base URL and `/models` requires auth.
- `base_url` is pinned to `https://inference.celeris.ai/celeris-1/v1` because the model id is part of the URL path.

## Testing

- `cargo check -p goose-providers` — clean.
- `cargo test -p goose-providers --lib declarative` — **10 passed**, including `all_bundled_providers_are_valid` and `expose_declarative_providers_enumerates_all_bundled_json_files`.
- Manually verified against the live API: basic completion, streaming, and tool calling all work, and both 400 paths above reproduce as described.

### Related Issues

None — happy to file one first if you'd prefer that order.
