### PR TITLE
feat(oauth): add logo_uri to client ID metadata documents

### DIFF
--- a/documentation/static/oauth/client-metadata.json
+++ b/documentation/static/oauth/client-metadata.json
@@ -1,6 +1,7 @@
 {
   "client_id": "https://goose-docs.ai/oauth/client-metadata.json",
   "client_name": "goose",
+  "logo_uri": "https://goose-docs.ai/img/logo_light.png",
   "redirect_uris": [
     "http://127.0.0.1/oauth_callback",
     "http://[::1]/oauth_callback"

--- a/documentation/static/oauth/huggingface-client-metadata.json
+++ b/documentation/static/oauth/huggingface-client-metadata.json
@@ -1,6 +1,7 @@
 {
   "client_id": "https://goose-docs.ai/oauth/huggingface-client-metadata.json",
   "client_name": "goose",
+  "logo_uri": "https://goose-docs.ai/img/logo_light.png",
   "redirect_uris": [
     "http://127.0.0.1:17863/oauth/huggingface/callback"
   ],


### PR DESCRIPTION
## What

Adds `logo_uri` to both client ID metadata documents (CIMD) served from goose-docs.ai:

- `documentation/static/oauth/client-metadata.json` (MCP OAuth client)
- `documentation/static/oauth/huggingface-client-metadata.json` (Hugging Face provider client)

## Why

`logo_uri` is standard OAuth client metadata (RFC 7591 §2). Authorization servers that resolve the CIMD can show the goose logo on their consent screen instead of a generic placeholder, so users see who they're granting access to.

## Details

- Points at `https://goose-docs.ai/img/logo_light.png` — the square (3370×3370) black goose mark already served by the docs site. The black-on-transparent variant renders on the light backgrounds consent screens typically use (`logo_dark.png` is white and would be invisible).
- Verified both the logo URL and the CIMD URLs return 200 on the live site, and both documents still parse as valid JSON.
- No code changes: the Rust OAuth flow references these documents by URL only and doesn't parse them locally.
