### PR TITLE
feat(acp): forward nested-provider terminal events to terminal-capable clients

### DIFF
--- a/crates/goose-provider-types/Cargo.toml
+++ b/crates/goose-provider-types/Cargo.toml
@@ -27,7 +27,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 strum = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true, features = ["time"] }
+tokio = { workspace = true, features = ["sync", "time"] }
 tracing = { workspace = true }
 unicode-normalization = { version = "0.1.22", default-features = false, features = ["std"] }
 uuid = { workspace = true, features = ["v4", "std"] }

--- a/crates/goose-provider-types/src/base.rs
+++ b/crates/goose-provider-types/src/base.rs
@@ -3,7 +3,7 @@ use futures::Stream;
 use rmcp::model::Tool;
 use serde::{Deserialize, Serialize};
 use std::pin::Pin;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, oneshot};
 
 use crate::{
     canonical::{map_to_canonical_model, CanonicalModelRegistry},
@@ -286,6 +286,8 @@ pub type MessageStream = Pin<
     Box<dyn Stream<Item = Result<(Option<Message>, Option<ProviderUsage>), ProviderError>> + Send>,
 >;
 
+pub type AcpNotification = (serde_json::Value, oneshot::Sender<()>);
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum PermissionRouting {
     ActionRequired,
@@ -402,7 +404,7 @@ pub trait Provider: Send + Sync {
     /// A single outer ACP session owns the stream until the provider is replaced.
     fn take_acp_notification_receiver(
         &self,
-    ) -> Option<(String, mpsc::UnboundedReceiver<serde_json::Value>)> {
+    ) -> Option<(String, mpsc::UnboundedReceiver<AcpNotification>)> {
         None
     }
 

--- a/crates/goose-provider-types/src/base.rs
+++ b/crates/goose-provider-types/src/base.rs
@@ -398,9 +398,8 @@ pub trait Provider: Send + Sync {
     /// Get the name of this provider instance
     fn get_name(&self) -> &str;
 
-    /// Take the provider-native ACP notification stream when available.
-    /// A single outer ACP session owns this lossless stream for the provider's
-    /// lifetime, avoiding prompt-boundary duplicate or dropped terminal output.
+    /// Subscribe to provider-native ACP terminal notifications when available.
+    /// A single outer ACP session owns the stream until the provider is replaced.
     fn take_acp_notification_receiver(
         &self,
     ) -> Option<(String, mpsc::UnboundedReceiver<serde_json::Value>)> {

--- a/crates/goose-provider-types/src/base.rs
+++ b/crates/goose-provider-types/src/base.rs
@@ -3,6 +3,7 @@ use futures::Stream;
 use rmcp::model::Tool;
 use serde::{Deserialize, Serialize};
 use std::pin::Pin;
+use tokio::sync::mpsc;
 
 use crate::{
     canonical::{map_to_canonical_model, CanonicalModelRegistry},
@@ -396,6 +397,15 @@ pub fn stream_from_single_message(message: Message, usage: ProviderUsage) -> Mes
 pub trait Provider: Send + Sync {
     /// Get the name of this provider instance
     fn get_name(&self) -> &str;
+
+    /// Take the provider-native ACP notification stream when available.
+    /// A single outer ACP session owns this lossless stream for the provider's
+    /// lifetime, avoiding prompt-boundary duplicate or dropped terminal output.
+    fn take_acp_notification_receiver(
+        &self,
+    ) -> Option<(String, mpsc::UnboundedReceiver<serde_json::Value>)> {
+        None
+    }
 
     /// Primary streaming method that all providers must implement.
     async fn stream(

--- a/crates/goose/src/acp/fs.rs
+++ b/crates/goose/src/acp/fs.rs
@@ -76,6 +76,14 @@ async fn acp_write_text_file(
     Ok(())
 }
 
+#[derive(Clone, Debug, serde::Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ClientTerminalShell {
+    pub(crate) executable: String,
+    #[serde(default)]
+    pub(crate) args_prefix: Vec<String>,
+}
+
 pub(crate) struct AcpTools {
     pub(crate) inner: Arc<dyn McpClientTrait>,
     pub(crate) cx: ConnectionTo<Client>,
@@ -84,14 +92,23 @@ pub(crate) struct AcpTools {
     pub(crate) fs_read: bool,
     pub(crate) fs_write: bool,
     pub(crate) terminal: bool,
+    pub(crate) terminal_shell: Option<ClientTerminalShell>,
 }
 
 fn create_terminal_request(
     session_id: &SessionId,
     params: &ShellParams,
     ctx: &crate::agents::ToolCallContext,
+    terminal_shell: Option<&ClientTerminalShell>,
 ) -> CreateTerminalRequest {
-    let (shell, args) = terminal_shell_command(&params.command);
+    let (shell, args) = match terminal_shell {
+        Some(shell) => {
+            let mut args = shell.args_prefix.clone();
+            args.push(params.command.clone());
+            (shell.executable.clone(), args)
+        }
+        None => terminal_shell_command(&params.command),
+    };
     CreateTerminalRequest::new(session_id.clone(), shell)
         .args(args)
         .env(vec![EnvVariable::new("AGENT_SESSION_ID", &ctx.session_id)])
@@ -279,7 +296,12 @@ impl AcpTools {
 
         let create_res = self
             .cx
-            .send_request(create_terminal_request(&self.session_id, &params, ctx))
+            .send_request(create_terminal_request(
+                &self.session_id,
+                &params,
+                ctx,
+                self.terminal_shell.as_ref(),
+            ))
             .block_task()
             .await
             .map_err(|e| {
@@ -533,6 +555,25 @@ mod tests {
     }
 
     #[test]
+    fn terminal_request_uses_client_negotiated_shell() {
+        let request = create_terminal_request(
+            &SessionId::new("acp-session"),
+            &ShellParams {
+                command: "echo test".to_string(),
+                timeout_secs: None,
+            },
+            &ToolCallContext::new("agent-session".to_string(), None, None),
+            Some(&ClientTerminalShell {
+                executable: "cmd".to_string(),
+                args_prefix: vec!["/C".to_string()],
+            }),
+        );
+
+        assert_eq!(request.command, "cmd");
+        assert_eq!(request.args, vec!["/C", "echo test"]);
+    }
+
+    #[test]
     fn terminal_request_uses_configured_shell_and_includes_agent_session_id() {
         let session_id = SessionId::new("acp-session");
         let params = ShellParams {
@@ -545,7 +586,7 @@ mod tests {
             None,
         );
 
-        let request = create_terminal_request(&session_id, &params, &ctx);
+        let request = create_terminal_request(&session_id, &params, &ctx, None);
 
         #[cfg(not(windows))]
         {

--- a/crates/goose/src/acp/fs.rs
+++ b/crates/goose/src/acp/fs.rs
@@ -26,6 +26,17 @@ use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::time::timeout;
+
+const TERMINAL_KILL_GRACE_PERIOD: Duration = Duration::from_secs(5);
+
+async fn wait_after_terminal_kill<F, T>(wait: F, grace_period: Duration) -> Result<T, &'static str>
+where
+    F: std::future::Future<Output = T>,
+{
+    timeout(grace_period, wait)
+        .await
+        .map_err(|_| "terminal did not exit within the post-kill grace period")
+}
 use tokio_util::sync::CancellationToken;
 
 async fn acp_read_text_file(
@@ -361,13 +372,22 @@ impl AcpTools {
                                 None,
                             ))
                         })?;
-                    self.cx
+                    let killed_wait = self
+                        .cx
                         .send_request(WaitForTerminalExitRequest::new(
                             self.session_id.clone(),
                             terminal_id.clone(),
                         ))
-                        .block_task()
+                        .block_task();
+                    wait_after_terminal_kill(killed_wait, TERMINAL_KILL_GRACE_PERIOD)
                         .await
+                        .map_err(|message| {
+                            McpError::McpError(rmcp::model::ErrorData::new(
+                                rmcp::model::ErrorCode::INTERNAL_ERROR,
+                                message,
+                                None,
+                            ))
+                        })?
                         .map_err(|e| {
                             McpError::McpError(rmcp::model::ErrorData::new(
                                 rmcp::model::ErrorCode::INTERNAL_ERROR,
@@ -481,6 +501,25 @@ impl McpClientTrait for AcpTools {
 mod tests {
     use super::*;
     use crate::agents::ToolCallContext;
+
+    #[tokio::test]
+    async fn post_kill_wait_is_bounded() {
+        let result =
+            wait_after_terminal_kill(std::future::pending::<()>(), Duration::from_millis(1)).await;
+
+        assert_eq!(
+            result,
+            Err("terminal did not exit within the post-kill grace period")
+        );
+    }
+
+    #[tokio::test]
+    async fn post_kill_wait_returns_successful_exit() {
+        assert_eq!(
+            wait_after_terminal_kill(async { 0 }, TERMINAL_KILL_GRACE_PERIOD).await,
+            Ok(0)
+        );
+    }
 
     #[test]
     fn terminal_shell_guidance_keeps_persistent_commands_foregrounded() {

--- a/crates/goose/src/acp/fs.rs
+++ b/crates/goose/src/acp/fs.rs
@@ -4,7 +4,9 @@ use crate::agents::mcp_client::{Error as McpError, McpClientTrait};
 use crate::agents::platform_extensions::developer::edit::{
     resolve_path, string_replace, FileEditParams, FileReadParams, FileWriteParams,
 };
-use crate::agents::platform_extensions::developer::shell::{ShellParams, OUTPUT_LIMIT_BYTES};
+use crate::agents::platform_extensions::developer::shell::{
+    terminal_shell_command, ShellParams, OUTPUT_LIMIT_BYTES,
+};
 use crate::agents::platform_extensions::developer::DeveloperClient;
 use agent_client_protocol::schema::v1::{
     CreateTerminalRequest, Diff, EnvVariable, KillTerminalRequest, ReadTextFileRequest,
@@ -78,12 +80,9 @@ fn create_terminal_request(
     params: &ShellParams,
     ctx: &crate::agents::ToolCallContext,
 ) -> CreateTerminalRequest {
-    let script = format!(
-        "{}\n__goose_command_status=$?\nwait\nexit \"$__goose_command_status\"",
-        params.command
-    );
-    CreateTerminalRequest::new(session_id.clone(), "sh")
-        .args(vec!["-c".to_string(), script])
+    let (shell, args) = terminal_shell_command(&params.command);
+    CreateTerminalRequest::new(session_id.clone(), shell)
+        .args(args)
         .env(vec![EnvVariable::new("AGENT_SESSION_ID", &ctx.session_id)])
         .cwd(ctx.working_dir.clone())
         .output_byte_limit(OUTPUT_LIMIT_BYTES as u64)
@@ -495,7 +494,7 @@ mod tests {
     }
 
     #[test]
-    fn terminal_request_wraps_shell_expression_and_includes_agent_session_id() {
+    fn terminal_request_uses_configured_shell_and_includes_agent_session_id() {
         let session_id = SessionId::new("acp-session");
         let params = ShellParams {
             command: "echo test".to_string(),
@@ -509,14 +508,18 @@ mod tests {
 
         let request = create_terminal_request(&session_id, &params, &ctx);
 
-        assert_eq!(request.command, "sh");
-        assert_eq!(
-            request.args,
-            vec![
-                "-c",
-                "echo test\n__goose_command_status=$?\nwait\nexit \"$__goose_command_status\""
-            ]
-        );
+        #[cfg(not(windows))]
+        {
+            assert_eq!(request.command, terminal_shell_command("echo test").0);
+            assert_eq!(request.args, vec!["-c", "echo test"]);
+        }
+        #[cfg(windows)]
+        {
+            assert_eq!(
+                (request.command, request.args),
+                terminal_shell_command("echo test")
+            );
+        }
         assert_eq!(
             request.env,
             vec![EnvVariable::new("AGENT_SESSION_ID", "agent-session")]

--- a/crates/goose/src/acp/fs.rs
+++ b/crates/goose/src/acp/fs.rs
@@ -78,7 +78,12 @@ fn create_terminal_request(
     params: &ShellParams,
     ctx: &crate::agents::ToolCallContext,
 ) -> CreateTerminalRequest {
-    CreateTerminalRequest::new(session_id.clone(), &params.command)
+    let script = format!(
+        "{}\n__goose_command_status=$?\nwait\nexit \"$__goose_command_status\"",
+        params.command
+    );
+    CreateTerminalRequest::new(session_id.clone(), "sh")
+        .args(vec!["-c".to_string(), script])
         .env(vec![EnvVariable::new("AGENT_SESSION_ID", &ctx.session_id)])
         .cwd(ctx.working_dir.clone())
         .output_byte_limit(OUTPUT_LIMIT_BYTES as u64)
@@ -90,6 +95,9 @@ fn visible_text(text: impl Into<String>) -> RmcpContent {
     )
 }
 
+fn acp_shell_description() -> &'static str {
+    "Execute a shell command in the current directory through an interactive ACP terminal. For a command the user asks to keep running, run that exact command in the foreground with a suitable timeout_secs; do not append &, use nohup/disown, redirect its output, or replace it with a background wrapper. The user can monitor and interrupt the foreground process in the client."
+}
 fn error_result(msg: impl std::fmt::Display) -> CallToolResult {
     CallToolResult::error(vec![visible_text(msg.to_string())])
 }
@@ -340,15 +348,34 @@ impl AcpTools {
                     false
                 }
                 Err(_) => {
-                    let _ = self
-                        .cx
+                    self.cx
                         .send_request(KillTerminalRequest::new(
                             self.session_id.clone(),
                             terminal_id.clone(),
                         ))
                         .block_task()
                         .await
-                        .inspect_err(|e| tracing::error!("failed to kill terminal: {e:?}"));
+                        .map_err(|e| {
+                            McpError::McpError(rmcp::model::ErrorData::new(
+                                rmcp::model::ErrorCode::INTERNAL_ERROR,
+                                format!("failed to kill terminal: {e:?}"),
+                                None,
+                            ))
+                        })?;
+                    self.cx
+                        .send_request(WaitForTerminalExitRequest::new(
+                            self.session_id.clone(),
+                            terminal_id.clone(),
+                        ))
+                        .block_task()
+                        .await
+                        .map_err(|e| {
+                            McpError::McpError(rmcp::model::ErrorData::new(
+                                rmcp::model::ErrorCode::INTERNAL_ERROR,
+                                format!("failed to wait for killed terminal exit: {e:?}"),
+                                None,
+                            ))
+                        })?;
                     true
                 }
             },
@@ -406,6 +433,11 @@ impl McpClientTrait for AcpTools {
         if self.fs_read {
             result.tools.insert(0, read_tool());
         }
+        if self.terminal {
+            if let Some(shell) = result.tools.iter_mut().find(|tool| tool.name == "shell") {
+                shell.description = Some(acp_shell_description().into());
+            }
+        }
         Ok(result)
     }
 
@@ -452,7 +484,18 @@ mod tests {
     use crate::agents::ToolCallContext;
 
     #[test]
-    fn terminal_request_includes_agent_session_id() {
+    fn terminal_shell_guidance_keeps_persistent_commands_foregrounded() {
+        let description = acp_shell_description();
+
+        assert!(description.contains("exact command in the foreground"));
+        assert!(description.contains("do not append &"));
+        assert!(description.contains("do not"));
+        assert!(description.contains("redirect its output"));
+        assert!(description.contains("monitor and interrupt"));
+    }
+
+    #[test]
+    fn terminal_request_wraps_shell_expression_and_includes_agent_session_id() {
         let session_id = SessionId::new("acp-session");
         let params = ShellParams {
             command: "echo test".to_string(),
@@ -466,6 +509,14 @@ mod tests {
 
         let request = create_terminal_request(&session_id, &params, &ctx);
 
+        assert_eq!(request.command, "sh");
+        assert_eq!(
+            request.args,
+            vec![
+                "-c",
+                "echo test\n__goose_command_status=$?\nwait\nexit \"$__goose_command_status\""
+            ]
+        );
         assert_eq!(
             request.env,
             vec![EnvVariable::new("AGENT_SESSION_ID", "agent-session")]

--- a/crates/goose/src/acp/mod.rs
+++ b/crates/goose/src/acp/mod.rs
@@ -10,6 +10,26 @@ pub(crate) mod tools;
 pub mod transport;
 
 pub use common::{map_permission_response, PermissionDecision};
+
+pub(crate) fn is_terminal_notification(notification: &serde_json::Value, session_id: &str) -> bool {
+    if notification
+        .get("sessionId")
+        .and_then(|value| value.as_str())
+        != Some(session_id)
+    {
+        return false;
+    }
+
+    notification
+        .get("update")
+        .and_then(|value| value.get("_meta"))
+        .and_then(|value| value.as_object())
+        .is_some_and(|meta| {
+            meta.contains_key("terminal_output")
+                || meta.contains_key("terminal_output_delta")
+                || meta.contains_key("terminal_exit")
+        })
+}
 pub use goose_sdk_types::{custom_notifications, custom_requests};
 pub use provider::{
     extension_configs_to_mcp_servers, AcpProvider, AcpProviderConfig, ACP_CURRENT_MODEL,

--- a/crates/goose/src/acp/provider.rs
+++ b/crates/goose/src/acp/provider.rs
@@ -152,6 +152,7 @@ pub struct AcpProvider {
     pending_confirmations:
         Arc<TokioMutex<HashMap<String, oneshot::Sender<PermissionConfirmation>>>>,
     pending_tool_updates: Arc<Mutex<HashMap<String, AccumulatedToolCall>>>,
+    notification_rx: Mutex<Option<mpsc::UnboundedReceiver<serde_json::Value>>>,
     handoff_context_sent: AtomicBool,
     /// Latest `size` reported by the ACP server in a `session/update` →
     /// `usage_update` notification. 0 means no real update has arrived yet,
@@ -245,6 +246,18 @@ impl AcpProvider {
         let pending_tool_updates: Arc<Mutex<HashMap<String, AccumulatedToolCall>>> =
             Arc::new(Mutex::new(HashMap::new()));
         let context_size = Arc::new(AtomicU64::new(0));
+        let (notification_tx, notification_rx) = mpsc::unbounded_channel();
+        let nested_notification_tx = notification_tx;
+        let mut config = config;
+        let configured_callback = config.notification_callback.take();
+        config.notification_callback = Some(Arc::new(move |notification| {
+            if let Some(callback) = configured_callback.as_ref() {
+                callback(notification.clone());
+            }
+            if let Ok(value) = serde_json::to_value(notification) {
+                let _ = nested_notification_tx.send(value);
+            }
+        }));
         let client_loop = AcpClientLoop::new(
             config,
             goose_mode_shared.clone(),
@@ -280,6 +293,7 @@ impl AcpProvider {
             session,
             pending_confirmations: Arc::new(TokioMutex::new(HashMap::new())),
             pending_tool_updates,
+            notification_rx: Mutex::new(Some(notification_rx)),
             handoff_context_sent: AtomicBool::new(false),
             context_size,
             model_config_option_id,
@@ -411,6 +425,16 @@ fn fresh_text_run() -> (String, i64) {
 impl Provider for AcpProvider {
     fn get_name(&self) -> &str {
         &self.name
+    }
+
+    fn take_acp_notification_receiver(
+        &self,
+    ) -> Option<(String, mpsc::UnboundedReceiver<serde_json::Value>)> {
+        self.notification_rx
+            .lock()
+            .ok()?
+            .take()
+            .map(|receiver| (self.session.id.0.to_string(), receiver))
     }
 
     async fn get_context_limit(&self, model_config: &ModelConfig) -> Result<usize, ProviderError> {
@@ -1699,6 +1723,7 @@ mod tests {
                 },
                 pending_confirmations: Arc::new(TokioMutex::new(HashMap::new())),
                 pending_tool_updates: Arc::new(Mutex::new(HashMap::new())),
+                notification_rx: Mutex::new(None),
                 handoff_context_sent: AtomicBool::new(false),
                 context_size: Arc::new(AtomicU64::new(0)),
                 model_config_option_id: None,

--- a/crates/goose/src/acp/provider.rs
+++ b/crates/goose/src/acp/provider.rs
@@ -114,6 +114,7 @@ enum AcpUpdate {
         content: Option<Vec<ToolCallContent>>,
         is_error: bool,
     },
+    TerminalNotification(serde_json::Value),
     PermissionRequest {
         request: Box<RequestPermissionRequest>,
         response_tx: oneshot::Sender<RequestPermissionResponse>,
@@ -175,29 +176,6 @@ impl std::fmt::Debug for AcpProvider {
         f.debug_struct("AcpProvider")
             .field("name", &self.name)
             .finish()
-    }
-}
-
-fn forward_terminal_notification(
-    notification: serde_json::Value,
-    subscriber: &Mutex<Option<mpsc::UnboundedSender<serde_json::Value>>>,
-) {
-    let Some(session_id) = notification
-        .get("sessionId")
-        .and_then(|value| value.as_str())
-    else {
-        return;
-    };
-    if !crate::acp::is_terminal_notification(&notification, session_id) {
-        return;
-    }
-    if let Ok(mut subscriber) = subscriber.lock() {
-        let disconnected = subscriber
-            .as_ref()
-            .is_some_and(|sender| sender.send(notification).is_err());
-        if disconnected {
-            *subscriber = None;
-        }
     }
 }
 
@@ -271,17 +249,6 @@ impl AcpProvider {
         let context_size = Arc::new(AtomicU64::new(0));
         let notification_subscriber =
             Arc::new(Mutex::new(None::<mpsc::UnboundedSender<serde_json::Value>>));
-        let nested_notification_subscriber = notification_subscriber.clone();
-        let mut config = config;
-        let configured_callback = config.notification_callback.take();
-        config.notification_callback = Some(Arc::new(move |notification| {
-            if let Some(callback) = configured_callback.as_ref() {
-                callback(notification.clone());
-            }
-            if let Ok(value) = serde_json::to_value(notification) {
-                forward_terminal_notification(value, &nested_notification_subscriber);
-            }
-        }));
         let client_loop = AcpClientLoop::new(
             config,
             goose_mode_shared.clone(),
@@ -562,6 +529,7 @@ impl Provider for AcpProvider {
         };
 
         let pending_confirmations = self.pending_confirmations.clone();
+        let notification_subscriber = self.notification_subscriber.clone();
         let goose_mode = *self
             .goose_mode
             .lock()
@@ -624,6 +592,16 @@ impl Provider for AcpProvider {
                                 tool_meta,
                             );
                             yield (Some(message), None);
+                        }
+                    }
+                    AcpUpdate::TerminalNotification(notification) => {
+                        if let Ok(mut subscriber) = notification_subscriber.lock() {
+                            let disconnected = subscriber
+                                .as_ref()
+                                .is_some_and(|sender| sender.send(notification).is_err());
+                            if disconnected {
+                                *subscriber = None;
+                            }
                         }
                     }
                     AcpUpdate::ToolCallComplete {
@@ -962,6 +940,21 @@ impl AcpClientLoop {
                                     } else {
                                         None
                                     };
+                                    if let Ok(notification) =
+                                        serde_json::to_value(SessionNotification::new(
+                                            notification.session_id.clone(),
+                                            SessionUpdate::ToolCallUpdate(update.clone()),
+                                        ))
+                                    {
+                                        if crate::acp::is_terminal_notification(
+                                            &notification,
+                                            notification["sessionId"].as_str().unwrap_or_default(),
+                                        ) {
+                                            let _ = tx.try_send(AcpUpdate::TerminalNotification(
+                                                notification,
+                                            ));
+                                        }
+                                    }
                                     if let (Some(accumulated), Some(status)) =
                                         (accumulated, terminal_status)
                                     {
@@ -1755,49 +1748,6 @@ mod tests {
             },
             ModelConfig::new("test-model"),
         )
-    }
-
-    #[test]
-    fn terminal_notification_forwarding_requires_an_active_subscriber() {
-        let subscriber = Mutex::new(None);
-        let terminal = serde_json::json!({
-            "sessionId": "nested-1",
-            "update": { "_meta": { "terminal_output_delta": { "data": "hello" } } }
-        });
-
-        forward_terminal_notification(terminal, &subscriber);
-
-        assert!(subscriber.lock().unwrap().is_none());
-    }
-
-    #[test]
-    fn terminal_notification_forwarding_filters_ordinary_notifications() {
-        let (sender, mut receiver) = mpsc::unbounded_channel();
-        let subscriber = Mutex::new(Some(sender));
-        let ordinary = serde_json::json!({
-            "sessionId": "nested-1",
-            "update": { "sessionUpdate": "agent_message_chunk" }
-        });
-
-        forward_terminal_notification(ordinary, &subscriber);
-
-        assert!(receiver.try_recv().is_err());
-        assert!(subscriber.lock().unwrap().is_some());
-    }
-
-    #[test]
-    fn terminal_notification_forwarding_clears_a_disconnected_subscriber() {
-        let (sender, receiver) = mpsc::unbounded_channel();
-        drop(receiver);
-        let subscriber = Mutex::new(Some(sender));
-        let terminal = serde_json::json!({
-            "sessionId": "nested-1",
-            "update": { "_meta": { "terminal_exit": { "exit_code": 0 } } }
-        });
-
-        forward_terminal_notification(terminal, &subscriber);
-
-        assert!(subscriber.lock().unwrap().is_none());
     }
 
     #[test]

--- a/crates/goose/src/acp/provider.rs
+++ b/crates/goose/src/acp/provider.rs
@@ -600,6 +600,13 @@ impl Provider for AcpProvider {
                         }
                     }
                     AcpUpdate::TerminalNotification(notification) => {
+                        let tool_call_id = notification
+                            .get("update")
+                            .and_then(|update| update.get("toolCallId"))
+                            .and_then(serde_json::Value::as_str);
+                        if tool_call_id.is_some_and(|id| rejected_tool_calls.contains(id)) {
+                            continue;
+                        }
                         let subscriber = notification_subscriber
                             .lock()
                             .ok()

--- a/crates/goose/src/acp/provider.rs
+++ b/crates/goose/src/acp/provider.rs
@@ -7,7 +7,7 @@ use agent_client_protocol::schema::v1::{
     SessionConfigOption, SessionConfigOptionCategory, SessionConfigSelectOptions, SessionId,
     SessionModeState, SessionNotification, SessionUpdate, SetSessionConfigOptionRequest,
     SetSessionModeRequest, SetSessionModeResponse, StopReason, TextContent, ToolCallContent,
-    ToolCallStatus, ToolKind,
+    ToolCallStatus, ToolCallUpdate, ToolKind,
 };
 use agent_client_protocol::schema::ProtocolVersion;
 use agent_client_protocol::{Agent, Client, ConnectionTo};
@@ -959,10 +959,15 @@ impl AcpClientLoop {
                                     } else {
                                         None
                                     };
+                                    let terminal_update = ToolCallUpdate::new(
+                                        update.tool_call_id.clone(),
+                                        agent_client_protocol::schema::v1::ToolCallUpdateFields::new(),
+                                    )
+                                    .meta(update.meta.clone());
                                     if let Ok(notification) =
                                         serde_json::to_value(SessionNotification::new(
                                             notification.session_id.clone(),
-                                            SessionUpdate::ToolCallUpdate(update.clone()),
+                                            SessionUpdate::ToolCallUpdate(terminal_update),
                                         ))
                                     {
                                         if crate::acp::is_terminal_notification(

--- a/crates/goose/src/acp/provider.rs
+++ b/crates/goose/src/acp/provider.rs
@@ -152,7 +152,7 @@ pub struct AcpProvider {
     pending_confirmations:
         Arc<TokioMutex<HashMap<String, oneshot::Sender<PermissionConfirmation>>>>,
     pending_tool_updates: Arc<Mutex<HashMap<String, AccumulatedToolCall>>>,
-    notification_rx: Mutex<Option<mpsc::UnboundedReceiver<serde_json::Value>>>,
+    notification_subscriber: Arc<Mutex<Option<mpsc::UnboundedSender<serde_json::Value>>>>,
     handoff_context_sent: AtomicBool,
     /// Latest `size` reported by the ACP server in a `session/update` →
     /// `usage_update` notification. 0 means no real update has arrived yet,
@@ -175,6 +175,29 @@ impl std::fmt::Debug for AcpProvider {
         f.debug_struct("AcpProvider")
             .field("name", &self.name)
             .finish()
+    }
+}
+
+fn forward_terminal_notification(
+    notification: serde_json::Value,
+    subscriber: &Mutex<Option<mpsc::UnboundedSender<serde_json::Value>>>,
+) {
+    let Some(session_id) = notification
+        .get("sessionId")
+        .and_then(|value| value.as_str())
+    else {
+        return;
+    };
+    if !crate::acp::is_terminal_notification(&notification, session_id) {
+        return;
+    }
+    if let Ok(mut subscriber) = subscriber.lock() {
+        let disconnected = subscriber
+            .as_ref()
+            .is_some_and(|sender| sender.send(notification).is_err());
+        if disconnected {
+            *subscriber = None;
+        }
     }
 }
 
@@ -246,8 +269,9 @@ impl AcpProvider {
         let pending_tool_updates: Arc<Mutex<HashMap<String, AccumulatedToolCall>>> =
             Arc::new(Mutex::new(HashMap::new()));
         let context_size = Arc::new(AtomicU64::new(0));
-        let (notification_tx, notification_rx) = mpsc::unbounded_channel();
-        let nested_notification_tx = notification_tx;
+        let notification_subscriber =
+            Arc::new(Mutex::new(None::<mpsc::UnboundedSender<serde_json::Value>>));
+        let nested_notification_subscriber = notification_subscriber.clone();
         let mut config = config;
         let configured_callback = config.notification_callback.take();
         config.notification_callback = Some(Arc::new(move |notification| {
@@ -255,7 +279,7 @@ impl AcpProvider {
                 callback(notification.clone());
             }
             if let Ok(value) = serde_json::to_value(notification) {
-                let _ = nested_notification_tx.send(value);
+                forward_terminal_notification(value, &nested_notification_subscriber);
             }
         }));
         let client_loop = AcpClientLoop::new(
@@ -293,7 +317,7 @@ impl AcpProvider {
             session,
             pending_confirmations: Arc::new(TokioMutex::new(HashMap::new())),
             pending_tool_updates,
-            notification_rx: Mutex::new(Some(notification_rx)),
+            notification_subscriber,
             handoff_context_sent: AtomicBool::new(false),
             context_size,
             model_config_option_id,
@@ -430,11 +454,9 @@ impl Provider for AcpProvider {
     fn take_acp_notification_receiver(
         &self,
     ) -> Option<(String, mpsc::UnboundedReceiver<serde_json::Value>)> {
-        self.notification_rx
-            .lock()
-            .ok()?
-            .take()
-            .map(|receiver| (self.session.id.0.to_string(), receiver))
+        let (sender, receiver) = mpsc::unbounded_channel();
+        *self.notification_subscriber.lock().ok()? = Some(sender);
+        Some((self.session.id.0.to_string(), receiver))
     }
 
     async fn get_context_limit(&self, model_config: &ModelConfig) -> Result<usize, ProviderError> {
@@ -1723,7 +1745,7 @@ mod tests {
                 },
                 pending_confirmations: Arc::new(TokioMutex::new(HashMap::new())),
                 pending_tool_updates: Arc::new(Mutex::new(HashMap::new())),
-                notification_rx: Mutex::new(None),
+                notification_subscriber: Arc::new(Mutex::new(None)),
                 handoff_context_sent: AtomicBool::new(false),
                 context_size: Arc::new(AtomicU64::new(0)),
                 model_config_option_id: None,
@@ -1733,6 +1755,49 @@ mod tests {
             },
             ModelConfig::new("test-model"),
         )
+    }
+
+    #[test]
+    fn terminal_notification_forwarding_requires_an_active_subscriber() {
+        let subscriber = Mutex::new(None);
+        let terminal = serde_json::json!({
+            "sessionId": "nested-1",
+            "update": { "_meta": { "terminal_output_delta": { "data": "hello" } } }
+        });
+
+        forward_terminal_notification(terminal, &subscriber);
+
+        assert!(subscriber.lock().unwrap().is_none());
+    }
+
+    #[test]
+    fn terminal_notification_forwarding_filters_ordinary_notifications() {
+        let (sender, mut receiver) = mpsc::unbounded_channel();
+        let subscriber = Mutex::new(Some(sender));
+        let ordinary = serde_json::json!({
+            "sessionId": "nested-1",
+            "update": { "sessionUpdate": "agent_message_chunk" }
+        });
+
+        forward_terminal_notification(ordinary, &subscriber);
+
+        assert!(receiver.try_recv().is_err());
+        assert!(subscriber.lock().unwrap().is_some());
+    }
+
+    #[test]
+    fn terminal_notification_forwarding_clears_a_disconnected_subscriber() {
+        let (sender, receiver) = mpsc::unbounded_channel();
+        drop(receiver);
+        let subscriber = Mutex::new(Some(sender));
+        let terminal = serde_json::json!({
+            "sessionId": "nested-1",
+            "update": { "_meta": { "terminal_exit": { "exit_code": 0 } } }
+        });
+
+        forward_terminal_notification(terminal, &subscriber);
+
+        assert!(subscriber.lock().unwrap().is_none());
     }
 
     #[test]

--- a/crates/goose/src/acp/provider.rs
+++ b/crates/goose/src/acp/provider.rs
@@ -841,24 +841,23 @@ impl AcpClientLoop {
                             }
                             _ => {}
                         }
-                        if let Some(tx) = prompt_response_tx
+                        let prompt_tx = prompt_response_tx
                             .lock()
                             .ok()
-                            .as_ref()
-                            .and_then(|g| g.as_ref())
-                        {
+                            .and_then(|guard| guard.as_ref().cloned());
+                        if let Some(tx) = prompt_tx {
                             match notification.update {
                                 SessionUpdate::AgentMessageChunk(ContentChunk {
                                     content: ContentBlock::Text(text),
                                     ..
                                 }) => {
-                                    let _ = tx.try_send(AcpUpdate::Text(text));
+                                    let _ = tx.send(AcpUpdate::Text(text)).await;
                                 }
                                 SessionUpdate::AgentThoughtChunk(ContentChunk {
                                     content: ContentBlock::Text(TextContent { text, .. }),
                                     ..
                                 }) => {
-                                    let _ = tx.try_send(AcpUpdate::Thought(text));
+                                    let _ = tx.send(AcpUpdate::Thought(text)).await;
                                 }
                                 SessionUpdate::ToolCall(tool_call) => {
                                     let id = tool_call.tool_call_id.0.to_string();
@@ -890,27 +889,31 @@ impl AcpClientLoop {
                                     // tool_meta for stable categorization, and the
                                     // goose.external_dispatch marker keeps `name` off the
                                     // agent loop's routing/auth paths.
-                                    let _ = tx.try_send(AcpUpdate::ToolCallStart {
-                                        id: id.clone(),
-                                        name: tool_call.title.clone(),
-                                        kind: tool_call.kind,
-                                        raw_input: tool_call.raw_input.clone(),
-                                    });
+                                    let _ = tx
+                                        .send(AcpUpdate::ToolCallStart {
+                                            id: id.clone(),
+                                            name: tool_call.title.clone(),
+                                            kind: tool_call.kind,
+                                            raw_input: tool_call.raw_input.clone(),
+                                        })
+                                        .await;
                                     if let Some(accumulated) = synchronous_accumulated {
                                         let content = if accumulated.content.is_empty() {
                                             None
                                         } else {
                                             Some(accumulated.content)
                                         };
-                                        let _ = tx.try_send(AcpUpdate::ToolCallComplete {
-                                            id,
-                                            raw_output: accumulated.raw_output,
-                                            content,
-                                            is_error: matches!(
-                                                initial_status,
-                                                ToolCallStatus::Failed
-                                            ),
-                                        });
+                                        let _ = tx
+                                            .send(AcpUpdate::ToolCallComplete {
+                                                id,
+                                                raw_output: accumulated.raw_output,
+                                                content,
+                                                is_error: matches!(
+                                                    initial_status,
+                                                    ToolCallStatus::Failed
+                                                ),
+                                            })
+                                            .await;
                                     }
                                 }
                                 SessionUpdate::ToolCallUpdate(update) => {
@@ -950,9 +953,9 @@ impl AcpClientLoop {
                                             &notification,
                                             notification["sessionId"].as_str().unwrap_or_default(),
                                         ) {
-                                            let _ = tx.try_send(AcpUpdate::TerminalNotification(
-                                                notification,
-                                            ));
+                                            let _ = tx
+                                                .send(AcpUpdate::TerminalNotification(notification))
+                                                .await;
                                         }
                                     }
                                     if let (Some(accumulated), Some(status)) =
@@ -963,12 +966,14 @@ impl AcpClientLoop {
                                         } else {
                                             Some(accumulated.content)
                                         };
-                                        let _ = tx.try_send(AcpUpdate::ToolCallComplete {
-                                            id,
-                                            raw_output: accumulated.raw_output,
-                                            content,
-                                            is_error: matches!(status, ToolCallStatus::Failed),
-                                        });
+                                        let _ = tx
+                                            .send(AcpUpdate::ToolCallComplete {
+                                                id,
+                                                raw_output: accumulated.raw_output,
+                                                content,
+                                                is_error: matches!(status, ToolCallStatus::Failed),
+                                            })
+                                            .await;
                                     }
                                 }
                                 _ => {}
@@ -997,10 +1002,11 @@ impl AcpClientLoop {
                             return Err(agent_client_protocol::Error::internal_error());
                         }
 
-                        tx.try_send(AcpUpdate::PermissionRequest {
+                        tx.send(AcpUpdate::PermissionRequest {
                             request: Box::new(request),
                             response_tx,
                         })
+                        .await
                         .map_err(|_| agent_client_protocol::Error::internal_error())?;
 
                         let response = response_rx.await.unwrap_or_else(|_| {
@@ -1202,13 +1208,15 @@ async fn handle_requests(
                 match response {
                     Ok(r) => {
                         log_undelivered(
-                            response_tx.try_send(AcpUpdate::Complete(r.stop_reason, r.usage)),
+                            response_tx
+                                .send(AcpUpdate::Complete(r.stop_reason, r.usage))
+                                .await,
                             AGENT_METHOD_NAMES.session_prompt,
                         );
                     }
                     Err(e) => {
                         log_undelivered(
-                            response_tx.try_send(AcpUpdate::Error(e.to_string())),
+                            response_tx.send(AcpUpdate::Error(e.to_string())).await,
                             AGENT_METHOD_NAMES.session_prompt,
                         );
                     }

--- a/crates/goose/src/acp/provider.rs
+++ b/crates/goose/src/acp/provider.rs
@@ -153,7 +153,8 @@ pub struct AcpProvider {
     pending_confirmations:
         Arc<TokioMutex<HashMap<String, oneshot::Sender<PermissionConfirmation>>>>,
     pending_tool_updates: Arc<Mutex<HashMap<String, AccumulatedToolCall>>>,
-    notification_subscriber: Arc<Mutex<Option<mpsc::UnboundedSender<serde_json::Value>>>>,
+    notification_subscriber:
+        Arc<Mutex<Option<mpsc::UnboundedSender<crate::providers::base::AcpNotification>>>>,
     handoff_context_sent: AtomicBool,
     /// Latest `size` reported by the ACP server in a `session/update` →
     /// `usage_update` notification. 0 means no real update has arrived yet,
@@ -247,8 +248,9 @@ impl AcpProvider {
         let pending_tool_updates: Arc<Mutex<HashMap<String, AccumulatedToolCall>>> =
             Arc::new(Mutex::new(HashMap::new()));
         let context_size = Arc::new(AtomicU64::new(0));
-        let notification_subscriber =
-            Arc::new(Mutex::new(None::<mpsc::UnboundedSender<serde_json::Value>>));
+        let notification_subscriber = Arc::new(Mutex::new(
+            None::<mpsc::UnboundedSender<crate::providers::base::AcpNotification>>,
+        ));
         let client_loop = AcpClientLoop::new(
             config,
             goose_mode_shared.clone(),
@@ -420,7 +422,10 @@ impl Provider for AcpProvider {
 
     fn take_acp_notification_receiver(
         &self,
-    ) -> Option<(String, mpsc::UnboundedReceiver<serde_json::Value>)> {
+    ) -> Option<(
+        String,
+        mpsc::UnboundedReceiver<crate::providers::base::AcpNotification>,
+    )> {
         let (sender, receiver) = mpsc::unbounded_channel();
         *self.notification_subscriber.lock().ok()? = Some(sender);
         Some((self.session.id.0.to_string(), receiver))
@@ -595,12 +600,16 @@ impl Provider for AcpProvider {
                         }
                     }
                     AcpUpdate::TerminalNotification(notification) => {
-                        if let Ok(mut subscriber) = notification_subscriber.lock() {
-                            let disconnected = subscriber
-                                .as_ref()
-                                .is_some_and(|sender| sender.send(notification).is_err());
-                            if disconnected {
-                                *subscriber = None;
+                        let subscriber = notification_subscriber
+                            .lock()
+                            .ok()
+                            .and_then(|guard| guard.as_ref().cloned());
+                        if let Some(subscriber) = subscriber {
+                            let (forwarded_tx, forwarded_rx) = oneshot::channel();
+                            if subscriber.send((notification, forwarded_tx)).is_ok() {
+                                let _ = forwarded_rx.await;
+                            } else if let Ok(mut guard) = notification_subscriber.lock() {
+                                *guard = None;
                             }
                         }
                     }

--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -1,6 +1,6 @@
 use crate::acp::custom_notifications::*;
 use crate::acp::custom_requests::*;
-use crate::acp::fs::AcpTools;
+use crate::acp::fs::{AcpTools, ClientTerminalShell};
 pub(super) use crate::acp::response_builder::{
     build_config_options, build_mode_state, build_model_state, build_provider_options,
     build_session_info, build_session_setup_config, send_session_setup_notifications, session_meta,
@@ -223,6 +223,7 @@ pub struct GooseAcpAgent {
     builtins: Vec<String>,
     client_fs_capabilities: OnceCell<FileSystemCapabilities>,
     client_terminal: OnceCell<bool>,
+    client_terminal_shell: OnceCell<ClientTerminalShell>,
     client_mcp_host_info: OnceCell<GooseMcpHostInfo>,
     client_supports_acp_elicitation: OnceCell<bool>,
     client_supports_goose_custom_notifications: OnceCell<bool>,
@@ -324,6 +325,8 @@ struct ClientCapabilitiesMeta {
 struct GooseClientCapabilities {
     #[serde(rename = "mcpHostCapabilities", default)]
     mcp_host_capabilities: Option<GooseMcpHostCapabilities>,
+    #[serde(rename = "terminalShell", default)]
+    terminal_shell: Option<ClientTerminalShell>,
     #[serde(rename = "customNotifications", default)]
     custom_notifications: Option<bool>,
     #[serde(rename = "recipeParameterRequests", default)]
@@ -646,6 +649,7 @@ impl GooseAcpAgent {
             builtins: options.builtins,
             client_fs_capabilities: OnceCell::new(),
             client_terminal: OnceCell::new(),
+            client_terminal_shell: OnceCell::new(),
             client_mcp_host_info: OnceCell::new(),
             client_supports_acp_elicitation: OnceCell::new(),
             client_supports_goose_custom_notifications: OnceCell::new(),
@@ -817,6 +821,7 @@ impl GooseAcpAgent {
             fs_read: client_fs_capabilities.read_text_file,
             fs_write: client_fs_capabilities.write_text_file,
             terminal: client_terminal,
+            terminal_shell: self.client_terminal_shell.get().cloned(),
         });
         let info = client.get_info().cloned();
 
@@ -1465,6 +1470,12 @@ impl GooseAcpAgent {
         let _ = self.client_terminal.set(args.client_capabilities.terminal);
         let goose_client_capabilities =
             extract_client_capabilities_meta(&args).and_then(|meta| meta.goose);
+        if let Some(terminal_shell) = goose_client_capabilities
+            .as_ref()
+            .and_then(|capabilities| capabilities.terminal_shell.clone())
+        {
+            let _ = self.client_terminal_shell.set(terminal_shell);
+        }
         let _ = self.client_mcp_host_info.set(extract_client_mcp_host_info(
             &args,
             goose_client_capabilities.as_ref(),
@@ -2814,6 +2825,34 @@ print(\"hello, world\")
         assert!(extract_client_supports_goose_custom_notifications(
             goose_client_capabilities.as_ref()
         ));
+    }
+
+    #[test]
+    fn test_terminal_shell_capability_reads_client_meta() {
+        let request =
+            InitializeRequest::new(agent_client_protocol::schema::ProtocolVersion::LATEST)
+                .client_capabilities(
+                    agent_client_protocol::schema::v1::ClientCapabilities::new().meta(
+                        serde_json::json!({
+                            "goose": {
+                                "terminalShell": {
+                                    "executable": "cmd",
+                                    "argsPrefix": ["/C"]
+                                }
+                            }
+                        })
+                        .as_object()
+                        .unwrap()
+                        .clone(),
+                    ),
+                );
+        let shell = extract_client_capabilities_meta(&request)
+            .and_then(|meta| meta.goose)
+            .and_then(|goose| goose.terminal_shell)
+            .unwrap();
+
+        assert_eq!(shell.executable, "cmd");
+        assert_eq!(shell.args_prefix, vec!["/C"]);
     }
 
     #[test]

--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -1853,23 +1853,28 @@ impl GooseAcpAgent {
                 let forward_session_id = args.session_id.clone();
                 let forward_cx = cx.clone();
                 let task = tokio::spawn(async move {
-                    while let Some(notification) = notifications.recv().await {
-                        match rescope_terminal_notification(
+                    while let Some((notification, forwarded_tx)) = notifications.recv().await {
+                        let should_continue = match rescope_terminal_notification(
                             notification,
                             &provider_session_id,
                             &forward_session_id,
                         ) {
                             Ok(Some(notification)) => {
-                                if forward_cx.send_notification(notification).is_err() {
-                                    break;
-                                }
+                                forward_cx.send_notification(notification).is_ok()
                             }
-                            Ok(None) => continue,
-                            Err(error) => warn!(
-                                %error,
-                                session = %forward_session_id.0,
-                                "could not decode ACP provider terminal notification"
-                            ),
+                            Ok(None) => true,
+                            Err(error) => {
+                                warn!(
+                                    %error,
+                                    session = %forward_session_id.0,
+                                    "could not decode ACP provider terminal notification"
+                                );
+                                true
+                            }
+                        };
+                        let _ = forwarded_tx.send(());
+                        if !should_continue {
+                            break;
                         }
                     }
                 });

--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -2254,6 +2254,7 @@ impl GooseAcpAgent {
             .update_thinking_effort(session_id, effort)
             .await
             .internal_err_ctx("Failed to update thinking effort")?;
+        self.reset_provider_notification_task(session_id).await;
 
         Ok(())
     }

--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -170,11 +170,35 @@ const PROVIDER_CONFIG_STATUS_CHECK_CONCURRENCY: usize = 16;
 /// below is keyed by session ID.
 struct GooseAcpSession {
     agent: Arc<Agent>,
+    provider_notification_task: Option<tokio::task::JoinHandle<()>>,
 }
 
 struct ActivePromptRun {
     run_id: String,
     cancel_token: CancellationToken,
+}
+
+fn is_terminal_provider_notification(
+    notification: &serde_json::Value,
+    provider_session_id: &str,
+) -> bool {
+    if notification
+        .get("sessionId")
+        .and_then(|value| value.as_str())
+        != Some(provider_session_id)
+    {
+        return false;
+    }
+
+    notification
+        .get("update")
+        .and_then(|value| value.get("_meta"))
+        .and_then(|value| value.as_object())
+        .is_some_and(|meta| {
+            meta.contains_key("terminal_output")
+                || meta.contains_key("terminal_output_delta")
+                || meta.contains_key("terminal_exit")
+        })
 }
 
 pub struct GooseAcpAgentOptions {
@@ -904,7 +928,10 @@ impl GooseAcpAgent {
     }
 
     async fn register_acp_session(&self, session_id: String, agent: Arc<Agent>) {
-        let acp_session = GooseAcpSession { agent };
+        let acp_session = GooseAcpSession {
+            agent,
+            provider_notification_task: None,
+        };
         self.sessions.lock().await.insert(session_id, acp_session);
     }
 
@@ -1802,6 +1829,53 @@ impl GooseAcpAgent {
             retry_config: None,
         };
 
+        let needs_provider_notification_task = self
+            .sessions
+            .lock()
+            .await
+            .get(&session_id)
+            .is_some_and(|session| {
+                session
+                    .provider_notification_task
+                    .as_ref()
+                    .is_none_or(tokio::task::JoinHandle::is_finished)
+            });
+        if needs_provider_notification_task {
+            let provider_notifications = agent
+                .provider()
+                .await
+                .ok()
+                .and_then(|provider| provider.take_acp_notification_receiver());
+            if let Some((provider_session_id, mut notifications)) = provider_notifications {
+                let forward_session_id = args.session_id.clone();
+                let forward_cx = cx.clone();
+                let task = tokio::spawn(async move {
+                    while let Some(mut notification) = notifications.recv().await {
+                        if !is_terminal_provider_notification(&notification, &provider_session_id) {
+                            continue;
+                        }
+                        notification["sessionId"] =
+                            serde_json::Value::String(forward_session_id.0.to_string());
+                        match serde_json::from_value::<SessionNotification>(notification) {
+                            Ok(notification) => {
+                                if forward_cx.send_notification(notification).is_err() {
+                                    break;
+                                }
+                            }
+                            Err(error) => warn!(
+                                %error,
+                                session = %forward_session_id.0,
+                                "could not decode ACP provider terminal notification"
+                            ),
+                        }
+                    }
+                });
+                if let Some(session) = self.sessions.lock().await.get_mut(&session_id) {
+                    session.provider_notification_task = Some(task);
+                }
+            }
+        }
+
         let mut stream = match agent
             .reply(user_message, session_config, Some(cancel_token.clone()))
             .await
@@ -2251,7 +2325,11 @@ impl GooseAcpAgent {
         }
 
         let mut sessions = self.sessions.lock().await;
-        sessions.remove(session_id);
+        if let Some(mut session) = sessions.remove(session_id) {
+            if let Some(task) = session.provider_notification_task.take() {
+                task.abort();
+            }
+        }
         drop(sessions);
 
         self.agent_manager
@@ -2355,6 +2433,30 @@ mod tests {
     use std::path::PathBuf;
     use tempfile::NamedTempFile;
     use test_case::test_case;
+
+    #[test]
+    fn terminal_provider_notifications_are_scoped_and_filtered() {
+        let terminal = serde_json::json!({
+            "sessionId": "nested-1",
+            "update": {
+                "sessionUpdate": "tool_call_update",
+                "_meta": {
+                    "terminal_output_delta": {
+                        "terminal_id": "command-1",
+                        "data": "hello"
+                    }
+                }
+            }
+        });
+        assert!(is_terminal_provider_notification(&terminal, "nested-1"));
+        assert!(!is_terminal_provider_notification(&terminal, "nested-2"));
+
+        let ordinary = serde_json::json!({
+            "sessionId": "nested-1",
+            "update": { "sessionUpdate": "agent_message_chunk" }
+        });
+        assert!(!is_terminal_provider_notification(&ordinary, "nested-1"));
+    }
 
     #[test_case(
         McpServer::Stdio(

--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -178,27 +178,29 @@ struct ActivePromptRun {
     cancel_token: CancellationToken,
 }
 
-fn is_terminal_provider_notification(
-    notification: &serde_json::Value,
-    provider_session_id: &str,
-) -> bool {
-    if notification
-        .get("sessionId")
-        .and_then(|value| value.as_str())
-        != Some(provider_session_id)
-    {
-        return false;
+fn abort_provider_notification_task(task: &mut Option<tokio::task::JoinHandle<()>>) {
+    if let Some(task) = task.take() {
+        task.abort();
     }
+}
 
-    notification
-        .get("update")
-        .and_then(|value| value.get("_meta"))
-        .and_then(|value| value.as_object())
-        .is_some_and(|meta| {
-            meta.contains_key("terminal_output")
-                || meta.contains_key("terminal_output_delta")
-                || meta.contains_key("terminal_exit")
-        })
+fn needs_provider_notification_task(
+    client_supports_terminal: bool,
+    task: Option<&tokio::task::JoinHandle<()>>,
+) -> bool {
+    client_supports_terminal && task.is_none_or(tokio::task::JoinHandle::is_finished)
+}
+
+fn rescope_terminal_notification(
+    mut notification: serde_json::Value,
+    provider_session_id: &str,
+    outer_session_id: &SessionId,
+) -> Result<Option<SessionNotification>, serde_json::Error> {
+    if !crate::acp::is_terminal_notification(&notification, provider_session_id) {
+        return Ok(None);
+    }
+    notification["sessionId"] = serde_json::Value::String(outer_session_id.0.to_string());
+    serde_json::from_value(notification).map(Some)
 }
 
 pub struct GooseAcpAgentOptions {
@@ -1829,16 +1831,17 @@ impl GooseAcpAgent {
             retry_config: None,
         };
 
+        let client_supports_terminal = self.client_terminal.get().copied().unwrap_or(false);
         let needs_provider_notification_task = self
             .sessions
             .lock()
             .await
             .get(&session_id)
             .is_some_and(|session| {
-                session
-                    .provider_notification_task
-                    .as_ref()
-                    .is_none_or(tokio::task::JoinHandle::is_finished)
+                needs_provider_notification_task(
+                    client_supports_terminal,
+                    session.provider_notification_task.as_ref(),
+                )
             });
         if needs_provider_notification_task {
             let provider_notifications = agent
@@ -1850,18 +1853,18 @@ impl GooseAcpAgent {
                 let forward_session_id = args.session_id.clone();
                 let forward_cx = cx.clone();
                 let task = tokio::spawn(async move {
-                    while let Some(mut notification) = notifications.recv().await {
-                        if !is_terminal_provider_notification(&notification, &provider_session_id) {
-                            continue;
-                        }
-                        notification["sessionId"] =
-                            serde_json::Value::String(forward_session_id.0.to_string());
-                        match serde_json::from_value::<SessionNotification>(notification) {
-                            Ok(notification) => {
+                    while let Some(notification) = notifications.recv().await {
+                        match rescope_terminal_notification(
+                            notification,
+                            &provider_session_id,
+                            &forward_session_id,
+                        ) {
+                            Ok(Some(notification)) => {
                                 if forward_cx.send_notification(notification).is_err() {
                                     break;
                                 }
                             }
+                            Ok(None) => continue,
                             Err(error) => warn!(
                                 %error,
                                 session = %forward_session_id.0,
@@ -2112,6 +2115,12 @@ impl GooseAcpAgent {
         Ok(())
     }
 
+    async fn reset_provider_notification_task(&self, session_id: &str) {
+        if let Some(session) = self.sessions.lock().await.get_mut(session_id) {
+            abort_provider_notification_task(&mut session.provider_notification_task);
+        }
+    }
+
     async fn on_set_model(
         &self,
         session_id: &str,
@@ -2140,6 +2149,7 @@ impl GooseAcpAgent {
             .recreate_provider_for_session(session_id, &provider_name, model_config)
             .await
             .internal_err_ctx("Failed to recreate provider")?;
+        self.reset_provider_notification_task(session_id).await;
         // model_config is already updated on the session by the agent's update_provider call.
         Ok(())
     }
@@ -2291,6 +2301,7 @@ impl GooseAcpAgent {
             .recreate_provider_for_session(session_id, &resolved_provider_name, model_config)
             .await
             .internal_err_ctx("Failed to recreate provider")?;
+        self.reset_provider_notification_task(session_id).await;
 
         // provider_name is already updated on the session by the agent's update_provider call.
         Ok(())
@@ -2326,9 +2337,7 @@ impl GooseAcpAgent {
 
         let mut sessions = self.sessions.lock().await;
         if let Some(mut session) = sessions.remove(session_id) {
-            if let Some(task) = session.provider_notification_task.take() {
-                task.abort();
-            }
+            abort_provider_notification_task(&mut session.provider_notification_task);
         }
         drop(sessions);
 
@@ -2435,6 +2444,21 @@ mod tests {
     use test_case::test_case;
 
     #[test]
+    fn forwarding_task_requires_terminal_capability() {
+        assert!(!needs_provider_notification_task(false, None));
+        assert!(needs_provider_notification_task(true, None));
+    }
+
+    #[tokio::test]
+    async fn aborting_provider_notification_task_clears_the_session_slot() {
+        let mut task = Some(tokio::spawn(std::future::pending::<()>()));
+
+        abort_provider_notification_task(&mut task);
+
+        assert!(task.is_none());
+    }
+
+    #[test]
     fn terminal_provider_notifications_are_scoped_and_filtered() {
         let terminal = serde_json::json!({
             "sessionId": "nested-1",
@@ -2448,14 +2472,44 @@ mod tests {
                 }
             }
         });
-        assert!(is_terminal_provider_notification(&terminal, "nested-1"));
-        assert!(!is_terminal_provider_notification(&terminal, "nested-2"));
+        assert!(crate::acp::is_terminal_notification(&terminal, "nested-1"));
+        assert!(!crate::acp::is_terminal_notification(&terminal, "nested-2"));
 
         let ordinary = serde_json::json!({
             "sessionId": "nested-1",
             "update": { "sessionUpdate": "agent_message_chunk" }
         });
-        assert!(!is_terminal_provider_notification(&ordinary, "nested-1"));
+        assert!(!crate::acp::is_terminal_notification(&ordinary, "nested-1"));
+    }
+
+    #[test]
+    fn terminal_provider_notifications_are_rescoped_to_the_outer_session() {
+        let terminal = serde_json::json!({
+            "sessionId": "nested-1",
+            "update": {
+                "sessionUpdate": "tool_call_update",
+                "toolCallId": "command-1",
+                "fields": {},
+                "_meta": {
+                    "terminal_output_delta": {
+                        "terminal_id": "command-1",
+                        "data": "hello"
+                    }
+                }
+            }
+        });
+
+        let forwarded =
+            rescope_terminal_notification(terminal, "nested-1", &SessionId::new("outer-1"))
+                .unwrap()
+                .expect("expected a terminal notification");
+
+        assert_eq!(forwarded.session_id.0.as_ref(), "outer-1");
+        let forwarded = serde_json::to_value(forwarded).unwrap();
+        assert_eq!(
+            forwarded["update"]["_meta"]["terminal_output_delta"]["data"],
+            "hello"
+        );
     }
 
     #[test_case(

--- a/crates/goose/src/agents/platform_extensions/developer/shell.rs
+++ b/crates/goose/src/agents/platform_extensions/developer/shell.rs
@@ -92,7 +92,7 @@ fn unix_shell_command_args(command_line: &str) -> [&str; 2] {
 /// the host filesystem. `GOOSE_SHELL` is passed through as-is.
 ///
 #[cfg(windows)]
-fn windows_shell() -> String {
+pub(crate) fn windows_shell() -> String {
     std::env::var("GOOSE_SHELL").unwrap_or_else(|_| "cmd".to_string())
 }
 
@@ -100,7 +100,7 @@ fn windows_shell() -> String {
 /// pick the right argument style on Windows and to tell the LLM which
 /// dialect to write in the tool description.
 #[cfg(windows)]
-fn shell_basename(shell: &str) -> String {
+pub(crate) fn shell_basename(shell: &str) -> String {
     Path::new(shell)
         .file_stem()
         .and_then(|s| s.to_str())
@@ -137,7 +137,7 @@ pub fn shell_display_name() -> String {
 /// to `sh`. Users who really want their login shell can opt in via
 /// `GOOSE_SHELL`.
 #[cfg(not(windows))]
-fn unix_shell() -> String {
+pub(crate) fn unix_shell() -> String {
     if let Ok(shell) = std::env::var("GOOSE_SHELL") {
         return shell;
     }
@@ -145,6 +145,32 @@ fn unix_shell() -> String {
         "bash".to_string()
     } else {
         "sh".to_string()
+    }
+}
+
+pub(crate) fn terminal_shell_command(command_line: &str) -> (String, Vec<String>) {
+    #[cfg(windows)]
+    {
+        let shell = windows_shell();
+        let args = match shell_basename(&shell).as_str() {
+            "pwsh" | "powershell" => vec![
+                "-NoProfile".to_string(),
+                "-NonInteractive".to_string(),
+                "-Command".to_string(),
+                command_line.to_string(),
+            ],
+            "cmd" => vec!["/C".to_string(), command_line.to_string()],
+            _ => vec!["-c".to_string(), command_line.to_string()],
+        };
+        (shell, args)
+    }
+
+    #[cfg(not(windows))]
+    {
+        (
+            unix_shell(),
+            vec!["-c".to_string(), command_line.to_string()],
+        )
     }
 }
 

--- a/crates/goose/tests/acp_common_tests/mod.rs
+++ b/crates/goose/tests/acp_common_tests/mod.rs
@@ -1454,11 +1454,13 @@ pub async fn run_shell_terminal_true<C: Connection>() {
     )
     .await;
 
-    let command = format!("echo {SHELL_TEST_CONTENT}");
+    let script = format!(
+        "echo {SHELL_TEST_CONTENT}\n__goose_command_status=$?\nwait\nexit \"$__goose_command_status\""
+    );
     let output_text = format!("{SHELL_TEST_CONTENT}\n");
     let tid = String::from("term-1");
     let terminal = TerminalFixture::new(vec![
-        TerminalCall::Create(command.clone(), tid.clone()),
+        TerminalCall::Create("sh".into(), vec!["-c".into(), script], tid.clone()),
         TerminalCall::WaitForExit(tid.clone(), 0),
         TerminalCall::Output(tid.clone(), output_text.clone(), 0),
         TerminalCall::Release(tid),

--- a/crates/goose/tests/acp_common_tests/mod.rs
+++ b/crates/goose/tests/acp_common_tests/mod.rs
@@ -1454,13 +1454,10 @@ pub async fn run_shell_terminal_true<C: Connection>() {
     )
     .await;
 
-    let script = format!(
-        "echo {SHELL_TEST_CONTENT}\n__goose_command_status=$?\nwait\nexit \"$__goose_command_status\""
-    );
     let output_text = format!("{SHELL_TEST_CONTENT}\n");
     let tid = String::from("term-1");
     let terminal = TerminalFixture::new(vec![
-        TerminalCall::Create("sh".into(), vec!["-c".into(), script], tid.clone()),
+        TerminalCall::Create(tid.clone()),
         TerminalCall::WaitForExit(tid.clone(), 0),
         TerminalCall::Output(tid.clone(), output_text.clone(), 0),
         TerminalCall::Release(tid),

--- a/crates/goose/tests/acp_fixtures/mod.rs
+++ b/crates/goose/tests/acp_fixtures/mod.rs
@@ -367,20 +367,23 @@ pub fn nested_terminal_agent() -> impl agent_client_protocol::ConnectTo<AcpClien
                     meta.insert(key.to_string(), value);
                     meta
                 };
-                cx.send_notification(SessionNotification::new(
-                    request.session_id.clone(),
-                    SessionUpdate::ToolCallUpdate(
-                        ToolCallUpdate::new(tool_call_id, ToolCallUpdateFields::new()).meta(
-                            terminal_meta(
-                                "terminal_output_delta",
-                                serde_json::json!({
-                                    "terminal_id": "nested-terminal-1",
-                                    "data": "hello"
-                                }),
+                for sequence in 0..128 {
+                    cx.send_notification(SessionNotification::new(
+                        request.session_id.clone(),
+                        SessionUpdate::ToolCallUpdate(
+                            ToolCallUpdate::new(tool_call_id, ToolCallUpdateFields::new()).meta(
+                                terminal_meta(
+                                    "terminal_output_delta",
+                                    serde_json::json!({
+                                        "terminal_id": "nested-terminal-1",
+                                        "data": format!("chunk-{sequence}"),
+                                        "sequence": sequence
+                                    }),
+                                ),
                             ),
                         ),
-                    ),
-                ))?;
+                    ))?;
+                }
                 cx.send_notification(SessionNotification::new(
                     request.session_id.clone(),
                     SessionUpdate::ToolCallUpdate(

--- a/crates/goose/tests/acp_fixtures/mod.rs
+++ b/crates/goose/tests/acp_fixtures/mod.rs
@@ -387,23 +387,18 @@ pub fn nested_terminal_agent() -> impl agent_client_protocol::ConnectTo<AcpClien
                 cx.send_notification(SessionNotification::new(
                     request.session_id.clone(),
                     SessionUpdate::ToolCallUpdate(
-                        ToolCallUpdate::new(tool_call_id, ToolCallUpdateFields::new()).meta(
-                            terminal_meta(
-                                "terminal_exit",
-                                serde_json::json!({
-                                    "terminal_id": "nested-terminal-1",
-                                    "exit_code": 0
-                                }),
-                            ),
-                        ),
+                        ToolCallUpdate::new(
+                            tool_call_id,
+                            ToolCallUpdateFields::new().status(ToolCallStatus::Completed),
+                        )
+                        .meta(terminal_meta(
+                            "terminal_exit",
+                            serde_json::json!({
+                                "terminal_id": "nested-terminal-1",
+                                "exit_code": 0
+                            }),
+                        )),
                     ),
-                ))?;
-                cx.send_notification(SessionNotification::new(
-                    request.session_id.clone(),
-                    SessionUpdate::ToolCallUpdate(ToolCallUpdate::new(
-                        tool_call_id,
-                        ToolCallUpdateFields::new().status(ToolCallStatus::Completed),
-                    )),
                 ))?;
                 responder.respond(PromptResponse::new(StopReason::EndTurn))
             },

--- a/crates/goose/tests/acp_fixtures/mod.rs
+++ b/crates/goose/tests/acp_fixtures/mod.rs
@@ -561,10 +561,10 @@ impl FsFixture {
 #[allow(dead_code)]
 pub enum TerminalCall {
     Create(String, Vec<String>, String), // (command, args, terminal_id)
-    WaitForExit(String, u32),    // (terminal_id, exit_code)
-    Output(String, String, u32), // (terminal_id, text, exit_code)
-    Release(String),             // terminal_id
-    Kill(String),                // terminal_id
+    WaitForExit(String, u32),            // (terminal_id, exit_code)
+    Output(String, String, u32),         // (terminal_id, text, exit_code)
+    Release(String),                     // terminal_id
+    Kill(String),                        // terminal_id
 }
 
 impl TerminalCall {

--- a/crates/goose/tests/acp_fixtures/mod.rs
+++ b/crates/goose/tests/acp_fixtures/mod.rs
@@ -560,7 +560,7 @@ impl FsFixture {
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
 pub enum TerminalCall {
-    Create(String, String),      // (command, terminal_id)
+    Create(String, Vec<String>, String), // (command, args, terminal_id)
     WaitForExit(String, u32),    // (terminal_id, exit_code)
     Output(String, String, u32), // (terminal_id, text, exit_code)
     Release(String),             // terminal_id
@@ -616,11 +616,18 @@ impl TerminalFixture {
         }
     }
 
-    pub fn on_create(&self, command: &str) -> CreateTerminalResponse {
-        if let Some(TerminalCall::Create(expect_command, terminal_id)) = self.pop("create") {
+    pub fn on_create(&self, command: &str, args: &[String]) -> CreateTerminalResponse {
+        if let Some(TerminalCall::Create(expect_command, expect_args, terminal_id)) =
+            self.pop("create")
+        {
             if command != expect_command {
                 self.record_error(format!(
                     "create: expected command {expect_command}, got {command}"
+                ));
+            }
+            if args != expect_args {
+                self.record_error(format!(
+                    "create: expected args {expect_args:?}, got {args:?}"
                 ));
             }
             CreateTerminalResponse::new(TerminalId::new(terminal_id))

--- a/crates/goose/tests/acp_fixtures/mod.rs
+++ b/crates/goose/tests/acp_fixtures/mod.rs
@@ -2,12 +2,15 @@
 #![allow(unused_attributes)]
 
 use agent_client_protocol::schema::v1::{
-    CreateTerminalResponse, KillTerminalResponse, ListSessionsResponse, McpServer,
-    ReadTextFileRequest, ReadTextFileResponse, ReleaseTerminalResponse, SessionModeState,
-    SessionUpdate, TerminalExitStatus, TerminalId, TerminalOutputResponse, ToolCallContent,
-    ToolCallStatus, ToolKind, WaitForTerminalExitResponse, WriteTextFileRequest,
-    WriteTextFileResponse,
+    AgentCapabilities, CreateTerminalResponse, InitializeRequest, InitializeResponse,
+    KillTerminalResponse, ListSessionsResponse, McpServer, NewSessionRequest, NewSessionResponse,
+    PromptRequest, PromptResponse, ReadTextFileRequest, ReadTextFileResponse,
+    ReleaseTerminalResponse, SessionModeState, SessionNotification, SessionUpdate, StopReason,
+    TerminalExitStatus, TerminalId, TerminalOutputResponse, ToolCall, ToolCallContent,
+    ToolCallStatus, ToolCallUpdate, ToolCallUpdateFields, ToolKind, WaitForTerminalExitResponse,
+    WriteTextFileRequest, WriteTextFileResponse,
 };
+use agent_client_protocol::{Agent as AcpAgent, Client as AcpClient};
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use fs_err as fs;
@@ -326,6 +329,83 @@ pub async fn serve_agent_in_process(
     let transport =
         agent_client_protocol::ByteStreams::new(client_write.compat_write(), client_read.compat());
     (transport, handle)
+}
+
+pub fn nested_terminal_agent() -> impl agent_client_protocol::ConnectTo<AcpClient> {
+    AcpAgent
+        .builder()
+        .name("nested-terminal-fixture")
+        .on_receive_request(
+            async move |initialize: InitializeRequest, responder, _cx| {
+                responder.respond(
+                    InitializeResponse::new(initialize.protocol_version)
+                        .agent_capabilities(AgentCapabilities::new()),
+                )
+            },
+            agent_client_protocol::on_receive_request!(),
+        )
+        .on_receive_request(
+            async move |_request: NewSessionRequest, responder, _cx| {
+                responder.respond(NewSessionResponse::new("nested-session"))
+            },
+            agent_client_protocol::on_receive_request!(),
+        )
+        .on_receive_request(
+            async move |request: PromptRequest, responder, cx| {
+                let tool_call_id = "provider-call-1";
+                cx.send_notification(SessionNotification::new(
+                    request.session_id.clone(),
+                    SessionUpdate::ToolCall(
+                        ToolCall::new(tool_call_id, "Run foreground command")
+                            .kind(ToolKind::Execute)
+                            .status(ToolCallStatus::InProgress),
+                    ),
+                ))?;
+
+                let terminal_meta = |key: &str, value: serde_json::Value| {
+                    let mut meta = agent_client_protocol::schema::v1::Meta::new();
+                    meta.insert(key.to_string(), value);
+                    meta
+                };
+                cx.send_notification(SessionNotification::new(
+                    request.session_id.clone(),
+                    SessionUpdate::ToolCallUpdate(
+                        ToolCallUpdate::new(tool_call_id, ToolCallUpdateFields::new()).meta(
+                            terminal_meta(
+                                "terminal_output_delta",
+                                serde_json::json!({
+                                    "terminal_id": "nested-terminal-1",
+                                    "data": "hello"
+                                }),
+                            ),
+                        ),
+                    ),
+                ))?;
+                cx.send_notification(SessionNotification::new(
+                    request.session_id.clone(),
+                    SessionUpdate::ToolCallUpdate(
+                        ToolCallUpdate::new(tool_call_id, ToolCallUpdateFields::new()).meta(
+                            terminal_meta(
+                                "terminal_exit",
+                                serde_json::json!({
+                                    "terminal_id": "nested-terminal-1",
+                                    "exit_code": 0
+                                }),
+                            ),
+                        ),
+                    ),
+                ))?;
+                cx.send_notification(SessionNotification::new(
+                    request.session_id.clone(),
+                    SessionUpdate::ToolCallUpdate(ToolCallUpdate::new(
+                        tool_call_id,
+                        ToolCallUpdateFields::new().status(ToolCallStatus::Completed),
+                    )),
+                ))?;
+                responder.respond(PromptResponse::new(StopReason::EndTurn))
+            },
+            agent_client_protocol::on_receive_request!(),
+        )
 }
 
 #[allow(dead_code)]

--- a/crates/goose/tests/acp_fixtures/mod.rs
+++ b/crates/goose/tests/acp_fixtures/mod.rs
@@ -560,11 +560,11 @@ impl FsFixture {
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
 pub enum TerminalCall {
-    Create(String, Vec<String>, String), // (command, args, terminal_id)
-    WaitForExit(String, u32),            // (terminal_id, exit_code)
-    Output(String, String, u32),         // (terminal_id, text, exit_code)
-    Release(String),                     // terminal_id
-    Kill(String),                        // terminal_id
+    Create(String),              // terminal_id
+    WaitForExit(String, u32),    // (terminal_id, exit_code)
+    Output(String, String, u32), // (terminal_id, text, exit_code)
+    Release(String),             // terminal_id
+    Kill(String),                // terminal_id
 }
 
 impl TerminalCall {
@@ -616,20 +616,8 @@ impl TerminalFixture {
         }
     }
 
-    pub fn on_create(&self, command: &str, args: &[String]) -> CreateTerminalResponse {
-        if let Some(TerminalCall::Create(expect_command, expect_args, terminal_id)) =
-            self.pop("create")
-        {
-            if command != expect_command {
-                self.record_error(format!(
-                    "create: expected command {expect_command}, got {command}"
-                ));
-            }
-            if args != expect_args {
-                self.record_error(format!(
-                    "create: expected args {expect_args:?}, got {args:?}"
-                ));
-            }
+    pub fn on_create(&self) -> CreateTerminalResponse {
+        if let Some(TerminalCall::Create(terminal_id)) = self.pop("create") {
             CreateTerminalResponse::new(TerminalId::new(terminal_id))
         } else {
             CreateTerminalResponse::new(TerminalId::new("error"))

--- a/crates/goose/tests/acp_fixtures/server.rs
+++ b/crates/goose/tests/acp_fixtures/server.rs
@@ -212,7 +212,7 @@ impl Connection for AcpServerConnection {
                         {
                             let t = terminal.clone();
                             async move |req: CreateTerminalRequest, responder, _cx| match t {
-                                Some(ref f) => responder.respond(f.on_create(&req.command)),
+                                Some(ref f) => responder.respond(f.on_create(&req.command, &req.args)),
                                 None => responder.respond_with_error(
                                     agent_client_protocol::Error::method_not_found(),
                                 ),

--- a/crates/goose/tests/acp_fixtures/server.rs
+++ b/crates/goose/tests/acp_fixtures/server.rs
@@ -212,7 +212,9 @@ impl Connection for AcpServerConnection {
                         {
                             let t = terminal.clone();
                             async move |req: CreateTerminalRequest, responder, _cx| match t {
-                                Some(ref f) => responder.respond(f.on_create(&req.command, &req.args)),
+                                Some(ref f) => {
+                                    responder.respond(f.on_create(&req.command, &req.args))
+                                }
                                 None => responder.respond_with_error(
                                     agent_client_protocol::Error::method_not_found(),
                                 ),

--- a/crates/goose/tests/acp_fixtures/server.rs
+++ b/crates/goose/tests/acp_fixtures/server.rs
@@ -211,10 +211,8 @@ impl Connection for AcpServerConnection {
                     .on_receive_request(
                         {
                             let t = terminal.clone();
-                            async move |req: CreateTerminalRequest, responder, _cx| match t {
-                                Some(ref f) => {
-                                    responder.respond(f.on_create(&req.command, &req.args))
-                                }
+                            async move |_req: CreateTerminalRequest, responder, _cx| match t {
+                                Some(ref f) => responder.respond(f.on_create()),
                                 None => responder.respond_with_error(
                                     agent_client_protocol::Error::method_not_found(),
                                 ),

--- a/crates/goose/tests/acp_provider_test.rs
+++ b/crates/goose/tests/acp_provider_test.rs
@@ -77,7 +77,7 @@ fn test_nested_terminal_notifications_follow_tool_call_start() {
             let completion = stream.next();
             tokio::pin!(completion);
             for expected_sequence in 0..128 {
-                let terminal_delta = tokio::select! {
+                let (terminal_delta, forwarded_tx) = tokio::select! {
                     biased;
                     update = terminal_notifications.recv() => {
                         update.expect("expected terminal output")
@@ -90,8 +90,13 @@ fn test_nested_terminal_notifications_follow_tool_call_start() {
                     terminal_delta["update"]["_meta"]["terminal_output_delta"]["sequence"],
                     expected_sequence
                 );
+                assert!(
+                    futures::poll!(&mut completion).is_pending(),
+                    "completion must wait for terminal delivery acknowledgement"
+                );
+                let _ = forwarded_tx.send(());
             }
-            let terminal_exit = tokio::select! {
+            let (terminal_exit, forwarded_tx) = tokio::select! {
                 biased;
                 update = terminal_notifications.recv() => update.expect("expected terminal exit"),
                 _ = &mut completion => panic!("tool call completed before terminal exit"),
@@ -99,6 +104,11 @@ fn test_nested_terminal_notifications_follow_tool_call_start() {
             assert!(terminal_exit["update"]["_meta"]
                 .get("terminal_exit")
                 .is_some());
+            assert!(
+                futures::poll!(&mut completion).is_pending(),
+                "completion must wait for terminal exit acknowledgement"
+            );
+            let _ = forwarded_tx.send(());
 
             let completion = completion
                 .await

--- a/crates/goose/tests/acp_provider_test.rs
+++ b/crates/goose/tests/acp_provider_test.rs
@@ -23,22 +23,26 @@ use goose::providers::base::Provider;
 use goose_providers::model::ModelConfig;
 use std::collections::HashMap;
 
+fn nested_terminal_provider_config() -> AcpProviderConfig {
+    AcpProviderConfig {
+        command: "unused".into(),
+        args: Vec::new(),
+        env: Vec::new(),
+        env_remove: Vec::new(),
+        work_dir: std::path::PathBuf::new(),
+        mcp_servers: Vec::new(),
+        session_mode_id: None,
+        session_config_options: Vec::new(),
+        model_config_option_id: None,
+        mode_mapping: HashMap::new(),
+        notification_callback: None,
+    }
+}
+
 #[test]
 fn test_nested_terminal_notifications_follow_tool_call_start() {
     run_test(async {
-        let config = AcpProviderConfig {
-            command: "unused".into(),
-            args: Vec::new(),
-            env: Vec::new(),
-            env_remove: Vec::new(),
-            work_dir: std::path::PathBuf::new(),
-            mcp_servers: Vec::new(),
-            session_mode_id: None,
-            session_config_options: Vec::new(),
-            model_config_option_id: None,
-            mode_mapping: HashMap::new(),
-            notification_callback: None,
-        };
+        let config = nested_terminal_provider_config();
         let provider = AcpProvider::connect_with_transport(
             "nested-acp".to_string(),
             GooseMode::Auto,
@@ -127,6 +131,42 @@ fn test_nested_terminal_notifications_follow_tool_call_start() {
         })
         .await
         .expect("terminal burst should drain without dropping lifecycle events");
+    });
+}
+
+#[test]
+fn test_chat_mode_suppresses_rejected_terminal_notifications() {
+    run_test(async {
+        let provider = AcpProvider::connect_with_transport(
+            "nested-acp".to_string(),
+            GooseMode::Chat,
+            nested_terminal_provider_config(),
+            agent_client_protocol::DynConnectTo::new(nested_terminal_agent()),
+        )
+        .await
+        .unwrap();
+        let (_session_id, mut terminal_notifications) = provider
+            .take_acp_notification_receiver()
+            .expect("ACP provider should expose terminal notifications");
+        let mut stream = provider
+            .stream(
+                &ModelConfig::new("nested-model"),
+                "",
+                &[Message::user().with_text("run a foreground command")],
+                &[],
+            )
+            .await
+            .unwrap();
+
+        let mut visible_text = Vec::new();
+        while let Some(item) = stream.next().await {
+            if let Some(message) = item.unwrap().0 {
+                visible_text.push(message.as_concat_text());
+            }
+        }
+
+        assert!(terminal_notifications.try_recv().is_err());
+        assert_eq!(visible_text, vec!["Tool call was denied."]);
     });
 }
 

--- a/crates/goose/tests/acp_provider_test.rs
+++ b/crates/goose/tests/acp_provider_test.rs
@@ -73,35 +73,50 @@ fn test_nested_terminal_notifications_follow_tool_call_start() {
         ));
         assert!(terminal_notifications.try_recv().is_err());
 
-        let completion = stream.next();
-        tokio::pin!(completion);
-        let terminal_delta = tokio::select! {
-            biased;
-            update = terminal_notifications.recv() => update.expect("expected terminal output"),
-            _ = &mut completion => panic!("tool call completed before terminal output"),
-        };
-        assert!(terminal_delta["update"]["_meta"]
-            .get("terminal_output_delta")
-            .is_some());
-        let terminal_exit = tokio::select! {
-            biased;
-            update = terminal_notifications.recv() => update.expect("expected terminal exit"),
-            _ = &mut completion => panic!("tool call completed before terminal exit"),
-        };
-        assert!(terminal_exit["update"]["_meta"]
-            .get("terminal_exit")
-            .is_some());
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            let completion = stream.next();
+            tokio::pin!(completion);
+            for expected_sequence in 0..128 {
+                let terminal_delta = tokio::select! {
+                    biased;
+                    update = terminal_notifications.recv() => {
+                        update.expect("expected terminal output")
+                    }
+                    _ = &mut completion => {
+                        panic!("tool call completed before terminal output burst")
+                    }
+                };
+                assert_eq!(
+                    terminal_delta["update"]["_meta"]["terminal_output_delta"]["sequence"],
+                    expected_sequence
+                );
+            }
+            let terminal_exit = tokio::select! {
+                biased;
+                update = terminal_notifications.recv() => update.expect("expected terminal exit"),
+                _ = &mut completion => panic!("tool call completed before terminal exit"),
+            };
+            assert!(terminal_exit["update"]["_meta"]
+                .get("terminal_exit")
+                .is_some());
 
-        let completion = completion
-            .await
-            .expect("expected a tool-call completion")
-            .unwrap()
-            .0
-            .expect("expected a message");
-        assert!(matches!(
-            completion.content.as_slice(),
-            [MessageContent::ToolResponse(_)]
-        ));
+            let completion = completion
+                .await
+                .expect("expected a tool-call completion")
+                .unwrap()
+                .0
+                .expect("expected a message");
+            assert!(matches!(
+                completion.content.as_slice(),
+                [MessageContent::ToolResponse(_)]
+            ));
+            assert!(
+                stream.next().await.is_none(),
+                "prompt stream must terminate"
+            );
+        })
+        .await
+        .expect("terminal burst should drain without dropping lifecycle events");
     });
 }
 

--- a/crates/goose/tests/acp_provider_test.rs
+++ b/crates/goose/tests/acp_provider_test.rs
@@ -4,7 +4,7 @@
 #[path = "acp_common_tests/mod.rs"]
 mod common_tests;
 use common_tests::fixtures::provider::AcpProviderConnection;
-use common_tests::fixtures::run_test;
+use common_tests::fixtures::{nested_terminal_agent, run_test};
 #[cfg(feature = "code-mode")]
 use common_tests::run_prompt_codemode;
 use common_tests::{
@@ -15,6 +15,95 @@ use common_tests::{
     run_prompt_mcp, run_prompt_model_mismatch, run_prompt_skill, run_shell_terminal_false,
     run_shell_terminal_true,
 };
+use futures::StreamExt;
+use goose::acp::{AcpProvider, AcpProviderConfig};
+use goose::config::GooseMode;
+use goose::conversation::message::{Message, MessageContent};
+use goose::providers::base::Provider;
+use goose_providers::model::ModelConfig;
+use std::collections::HashMap;
+
+#[test]
+fn test_nested_terminal_notifications_follow_tool_call_start() {
+    run_test(async {
+        let config = AcpProviderConfig {
+            command: "unused".into(),
+            args: Vec::new(),
+            env: Vec::new(),
+            env_remove: Vec::new(),
+            work_dir: std::path::PathBuf::new(),
+            mcp_servers: Vec::new(),
+            session_mode_id: None,
+            session_config_options: Vec::new(),
+            model_config_option_id: None,
+            mode_mapping: HashMap::new(),
+            notification_callback: None,
+        };
+        let provider = AcpProvider::connect_with_transport(
+            "nested-acp".to_string(),
+            GooseMode::Auto,
+            config,
+            agent_client_protocol::DynConnectTo::new(nested_terminal_agent()),
+        )
+        .await
+        .unwrap();
+        let (_session_id, mut terminal_notifications) = provider
+            .take_acp_notification_receiver()
+            .expect("ACP provider should expose terminal notifications");
+        let mut stream = provider
+            .stream(
+                &ModelConfig::new("nested-model"),
+                "",
+                &[Message::user().with_text("run a foreground command")],
+                &[],
+            )
+            .await
+            .unwrap();
+
+        let first = stream
+            .next()
+            .await
+            .expect("expected a tool-call start")
+            .unwrap()
+            .0
+            .expect("expected a message");
+        assert!(matches!(
+            first.content.as_slice(),
+            [MessageContent::ToolRequest(_)]
+        ));
+        assert!(terminal_notifications.try_recv().is_err());
+
+        let completion = stream.next();
+        tokio::pin!(completion);
+        let terminal_delta = tokio::select! {
+            biased;
+            update = terminal_notifications.recv() => update.expect("expected terminal output"),
+            _ = &mut completion => panic!("tool call completed before terminal output"),
+        };
+        assert!(terminal_delta["update"]["_meta"]
+            .get("terminal_output_delta")
+            .is_some());
+        let terminal_exit = tokio::select! {
+            biased;
+            update = terminal_notifications.recv() => update.expect("expected terminal exit"),
+            _ = &mut completion => panic!("tool call completed before terminal exit"),
+        };
+        assert!(terminal_exit["update"]["_meta"]
+            .get("terminal_exit")
+            .is_some());
+
+        let completion = completion
+            .await
+            .expect("expected a tool-call completion")
+            .unwrap()
+            .0
+            .expect("expected a message");
+        assert!(matches!(
+            completion.content.as_slice(),
+            [MessageContent::ToolResponse(_)]
+        ));
+    });
+}
 
 #[test]
 fn test_config_mcp() {

--- a/crates/goose/tests/acp_provider_test.rs
+++ b/crates/goose/tests/acp_provider_test.rs
@@ -108,6 +108,7 @@ fn test_nested_terminal_notifications_follow_tool_call_start() {
             assert!(terminal_exit["update"]["_meta"]
                 .get("terminal_exit")
                 .is_some());
+            assert!(terminal_exit["update"].get("status").is_none());
             assert!(
                 futures::poll!(&mut completion).is_pending(),
                 "completion must wait for terminal exit acknowledgement"

--- a/goose-self-test.yaml
+++ b/goose-self-test.yaml
@@ -20,7 +20,7 @@ parameters:
     input_type: string
     requirement: optional
     default: "all"
-    description: "Which test phases to run: all, basic, extensions, delegation, advanced"
+    description: "Which test phases to run: all, basic, extensions, delegation, terminal, vision, advanced"
 
   - key: test_depth
     input_type: string
@@ -323,8 +323,22 @@ prompt: |
   Log results to: {{ workspace_dir }}/phase3_delegation.md
   {% endif %}
 
+  {% if test_phases == "all" or "terminal" in test_phases %}
+  ## 🖥️ PHASE 3B: Nested Agent Foreground Terminal Testing
+
+  Use a synchronous delegate to run a foreground shell command that emits three delayed markers:
+  ```
+  delegate(instructions: "Run this exact command in the foreground and return its complete output: printf 'terminal-start\\n'; sleep 1; printf 'terminal-middle\\n'; sleep 1; printf 'terminal-end\\n'")
+  ```
+  Verify the delegate completes, the parent receives all three markers in order, and no output is
+  duplicated or delayed until a later prompt. Record a failure if terminal output is missing,
+  reordered, duplicated, or attached to the wrong session.
+
+  Log results to: {{ workspace_dir }}/phase3b_terminal.md
+  {% endif %}
+
   {% if test_phases == "all" or "vision" in test_phases %}
-  ## 📷 PHASE 3B: Local Inference Vision Testing
+  ## 📷 PHASE 3C: Local Inference Vision Testing
 
   **Prerequisites**: A vision-capable local model must be downloaded (e.g., gemma-4-E4B).
   Skip this phase if no local vision model is available.

--- a/goose-self-test.yaml
+++ b/goose-self-test.yaml
@@ -20,7 +20,7 @@ parameters:
     input_type: string
     requirement: optional
     default: "all"
-    description: "Which test phases to run: all, basic, extensions, delegation, terminal, vision, advanced"
+    description: "Which test phases to run: all, basic, extensions, delegation, vision, advanced"
 
   - key: test_depth
     input_type: string
@@ -323,22 +323,8 @@ prompt: |
   Log results to: {{ workspace_dir }}/phase3_delegation.md
   {% endif %}
 
-  {% if test_phases == "all" or "terminal" in test_phases %}
-  ## 🖥️ PHASE 3B: Nested Agent Foreground Terminal Testing
-
-  Use a synchronous delegate to run a foreground shell command that emits three delayed markers:
-  ```
-  delegate(instructions: "Run this exact command in the foreground and return its complete output: printf 'terminal-start\\n'; sleep 1; printf 'terminal-middle\\n'; sleep 1; printf 'terminal-end\\n'")
-  ```
-  Verify the delegate completes, the parent receives all three markers in order, and no output is
-  duplicated or delayed until a later prompt. Record a failure if terminal output is missing,
-  reordered, duplicated, or attached to the wrong session.
-
-  Log results to: {{ workspace_dir }}/phase3b_terminal.md
-  {% endif %}
-
   {% if test_phases == "all" or "vision" in test_phases %}
-  ## 📷 PHASE 3C: Local Inference Vision Testing
+  ## 📷 PHASE 3B: Local Inference Vision Testing
 
   **Prerequisites**: A vision-capable local model must be downloaded (e.g., gemma-4-E4B).
   Skip this phase if no local vision model is available.

--- a/ui/desktop/src/acp/__tests__/acpConnection.test.ts
+++ b/ui/desktop/src/acp/__tests__/acpConnection.test.ts
@@ -235,3 +235,23 @@ describe('ACP connection ownership', () => {
     expect(listener).toHaveBeenLastCalledWith(false);
   });
 });
+
+describe('terminalShellForPlatform', () => {
+  it('uses cmd on Windows clients', async () => {
+    const { terminalShellForPlatform } = await import('../acpConnection');
+
+    expect(terminalShellForPlatform('win32')).toEqual({
+      executable: 'cmd',
+      argsPrefix: ['/C'],
+    });
+  });
+
+  it.each(['darwin', 'linux'])('uses sh on %s clients', async (platform) => {
+    const { terminalShellForPlatform } = await import('../acpConnection');
+
+    expect(terminalShellForPlatform(platform)).toEqual({
+      executable: 'sh',
+      argsPrefix: ['-c'],
+    });
+  });
+});

--- a/ui/desktop/src/acp/acpConnection.ts
+++ b/ui/desktop/src/acp/acpConnection.ts
@@ -126,6 +126,15 @@ async function getConnection(): Promise<AcpConnection> {
   return pendingConnection;
 }
 
+export function terminalShellForPlatform(platform: string): {
+  executable: string;
+  argsPrefix: string[];
+} {
+  return platform === 'win32'
+    ? { executable: 'cmd', argsPrefix: ['/C'] }
+    : { executable: 'sh', argsPrefix: ['-c'] };
+}
+
 async function openConnection(generation: number): Promise<AcpConnection> {
   const wsUrl = await window.electron.getAcpUrl();
   if (!wsUrl) {
@@ -147,6 +156,7 @@ async function openConnection(generation: number): Promise<AcpConnection> {
           _meta: {
             goose: {
               mcpHostCapabilities: DEFAULT_GOOSE_MCP_HOST_CAPABILITIES,
+              terminalShell: terminalShellForPlatform(window.electron.platform),
               customNotifications: true,
               recipeParameterRequests: true,
             },

--- a/ui/sdk/src/client-capabilities.ts
+++ b/ui/sdk/src/client-capabilities.ts
@@ -1,8 +1,14 @@
 import type { GooseMcpHostCapabilities } from "./mcp-apps.js";
 
+export interface GooseTerminalShellCapabilities {
+  executable: string;
+  argsPrefix: string[];
+}
+
 export interface GooseClientCapabilitiesMeta {
   goose?: {
     mcpHostCapabilities?: GooseMcpHostCapabilities;
+    terminalShell?: GooseTerminalShellCapabilities;
     customNotifications?: boolean;
   };
 }


### PR DESCRIPTION
## Problem

When Goose runs a nested ACP agent (e.g. Codex over ACP), the inner agent's terminal output events are dropped at the provider boundary. Terminal-capable clients never see live output from commands the nested agent runs — they get silence until the tool call completes, and lose the ability to monitor or interrupt long-running processes.

Two smaller correctness gaps in the same area:

- ACP terminal shell commands were passed as a raw command string, so shell expressions didn't execute correctly.
- Terminal stop was fire-and-forget: kill errors were logged and swallowed, and the process wasn't awaited, so a "stopped" terminal could still be running.

## Solution

- **On-demand, ordered terminal subscription.** Add `take_acp_notification_receiver()` to the `Provider` trait (default `None`). ACP providers install a subscriber only when an outer ACP session asks for one; direct CLI/desktop provider use does not queue notifications. Terminal metadata enters the provider’s existing ordered prompt-update stream, so the outer tool-call start is yielded before terminal output/exit and completion remains last. Ordered updates use backpressured sends, preventing output bursts from dropping tool or prompt lifecycle events.
- **Capability-gated forwarding.** The ACP server starts a per-session forwarding task only when the outer client declared terminal capability. It re-scopes nested terminal events to the outer session id and forwards structurally valid ACP notifications.
- **Cross-platform shell execution.** Terminal requests use Goose's existing configured platform shell conventions (`bash`/`sh`, PowerShell, `cmd`, or another `GOOSE_SHELL`) instead of hard-coded `sh`, while preserving the exact foreground command for client lifecycle control.
- **Stop semantics.** Kill-then-wait on terminal stop, surfacing errors as MCP errors instead of logging and continuing.
- **Tool guidance.** When the client offers terminals, the shell tool description steers agents to keep user-requested long-running commands in the foreground where the client can monitor and interrupt them.

## A convention proposal

The forwarded events are identified by `_meta` keys on `session/update` notifications: `terminal_output`, `terminal_output_delta`, and `terminal_exit`. These aren't part of the formal ACP spec — this PR effectively proposes them as the convention for provider-forwarded terminal events. Happy to adjust naming or shape if maintainers prefer something else; flagging it explicitly so it gets deliberate review.

## Testing

- An in-process fake nested ACP agent drives a real `AcpProvider`; the integration test requires the exact order: tool-call start → 128 terminal output deltas (double channel capacity) → terminal exit → tool-call completion → prompt stream termination. It also proves no terminal event is available before the start is consumed.
- Outer ACP server unit coverage verifies capability gating, event filtering, and nested-to-outer session re-scoping.
- ACP terminal integration fixtures validate create → wait → output → release with terminal capability enabled.
- Local validation:
  - `cargo test -p goose --lib acp::` — 202 passed
  - `cargo test --test acp_provider_test` — 14 passed, 9 ignored
  - `cargo test --test acp_server_test test_shell_terminal` — 2 passed
  - `cargo test -p goose-provider-types --lib` — 440 passed
  - `cargo clippy --all-targets -- -D warnings`
- Battle-tested downstream: the original behavior has been shipping in Berd (Block's ACP desktop client) as a carried patch, driving live terminal tabs for agent-run commands, including nested Codex-over-ACP sessions.


