### PR TITLE
fix(desktop): surface each provider's live models in the model picker

### DIFF
--- a/crates/goose/src/acp/provider.rs
+++ b/crates/goose/src/acp/provider.rs
@@ -56,7 +56,15 @@ pub const ACP_CURRENT_MODEL: &str = "current";
 /// `connect()` future. Failing the request instead lets the loop unwind to `run_with_child`,
 /// which kills the child. Generous enough for a cold adapter start; this is a wedge backstop,
 /// not a latency budget.
-const STARTUP_TIMEOUT: Duration = Duration::from_secs(60);
+///
+/// It has to clear the desktop `node` shim's own worst case. An adapter invoked as
+/// `#!/usr/bin/env node` resolves through `Resources/bin/node`, which serializes hermit setup
+/// on a mkdir lock and waits up to 300s before reclaiming an orphaned one
+/// (`ui/desktop/src/bin/node-setup-common.sh`). Timing out inside that window would SIGKILL the
+/// shim mid-wait, and since the shim releases its lock from a `trap ... EXIT` that SIGKILL
+/// skips, every later start would inherit the orphaned lock — turning a stall that recovers on
+/// its own into a permanent failure.
+const STARTUP_TIMEOUT: Duration = Duration::from_secs(360);
 
 pub struct AcpProviderConfig {
     pub command: PathBuf,

--- a/crates/goose/src/acp/provider.rs
+++ b/crates/goose/src/acp/provider.rs
@@ -1117,31 +1117,33 @@ async fn handle_requests(
         match request {
             ClientRequest::NewSession { response_tx } => {
                 let mcp_servers = filter_supported_servers(&config.mcp_servers, &mcp_capabilities);
-                let session = tokio::time::timeout(
-                    STARTUP_TIMEOUT,
-                    cx.send_request(
-                        NewSessionRequest::new(config.work_dir.clone()).mcp_servers(mcp_servers),
-                    )
-                    .block_task(),
-                )
+                // One deadline over the whole startup exchange: `session/new` plus the
+                // config-option and mode requests that follow it. Any of them can wedge, and
+                // `AcpProvider::start` is blocked on the session oneshot while this thread owns
+                // the child, so an unbounded await anywhere here pins the adapter process.
+                let started = tokio::time::timeout(STARTUP_TIMEOUT, async {
+                    let session = cx
+                        .send_request(
+                            NewSessionRequest::new(config.work_dir.clone())
+                                .mcp_servers(mcp_servers),
+                        )
+                        .block_task()
+                        .await
+                        .map_err(|err| {
+                            anyhow::anyhow!("ACP {} failed: {err}", AGENT_METHOD_NAMES.session_new)
+                        })?;
+                    session_ids.push(session.session_id.clone());
+                    apply_session_config_options(&config, &cx, session.session_id.clone()).await?;
+                    apply_session_mode(&config, &goose_mode, &cx, session).await
+                })
                 .await;
-                let result = match session {
-                    Ok(Ok(session)) => {
-                        session_ids.push(session.session_id.clone());
-                        apply_session_config_options(&config, &cx, session.session_id.clone())
-                            .await?;
-                        apply_session_mode(&config, &goose_mode, &cx, session).await
-                    }
-                    Ok(Err(err)) => Err(anyhow::anyhow!(
-                        "ACP {} failed: {err}",
-                        AGENT_METHOD_NAMES.session_new
-                    )),
-                    Err(_) => Err(anyhow::anyhow!(
-                        "ACP {} timed out after {}s",
+                let result = started.unwrap_or_else(|_| {
+                    Err(anyhow::anyhow!(
+                        "ACP {} startup timed out after {}s",
                         AGENT_METHOD_NAMES.session_new,
                         STARTUP_TIMEOUT.as_secs()
-                    )),
-                };
+                    ))
+                });
                 log_undelivered(response_tx.send(result), AGENT_METHOD_NAMES.session_new);
             }
             ClientRequest::SetMode {

--- a/crates/goose/src/acp/provider.rs
+++ b/crates/goose/src/acp/provider.rs
@@ -27,6 +27,7 @@ use std::sync::{
     Arc, Mutex,
 };
 use std::thread::JoinHandle;
+use std::time::Duration;
 use tokio::io::AsyncReadExt;
 use tokio::process::{Child, Command};
 use tokio::sync::{mpsc, oneshot, Mutex as TokioMutex};
@@ -47,6 +48,15 @@ use goose_providers::model::ModelConfig;
 
 /// Sentinel: resolved to the actual model name during connect().
 pub const ACP_CURRENT_MODEL: &str = "current";
+
+/// Bound on the ACP startup handshake (`initialize`, `session/new`).
+///
+/// The adapter's child process is owned by the client-loop thread, so an unanswered startup
+/// request wedges that thread and keeps the process alive however the caller disposes of its
+/// `connect()` future. Failing the request instead lets the loop unwind to `run_with_child`,
+/// which kills the child. Generous enough for a cold adapter start; this is a wedge backstop,
+/// not a latency budget.
+const STARTUP_TIMEOUT: Duration = Duration::from_secs(60);
 
 pub struct AcpProviderConfig {
     pub command: PathBuf,
@@ -1063,20 +1073,33 @@ async fn handle_requests(
     let mut init_tx = Some(init_tx);
 
     let client_capabilities = ClientCapabilities::new();
-    let init_response: InitializeResponse = cx
-        .send_request(
+    let initialized = tokio::time::timeout(
+        STARTUP_TIMEOUT,
+        cx.send_request(
             InitializeRequest::new(ProtocolVersion::LATEST)
                 .client_capabilities(client_capabilities),
         )
-        .block_task()
-        .await
-        .map_err(|err| {
-            let message = format!("ACP {} failed: {err}", AGENT_METHOD_NAMES.initialize);
-            if let Some(tx) = init_tx.take() {
-                let _ = tx.send(Err(anyhow::anyhow!(message.clone())));
-            }
-            agent_client_protocol::Error::internal_error().data(message)
-        })?;
+        .block_task(),
+    )
+    .await;
+    let init_response: InitializeResponse = match initialized {
+        Ok(Ok(response)) => Ok(response),
+        Ok(Err(err)) => Err(format!(
+            "ACP {} failed: {err}",
+            AGENT_METHOD_NAMES.initialize
+        )),
+        Err(_) => Err(format!(
+            "ACP {} timed out after {}s",
+            AGENT_METHOD_NAMES.initialize,
+            STARTUP_TIMEOUT.as_secs()
+        )),
+    }
+    .map_err(|message| {
+        if let Some(tx) = init_tx.take() {
+            let _ = tx.send(Err(anyhow::anyhow!(message.clone())));
+        }
+        agent_client_protocol::Error::internal_error().data(message)
+    })?;
 
     let supports_close = init_response
         .agent_capabilities
@@ -1094,22 +1117,29 @@ async fn handle_requests(
         match request {
             ClientRequest::NewSession { response_tx } => {
                 let mcp_servers = filter_supported_servers(&config.mcp_servers, &mcp_capabilities);
-                let session = cx
-                    .send_request(
+                let session = tokio::time::timeout(
+                    STARTUP_TIMEOUT,
+                    cx.send_request(
                         NewSessionRequest::new(config.work_dir.clone()).mcp_servers(mcp_servers),
                     )
-                    .block_task()
-                    .await;
+                    .block_task(),
+                )
+                .await;
                 let result = match session {
-                    Ok(session) => {
+                    Ok(Ok(session)) => {
                         session_ids.push(session.session_id.clone());
                         apply_session_config_options(&config, &cx, session.session_id.clone())
                             .await?;
                         apply_session_mode(&config, &goose_mode, &cx, session).await
                     }
-                    Err(err) => Err(anyhow::anyhow!(
+                    Ok(Err(err)) => Err(anyhow::anyhow!(
                         "ACP {} failed: {err}",
                         AGENT_METHOD_NAMES.session_new
+                    )),
+                    Err(_) => Err(anyhow::anyhow!(
+                        "ACP {} timed out after {}s",
+                        AGENT_METHOD_NAMES.session_new,
+                        STARTUP_TIMEOUT.as_secs()
                     )),
                 };
                 log_undelivered(response_tx.send(result), AGENT_METHOD_NAMES.session_new);

--- a/crates/goose/src/acp/server/providers.rs
+++ b/crates/goose/src/acp/server/providers.rs
@@ -3,6 +3,13 @@ use crate::config::declarative_providers;
 use crate::providers::inventory::ensure_refresh_identity_current;
 use crate::providers::provider_secrets;
 use std::str::FromStr;
+use std::time::Duration;
+
+/// Upper bound on a single live supported-models fetch. Some providers accept the request but
+/// never complete it (e.g. Claude Code's control request waits indefinitely for a model_list
+/// response), and the fetch future may own a spawned child process. Timing out drops that
+/// future, tearing the fetch (and its subprocess) down instead of leaking it.
+const SUPPORTED_MODELS_TIMEOUT: Duration = Duration::from_secs(10);
 
 fn provider_secret_to_dto(secret: provider_secrets::ProviderSecret) -> ProviderSecretDto {
     let storage = match secret.storage {
@@ -478,10 +485,17 @@ impl GooseAcpAgent {
             .create_provider(&req.provider_id, Vec::new(), None)
             .await
             .internal_err_ctx("Failed to initialize provider")?;
-        let models = provider
-            .fetch_supported_models()
-            .await
-            .internal_err_ctx("Failed to fetch provider supported models")?;
+        let models =
+            tokio::time::timeout(SUPPORTED_MODELS_TIMEOUT, provider.fetch_supported_models())
+                .await
+                .map_err(|_| {
+                    agent_client_protocol::Error::internal_error().data(format!(
+                        "Live model discovery for '{}' timed out after {}s",
+                        req.provider_id,
+                        SUPPORTED_MODELS_TIMEOUT.as_secs()
+                    ))
+                })?
+                .internal_err_ctx("Failed to fetch provider supported models")?;
 
         Ok(ProviderSupportedModelsListResponse {
             provider_id: req.provider_id,

--- a/crates/goose/src/acp/server/providers.rs
+++ b/crates/goose/src/acp/server/providers.rs
@@ -481,21 +481,27 @@ impl GooseAcpAgent {
         &self,
         req: ProviderSupportedModelsListRequest,
     ) -> Result<ProviderSupportedModelsListResponse, agent_client_protocol::Error> {
-        let provider = self
-            .create_provider(&req.provider_id, Vec::new(), None)
-            .await
-            .internal_err_ctx("Failed to initialize provider")?;
-        let models =
-            tokio::time::timeout(SUPPORTED_MODELS_TIMEOUT, provider.fetch_supported_models())
+        // An ACP adapter can hang during startup as easily as during the fetch, so the
+        // deadline has to cover provider creation too.
+        let discover = async {
+            let provider = self
+                .create_provider(&req.provider_id, Vec::new(), None)
                 .await
-                .map_err(|_| {
-                    agent_client_protocol::Error::internal_error().data(format!(
-                        "Live model discovery for '{}' timed out after {}s",
-                        req.provider_id,
-                        SUPPORTED_MODELS_TIMEOUT.as_secs()
-                    ))
-                })?
-                .internal_err_ctx("Failed to fetch provider supported models")?;
+                .internal_err_ctx("Failed to initialize provider")?;
+            provider
+                .fetch_supported_models()
+                .await
+                .internal_err_ctx("Failed to fetch provider supported models")
+        };
+        let models = tokio::time::timeout(SUPPORTED_MODELS_TIMEOUT, discover)
+            .await
+            .map_err(|_| {
+                agent_client_protocol::Error::internal_error().data(format!(
+                    "Live model discovery for '{}' timed out after {}s",
+                    req.provider_id,
+                    SUPPORTED_MODELS_TIMEOUT.as_secs()
+                ))
+            })??;
 
         Ok(ProviderSupportedModelsListResponse {
             provider_id: req.provider_id,

--- a/crates/goose/src/providers/claude_code.rs
+++ b/crates/goose/src/providers/claude_code.rs
@@ -656,6 +656,9 @@ impl Provider for ClaudeCodeProvider {
         // but it's unavailable during model listing.
         // See: https://code.claude.com/docs/en/cli-reference#system-prompt-flags
         let mut cmd = self.build_stream_json_command();
+        // A caller that times out drops this future before the kill below runs, so the
+        // child has to reap itself rather than outlive the request.
+        cmd.kill_on_drop(true);
         let mut child = cmd.spawn().map_err(|e| {
             ProviderError::RequestFailed(format!("Failed to spawn CLI for model listing: {e}"))
         })?;

--- a/ui/desktop/src/acp/__tests__/providers.test.ts
+++ b/ui/desktop/src/acp/__tests__/providers.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { getAcpClient } from '../acpConnection';
-import { acpSetSessionProviderModel } from '../providers';
+import { acpListProviderModels, acpSetSessionProviderModel } from '../providers';
 
 vi.mock('../acpConnection', () => ({
   getAcpClient: vi.fn(),
@@ -75,6 +75,66 @@ describe('ACP providers', () => {
     expect(applied).toEqual({
       providerId: 'anthropic',
       modelId: 'claude-sonnet-4-5',
+    });
+  });
+
+  describe('acpListProviderModels', () => {
+    it('unions live supported models with the inventory cache, live ids first', async () => {
+      const client = {
+        goose: {
+          providersList_unstable: vi.fn().mockResolvedValue({
+            entries: [
+              {
+                providerId: 'anthropic',
+                models: [
+                  { id: 'claude-opus-4-7', name: 'Claude Opus 4.7', contextLimit: 200000, reasoning: true },
+                  { id: 'claude-sonnet-4-5', name: 'Claude Sonnet 4.5', contextLimit: 200000 },
+                ],
+              },
+            ],
+          }),
+          // Live list omits a cached model (sonnet-4-5) and adds one the cache never had (opus-5).
+          providersSupportedModelsList_unstable: vi
+            .fn()
+            .mockResolvedValue({ providerId: 'anthropic', models: ['claude-opus-5', 'claude-opus-4-7'] }),
+        },
+      };
+      vi.mocked(getAcpClient).mockResolvedValue(
+        client as unknown as Awaited<ReturnType<typeof getAcpClient>>
+      );
+
+      const models = await acpListProviderModels('anthropic');
+
+      // Live ids lead in their advertised order; the live-only model appears with a synthetic
+      // entry; cached metadata is grafted onto matching ids; cached-only models are appended.
+      expect(models).toEqual([
+        { id: 'claude-opus-5', name: 'claude-opus-5' },
+        { id: 'claude-opus-4-7', name: 'Claude Opus 4.7', contextLimit: 200000, reasoning: true },
+        { id: 'claude-sonnet-4-5', name: 'Claude Sonnet 4.5', contextLimit: 200000 },
+      ]);
+    });
+
+    it('falls back to the inventory cache when live discovery fails', async () => {
+      const inventory = [
+        { id: 'claude-sonnet-4-5', name: 'Claude Sonnet 4.5', contextLimit: 200000 },
+      ];
+      const client = {
+        goose: {
+          providersList_unstable: vi
+            .fn()
+            .mockResolvedValue({ entries: [{ providerId: 'anthropic', models: inventory }] }),
+          providersSupportedModelsList_unstable: vi
+            .fn()
+            .mockRejectedValue(new Error('adapter unavailable')),
+        },
+      };
+      vi.mocked(getAcpClient).mockResolvedValue(
+        client as unknown as Awaited<ReturnType<typeof getAcpClient>>
+      );
+
+      const models = await acpListProviderModels('anthropic');
+
+      expect(models).toEqual(inventory);
     });
   });
 });

--- a/ui/desktop/src/acp/__tests__/providers.test.ts
+++ b/ui/desktop/src/acp/__tests__/providers.test.ts
@@ -136,5 +136,33 @@ describe('ACP providers', () => {
 
       expect(models).toEqual(inventory);
     });
+
+    it('falls back to the inventory cache when live discovery stalls past the timeout', async () => {
+      vi.useFakeTimers();
+      try {
+        const inventory = [
+          { id: 'claude-sonnet-4-5', name: 'Claude Sonnet 4.5', contextLimit: 200000 },
+        ];
+        const client = {
+          goose: {
+            providersList_unstable: vi
+              .fn()
+              .mockResolvedValue({ entries: [{ providerId: 'anthropic', models: inventory }] }),
+            // Never resolves — simulates a provider that accepts the request but hangs.
+            providersSupportedModelsList_unstable: vi.fn().mockReturnValue(new Promise(() => {})),
+          },
+        };
+        vi.mocked(getAcpClient).mockResolvedValue(
+          client as unknown as Awaited<ReturnType<typeof getAcpClient>>
+        );
+
+        const promise = acpListProviderModels('anthropic');
+        await vi.runAllTimersAsync();
+
+        await expect(promise).resolves.toEqual(inventory);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
   });
 });

--- a/ui/desktop/src/acp/__tests__/providers.test.ts
+++ b/ui/desktop/src/acp/__tests__/providers.test.ts
@@ -164,5 +164,57 @@ describe('ACP providers', () => {
         vi.useRealTimers();
       }
     });
+
+    it('unions live models for agent-category providers regardless of id', async () => {
+      const client = {
+        goose: {
+          providersList_unstable: vi.fn().mockResolvedValue({
+            entries: [
+              {
+                providerId: 'claude-acp',
+                category: 'agent',
+                models: [{ id: 'sonnet', name: 'Sonnet' }],
+              },
+            ],
+          }),
+          providersSupportedModelsList_unstable: vi
+            .fn()
+            .mockResolvedValue({ providerId: 'claude-acp', models: ['opus[1m]', 'sonnet'] }),
+        },
+      };
+      vi.mocked(getAcpClient).mockResolvedValue(
+        client as unknown as Awaited<ReturnType<typeof getAcpClient>>
+      );
+
+      const models = await acpListProviderModels('claude-acp');
+
+      expect(models).toEqual([
+        { id: 'opus[1m]', name: 'opus[1m]' },
+        { id: 'sonnet', name: 'Sonnet' },
+      ]);
+    });
+
+    it('does not union live models for non-allowlisted model providers', async () => {
+      const inventory = [{ id: 'gpt-5', name: 'GPT-5', contextLimit: 400000 }];
+      const supportedModels = vi.fn();
+      const client = {
+        goose: {
+          providersList_unstable: vi.fn().mockResolvedValue({
+            entries: [{ providerId: 'openai', category: 'model', models: inventory }],
+          }),
+          // OpenAI's raw /models lists embeddings/audio/image models, so it must not be unioned.
+          providersSupportedModelsList_unstable: supportedModels,
+        },
+      };
+      vi.mocked(getAcpClient).mockResolvedValue(
+        client as unknown as Awaited<ReturnType<typeof getAcpClient>>
+      );
+
+      const models = await acpListProviderModels('openai');
+
+      expect(models).toEqual(inventory);
+      // Live discovery is skipped entirely for filtered model providers.
+      expect(supportedModels).not.toHaveBeenCalled();
+    });
   });
 });

--- a/ui/desktop/src/acp/__tests__/providers.test.ts
+++ b/ui/desktop/src/acp/__tests__/providers.test.ts
@@ -194,6 +194,31 @@ describe('ACP providers', () => {
       ]);
     });
 
+    it('unions live models for the pre-ACP claude-code provider', async () => {
+      const client = {
+        goose: {
+          providersList_unstable: vi.fn().mockResolvedValue({
+            // Absent from the curated setup catalog, so its category falls back to 'model'
+            // and its inventory has no static models.
+            entries: [{ providerId: 'claude-code', category: 'model', models: [] }],
+          }),
+          providersSupportedModelsList_unstable: vi
+            .fn()
+            .mockResolvedValue({ providerId: 'claude-code', models: ['opus', 'sonnet'] }),
+        },
+      };
+      vi.mocked(getAcpClient).mockResolvedValue(
+        client as unknown as Awaited<ReturnType<typeof getAcpClient>>
+      );
+
+      const models = await acpListProviderModels('claude-code');
+
+      expect(models).toEqual([
+        { id: 'opus', name: 'opus' },
+        { id: 'sonnet', name: 'sonnet' },
+      ]);
+    });
+
     it('does not union live models for non-allowlisted model providers', async () => {
       const inventory = [{ id: 'gpt-5', name: 'GPT-5', contextLimit: 400000 }];
       const supportedModels = vi.fn();

--- a/ui/desktop/src/acp/providers.ts
+++ b/ui/desktop/src/acp/providers.ts
@@ -72,6 +72,28 @@ export async function acpListProviderSupportedModels(providerId: string): Promis
   return models;
 }
 
+// Live discovery spawns/queries the provider, which can stall: Claude Code's control
+// request waits indefinitely for a model_list response and HTTP providers can hang up to
+// their request timeout. Bound it so a single slow provider can't leave the whole picker
+// (RecipeModelSelector awaits every provider via Promise.all) loading forever.
+const LIVE_MODELS_TIMEOUT_MS = 4000;
+
+function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms);
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (err) => {
+        clearTimeout(timer);
+        reject(err);
+      }
+    );
+  });
+}
+
 export async function acpListProviderModels(
   providerId: string
 ): Promise<ProviderInventoryModelDto[]> {
@@ -82,13 +104,19 @@ export async function acpListProviderModels(
   // The inventory cache is canonical-filtered and populated by a background refresh, so it
   // lags new releases and can silently drop models the key/adapter actually has (e.g. Opus 5,
   // or an ACP adapter's advertised aliases). Union in the live supported-models list so the
-  // picker never hides a currently-available model. Live ids lead (freshest ordering); cached
-  // metadata (context limit, reasoning) is grafted on by id where we have it.
+  // picker never hides a currently-available model. Live ids lead, in the order the backend
+  // returns them — each provider owns its own ordering (the Anthropic provider sorts
+  // newest-first); cached metadata (context limit, reasoning) is grafted on by id where we
+  // have it.
   let liveIds: string[];
   try {
-    liveIds = await acpListProviderSupportedModels(providerId);
+    liveIds = await withTimeout(
+      acpListProviderSupportedModels(providerId),
+      LIVE_MODELS_TIMEOUT_MS,
+      `live model discovery for ${providerId}`
+    );
   } catch {
-    // Live discovery is best-effort; fall back to the inventory cache when it's unavailable.
+    // Live discovery is best-effort; fall back to the inventory cache when it's slow or fails.
     return inventory;
   }
 

--- a/ui/desktop/src/acp/providers.ts
+++ b/ui/desktop/src/acp/providers.ts
@@ -2,6 +2,7 @@ import type {
   CanonicalModelInfoDto,
   CustomProviderCreateRequest_unstable,
   CustomProviderReadResponse_unstable,
+  ProviderInventoryModelDto,
   ProviderSecretDto,
   ProviderTemplateCatalogEntryDto,
   ProviderTemplateDto,
@@ -62,10 +63,48 @@ export async function acpListProviderDetails(): Promise<ProviderDetails[]> {
   }));
 }
 
-export async function acpListProviderModels(providerId: string) {
+// Raw model ids from a provider's live supported-models API (e.g. Anthropic's /v1/models,
+// or the model list an ACP adapter advertises). Unlike the inventory cache this is neither
+// canonical-filtered nor asynchronously refreshed, so it reflects what the provider offers now.
+export async function acpListProviderSupportedModels(providerId: string): Promise<string[]> {
+  const client = await getAcpClient();
+  const { models } = await client.goose.providersSupportedModelsList_unstable({ providerId });
+  return models;
+}
+
+export async function acpListProviderModels(
+  providerId: string
+): Promise<ProviderInventoryModelDto[]> {
   const client = await getAcpClient();
   const { entries } = await client.goose.providersList_unstable({ providerIds: [providerId] });
-  return entries.find((e) => e.providerId === providerId)?.models ?? [];
+  const inventory = entries.find((e) => e.providerId === providerId)?.models ?? [];
+
+  // The inventory cache is canonical-filtered and populated by a background refresh, so it
+  // lags new releases and can silently drop models the key/adapter actually has (e.g. Opus 5,
+  // or an ACP adapter's advertised aliases). Union in the live supported-models list so the
+  // picker never hides a currently-available model. Live ids lead (freshest ordering); cached
+  // metadata (context limit, reasoning) is grafted on by id where we have it.
+  let liveIds: string[];
+  try {
+    liveIds = await acpListProviderSupportedModels(providerId);
+  } catch {
+    // Live discovery is best-effort; fall back to the inventory cache when it's unavailable.
+    return inventory;
+  }
+
+  const inventoryById = new Map(inventory.map((model) => [model.id, model]));
+  const seen = new Set<string>();
+  const merged: ProviderInventoryModelDto[] = [];
+  for (const id of liveIds) {
+    seen.add(id);
+    merged.push(inventoryById.get(id) ?? { id, name: id });
+  }
+  for (const model of inventory) {
+    if (!seen.has(model.id)) {
+      merged.push(model);
+    }
+  }
+  return merged;
 }
 
 export async function acpListProviderCatalogEntries(

--- a/ui/desktop/src/acp/providers.ts
+++ b/ui/desktop/src/acp/providers.ts
@@ -2,6 +2,7 @@ import type {
   CanonicalModelInfoDto,
   CustomProviderCreateRequest_unstable,
   CustomProviderReadResponse_unstable,
+  ProviderInventoryEntryDto,
   ProviderInventoryModelDto,
   ProviderSecretDto,
   ProviderTemplateCatalogEntryDto,
@@ -78,6 +79,23 @@ export async function acpListProviderSupportedModels(providerId: string): Promis
 // (RecipeModelSelector awaits every provider via Promise.all) loading forever.
 const LIVE_MODELS_TIMEOUT_MS = 4000;
 
+// Model providers whose live supported-models endpoint returns *only* agent-usable models.
+// The first-party Anthropic API's /v1/models is all chat/tool-capable, so its raw list is safe
+// to surface directly. Other model providers (OpenAI, Google, OpenRouter, …) also return
+// embeddings, audio, and image models from their raw endpoint, which would fail an agent
+// request; for those we keep the canonical-filtered inventory list instead.
+const LIVE_UNION_MODEL_PROVIDERS = new Set(['anthropic']);
+
+// Whether to union a provider's live supported-models list into the picker. Agent adapters
+// (category 'agent', e.g. Claude Code / Codex over ACP) advertise only the agent's own chat
+// models, so their raw list is always safe; other providers must be explicitly allowlisted.
+function shouldUnionLiveModels(entry: ProviderInventoryEntryDto | undefined): boolean {
+  if (!entry) {
+    return false;
+  }
+  return entry.category === 'agent' || LIVE_UNION_MODEL_PROVIDERS.has(entry.providerId);
+}
+
 function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
   return new Promise((resolve, reject) => {
     const timer = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms);
@@ -99,7 +117,15 @@ export async function acpListProviderModels(
 ): Promise<ProviderInventoryModelDto[]> {
   const client = await getAcpClient();
   const { entries } = await client.goose.providersList_unstable({ providerIds: [providerId] });
-  const inventory = entries.find((e) => e.providerId === providerId)?.models ?? [];
+  const entry = entries.find((e) => e.providerId === providerId);
+  const inventory = entry?.models ?? [];
+
+  // Only union the live list for providers whose supported-models endpoint returns exclusively
+  // agent-usable models (see shouldUnionLiveModels). For the rest we keep the canonical-filtered
+  // inventory so non-chat models (embeddings, audio, image) never leak into the picker.
+  if (!shouldUnionLiveModels(entry)) {
+    return inventory;
+  }
 
   // The inventory cache is canonical-filtered and populated by a background refresh, so it
   // lags new releases and can silently drop models the key/adapter actually has (e.g. Opus 5,

--- a/ui/desktop/src/acp/providers.ts
+++ b/ui/desktop/src/acp/providers.ts
@@ -79,12 +79,14 @@ export async function acpListProviderSupportedModels(providerId: string): Promis
 // (RecipeModelSelector awaits every provider via Promise.all) loading forever.
 const LIVE_MODELS_TIMEOUT_MS = 4000;
 
-// Model providers whose live supported-models endpoint returns *only* agent-usable models.
-// The first-party Anthropic API's /v1/models is all chat/tool-capable, so its raw list is safe
-// to surface directly. Other model providers (OpenAI, Google, OpenRouter, …) also return
-// embeddings, audio, and image models from their raw endpoint, which would fail an agent
-// request; for those we keep the canonical-filtered inventory list instead.
-const LIVE_UNION_MODEL_PROVIDERS = new Set(['anthropic']);
+// Providers whose live supported-models endpoint returns *only* agent-usable models but whose
+// inventory entry isn't category 'agent'. The first-party Anthropic API's /v1/models is all
+// chat/tool-capable. 'claude-code' is the pre-ACP Claude Code provider: still registered, but
+// absent from the curated setup catalog, so its category falls back to 'model' even though it
+// advertises nothing but Claude's own aliases. Other model providers (OpenAI, Google,
+// OpenRouter, …) also return embeddings, audio, and image models from their raw endpoint, which
+// would fail an agent request; for those we keep the canonical-filtered inventory list instead.
+const LIVE_UNION_MODEL_PROVIDERS = new Set(['anthropic', 'claude-code']);
 
 // Whether to union a provider's live supported-models list into the picker. Agent adapters
 // (category 'agent', e.g. Claude Code / Codex over ACP) advertise only the agent's own chat


### PR DESCRIPTION
## Problem

The desktop Settings model picker gets its list from `acpListProviderModels()` → `providersList_unstable` → the server's provider **inventory cache** (`entry.models`). That cache is:

1. **Async** — filled by a background refresh job that spawns the provider, so it's empty/stale until the refresh completes.
2. **Canonical-filtered** — populated via `fetch_recommended_models()`, which runs every model through the bundled `canonical_models.json`.

So newly released models (e.g. `claude-opus-5`) and adapter-advertised aliases from the **Claude Code (ACP)** provider (`opus[1m]`, `sonnet`, `claude-fable-5[1m]`, `default`, …) get silently dropped or never appear — even though the backend can enumerate them.

Meanwhile a purpose-built RPC already exists on both sides and returns the **raw, live, unfiltered** list — `_goose/unstable/providers/supported-models/list` → `on_list_provider_supported_models` → `fetch_supported_models()` — but the desktop never called it.

Fixes #10309 and #10691. Fixes #10260.

## Fix

Wire the picker to that endpoint. `acpListProviderModels` now **unions** the live supported-models list with the inventory cache:

- Live ids lead, in their advertised order (freshest first — e.g. Anthropic's `/v1/models` is now newest-first).
- Cached metadata (context limit, reasoning) is grafted onto matching ids; live-only ids get a synthetic entry.
- Cached-only models are appended, so nothing that showed before disappears (purely additive).
- Live discovery is best-effort — on error it falls back to the inventory cache unchanged.

Applied to **all providers**, so it also surfaces first-party API models absent from the bundled canonical registry (the #8321 class of drops), not just the ACP path.

No Rust changes — the endpoint was already there; this connects the existing wire.

## Testing

- New unit tests in `providers.test.ts` cover the union ordering/metadata-graft and the fallback-on-error path.
- `pnpm typecheck`, `eslint`, and `vitest` all pass.

## Notes / follow-ups

- This makes models **selectable/visible**; a live-only model's context limit still falls back to the default until the canonical registry knows it (the `max_input_tokens` enrichment is a separate follow-up).
- Complements #10675 (which makes the Claude Code ACP picker's *selection* actually reach the adapter) — together: the list is complete **and** the selection sticks.