### PR TITLE
fix(providers): update DeepSeek model names to v4 API

### DIFF
--- a/crates/goose-providers/src/declarative/definitions/deepseek.json
+++ b/crates/goose-providers/src/declarative/definitions/deepseek.json
@@ -7,7 +7,15 @@
   "base_url": "https://api.deepseek.com",
   "models": [
     {
-      "name": "deepseek-chat",
+      "name": "deepseek-v4-flash",
+      "context_limit": 128000,
+      "input_token_cost": null,
+      "output_token_cost": null,
+      "currency": null,
+      "supports_cache_control": null
+    },
+    {
+      "name": "deepseek-v4-pro",
       "context_limit": 128000,
       "input_token_cost": null,
       "output_token_cost": null,

--- a/crates/goose-sdk/examples/deepseek.json
+++ b/crates/goose-sdk/examples/deepseek.json
@@ -7,7 +7,7 @@
   "base_url": "https://api.deepseek.com",
   "models": [
     {
-      "name": "deepseek-chat",
+      "name": "deepseek-v4-flash",
       "context_limit": 128000,
       "input_token_cost": null,
       "output_token_cost": null,


### PR DESCRIPTION
Fixes #10698

## Summary

DeepSeek deprecated deepseek-chat, their API now only accepts deepseek-v4-flash and deepseek-v4-pro. Updated both deepseek.json definition files to use the current model names and added deepseek-v4-pro as an option 

### Testing
manual  - one thing want to share when tested that deepseek-chat now also silently maps to deepseek-v4-flash (the issue reporter may have hit this during a migration window), But the fix is still the right call as we're using the official current model names instead of a deprecated alias that may or may not work depending on account tier or region.

