### PR TITLE
feat(tui): show context-window usage and working directory

### DIFF
--- a/ui/text/src/components/ContextBar.tsx
+++ b/ui/text/src/components/ContextBar.tsx
@@ -7,6 +7,8 @@ import {
   CONTEXT_CRITICAL_THRESHOLD,
 } from "../constants.js";
 
+const INDENT = "  ";
+
 interface ContextBarProps {
   used: number;
   size: number;
@@ -33,23 +35,26 @@ export const ContextBar = React.memo(function ContextBar({
   let line: string;
   let color: string;
   if (size === 0) {
-    line = "  context usage unavailable";
+    line = `${INDENT}context usage unavailable`;
     color = TEXT_DIM;
   } else {
     const percentage = Math.min(Math.round((used / size) * 100), 100);
-    const filled = Math.min(
-      Math.round((percentage / 100) * CONTEXT_BAR_WIDTH),
-      CONTEXT_BAR_WIDTH,
+    const counts = `${percentage}% ${formatTokenCount(used)}/${formatTokenCount(size)}`;
+    // The numbers carry the information, the bar only illustrates it — so the
+    // bar gives up width first. At 40 columns "100% 128k/128k" alone fills it.
+    const barWidth = Math.max(
+      0,
+      Math.min(CONTEXT_BAR_WIDTH, constrainedWidth - INDENT.length - counts.length - 1),
     );
-    const empty = CONTEXT_BAR_WIDTH - filled;
-    const bar = "━".repeat(filled) + "╌".repeat(empty);
+    const filled = Math.round((percentage / 100) * barWidth);
+    const bar = "━".repeat(filled) + "╌".repeat(barWidth - filled);
     color =
       percentage < CONTEXT_WARNING_THRESHOLD
         ? TEAL
         : percentage < CONTEXT_CRITICAL_THRESHOLD
           ? GOLD
           : CRANBERRY;
-    line = `  ${bar} ${percentage}% ${formatTokenCount(used)}/${formatTokenCount(size)}`;
+    line = barWidth > 0 ? `${INDENT}${bar} ${counts}` : `${INDENT}${counts}`;
   }
 
   return (

--- a/ui/text/src/components/ContextBar.tsx
+++ b/ui/text/src/components/ContextBar.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { Box, Text } from "ink";
+import { TEAL, GOLD, CRANBERRY, TEXT_DIM } from "../colors.js";
+import {
+  CONTEXT_BAR_WIDTH,
+  CONTEXT_WARNING_THRESHOLD,
+  CONTEXT_CRITICAL_THRESHOLD,
+} from "../constants.js";
+
+interface ContextBarProps {
+  used: number;
+  size: number;
+  width: number;
+  marginTop: number;
+}
+
+function formatTokenCount(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${Math.round(n / 1_000)}k`;
+  return `${n}`;
+}
+
+export const ContextBar = React.memo(function ContextBar({
+  used,
+  size,
+  width,
+  marginTop,
+}: ContextBarProps) {
+  const constrainedWidth = Math.max(width, 1);
+
+  // Mirrors crates/goose-cli/src/session/output.rs::display_context_usage
+  // so the TUI and CLI agree on what "context usage" means for the same session.
+  let line: string;
+  let color: string;
+  if (size === 0) {
+    line = "  context usage unavailable";
+    color = TEXT_DIM;
+  } else {
+    const percentage = Math.min(Math.round((used / size) * 100), 100);
+    const filled = Math.min(
+      Math.round((percentage / 100) * CONTEXT_BAR_WIDTH),
+      CONTEXT_BAR_WIDTH,
+    );
+    const empty = CONTEXT_BAR_WIDTH - filled;
+    const bar = "━".repeat(filled) + "╌".repeat(empty);
+    color =
+      percentage < CONTEXT_WARNING_THRESHOLD
+        ? TEAL
+        : percentage < CONTEXT_CRITICAL_THRESHOLD
+          ? GOLD
+          : CRANBERRY;
+    line = `  ${bar} ${percentage}% ${formatTokenCount(used)}/${formatTokenCount(size)}`;
+  }
+
+  return (
+    <Box width={constrainedWidth} marginTop={marginTop} flexShrink={0}>
+      <Text color={color} wrap="truncate-end">
+        {line}
+      </Text>
+    </Box>
+  );
+});

--- a/ui/text/src/components/Header.tsx
+++ b/ui/text/src/components/Header.tsx
@@ -42,11 +42,15 @@ export const Header = React.memo(function Header({
         </Box>
         <Box width={rightSideWidth} justifyContent="flex-end">
           {turnInfo && turnInfo.total > 1 && (
-            <Text color={TEXT_DIM}>
+            <Text color={TEXT_DIM} wrap="truncate-end">
               {turnInfo.current}/{turnInfo.total}{"  "}
             </Text>
           )}
-          <Text color={TEXT_DIM}>^E exts · ^M models · ^P providers</Text>
+          {/* Without truncation this wraps on a narrow terminal and the header
+              silently becomes three rows, breaking the height budget. */}
+          <Text color={TEXT_DIM} wrap="truncate-end">
+            ^E exts · ^M models · ^P providers
+          </Text>
         </Box>
       </Box>
       <Rule width={constrainedWidth} />

--- a/ui/text/src/components/ToolCallExpanded.tsx
+++ b/ui/text/src/components/ToolCallExpanded.tsx
@@ -169,7 +169,9 @@ export function ToolCallExpanded({
   onClose,
 }: Props) {
   const safeWidth = Math.max(width, 20);
-  const safeHeight = Math.max(height, 5);
+  // This sits in the normal layout where the viewport would be, not in an
+  // overlay, so a minimum here claims rows the caller already gave away.
+  const safeHeight = Math.max(height, 0);
   const contentWidth = Math.max(safeWidth - 4, 10);
 
   const allLines = useMemo(
@@ -194,13 +196,15 @@ export function ToolCallExpanded({
     }
   });
 
-  const headerH = 2;
-  const footerH = 2;
-  const bodyHeight = Math.max(safeHeight - headerH - footerH, 1);
+  const headerH = 2; // border top + status row
+  const footerH = 2; // hint row + border bottom
+  const bodyHeight = Math.max(safeHeight - headerH - footerH, 0);
 
   const total = allLines.length;
-  const overflows = total > bodyHeight;
-  const contentHeight = overflows ? Math.max(bodyHeight - 2, 1) : bodyHeight;
+  // Indicators cost a row each, so they only fit once content remains beside
+  // them — otherwise the body would render more rows than it was given.
+  const showIndicators = total > bodyHeight && bodyHeight >= 3;
+  const contentHeight = showIndicators ? bodyHeight - 2 : bodyHeight;
 
   const maxEnd = total;
   const minEnd = Math.min(contentHeight, total);
@@ -210,7 +214,7 @@ export function ToolCallExpanded({
   const padCount = contentHeight - visible.length;
 
   const elements: React.ReactElement[] = [];
-  if (overflows) {
+  if (showIndicators) {
     const above = startIdx;
     elements.push(
       <Box key="exp-up" width={safeWidth} height={1} justifyContent="center">
@@ -230,7 +234,7 @@ export function ToolCallExpanded({
     );
   }
   elements.push(...visible);
-  if (overflows) {
+  if (showIndicators) {
     const below = total - endIdx;
     elements.push(
       <Box key="exp-dn" width={safeWidth} height={1} justifyContent="center">

--- a/ui/text/src/components/ToolCallExpanded.tsx
+++ b/ui/text/src/components/ToolCallExpanded.tsx
@@ -14,6 +14,7 @@ import {
   TEXT_DIM,
 } from "../colors.js";
 import { SCROLL_STEP, SCROLL_FAST_MULTIPLIER } from "../constants.js";
+import { viewportGeometry } from "../utils.js";
 
 interface Props {
   info: ToolCallInfo;
@@ -203,8 +204,7 @@ export function ToolCallExpanded({
   const total = allLines.length;
   // Indicators cost a row each, so they only fit once content remains beside
   // them — otherwise the body would render more rows than it was given.
-  const showIndicators = total > bodyHeight && bodyHeight >= 3;
-  const contentHeight = showIndicators ? bodyHeight - 2 : bodyHeight;
+  const { showIndicators, contentHeight } = viewportGeometry(total, bodyHeight);
 
   const maxEnd = total;
   const minEnd = Math.min(contentHeight, total);

--- a/ui/text/src/constants.tsx
+++ b/ui/text/src/constants.tsx
@@ -8,6 +8,11 @@ export const SENT_PREVIEW_LEN = 60;
 export const SCROLL_STEP = 3;
 export const SCROLL_FAST_MULTIPLIER = 10;
 
+// Context usage bar, mirrors crates/goose-cli/src/session/output.rs
+export const CONTEXT_BAR_WIDTH = 20;
+export const CONTEXT_WARNING_THRESHOLD = 50;
+export const CONTEXT_CRITICAL_THRESHOLD = 85;
+
 export const GOOSE_FRAMES = [
   [
     "    ,_",

--- a/ui/text/src/constants.tsx
+++ b/ui/text/src/constants.tsx
@@ -6,6 +6,8 @@ export const SENT_PREVIEW_LEN = 60;
 
 // Viewport scroll step (lines per arrow press). Option/Alt applies the multiplier.
 export const SCROLL_STEP = 3;
+// The "▲ n more" / "▼ n more" pair framing a scrollable area.
+export const INDICATOR_ROWS = 2;
 export const SCROLL_FAST_MULTIPLIER = 10;
 
 // Context usage bar, mirrors crates/goose-cli/src/session/output.rs

--- a/ui/text/src/tui.tsx
+++ b/ui/text/src/tui.tsx
@@ -547,6 +547,7 @@ function App({
   const clientRef = useRef<GooseClient | null>(null);
   const sessionIdRef = useRef<string | null>(null);
   const sessionCwdRef = useRef<string>(process.cwd());
+  const modelRef = useRef<string | undefined>(undefined);
   const streamBuf = useRef("");
   const sentInitialPrompt = useRef(false);
   const queueRef = useRef<string[]>([]);
@@ -800,6 +801,20 @@ function App({
                 handleToolCallUpdate(update);
               } else if (update.sessionUpdate === "usage_update") {
                 setUsage({ used: update.used, size: update.size });
+              } else if (update.sessionUpdate === "config_option_update") {
+                // Switching models can change the context limit, but the agent
+                // sends no fresh usage with the change. Drop the snapshot
+                // rather than divide by the previous model's limit until the
+                // next turn ends.
+                const option = update.configOptions.find(
+                  (o) => o.id === "model",
+                );
+                const modelId =
+                  option?.type === "select" ? option.currentValue : undefined;
+                if (modelId !== undefined && modelId !== modelRef.current) {
+                  modelRef.current = modelId;
+                  setUsage(null);
+                }
               }
             },
           }),

--- a/ui/text/src/tui.tsx
+++ b/ui/text/src/tui.tsx
@@ -63,6 +63,10 @@ import {
 } from "./constants.js";
 import { tryRunSlashCommand } from "./slashCommands.js";
 
+// Border, status row, one row of body and the hint row. Below that the
+// expanded view cannot exist, so the transcript is shown instead.
+const MIN_EXPANDED_HEIGHT = 5;
+
 const InputBar = React.memo(function InputBar({
   width,
   input,
@@ -355,9 +359,11 @@ const Viewport = React.memo(function Viewport({
   scrollOffset: number;
 }) {
   const total = lines.length;
-  const overflows = total > height;
+  // The two scroll indicators cost a row each, so they only fit once there is
+  // something left to indicate — below that the rows go to content instead.
+  const showIndicators = total > height && height >= 3;
 
-  const contentHeight = overflows ? Math.max(height - 2, 1) : height;
+  const contentHeight = showIndicators ? height - 2 : height;
 
   const maxEnd = total;
   const minEnd = Math.min(contentHeight, total);
@@ -370,7 +376,7 @@ const Viewport = React.memo(function Viewport({
 
   const elements: React.ReactElement[] = [];
 
-  if (overflows) {
+  if (showIndicators) {
     const above = startIdx;
     elements.push(
       <Box key="si-up" width={width} height={1} justifyContent="center">
@@ -388,7 +394,7 @@ const Viewport = React.memo(function Viewport({
   }
   elements.push(...visible);
 
-  if (overflows) {
+  if (showIndicators) {
     const below = total - endIdx;
     elements.push(
       <Box key="si-dn" width={width} height={1} justifyContent="center">
@@ -1314,7 +1320,9 @@ function App({
             }
           />
 
-          {toolCallExpanded && selectedToolCallInfo ? (
+          {toolCallExpanded &&
+          selectedToolCallInfo &&
+          viewportHeight >= MIN_EXPANDED_HEIGHT ? (
             <ToolCallExpanded
               info={selectedToolCallInfo}
               width={contentWidth}

--- a/ui/text/src/tui.tsx
+++ b/ui/text/src/tui.tsx
@@ -43,7 +43,12 @@ import { Rule } from "./components/Rule.js";
 import { ToolCallExpanded } from "./components/ToolCallExpanded.js";
 import { ContextBar } from "./components/ContextBar.js";
 import type { ToolCallInfo } from "./toolcall.js";
-import { isErrorStatus, formatError, shortenPath } from "./utils.js";
+import {
+  isErrorStatus,
+  formatError,
+  shortenPath,
+  viewportGeometry,
+} from "./utils.js";
 import {
   CRANBERRY,
   TEAL,
@@ -77,17 +82,6 @@ function usageResetKey(options: SessionConfigOption[]): string {
     return option?.type === "select" ? option.currentValue : "";
   };
   return `${selected("provider")}/${selected("model")}`;
-}
-
-// The viewport's geometry, in one place: the scroll-offset maths has to agree
-// with what is actually rendered, and two copies of it drifted apart once the
-// indicators became conditional.
-function viewportGeometry(total: number, height: number) {
-  const showIndicators = total > height && height >= 3;
-  return {
-    showIndicators,
-    contentHeight: showIndicators ? height - 2 : height,
-  };
 }
 
 const InputBar = React.memo(function InputBar({

--- a/ui/text/src/tui.tsx
+++ b/ui/text/src/tui.tsx
@@ -449,7 +449,9 @@ const SplashScreen = React.memo(function SplashScreen({
 
   // Use original dimensions for outer container to maintain centering
   const safeWidth = Math.max(width, 20);
-  const safeHeight = Math.max(height, 10);
+  // No lower clamp: the caller already subtracted everything below, so anything
+  // we insist on here is a row the root does not have.
+  const safeHeight = Math.max(height, 0);
 
   return (
     <Box

--- a/ui/text/src/tui.tsx
+++ b/ui/text/src/tui.tsx
@@ -13,6 +13,7 @@ import { spawn } from "node:child_process";
 import { Readable, Writable } from "node:stream";
 import type {
   SessionNotification,
+  SessionConfigOption,
   Stream,
   ContentChunk,
   ToolCall,
@@ -66,6 +67,28 @@ import { tryRunSlashCommand } from "./slashCommands.js";
 // Border, status row, one row of body and the hint row. Below that the
 // expanded view cannot exist, so the transcript is shown instead.
 const MIN_EXPANDED_HEIGHT = 5;
+
+// Context limits are per provider AND per model, so the usage snapshot is only
+// valid for one pair. Seeded at session start and compared on every config
+// change, hence one function rather than two spellings of the same key.
+function usageResetKey(options: SessionConfigOption[]): string {
+  const selected = (id: string) => {
+    const option = options.find((o) => o.id === id);
+    return option?.type === "select" ? option.currentValue : "";
+  };
+  return `${selected("provider")}/${selected("model")}`;
+}
+
+// The viewport's geometry, in one place: the scroll-offset maths has to agree
+// with what is actually rendered, and two copies of it drifted apart once the
+// indicators became conditional.
+function viewportGeometry(total: number, height: number) {
+  const showIndicators = total > height && height >= 3;
+  return {
+    showIndicators,
+    contentHeight: showIndicators ? height - 2 : height,
+  };
+}
 
 const InputBar = React.memo(function InputBar({
   width,
@@ -359,11 +382,7 @@ const Viewport = React.memo(function Viewport({
   scrollOffset: number;
 }) {
   const total = lines.length;
-  // The two scroll indicators cost a row each, so they only fit once there is
-  // something left to indicate — below that the rows go to content instead.
-  const showIndicators = total > height && height >= 3;
-
-  const contentHeight = showIndicators ? height - 2 : height;
+  const { showIndicators, contentHeight } = viewportGeometry(total, height);
 
   const maxEnd = total;
   const minEnd = Math.min(contentHeight, total);
@@ -785,6 +804,10 @@ function App({
           mcpServers: [],
         });
         sessionIdRef.current = session.sessionId;
+        // Seed the key, or the first config notification — even one that
+        // changes nothing, such as reselecting the active model — would look
+        // like a switch and clear the bar for no reason.
+        modelRef.current = usageResetKey(session.configOptions ?? []);
         setLoading(false);
         setStatus("ready");
 
@@ -843,17 +866,9 @@ function App({
                 setUsage({ used: update.used, size: update.size });
               } else if (update.sessionUpdate === "config_option_update") {
                 // Switching models or providers can change the context limit,
-                // but the agent sends no fresh usage with the change. Drop the
-                // snapshot rather than divide by the old limit until the next
-                // turn ends. The key carries both, since the same model id can
-                // sit behind two providers with different limits.
-                const selected = (id: string) => {
-                  const option = update.configOptions.find((o) => o.id === id);
-                  return option?.type === "select"
-                    ? option.currentValue
-                    : undefined;
-                };
-                const key = `${selected("provider") ?? ""}/${selected("model") ?? ""}`;
+                // but no fresh usage arrives with the change. Drop the snapshot
+                // rather than divide by the old limit until the next turn ends.
+                const key = usageResetKey(update.configOptions);
                 if (key !== "/" && key !== modelRef.current) {
                   modelRef.current = key;
                   setUsage(null);
@@ -1084,11 +1099,8 @@ function App({
   const scrollOffsetForRange = useCallback(
     (range: ToolCallRange, current: number): number => {
       const total = contentLines.length;
-      const overflows = total > viewportHeight;
-      const contentHeight = overflows
-        ? Math.max(viewportHeight - 2, 1)
-        : viewportHeight;
-      if (!overflows) return 0;
+      const { contentHeight } = viewportGeometry(total, viewportHeight);
+      if (total <= viewportHeight) return 0;
       const maxOffset = total - contentHeight;
       const minForTop = total - range.startLine - contentHeight;
       const maxForBottom = total - range.endLine - 1;

--- a/ui/text/src/tui.tsx
+++ b/ui/text/src/tui.tsx
@@ -815,17 +815,20 @@ function App({
               } else if (update.sessionUpdate === "usage_update") {
                 setUsage({ used: update.used, size: update.size });
               } else if (update.sessionUpdate === "config_option_update") {
-                // Switching models can change the context limit, but the agent
-                // sends no fresh usage with the change. Drop the snapshot
-                // rather than divide by the previous model's limit until the
-                // next turn ends.
-                const option = update.configOptions.find(
-                  (o) => o.id === "model",
-                );
-                const modelId =
-                  option?.type === "select" ? option.currentValue : undefined;
-                if (modelId !== undefined && modelId !== modelRef.current) {
-                  modelRef.current = modelId;
+                // Switching models or providers can change the context limit,
+                // but the agent sends no fresh usage with the change. Drop the
+                // snapshot rather than divide by the old limit until the next
+                // turn ends. The key carries both, since the same model id can
+                // sit behind two providers with different limits.
+                const selected = (id: string) => {
+                  const option = update.configOptions.find((o) => o.id === id);
+                  return option?.type === "select"
+                    ? option.currentValue
+                    : undefined;
+                };
+                const key = `${selected("provider") ?? ""}/${selected("model") ?? ""}`;
+                if (key !== "/" && key !== modelRef.current) {
+                  modelRef.current = key;
                   setUsage(null);
                 }
               }
@@ -985,9 +988,11 @@ function App({
   // Everything below the transcript. Both the viewport and the splash screen
   // size themselves against this, so they cannot drift apart.
   const inputAreaH = inputGapH + usageBarH + inputBarH;
+  // No lower bound: a floor here would claim rows the terminal does not have,
+  // and the transcript is what can be given up when the input grows tall.
   const viewportHeight = Math.max(
     safeTermHeight - PAD_TOP - PAD_BOTTOM - headerH - historyBarH - inputAreaH,
-    3,
+    0,
   );
 
   const contentLayout = useMemo(

--- a/ui/text/src/tui.tsx
+++ b/ui/text/src/tui.tsx
@@ -954,15 +954,11 @@ function App({
   // One blank line separates the transcript from the input area. Whichever of
   // the two comes first carries it as its marginTop.
   const inputGapH = showInputBar ? 1 : 0;
+  // Everything below the transcript. Both the viewport and the splash screen
+  // size themselves against this, so they cannot drift apart.
+  const inputAreaH = inputGapH + usageBarH + inputBarH;
   const viewportHeight = Math.max(
-    safeTermHeight -
-      PAD_TOP -
-      PAD_BOTTOM -
-      headerH -
-      inputBarH -
-      historyBarH -
-      usageBarH -
-      inputGapH,
+    safeTermHeight - PAD_TOP - PAD_BOTTOM - headerH - historyBarH - inputAreaH,
     3,
   );
 
@@ -1242,7 +1238,7 @@ function App({
           animFrame={gooseFrame}
           width={contentWidth}
           height={Math.max(
-            safeTermHeight - PAD_TOP - PAD_BOTTOM - inputBarH,
+            safeTermHeight - PAD_TOP - PAD_BOTTOM - inputAreaH,
             0,
           )}
           status={status}

--- a/ui/text/src/tui.tsx
+++ b/ui/text/src/tui.tsx
@@ -436,7 +436,12 @@ const SplashScreen = React.memo(function SplashScreen({
   const statusColor =
     status === "ready" ? TEAL : isErrorStatus(status) ? CRANBERRY : TEXT_DIM;
 
-  const contentHeight = frame.length + 1 + 1 + 1 + 1 + 2 + 1;
+  // frame, title (margin + line), tagline, then the status (margin + line).
+  const baseHeight = frame.length + 1 + 1 + 1 + 2 + 1;
+  // The cwd is the one dispensable row here, so on a short terminal it goes
+  // first rather than pushing the status out of the allotted height.
+  const showCwd = height >= baseHeight + 1;
+  const contentHeight = baseHeight + (showCwd ? 1 : 0);
 
   const topPad = Math.max(0, Math.floor((height - contentHeight) / 2));
 
@@ -468,9 +473,11 @@ const SplashScreen = React.memo(function SplashScreen({
       <Box alignItems="center">
         <Text color={TEXT_DIM}>your on-machine AI agent</Text>
       </Box>
-      <Box width={Math.min(safeWidth, 60)} justifyContent="center">
-        <Text color={TEXT_DIM} wrap="truncate-middle">{cwd}</Text>
-      </Box>
+      {showCwd && (
+        <Box width={Math.min(safeWidth, 60)} justifyContent="center">
+          <Text color={TEXT_DIM} wrap="truncate-middle">{cwd}</Text>
+        </Box>
+      )}
       <Box marginTop={2} gap={1} alignItems="center">
         {loading && <Spinner idx={spinIdx} />}
         <Text color={statusColor}>{status}</Text>

--- a/ui/text/src/tui.tsx
+++ b/ui/text/src/tui.tsx
@@ -401,15 +401,14 @@ const Viewport = React.memo(function Viewport({
     );
   }
 
+  // A tall input can leave nothing for the transcript. Render nothing at all
+  // then — a one-row floor here would re-take the row the caller just gave up.
+  if (height <= 0) return null;
+
   const constrainedWidth = Math.max(width, 10);
-  const constrainedHeight = Math.max(height, 1);
 
   return (
-    <Box
-      flexDirection="column"
-      height={constrainedHeight}
-      width={constrainedWidth}
-    >
+    <Box flexDirection="column" height={height} width={constrainedWidth}>
       {elements}
     </Box>
   );
@@ -432,6 +431,8 @@ const SplashScreen = React.memo(function SplashScreen({
   spinIdx: number;
   cwd: string;
 }) {
+  if (height <= 0) return null;
+
   const frame = GOOSE_FRAMES[animFrame % GOOSE_FRAMES.length]!;
   const statusColor =
     status === "ready" ? TEAL : isErrorStatus(status) ? CRANBERRY : TEXT_DIM;
@@ -439,11 +440,27 @@ const SplashScreen = React.memo(function SplashScreen({
   // Shed content as the allotted height shrinks, largest first, so the splash
   // always fits: the goose frame goes before the title, tagline and status, and
   // the cwd only appears once everything else has room.
-  const chromeHeight = 1 + 1 + 1 + 2 + 1; // title (margin + line), tagline, status (margin + line)
+  // Shed rows as the allocation shrinks. The status line goes last: it is the
+  // only one carrying state, everything else is decoration.
+  const STATUS_ROW = 1;
+  const STATUS_MARGIN = 2;
+  const TITLE_ROWS = 2; // margin + line
+  const TAGLINE_ROWS = 1;
+  const CWD_ROWS = 1;
+
+  const statusMargin =
+    height >= STATUS_ROW + STATUS_MARGIN ? STATUS_MARGIN : 0;
+  const statusHeight = STATUS_ROW + statusMargin;
+  const showTitle = height >= statusHeight + TITLE_ROWS;
+  const showTagline = showTitle && height >= statusHeight + TITLE_ROWS + TAGLINE_ROWS;
+  const chromeHeight =
+    statusHeight +
+    (showTitle ? TITLE_ROWS : 0) +
+    (showTagline ? TAGLINE_ROWS : 0);
   const showFrame = height >= chromeHeight + frame.length;
   const baseHeight = chromeHeight + (showFrame ? frame.length : 0);
-  const showCwd = height >= baseHeight + 1;
-  const contentHeight = baseHeight + (showCwd ? 1 : 0);
+  const showCwd = height >= baseHeight + CWD_ROWS;
+  const contentHeight = baseHeight + (showCwd ? CWD_ROWS : 0);
 
   const topPad = Math.max(0, Math.floor((height - contentHeight) / 2));
 
@@ -471,20 +488,24 @@ const SplashScreen = React.memo(function SplashScreen({
           ))}
         </Box>
       )}
-      <Box marginTop={1}>
-        <Text color={TEXT_PRIMARY} bold>
-          goose
-        </Text>
-      </Box>
-      <Box alignItems="center">
-        <Text color={TEXT_DIM}>your on-machine AI agent</Text>
-      </Box>
+      {showTitle && (
+        <Box marginTop={1}>
+          <Text color={TEXT_PRIMARY} bold>
+            goose
+          </Text>
+        </Box>
+      )}
+      {showTagline && (
+        <Box alignItems="center">
+          <Text color={TEXT_DIM}>your on-machine AI agent</Text>
+        </Box>
+      )}
       {showCwd && (
         <Box width={Math.min(safeWidth, 60)} justifyContent="center">
           <Text color={TEXT_DIM} wrap="truncate-middle">{cwd}</Text>
         </Box>
       )}
-      <Box marginTop={2} gap={1} alignItems="center">
+      <Box marginTop={statusMargin} gap={1} alignItems="center">
         {loading && <Spinner idx={spinIdx} />}
         <Text color={statusColor}>{status}</Text>
       </Box>

--- a/ui/text/src/tui.tsx
+++ b/ui/text/src/tui.tsx
@@ -40,8 +40,9 @@ import {
 import { Header } from "./components/Header.js";
 import { Rule } from "./components/Rule.js";
 import { ToolCallExpanded } from "./components/ToolCallExpanded.js";
+import { ContextBar } from "./components/ContextBar.js";
 import type { ToolCallInfo } from "./toolcall.js";
-import { isErrorStatus, formatError } from "./utils.js";
+import { isErrorStatus, formatError, shortenPath } from "./utils.js";
 import {
   CRANBERRY,
   TEAL,
@@ -73,6 +74,7 @@ const InputBar = React.memo(function InputBar({
   focused,
   pastedFull,
   onPastedFullChange,
+  marginTop,
 }: {
   width: number;
   input: string;
@@ -84,6 +86,7 @@ const InputBar = React.memo(function InputBar({
   focused: boolean;
   pastedFull: string | null;
   onPastedFullChange: (v: string | null) => void;
+  marginTop: number;
 }) {
   const prevLenRef = useRef(input.length);
 
@@ -148,7 +151,7 @@ const InputBar = React.memo(function InputBar({
       borderStyle="round"
       borderColor={RULE_COLOR}
       paddingX={1}
-      marginTop={1}
+      marginTop={marginTop}
       width={constrainedWidth}
       flexShrink={0}
     >
@@ -419,6 +422,7 @@ const SplashScreen = React.memo(function SplashScreen({
   status,
   loading,
   spinIdx,
+  cwd,
 }: {
   animFrame: number;
   width: number;
@@ -426,12 +430,13 @@ const SplashScreen = React.memo(function SplashScreen({
   status: string;
   loading: boolean;
   spinIdx: number;
+  cwd: string;
 }) {
   const frame = GOOSE_FRAMES[animFrame % GOOSE_FRAMES.length]!;
   const statusColor =
     status === "ready" ? TEAL : isErrorStatus(status) ? CRANBERRY : TEXT_DIM;
 
-  const contentHeight = frame.length + 1 + 1 + 1 + 2 + 1;
+  const contentHeight = frame.length + 1 + 1 + 1 + 1 + 2 + 1;
 
   const topPad = Math.max(0, Math.floor((height - contentHeight) / 2));
 
@@ -463,6 +468,9 @@ const SplashScreen = React.memo(function SplashScreen({
       <Box alignItems="center">
         <Text color={TEXT_DIM}>your on-machine AI agent</Text>
       </Box>
+      <Box width={Math.min(safeWidth, 60)} justifyContent="center">
+        <Text color={TEXT_DIM} wrap="truncate-middle">{cwd}</Text>
+      </Box>
       <Box marginTop={2} gap={1} alignItems="center">
         {loading && <Spinner idx={spinIdx} />}
         <Text color={statusColor}>{status}</Text>
@@ -470,6 +478,9 @@ const SplashScreen = React.memo(function SplashScreen({
     </Box>
   );
 });
+
+// The TUI cannot change directory, so this is fixed for the whole process.
+const CWD_DISPLAY = shortenPath(process.cwd());
 
 function App({
   serverConnection,
@@ -508,6 +519,11 @@ function App({
   const [input, setInput] = useState("");
   const [loading, setLoading] = useState(true);
   const [status, setStatus] = useState("connecting…");
+  // null means "no usage_update received yet" (renders nothing), distinct
+  // from a real {used: 0, size: 0} snapshot.
+  const [usage, setUsage] = useState<{ used: number; size: number } | null>(
+    null,
+  );
   const [spinIdx, setSpinIdx] = useState(0);
   const [gooseFrame, setGooseFrame] = useState(0);
   const [bannerVisible, setBannerVisible] = useState(true);
@@ -782,6 +798,8 @@ function App({
                 handleToolCall(update);
               } else if (update.sessionUpdate === "tool_call_update") {
                 handleToolCallUpdate(update);
+              } else if (update.sessionUpdate === "usage_update") {
+                setUsage({ used: update.used, size: update.size });
               }
             },
           }),
@@ -930,12 +948,21 @@ function App({
     : 0;
   const inputExtraLines =
     (isPasteMode ? 1 : 0) + (queuedMessages.length > 0 ? 1 : 0);
-  const inputBarH = showInputBar
-    ? 2 + inputContentRows + inputExtraLines + 1 // +1 for marginTop gap above input bar
-    : 0;
+  const inputBarH = showInputBar ? 2 + inputContentRows + inputExtraLines : 0;
   const historyBarH = isViewingHistory ? 2 : 0;
+  const usageBarH = showInputBar && usage !== null ? 1 : 0;
+  // One blank line separates the transcript from the input area. Whichever of
+  // the two comes first carries it as its marginTop.
+  const inputGapH = showInputBar ? 1 : 0;
   const viewportHeight = Math.max(
-    safeTermHeight - PAD_TOP - PAD_BOTTOM - headerH - inputBarH - historyBarH,
+    safeTermHeight -
+      PAD_TOP -
+      PAD_BOTTOM -
+      headerH -
+      inputBarH -
+      historyBarH -
+      usageBarH -
+      inputGapH,
     3,
   );
 
@@ -1221,6 +1248,7 @@ function App({
           status={status}
           loading={loading}
           spinIdx={spinIdx}
+          cwd={CWD_DISPLAY}
         />
       ) : (
         <>
@@ -1270,8 +1298,17 @@ function App({
           )}
         </>
       )}
+      {usageBarH > 0 && usage !== null && (
+        <ContextBar
+          used={usage.used}
+          size={usage.size}
+          width={contentWidth}
+          marginTop={1}
+        />
+      )}
       {showInputBar && (
         <InputBar
+          marginTop={usageBarH > 0 ? 0 : 1}
           width={contentWidth}
           input={input}
           onChange={setInput}

--- a/ui/text/src/tui.tsx
+++ b/ui/text/src/tui.tsx
@@ -436,10 +436,12 @@ const SplashScreen = React.memo(function SplashScreen({
   const statusColor =
     status === "ready" ? TEAL : isErrorStatus(status) ? CRANBERRY : TEXT_DIM;
 
-  // frame, title (margin + line), tagline, then the status (margin + line).
-  const baseHeight = frame.length + 1 + 1 + 1 + 2 + 1;
-  // The cwd is the one dispensable row here, so on a short terminal it goes
-  // first rather than pushing the status out of the allotted height.
+  // Shed content as the allotted height shrinks, largest first, so the splash
+  // always fits: the goose frame goes before the title, tagline and status, and
+  // the cwd only appears once everything else has room.
+  const chromeHeight = 1 + 1 + 1 + 2 + 1; // title (margin + line), tagline, status (margin + line)
+  const showFrame = height >= chromeHeight + frame.length;
+  const baseHeight = chromeHeight + (showFrame ? frame.length : 0);
   const showCwd = height >= baseHeight + 1;
   const contentHeight = baseHeight + (showCwd ? 1 : 0);
 
@@ -458,13 +460,15 @@ const SplashScreen = React.memo(function SplashScreen({
       overflow="hidden"
     >
       {topPad > 0 && <Box height={topPad} />}
-      <Box flexDirection="column" alignItems="center">
-        {frame.map((line, i) => (
-          <Text key={i} color={TEXT_PRIMARY}>
-            {line}
-          </Text>
-        ))}
-      </Box>
+      {showFrame && (
+        <Box flexDirection="column" alignItems="center">
+          {frame.map((line, i) => (
+            <Text key={i} color={TEXT_PRIMARY}>
+              {line}
+            </Text>
+          ))}
+        </Box>
+      )}
       <Box marginTop={1}>
         <Text color={TEXT_PRIMARY} bold>
           goose

--- a/ui/text/src/tui.tsx
+++ b/ui/text/src/tui.tsx
@@ -1339,10 +1339,12 @@ function App({
             <Box flexDirection="column" width={contentWidth} flexShrink={0}>
               <Rule width={contentWidth} />
               <Box justifyContent="center" width={contentWidth}>
-                <Text color={GOLD}>
+                <Text color={GOLD} wrap="truncate-end">
                   turn {effectiveTurnIdx + 1}/{turns.length}
                 </Text>
-                <Text color={TEXT_DIM}> — shift+↓ to return</Text>
+                <Text color={TEXT_DIM} wrap="truncate-end">
+                  {" — shift+↓ to return"}
+                </Text>
               </Box>
             </Box>
           )}

--- a/ui/text/src/tui.tsx
+++ b/ui/text/src/tui.tsx
@@ -1069,6 +1069,16 @@ function App({
     }
   }, [toolCallRanges.length, selectedToolCallIdx]);
 
+  // The expanded view is not rendered below its minimum height, and its key
+  // handler lives inside it. Leaving the flag set there would strand the UI:
+  // App's handler bows out while expanded, so nothing would answer a keypress.
+  // This also covers growing the input until the room runs out mid-view.
+  useEffect(() => {
+    if (toolCallExpanded && viewportHeight < MIN_EXPANDED_HEIGHT) {
+      setToolCallExpanded(false);
+    }
+  }, [toolCallExpanded, viewportHeight]);
+
   const selectedToolCallInfo = useMemo<ToolCallInfo | null>(() => {
     if (selectedToolCallIdx === null || !currentTurn) return null;
     const range = toolCallRanges[selectedToolCallIdx];

--- a/ui/text/src/utils.tsx
+++ b/ui/text/src/utils.tsx
@@ -1,8 +1,23 @@
 import os from "node:os";
 import path from "node:path";
+import { INDICATOR_ROWS } from "./constants.js";
 
 const SHORTEN_PATH_MAX_LEN = 60;
 const SHORTEN_PATH_MAX_PARTS = 3;
+
+// Scroll indicators cost a row each, so they only earn their place once
+// content remains beside them. Shared because the scroll-offset maths and the
+// render have to agree — two hand-written copies already drifted apart once.
+export function viewportGeometry(
+  total: number,
+  height: number,
+): { showIndicators: boolean; contentHeight: number } {
+  const showIndicators = total > height && height > INDICATOR_ROWS;
+  return {
+    showIndicators,
+    contentHeight: showIndicators ? height - INDICATOR_ROWS : height,
+  };
+}
 
 export function isErrorStatus(status: string): boolean {
   return status.startsWith("error") || status.startsWith("failed");

--- a/ui/text/src/utils.tsx
+++ b/ui/text/src/utils.tsx
@@ -13,7 +13,10 @@ export function isErrorStatus(status: string): boolean {
 export function shortenPath(target: string): string {
   const home = os.homedir();
   const sep = path.sep;
-  const normalized = path.normalize(target);
+  // A directory name may legally contain newlines or escape sequences. Left in,
+  // they would break the single-row layout or drive the terminal, so drop them
+  // the way the CLI does for the window title (session/output.rs).
+  const normalized = path.normalize(target).replace(/\p{Cc}/gu, "");
   const withTilde =
     normalized === home
       ? "~"

--- a/ui/text/src/utils.tsx
+++ b/ui/text/src/utils.tsx
@@ -1,4 +1,5 @@
 import os from "node:os";
+import path from "node:path";
 
 const SHORTEN_PATH_MAX_LEN = 60;
 const SHORTEN_PATH_MAX_PARTS = 3;
@@ -7,18 +8,22 @@ export function isErrorStatus(status: string): boolean {
   return status.startsWith("error") || status.startsWith("failed");
 }
 
-export function shortenPath(path: string): string {
+// Separators come from node:path so this also works on Windows, where the
+// launcher (scripts/dev-start.mjs) supports goose.exe and paths use backslashes.
+export function shortenPath(target: string): string {
   const home = os.homedir();
+  const sep = path.sep;
+  const normalized = path.normalize(target);
   const withTilde =
-    path === home
+    normalized === home
       ? "~"
-      : path.startsWith(`${home}/`)
-        ? `~${path.slice(home.length)}`
-        : path;
+      : normalized.startsWith(`${home}${sep}`)
+        ? `~${normalized.slice(home.length)}`
+        : normalized;
 
   if (withTilde.length <= SHORTEN_PATH_MAX_LEN) return withTilde;
 
-  const parts = withTilde.split("/");
+  const parts = withTilde.split(sep);
   if (parts.length <= SHORTEN_PATH_MAX_PARTS) return withTilde;
 
   const shortened = [parts[0]];
@@ -27,7 +32,7 @@ export function shortenPath(path: string): string {
   }
   shortened.push(...parts.slice(-2));
 
-  return shortened.join("/");
+  return shortened.join(sep);
 }
 
 export function formatError(e: unknown): string {

--- a/ui/text/src/utils.tsx
+++ b/ui/text/src/utils.tsx
@@ -28,7 +28,9 @@ export function shortenPath(target: string): string {
 
   const shortened = [parts[0]];
   for (const part of parts.slice(1, -2)) {
-    if (part) shortened.push(part[0]!);
+    // Take the first code point, not the first UTF-16 unit: a directory name
+    // starting with an emoji would otherwise leave half a surrogate pair.
+    if (part) shortened.push([...part][0]!);
   }
   shortened.push(...parts.slice(-2));
 

--- a/ui/text/src/utils.tsx
+++ b/ui/text/src/utils.tsx
@@ -26,18 +26,21 @@ export function shortenPath(target: string): string {
 
   if (withTilde.length <= SHORTEN_PATH_MAX_LEN) return withTilde;
 
-  const parts = withTilde.split(sep);
+  // Split off the root first — a Windows UNC path ("\\\\server\\share\\") is two
+  // empty leading segments, and abbreviating those would name a different host.
+  const root = path.parse(withTilde).root;
+  const parts = withTilde.slice(root.length).split(sep).filter(Boolean);
   if (parts.length <= SHORTEN_PATH_MAX_PARTS) return withTilde;
 
-  const shortened = [parts[0]];
+  const shortened = [parts[0]!];
   for (const part of parts.slice(1, -2)) {
     // Take the first code point, not the first UTF-16 unit: a directory name
     // starting with an emoji would otherwise leave half a surrogate pair.
-    if (part) shortened.push([...part][0]!);
+    shortened.push([...part][0]!);
   }
   shortened.push(...parts.slice(-2));
 
-  return shortened.join(sep);
+  return root + shortened.join(sep);
 }
 
 export function formatError(e: unknown): string {

--- a/ui/text/src/utils.tsx
+++ b/ui/text/src/utils.tsx
@@ -1,5 +1,33 @@
+import os from "node:os";
+
+const SHORTEN_PATH_MAX_LEN = 60;
+const SHORTEN_PATH_MAX_PARTS = 3;
+
 export function isErrorStatus(status: string): boolean {
   return status.startsWith("error") || status.startsWith("failed");
+}
+
+export function shortenPath(path: string): string {
+  const home = os.homedir();
+  const withTilde =
+    path === home
+      ? "~"
+      : path.startsWith(`${home}/`)
+        ? `~${path.slice(home.length)}`
+        : path;
+
+  if (withTilde.length <= SHORTEN_PATH_MAX_LEN) return withTilde;
+
+  const parts = withTilde.split("/");
+  if (parts.length <= SHORTEN_PATH_MAX_PARTS) return withTilde;
+
+  const shortened = [parts[0]];
+  for (const part of parts.slice(1, -2)) {
+    if (part) shortened.push(part[0]!);
+  }
+  shortened.push(...parts.slice(-2));
+
+  return shortened.join("/");
 }
 
 export function formatError(e: unknown): string {


### PR DESCRIPTION
## What

The CLI shows how full the context window is and which directory the session
runs in. The TUI showed neither.

- **Context usage bar** above the input, mirroring the format and colour
  thresholds of `crates/goose-cli/src/session/output.rs`: a 20-character bar,
  the percentage, and `used/limit` in humanised tokens (`12k/60k`). Green below
  50%, amber to 85%, red above.
- **Working directory** on the splash screen, shortened by the same algorithm
  as the CLI's `shorten_path` (`~` for home; past 60 characters the middle
  segments collapse to their initial). Shown once at startup — where the CLI
  shows it too.

## Screenshots

**Before**
<img width="937" height="621" alt="Bildschirmfoto 2026-07-27 um 14 00 13" src="https://github.com/user-attachments/assets/b427276c-1a2b-4e40-aedf-663d01d3db13" />

**After**
<img width="797" height="661" alt="Bildschirmfoto 2026-07-27 um 13 59 27" src="https://github.com/user-attachments/assets/fd5af878-6653-44cb-84fa-60cdafe1d35d" />

## Why this needs no plumbing

The agent already pushes `SessionUpdate::UsageUpdate` ungated, at session setup
and after every prompt turn, and its `size` field carries the context limit.
The TUI's notification handler simply dropped the variant. No polling, no extra
client capability — one new branch.

## Layout

Ink does not clip, so per AGENTS.md every row is accounted for. The blank line
between transcript and input is now its own term in the height budget, carried
by whichever element comes first, so the bar costs exactly one row and the
total is unchanged while it is hidden.

The bar renders only once a usage update has arrived: the state starts as
`null`, keeping "nothing received yet" distinguishable from a genuine zero.

## Testing

Manual — `ui/text` has no test infrastructure (`scripts` are build/start/lint).
Verified: the bar appears before the first prompt and tracks usage across
turns, colours switch at the thresholds, the splash stays vertically centred
with the added row, and the layout holds when the terminal is narrowed.
`pnpm run lint` (`tsc --noEmit`) is clean.
