### PR TITLE
feat(acp): add GOOSE_ACP_SCHEDULER_DISABLED kill-switch

### DIFF
--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -185,7 +185,7 @@ pub struct GooseAcpAgentOptions {
     pub disable_session_naming: bool,
     pub goose_platform: GoosePlatform,
     pub additional_source_roots: Vec<SourceRoot>,
-    pub scheduler: Arc<dyn SchedulerTrait>,
+    pub scheduler: Option<Arc<dyn SchedulerTrait>>,
 }
 
 pub struct GooseAcpAgent {
@@ -604,7 +604,7 @@ impl GooseAcpAgent {
         let agent_config = AgentConfig::new(
             Arc::clone(&session_manager),
             Arc::clone(&permission_manager),
-            Some(options.scheduler),
+            options.scheduler,
             Config::global().get_goose_mode().unwrap_or_default(),
             options.disable_session_naming,
             options.goose_platform.clone(),

--- a/crates/goose/src/acp/server/recipe/mod.rs
+++ b/crates/goose/src/acp/server/recipe/mod.rs
@@ -153,7 +153,11 @@ impl GooseAcpAgent {
             .collect();
         *self.recipe_path_cache.lock().await = recipe_file_hash_map;
 
-        let scheduled_jobs = self.agent_manager.scheduler().list_scheduled_jobs().await;
+        // A runtime without a scheduler simply reports no cron entries.
+        let scheduled_jobs = match self.agent_manager.scheduler() {
+            Some(scheduler) => scheduler.list_scheduled_jobs().await,
+            None => Vec::new(),
+        };
         let schedule_map: HashMap<_, _> = scheduled_jobs
             .into_iter()
             .map(|job| (PathBuf::from(job.source), job.cron))
@@ -200,8 +204,7 @@ impl GooseAcpAgent {
     ) -> Result<EmptyResponse, agent_client_protocol::Error> {
         let file_path = self.resolve_recipe_path_by_id(&req.id).await?;
         if let Err(err) = self
-            .agent_manager
-            .scheduler()
+            .scheduler()?
             .schedule_recipe(file_path, req.cron_schedule)
             .await
         {

--- a/crates/goose/src/acp/server/recipe/mod.rs
+++ b/crates/goose/src/acp/server/recipe/mod.rs
@@ -202,9 +202,12 @@ impl GooseAcpAgent {
         &self,
         req: ScheduleRecipeRequest,
     ) -> Result<EmptyResponse, agent_client_protocol::Error> {
+        // Resolved before the recipe lookup so a disabled runtime answers
+        // uniformly with the disabled error, never `invalid_params`.
+        let scheduler = self.scheduler()?;
+
         let file_path = self.resolve_recipe_path_by_id(&req.id).await?;
-        if let Err(err) = self
-            .scheduler()?
+        if let Err(err) = scheduler
             .schedule_recipe(file_path, req.cron_schedule)
             .await
         {

--- a/crates/goose/src/acp/server/schedule.rs
+++ b/crates/goose/src/acp/server/schedule.rs
@@ -355,9 +355,12 @@ mod tests {
     use crate::acp::server_factory::{
         AcpServer, AcpServerFactoryConfig, GOOSE_ACP_SCHEDULER_DISABLED_ENV,
     };
+    use crate::agents::platform_tools::PLATFORM_MANAGE_SCHEDULE_TOOL_NAME;
     use crate::agents::GoosePlatform;
-    use goose_sdk_types::custom_requests::ListRecipesRequest;
+    use futures::future::BoxFuture;
+    use goose_sdk_types::custom_requests::{ListRecipesRequest, ScheduleRecipeRequest};
     use serial_test::serial;
+    use std::future::Future;
 
     /// Builds an ACP agent with scheduling disabled, rooted entirely inside a
     /// temp dir so no assertion can touch the developer's real goose data.
@@ -380,21 +383,130 @@ mod tests {
         (server.create_agent().await.unwrap(), guard)
     }
 
+    /// Every request whose handler needs the scheduler, paired with the wire
+    /// method name read off the request type itself so the labels cannot drift
+    /// from the protocol. Response types differ per handler, so each future
+    /// discards its success value to give the table one uniform shape.
+    ///
+    /// The `_goose/unstable/recipes/schedule` case deliberately names a recipe
+    /// that does not exist: a disabled runtime must answer with the disabled
+    /// error rather than leaking `invalid_params` from the recipe lookup.
+    fn scheduler_dependent_requests(
+        agent: &GooseAcpAgent,
+    ) -> Vec<(
+        String,
+        BoxFuture<'_, Result<(), agent_client_protocol::Error>>,
+    )> {
+        fn case<'a, Req, Res, Fut>(
+            request: Req,
+            handler: impl FnOnce(Req) -> Fut,
+        ) -> (
+            String,
+            BoxFuture<'a, Result<(), agent_client_protocol::Error>>,
+        )
+        where
+            Req: agent_client_protocol::JsonRpcMessage,
+            Res: 'a,
+            Fut: Future<Output = Result<Res, agent_client_protocol::Error>> + Send + 'a,
+        {
+            let method = request.method().to_string();
+            let future = handler(request);
+            (method, Box::pin(async move { future.await.map(|_| ()) }))
+        }
+
+        let schedule_id = "nightly".to_string();
+        vec![
+            case(ListSchedulesRequest {}, |req| agent.on_list_schedules(req)),
+            case(
+                ListScheduleSessionsRequest {
+                    schedule_id: schedule_id.clone(),
+                    limit: 10,
+                },
+                |req| agent.on_list_schedule_sessions(req),
+            ),
+            case(
+                CreateScheduleRequest {
+                    id: schedule_id.clone(),
+                    recipe: Default::default(),
+                    cron: "0 0 0 * * *".to_string(),
+                },
+                |req| agent.on_create_schedule(req),
+            ),
+            case(
+                DeleteScheduleRequest {
+                    schedule_id: schedule_id.clone(),
+                },
+                |req| agent.on_delete_schedule(req),
+            ),
+            case(
+                PauseScheduleRequest {
+                    schedule_id: schedule_id.clone(),
+                },
+                |req| agent.on_pause_schedule(req),
+            ),
+            case(
+                UnpauseScheduleRequest {
+                    schedule_id: schedule_id.clone(),
+                },
+                |req| agent.on_unpause_schedule(req),
+            ),
+            case(
+                UpdateScheduleRequest {
+                    schedule_id: schedule_id.clone(),
+                    cron: "0 0 1 * * *".to_string(),
+                },
+                |req| agent.on_update_schedule(req),
+            ),
+            case(
+                RunScheduleNowRequest {
+                    schedule_id: schedule_id.clone(),
+                },
+                |req| agent.on_run_schedule_now(req),
+            ),
+            case(
+                KillRunningJobRequest {
+                    job_id: schedule_id.clone(),
+                },
+                |req| agent.on_kill_running_job(req),
+            ),
+            case(
+                InspectRunningJobRequest {
+                    job_id: schedule_id,
+                },
+                |req| agent.on_inspect_running_job(req),
+            ),
+            case(
+                ScheduleRecipeRequest {
+                    id: "no-such-recipe".to_string(),
+                    cron_schedule: Some("0 0 0 * * *".to_string()),
+                },
+                |req| agent.on_schedule_recipe(req),
+            ),
+        ]
+    }
+
     #[tokio::test]
     #[serial]
     async fn schedule_requests_report_method_not_found_when_scheduler_disabled() {
         let root = tempfile::tempdir().unwrap();
         let (agent, _guard) = agent_without_scheduler(&root).await;
 
-        let error = agent
-            .on_list_schedules(ListSchedulesRequest {})
-            .await
-            .expect_err("scheduling is unsupported without a scheduler");
+        for (method, request) in scheduler_dependent_requests(&agent) {
+            let error = request
+                .await
+                .expect_err(&format!("{method} is unsupported without a scheduler"));
 
-        assert_eq!(
-            error.code,
-            agent_client_protocol::Error::method_not_found().code
-        );
+            assert_eq!(
+                error.code,
+                agent_client_protocol::Error::method_not_found().code,
+                "{method} returned the wrong error code"
+            );
+            assert_eq!(
+                error.data.as_ref().and_then(serde_json::Value::as_str),
+                Some("scheduler is disabled in this ACP runtime"),
+                "{method} returned the wrong error data"
+            );
+        }
     }
 
     #[tokio::test]
@@ -432,5 +544,63 @@ mod tests {
             .on_list_recipes(ListRecipesRequest {})
             .await
             .expect("recipes remain listable without a scheduler");
+    }
+
+    /// Drives the agent through the session-creation path that configures a
+    /// session's tool surface, which is where the scheduler's absence has to
+    /// take effect.
+    async fn create_session_agent(
+        agent: &GooseAcpAgent,
+        session_id: &str,
+    ) -> Arc<crate::agents::Agent> {
+        agent
+            .agent_manager
+            .get_or_create_agent(session_id.to_string())
+            .await
+            .expect("session agent is creatable without a scheduler")
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn disabled_runtime_starts_without_scheduler_or_schedule_file() {
+        let root = tempfile::tempdir().unwrap();
+        let (agent, _guard) = agent_without_scheduler(&root).await;
+
+        assert!(agent.agent_manager.scheduler().is_none());
+        assert!(!root.path().join("schedule.json").exists());
+
+        let session_agent = create_session_agent(&agent, "disabled-runtime").await;
+        let tools = session_agent.list_tools("disabled-runtime", None).await;
+        assert!(!tools
+            .iter()
+            .any(|tool| tool.name == PLATFORM_MANAGE_SCHEDULE_TOOL_NAME));
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn disabled_runtime_leaves_an_existing_schedule_file_untouched() {
+        let root = tempfile::tempdir().unwrap();
+        let schedule_file = root.path().join("schedule.json");
+        // `currently_running` is stale running state, which an enabled
+        // scheduler rewrites on startup — so an unchanged file proves the read
+        // never happened, not merely that nothing needed changing.
+        let sentinel = r#"[{"id":"pre-existing","source":"/tmp/pre-existing.yaml","cron":"0 0 0 * * *","currently_running":true}]"#;
+        std::fs::write(&schedule_file, sentinel).unwrap();
+        let modified_before = std::fs::metadata(&schedule_file)
+            .unwrap()
+            .modified()
+            .unwrap();
+
+        let (agent, _guard) = agent_without_scheduler(&root).await;
+        create_session_agent(&agent, "disabled-runtime").await;
+
+        assert_eq!(std::fs::read_to_string(&schedule_file).unwrap(), sentinel);
+        assert_eq!(
+            std::fs::metadata(&schedule_file)
+                .unwrap()
+                .modified()
+                .unwrap(),
+            modified_before
+        );
     }
 }

--- a/crates/goose/src/acp/server/schedule.rs
+++ b/crates/goose/src/acp/server/schedule.rs
@@ -12,6 +12,8 @@ use super::{build_session_info, GooseAcpAgent, ResultExt};
 use crate::recipe::validate_recipe::validate_recipe_template_from_content;
 use crate::recipe::Recipe;
 use crate::scheduler::{get_default_scheduled_recipes_dir, ScheduledJob, SchedulerError};
+use crate::scheduler_trait::SchedulerTrait;
+use std::sync::Arc;
 
 fn validate_schedule_id(id: &str) -> Result<(), agent_client_protocol::Error> {
     let is_valid = !id.is_empty()
@@ -121,13 +123,26 @@ fn scheduled_job_to_dto(job: ScheduledJob) -> ScheduledJobDto {
 }
 
 impl GooseAcpAgent {
+    /// Returns this runtime's scheduler.
+    ///
+    /// Errors with `method_not_found` when the runtime was started without a
+    /// scheduler (see `GOOSE_ACP_SCHEDULER_DISABLED`), so clients treat
+    /// scheduling as unsupported rather than broken.
+    pub(super) fn scheduler(
+        &self,
+    ) -> Result<Arc<dyn SchedulerTrait>, agent_client_protocol::Error> {
+        self.agent_manager.scheduler().ok_or_else(|| {
+            agent_client_protocol::Error::method_not_found()
+                .data("scheduler is disabled in this ACP runtime")
+        })
+    }
+
     pub(super) async fn on_list_schedules(
         &self,
         _req: ListSchedulesRequest,
     ) -> Result<ListSchedulesResponse, agent_client_protocol::Error> {
         let jobs = self
-            .agent_manager
-            .scheduler()
+            .scheduler()?
             .list_scheduled_jobs()
             .await
             .into_iter()
@@ -142,8 +157,7 @@ impl GooseAcpAgent {
         req: ListScheduleSessionsRequest,
     ) -> Result<ListScheduleSessionsResponse, agent_client_protocol::Error> {
         let sessions = self
-            .agent_manager
-            .scheduler()
+            .scheduler()?
             .sessions(&req.schedule_id, req.limit)
             .await
             .internal_err_ctx("Failed to fetch schedule sessions")?
@@ -158,6 +172,10 @@ impl GooseAcpAgent {
         &self,
         req: CreateScheduleRequest,
     ) -> Result<CreateScheduleResponse, agent_client_protocol::Error> {
+        // Resolved before the recipe file is written so a disabled runtime
+        // leaves no orphaned recipe behind.
+        let scheduler = self.scheduler()?;
+
         let id = req.id.trim().to_string();
         validate_schedule_id(&id)?;
 
@@ -200,8 +218,7 @@ impl GooseAcpAgent {
             recipe_base_dir: None,
         };
 
-        self.agent_manager
-            .scheduler()
+        scheduler
             .add_scheduled_job(job.clone(), false)
             .await
             .map_err(create_schedule_error)?;
@@ -215,8 +232,7 @@ impl GooseAcpAgent {
         &self,
         req: DeleteScheduleRequest,
     ) -> Result<EmptyResponse, agent_client_protocol::Error> {
-        self.agent_manager
-            .scheduler()
+        self.scheduler()?
             .remove_scheduled_job(&req.schedule_id, false)
             .await
             .map_err(schedule_not_found_or_internal)?;
@@ -228,8 +244,7 @@ impl GooseAcpAgent {
         &self,
         req: PauseScheduleRequest,
     ) -> Result<EmptyResponse, agent_client_protocol::Error> {
-        self.agent_manager
-            .scheduler()
+        self.scheduler()?
             .pause_schedule(&req.schedule_id)
             .await
             .map_err(schedule_state_error)?;
@@ -241,8 +256,7 @@ impl GooseAcpAgent {
         &self,
         req: UnpauseScheduleRequest,
     ) -> Result<EmptyResponse, agent_client_protocol::Error> {
-        self.agent_manager
-            .scheduler()
+        self.scheduler()?
             .unpause_schedule(&req.schedule_id)
             .await
             .map_err(schedule_not_found_or_internal)?;
@@ -256,7 +270,7 @@ impl GooseAcpAgent {
     ) -> Result<UpdateScheduleResponse, agent_client_protocol::Error> {
         let schedule_id = req.schedule_id;
         let cron = req.cron;
-        let scheduler = self.agent_manager.scheduler();
+        let scheduler = self.scheduler()?;
         scheduler
             .update_schedule(&schedule_id, cron)
             .await
@@ -281,12 +295,7 @@ impl GooseAcpAgent {
         &self,
         req: RunScheduleNowRequest,
     ) -> Result<RunScheduleNowResponse, agent_client_protocol::Error> {
-        match self
-            .agent_manager
-            .scheduler()
-            .run_now(&req.schedule_id)
-            .await
-        {
+        match self.scheduler()?.run_now(&req.schedule_id).await {
             Ok(session_id) => Ok(RunScheduleNowResponse {
                 status: RunScheduleNowStatus::Completed,
                 session_id: Some(session_id),
@@ -299,8 +308,7 @@ impl GooseAcpAgent {
         &self,
         req: KillRunningJobRequest,
     ) -> Result<KillRunningJobResponse, agent_client_protocol::Error> {
-        self.agent_manager
-            .scheduler()
+        self.scheduler()?
             .kill_running_job(&req.job_id)
             .await
             .map_err(schedule_state_error)?;
@@ -315,8 +323,7 @@ impl GooseAcpAgent {
         req: InspectRunningJobRequest,
     ) -> Result<InspectRunningJobResponse, agent_client_protocol::Error> {
         let job = self
-            .agent_manager
-            .scheduler()
+            .scheduler()?
             .list_scheduled_jobs()
             .await
             .into_iter()
@@ -339,5 +346,91 @@ impl GooseAcpAgent {
             job_start_time: job.process_start_time.map(|value| value.to_rfc3339()),
             running_duration_seconds,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::acp::server_factory::{
+        AcpServer, AcpServerFactoryConfig, GOOSE_ACP_SCHEDULER_DISABLED_ENV,
+    };
+    use crate::agents::GoosePlatform;
+    use goose_sdk_types::custom_requests::ListRecipesRequest;
+    use serial_test::serial;
+
+    /// Builds an ACP agent with scheduling disabled, rooted entirely inside a
+    /// temp dir so no assertion can touch the developer's real goose data.
+    async fn agent_without_scheduler(
+        root: &tempfile::TempDir,
+    ) -> (Arc<GooseAcpAgent>, env_lock::EnvGuard<'static>) {
+        let guard = env_lock::lock_env([
+            (GOOSE_ACP_SCHEDULER_DISABLED_ENV, Some("true")),
+            ("GOOSE_DISABLE_KEYRING", Some("true")),
+            ("GOOSE_PATH_ROOT", root.path().to_str()),
+        ]);
+        let server = AcpServer::new(AcpServerFactoryConfig {
+            builtins: Vec::new(),
+            data_dir: root.path().to_path_buf(),
+            config_dir: root.path().to_path_buf(),
+            goose_platform: GoosePlatform::GooseCli,
+            additional_source_roots: Vec::new(),
+        });
+
+        (server.create_agent().await.unwrap(), guard)
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn schedule_requests_report_method_not_found_when_scheduler_disabled() {
+        let root = tempfile::tempdir().unwrap();
+        let (agent, _guard) = agent_without_scheduler(&root).await;
+
+        let error = agent
+            .on_list_schedules(ListSchedulesRequest {})
+            .await
+            .expect_err("scheduling is unsupported without a scheduler");
+
+        assert_eq!(
+            error.code,
+            agent_client_protocol::Error::method_not_found().code
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn creating_a_schedule_writes_no_recipe_when_scheduler_disabled() {
+        let root = tempfile::tempdir().unwrap();
+        let (agent, _guard) = agent_without_scheduler(&root).await;
+
+        let error = agent
+            .on_create_schedule(CreateScheduleRequest {
+                id: "nightly".to_string(),
+                recipe: Default::default(),
+                cron: "0 0 0 * * *".to_string(),
+            })
+            .await
+            .expect_err("scheduling is unsupported without a scheduler");
+
+        assert_eq!(
+            error.code,
+            agent_client_protocol::Error::method_not_found().code
+        );
+        assert!(!get_default_scheduled_recipes_dir()
+            .unwrap()
+            .join("nightly.yaml")
+            .exists());
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn listing_recipes_succeeds_when_scheduler_disabled() {
+        let root = tempfile::tempdir().unwrap();
+        let (agent, _guard) = agent_without_scheduler(&root).await;
+
+        agent
+            .on_list_recipes(ListRecipesRequest {})
+            .await
+            .expect("recipes remain listable without a scheduler");
     }
 }

--- a/crates/goose/src/acp/server_factory.rs
+++ b/crates/goose/src/acp/server_factory.rs
@@ -62,9 +62,6 @@ impl AcpServer {
     /// so `schedule.json` is neither read nor written.
     async fn scheduler(&self) -> Result<Option<Arc<dyn SchedulerTrait>>> {
         if scheduler_disabled_by_env() {
-            info!(
-                "{GOOSE_ACP_SCHEDULER_DISABLED_ENV}=true; scheduled recipes are disabled in this ACP runtime"
-            );
             return Ok(None);
         }
 

--- a/crates/goose/src/acp/server_factory.rs
+++ b/crates/goose/src/acp/server_factory.rs
@@ -1,5 +1,6 @@
 use crate::acp::server::{AcpProviderFactory, GooseAcpAgent, GooseAcpAgentOptions};
 use crate::agents::GoosePlatform;
+use crate::scheduler::scheduler_disabled_by_env;
 use crate::scheduler_trait::SchedulerTrait;
 use crate::session::SessionManager;
 use crate::source_roots::SourceRoot;
@@ -8,31 +9,9 @@ use std::sync::Arc;
 use tokio::sync::OnceCell;
 use tracing::info;
 
-/// Environment variable that suppresses the cron scheduler in `goose acp`.
-///
-/// Hosts that run a pool of ACP workers (for example Buzz, which spawns one
-/// `goose acp` child per agent slot) would otherwise have every worker execute
-/// the user's personal schedule, so a single cron entry fires once per worker.
-/// Such hosts set this variable on every child they spawn.
-pub const GOOSE_ACP_SCHEDULER_DISABLED_ENV: &str = "GOOSE_ACP_SCHEDULER_DISABLED";
-
-/// Reads [`GOOSE_ACP_SCHEDULER_DISABLED`] straight from the process
-/// environment.
-///
-/// Deliberately not routed through [`crate::config::Config`]: this must be a
-/// read-only, environment-only switch, and the config layer both falls back to
-/// persisted YAML and coerces values like `"1"` into JSON numbers that fail to
-/// deserialize as `bool`.
-///
-/// Only `true` disables scheduling, matched case-insensitively after trimming
-/// surrounding whitespace. Unset, `false`, and unparseable values all leave
-/// scheduling enabled, so a typo can never silently disable a user's cron jobs.
-///
-/// [`GOOSE_ACP_SCHEDULER_DISABLED`]: GOOSE_ACP_SCHEDULER_DISABLED_ENV
-fn scheduler_disabled_by_env() -> bool {
-    std::env::var(GOOSE_ACP_SCHEDULER_DISABLED_ENV)
-        .is_ok_and(|value| value.trim().eq_ignore_ascii_case("true"))
-}
+/// Re-exported so callers that reach the switch through the ACP surface keep
+/// working; the switch itself is process-wide and lives with the scheduler.
+pub use crate::scheduler::GOOSE_ACP_SCHEDULER_DISABLED_ENV;
 
 pub struct AcpServerFactoryConfig {
     pub builtins: Vec<String>,
@@ -124,22 +103,6 @@ impl AcpServer {
 mod tests {
     use super::*;
     use serial_test::serial;
-    use test_case::test_case;
-
-    #[test_case(None, false ; "unset keeps scheduling enabled")]
-    #[test_case(Some("true"), true ; "true disables scheduling")]
-    #[test_case(Some("TRUE"), true ; "value is case insensitive")]
-    #[test_case(Some("  true  "), true ; "surrounding whitespace is trimmed")]
-    #[test_case(Some("false"), false ; "false keeps scheduling enabled")]
-    #[test_case(Some("1"), false ; "one keeps scheduling enabled")]
-    #[test_case(Some(""), false ; "empty keeps scheduling enabled")]
-    #[test_case(Some("yes please"), false ; "unparseable keeps scheduling enabled")]
-    #[serial]
-    fn scheduler_disabled_by_env_only_honors_true(value: Option<&str>, expected: bool) {
-        let _guard = env_lock::lock_env([(GOOSE_ACP_SCHEDULER_DISABLED_ENV, value)]);
-
-        assert_eq!(scheduler_disabled_by_env(), expected);
-    }
 
     #[tokio::test]
     #[serial]

--- a/crates/goose/src/acp/server_factory.rs
+++ b/crates/goose/src/acp/server_factory.rs
@@ -8,6 +8,32 @@ use std::sync::Arc;
 use tokio::sync::OnceCell;
 use tracing::info;
 
+/// Environment variable that suppresses the cron scheduler in `goose acp`.
+///
+/// Hosts that run a pool of ACP workers (for example Buzz, which spawns one
+/// `goose acp` child per agent slot) would otherwise have every worker execute
+/// the user's personal schedule, so a single cron entry fires once per worker.
+/// Such hosts set this variable on every child they spawn.
+pub const GOOSE_ACP_SCHEDULER_DISABLED_ENV: &str = "GOOSE_ACP_SCHEDULER_DISABLED";
+
+/// Reads [`GOOSE_ACP_SCHEDULER_DISABLED`] straight from the process
+/// environment.
+///
+/// Deliberately not routed through [`crate::config::Config`]: this must be a
+/// read-only, environment-only switch, and the config layer both falls back to
+/// persisted YAML and coerces values like `"1"` into JSON numbers that fail to
+/// deserialize as `bool`.
+///
+/// Only `true` disables scheduling, matched case-insensitively after trimming
+/// surrounding whitespace. Unset, `false`, and unparseable values all leave
+/// scheduling enabled, so a typo can never silently disable a user's cron jobs.
+///
+/// [`GOOSE_ACP_SCHEDULER_DISABLED`]: GOOSE_ACP_SCHEDULER_DISABLED_ENV
+fn scheduler_disabled_by_env() -> bool {
+    std::env::var(GOOSE_ACP_SCHEDULER_DISABLED_ENV)
+        .is_ok_and(|value| value.trim().eq_ignore_ascii_case("true"))
+}
+
 pub struct AcpServerFactoryConfig {
     pub builtins: Vec<String>,
     pub data_dir: std::path::PathBuf,
@@ -29,7 +55,19 @@ impl AcpServer {
         }
     }
 
-    async fn scheduler(&self) -> Result<Arc<dyn SchedulerTrait>> {
+    /// Returns the scheduler for ACP agents, or `None` when scheduling is
+    /// disabled for this runtime.
+    ///
+    /// When disabled the [`crate::scheduler::Scheduler`] is never constructed,
+    /// so `schedule.json` is neither read nor written.
+    async fn scheduler(&self) -> Result<Option<Arc<dyn SchedulerTrait>>> {
+        if scheduler_disabled_by_env() {
+            info!(
+                "{GOOSE_ACP_SCHEDULER_DISABLED_ENV}=true; scheduled recipes are disabled in this ACP runtime"
+            );
+            return Ok(None);
+        }
+
         let data_dir = self.config.data_dir.clone();
         self.scheduler
             .get_or_try_init(|| async move {
@@ -43,6 +81,7 @@ impl AcpServer {
             })
             .await
             .cloned()
+            .map(Some)
     }
 
     pub async fn create_agent(&self) -> Result<Arc<GooseAcpAgent>> {
@@ -81,5 +120,60 @@ impl AcpServer {
         info!("Created new ACP agent");
 
         Ok(Arc::new(agent))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+    use test_case::test_case;
+
+    #[test_case(None, false ; "unset keeps scheduling enabled")]
+    #[test_case(Some("true"), true ; "true disables scheduling")]
+    #[test_case(Some("TRUE"), true ; "value is case insensitive")]
+    #[test_case(Some("  true  "), true ; "surrounding whitespace is trimmed")]
+    #[test_case(Some("false"), false ; "false keeps scheduling enabled")]
+    #[test_case(Some("1"), false ; "one keeps scheduling enabled")]
+    #[test_case(Some(""), false ; "empty keeps scheduling enabled")]
+    #[test_case(Some("yes please"), false ; "unparseable keeps scheduling enabled")]
+    #[serial]
+    fn scheduler_disabled_by_env_only_honors_true(value: Option<&str>, expected: bool) {
+        let _guard = env_lock::lock_env([(GOOSE_ACP_SCHEDULER_DISABLED_ENV, value)]);
+
+        assert_eq!(scheduler_disabled_by_env(), expected);
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn scheduler_is_none_and_writes_nothing_when_disabled() {
+        let data_dir = tempfile::tempdir().unwrap();
+        let server = AcpServer::new(AcpServerFactoryConfig {
+            builtins: Vec::new(),
+            data_dir: data_dir.path().to_path_buf(),
+            config_dir: data_dir.path().to_path_buf(),
+            goose_platform: GoosePlatform::GooseCli,
+            additional_source_roots: Vec::new(),
+        });
+        let _guard = env_lock::lock_env([(GOOSE_ACP_SCHEDULER_DISABLED_ENV, Some("true"))]);
+
+        assert!(server.scheduler().await.unwrap().is_none());
+        assert!(!data_dir.path().join("schedule.json").exists());
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn scheduler_is_built_when_enabled() {
+        let data_dir = tempfile::tempdir().unwrap();
+        let server = AcpServer::new(AcpServerFactoryConfig {
+            builtins: Vec::new(),
+            data_dir: data_dir.path().to_path_buf(),
+            config_dir: data_dir.path().to_path_buf(),
+            goose_platform: GoosePlatform::GooseCli,
+            additional_source_roots: Vec::new(),
+        });
+        let _guard = env_lock::lock_env([(GOOSE_ACP_SCHEDULER_DISABLED_ENV, None::<&str>)]);
+
+        assert!(server.scheduler().await.unwrap().is_some());
     }
 }

--- a/crates/goose/src/execution/manager.rs
+++ b/crates/goose/src/execution/manager.rs
@@ -92,13 +92,10 @@ impl AgentManager {
             .cloned()
     }
 
-    pub fn scheduler(&self) -> Arc<dyn SchedulerTrait> {
-        Arc::clone(
-            self.agent_config
-                .scheduler_service
-                .as_ref()
-                .expect("AgentManager scheduler is not configured"),
-        )
+    /// Returns the scheduler, or `None` when this runtime was configured
+    /// without one (see `GOOSE_ACP_SCHEDULER_DISABLED`).
+    pub fn scheduler(&self) -> Option<Arc<dyn SchedulerTrait>> {
+        self.agent_config.scheduler_service.as_ref().map(Arc::clone)
     }
 
     /// Get the shared SessionManager for session-only operations

--- a/crates/goose/src/execution/manager.rs
+++ b/crates/goose/src/execution/manager.rs
@@ -3,7 +3,7 @@ use crate::agents::{Agent, AgentConfig, ExtensionLoadResult, GoosePlatform};
 use crate::config::paths::Paths;
 use crate::config::permission::PermissionManager;
 use crate::config::Config;
-use crate::scheduler::Scheduler;
+use crate::scheduler::{scheduler_disabled_by_env, Scheduler};
 use crate::scheduler_trait::SchedulerTrait;
 use crate::session::{SessionManager, SessionNameUpdate};
 use anyhow::Result;
@@ -64,6 +64,14 @@ impl AgentManager {
         Ok(manager)
     }
 
+    /// Returns the process-global manager, constructing it on first call.
+    ///
+    /// The scheduler is omitted when [`scheduler_disabled_by_env`] holds, which
+    /// keeps hosts that run a pool of workers from executing the user's cron
+    /// schedule once per process. The gate lives here and not only in the ACP
+    /// server factory because platform extensions — `orchestrator` in
+    /// particular — reach this singleton from inside an ACP process and would
+    /// otherwise resurrect scheduling behind the switch's back.
     pub async fn instance() -> Result<Arc<Self>> {
         AGENT_MANAGER
             .get_or_try_init(|| async {
@@ -72,15 +80,25 @@ impl AgentManager {
                     .get_goose_max_active_agents()
                     .unwrap_or(DEFAULT_MAX_SESSION);
                 let default_mode = config.get_goose_mode().unwrap_or_default();
-                let schedule_file_path = Paths::data_dir().join("schedule.json");
                 let session_manager = Arc::new(SessionManager::instance());
-                let scheduler = Scheduler::new(schedule_file_path, Arc::clone(&session_manager))
-                    .await
-                    .map(|scheduler| scheduler as Arc<dyn SchedulerTrait>)?;
+                // Constructing the `Scheduler` is itself the side effect to
+                // avoid: it reads `schedule.json`, rewrites stale running
+                // state, and starts cron polling. So skip it entirely rather
+                // than building one and ignoring it.
+                let scheduler = if scheduler_disabled_by_env() {
+                    None
+                } else {
+                    let schedule_file_path = Paths::data_dir().join("schedule.json");
+                    Some(
+                        Scheduler::new(schedule_file_path, Arc::clone(&session_manager))
+                            .await
+                            .map(|scheduler| scheduler as Arc<dyn SchedulerTrait>)?,
+                    )
+                };
                 let agent_config = AgentConfig::new(
                     session_manager,
                     PermissionManager::instance(),
-                    Some(scheduler),
+                    scheduler,
                     default_mode,
                     config.get_goose_disable_session_naming().unwrap_or(false),
                     GoosePlatform::GooseDesktop,
@@ -93,7 +111,7 @@ impl AgentManager {
     }
 
     /// Returns the scheduler, or `None` when this runtime was configured
-    /// without one (see `GOOSE_ACP_SCHEDULER_DISABLED`).
+    /// without one (see [`crate::scheduler::GOOSE_ACP_SCHEDULER_DISABLED_ENV`]).
     pub fn scheduler(&self) -> Option<Arc<dyn SchedulerTrait>> {
         self.agent_config.scheduler_service.as_ref().map(Arc::clone)
     }

--- a/crates/goose/src/scheduler.rs
+++ b/crates/goose/src/scheduler.rs
@@ -140,8 +140,8 @@ fn write_schedule_recipe_bytes(destination: &Path, bytes: &[u8]) -> Result<(), S
     Ok(())
 }
 
-/// Environment variable that suppresses the cron scheduler for the whole
-/// process.
+/// Environment variable that suppresses every scheduler-ownership path
+/// reachable inside an ACP process.
 ///
 /// Hosts that run a pool of ACP workers (for example Buzz, which spawns one
 /// `goose acp` child per agent slot) would otherwise have every worker execute

--- a/crates/goose/src/scheduler.rs
+++ b/crates/goose/src/scheduler.rs
@@ -140,6 +140,39 @@ fn write_schedule_recipe_bytes(destination: &Path, bytes: &[u8]) -> Result<(), S
     Ok(())
 }
 
+/// Environment variable that suppresses the cron scheduler for the whole
+/// process.
+///
+/// Hosts that run a pool of ACP workers (for example Buzz, which spawns one
+/// `goose acp` child per agent slot) would otherwise have every worker execute
+/// the user's personal schedule, so a single cron entry fires once per worker.
+/// Such hosts set this variable on every child they spawn.
+///
+/// The `ACP` in the name records who sets the variable, not the only thing it
+/// gates: it is honored everywhere a [`Scheduler`] would otherwise be built,
+/// including the process-global [`crate::execution::manager::AgentManager`].
+/// That manager is reachable from inside an ACP process through the
+/// `orchestrator` platform extension, so gating only the ACP server factory
+/// would let an extension resurrect cron execution in a process whose host
+/// asked for none.
+pub const GOOSE_ACP_SCHEDULER_DISABLED_ENV: &str = "GOOSE_ACP_SCHEDULER_DISABLED";
+
+/// Reads [`GOOSE_ACP_SCHEDULER_DISABLED_ENV`] straight from the process
+/// environment.
+///
+/// Deliberately not routed through [`crate::config::Config`]: this must be a
+/// read-only, environment-only switch, and the config layer both falls back to
+/// persisted YAML and coerces values like `"1"` into JSON numbers that fail to
+/// deserialize as `bool`.
+///
+/// Only `true` disables scheduling, matched case-insensitively after trimming
+/// surrounding whitespace. Unset, `false`, and unparseable values all leave
+/// scheduling enabled, so a typo can never silently disable a user's cron jobs.
+pub fn scheduler_disabled_by_env() -> bool {
+    std::env::var(GOOSE_ACP_SCHEDULER_DISABLED_ENV)
+        .is_ok_and(|value| value.trim().eq_ignore_ascii_case("true"))
+}
+
 pub fn get_default_scheduler_storage_path() -> Result<PathBuf, io::Error> {
     let data_dir = Paths::data_dir();
     fs::create_dir_all(&data_dir)?;
@@ -1296,8 +1329,25 @@ impl SchedulerTrait for Scheduler {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
     use tempfile::tempdir;
+    use test_case::test_case;
     use tokio::time::{sleep, Duration};
+
+    #[test_case(None, false ; "unset keeps scheduling enabled")]
+    #[test_case(Some("true"), true ; "true disables scheduling")]
+    #[test_case(Some("TRUE"), true ; "value is case insensitive")]
+    #[test_case(Some("  true  "), true ; "surrounding whitespace is trimmed")]
+    #[test_case(Some("false"), false ; "false keeps scheduling enabled")]
+    #[test_case(Some("1"), false ; "one keeps scheduling enabled")]
+    #[test_case(Some(""), false ; "empty keeps scheduling enabled")]
+    #[test_case(Some("yes please"), false ; "unparseable keeps scheduling enabled")]
+    #[serial]
+    fn scheduler_disabled_by_env_only_honors_true(value: Option<&str>, expected: bool) {
+        let _guard = env_lock::lock_env([(GOOSE_ACP_SCHEDULER_DISABLED_ENV, value)]);
+
+        assert_eq!(scheduler_disabled_by_env(), expected);
+    }
 
     fn create_test_recipe(dir: &Path, name: &str) -> PathBuf {
         let recipe_path = dir.join(format!("{}.yaml", name));

--- a/crates/goose/src/scheduler.rs
+++ b/crates/goose/src/scheduler.rs
@@ -149,12 +149,17 @@ fn write_schedule_recipe_bytes(destination: &Path, bytes: &[u8]) -> Result<(), S
 /// Such hosts set this variable on every child they spawn.
 ///
 /// The `ACP` in the name records who sets the variable, not the only thing it
-/// gates: it is honored everywhere a [`Scheduler`] would otherwise be built,
-/// including the process-global [`crate::execution::manager::AgentManager`].
-/// That manager is reachable from inside an ACP process through the
-/// `orchestrator` platform extension, so gating only the ACP server factory
-/// would let an extension resurrect cron execution in a process whose host
-/// asked for none.
+/// gates: it is honored at every scheduler-ownership path reachable inside an
+/// ACP process — both the ACP server factory and the process-global
+/// [`crate::execution::manager::AgentManager`]. That manager is reachable from
+/// inside an ACP process through the `orchestrator` platform extension, so
+/// gating only the ACP server factory would let an extension resurrect cron
+/// execution in a process whose host asked for none.
+///
+/// The `goose schedule` CLI subcommands build their own [`Scheduler`] without
+/// consulting this variable. They are deliberately left alone: they are not
+/// reachable inside an ACP worker, and a user invoking them is asking for
+/// scheduling explicitly.
 pub const GOOSE_ACP_SCHEDULER_DISABLED_ENV: &str = "GOOSE_ACP_SCHEDULER_DISABLED";
 
 /// Reads [`GOOSE_ACP_SCHEDULER_DISABLED_ENV`] straight from the process

--- a/crates/goose/tests/acp_fixtures/mod.rs
+++ b/crates/goose/tests/acp_fixtures/mod.rs
@@ -378,7 +378,7 @@ pub async fn spawn_acp_server_in_process(
         disable_session_naming,
         goose_platform: GoosePlatform::GooseCli,
         additional_source_roots: Vec::new(),
-        scheduler: Arc::new(FixtureScheduler::new()),
+        scheduler: Some(Arc::new(FixtureScheduler::new())),
     })
     .await
     .unwrap();

--- a/crates/goose/tests/agent_manager_scheduler_disabled.rs
+++ b/crates/goose/tests/agent_manager_scheduler_disabled.rs
@@ -1,0 +1,74 @@
+//! Regression: the process-global `AgentManager` must honor the scheduler
+//! kill-switch.
+//!
+//! `AgentManager::instance()` used to construct a `Scheduler` unconditionally,
+//! so a host that asked for no scheduling still got cron polling and
+//! `schedule.json` mutation as soon as anything touched the singleton. See the
+//! sibling `orchestrator_scheduler_disabled` test for the extension path that
+//! makes this reachable from inside an ACP process.
+//!
+//! This lives in its own integration-test binary on purpose: `AGENT_MANAGER` is
+//! a process-global `OnceCell`, so the first `instance()` call in a process
+//! decides what every later caller sees. A second test in this binary would
+//! observe this test's singleton rather than building its own.
+
+use goose::execution::manager::AgentManager;
+use goose::scheduler::GOOSE_ACP_SCHEDULER_DISABLED_ENV;
+
+/// A job left with `currently_running: true` is stale running state, which an
+/// enabled scheduler rewrites during startup (`Scheduler::load_jobs_from_storage`).
+/// That is what makes this file discriminating: an unchanged file proves the
+/// read never happened, rather than proving nothing needed changing.
+///
+/// Asserting instead that no `schedule.json` was *created* would prove nothing
+/// here — an enabled scheduler also writes no file when none exists.
+const STALE_RUNNING_JOB: &str = r#"[{"id":"sentinel","source":"/nonexistent/sentinel.yaml","cron":"0 0 0 * * *","currently_running":true}]"#;
+
+#[tokio::test]
+async fn global_agent_manager_has_no_scheduler_and_leaves_schedule_file_untouched() {
+    let root = tempfile::tempdir().unwrap();
+    // `Paths::data_dir()` is `$GOOSE_PATH_ROOT/data`, and the root is silently
+    // ignored unless it is absolute — an ignored root would point this test at
+    // the developer's real schedule file.
+    let data_dir = root.path().join("data");
+    std::fs::create_dir_all(&data_dir).unwrap();
+    assert!(
+        root.path().is_absolute(),
+        "GOOSE_PATH_ROOT is ignored unless absolute"
+    );
+
+    let schedule_file = data_dir.join("schedule.json");
+    std::fs::write(&schedule_file, STALE_RUNNING_JOB).unwrap();
+    let modified_before = std::fs::metadata(&schedule_file)
+        .unwrap()
+        .modified()
+        .unwrap();
+
+    let _guard = env_lock::lock_env([
+        (GOOSE_ACP_SCHEDULER_DISABLED_ENV, Some("true")),
+        ("GOOSE_DISABLE_KEYRING", Some("true")),
+        ("GOOSE_PATH_ROOT", root.path().to_str()),
+    ]);
+
+    let manager = AgentManager::instance()
+        .await
+        .expect("the global manager is constructible without a scheduler");
+
+    assert!(
+        manager.scheduler().is_none(),
+        "the global manager must not build a scheduler when the switch is set"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&schedule_file).unwrap(),
+        STALE_RUNNING_JOB,
+        "a disabled runtime must not rewrite the schedule file"
+    );
+    assert_eq!(
+        std::fs::metadata(&schedule_file)
+            .unwrap()
+            .modified()
+            .unwrap(),
+        modified_before,
+        "a disabled runtime must not even touch the schedule file"
+    );
+}

--- a/crates/goose/tests/orchestrator_scheduler_disabled.rs
+++ b/crates/goose/tests/orchestrator_scheduler_disabled.rs
@@ -1,0 +1,125 @@
+//! Regression: the `orchestrator` platform extension must not resurrect
+//! scheduling inside a runtime whose host disabled it.
+//!
+//! `orchestrator` is loadable into an ACP process (`goose acp --with-builtin
+//! orchestrator`, or via persisted extension configuration) and every one of
+//! its tools reaches the process-global `AgentManager` through the private
+//! `get_agent_manager()`. That singleton owned `Paths::data_dir()/schedule.json`
+//! unconditionally, so touching any orchestrator tool restarted cron execution
+//! and schedule-file mutation behind the kill-switch's back.
+//!
+//! This binds the edge at the real orchestrator tool call rather than at a
+//! stand-in: the test dispatches `orchestrator__list_sessions`, which calls
+//! `get_agent_manager()` before it can produce a result.
+//!
+//! Its own integration-test binary, like the sibling
+//! `agent_manager_scheduler_disabled` test: `AGENT_MANAGER` is a process-global
+//! `OnceCell`, so the first initializer in a process decides what every later
+//! caller observes.
+
+use std::sync::Arc;
+
+use goose::agents::{Agent, AgentConfig, ExtensionConfig, GoosePlatform};
+use goose::config::permission::PermissionManager;
+use goose::config::GooseMode;
+use goose::scheduler::GOOSE_ACP_SCHEDULER_DISABLED_ENV;
+use goose::session::session_manager::SessionType;
+use goose::session::SessionManager;
+use rmcp::model::CallToolRequestParams;
+
+/// Stale running state, which an enabled scheduler rewrites at startup — so an
+/// unchanged file proves the read never happened.
+const STALE_RUNNING_JOB: &str = r#"[{"id":"sentinel","source":"/nonexistent/sentinel.yaml","cron":"0 0 0 * * *","currently_running":true}]"#;
+
+#[tokio::test]
+async fn orchestrator_tool_call_starts_no_scheduler_when_disabled() {
+    let root = tempfile::tempdir().unwrap();
+    // `Paths::data_dir()` is `$GOOSE_PATH_ROOT/data`, and a non-absolute root is
+    // silently ignored — which would aim this test at the real schedule file.
+    assert!(
+        root.path().is_absolute(),
+        "GOOSE_PATH_ROOT is ignored unless absolute"
+    );
+    let data_dir = root.path().join("data");
+    std::fs::create_dir_all(&data_dir).unwrap();
+
+    let schedule_file = data_dir.join("schedule.json");
+    std::fs::write(&schedule_file, STALE_RUNNING_JOB).unwrap();
+    let modified_before = std::fs::metadata(&schedule_file)
+        .unwrap()
+        .modified()
+        .unwrap();
+
+    let _guard = env_lock::lock_env([
+        (GOOSE_ACP_SCHEDULER_DISABLED_ENV, Some("true")),
+        ("GOOSE_DISABLE_KEYRING", Some("true")),
+        ("GOOSE_PATH_ROOT", root.path().to_str()),
+    ]);
+
+    // An ACP-shaped agent: no scheduler of its own, matching what
+    // `AcpServer::create_agent()` builds when the switch is set.
+    let session_manager = Arc::new(SessionManager::new(data_dir.clone()));
+    let agent = Agent::with_config(AgentConfig::new(
+        Arc::clone(&session_manager),
+        PermissionManager::instance(),
+        None,
+        GooseMode::default(),
+        false,
+        GoosePlatform::GooseCli,
+    ));
+    let session = session_manager
+        .create_session(
+            root.path().to_path_buf(),
+            "orchestrator-disabled".to_string(),
+            SessionType::Hidden,
+            GooseMode::default(),
+        )
+        .await
+        .expect("session is creatable without a scheduler");
+
+    agent
+        .add_extension(
+            ExtensionConfig::Platform {
+                name: "orchestrator".to_string(),
+                description: "Orchestrator".to_string(),
+                display_name: Some("Orchestrator".to_string()),
+                bundled: Some(true),
+                available_tools: vec![],
+            },
+            &session.id,
+        )
+        .await
+        .expect("orchestrator is loadable into a runtime without a scheduler");
+
+    // `list_sessions` resolves the process-global AgentManager before it can
+    // answer, which is the resurrection edge under test.
+    let (_id, result) = agent
+        .dispatch_tool_call(
+            CallToolRequestParams::new("orchestrator__list_sessions"),
+            "req-1".to_string(),
+            None,
+            &session,
+        )
+        .await;
+    let tool_result = result.expect("orchestrator tool call is dispatchable");
+    let call_result = tool_result.result.await;
+    assert!(
+        call_result.is_ok(),
+        "the orchestrator tool must succeed, otherwise it might never have \
+         reached the agent manager: {call_result:?}"
+    );
+
+    assert_eq!(
+        std::fs::read_to_string(&schedule_file).unwrap(),
+        STALE_RUNNING_JOB,
+        "an orchestrator tool call must not let a scheduler rewrite the schedule file"
+    );
+    assert_eq!(
+        std::fs::metadata(&schedule_file)
+            .unwrap()
+            .modified()
+            .unwrap(),
+        modified_before,
+        "an orchestrator tool call must not touch the schedule file at all"
+    );
+}

--- a/crates/goose/tests/orchestrator_scheduler_disabled.rs
+++ b/crates/goose/tests/orchestrator_scheduler_disabled.rs
@@ -31,6 +31,10 @@ use rmcp::model::CallToolRequestParams;
 /// unchanged file proves the read never happened.
 const STALE_RUNNING_JOB: &str = r#"[{"id":"sentinel","source":"/nonexistent/sentinel.yaml","cron":"0 0 0 * * *","currently_running":true}]"#;
 
+/// Named so the assertion on the tool's output can prove `list_sessions`
+/// produced a real listing rather than an error rendered as success.
+const SESSION_NAME: &str = "orchestrator-disabled";
+
 #[tokio::test]
 async fn orchestrator_tool_call_starts_no_scheduler_when_disabled() {
     let root = tempfile::tempdir().unwrap();
@@ -70,8 +74,10 @@ async fn orchestrator_tool_call_starts_no_scheduler_when_disabled() {
     let session = session_manager
         .create_session(
             root.path().to_path_buf(),
-            "orchestrator-disabled".to_string(),
-            SessionType::Hidden,
+            SESSION_NAME.to_string(),
+            // `list_sessions` reports only User and Scheduled sessions, and the
+            // assertion below needs this one to appear in the listing.
+            SessionType::User,
             GooseMode::default(),
         )
         .await
@@ -102,11 +108,29 @@ async fn orchestrator_tool_call_starts_no_scheduler_when_disabled() {
         )
         .await;
     let tool_result = result.expect("orchestrator tool call is dispatchable");
-    let call_result = tool_result.result.await;
+    // The orchestrator converts every internal failure — including one from
+    // resolving the agent manager — into `Ok(CallToolResult::error(..))`, so
+    // the Rust `Ok` alone would also cover a run that never reached the
+    // singleton. Assert on the MCP-level outcome and its payload instead.
+    let call_result = tool_result
+        .result
+        .await
+        .expect("orchestrator tool call is dispatchable");
+    assert_ne!(
+        call_result.is_error,
+        Some(true),
+        "the orchestrator tool must not return an MCP error, otherwise it might \
+         never have reached the agent manager: {call_result:?}"
+    );
+    let listing = call_result
+        .content
+        .iter()
+        .filter_map(|block| block.as_text().map(|text| text.text.as_str()))
+        .collect::<String>();
     assert!(
-        call_result.is_ok(),
-        "the orchestrator tool must succeed, otherwise it might never have \
-         reached the agent manager: {call_result:?}"
+        listing.contains(SESSION_NAME),
+        "the listing must name the session this test created, proving \
+         list_sessions ran past the agent manager: {listing:?}"
     );
 
     assert_eq!(

--- a/goose-self-test.yaml
+++ b/goose-self-test.yaml
@@ -13,6 +13,7 @@ activities:
   - Test load tool for knowledge injection and discovery
   - Test delegate tool for task delegation (sync and async)
   - Test error boundaries including nested delegation prevention
+  - Validate the ACP scheduler kill-switch in a child goose acp process
   - Generate comprehensive test report
 
 parameters:
@@ -371,6 +372,42 @@ prompt: |
   2. Attempt directory traversal: ../../../etc/passwd
   3. Test with harmful Unicode characters
   4. Verify command injection prevention
+
+  ### ACP Scheduler Kill-Switch Validation
+  Hosts that run a pool of `goose acp` workers set `GOOSE_ACP_SCHEDULER_DISABLED=true` so only
+  one process executes the user's cron schedule. Verify the flag from outside the running instance,
+  by driving a child `goose acp` over stdio — this cannot be tested from within your own session,
+  because the flag is read once at startup.
+
+  1. Seed a schedule file the child must not touch, under an isolated path root. `GOOSE_PATH_ROOT`
+     is ignored unless it is absolute, and an ignored root would point the child at the user's real
+     schedule — so resolve it to an absolute path and confirm that before continuing. The scheduler
+     skips jobs whose recipe file is missing, so the sentinel job needs a real one:
+     ```
+     mkdir -p {{ workspace_dir }}/acp_root/data
+     ACP_ROOT=$(cd {{ workspace_dir }}/acp_root && pwd)
+     case "$ACP_ROOT" in /*) ;; *) echo "ABORT: path root is not absolute"; exit 1 ;; esac
+     printf 'version: 1.0.0\ntitle: sentinel\ndescription: placeholder for the kill-switch test\nprompt: noop\n' > "$ACP_ROOT/sentinel.yaml"
+     printf '[{"id":"sentinel","source":"%s","cron":"0 0 0 * * *","currently_running":true}]\n' "$ACP_ROOT/sentinel.yaml" > "$ACP_ROOT/data/schedule.json"
+     cp "$ACP_ROOT/data/schedule.json" "$ACP_ROOT/expected.json"
+     ```
+  2. Speak JSON-RPC to a child with the flag set. `goose acp` does not exit on stdin EOF, so bound
+     it with `timeout`:
+     ```
+     { printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":1,"clientCapabilities":{}}}'
+       sleep 2
+       printf '%s\n' '{"jsonrpc":"2.0","id":2,"method":"_goose/unstable/schedules/list","params":{}}'
+       sleep 3
+     } | GOOSE_ACP_SCHEDULER_DISABLED=true GOOSE_PATH_ROOT="$ACP_ROOT" timeout 30 goose acp > {{ workspace_dir }}/acp_disabled.jsonl
+     ```
+  3. **Expected**: the `id:2` response is an error with code `-32601` and data
+     `scheduler is disabled in this ACP runtime` — not a job list, and not a crash.
+  4. **Expected**: `diff "$ACP_ROOT/data/schedule.json" "$ACP_ROOT/expected.json"` reports no
+     difference. A disabled runtime never reads the file, so it cannot rewrite the stale
+     `currently_running` flag the way an enabled scheduler does at startup.
+  5. Repeat step 2 with `GOOSE_ACP_SCHEDULER_DISABLED` unset. **Expected**: `id:2` now returns a
+     `result` with a `jobs` array containing `sentinel`, and the file's `currently_running` has been
+     reset to `false` — confirming the default path is unchanged and that step 4 proved something.
 
   Log results to: {{ workspace_dir }}/phase4_advanced.md
   {% endif %}

--- a/goose-self-test.yaml
+++ b/goose-self-test.yaml
@@ -392,16 +392,32 @@ prompt: |
      cp "$ACP_ROOT/data/schedule.json" "$ACP_ROOT/expected.json"
      ```
   2. Speak JSON-RPC to a child with the flag set. `goose acp` does not exit on stdin EOF, so bound
-     it with `timeout`:
+     it yourself. Do not use `timeout` — it is not a macOS system utility. Background the child,
+     poll for the response, and reap it on every exit path, including signals: this test exists
+     because orphaned `goose` processes are the bug under investigation.
      ```
+     out={{ workspace_dir }}/acp_disabled.jsonl
+     : > "$out"
      { printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":1,"clientCapabilities":{}}}'
        sleep 2
        printf '%s\n' '{"jsonrpc":"2.0","id":2,"method":"_goose/unstable/schedules/list","params":{}}'
-       sleep 3
-     } | GOOSE_ACP_SCHEDULER_DISABLED=true GOOSE_PATH_ROOT="$ACP_ROOT" timeout 30 goose acp > {{ workspace_dir }}/acp_disabled.jsonl
+       sleep 30
+     } | GOOSE_ACP_SCHEDULER_DISABLED=true GOOSE_PATH_ROOT="$ACP_ROOT" goose acp > "$out" &
+     child=$!
+     trap 'kill "$child" 2>/dev/null; exit 143' INT TERM
+     trap 'kill "$child" 2>/dev/null' EXIT
+     i=0
+     while [ "$i" -lt 30 ]; do
+       grep -q '"id":2' "$out" && break
+       sleep 1
+       i=$((i+1))
+     done
+     kill "$child" 2>/dev/null
      ```
-  3. **Expected**: the `id:2` response is an error with code `-32601` and data
-     `scheduler is disabled in this ACP runtime` — not a job list, and not a crash.
+  3. **Expected**: the `id:2` response in `$out` is an error with code `-32601` and data
+     `scheduler is disabled in this ACP runtime` — not a job list, and not a crash. Assert on that
+     captured response, never on the child's exit status: the child is signalled, so its status
+     reports termination rather than anything about the feature.
   4. **Expected**: `diff "$ACP_ROOT/data/schedule.json" "$ACP_ROOT/expected.json"` reports no
      difference. A disabled runtime never reads the file, so it cannot rewrite the stale
      `currently_running` flag the way an enabled scheduler does at startup.

--- a/goose-self-test.yaml
+++ b/goose-self-test.yaml
@@ -392,28 +392,33 @@ prompt: |
      cp "$ACP_ROOT/data/schedule.json" "$ACP_ROOT/expected.json"
      ```
   2. Speak JSON-RPC to a child with the flag set. `goose acp` does not exit on stdin EOF, so bound
-     it yourself. Do not use `timeout` — it is not a macOS system utility. Background the child,
-     poll for the response, and reap it on every exit path, including signals: this test exists
-     because orphaned `goose` processes are the bug under investigation.
+     it yourself. Do not use `timeout` — it is not a macOS system utility. Write both requests to a
+     regular file first and redirect it into the child: `goose acp` reads pipelined requests without
+     waiting for a reply, so no feeder process is needed. That leaves exactly one process to own —
+     `wait` it after every kill, on every exit path including signals, and this test cannot leak the
+     processes it exists to investigate.
      ```
+     reqs={{ workspace_dir }}/acp_requests.jsonl
+     { printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":1,"clientCapabilities":{}}}'
+       printf '%s\n' '{"jsonrpc":"2.0","id":2,"method":"_goose/unstable/schedules/list","params":{}}'
+     } > "$reqs"
      out={{ workspace_dir }}/acp_disabled.jsonl
      : > "$out"
-     { printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":1,"clientCapabilities":{}}}'
-       sleep 2
-       printf '%s\n' '{"jsonrpc":"2.0","id":2,"method":"_goose/unstable/schedules/list","params":{}}'
-       sleep 30
-     } | GOOSE_ACP_SCHEDULER_DISABLED=true GOOSE_PATH_ROOT="$ACP_ROOT" goose acp > "$out" &
+     GOOSE_ACP_SCHEDULER_DISABLED=true GOOSE_PATH_ROOT="$ACP_ROOT" goose acp < "$reqs" > "$out" &
      child=$!
-     trap 'kill "$child" 2>/dev/null; exit 143' INT TERM
-     trap 'kill "$child" 2>/dev/null' EXIT
+     reap() { kill "$child" 2>/dev/null; wait "$child" 2>/dev/null; }
+     trap 'reap; exit 143' INT TERM
+     trap reap EXIT
      i=0
      while [ "$i" -lt 30 ]; do
        grep -q '"id":2' "$out" && break
        sleep 1
        i=$((i+1))
      done
-     kill "$child" 2>/dev/null
+     reap
      ```
+     A bare `trap` masks the default action for a signal, so the INT/TERM handler must `exit 143`
+     itself or the driver ignores the signal and keeps running.
   3. **Expected**: the `id:2` response in `$out` is an error with code `-32601` and data
      `scheduler is disabled in this ACP runtime` — not a job list, and not a crash. Assert on that
      captured response, never on the child's exit status: the child is signalled, so its status


### PR DESCRIPTION
Every `goose acp` process unconditionally constructs and starts a cron `Scheduler` over the shared `data_dir/schedule.json`, and there was no way to turn that off. When an ACP harness runs a pool of Goose workers, each worker independently fires the same cron entries — a single weekly job can execute once per pool slot, producing duplicate side effects and write races against the shared schedule file. Standalone `goose` and any other scheduler on the same machine race the same file.

This adds `GOOSE_ACP_SCHEDULER_DISABLED` so an embedding harness can declare that its Goose workers must never own scheduling.

Related: [block/buzz#3144](https://github.com/block/buzz/pull/3144) — the Buzz harness half, which injects `GOOSE_ACP_SCHEDULER_DISABLED=true` into every managed `goose acp` child.

## Behavior

`GOOSE_ACP_SCHEDULER_DISABLED=true` (case-insensitive, surrounding whitespace trimmed) suppresses the cron scheduler at every scheduler-ownership path reachable inside an ACP process. Any other value — unset, empty, `false`, `1`, unparseable — leaves scheduling enabled, so the flag can never silently disable a user's cron jobs.

The value is read directly from the environment rather than through `Config`, so a persisted `config.yaml` key cannot disable scheduling for a normal interactive `goose` session.

The gate covers all scheduler-ownership paths reachable in an ACP process, not the ACP factory alone. It is honored at both sites that would otherwise build a `Scheduler`: the ACP server factory and the process-global `AgentManager::instance()`. `AgentManager` is reachable from inside an ACP process through the `orchestrator` platform extension — every orchestrator tool resolves that singleton — so gating only the factory would let an extension resurrect cron execution and schedule-file mutation in a process whose host asked for none. `ACP` in the variable name records who sets it, not the only thing it gates.

The `goose schedule` CLI subcommands build their own `Scheduler` without consulting the variable, and are deliberately left ungated: they are not reachable inside a `goose acp` worker, and a user invoking them is asking for scheduling explicitly.

When disabled:

- Neither of those paths constructs a `Scheduler`, so nothing an ACP worker can reach opens, reads, or writes `schedule.json`. Skipping construction is the point: `Scheduler::new` reads the schedule file, rewrites stale `currently_running` state, and starts cron polling, so building one and ignoring it would still fire the side effects.
- The existing `config.scheduler_service.is_some()` gate already hides the `platform__manage_schedule` tool, so the model is not offered scheduling it cannot perform.
- All eleven scheduler-dependent handlers — the ten `_goose/unstable/schedules/*` methods plus `_goose/unstable/recipes/schedule` — return `method_not_found` with data `scheduler is disabled in this ACP runtime`. `method_not_found` (rather than an internal error) tells clients that scheduling is unsupported on this runtime, not broken.
- Recipe listing still works — recipes are independent of the scheduler.
- `on_create_schedule` and `on_schedule_recipe` resolve the scheduler *before* touching recipe state, so a disabled runtime leaves no orphaned recipe on disk and never leaks `invalid_params` from a recipe lookup in place of the uniform disabled error.

## Implementation

Scheduler state is modeled as `Option<Arc<dyn SchedulerTrait>>` end to end rather than as a no-op scheduler. This reuses the pre-existing `AgentConfig::scheduler_service.is_some()` tool gate and makes "no scheduler" statically unrepresentable as file I/O. It also removes the `.expect("AgentManager scheduler is not configured")` panic path.

`GOOSE_ACP_SCHEDULER_DISABLED_ENV` and the `scheduler_disabled_by_env()` predicate live in `goose::scheduler`, next to the type they gate and reachable from both call sites. `goose::acp::server_factory` re-exports `GOOSE_ACP_SCHEDULER_DISABLED_ENV`, so callers that reach the switch through the ACP surface — including the Buzz harness — are unaffected.

### API changes

Two public signatures become optional:

| Item | Before | After |
|------|--------|-------|
| `GooseAcpAgentOptions::scheduler` (field) | `Arc<dyn SchedulerTrait>` | `Option<Arc<dyn SchedulerTrait>>` |
| `AgentManager::scheduler()` | `Arc<dyn SchedulerTrait>` | `Option<Arc<dyn SchedulerTrait>>` |

Constructors that always have a scheduler now pass `Some(..)`; callers of `AgentManager::scheduler()` handle `None` instead of relying on the removed `.expect()`. `AgentConfig::scheduler_service` was already `Option` and is unchanged.

## Tests

- Eight cases pin the env parser: unset, empty, `true`, `TRUE`, whitespace-padded, `false`, `1`, and unparseable input.
- One table-driven test covers all eleven scheduler-dependent RPCs, asserting both the error code and the exact error data. Method labels are read off `JsonRpcMessage::method()` so they cannot drift from the protocol, and the `recipes/schedule` case passes a nonexistent recipe ID to pin the resolve-scheduler-first ordering.
- Two fixtures drive the production `create_agent()` boundary: one asserts no scheduler, no `schedule.json`, and `platform__manage_schedule` absent from the session agent's advertised tools; the other seeds a `schedule.json` whose job carries stale `currently_running` state — which an enabled scheduler rewrites at startup — and asserts the file is byte- and mtime-identical afterward, proving the read never happened.
- Two integration-test binaries cover the process-global path, each in its own file because `AGENT_MANAGER` is a `OnceCell` whose first initializer decides what every later caller in the process observes. `agent_manager_scheduler_disabled` asserts `AgentManager::instance()` yields no scheduler and leaves a seeded stale-state `schedule.json` byte-identical. `orchestrator_scheduler_disabled` dispatches a real `orchestrator__list_sessions` tool call against a scheduler-less agent and asserts the same file is untouched, binding the resurrection edge at the actual extension boundary rather than at a stand-in. Because the orchestrator renders internal failures as `Ok(CallToolResult::error(..))`, it also asserts the result is not an MCP error and that the listing names the session it created, so a run that never reached the singleton cannot pass.
- `goose-self-test.yaml` gains an "ACP Scheduler Kill-Switch Validation" scenario that drives a child `goose acp` over stdio JSON-RPC under an isolated absolute path root, comparing the disabled and enabled arms against the same seeded schedule file. Both JSON-RPC requests are written to a file and redirected into the child — `goose acp` reads pipelined requests without waiting for replies — so the scenario owns exactly one process, polls for its response rather than bounding it with `timeout` (not a macOS system utility), and reaps it on every exit path including signals.

