### PR TITLE
fix(deps): bump nostr to 0.44.6 to clear RUSTSEC-2026-0216

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -532,9 +532,9 @@ dependencies = [
 
 [[package]]
 name = "async-utility"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a34a3b57207a7a1007832416c3e4862378c8451b4e8e093e436f48c2d3d2c151"
+checksum = "188f83b9a198af8c336e505611edb00d6d2ac5c694241c5a4f9a12316938cfe9"
 dependencies = [
  "futures-util",
  "gloo-timers",
@@ -7020,9 +7020,9 @@ dependencies = [
 
 [[package]]
 name = "nostr"
-version = "0.44.4"
+version = "0.44.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98cf5d15d70d1f8f4059e5f79923ac15891eb691d2843d01191e0585fb064d70"
+checksum = "e826dd648489de2c5b293920e20b92932ef820302007c1987c758d4d06eeb2cf"
 dependencies = [
  "base64 0.22.1",
  "bech32",


### PR DESCRIPTION
Cargo Deny has been failing on `main` since the 07-26 nightly, and on every open PR. Three errors, all in the `nostr` tree:

- `RUSTSEC-2026-0216` - reachable panic / remote DoS in `nostr` 0.44.4's NIP-44 v2 decrypt path
- yanked `nostr` 0.44.4
- yanked `async-utility` 0.3.1

Lockfile only; the `nostr = "0.44"` requirement in `crates/goose/Cargo.toml` is unchanged.

```
async-utility 0.3.1  -> 0.3.2
nostr         0.44.4 -> 0.44.6
```

Verified with `cargo metadata --locked` (no re-resolution needed) and `cargo check -p goose --features nostr,rustls-tls --locked`.

Note: a plain `cargo update` also re-picks ~15 unrelated `windows-sys`/`base64`/`getrandom` edges downward, because those crates declare open ranges (e.g. `windows-sys >=0.60.2, <0.62`) and cargo resolves ranges to the low end. That churn is latent in the lockfile and unrelated to this advisory, so it is left out here rather than mixed into a security fix that touches Windows build edges.