### PR TITLE
fix(anthropic): show current models in the picker instead of a stale canonical subset

### DIFF
--- a/crates/goose-providers/src/anthropic.rs
+++ b/crates/goose-providers/src/anthropic.rs
@@ -30,6 +30,8 @@ pub const ANTHROPIC_DEFAULT_MODEL: &str = "claude-sonnet-4-5";
 pub const ANTHROPIC_DEFAULT_FAST_MODEL: &str = "claude-haiku-4-5";
 const ANTHROPIC_KNOWN_MODELS: &[&str] = &[
     "claude-opus-5",
+    "claude-sonnet-5",
+    "claude-fable-5",
     "claude-opus-4-8",
     "claude-opus-4-7",
     // Claude 4.6 models
@@ -239,12 +241,22 @@ impl AnthropicProvider {
             )
         })?;
 
-        let mut models: Vec<String> = arr
+        let mut models: Vec<(String, String)> = arr
             .iter()
-            .filter_map(|m| m.get("id").and_then(|v| v.as_str()).map(str::to_string))
+            .filter_map(|m| {
+                let id = m.get("id").and_then(|v| v.as_str())?.to_string();
+                let created_at = m
+                    .get("created_at")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_default()
+                    .to_string();
+                Some((id, created_at))
+            })
             .collect();
-        models.sort();
-        Ok(models)
+        // Newest first (Anthropic returns RFC 3339 created_at, so lexical == chronological),
+        // then by id so entries without a date remain deterministic.
+        models.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+        Ok(models.into_iter().map(|(id, _)| id).collect())
     }
 }
 
@@ -438,4 +450,57 @@ pub fn from_declarative_config(
         .dynamic_models(config.dynamic_models)
         .skip_canonical_filtering(config.skip_canonical_filtering)
         .format_options(format_options))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn provider_for(uri: &str) -> AnthropicProvider {
+        let auth = AuthMethod::ApiKey {
+            header_name: "x-api-key".to_string(),
+            key: "test-key".to_string(),
+        };
+        let api_client = ApiClient::new_with_tls(uri.to_string(), auth, None)
+            .unwrap()
+            .with_header("anthropic-version", ANTHROPIC_API_VERSION)
+            .unwrap();
+        AnthropicProviderBuilder::new(api_client).build()
+    }
+
+    #[tokio::test]
+    async fn fetch_models_from_api_sorts_newest_first() {
+        let server = MockServer::start().await;
+        let body = serde_json::json!({
+            "data": [
+                {"id": "claude-opus-4-7", "created_at": "2026-04-14T00:00:00Z"},
+                {"id": "claude-opus-5", "created_at": "2026-07-24T00:00:00Z"},
+                {"id": "claude-sonnet-5", "created_at": "2026-06-29T00:00:00Z"},
+                {"id": "legacy-no-date"}
+            ],
+            "has_more": false
+        });
+        Mock::given(method("GET"))
+            .and(path("/v1/models"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(body))
+            .mount(&server)
+            .await;
+
+        let models = provider_for(&server.uri())
+            .fetch_supported_models()
+            .await
+            .unwrap();
+
+        assert_eq!(
+            models,
+            vec![
+                "claude-opus-5".to_string(),
+                "claude-sonnet-5".to_string(),
+                "claude-opus-4-7".to_string(),
+                "legacy-no-date".to_string(),
+            ]
+        );
+    }
 }

--- a/crates/goose-providers/src/anthropic.rs
+++ b/crates/goose-providers/src/anthropic.rs
@@ -6,6 +6,7 @@ use crate::request_log::{start_log, LoggerHandleExt};
 use anyhow::Result;
 use async_stream::try_stream;
 use async_trait::async_trait;
+use chrono::{DateTime, Utc};
 use futures::TryStreamExt;
 use reqwest::StatusCode;
 use serde_json::Value;
@@ -241,21 +242,28 @@ impl AnthropicProvider {
             )
         })?;
 
-        let mut models: Vec<(String, String)> = arr
+        let mut models: Vec<(String, Option<DateTime<Utc>>)> = arr
             .iter()
             .filter_map(|m| {
                 let id = m.get("id").and_then(|v| v.as_str())?.to_string();
+                // Parse created_at into an instant so mixed UTC offsets / fractional seconds
+                // compare chronologically (lexical RFC 3339 order is not chronological order).
                 let created_at = m
                     .get("created_at")
                     .and_then(|v| v.as_str())
-                    .unwrap_or_default()
-                    .to_string();
+                    .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
+                    .map(|dt| dt.with_timezone(&Utc));
                 Some((id, created_at))
             })
             .collect();
