### PR TITLE
Add Publora MCP server to the extensions registry

### DIFF
--- a/documentation/docs/mcp/publora-mcp.md
+++ b/documentation/docs/mcp/publora-mcp.md
@@ -1,0 +1,126 @@
+---
+title: Publora Extension
+description: Add Publora MCP Server as a goose Extension to publish and schedule social media posts
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import CLIExtensionInstructions from '@site/src/components/CLIExtensionInstructions';
+import GooseDesktopInstaller from '@site/src/components/GooseDesktopInstaller';
+
+This tutorial covers how to add the [Publora MCP Server](https://github.com/publora/mcp-server) as a goose extension so goose can publish and schedule social media posts, manage drafts and media, and read LinkedIn analytics.
+
+:::tip Quick Install
+<Tabs groupId="interface">
+  <TabItem value="ui" label="goose Desktop" default>
+  [Launch the installer](goose://extension?type=streamable_http&url=https%3A%2F%2Fmcp.publora.com%2Fmcp&id=publora&name=Publora&description=Publish%20and%20schedule%20social%20media%20posts%20across%2010%20networks&header=x-publora-key%3Dsk_YOUR_PUBLORA_API_KEY)
+  </TabItem>
+  <TabItem value="cli" label="goose CLI">
+  Add a `Remote Extension (Streamable HTTP)` extension type with:
+
+  **Endpoint URL**
+  ```
+  https://mcp.publora.com/mcp
+  ```
+  </TabItem>
+</Tabs>
+
+  **Custom Request Header**
+  ```
+  x-publora-key: sk_<YOUR_PUBLORA_API_KEY>
+  ```
+:::
+
+## What is Publora?
+
+[Publora](https://publora.com) is a social media publishing API and scheduler. Its remote MCP server lets an agent publish or schedule posts to LinkedIn, X, Instagram, Threads, TikTok, YouTube, Facebook, Bluesky, Mastodon and Telegram through one interface, instead of wiring up each network's own API and OAuth flow.
+
+Publora is a commercial service with a free tier. You connect your social accounts once in the Publora dashboard, then create an API key under **Settings > API** and pass it to goose as the `x-publora-key` request header. The server acts on the accounts belonging to that key.
+
+## Configuration
+
+:::info
+You need a [Publora](https://publora.com) account with at least one connected social account, and an API key from **Settings > API**.
+:::
+
+<Tabs groupId="interface">
+  <TabItem value="ui" label="goose Desktop" default>
+    <GooseDesktopInstaller
+      extensionId="publora"
+      extensionName="Publora"
+      description="Publish and schedule social media posts across 10 networks"
+      type="http"
+      url="https://mcp.publora.com/mcp"
+      envVars={[
+        { name: "x-publora-key", label: "sk_YOUR_PUBLORA_API_KEY" }
+      ]}
+      apiKeyLink="https://publora.com"
+      apiKeyLinkText="Publora API key"
+    />
+
+  </TabItem>
+  <TabItem value="cli" label="goose CLI">
+    <CLIExtensionInstructions
+      name="Publora"
+      description="Publish and schedule social media posts across 10 networks"
+      type="http"
+      url="https://mcp.publora.com/mcp"
+      envVars={[
+        { key: "x-publora-key", value: "sk_YOUR_PUBLORA_API_KEY" }
+      ]}
+      timeout={300}
+      infoNote="Get your API key from the Publora dashboard under Settings > API."
+    />
+  </TabItem>
+</Tabs>
+
+## Available Tools
+
+| Tool | Description |
+|------|-------------|
+| `list_connections` | List connected social accounts |
+| `create_post` | Publish or schedule a post to one or more platforms |
+| `list_posts` | List posts with filters (status, platform, dates) |
+| `get_post` | Get post details and status |
+| `update_post` | Reschedule a post or change its status |
+| `delete_post` | Delete a post |
+| `get_upload_url` | Get a presigned URL for media upload |
+| `linkedin_post_stats` | Post engagement metrics |
+| `linkedin_account_stats` | Account-level statistics |
+| `linkedin_followers` | Follower count and growth |
+| `linkedin_profile_summary` | Combined profile overview |
+| `linkedin_create_comment` / `linkedin_delete_comment` | Comment on a LinkedIn post |
+| `linkedin_create_reaction` / `linkedin_delete_reaction` | React to a LinkedIn post |
+
+Comments and reactions are LinkedIn-only. The other nine networks support publishing and scheduling.
+
+## Example Usage
+
+Once Publora is configured, you can ask goose to publish on your behalf. Media-only networks such as Instagram, TikTok and YouTube require an image or video.
+
+### Goose Prompt
+
+```
+Which social accounts do I have connected? Draft a short post about our new
+changelog page and schedule it to LinkedIn and Bluesky for tomorrow at 9am UTC.
+```
+
+### Goose Output
+
+```
+I'll check your connected accounts first.
+
+─── list_connections ───
+
+You have LinkedIn, X, Bluesky and Telegram connected.
+
+─── create_post ───
+
+Scheduled for tomorrow at 09:00 UTC on LinkedIn and Bluesky:
+
+"Our changelog now lives in one place — every shipped fix, in plain language,
+with the date it landed. No more digging through release notes."
+
+The post is in your Publora queue as scheduled. Want me to add an image or
+adjust the wording before it goes out?
+```

--- a/documentation/docs/mcp/publora-mcp.md
+++ b/documentation/docs/mcp/publora-mcp.md
@@ -98,14 +98,14 @@ Comments and reactions are LinkedIn-only. The other nine networks support publis
 
 Once Publora is configured, you can ask goose to publish on your behalf. Media-only networks such as Instagram, TikTok and YouTube require an image or video.
 
-### Goose Prompt
+### goose Prompt
 
 ```
 Which social accounts do I have connected? Draft a short post about our new
 changelog page and schedule it to LinkedIn and Bluesky for tomorrow at 9am UTC.
 ```
 
-### Goose Output
+### goose Output
 
 ```
 I'll check your connected accounts first.

--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -599,6 +599,7 @@
         "required": true
       }
     ],
+    "show_install_command": false,
     "type": "streamable-http"
   },
   {

--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -583,6 +583,25 @@
     ]
   },
   {
+    "id": "publora",
+    "name": "Publora",
+    "description": "Publish and schedule social media posts across 10 networks",
+    "url": "https://mcp.publora.com/mcp",
+    "link": "https://github.com/publora/mcp-server",
+    "installation_notes": "This is a remote extension. It requires a Publora API key sent as the x-publora-key request header. Create a key at https://publora.com under Settings > API.",
+    "is_builtin": false,
+    "endorsed": false,
+    "environmentVariables": [],
+    "headers": [
+      {
+        "name": "x-publora-key",
+        "description": "sk_<YOUR_PUBLORA_API_KEY>",
+        "required": true
+      }
+    ],
+    "type": "streamable-http"
+  },
+  {
     "id": "reddit-mcp",
     "name": "Reddit",
     "description": "Reddit API integration for posts and comments",


### PR DESCRIPTION
## Add Publora MCP server to the extensions registry

Adds [Publora](https://publora.com) as a remote (`streamable-http`) extension, plus a tutorial page following the pattern of the other remote extensions (GitHub, Ophis).

**What it does:** Publora is a social media publishing API. Its MCP server lets goose publish and schedule posts to LinkedIn, X, Instagram, Threads, TikTok, YouTube, Facebook, Bluesky, Mastodon and Telegram through one interface, plus read LinkedIn analytics and comment/react on LinkedIn — instead of wiring up each network's own API and OAuth flow.

**Server:** `https://mcp.publora.com/mcp` — hosted, no local install. Auth is a single request header, `x-publora-key: sk_...`, created by the user in the Publora dashboard under Settings > API. Publora is a commercial service with a free tier.

**Source:** [publora/mcp-server](https://github.com/publora/mcp-server) (MIT). Already listed in the official MCP registry as `com.publora/mcp-server`, and on Smithery, Glama, mcp.so and PulseMCP.

**Changes**
- `documentation/static/servers.json` — one entry, inserted alphabetically, with the `headers` field for the API key (same shape as the `github-mcp` entry)
- `documentation/docs/mcp/publora-mcp.md` — tutorial page with Desktop deeplink + CLI instructions, tool table and an example prompt