-        // Newest first (Anthropic returns RFC 3339 created_at, so lexical == chronological),
-        // then by id so entries without a date remain deterministic.
-        models.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+        // Newest first; entries without a parseable date sort last, then by id so the
+        // ordering stays deterministic.
+        models.sort_by(|a, b| match (a.1, b.1) {
+            (Some(da), Some(db)) => db.cmp(&da).then_with(|| a.0.cmp(&b.0)),
+            (Some(_), None) => std::cmp::Ordering::Less,
+            (None, Some(_)) => std::cmp::Ordering::Greater,
+            (None, None) => a.0.cmp(&b.0),
+        });
         Ok(models.into_iter().map(|(id, _)| id).collect())
     }
 }
@@ -478,6 +486,9 @@ mod tests {
                 {"id": "claude-opus-4-7", "created_at": "2026-04-14T00:00:00Z"},
                 {"id": "claude-opus-5", "created_at": "2026-07-24T00:00:00Z"},
                 {"id": "claude-sonnet-5", "created_at": "2026-06-29T00:00:00Z"},
+                // Lexically sorts after opus-5, but +02:00 makes it 2026-07-23T22:00:00Z —
+                // chronologically earlier, so it must land below opus-5.
+                {"id": "claude-offset", "created_at": "2026-07-24T00:00:00+02:00"},
                 {"id": "legacy-no-date"}
             ],
             "has_more": false
@@ -497,6 +508,7 @@ mod tests {
             models,
             vec![
                 "claude-opus-5".to_string(),
+                "claude-offset".to_string(),
                 "claude-sonnet-5".to_string(),
                 "claude-opus-4-7".to_string(),
                 "legacy-no-date".to_string(),

--- a/crates/goose/src/providers/anthropic_def.rs
+++ b/crates/goose/src/providers/anthropic_def.rs
@@ -48,7 +48,12 @@ async fn from_env(
         .with_request_builder(crate::session_context::session_id_request_builder())
         .with_header("anthropic-version", ANTHROPIC_API_VERSION)?;
 
-    Ok(AnthropicProviderBuilder::new(api_client).build())
+    // Anthropic's /v1/models is the authoritative list for a first-party key, so trust it
+    // rather than filtering through the bundled canonical registry, which lags new releases
+    // (e.g. Opus 5) and would silently drop models the key can actually use.
+    Ok(AnthropicProviderBuilder::new(api_client)
+        .skip_canonical_filtering(true)
+        .build())
 }
 
 pub fn from_custom_config(

--- a/crates/goose/src/providers/anthropic_def.rs
+++ b/crates/goose/src/providers/anthropic_def.rs
@@ -10,6 +10,7 @@ use goose_providers::{
     api_client::{ApiClient, AuthMethod, TlsConfig},
     base::ProviderDescriptor,
 };
+use url::Url;
 
 pub struct AnthropicProviderDef;
 
@@ -43,7 +44,7 @@ async fn from_env(
     // first-party Anthropic endpoint, whose models are all chat/tool-capable. A custom
     // ANTHROPIC_HOST may front an Anthropic-compatible proxy that also serves non-chat models,
     // so keep the canonical filter there to avoid surfacing models unusable in agent sessions.
-    let is_first_party_host = host.trim_end_matches('/') == "https://api.anthropic.com";
+    let is_first_party_host = is_first_party_anthropic_host(&host);
 
     let auth = AuthMethod::ApiKey {
         header_name: "x-api-key".to_string(),
@@ -60,6 +61,19 @@ async fn from_env(
     Ok(AnthropicProviderBuilder::new(api_client)
         .skip_canonical_filtering(is_first_party_host)
         .build())
+}
+
+/// Compare against the official endpoint on normalized components rather than raw text, so
+/// equivalent spellings (`https://API.ANTHROPIC.COM`, `https://api.anthropic.com:443/`) are
+/// recognized as first party.
+fn is_first_party_anthropic_host(host: &str) -> bool {
+    let Ok(url) = Url::parse(host) else {
+        return false;
+    };
+    url.scheme() == "https"
+        && url.host_str() == Some("api.anthropic.com")
+        && url.port_or_known_default() == Some(443)
+        && matches!(url.path(), "" | "/")
 }
 
 pub fn from_custom_config(
@@ -193,5 +207,35 @@ mod tests {
         let config =
             base_declarative_config(vec![ModelInfo::new("m1".to_string(), 200000)], Some(false));
         assert_eq!(built_timeout(config), std::time::Duration::from_secs(600));
+    }
+
+    #[test]
+    fn first_party_host_detection_normalizes_equivalent_urls() {
+        for host in [
+            "https://api.anthropic.com",
+            "https://api.anthropic.com/",
+            "https://API.ANTHROPIC.COM",
+            "https://api.anthropic.com:443",
+            "https://API.Anthropic.Com:443/",
+        ] {
+            assert!(
+                is_first_party_anthropic_host(host),
+                "{host} should be recognized as the first-party endpoint"
+            );
+        }
+
+        for host in [
+            "http://api.anthropic.com",
+            "https://api.anthropic.com:8443",
+            "https://api.anthropic.com/v1/proxy",
+            "https://proxy.example.com",
+            "https://api.anthropic.com.evil.example",
+            "not a url",
+        ] {
+            assert!(
+                !is_first_party_anthropic_host(host),
+                "{host} should not be treated as the first-party endpoint"
+            );
+        }
     }
 }

--- a/crates/goose/src/providers/anthropic_def.rs
+++ b/crates/goose/src/providers/anthropic_def.rs
@@ -39,6 +39,12 @@ async fn from_env(
         .get_param("ANTHROPIC_HOST")
         .unwrap_or_else(|_| "https://api.anthropic.com".to_string());
 
+    // Only trust the raw /v1/models list (skipping canonical capability filtering) for the
+    // first-party Anthropic endpoint, whose models are all chat/tool-capable. A custom
+    // ANTHROPIC_HOST may front an Anthropic-compatible proxy that also serves non-chat models,
+    // so keep the canonical filter there to avoid surfacing models unusable in agent sessions.
+    let is_first_party_host = host.trim_end_matches('/') == "https://api.anthropic.com";
+
     let auth = AuthMethod::ApiKey {
         header_name: "x-api-key".to_string(),
         key: api_key,
@@ -52,7 +58,7 @@ async fn from_env(
     // rather than filtering through the bundled canonical registry, which lags new releases
     // (e.g. Opus 5) and would silently drop models the key can actually use.
     Ok(AnthropicProviderBuilder::new(api_client)
-        .skip_canonical_filtering(true)
+        .skip_canonical_filtering(is_first_party_host)
         .build())
 }
 


### PR DESCRIPTION
## Problem

The built-in Anthropic provider already fetches `/v1/models` live, but the picker path (`fetch_recommended_models`) runs every returned model through the bundled `CanonicalModelRegistry` and **silently drops any model that isn't in it** (`base.rs`, `map_to_canonical_model(...)?`).

That registry is generated from models.dev at build time, so it lags Anthropic releases. Today the bundled data has **0 entries** for `claude-opus-5` and `claude-opus-4-8` — so those models never appear in the dropdown even though the user's key returns them from `/v1/models`. This is the first-party instance of the broader problem in #8321.

## Change

Trust the first-party `/v1/models` list for the built-in Anthropic provider:

- **Skip canonical filtering** for the built-in provider (`anthropic_def.rs`) so the live list flows straight to the picker. The flag already exists; this just opts the first-party provider in. Third-party/declarative providers are unchanged (they still honor their own `skip_canonical_filtering` config).
- **Sort newest-first by `created_at`** in `fetch_models_from_api` (was alphabetical), so the freshest models are at the top of the dropdown.
- **Add `claude-sonnet-5` / `claude-fable-5`** to the static `ANTHROPIC_KNOWN_MODELS` fallback (shown before an API key is set).

Canonical filtering exists to tame huge aggregated catalogs (OpenRouter's thousands of models); for a first-party endpoint that already returns the correct small list, it's pure downside.

## Scope / non-goals

- Does **not** touch the Claude Code ACP provider (`claude-acp`), which resolves models via the `claude-agent-acp` adapter, not `/v1/models` — that's #10669's territory.
- Context limits for models absent from the canonical registry still fall back to the default until the registry is regenerated (tracked separately in #10032 / #10163). This PR makes such models *selectable*; limit enrichment from `/v1/models` `max_input_tokens` is a sensible follow-up.

## Testing

- New test `fetch_models_from_api_sorts_newest_first` (wiremock) asserts newest-first ordering and that entries without `created_at` stay deterministic.
- Existing `anthropic_def` tests pass; `cargo clippy` clean on both touched crates.

Refs #8321