### PR TITLE
feat: preserve and report truncated model responses

### DIFF
--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -89,6 +89,16 @@ struct JsonMetadata {
     #[serde(skip_serializing_if = "Option::is_none")]
     cost_usd: Option<f64>,
     status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    stop_reason: Option<String>,
+}
+
+fn completion_status(reached_max_tokens: bool) -> (String, Option<String>) {
+    if reached_max_tokens {
+        ("incomplete".to_string(), Some("max_tokens".to_string()))
+    } else {
+        ("completed".to_string(), None)
+    }
 }
 
 #[derive(Serialize, Debug)]
@@ -117,6 +127,9 @@ enum StreamEvent {
         cache_write_input_tokens: Option<i32>,
         #[serde(skip_serializing_if = "Option::is_none")]
         cost_usd: Option<f64>,
+        status: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        stop_reason: Option<String>,
     },
 }
 
@@ -1304,6 +1317,7 @@ impl CliSession {
     ) -> Result<()> {
         let is_json_mode = self.output_format == "json";
         let is_stream_json_mode = self.output_format == "stream-json";
+        let mut reached_max_tokens = false;
 
         let session_config = SessionConfig {
             id: self.session_id.clone(),
@@ -1480,7 +1494,8 @@ impl CliSession {
                         }
                         Some(Ok(AgentEvent::MessageUsage { .. })) => {}
                         Some(Ok(AgentEvent::MaxTokens)) => {
-                            if !is_json_mode {
+                            reached_max_tokens = true;
+                            if !is_json_mode && !is_stream_json_mode {
                                 output::render_text(
                                     "Response reached the model's output token limit. Ask the agent to continue.",
                                     Some(Color::Yellow),
@@ -1535,6 +1550,8 @@ impl CliSession {
             output::flush_markdown_buffer_current_theme(&mut markdown_buffer);
         }
 
+        let (completion_status, completion_stop_reason) = completion_status(reached_max_tokens);
+
         if is_json_mode {
             let metadata = match self
                 .agent
@@ -1550,7 +1567,8 @@ impl CliSession {
                     cache_read_input_tokens: totals.accumulated_usage.cache_read_input_tokens,
                     cache_write_input_tokens: totals.accumulated_usage.cache_write_input_tokens,
                     cost_usd: totals.accumulated_cost,
-                    status: "completed".to_string(),
+                    status: completion_status.clone(),
+                    stop_reason: completion_stop_reason.clone(),
                 },
                 Err(_) => JsonMetadata {
                     total_tokens: None,
@@ -1559,7 +1577,8 @@ impl CliSession {
                     cache_read_input_tokens: None,
                     cache_write_input_tokens: None,
                     cost_usd: None,
-                    status: "completed".to_string(),
+                    status: completion_status.clone(),
+                    stop_reason: completion_stop_reason.clone(),
                 },
             };
             let json_output = JsonOutput {
@@ -1600,6 +1619,8 @@ impl CliSession {
                 cache_read_input_tokens,
                 cache_write_input_tokens,
                 cost_usd,
+                status: completion_status,
+                stop_reason: completion_stop_reason,
             });
         } else {
             println!();
@@ -2550,6 +2571,51 @@ mod tests {
     use std::collections::HashMap;
     use std::time::Duration;
     use test_case::test_case;
+
+    #[test_case(false, "completed", None; "completed")]
+    #[test_case(true, "incomplete", Some("max_tokens"); "max tokens")]
+    fn completion_status_reports_terminal_state(
+        reached_max_tokens: bool,
+        expected_status: &str,
+        expected_stop_reason: Option<&str>,
+    ) {
+        let (status, stop_reason) = completion_status(reached_max_tokens);
+
+        assert_eq!(status, expected_status);
+        assert_eq!(stop_reason.as_deref(), expected_stop_reason);
+    }
+
+    #[test]
+    fn structured_completion_serializes_max_tokens_state() {
+        let metadata = JsonMetadata {
+            total_tokens: None,
+            input_tokens: None,
+            output_tokens: None,
+            cache_read_input_tokens: None,
+            cache_write_input_tokens: None,
+            cost_usd: None,
+            status: "incomplete".to_string(),
+            stop_reason: Some("max_tokens".to_string()),
+        };
+        let metadata = serde_json::to_value(metadata).unwrap();
+        assert_eq!(metadata["status"], "incomplete");
+        assert_eq!(metadata["stop_reason"], "max_tokens");
+
+        let event = serde_json::to_value(StreamEvent::Complete {
+            total_tokens: None,
+            input_tokens: None,
+            output_tokens: None,
+            cache_read_input_tokens: None,
+            cache_write_input_tokens: None,
+            cost_usd: None,
+            status: "incomplete".to_string(),
+            stop_reason: Some("max_tokens".to_string()),
+        })
+        .unwrap();
+        assert_eq!(event["type"], "complete");
+        assert_eq!(event["status"], "incomplete");
+        assert_eq!(event["stop_reason"], "max_tokens");
+    }
 
     #[test]
     fn planner_classification_excludes_user_only_content() {

--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -1479,6 +1479,15 @@ impl CliSession {
                             last_usage = Some(usage);
                         }
                         Some(Ok(AgentEvent::MessageUsage { .. })) => {}
+                        Some(Ok(AgentEvent::MaxTokens)) => {
+                            if !is_json_mode {
+                                output::render_text(
+                                    "Response reached the model's output token limit. Ask the agent to continue.",
+                                    Some(Color::Yellow),
+                                    true,
+                                );
+                            }
+                        }
                         Some(Ok(AgentEvent::McpNotification((extension_id, notification)))) => {
                             handle_mcp_notification(
                                 &extension_id,

--- a/crates/goose-provider-types/src/errors.rs
+++ b/crates/goose-provider-types/src/errors.rs
@@ -50,6 +50,9 @@ pub enum ProviderError {
         details: String,
         category: Option<String>,
     },
+
+    #[error("Provider stopped because it reached the output token limit")]
+    MaxTokens,
 }
 
 impl ProviderError {
@@ -71,6 +74,7 @@ impl ProviderError {
             ProviderError::EndpointNotFound(_) => "endpoint_not_found",
             ProviderError::CreditsExhausted { .. } => "credits_exhausted",
             ProviderError::Refusal { .. } => "refusal",
+            ProviderError::MaxTokens => "max_tokens",
         }
     }
 

--- a/crates/goose-provider-types/src/formats/anthropic.rs
+++ b/crates/goose-provider-types/src/formats/anthropic.rs
@@ -1029,8 +1029,8 @@ where
 
         // A tool_use block left open at stream end never received its
         // content_block_stop, so its args are truncated rather than complete.
+        let truncated_by_limit = stop_reason.as_deref() == Some("max_tokens");
         if !accumulated_tool_calls.is_empty() {
-            let truncated_by_limit = stop_reason.as_deref() == Some("max_tokens");
             let mut ids: Vec<String> = accumulated_tool_calls.keys().cloned().collect();
             ids.sort();
             for id in ids {
@@ -1061,6 +1061,13 @@ where
 
         if let Some(usage) = final_usage {
             yield (None, Some(usage));
+        }
+
+        // Keep the partial text/tool updates above, then terminate the provider
+        // turn with a typed signal so the agent and ACP layers can distinguish
+        // truncation from a successful end_turn.
+        if truncated_by_limit {
+            Err(ProviderError::MaxTokens)?;
         }
     }
 }
@@ -2211,6 +2218,58 @@ mod tests {
             parts.text[0]
         );
         assert!(parts.text[0].contains("context_window"));
+    }
+
+    #[tokio::test]
+    async fn test_streaming_partial_text_ends_with_max_tokens_error() {
+        let events = concat!(
+            r#"data: {"type":"message_start","message":{"id":"msg_partial","role":"assistant","content":[],"model":"claude-opus-4-8","usage":{"input_tokens":10,"output_tokens":0}}}"#,
+            "\n",
+            r#"data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}"#,
+            "\n",
+            r#"data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"There is a core dir — the c"}}"#,
+            "\n",
+            r#"data: {"type":"content_block_stop","index":0}"#,
+            "\n",
+            r#"data: {"type":"message_delta","delta":{"stop_reason":"max_tokens"},"usage":{"output_tokens":128000}}"#,
+            "\n",
+            r#"data: {"type":"message_stop"}"#,
+        );
+
+        let results = collect_stream_results(events).await;
+        assert!(results.iter().any(|result| {
+            matches!(result, Ok((Some(message), _)) if message.as_concat_text() == "There is a core dir — the c")
+        }));
+        assert!(results.iter().any(|result| {
+            result
+                .as_ref()
+                .err()
+                .and_then(|error| error.downcast_ref::<ProviderError>())
+                == Some(&ProviderError::MaxTokens)
+        }));
+    }
+
+    #[tokio::test]
+    async fn test_streaming_unexpected_eof_without_max_tokens_is_not_typed_as_limit() {
+        let events = concat!(
+            r#"data: {"type":"message_start","message":{"id":"msg_eof","role":"assistant","content":[],"model":"claude-opus-4-8","usage":{"input_tokens":10,"output_tokens":0}}}"#,
+            "\n",
+            r#"data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}"#,
+            "\n",
+            r#"data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"partial before eof"}}"#,
+        );
+
+        let results = collect_stream_results(events).await;
+        assert!(results.iter().any(|result| {
+            matches!(result, Ok((Some(message), _)) if message.as_concat_text() == "partial before eof")
+        }));
+        assert!(!results.iter().any(|result| {
+            result
+                .as_ref()
+                .err()
+                .and_then(|error| error.downcast_ref::<ProviderError>())
+                == Some(&ProviderError::MaxTokens)
+        }));
     }
 
     #[tokio::test]

--- a/crates/goose-provider-types/src/formats/google.rs
+++ b/crates/goose-provider-types/src/formats/google.rs
@@ -430,6 +430,7 @@ where
         let mut last_signature: Option<String> = None;
         let stream_id = Uuid::new_v4().to_string();
         let mut incomplete_data: Option<String> = None;
+        let mut truncated_by_limit = false;
 
         while let Some(line_result) = stream.next().await {
             let line = line_result?;
@@ -506,6 +507,17 @@ where
                 }
             }
 
+            if chunk
+                .get("candidates")
+                .and_then(Value::as_array)
+                .and_then(|candidates| candidates.first())
+                .and_then(|candidate| candidate.get("finishReason"))
+                .and_then(Value::as_str)
+                == Some("MAX_TOKENS")
+            {
+                truncated_by_limit = true;
+            }
+
             let parts = chunk
                 .get("candidates")
                 .and_then(|v| v.as_array())
@@ -530,6 +542,10 @@ where
 
         if let Some(usage) = final_usage {
             yield (None, Some(usage));
+        }
+
+        if truncated_by_limit {
+            Err(ProviderError::MaxTokens)?;
         }
     }
 }
@@ -1355,6 +1371,71 @@ mod tests {
             message_ids.iter().all(|id| id == first_id),
             "All streaming messages should have the same ID"
         );
+    }
+
+    #[tokio::test]
+    async fn test_streaming_max_tokens_preserves_partial_output_and_usage() {
+        use futures::StreamExt;
+
+        let response = concat!(
+            r#"data: {"candidates":[{"content":{"role":"model","parts":[{"text":"partial response"}]},"finishReason":"MAX_TOKENS"}],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":20,"totalTokenCount":30},"modelVersion":"gemini-test"}"#,
+            "\n",
+            "data: [DONE]"
+        );
+        let lines = response.lines().map(|line| Ok(line.to_string()));
+        let mut stream =
+            std::pin::pin!(response_to_streaming_message(futures::stream::iter(lines),));
+        let mut partial_text = None;
+        let mut final_usage = None;
+        let mut max_tokens_error = false;
+
+        while let Some(result) = stream.next().await {
+            match result {
+                Ok((Some(message), _)) => partial_text = Some(message.as_concat_text()),
+                Ok((_, Some(usage))) => final_usage = Some(usage),
+                Ok((None, None)) => {}
+                Err(error) => {
+                    max_tokens_error =
+                        error.downcast_ref::<ProviderError>() == Some(&ProviderError::MaxTokens);
+                }
+            }
+        }
+
+        assert_eq!(partial_text.as_deref(), Some("partial response"));
+        let usage = final_usage.expect("usage should be emitted before the error");
+        assert_eq!(usage.model, "gemini-test");
+        assert_eq!(usage.usage.input_tokens, Some(10));
+        assert_eq!(usage.usage.output_tokens, Some(20));
+        assert!(max_tokens_error);
+    }
+
+    #[tokio::test]
+    async fn test_streaming_normal_completion_does_not_return_max_tokens() {
+        use futures::StreamExt;
+
+        let response = concat!(
+            r#"data: {"candidates":[{"content":{"role":"model","parts":[{"text":"complete response"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":4,"candidatesTokenCount":2,"totalTokenCount":6},"modelVersion":"gemini-test"}"#,
+            "\n",
+            "data: [DONE]"
+        );
+        let lines = response.lines().map(|line| Ok(line.to_string()));
+        let mut stream =
+            std::pin::pin!(response_to_streaming_message(futures::stream::iter(lines),));
+        let mut partial_text = None;
+        let mut final_usage = None;
+
+        while let Some(result) = stream.next().await {
+            let (message, usage) = result.expect("normal completion should not return an error");
+            if let Some(message) = message {
+                partial_text = Some(message.as_concat_text());
+            }
+            if usage.is_some() {
+                final_usage = usage;
+            }
+        }
+
+        assert_eq!(partial_text.as_deref(), Some("complete response"));
+        assert_eq!(final_usage.unwrap().usage.total_tokens, Some(6));
     }
 
     #[tokio::test]

--- a/crates/goose-provider-types/src/formats/openai.rs
+++ b/crates/goose-provider-types/src/formats/openai.rs
@@ -1080,6 +1080,11 @@ where
             }
 
             let mut usage = extract_usage_with_output_tokens(&chunk, last_seen_model.as_deref());
+            let mut max_tokens_reached = chunk
+                .choices
+                .first()
+                .and_then(|choice| choice.finish_reason.as_deref())
+                == Some("length");
 
             if chunk.choices.is_empty() {
                 yield (None, usage)
@@ -1095,7 +1100,7 @@ where
                     }
                 }
 
-                let is_complete = chunk.choices[0].finish_reason == Some("tool_calls".to_string());
+                let is_complete = chunk.choices[0].finish_reason.is_some();
 
                 if !is_complete {
                     let mut done = false;
@@ -1144,6 +1149,9 @@ where
                                                 }
                                             }
                                         }
+                                    }
+                                    if tool_chunk.choices[0].finish_reason.as_deref() == Some("length") {
+                                        max_tokens_reached = true;
                                     }
                                     if tool_chunk.choices[0].finish_reason.is_some() {
                                         done = true;
@@ -1338,6 +1346,10 @@ where
                 }
             } else if usage.is_some() {
                 yield (None, usage)
+            }
+
+            if max_tokens_reached {
+                Err(ProviderError::MaxTokens)?;
             }
         }
 
@@ -2822,6 +2834,61 @@ data: [DONE]
         assert_usage_yielded_once(&result, 100, 20, 120);
 
         Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_streaming_length_finish_preserves_text_and_usage_before_error() {
+        let response_lines = r#"data: {"model":"m","choices":[{"delta":{"role":"assistant","content":"truncated text"},"index":0,"finish_reason":"length"}],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15},"id":"1"}
+data: [DONE]"#;
+        let response_stream =
+            tokio_stream::iter(response_lines.lines().map(|line| Ok(line.to_string())));
+        let mut messages = std::pin::pin!(response_to_streaming_message(response_stream));
+
+        let (message, usage) = messages.next().await.unwrap().unwrap();
+        let message = message.expect("partial message should be yielded");
+        assert!(matches!(
+            message.content.as_slice(),
+            [MessageContentBlock::Text(text)] if text.text == "truncated text"
+        ));
+        let usage = usage.expect("usage should be yielded with partial content");
+        assert_eq!(usage.usage.input_tokens, Some(10));
+        assert_eq!(usage.usage.output_tokens, Some(5));
+        assert_eq!(usage.usage.total_tokens, Some(15));
+
+        let error = messages.next().await.unwrap().unwrap_err();
+        assert_eq!(
+            error.downcast_ref::<ProviderError>(),
+            Some(&ProviderError::MaxTokens)
+        );
+        assert!(messages.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_streaming_length_finish_preserves_partial_tool_call_and_usage() {
+        let response_lines = r#"data: {"model":"m","choices":[{"delta":{"role":"assistant","tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"developer__shell","arguments":"{\"command\":\"ls"}}]},"index":0,"finish_reason":null}],"id":"1"}
+data: {"model":"m","choices":[{"delta":{"role":"assistant"},"index":0,"finish_reason":"length"}],"usage":{"prompt_tokens":20,"completion_tokens":8,"total_tokens":28},"id":"1"}
+data: [DONE]"#;
+        let response_stream =
+            tokio_stream::iter(response_lines.lines().map(|line| Ok(line.to_string())));
+        let mut messages = std::pin::pin!(response_to_streaming_message(response_stream));
+
+        let (message, usage) = messages.next().await.unwrap().unwrap();
+        let message = message.expect("partial tool call should be yielded");
+        assert!(matches!(
+            message.content.as_slice(),
+            [MessageContentBlock::ToolRequest(request)] if request.tool_call.is_err()
+        ));
+        let usage = usage.expect("usage should be yielded with partial tool call");
+        assert_eq!(usage.usage.input_tokens, Some(20));
+        assert_eq!(usage.usage.output_tokens, Some(8));
+        assert_eq!(usage.usage.total_tokens, Some(28));
+
+        let error = messages.next().await.unwrap().unwrap_err();
+        assert_eq!(
+            error.downcast_ref::<ProviderError>(),
+            Some(&ProviderError::MaxTokens)
+        );
+        assert!(messages.next().await.is_none());
     }
 
     #[tokio::test]

--- a/crates/goose-provider-types/src/formats/openai_responses.rs
+++ b/crates/goose-provider-types/src/formats/openai_responses.rs
@@ -207,6 +207,11 @@ pub enum ResponsesStreamEvent {
         sequence_number: i32,
         response: ResponseMetadata,
     },
+    #[serde(rename = "response.incomplete")]
+    ResponseIncomplete {
+        sequence_number: i32,
+        response: ResponseMetadata,
+    },
     #[serde(rename = "response.failed")]
     ResponseFailed { sequence_number: i32, error: Value },
     #[serde(rename = "response.function_call_arguments.delta")]
@@ -262,6 +267,7 @@ fn is_known_responses_stream_event_type(event_type: &str) -> bool {
             | "response.content_part.done"
             | "response.output_text.done"
             | "response.completed"
+            | "response.incomplete"
             | "response.failed"
             | "response.function_call_arguments.delta"
             | "response.function_call_arguments.done"
@@ -310,6 +316,13 @@ pub struct ResponseMetadata {
     pub usage: Option<ResponseUsage>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reasoning: Option<ResponseReasoningInfo>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub incomplete_details: Option<ResponseIncompleteDetails>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ResponseIncompleteDetails {
+    pub reason: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -857,6 +870,7 @@ where
         let mut final_usage: Option<ProviderUsage> = None;
         let mut output_items: Vec<ResponseOutputItemInfo> = Vec::new();
         let mut is_text_response = false;
+        let mut terminal_error: Option<ProviderError> = None;
 
         'outer: while let Some(response) = stream.next().await {
             let response_str = response?;
@@ -944,6 +958,33 @@ where
                     break 'outer;
                 }
 
+                ResponsesStreamEvent::ResponseIncomplete { response, .. } => {
+                    let model = model_name.as_ref().unwrap_or(&response.model);
+                    let usage = response.usage.as_ref().map_or_else(
+                        Usage::default,
+                        ResponseUsage::to_usage,
+                    );
+                    final_usage = Some(ProviderUsage::new(model.clone(), usage));
+
+                    if !response.output.is_empty() {
+                        output_items = response.output;
+                    }
+
+                    terminal_error = Some(match response.incomplete_details {
+                        Some(details) if details.reason == "max_output_tokens" => {
+                            ProviderError::MaxTokens
+                        }
+                        Some(details) => ProviderError::RequestFailed(format!(
+                            "Responses API response incomplete: {}",
+                            details.reason
+                        )),
+                        None => ProviderError::RequestFailed(
+                            "Responses API response incomplete without a reason".to_string(),
+                        ),
+                    });
+                    break 'outer;
+                }
+
                 ResponsesStreamEvent::FunctionCallArgumentsDelta { .. } => {
                     // Function call arguments are being streamed, but we'll get the complete
                     // arguments in the OutputItemDone event, so we can ignore deltas for now
@@ -1007,6 +1048,10 @@ where
             yield (Some(message), final_usage);
         } else if let Some(usage) = final_usage {
             yield (None, Some(usage));
+        }
+
+        if let Some(error) = terminal_error {
+            Err(error)?;
         }
     }
 }
@@ -1322,6 +1367,66 @@ mod tests {
         Ok(())
     }
 
+    #[tokio::test]
+    async fn test_responses_stream_incomplete_max_tokens_preserves_partial_output_and_usage() {
+        let lines = vec![
+            r#"data: {"type":"response.created","sequence_number":1,"response":{"id":"resp_1","object":"response","created_at":1737368310,"status":"in_progress","model":"gpt-5.2-pro","output":[]}}"#.to_string(),
+            r#"data: {"type":"response.output_text.delta","sequence_number":2,"item_id":"msg_1","output_index":0,"content_index":0,"delta":"partial output"}"#.to_string(),
+            r#"data: {"type":"response.incomplete","sequence_number":3,"response":{"id":"resp_1","object":"response","created_at":1737368310,"status":"incomplete","model":"gpt-5.2-pro","output":[],"incomplete_details":{"reason":"max_output_tokens"},"usage":{"input_tokens":10,"output_tokens":20,"total_tokens":30}}}"#.to_string(),
+        ];
+
+        let response_stream = tokio_stream::iter(lines.into_iter().map(Ok));
+        let messages = responses_api_to_streaming_message(response_stream);
+        futures::pin_mut!(messages);
+        let results: Vec<_> = messages.collect().await;
+
+        assert!(results.iter().any(|result| {
+            matches!(result, Ok((Some(message), _)) if message.as_concat_text() == "partial output")
+        }));
+        assert!(results.iter().any(|result| {
+            matches!(result, Ok((_, Some(usage)))
+                if usage.usage.input_tokens == Some(10)
+                    && usage.usage.output_tokens == Some(20)
+                    && usage.usage.total_tokens == Some(30))
+        }));
+        assert!(results.iter().any(|result| {
+            result
+                .as_ref()
+                .err()
+                .and_then(|error| error.downcast_ref::<ProviderError>())
+                == Some(&ProviderError::MaxTokens)
+        }));
+    }
+
+    #[tokio::test]
+    async fn test_responses_stream_unknown_incomplete_reason_is_not_max_tokens() {
+        let lines = vec![
+            r#"data: {"type":"response.incomplete","sequence_number":1,"response":{"id":"resp_1","object":"response","created_at":1737368310,"status":"incomplete","model":"gpt-5.2-pro","output":[],"incomplete_details":{"reason":"content_filter"},"usage":{"input_tokens":10,"output_tokens":2,"total_tokens":12}}}"#.to_string(),
+        ];
+
+        let response_stream = tokio_stream::iter(lines.into_iter().map(Ok));
+        let messages = responses_api_to_streaming_message(response_stream);
+        futures::pin_mut!(messages);
+        let results: Vec<_> = messages.collect().await;
+
+        assert!(results.iter().any(|result| matches!(
+            result,
+            Ok((_, Some(usage))) if usage.usage.total_tokens == Some(12)
+        )));
+        let error = results
+            .iter()
+            .find_map(|result| result.as_ref().err())
+            .expect("incomplete response should emit an error");
+        assert_ne!(
+            error.downcast_ref::<ProviderError>(),
+            Some(&ProviderError::MaxTokens)
+        );
+        assert!(matches!(
+            error.downcast_ref::<ProviderError>(),
+            Some(ProviderError::RequestFailed(message)) if message.contains("content_filter")
+        ));
+    }
+
     #[test]
     fn test_history_preserves_chronological_order() {
         let model_config = ModelConfig {
@@ -1449,8 +1554,11 @@ mod tests {
             .as_array()
             .expect("tools should be an array");
         assert_eq!(tools.len(), 1);
-        assert_eq!(tools[0]["strict"], json!(false),
-            "Responses API defaults strict to true, but MCP tool schemas are not strict-compatible; must explicitly set strict: false");
+        assert_eq!(
+            tools[0]["strict"],
+            json!(false),
+            "Responses API defaults strict to true, but MCP tool schemas are not strict-compatible; must explicitly set strict: false"
+        );
     }
 
     #[test]

--- a/crates/goose-sdk-types/src/custom_requests/schedule.rs
+++ b/crates/goose-sdk-types/src/custom_requests/schedule.rs
@@ -95,6 +95,7 @@ pub struct RunScheduleNowResponse {
 pub enum RunScheduleNowStatus {
     #[default]
     Completed,
+    Incomplete,
     Cancelled,
 }
 

--- a/crates/goose/acp-schema.json
+++ b/crates/goose/acp-schema.json
@@ -4662,6 +4662,7 @@
       "type": "string",
       "enum": [
         "completed",
+        "incomplete",
         "cancelled"
       ]
     },

--- a/crates/goose/src/acp/provider.rs
+++ b/crates/goose/src/acp/provider.rs
@@ -652,7 +652,7 @@ impl Provider for AcpProvider {
                         }
                         let _ = response_tx.send(map_permission_response(&request, decision));
                     }
-                    AcpUpdate::Complete(_reason, usage) => {
+                    AcpUpdate::Complete(reason, usage) => {
                         if let Some(usage) = usage {
                             let provider_usage = ProviderUsage::new(
                                 model_name.clone(),
@@ -663,6 +663,9 @@ impl Provider for AcpProvider {
                                 ),
                             );
                             yield (None, Some(provider_usage));
+                        }
+                        if reason == StopReason::MaxTokens {
+                            Err(ProviderError::MaxTokens)?;
                         }
                         break;
                     }
@@ -1920,6 +1923,62 @@ mod tests {
         let later_claim = provider.claim_handoff_context(&later_prompt_with_history);
         assert!(!later_claim.first_prompt);
         assert!(!later_claim.include_context);
+    }
+
+    #[tokio::test]
+    async fn nested_acp_max_tokens_preserves_usage_then_returns_typed_error() {
+        use futures::StreamExt;
+
+        let (tx, mut rx) = mpsc::channel(1);
+        let (provider, model) = test_provider_with_tx(Some(tx));
+        let messages = vec![Message::user().with_text("continue")];
+        let mut stream = provider.stream(&model, "", &messages, &[]).await.unwrap();
+        let request = rx.recv().await.expect("provider should send ACP prompt");
+        let ClientRequest::Prompt { response_tx, .. } = request else {
+            panic!("expected prompt request");
+        };
+        response_tx
+            .send(AcpUpdate::Complete(
+                StopReason::MaxTokens,
+                Some(AcpUsage::new(30, 10, 20)),
+            ))
+            .await
+            .unwrap();
+
+        let usage = stream
+            .next()
+            .await
+            .expect("usage item should be emitted first")
+            .expect("usage item should succeed")
+            .1
+            .expect("usage should be present");
+        assert_eq!(usage.usage.input_tokens, Some(10));
+        assert_eq!(usage.usage.output_tokens, Some(20));
+        assert!(matches!(
+            stream.next().await.expect("typed error should follow"),
+            Err(ProviderError::MaxTokens)
+        ));
+        assert!(stream.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn nested_acp_end_turn_completes_without_max_tokens_error() {
+        use futures::StreamExt;
+
+        let (tx, mut rx) = mpsc::channel(1);
+        let (provider, model) = test_provider_with_tx(Some(tx));
+        let messages = vec![Message::user().with_text("continue")];
+        let mut stream = provider.stream(&model, "", &messages, &[]).await.unwrap();
+        let request = rx.recv().await.expect("provider should send ACP prompt");
+        let ClientRequest::Prompt { response_tx, .. } = request else {
+            panic!("expected prompt request");
+        };
+        response_tx
+            .send(AcpUpdate::Complete(StopReason::EndTurn, None))
+            .await
+            .unwrap();
+
+        assert!(stream.next().await.is_none());
     }
 
     #[tokio::test]

--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -1286,6 +1286,16 @@ fn extract_client_supports_recipe_param_requests(
         .unwrap_or(false)
 }
 
+fn prompt_stop_reason(was_cancelled: bool, reached_max_tokens: bool) -> StopReason {
+    if was_cancelled {
+        StopReason::Cancelled
+    } else if reached_max_tokens {
+        StopReason::MaxTokens
+    } else {
+        StopReason::EndTurn
+    }
+}
+
 fn outcome_to_confirmation(outcome: &RequestPermissionOutcome) -> PermissionConfirmation {
     PermissionConfirmation {
         principal_type: PrincipalType::Tool,
@@ -1816,6 +1826,7 @@ impl GooseAcpAgent {
         };
 
         let mut was_cancelled = false;
+        let mut reached_max_tokens = false;
         let mut tool_requests = HashMap::new();
         let mut chain_tracker = ToolChainTracker::default();
         let mut stream_error = None;
@@ -1914,6 +1925,9 @@ impl GooseAcpAgent {
                         })?;
                     }
                 }
+                Ok(crate::agents::AgentEvent::MaxTokens) => {
+                    reached_max_tokens = true;
+                }
                 Ok(_) => {}
                 Err(e) => {
                     stream_error = Some(
@@ -1959,13 +1973,8 @@ impl GooseAcpAgent {
             ))?;
         }
 
-        let stop_reason = if was_cancelled {
-            StopReason::Cancelled
-        } else {
-            StopReason::EndTurn
-        };
-
-        let mut response = PromptResponse::new(stop_reason);
+        let mut response =
+            PromptResponse::new(prompt_stop_reason(was_cancelled, reached_max_tokens));
         if let Some(usage) = build_prompt_usage(&session) {
             response = response.usage(usage);
         }
@@ -2444,6 +2453,21 @@ print(\"hello, world\")
         );
 
         assert_eq!(result, expected,)
+    }
+
+    #[test_case(false, false, StopReason::EndTurn; "normal completion")]
+    #[test_case(false, true, StopReason::MaxTokens; "max tokens completion")]
+    #[test_case(true, false, StopReason::Cancelled; "cancelled completion")]
+    #[test_case(true, true, StopReason::Cancelled; "cancellation wins over max tokens")]
+    fn test_prompt_stop_reason(
+        was_cancelled: bool,
+        reached_max_tokens: bool,
+        expected: StopReason,
+    ) {
+        assert_eq!(
+            prompt_stop_reason(was_cancelled, reached_max_tokens),
+            expected
+        );
     }
 
     #[test_case(

--- a/crates/goose/src/acp/server/schedule.rs
+++ b/crates/goose/src/acp/server/schedule.rs
@@ -94,6 +94,10 @@ fn run_schedule_now_error(
         SchedulerError::JobNotFound(id) => {
             Err(agent_client_protocol::Error::resource_not_found(Some(id)))
         }
+        SchedulerError::IncompleteRun { session_id } => Ok(RunScheduleNowResponse {
+            status: RunScheduleNowStatus::Incomplete,
+            session_id: Some(session_id),
+        }),
         SchedulerError::AnyhowError(error)
             if error.to_string().contains("was successfully cancelled") =>
         {
@@ -339,5 +343,21 @@ impl GooseAcpAgent {
             job_start_time: job.process_start_time.map(|value| value.to_rfc3339()),
             running_duration_seconds,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn incomplete_schedule_error_returns_partial_session() {
+        let response = run_schedule_now_error(SchedulerError::IncompleteRun {
+            session_id: "partial-session".to_string(),
+        })
+        .unwrap();
+
+        assert!(matches!(response.status, RunScheduleNowStatus::Incomplete));
+        assert_eq!(response.session_id.as_deref(), Some("partial-session"));
     }
 }

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -1941,6 +1941,7 @@ impl Agent {
             let mut compaction_attempts = 0;
             let mut empty_turn_retries = 0u32;
             let mut max_token_continuations = 0u32;
+            let mut pending_max_tokens_stop = false;
             let mut retrying_after_empty_turn = false;
             let mut retrying_after_max_tokens = false;
             let mut last_assistant_text = String::new();
@@ -2731,7 +2732,7 @@ impl Agent {
                             "Provider repeatedly reached its output token limit; ending turn after {} continuations",
                             MAX_TOKEN_CONTINUATIONS
                         );
-                        yield AgentEvent::MaxTokens;
+                        pending_max_tokens_stop = true;
                         exit_chat = true;
                     }
                 }
@@ -2928,6 +2929,7 @@ impl Agent {
 
                 if exit_chat && self.has_pending_steers(&session_config.id).await {
                     exit_chat = false;
+                    pending_max_tokens_stop = false;
                 }
 
                 if exit_chat {
@@ -2936,6 +2938,9 @@ impl Agent {
                         .await
                     {
                         crate::hooks::HookDecision::Allow => {
+                            if pending_max_tokens_stop {
+                                yield AgentEvent::MaxTokens;
+                            }
                             stop_hook_handled_for_exit = true;
                             break;
                         }
@@ -2945,9 +2950,13 @@ impl Agent {
                                 let message = stop_hook_block_cap_warning(&plugin, stop_hook_block_cap);
                                 session_manager.add_message(&session_config.id, &message).await?;
                                 yield AgentEvent::Message(message);
+                                if pending_max_tokens_stop {
+                                    yield AgentEvent::MaxTokens;
+                                }
                                 stop_hook_handled_for_exit = true;
                                 break;
                             }
+                            pending_max_tokens_stop = false;
                             let message = stop_hook_denial_context_message(&plugin, &reason);
                             session_manager.add_message(&session_config.id, &message).await?;
                             conversation.push(message);
@@ -4090,6 +4099,81 @@ echo start >> "$PLUGIN_ROOT/hook.log"
                 .as_concat_text(),
             "partial 8"
         );
+        Ok(())
+    }
+
+    struct RecoversAfterMaxTokensProvider {
+        call_count: AtomicUsize,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::providers::base::Provider for RecoversAfterMaxTokensProvider {
+        async fn stream(
+            &self,
+            _model_config: &goose_providers::model::ModelConfig,
+            _system_prompt: &str,
+            _messages: &[Message],
+            _tools: &[Tool],
+        ) -> Result<MessageStream, ProviderError> {
+            let call = self.call_count.fetch_add(1, Ordering::SeqCst);
+            if call <= MAX_TOKEN_CONTINUATIONS as usize {
+                return Ok(Box::pin(futures::stream::iter(vec![
+                    Ok((
+                        Some(Message::assistant().with_text(format!("partial {call}"))),
+                        None,
+                    )),
+                    Err(ProviderError::MaxTokens),
+                ])));
+            }
+
+            Ok(stream_from_single_message(
+                Message::assistant().with_text("complete response"),
+                ProviderUsage::new("mock-model".to_string(), Usage::default()),
+            ))
+        }
+
+        fn get_name(&self) -> &str {
+            "recovers-after-max-tokens"
+        }
+    }
+
+    #[tokio::test]
+    async fn max_tokens_is_not_emitted_when_stop_hook_continues_and_run_succeeds() -> Result<()> {
+        let env = StopHookTestEnv::new(ALTERNATE_BLOCK_ALLOW_SCRIPT)?;
+        let provider = Arc::new(RecoversAfterMaxTokensProvider {
+            call_count: AtomicUsize::new(0),
+        });
+        let (agent, session_id) =
+            create_test_agent(env.data_dir(), env.hook_manager(), provider.clone()).await?;
+        let session_config = SessionConfig {
+            id: session_id,
+            schedule_id: None,
+            max_turns: Some(10),
+            retry_config: None,
+        };
+        let reply_stream = agent
+            .reply(
+                Message::user().with_text("write a very long response"),
+                session_config,
+                None,
+            )
+            .await?;
+        tokio::pin!(reply_stream);
+
+        let mut emitted_max_tokens = false;
+        let mut visible_text = Vec::new();
+        while let Some(event) = reply_stream.next().await {
+            match event? {
+                AgentEvent::MaxTokens => emitted_max_tokens = true,
+                AgentEvent::Message(message) => visible_text.push(message.as_concat_text()),
+                _ => {}
+            }
+        }
+
+        assert!(!emitted_max_tokens);
+        assert_eq!(provider.call_count.load(Ordering::SeqCst), 10);
+        assert_eq!(env.hook_invocations(), 2);
+        assert!(visible_text.iter().any(|text| text == "complete response"));
         Ok(())
     }
 

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -4014,6 +4014,84 @@ echo start >> "$PLUGIN_ROOT/hook.log"
         Ok(())
     }
 
+    struct ToolshimMaxTokensThenCompletesProvider {
+        call_count: AtomicUsize,
+        second_call_messages: std::sync::Mutex<Vec<Message>>,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::providers::base::Provider for ToolshimMaxTokensThenCompletesProvider {
+        async fn stream(
+            &self,
+            _model_config: &goose_providers::model::ModelConfig,
+            _system_prompt: &str,
+            messages: &[Message],
+            _tools: &[Tool],
+        ) -> Result<MessageStream, ProviderError> {
+            let call = self.call_count.fetch_add(1, Ordering::SeqCst);
+            if call == 0 {
+                return Ok(Box::pin(futures::stream::iter(vec![
+                    Ok((
+                        Some(
+                            Message::assistant()
+                                .with_text("partial opening <|tool_call_begin|> incomplete"),
+                        ),
+                        None,
+                    )),
+                    Err(ProviderError::MaxTokens),
+                ])));
+            }
+
+            *self.second_call_messages.lock().unwrap() = messages.to_vec();
+            Ok(stream_from_single_message(
+                Message::assistant().with_text("continued response"),
+                ProviderUsage::new("mock-model".to_string(), Usage::default()),
+            ))
+        }
+
+        fn get_name(&self) -> &str {
+            "toolshim-max-tokens-then-completes"
+        }
+    }
+
+    #[tokio::test]
+    async fn toolshim_max_tokens_persists_partial_output_before_continuing() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let provider = Arc::new(ToolshimMaxTokensThenCompletesProvider {
+            call_count: AtomicUsize::new(0),
+            second_call_messages: std::sync::Mutex::new(Vec::new()),
+        });
+        let hook_manager = crate::hooks::HookManager::from_plugins_for_test(vec![]);
+        let (agent, session_id) =
+            create_test_agent(temp_dir.path().join("data"), hook_manager, provider.clone()).await?;
+        agent
+            .update_provider(
+                provider.clone(),
+                goose_providers::model::ModelConfig::new("mock-model").with_toolshim(true),
+                &session_id,
+            )
+            .await?;
+
+        let messages =
+            run_stop_hook_test_turn(&agent, &session_id, "write a long response").await?;
+
+        assert_eq!(provider.call_count.load(Ordering::SeqCst), 2);
+        let visible = visible_texts(&messages);
+        assert!(visible
+            .iter()
+            .any(|text| text.contains("partial opening") && !text.contains("tool_call_begin")));
+        assert!(visible.iter().any(|text| text == "continued response"));
+        let second_call_messages = provider.second_call_messages.lock().unwrap();
+        assert!(second_call_messages.iter().any(|message| {
+            let text = message.as_concat_text();
+            text.contains("partial opening") && !text.contains("tool_call_begin")
+        }));
+        assert!(second_call_messages.iter().any(|message| message
+            .as_concat_text()
+            .contains(MAX_TOKEN_CONTINUATION_MESSAGE)));
+        Ok(())
+    }
+
     struct AlwaysMaxTokensProvider {
         call_count: AtomicUsize,
     }

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -71,6 +71,9 @@ const DEFAULT_STOP_HOOK_BLOCK_CAP: u32 = 8;
 const COMPACTION_PROGRESS_TEXT: &str = "goose is compacting the conversation...";
 const MAX_TURNS_MESSAGE: &str = "I've reached the maximum number of actions I can do without user input. Would you like me to continue?";
 const MAX_EMPTY_TURN_RETRIES: u32 = 3;
+const MAX_TOKEN_CONTINUATIONS: u32 = 8;
+const MAX_TOKEN_CONTINUATION_MESSAGE: &str =
+    "Continue the response exactly where it was cut off. Do not repeat completed content.";
 const EMPTY_TURN_MESSAGE: &str =
     "The model returned an empty response. Please resend your message to continue.";
 const DEFAULT_FRONTEND_INSTRUCTIONS: &str = "The following tools are provided directly by the frontend and will be executed by the frontend when called.";
@@ -272,6 +275,7 @@ pub enum AgentEvent {
         message_id: Option<String>,
         usage: MessageUsage,
     },
+    MaxTokens,
     McpNotification((String, ServerNotification)),
     HistoryReplaced(Conversation),
 }
@@ -1936,7 +1940,9 @@ impl Agent {
             });
             let mut compaction_attempts = 0;
             let mut empty_turn_retries = 0u32;
+            let mut max_token_continuations = 0u32;
             let mut retrying_after_empty_turn = false;
+            let mut retrying_after_max_tokens = false;
             let mut last_assistant_text = String::new();
             let mut goal_check_pending = false;
             let mut tool_pair_summarization_done = false;
@@ -2015,6 +2021,8 @@ impl Agent {
                     retrying_after_stop_hook_denial = false;
                 } else if retrying_after_empty_turn {
                     retrying_after_empty_turn = false;
+                } else if retrying_after_max_tokens {
+                    retrying_after_max_tokens = false;
                 } else {
                     turns_taken += 1;
                 }
@@ -2066,6 +2074,7 @@ impl Agent {
                 let mut messages_to_add = Conversation::default();
                 let mut tools_updated = false;
                 let mut did_recovery_compact_this_iteration = false;
+                let mut did_hit_max_tokens = false;
                 let mut exit_chat = false;
                 let mut provider_errored = false;
                 let mut provider_produced_content = false;
@@ -2631,6 +2640,13 @@ impl Agent {
                             exit_chat = true;
                             break;
                         }
+                        Err(ProviderError::MaxTokens) => {
+                            // Partial chunks are already in messages_to_add. Persist
+                            // them below, then prompt the model to resume inside this
+                            // same run instead of making the user say "keep going".
+                            did_hit_max_tokens = true;
+                            break;
+                        }
                         Err(ref provider_err @ ProviderError::NetworkError(_)) => {
                             provider_errored = true;
                             #[cfg(feature = "telemetry")]
@@ -2695,7 +2711,32 @@ impl Agent {
                     empty_turn_retries = 0;
                 }
 
-                if no_tools_called && !exit_chat {
+                if did_hit_max_tokens {
+                    if is_token_cancelled(&cancel_token) {
+                        // Preserve partial assistant output, but do not persist a
+                        // continuation instruction after cancellation has won.
+                    } else if max_token_continuations < MAX_TOKEN_CONTINUATIONS {
+                        max_token_continuations += 1;
+                        retrying_after_max_tokens = true;
+                        let continuation = Message::user()
+                            .with_text(MAX_TOKEN_CONTINUATION_MESSAGE)
+                            .with_visibility(false, true);
+                        messages_to_add.push(continuation);
+                        warn!(
+                            "Provider reached its output token limit; continuing automatically ({}/{})",
+                            max_token_continuations, MAX_TOKEN_CONTINUATIONS
+                        );
+                    } else {
+                        warn!(
+                            "Provider repeatedly reached its output token limit; ending turn after {} continuations",
+                            MAX_TOKEN_CONTINUATIONS
+                        );
+                        yield AgentEvent::MaxTokens;
+                        exit_chat = true;
+                    }
+                }
+
+                if no_tools_called && !exit_chat && !did_hit_max_tokens {
                     // Lock, extract state, drop guard before branching — handle_retry_logic
                     // also locks final_output_tool and tokio::sync::Mutex is not reentrant.
                     let final_output = {
@@ -3883,6 +3924,271 @@ echo start >> "$PLUGIN_ROOT/hook.log"
         }
     }
 
+    struct MaxTokensThenCompletesProvider {
+        call_count: AtomicUsize,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::providers::base::Provider for MaxTokensThenCompletesProvider {
+        async fn stream(
+            &self,
+            _model_config: &goose_providers::model::ModelConfig,
+            _system_prompt: &str,
+            _messages: &[Message],
+            _tools: &[Tool],
+        ) -> Result<MessageStream, ProviderError> {
+            let call = self.call_count.fetch_add(1, Ordering::SeqCst);
+            if call == 0 {
+                return Ok(Box::pin(futures::stream::iter(vec![
+                    Ok((
+                        Some(Message::assistant().with_text("partial response ")),
+                        None,
+                    )),
+                    Err(ProviderError::MaxTokens),
+                ])));
+            }
+
+            let usage = ProviderUsage::new("mock-model".to_string(), Usage::default());
+            Ok(stream_from_single_message(
+                Message::assistant().with_text("continued response"),
+                usage,
+            ))
+        }
+
+        fn get_name(&self) -> &str {
+            "max-tokens-then-completes"
+        }
+    }
+
+    #[tokio::test]
+    async fn max_tokens_continues_automatically_in_the_same_run() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let provider = Arc::new(MaxTokensThenCompletesProvider {
+            call_count: AtomicUsize::new(0),
+        });
+        let hook_manager = crate::hooks::HookManager::from_plugins_for_test(vec![]);
+        let (agent, session_id) =
+            create_test_agent(temp_dir.path().join("data"), hook_manager, provider.clone()).await?;
+
+        let messages =
+            run_stop_hook_test_turn(&agent, &session_id, "write a long response").await?;
+
+        assert_eq!(provider.call_count.load(Ordering::SeqCst), 2);
+        assert_eq!(
+            visible_texts(&messages),
+            vec!["partial response ", "continued response"]
+        );
+        let session = agent
+            .config
+            .session_manager
+            .get_session(&session_id, true)
+            .await?;
+        let conversation = session
+            .conversation
+            .expect("test session should have persisted conversation");
+        let continuation_index = conversation
+            .messages()
+            .iter()
+            .position(|message| message.as_concat_text() == MAX_TOKEN_CONTINUATION_MESSAGE)
+            .expect("automatic continuation should be persisted");
+        assert_eq!(
+            conversation.messages()[continuation_index - 1].as_concat_text(),
+            "partial response "
+        );
+        let continuation = &conversation.messages()[continuation_index];
+        assert!(continuation.is_agent_visible());
+        assert!(!continuation.is_user_visible());
+        assert_eq!(
+            conversation.messages()[continuation_index + 1].as_concat_text(),
+            "continued response"
+        );
+        Ok(())
+    }
+
+    struct AlwaysMaxTokensProvider {
+        call_count: AtomicUsize,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::providers::base::Provider for AlwaysMaxTokensProvider {
+        async fn stream(
+            &self,
+            _model_config: &goose_providers::model::ModelConfig,
+            _system_prompt: &str,
+            _messages: &[Message],
+            _tools: &[Tool],
+        ) -> Result<MessageStream, ProviderError> {
+            let call = self.call_count.fetch_add(1, Ordering::SeqCst);
+            Ok(Box::pin(futures::stream::iter(vec![
+                Ok((
+                    Some(Message::assistant().with_text(format!("partial {call}"))),
+                    None,
+                )),
+                Err(ProviderError::MaxTokens),
+            ])))
+        }
+
+        fn get_name(&self) -> &str {
+            "always-max-tokens"
+        }
+    }
+
+    #[tokio::test]
+    async fn max_tokens_stops_after_eight_continuations() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let provider = Arc::new(AlwaysMaxTokensProvider {
+            call_count: AtomicUsize::new(0),
+        });
+        let hook_manager = crate::hooks::HookManager::from_plugins_for_test(vec![]);
+        let (agent, session_id) =
+            create_test_agent(temp_dir.path().join("data"), hook_manager, provider.clone()).await?;
+        let session_config = SessionConfig {
+            id: session_id.clone(),
+            schedule_id: None,
+            max_turns: Some(1),
+            retry_config: None,
+        };
+        let reply_stream = agent
+            .reply(
+                Message::user().with_text("write a very long response"),
+                session_config,
+                None,
+            )
+            .await?;
+        tokio::pin!(reply_stream);
+
+        let mut max_tokens_events = 0;
+        while let Some(event) = reply_stream.next().await {
+            if matches!(event?, AgentEvent::MaxTokens) {
+                max_tokens_events += 1;
+            }
+        }
+
+        assert_eq!(provider.call_count.load(Ordering::SeqCst), 9);
+        assert_eq!(max_tokens_events, 1);
+        let session = agent
+            .config
+            .session_manager
+            .get_session(&session_id, true)
+            .await?;
+        let conversation = session
+            .conversation
+            .expect("test session should have persisted conversation");
+        assert_eq!(
+            conversation
+                .messages()
+                .iter()
+                .filter(|message| message.as_concat_text() == MAX_TOKEN_CONTINUATION_MESSAGE)
+                .count(),
+            MAX_TOKEN_CONTINUATIONS as usize
+        );
+        assert_eq!(
+            conversation
+                .messages()
+                .last()
+                .expect("final partial response should be persisted")
+                .as_concat_text(),
+            "partial 8"
+        );
+        Ok(())
+    }
+
+    struct CancellingMaxTokensProvider {
+        call_count: AtomicUsize,
+        cancel_token: CancellationToken,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::providers::base::Provider for CancellingMaxTokensProvider {
+        async fn stream(
+            &self,
+            _model_config: &goose_providers::model::ModelConfig,
+            _system_prompt: &str,
+            _messages: &[Message],
+            _tools: &[Tool],
+        ) -> Result<MessageStream, ProviderError> {
+            self.call_count.fetch_add(1, Ordering::SeqCst);
+            let cancel_token = self.cancel_token.clone();
+            Ok(Box::pin(futures::stream::unfold(0, move |step| {
+                let cancel_token = cancel_token.clone();
+                async move {
+                    match step {
+                        0 => Some((
+                            Ok((
+                                Some(Message::assistant().with_text("partial response")),
+                                None,
+                            )),
+                            1,
+                        )),
+                        1 => {
+                            cancel_token.cancel();
+                            Some((Err(ProviderError::MaxTokens), 2))
+                        }
+                        _ => None,
+                    }
+                }
+            })))
+        }
+
+        fn get_name(&self) -> &str {
+            "cancelling-max-tokens"
+        }
+    }
+
+    #[tokio::test]
+    async fn cancellation_after_max_tokens_does_not_persist_or_start_continuation() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let cancel_token = CancellationToken::new();
+        let provider = Arc::new(CancellingMaxTokensProvider {
+            call_count: AtomicUsize::new(0),
+            cancel_token: cancel_token.clone(),
+        });
+        let hook_manager = crate::hooks::HookManager::from_plugins_for_test(vec![]);
+        let (agent, session_id) =
+            create_test_agent(temp_dir.path().join("data"), hook_manager, provider.clone()).await?;
+        let session_config = SessionConfig {
+            id: session_id.clone(),
+            schedule_id: None,
+            max_turns: Some(10),
+            retry_config: None,
+        };
+        let reply_stream = agent
+            .reply(
+                Message::user().with_text("write a long response"),
+                session_config,
+                Some(cancel_token),
+            )
+            .await?;
+        tokio::pin!(reply_stream);
+
+        let mut emitted_max_tokens = false;
+        while let Some(event) = reply_stream.next().await {
+            emitted_max_tokens |= matches!(event?, AgentEvent::MaxTokens);
+        }
+
+        assert_eq!(provider.call_count.load(Ordering::SeqCst), 1);
+        assert!(!emitted_max_tokens);
+        let session = agent
+            .config
+            .session_manager
+            .get_session(&session_id, true)
+            .await?;
+        let persisted_texts = session
+            .conversation
+            .expect("test session should have persisted conversation")
+            .into_iter()
+            .map(|message| message.as_concat_text())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            persisted_texts,
+            vec!["write a long response", "partial response"]
+        );
+        assert!(!persisted_texts
+            .iter()
+            .any(|text| text == MAX_TOKEN_CONTINUATION_MESSAGE));
+        Ok(())
+    }
+
     struct RefusingProvider {
         call_count: AtomicUsize,
     }
@@ -4020,7 +4326,8 @@ echo start >> "$PLUGIN_ROOT/hook.log"
                 AgentEvent::McpNotification(_)
                 | AgentEvent::HistoryReplaced(_)
                 | AgentEvent::Usage(_)
-                | AgentEvent::MessageUsage { .. } => {}
+                | AgentEvent::MessageUsage { .. }
+                | AgentEvent::MaxTokens => {}
             }
         }
         Ok(messages)

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -71,9 +71,6 @@ const DEFAULT_STOP_HOOK_BLOCK_CAP: u32 = 8;
 const COMPACTION_PROGRESS_TEXT: &str = "goose is compacting the conversation...";
 const MAX_TURNS_MESSAGE: &str = "I've reached the maximum number of actions I can do without user input. Would you like me to continue?";
 const MAX_EMPTY_TURN_RETRIES: u32 = 3;
-const MAX_TOKEN_CONTINUATIONS: u32 = 8;
-const MAX_TOKEN_CONTINUATION_MESSAGE: &str =
-    "Continue the response exactly where it was cut off. Do not repeat completed content.";
 const EMPTY_TURN_MESSAGE: &str =
     "The model returned an empty response. Please resend your message to continue.";
 const DEFAULT_FRONTEND_INSTRUCTIONS: &str = "The following tools are provided directly by the frontend and will be executed by the frontend when called.";
@@ -1940,10 +1937,8 @@ impl Agent {
             });
             let mut compaction_attempts = 0;
             let mut empty_turn_retries = 0u32;
-            let mut max_token_continuations = 0u32;
             let mut pending_max_tokens_stop = false;
             let mut retrying_after_empty_turn = false;
-            let mut retrying_after_max_tokens = false;
             let mut last_assistant_text = String::new();
             let mut goal_check_pending = false;
             let mut tool_pair_summarization_done = false;
@@ -2022,8 +2017,6 @@ impl Agent {
                     retrying_after_stop_hook_denial = false;
                 } else if retrying_after_empty_turn {
                     retrying_after_empty_turn = false;
-                } else if retrying_after_max_tokens {
-                    retrying_after_max_tokens = false;
                 } else {
                     turns_taken += 1;
                 }
@@ -2713,28 +2706,8 @@ impl Agent {
                 }
 
                 if did_hit_max_tokens {
-                    if is_token_cancelled(&cancel_token) {
-                        // Preserve partial assistant output, but do not persist a
-                        // continuation instruction after cancellation has won.
-                    } else if max_token_continuations < MAX_TOKEN_CONTINUATIONS {
-                        max_token_continuations += 1;
-                        retrying_after_max_tokens = true;
-                        let continuation = Message::user()
-                            .with_text(MAX_TOKEN_CONTINUATION_MESSAGE)
-                            .with_visibility(false, true);
-                        messages_to_add.push(continuation);
-                        warn!(
-                            "Provider reached its output token limit; continuing automatically ({}/{})",
-                            max_token_continuations, MAX_TOKEN_CONTINUATIONS
-                        );
-                    } else {
-                        warn!(
-                            "Provider repeatedly reached its output token limit; ending turn after {} continuations",
-                            MAX_TOKEN_CONTINUATIONS
-                        );
-                        pending_max_tokens_stop = true;
-                        exit_chat = true;
-                    }
+                    pending_max_tokens_stop = true;
+                    exit_chat = true;
                 }
 
                 if no_tools_called && !exit_chat && !did_hit_max_tokens {
@@ -2927,9 +2900,15 @@ impl Agent {
                 }
                 conversation.extend(messages_to_add);
 
+                if pending_max_tokens_stop {
+                    if !is_token_cancelled(&cancel_token) {
+                        yield AgentEvent::MaxTokens;
+                    }
+                    break;
+                }
+
                 if exit_chat && self.has_pending_steers(&session_config.id).await {
                     exit_chat = false;
-                    pending_max_tokens_stop = false;
                 }
 
                 if exit_chat {
@@ -2938,9 +2917,6 @@ impl Agent {
                         .await
                     {
                         crate::hooks::HookDecision::Allow => {
-                            if pending_max_tokens_stop {
-                                yield AgentEvent::MaxTokens;
-                            }
                             stop_hook_handled_for_exit = true;
                             break;
                         }
@@ -2950,13 +2926,9 @@ impl Agent {
                                 let message = stop_hook_block_cap_warning(&plugin, stop_hook_block_cap);
                                 session_manager.add_message(&session_config.id, &message).await?;
                                 yield AgentEvent::Message(message);
-                                if pending_max_tokens_stop {
-                                    yield AgentEvent::MaxTokens;
-                                }
                                 stop_hook_handled_for_exit = true;
                                 break;
                             }
-                            pending_max_tokens_stop = false;
                             let message = stop_hook_denial_context_message(&plugin, &reason);
                             session_manager.add_message(&session_config.id, &message).await?;
                             conversation.push(message);
@@ -3933,12 +3905,12 @@ echo start >> "$PLUGIN_ROOT/hook.log"
         }
     }
 
-    struct MaxTokensThenCompletesProvider {
+    struct TruncatingProvider {
         call_count: AtomicUsize,
     }
 
     #[async_trait::async_trait]
-    impl crate::providers::base::Provider for MaxTokensThenCompletesProvider {
+    impl crate::providers::base::Provider for TruncatingProvider {
         async fn stream(
             &self,
             _model_config: &goose_providers::model::ModelConfig,
@@ -3946,169 +3918,10 @@ echo start >> "$PLUGIN_ROOT/hook.log"
             _messages: &[Message],
             _tools: &[Tool],
         ) -> Result<MessageStream, ProviderError> {
-            let call = self.call_count.fetch_add(1, Ordering::SeqCst);
-            if call == 0 {
-                return Ok(Box::pin(futures::stream::iter(vec![
-                    Ok((
-                        Some(Message::assistant().with_text("partial response ")),
-                        None,
-                    )),
-                    Err(ProviderError::MaxTokens),
-                ])));
-            }
-
-            let usage = ProviderUsage::new("mock-model".to_string(), Usage::default());
-            Ok(stream_from_single_message(
-                Message::assistant().with_text("continued response"),
-                usage,
-            ))
-        }
-
-        fn get_name(&self) -> &str {
-            "max-tokens-then-completes"
-        }
-    }
-
-    #[tokio::test]
-    async fn max_tokens_continues_automatically_in_the_same_run() -> Result<()> {
-        let temp_dir = tempfile::tempdir()?;
-        let provider = Arc::new(MaxTokensThenCompletesProvider {
-            call_count: AtomicUsize::new(0),
-        });
-        let hook_manager = crate::hooks::HookManager::from_plugins_for_test(vec![]);
-        let (agent, session_id) =
-            create_test_agent(temp_dir.path().join("data"), hook_manager, provider.clone()).await?;
-
-        let messages =
-            run_stop_hook_test_turn(&agent, &session_id, "write a long response").await?;
-
-        assert_eq!(provider.call_count.load(Ordering::SeqCst), 2);
-        assert_eq!(
-            visible_texts(&messages),
-            vec!["partial response ", "continued response"]
-        );
-        let session = agent
-            .config
-            .session_manager
-            .get_session(&session_id, true)
-            .await?;
-        let conversation = session
-            .conversation
-            .expect("test session should have persisted conversation");
-        let continuation_index = conversation
-            .messages()
-            .iter()
-            .position(|message| message.as_concat_text() == MAX_TOKEN_CONTINUATION_MESSAGE)
-            .expect("automatic continuation should be persisted");
-        assert_eq!(
-            conversation.messages()[continuation_index - 1].as_concat_text(),
-            "partial response "
-        );
-        let continuation = &conversation.messages()[continuation_index];
-        assert!(continuation.is_agent_visible());
-        assert!(!continuation.is_user_visible());
-        assert_eq!(
-            conversation.messages()[continuation_index + 1].as_concat_text(),
-            "continued response"
-        );
-        Ok(())
-    }
-
-    struct ToolshimMaxTokensThenCompletesProvider {
-        call_count: AtomicUsize,
-        second_call_messages: std::sync::Mutex<Vec<Message>>,
-    }
-
-    #[async_trait::async_trait]
-    impl crate::providers::base::Provider for ToolshimMaxTokensThenCompletesProvider {
-        async fn stream(
-            &self,
-            _model_config: &goose_providers::model::ModelConfig,
-            _system_prompt: &str,
-            messages: &[Message],
-            _tools: &[Tool],
-        ) -> Result<MessageStream, ProviderError> {
-            let call = self.call_count.fetch_add(1, Ordering::SeqCst);
-            if call == 0 {
-                return Ok(Box::pin(futures::stream::iter(vec![
-                    Ok((
-                        Some(
-                            Message::assistant()
-                                .with_text("partial opening <|tool_call_begin|> incomplete"),
-                        ),
-                        None,
-                    )),
-                    Err(ProviderError::MaxTokens),
-                ])));
-            }
-
-            *self.second_call_messages.lock().unwrap() = messages.to_vec();
-            Ok(stream_from_single_message(
-                Message::assistant().with_text("continued response"),
-                ProviderUsage::new("mock-model".to_string(), Usage::default()),
-            ))
-        }
-
-        fn get_name(&self) -> &str {
-            "toolshim-max-tokens-then-completes"
-        }
-    }
-
-    #[tokio::test]
-    async fn toolshim_max_tokens_persists_partial_output_before_continuing() -> Result<()> {
-        let temp_dir = tempfile::tempdir()?;
-        let provider = Arc::new(ToolshimMaxTokensThenCompletesProvider {
-            call_count: AtomicUsize::new(0),
-            second_call_messages: std::sync::Mutex::new(Vec::new()),
-        });
-        let hook_manager = crate::hooks::HookManager::from_plugins_for_test(vec![]);
-        let (agent, session_id) =
-            create_test_agent(temp_dir.path().join("data"), hook_manager, provider.clone()).await?;
-        agent
-            .update_provider(
-                provider.clone(),
-                goose_providers::model::ModelConfig::new("mock-model").with_toolshim(true),
-                &session_id,
-            )
-            .await?;
-
-        let messages =
-            run_stop_hook_test_turn(&agent, &session_id, "write a long response").await?;
-
-        assert_eq!(provider.call_count.load(Ordering::SeqCst), 2);
-        let visible = visible_texts(&messages);
-        assert!(visible
-            .iter()
-            .any(|text| text.contains("partial opening") && !text.contains("tool_call_begin")));
-        assert!(visible.iter().any(|text| text == "continued response"));
-        let second_call_messages = provider.second_call_messages.lock().unwrap();
-        assert!(second_call_messages.iter().any(|message| {
-            let text = message.as_concat_text();
-            text.contains("partial opening") && !text.contains("tool_call_begin")
-        }));
-        assert!(second_call_messages.iter().any(|message| message
-            .as_concat_text()
-            .contains(MAX_TOKEN_CONTINUATION_MESSAGE)));
-        Ok(())
-    }
-
-    struct AlwaysMaxTokensProvider {
-        call_count: AtomicUsize,
-    }
-
-    #[async_trait::async_trait]
-    impl crate::providers::base::Provider for AlwaysMaxTokensProvider {
-        async fn stream(
-            &self,
-            _model_config: &goose_providers::model::ModelConfig,
-            _system_prompt: &str,
-            _messages: &[Message],
-            _tools: &[Tool],
-        ) -> Result<MessageStream, ProviderError> {
-            let call = self.call_count.fetch_add(1, Ordering::SeqCst);
+            self.call_count.fetch_add(1, Ordering::SeqCst);
             Ok(Box::pin(futures::stream::iter(vec![
                 Ok((
-                    Some(Message::assistant().with_text(format!("partial {call}"))),
+                    Some(Message::assistant().with_text("partial response")),
                     None,
                 )),
                 Err(ProviderError::MaxTokens),
@@ -4116,14 +3929,14 @@ echo start >> "$PLUGIN_ROOT/hook.log"
         }
 
         fn get_name(&self) -> &str {
-            "always-max-tokens"
+            "truncating"
         }
     }
 
     #[tokio::test]
-    async fn max_tokens_stops_after_eight_continuations() -> Result<()> {
+    async fn max_tokens_preserves_partial_output_and_stops_without_retrying() -> Result<()> {
         let temp_dir = tempfile::tempdir()?;
-        let provider = Arc::new(AlwaysMaxTokensProvider {
+        let provider = Arc::new(TruncatingProvider {
             call_count: AtomicUsize::new(0),
         });
         let hook_manager = crate::hooks::HookManager::from_plugins_for_test(vec![]);
@@ -4132,12 +3945,12 @@ echo start >> "$PLUGIN_ROOT/hook.log"
         let session_config = SessionConfig {
             id: session_id.clone(),
             schedule_id: None,
-            max_turns: Some(1),
+            max_turns: Some(10),
             retry_config: None,
         };
         let reply_stream = agent
             .reply(
-                Message::user().with_text("write a very long response"),
+                Message::user().with_text("write a long response"),
                 session_config,
                 None,
             )
@@ -4151,112 +3964,27 @@ echo start >> "$PLUGIN_ROOT/hook.log"
             }
         }
 
-        assert_eq!(provider.call_count.load(Ordering::SeqCst), 9);
+        assert_eq!(provider.call_count.load(Ordering::SeqCst), 1);
         assert_eq!(max_tokens_events, 1);
         let session = agent
             .config
             .session_manager
             .get_session(&session_id, true)
             .await?;
-        let conversation = session
+        let persisted_texts = session
             .conversation
-            .expect("test session should have persisted conversation");
+            .expect("test session should have persisted conversation")
+            .into_iter()
+            .map(|message| message.as_concat_text())
+            .collect::<Vec<_>>();
         assert_eq!(
-            conversation
-                .messages()
-                .iter()
-                .filter(|message| message.as_concat_text() == MAX_TOKEN_CONTINUATION_MESSAGE)
-                .count(),
-            MAX_TOKEN_CONTINUATIONS as usize
+            persisted_texts,
+            vec!["write a long response", "partial response"]
         );
-        assert_eq!(
-            conversation
-                .messages()
-                .last()
-                .expect("final partial response should be persisted")
-                .as_concat_text(),
-            "partial 8"
-        );
-        Ok(())
-    }
-
-    struct RecoversAfterMaxTokensProvider {
-        call_count: AtomicUsize,
-    }
-
-    #[async_trait::async_trait]
-    impl crate::providers::base::Provider for RecoversAfterMaxTokensProvider {
-        async fn stream(
-            &self,
-            _model_config: &goose_providers::model::ModelConfig,
-            _system_prompt: &str,
-            _messages: &[Message],
-            _tools: &[Tool],
-        ) -> Result<MessageStream, ProviderError> {
-            let call = self.call_count.fetch_add(1, Ordering::SeqCst);
-            if call <= MAX_TOKEN_CONTINUATIONS as usize {
-                return Ok(Box::pin(futures::stream::iter(vec![
-                    Ok((
-                        Some(Message::assistant().with_text(format!("partial {call}"))),
-                        None,
-                    )),
-                    Err(ProviderError::MaxTokens),
-                ])));
-            }
-
-            Ok(stream_from_single_message(
-                Message::assistant().with_text("complete response"),
-                ProviderUsage::new("mock-model".to_string(), Usage::default()),
-            ))
-        }
-
-        fn get_name(&self) -> &str {
-            "recovers-after-max-tokens"
-        }
-    }
-
-    #[tokio::test]
-    async fn max_tokens_is_not_emitted_when_stop_hook_continues_and_run_succeeds() -> Result<()> {
-        let env = StopHookTestEnv::new(ALTERNATE_BLOCK_ALLOW_SCRIPT)?;
-        let provider = Arc::new(RecoversAfterMaxTokensProvider {
-            call_count: AtomicUsize::new(0),
-        });
-        let (agent, session_id) =
-            create_test_agent(env.data_dir(), env.hook_manager(), provider.clone()).await?;
-        let session_config = SessionConfig {
-            id: session_id,
-            schedule_id: None,
-            max_turns: Some(10),
-            retry_config: None,
-        };
-        let reply_stream = agent
-            .reply(
-                Message::user().with_text("write a very long response"),
-                session_config,
-                None,
-            )
-            .await?;
-        tokio::pin!(reply_stream);
-
-        let mut emitted_max_tokens = false;
-        let mut visible_text = Vec::new();
-        while let Some(event) = reply_stream.next().await {
-            match event? {
-                AgentEvent::MaxTokens => emitted_max_tokens = true,
-                AgentEvent::Message(message) => visible_text.push(message.as_concat_text()),
-                _ => {}
-            }
-        }
-
-        assert!(!emitted_max_tokens);
-        assert_eq!(provider.call_count.load(Ordering::SeqCst), 10);
-        assert_eq!(env.hook_invocations(), 2);
-        assert!(visible_text.iter().any(|text| text == "complete response"));
         Ok(())
     }
 
     struct CancellingMaxTokensProvider {
-        call_count: AtomicUsize,
         cancel_token: CancellationToken,
     }
 
@@ -4269,7 +3997,6 @@ echo start >> "$PLUGIN_ROOT/hook.log"
             _messages: &[Message],
             _tools: &[Tool],
         ) -> Result<MessageStream, ProviderError> {
-            self.call_count.fetch_add(1, Ordering::SeqCst);
             let cancel_token = self.cancel_token.clone();
             Ok(Box::pin(futures::stream::unfold(0, move |step| {
                 let cancel_token = cancel_token.clone();
@@ -4298,26 +4025,24 @@ echo start >> "$PLUGIN_ROOT/hook.log"
     }
 
     #[tokio::test]
-    async fn cancellation_after_max_tokens_does_not_persist_or_start_continuation() -> Result<()> {
+    async fn cancellation_wins_over_max_tokens() -> Result<()> {
         let temp_dir = tempfile::tempdir()?;
         let cancel_token = CancellationToken::new();
         let provider = Arc::new(CancellingMaxTokensProvider {
-            call_count: AtomicUsize::new(0),
             cancel_token: cancel_token.clone(),
         });
         let hook_manager = crate::hooks::HookManager::from_plugins_for_test(vec![]);
         let (agent, session_id) =
-            create_test_agent(temp_dir.path().join("data"), hook_manager, provider.clone()).await?;
-        let session_config = SessionConfig {
-            id: session_id.clone(),
-            schedule_id: None,
-            max_turns: Some(10),
-            retry_config: None,
-        };
+            create_test_agent(temp_dir.path().join("data"), hook_manager, provider).await?;
         let reply_stream = agent
             .reply(
                 Message::user().with_text("write a long response"),
-                session_config,
+                SessionConfig {
+                    id: session_id,
+                    schedule_id: None,
+                    max_turns: Some(10),
+                    retry_config: None,
+                },
                 Some(cancel_token),
             )
             .await?;
@@ -4328,26 +4053,7 @@ echo start >> "$PLUGIN_ROOT/hook.log"
             emitted_max_tokens |= matches!(event?, AgentEvent::MaxTokens);
         }
 
-        assert_eq!(provider.call_count.load(Ordering::SeqCst), 1);
         assert!(!emitted_max_tokens);
-        let session = agent
-            .config
-            .session_manager
-            .get_session(&session_id, true)
-            .await?;
-        let persisted_texts = session
-            .conversation
-            .expect("test session should have persisted conversation")
-            .into_iter()
-            .map(|message| message.as_concat_text())
-            .collect::<Vec<_>>();
-        assert_eq!(
-            persisted_texts,
-            vec!["write a long response", "partial response"]
-        );
-        assert!(!persisted_texts
-            .iter()
-            .any(|text| text == MAX_TOKEN_CONTINUATION_MESSAGE));
         Ok(())
     }
 

--- a/crates/goose/src/agents/platform_extensions/orchestrator.rs
+++ b/crates/goose/src/agents/platform_extensions/orchestrator.rs
@@ -26,6 +26,29 @@ use tokio_util::sync::CancellationToken;
 
 pub static EXTENSION_NAME: &str = "orchestrator";
 
+fn orchestrator_response_result(
+    session_id: &str,
+    response_parts: &[String],
+    reached_max_tokens: bool,
+) -> CallToolResult {
+    let response = if response_parts.is_empty() {
+        "Agent completed without producing text output.".to_string()
+    } else {
+        format!(
+            "## Response from session {session_id}\n\n{}",
+            response_parts.join("\n\n")
+        )
+    };
+
+    if reached_max_tokens {
+        CallToolResult::error(vec![ContentBlock::text(format!(
+            "Agent response reached the model's output token limit and is incomplete.\n\n{response}"
+        ))])
+    } else {
+        CallToolResult::success(vec![ContentBlock::text(response)])
+    }
+}
+
 struct CancelTokenGuard {
     manager: Arc<AgentManager>,
     session_id: String,
@@ -508,6 +531,7 @@ impl OrchestratorClient {
 
         let mut response_parts: Vec<String> = Vec::new();
         let mut cancelled = false;
+        let mut reached_max_tokens = false;
 
         loop {
             tokio::select! {
@@ -524,6 +548,7 @@ impl OrchestratorClient {
                                 response_parts.push(text);
                             }
                         }
+                        Some(Ok(AgentEvent::MaxTokens)) => reached_max_tokens = true,
                         Some(Ok(_)) => {}
                         Some(Err(e)) => {
                             response_parts.push(format!("Error during agent processing: {}", e));
@@ -543,17 +568,11 @@ impl OrchestratorClient {
             return Err("Cancelled by parent session".into());
         }
 
-        if response_parts.is_empty() {
-            Ok(CallToolResult::success(vec![ContentBlock::text(
-                "Agent completed without producing text output.",
-            )]))
-        } else {
-            Ok(CallToolResult::success(vec![ContentBlock::text(format!(
-                "## Response from session {}\n\n{}",
-                session_id,
-                response_parts.join("\n\n")
-            ))]))
-        }
+        Ok(orchestrator_response_result(
+            &session_id,
+            &response_parts,
+            reached_max_tokens,
+        ))
     }
 
     async fn handle_interrupt_agent(
@@ -683,6 +702,33 @@ mod tests {
     use super::*;
     use crate::conversation::message::MessageContent;
     use rmcp::model::{Annotations, Role, TextContent};
+
+    #[test]
+    fn truncated_orchestrator_response_is_an_error_with_partial_output() {
+        let result =
+            orchestrator_response_result("child-session", &["partial research".to_string()], true);
+
+        assert_eq!(result.is_error, Some(true));
+        let text = result.content[0].as_text().unwrap().text.as_str();
+        assert!(text.contains("output token limit"));
+        assert!(text.contains("partial research"));
+    }
+
+    #[test]
+    fn complete_orchestrator_response_remains_successful() {
+        let result = orchestrator_response_result(
+            "child-session",
+            &["complete research".to_string()],
+            false,
+        );
+
+        assert_eq!(result.is_error, Some(false));
+        assert!(result.content[0]
+            .as_text()
+            .unwrap()
+            .text
+            .contains("complete research"));
+    }
 
     #[test]
     fn first_last_projection_drops_hidden_endpoints_and_content() {

--- a/crates/goose/src/agents/reply_parts.rs
+++ b/crates/goose/src/agents/reply_parts.rs
@@ -18,7 +18,8 @@ use crate::conversation::{fix_conversation, Conversation};
 use crate::providers::base::stream_from_single_message;
 use crate::providers::base::{MessageStream, Provider};
 use crate::providers::toolshim::{
-    augment_message_with_selected_tool_interpreter, convert_tool_messages_to_text,
+    augment_message_with_selected_tool_interpreter,
+    augment_truncated_message_with_complete_tool_calls, convert_tool_messages_to_text,
     modify_system_prompt_for_tool_json, sanitize_residual_markers,
 };
 use goose_providers::conversation::token_usage::{CostSource, ProviderStats, ProviderUsage, Usage};
@@ -362,7 +363,10 @@ impl Agent {
                             }
                             if let Some(message) = accumulated_message.take() {
                                 yield (
-                                    Some(sanitize_residual_markers(message)),
+                                    Some(augment_truncated_message_with_complete_tool_calls(
+                                        message,
+                                        &toolshim_tools,
+                                    )),
                                     final_usage.take(),
                                 );
                             } else if final_usage.is_some() {
@@ -751,10 +755,15 @@ mod tests {
         ) -> Result<MessageStream, ProviderError> {
             Ok(Box::pin(futures::stream::iter(vec![
                 Ok((
-                    Some(
-                        Message::assistant()
-                            .with_text("partial opening <|tool_call_begin|> incomplete"),
-                    ),
+                    Some(Message::assistant().with_text(
+                        "partial opening \
+                             <|tool_calls_section_begin|> \
+                             <|tool_call_begin|> functions.shell:0 \
+                             <|tool_call_argument_begin|> {\"command\":\"echo first\"} \
+                             <|tool_call_end|> \
+                             <|tool_call_begin|> functions.shell:1 \
+                             <|tool_call_argument_begin|> {\"command\":\"echo unfinished\"",
+                    )),
                     None,
                 )),
                 Err(ProviderError::MaxTokens),
@@ -791,6 +800,51 @@ mod tests {
         assert_eq!(partial_text.len(), 1);
         assert!(partial_text[0].contains("partial opening"));
         assert!(!partial_text[0].contains("tool_call_begin"));
+    }
+
+    #[tokio::test]
+    async fn toolshim_flushes_complete_call_before_truncated_suffix() {
+        let tools = vec![Tool::new(
+            "shell".to_string(),
+            "Shell command execution".to_string(),
+            serde_json::Map::new(),
+        )];
+        let provider = Arc::new(TruncatingToolshimProvider);
+        let mut stream = Agent::stream_response_from_provider(
+            provider,
+            ModelConfig::new("test-model").with_toolshim(true),
+            "test-session",
+            "system",
+            &[Message::user().with_text("write a long response")],
+            &[],
+            &tools,
+        )
+        .await
+        .unwrap();
+
+        let mut processed_message = None;
+        let mut saw_max_tokens = false;
+        while let Some(item) = stream.next().await {
+            match item {
+                Ok((Some(message), _)) => processed_message = Some(message),
+                Ok((None, _)) => {}
+                Err(ProviderError::MaxTokens) => saw_max_tokens = true,
+                Err(error) => panic!("unexpected error: {error}"),
+            }
+        }
+
+        let processed_message = processed_message.expect("expected truncated prefix");
+        let requests = processed_message
+            .content
+            .iter()
+            .filter_map(MessageContent::as_tool_request)
+            .collect::<Vec<_>>();
+        assert!(saw_max_tokens);
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].tool_call.as_ref().unwrap().name, "shell");
+        assert!(!processed_message
+            .as_concat_text()
+            .contains("echo unfinished"));
     }
 
     #[derive(Clone)]

--- a/crates/goose/src/agents/reply_parts.rs
+++ b/crates/goose/src/agents/reply_parts.rs
@@ -354,7 +354,28 @@ impl Agent {
                 let mut first_content_at: Option<std::time::Instant> = None;
 
                 while let Some(result) = stream.next().await {
-                    let (msg_opt, usage_opt) = result?;
+                    let (msg_opt, usage_opt) = match result {
+                        Ok(item) => item,
+                        Err(error @ ProviderError::MaxTokens) => {
+                            if let Some(usage) = final_usage.as_mut() {
+                                fill_stream_timing(usage, request_started, first_content_at);
+                            }
+                            if let Some(message) = accumulated_message.take() {
+                                yield (
+                                    Some(sanitize_residual_markers(message)),
+                                    final_usage.take(),
+                                );
+                            } else if final_usage.is_some() {
+                                yield (None, final_usage.take());
+                            }
+                            Err(error)?;
+                            unreachable!();
+                        }
+                        Err(error) => {
+                            Err(error)?;
+                            unreachable!();
+                        }
+                    };
 
                     if let Some(msg) = msg_opt {
                         if first_content_at.is_none() && message_has_timing_content(&msg) {
@@ -710,6 +731,66 @@ mod tests {
             let usage = ProviderUsage::new("mock".to_string(), Usage::default());
             Ok(stream_from_single_message(message, usage))
         }
+    }
+
+    #[derive(Clone)]
+    struct TruncatingToolshimProvider;
+
+    #[async_trait]
+    impl Provider for TruncatingToolshimProvider {
+        fn get_name(&self) -> &str {
+            "truncating-toolshim"
+        }
+
+        async fn stream(
+            &self,
+            _model_config: &ModelConfig,
+            _system: &str,
+            _messages: &[Message],
+            _tools: &[Tool],
+        ) -> Result<MessageStream, ProviderError> {
+            Ok(Box::pin(futures::stream::iter(vec![
+                Ok((
+                    Some(
+                        Message::assistant()
+                            .with_text("partial opening <|tool_call_begin|> incomplete"),
+                    ),
+                    None,
+                )),
+                Err(ProviderError::MaxTokens),
+            ])))
+        }
+    }
+
+    #[tokio::test]
+    async fn toolshim_flushes_sanitized_partial_output_before_max_tokens() {
+        let mut stream = Agent::stream_response_from_provider(
+            Arc::new(TruncatingToolshimProvider),
+            ModelConfig::new("test-model").with_toolshim(true),
+            "test-session",
+            "system",
+            &[Message::user().with_text("write a long response")],
+            &[],
+            &[],
+        )
+        .await
+        .unwrap();
+
+        let mut partial_text = Vec::new();
+        let mut saw_max_tokens = false;
+        while let Some(item) = stream.next().await {
+            match item {
+                Ok((Some(message), _)) => partial_text.push(message.as_concat_text()),
+                Ok((None, _)) => {}
+                Err(ProviderError::MaxTokens) => saw_max_tokens = true,
+                Err(error) => panic!("unexpected error: {error}"),
+            }
+        }
+
+        assert!(saw_max_tokens);
+        assert_eq!(partial_text.len(), 1);
+        assert!(partial_text[0].contains("partial opening"));
+        assert!(!partial_text[0].contains("tool_call_begin"));
     }
 
     #[derive(Clone)]

--- a/crates/goose/src/agents/subagent_handler.rs
+++ b/crates/goose/src/agents/subagent_handler.rs
@@ -31,7 +31,7 @@ pub struct SubagentPromptContext {
 }
 
 type AgentMessagesFuture =
-    Pin<Box<dyn Future<Output = Result<(Conversation, Option<String>)>> + Send>>;
+    Pin<Box<dyn Future<Output = Result<(Conversation, Option<String>, bool)>> + Send>>;
 
 pub struct SubagentRunParams {
     pub config: AgentConfig,
@@ -46,19 +46,36 @@ pub struct SubagentRunParams {
 
 pub async fn run_subagent_task(params: SubagentRunParams) -> Result<String, anyhow::Error> {
     let return_last_only = params.return_last_only;
-    let (messages, final_output) = get_agent_messages(params).await.map_err(|e| {
-        ErrorData::new(
-            ErrorCode::INTERNAL_ERROR,
-            format!("Failed to execute task: {}", e),
-            None,
-        )
-    })?;
+    let (messages, final_output, reached_max_tokens) =
+        get_agent_messages(params).await.map_err(|e| {
+            ErrorData::new(
+                ErrorCode::INTERNAL_ERROR,
+                format!("Failed to execute task: {}", e),
+                None,
+            )
+        })?;
 
-    if let Some(output) = final_output {
-        return Ok(output);
+    resolve_subagent_output(
+        &messages,
+        final_output,
+        return_last_only,
+        reached_max_tokens,
+    )
+}
+
+fn resolve_subagent_output(
+    messages: &Conversation,
+    final_output: Option<String>,
+    return_last_only: bool,
+    reached_max_tokens: bool,
+) -> Result<String, anyhow::Error> {
+    let output = final_output.unwrap_or_else(|| extract_response_text(messages, return_last_only));
+    if reached_max_tokens {
+        return Err(anyhow!(
+            "Subagent response reached the model's output token limit and is incomplete. Partial output:\n\n{output}"
+        ));
     }
-
-    Ok(extract_response_text(&messages, return_last_only))
+    Ok(output)
 }
 
 fn extract_response_text(messages: &Conversation, return_last_only: bool) -> String {
@@ -169,6 +186,7 @@ fn get_agent_messages(params: SubagentRunParams) -> AgentMessagesFuture {
 
         let user_message = Message::user().with_text(user_task);
         let mut conversation = Conversation::new_unvalidated(vec![user_message.clone()]);
+        let mut reached_max_tokens = false;
 
         if let Some(activities) = recipe.activities {
             for activity in activities {
@@ -213,7 +231,7 @@ fn get_agent_messages(params: SubagentRunParams) -> AgentMessagesFuture {
                 }
                 Ok(AgentEvent::Usage(_)) => {}
                 Ok(AgentEvent::MessageUsage { .. }) => {}
-                Ok(AgentEvent::MaxTokens) => {}
+                Ok(AgentEvent::MaxTokens) => reached_max_tokens = true,
                 Ok(AgentEvent::McpNotification(_)) => {}
                 Ok(AgentEvent::HistoryReplaced(updated_conversation)) => {
                     conversation = updated_conversation;
@@ -227,7 +245,7 @@ fn get_agent_messages(params: SubagentRunParams) -> AgentMessagesFuture {
 
         let final_output = get_final_output(&agent, has_response_schema).await;
 
-        Ok((conversation, final_output))
+        Ok((conversation, final_output, reached_max_tokens))
     })
 }
 
@@ -306,10 +324,47 @@ pub fn create_tool_notification(
 
 #[cfg(test)]
 mod tests {
-    use super::{create_tool_notification, SUBAGENT_TOOL_REQUEST_TYPE};
-    use crate::conversation::message::MessageContent;
+    use super::{create_tool_notification, resolve_subagent_output, SUBAGENT_TOOL_REQUEST_TYPE};
+    use crate::conversation::message::Message;
+    use crate::conversation::{message::MessageContent, Conversation};
     use rmcp::model::{CallToolRequestParams, ServerNotification};
     use serde_json::json;
+
+    #[test]
+    fn incomplete_subagent_output_is_an_error_with_partial_text() {
+        let conversation = Conversation::new_unvalidated(vec![
+            Message::user().with_text("task"),
+            Message::assistant().with_text("partial research"),
+        ]);
+
+        let error = resolve_subagent_output(&conversation, None, true, true).unwrap_err();
+
+        assert!(error.to_string().contains("output token limit"));
+        assert!(error.to_string().contains("partial research"));
+    }
+
+    #[test]
+    fn complete_subagent_output_remains_successful() {
+        let conversation = Conversation::new_unvalidated(vec![
+            Message::user().with_text("task"),
+            Message::assistant().with_text("complete research"),
+        ]);
+
+        assert_eq!(
+            resolve_subagent_output(&conversation, None, true, false).unwrap(),
+            "complete research"
+        );
+        assert_eq!(
+            resolve_subagent_output(
+                &conversation,
+                Some("structured result".to_string()),
+                true,
+                false,
+            )
+            .unwrap(),
+            "structured result"
+        );
+    }
 
     #[test]
     #[expect(deprecated)]

--- a/crates/goose/src/agents/subagent_handler.rs
+++ b/crates/goose/src/agents/subagent_handler.rs
@@ -213,6 +213,7 @@ fn get_agent_messages(params: SubagentRunParams) -> AgentMessagesFuture {
                 }
                 Ok(AgentEvent::Usage(_)) => {}
                 Ok(AgentEvent::MessageUsage { .. }) => {}
+                Ok(AgentEvent::MaxTokens) => {}
                 Ok(AgentEvent::McpNotification(_)) => {}
                 Ok(AgentEvent::HistoryReplaced(updated_conversation)) => {
                     conversation = updated_conversation;

--- a/crates/goose/src/gateway/handler.rs
+++ b/crates/goose/src/gateway/handler.rs
@@ -47,7 +47,7 @@ struct PendingConfirmation {
 
 fn max_tokens_warning(reached_max_tokens: bool) -> Option<OutgoingMessage> {
     reached_max_tokens.then(|| OutgoingMessage::Text {
-        body: "⚠️ This response repeatedly reached the model's output limit and couldn't finish. Try narrowing your request or splitting it into parts."
+        body: "⚠️ This response reached the model's output limit and couldn't finish. Ask the agent to continue, narrow your request, or split it into parts."
             .to_string(),
     })
 }
@@ -761,13 +761,13 @@ mod tests {
     use super::*;
 
     #[test]
-    fn max_tokens_warning_is_user_visible_only_when_exhausted() {
+    fn max_tokens_warning_is_user_visible_only_when_incomplete() {
         assert!(max_tokens_warning(false).is_none());
         let Some(OutgoingMessage::Text { body }) = max_tokens_warning(true) else {
-            panic!("max token exhaustion should produce a text warning");
+            panic!("max token truncation should produce a text warning");
         };
         assert!(body.contains("output limit"));
-        assert!(body.contains("splitting it into parts"));
+        assert!(body.contains("Ask the agent to continue"));
     }
 
     #[test]

--- a/crates/goose/src/gateway/handler.rs
+++ b/crates/goose/src/gateway/handler.rs
@@ -45,6 +45,13 @@ struct PendingConfirmation {
     request_id: String,
 }
 
+fn max_tokens_warning(reached_max_tokens: bool) -> Option<OutgoingMessage> {
+    reached_max_tokens.then(|| OutgoingMessage::Text {
+        body: "⚠️ This response repeatedly reached the model's output limit and couldn't finish. Try narrowing your request or splitting it into parts."
+            .to_string(),
+    })
+}
+
 #[derive(Clone)]
 pub struct GatewayHandler {
     agent_manager: Arc<AgentManager>,
@@ -527,6 +534,7 @@ impl GatewayHandler {
         // typing indicator while the tool runs, then the next response.
         let mut pending_text = String::new();
         let mut sent_any = false;
+        let mut reached_max_tokens = false;
         let mut event_count: u64 = 0;
 
         while let Some(event) = stream.next().await {
@@ -669,6 +677,10 @@ impl GatewayHandler {
                 }
                 Ok(AgentEvent::Usage(_)) => {}
                 Ok(AgentEvent::MessageUsage { .. }) => {}
+                Ok(AgentEvent::MaxTokens) => {
+                    reached_max_tokens = true;
+                    tracing::warn!(session_id, "gateway response hit the output token limit");
+                }
                 Ok(AgentEvent::McpNotification(_)) => {
                     tracing::debug!(
                         session_id,
@@ -717,7 +729,7 @@ impl GatewayHandler {
             self.gateway
                 .send_message(&message.user, OutgoingMessage::Text { body: pending_text })
                 .await?;
-        } else if !sent_any {
+        } else if !sent_any && !reached_max_tokens {
             // Nothing was ever sent — let the user know.
             self.gateway
                 .send_message(
@@ -727,6 +739,10 @@ impl GatewayHandler {
                     },
                 )
                 .await?;
+        }
+
+        if let Some(warning) = max_tokens_warning(reached_max_tokens) {
+            self.gateway.send_message(&message.user, warning).await?;
         }
 
         Ok(())
@@ -743,6 +759,16 @@ fn gateway_working_dir(platform: &str, user_id: &str) -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn max_tokens_warning_is_user_visible_only_when_exhausted() {
+        assert!(max_tokens_warning(false).is_none());
+        let Some(OutgoingMessage::Text { body }) = max_tokens_warning(true) else {
+            panic!("max token exhaustion should produce a text warning");
+        };
+        assert!(body.contains("output limit"));
+        assert!(body.contains("splitting it into parts"));
+    }
 
     #[test]
     fn defaults_when_no_overrides() {

--- a/crates/goose/src/providers/toolshim.rs
+++ b/crates/goose/src/providers/toolshim.rs
@@ -1026,6 +1026,35 @@ pub async fn augment_message_with_tool_calls<T: ToolInterpreter>(
     )))
 }
 
+pub fn augment_truncated_message_with_complete_tool_calls(
+    message: Message,
+    tools: &[Tool],
+) -> Message {
+    let content = message
+        .content
+        .iter()
+        .filter_map(|content| match content {
+            MessageContent::Text(text) => Some(text.text.as_str()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let tool_calls = parse_tokenized_tool_calls(&content, tools);
+    if !tool_calls.is_empty() {
+        let cleaned = sanitize_message_after_tokenized_parse(message);
+        return sanitize_residual_markers(append_tool_calls_to_message(cleaned, tool_calls));
+    }
+
+    let tool_calls = parse_inline_json_tool_calls(&content, tools);
+    if !tool_calls.is_empty() {
+        let cleaned = sanitize_message_after_json_tool_parse(message);
+        return sanitize_residual_markers(append_tool_calls_to_message(cleaned, tool_calls));
+    }
+
+    sanitize_residual_markers(message)
+}
+
 pub async fn augment_message_with_selected_tool_interpreter(
     message: Message,
     tools: &[Tool],
@@ -1271,6 +1300,42 @@ mod tests {
             .content
             .iter()
             .any(|c| matches!(c, MessageContent::ToolRequest(_))));
+    }
+
+    #[test]
+    fn truncated_message_preserves_complete_call_and_discards_incomplete_suffix() {
+        let tools = vec![Tool::new(
+            "shell".to_string(),
+            "Shell command execution".to_string(),
+            serde_json::Map::new(),
+        )];
+        let message = Message::assistant().with_text(format!(
+            "{TOOL_CALLS_SECTION_BEGIN} \
+             {TOOL_CALL_BEGIN} functions.shell:0 {TOOL_CALL_ARGUMENT_BEGIN} \
+             {{\"command\":\"echo first\"}} {TOOL_CALL_END} \
+             {TOOL_CALL_BEGIN} functions.shell:1 {TOOL_CALL_ARGUMENT_BEGIN} \
+             {{\"command\":\"echo unfinished\""
+        ));
+
+        let result = augment_truncated_message_with_complete_tool_calls(message, &tools);
+        let requests = result
+            .content
+            .iter()
+            .filter_map(MessageContent::as_tool_request)
+            .collect::<Vec<_>>();
+
+        assert_eq!(requests.len(), 1);
+        let call = requests[0].tool_call.as_ref().unwrap();
+        assert_eq!(call.name, "shell");
+        assert_eq!(
+            call.arguments
+                .as_ref()
+                .and_then(|args| args.get("command"))
+                .and_then(serde_json::Value::as_str),
+            Some("echo first")
+        );
+        assert!(!has_tool_markers(&result.as_concat_text()));
+        assert!(!result.as_concat_text().contains("echo unfinished"));
     }
 
     // ── Regression tests: malformed marker leakage ──────────────────────

--- a/crates/goose/src/scheduler.rs
+++ b/crates/goose/src/scheduler.rs
@@ -32,6 +32,33 @@ type JobsMap = HashMap<String, (JobId, ScheduledJob)>;
 
 pub(crate) const MAX_SCHEDULE_RECIPE_BYTES: u64 = 1024 * 1024;
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ScheduledRunOutcome {
+    Normal,
+    Incomplete,
+    Error,
+}
+
+impl ScheduledRunOutcome {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Normal => "normal",
+            Self::Incomplete => "incomplete",
+            Self::Error => "error",
+        }
+    }
+}
+
+fn scheduled_run_outcome(stream_error: bool, reached_max_tokens: bool) -> ScheduledRunOutcome {
+    if stream_error {
+        ScheduledRunOutcome::Error
+    } else if reached_max_tokens {
+        ScheduledRunOutcome::Incomplete
+    } else {
+        ScheduledRunOutcome::Normal
+    }
+}
+
 pub struct ValidatedScheduleRecipe {
     bytes: Vec<u8>,
     source: PathBuf,
@@ -1121,6 +1148,7 @@ async fn execute_job(
     let mut stream = std::pin::pin!(stream);
 
     let mut stream_error = false;
+    let mut reached_max_tokens = false;
     while let Some(message_result) = stream.next().await {
         tokio::task::yield_now().await;
 
@@ -1131,6 +1159,7 @@ async fn execute_job(
             Ok(AgentEvent::HistoryReplaced(updated)) => {
                 conversation = updated;
             }
+            Ok(AgentEvent::MaxTokens) => reached_max_tokens = true,
             Ok(_) => {}
             Err(e) => {
                 tracing::error!("Error in agent stream: {}", e);
@@ -1139,6 +1168,8 @@ async fn execute_job(
             }
         }
     }
+
+    let run_outcome = scheduled_run_outcome(stream_error, reached_max_tokens);
 
     agent
         .config
@@ -1151,7 +1182,7 @@ async fn execute_job(
 
     {
         let session_duration = start_time.elapsed();
-        let exit_type = if stream_error { "error" } else { "normal" };
+        let exit_type = run_outcome.as_str();
         let (total_tokens, message_count) = agent
             .config
             .session_manager
@@ -1199,7 +1230,7 @@ async fn execute_job(
             );
             props.insert(
                 "status".to_string(),
-                serde_json::Value::String("completed".to_string()),
+                serde_json::Value::String(run_outcome.as_str().to_string()),
             );
             props.insert(
                 "duration_seconds".to_string(),
@@ -1303,6 +1334,27 @@ mod tests {
         let recipe_path = dir.join(format!("{}.yaml", name));
         fs::write(&recipe_path, "prompt: test\n").unwrap();
         recipe_path
+    }
+
+    #[test]
+    fn scheduled_run_outcome_reports_normal_incomplete_and_error() {
+        assert_eq!(
+            scheduled_run_outcome(false, false),
+            ScheduledRunOutcome::Normal
+        );
+        assert_eq!(
+            scheduled_run_outcome(false, true),
+            ScheduledRunOutcome::Incomplete
+        );
+        assert_eq!(
+            scheduled_run_outcome(true, false),
+            ScheduledRunOutcome::Error
+        );
+        assert_eq!(
+            scheduled_run_outcome(true, true),
+            ScheduledRunOutcome::Error
+        );
+        assert_eq!(ScheduledRunOutcome::Incomplete.as_str(), "incomplete");
     }
 
     #[test]

--- a/crates/goose/src/scheduler.rs
+++ b/crates/goose/src/scheduler.rs
@@ -33,10 +33,15 @@ type JobsMap = HashMap<String, (JobId, ScheduledJob)>;
 pub(crate) const MAX_SCHEDULE_RECIPE_BYTES: u64 = 1024 * 1024;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum ScheduledRunOutcome {
+pub(crate) enum ScheduledRunOutcome {
     Normal,
     Incomplete,
     Error,
+}
+
+struct ScheduledExecutionResult {
+    session_id: String,
+    outcome: ScheduledRunOutcome,
 }
 
 impl ScheduledRunOutcome {
@@ -190,6 +195,7 @@ pub enum SchedulerError {
     PersistError(String),
     CronParseError(String),
     SchedulerInternalError(String),
+    IncompleteRun { session_id: String },
     AnyhowError(anyhow::Error),
 }
 
@@ -206,6 +212,10 @@ impl std::fmt::Display for SchedulerError {
             SchedulerError::SchedulerInternalError(e) => {
                 write!(f, "Scheduler internal error: {}", e)
             }
+            SchedulerError::IncompleteRun { session_id } => write!(
+                f,
+                "Scheduled run reached the model's output token limit. Partial session: {session_id}"
+            ),
             SchedulerError::AnyhowError(e) => write!(f, "Scheduler operation failed: {}", e),
         }
     }
@@ -866,7 +876,12 @@ impl Scheduler {
                 "Job '{}' was successfully cancelled",
                 sched_id
             ))),
-            Ok(session_id) => Ok(session_id),
+            Ok(result) if result.outcome == ScheduledRunOutcome::Incomplete => {
+                Err(SchedulerError::IncompleteRun {
+                    session_id: result.session_id,
+                })
+            }
+            Ok(result) => Ok(result.session_id),
             Err(e) => Err(SchedulerError::AnyhowError(anyhow!(
                 "Job '{}' failed: {}",
                 sched_id,
@@ -1014,9 +1029,12 @@ async fn execute_job(
     jobs: Arc<Mutex<JobsMap>>,
     job_id: String,
     cancel_token: CancellationToken,
-) -> Result<String> {
+) -> Result<ScheduledExecutionResult> {
     if job.source.is_empty() {
-        return Ok(job.id.to_string());
+        return Ok(ScheduledExecutionResult {
+            session_id: job.id.to_string(),
+            outcome: ScheduledRunOutcome::Normal,
+        });
     }
 
     let recipe_path = Path::new(&job.source);
@@ -1242,7 +1260,10 @@ async fn execute_job(
         });
     }
 
-    Ok(session.id)
+    Ok(ScheduledExecutionResult {
+        session_id: session.id,
+        outcome: run_outcome,
+    })
 }
 
 #[async_trait]

--- a/crates/goose/tests/agent.rs
+++ b/crates/goose/tests/agent.rs
@@ -620,6 +620,7 @@ mod tests {
                     Ok(AgentEvent::McpNotification(_)) => {}
                     Ok(AgentEvent::Usage(_)) => {}
                     Ok(AgentEvent::MessageUsage { .. }) => {}
+                    Ok(AgentEvent::MaxTokens) => {}
                     Ok(AgentEvent::HistoryReplaced(_updated_conversation)) => {
                         // We should update the conversation here, but we're not reading it
                     }

--- a/goose-self-test.yaml
+++ b/goose-self-test.yaml
@@ -20,7 +20,7 @@ parameters:
     input_type: string
     requirement: optional
     default: "all"
-    description: "Which test phases to run: all, basic, extensions, delegation, advanced"
+    description: "Which test phases to run: all, basic, extensions, delegation, vision, max_tokens, advanced"
 
   - key: test_depth
     input_type: string
@@ -346,6 +346,34 @@ prompt: |
      not with a crash or FFI error.
 
   Log results to: {{ workspace_dir }}/phase3b_vision.md
+  {% endif %}
+
+  {% if "max_tokens" in test_phases %}
+  ## ✂️ PHASE 3C: Max-Token Continuation Testing
+
+  **Prerequisites**: Run this phase explicitly with an Anthropic model and a deliberately small
+  output budget, for example:
+  ```
+  GOOSE_MAX_TOKENS=64 goose run --recipe goose-self-test.yaml \
+    --params test_phases=max_tokens --params test_depth=quick
+  ```
+  Do not run this phase as part of the default `all` suite because it intentionally constrains
+  provider output and requires a provider/model that reports `max_tokens` stop reasons.
+
+  ### Automatic Continuation Test
+  1. Before starting, record the configured provider, model, and `GOOSE_MAX_TOKENS` value.
+  2. Produce a numbered list from 1 through 150, one item per line, with a unique short sentence
+     for each item. Do not summarize, omit numbers, or use tools to generate the answer.
+  3. Verify the response continues automatically across provider output-limit boundaries without
+     asking the user to say "continue".
+  4. Verify the final visible answer preserves earlier segments and maintains consecutive numbering.
+  5. If all automatic continuation attempts are exhausted, verify the client reports the response
+     as incomplete rather than presenting it as a normal completion.
+  6. If structured output is available, verify its final record reports
+     `status: "incomplete"` and `stop_reason: "max_tokens"`, with no non-JSON lines.
+
+  Log provider/model settings, continuation observations, final status, and pass/fail details to:
+  {{ workspace_dir }}/phase3c_max_tokens.md
   {% endif %}
 
   {% if test_phases == "all" or "advanced" in test_phases %}

--- a/goose-self-test.yaml
+++ b/goose-self-test.yaml
@@ -349,7 +349,7 @@ prompt: |
   {% endif %}
 
   {% if "max_tokens" in test_phases %}
-  ## ✂️ PHASE 3C: Max-Token Continuation Testing
+  ## ✂️ PHASE 3C: Max-Token Truncation Testing
 
   **Prerequisites**: Run this phase explicitly with an Anthropic model and a deliberately small
   output budget, for example:
@@ -360,19 +360,18 @@ prompt: |
   Do not run this phase as part of the default `all` suite because it intentionally constrains
   provider output and requires a provider/model that reports `max_tokens` stop reasons.
 
-  ### Automatic Continuation Test
+  ### Incomplete Response Test
   1. Before starting, record the configured provider, model, and `GOOSE_MAX_TOKENS` value.
   2. Produce a numbered list from 1 through 150, one item per line, with a unique short sentence
      for each item. Do not summarize, omit numbers, or use tools to generate the answer.
-  3. Verify the response continues automatically across provider output-limit boundaries without
-     asking the user to say "continue".
-  4. Verify the final visible answer preserves earlier segments and maintains consecutive numbering.
-  5. If all automatic continuation attempts are exhausted, verify the client reports the response
-     as incomplete rather than presenting it as a normal completion.
+  3. Verify the partial response remains visible when the provider reaches its output limit.
+  4. Verify goose does not make a hidden continuation request and reports the response as incomplete
+     rather than presenting it as a normal completion.
+  5. Ask the agent to continue and verify it can use the preserved partial response as context.
   6. If structured output is available, verify its final record reports
      `status: "incomplete"` and `stop_reason: "max_tokens"`, with no non-JSON lines.
 
-  Log provider/model settings, continuation observations, final status, and pass/fail details to:
+  Log provider/model settings, truncation observations, final status, and pass/fail details to:
   {{ workspace_dir }}/phase3c_max_tokens.md
   {% endif %}
 

--- a/ui/desktop/src/acp/__tests__/chatSessionController.test.ts
+++ b/ui/desktop/src/acp/__tests__/chatSessionController.test.ts
@@ -214,7 +214,37 @@ describe('acpChatSessionController.submitMessage', () => {
     vi.mocked(acpChatSessionStore.getSnapshot).mockReturnValue(snapshotWithActivePrompt(null));
     vi.mocked(acpPromptSession).mockResolvedValue({ stopReason: 'cancelled' } as never);
     vi.mocked(acpChatSessionActions.clearPromptCancellation).mockReturnValue(undefined);
+    vi.mocked(acpChatSessionActions.isCurrentPromptAttempt).mockReturnValue(true);
     vi.mocked(acpChatSessionActions.finishPromptAttemptIfCurrent).mockReturnValue(true);
+  });
+
+  it('appends an agent-invisible notice when the response reaches max tokens', async () => {
+    vi.mocked(acpPromptSession).mockResolvedValue({ stopReason: 'max_tokens' } as never);
+    const existingMessage = userMessage();
+    const currentSnapshot: AcpChatSessionSnapshot = {
+      ...snapshotWithActivePrompt(null),
+      messages: [existingMessage],
+    };
+
+    await acpChatSessionController.submitMessage(SESSION_ID, existingMessage, {
+      getCurrentSnapshot: () => currentSnapshot,
+      onFinish: vi.fn(),
+    });
+
+    expect(acpChatSessionActions.setMessages).toHaveBeenCalledWith(SESSION_ID, [
+      existingMessage,
+      expect.objectContaining({
+        role: 'assistant',
+        content: [
+          expect.objectContaining({
+            type: 'systemNotification',
+            notificationType: 'inlineMessage',
+            msg: expect.stringContaining("couldn't finish"),
+          }),
+        ],
+        metadata: { userVisible: true, agentVisible: false },
+      }),
+    ]);
   });
 
   it('clears a pending cancellation barrier when the original prompt settles', async () => {

--- a/ui/desktop/src/acp/chatSessionController.ts
+++ b/ui/desktop/src/acp/chatSessionController.ts
@@ -60,6 +60,22 @@ export interface AcpChatSessionController {
   ): Promise<void>;
 }
 
+function createAcpMaxTokensMessage(): Message {
+  return {
+    id: uuidv7(),
+    role: 'assistant',
+    created: Math.floor(Date.now() / 1000),
+    content: [
+      {
+        type: 'systemNotification',
+        notificationType: 'inlineMessage',
+        msg: "This response couldn't finish because it reached the model's output limit. Ask the agent to continue.",
+      },
+    ],
+    metadata: { userVisible: true, agentVisible: false },
+  };
+}
+
 function createAcpCreditsExhaustedMessage(error: AcpCreditsExhaustedError): Message {
   return {
     id: uuidv7(),
@@ -174,9 +190,19 @@ async function submitMessage(
   acpChatSessionActions.startPromptAttempt(sessionId, promptAttemptId);
 
   try {
-    await acpPromptSession(sessionId, userMessage);
+    const response = await acpPromptSession(sessionId, userMessage);
     if (acpChatSessionActions.clearPromptCancellation(sessionId, promptAttemptId)) {
       return;
+    }
+    if (
+      response.stopReason === 'max_tokens' &&
+      acpChatSessionActions.isCurrentPromptAttempt(sessionId, promptAttemptId)
+    ) {
+      const messages = [
+        ...(options.getCurrentSnapshot()?.messages ?? []),
+        createAcpMaxTokensMessage(),
+      ];
+      acpChatSessionActions.setMessages(sessionId, messages);
     }
     if (acpChatSessionActions.finishPromptAttemptIfCurrent(sessionId, promptAttemptId)) {
       void options.onFinish();

--- a/ui/desktop/src/components/schedule/ScheduleDetailView.tsx
+++ b/ui/desktop/src/components/schedule/ScheduleDetailView.tsx
@@ -15,7 +15,7 @@ import {
   acpInspectRunningJob,
 } from '../../acp/schedules';
 import { ScheduleModal, NewSchedulePayload } from './ScheduleModal';
-import { toastError, toastSuccess } from '../../toasts';
+import { toastError, toastSuccess, toastWarning } from '../../toasts';
 import { Loader2, Pause, Play, Edit, Square, Eye } from 'lucide-react';
 import cronstrue from 'cronstrue';
 import { formatToLocalDateWithTimezone } from '../../utils/date';
@@ -60,6 +60,8 @@ const i18n = defineMessages({
   jobCancelled: { id: 'scheduleDetailView.jobCancelled', defaultMessage: 'Job Cancelled' },
   jobCancelledMsg: { id: 'scheduleDetailView.jobCancelledMsg', defaultMessage: 'The job was cancelled while starting up.' },
   scheduleCompleted: { id: 'scheduleDetailView.scheduleCompleted', defaultMessage: 'Run completed' },
+  scheduleIncomplete: { id: 'scheduleDetailView.scheduleIncomplete', defaultMessage: 'Run incomplete' },
+  incompleteSession: { id: 'scheduleDetailView.incompleteSession', defaultMessage: 'The response reached the model output limit. Partial session: {sessionId}' },
   completedSession: { id: 'scheduleDetailView.completedSession', defaultMessage: 'Session: {sessionId}' },
   runScheduleError: { id: 'scheduleDetailView.runScheduleError', defaultMessage: 'Run Schedule Error' },
   scheduleUnpaused: { id: 'scheduleDetailView.scheduleUnpaused', defaultMessage: 'Schedule Unpaused' },
@@ -165,6 +167,8 @@ const ScheduleDetailView: React.FC<ScheduleDetailViewProps> = ({ scheduleId, onN
       trackScheduleRunNow(true);
       if (result.status === 'completed' && result.sessionId) {
         toastSuccess({ title: intl.formatMessage(i18n.scheduleCompleted), msg: intl.formatMessage(i18n.completedSession, { sessionId: result.sessionId }) });
+      } else if (result.status === 'incomplete' && result.sessionId) {
+        toastWarning({ title: intl.formatMessage(i18n.scheduleIncomplete), msg: intl.formatMessage(i18n.incompleteSession, { sessionId: result.sessionId }) });
       }
       await fetchSessions(scheduleId);
       await fetchSchedule(scheduleId);

--- a/ui/desktop/src/i18n/messages/de.json
+++ b/ui/desktop/src/i18n/messages/de.json
@@ -3290,6 +3290,9 @@
   "scheduleDetailView.idLabel": {
     "defaultMessage": "ID:"
   },
+  "scheduleDetailView.incompleteSession": {
+    "defaultMessage": "Die Antwort hat das Ausgabelimit des Modells erreicht. Teilsitzung: {sessionId}"
+  },
   "scheduleDetailView.inspectJobError": {
     "defaultMessage": "Fehler beim Untersuchen des Auftrags"
   },
@@ -3370,6 +3373,9 @@
   },
   "scheduleDetailView.scheduleDetails": {
     "defaultMessage": "Zeitplandetails"
+  },
+  "scheduleDetailView.scheduleIncomplete": {
+    "defaultMessage": "Ausführung unvollständig"
   },
   "scheduleDetailView.scheduleInformation": {
     "defaultMessage": "Zeitplaninformationen"

--- a/ui/desktop/src/i18n/messages/en.json
+++ b/ui/desktop/src/i18n/messages/en.json
@@ -3290,6 +3290,9 @@
   "scheduleDetailView.idLabel": {
     "defaultMessage": "ID:"
   },
+  "scheduleDetailView.incompleteSession": {
+    "defaultMessage": "The response reached the model output limit. Partial session: {sessionId}"
+  },
   "scheduleDetailView.inspectJobError": {
     "defaultMessage": "Inspect Job Error"
   },
@@ -3370,6 +3373,9 @@
   },
   "scheduleDetailView.scheduleDetails": {
     "defaultMessage": "Schedule Details"
+  },
+  "scheduleDetailView.scheduleIncomplete": {
+    "defaultMessage": "Run incomplete"
   },
   "scheduleDetailView.scheduleInformation": {
     "defaultMessage": "Schedule Information"

--- a/ui/desktop/src/i18n/messages/es.json
+++ b/ui/desktop/src/i18n/messages/es.json
@@ -3290,6 +3290,9 @@
   "scheduleDetailView.idLabel": {
     "defaultMessage": "ID:"
   },
+  "scheduleDetailView.incompleteSession": {
+    "defaultMessage": "La respuesta alcanzó el límite de salida del modelo. Sesión parcial: {sessionId}"
+  },
   "scheduleDetailView.inspectJobError": {
     "defaultMessage": "Error al inspeccionar el trabajo"
   },
@@ -3370,6 +3373,9 @@
   },
   "scheduleDetailView.scheduleDetails": {
     "defaultMessage": "Detalles de la programación"
+  },
+  "scheduleDetailView.scheduleIncomplete": {
+    "defaultMessage": "Ejecución incompleta"
   },
   "scheduleDetailView.scheduleInformation": {
     "defaultMessage": "Información de la programación"

--- a/ui/desktop/src/i18n/messages/fr.json
+++ b/ui/desktop/src/i18n/messages/fr.json
@@ -3290,6 +3290,9 @@
   "scheduleDetailView.idLabel": {
     "defaultMessage": "ID :"
   },
+  "scheduleDetailView.incompleteSession": {
+    "defaultMessage": "La réponse a atteint la limite de sortie du modèle. Session partielle : {sessionId}"
+  },
   "scheduleDetailView.inspectJobError": {
     "defaultMessage": "Erreur d'inspection de la tâche"
   },
@@ -3370,6 +3373,9 @@
   },
   "scheduleDetailView.scheduleDetails": {
     "defaultMessage": "Détails de la planification"
+  },
+  "scheduleDetailView.scheduleIncomplete": {
+    "defaultMessage": "Exécution incomplète"
   },
   "scheduleDetailView.scheduleInformation": {
     "defaultMessage": "Informations sur la planification"

--- a/ui/desktop/src/i18n/messages/hi.json
+++ b/ui/desktop/src/i18n/messages/hi.json
@@ -3290,6 +3290,9 @@
   "scheduleDetailView.idLabel": {
     "defaultMessage": "आईडी:"
   },
+  "scheduleDetailView.incompleteSession": {
+    "defaultMessage": "जवाब मॉडल की आउटपुट सीमा तक पहुँच गया। आंशिक सत्र: {sessionId}"
+  },
   "scheduleDetailView.inspectJobError": {
     "defaultMessage": "कार्य त्रुटि का निरीक्षण करें"
   },
@@ -3370,6 +3373,9 @@
   },
   "scheduleDetailView.scheduleDetails": {
     "defaultMessage": "अनुसूची विवरण"
+  },
+  "scheduleDetailView.scheduleIncomplete": {
+    "defaultMessage": "रन अधूरा है"
   },
   "scheduleDetailView.scheduleInformation": {
     "defaultMessage": "अनुसूची सूचना"

--- a/ui/desktop/src/i18n/messages/id.json
+++ b/ui/desktop/src/i18n/messages/id.json
@@ -3290,6 +3290,9 @@
   "scheduleDetailView.idLabel": {
     "defaultMessage": "ID:"
   },
+  "scheduleDetailView.incompleteSession": {
+    "defaultMessage": "Respons mencapai batas output model. Sesi parsial: {sessionId}"
+  },
   "scheduleDetailView.inspectJobError": {
     "defaultMessage": "Periksa Kesalahan Pekerjaan"
   },
@@ -3370,6 +3373,9 @@
   },
   "scheduleDetailView.scheduleDetails": {
     "defaultMessage": "Detail Jadwal"
+  },
+  "scheduleDetailView.scheduleIncomplete": {
+    "defaultMessage": "Proses tidak lengkap"
   },
   "scheduleDetailView.scheduleInformation": {
     "defaultMessage": "Informasi Jadwal"

--- a/ui/desktop/src/i18n/messages/it.json
+++ b/ui/desktop/src/i18n/messages/it.json
@@ -3290,6 +3290,9 @@
   "scheduleDetailView.idLabel": {
     "defaultMessage": "ID:"
   },
+  "scheduleDetailView.incompleteSession": {
+    "defaultMessage": "La risposta ha raggiunto il limite di output del modello. Sessione parziale: {sessionId}"
+  },
   "scheduleDetailView.inspectJobError": {
     "defaultMessage": "Errore di ispezione del processo"
   },
@@ -3370,6 +3373,9 @@
   },
   "scheduleDetailView.scheduleDetails": {
     "defaultMessage": "Dettagli pianificazione"
+  },
+  "scheduleDetailView.scheduleIncomplete": {
+    "defaultMessage": "Esecuzione incompleta"
   },
   "scheduleDetailView.scheduleInformation": {
     "defaultMessage": "Informazioni sulla pianificazione"

--- a/ui/desktop/src/i18n/messages/ja.json
+++ b/ui/desktop/src/i18n/messages/ja.json
@@ -3290,6 +3290,9 @@
   "scheduleDetailView.idLabel": {
     "defaultMessage": "ID:"
   },
+  "scheduleDetailView.incompleteSession": {
+    "defaultMessage": "応答がモデルの出力上限に達しました。部分的なセッション: {sessionId}"
+  },
   "scheduleDetailView.inspectJobError": {
     "defaultMessage": "ジョブ確認エラー"
   },
@@ -3370,6 +3373,9 @@
   },
   "scheduleDetailView.scheduleDetails": {
     "defaultMessage": "スケジュール詳細"
+  },
+  "scheduleDetailView.scheduleIncomplete": {
+    "defaultMessage": "実行が未完了です"
   },
   "scheduleDetailView.scheduleInformation": {
     "defaultMessage": "スケジュール情報"

--- a/ui/desktop/src/i18n/messages/ko.json
+++ b/ui/desktop/src/i18n/messages/ko.json
@@ -3290,6 +3290,9 @@
   "scheduleDetailView.idLabel": {
     "defaultMessage": "ID:"
   },
+  "scheduleDetailView.incompleteSession": {
+    "defaultMessage": "응답이 모델의 출력 한도에 도달했습니다. 부분 세션: {sessionId}"
+  },
   "scheduleDetailView.inspectJobError": {
     "defaultMessage": "작업 검사 오류"
   },
@@ -3370,6 +3373,9 @@
   },
   "scheduleDetailView.scheduleDetails": {
     "defaultMessage": "일정 세부정보"
+  },
+  "scheduleDetailView.scheduleIncomplete": {
+    "defaultMessage": "실행 미완료"
   },
   "scheduleDetailView.scheduleInformation": {
     "defaultMessage": "일정 정보"

--- a/ui/desktop/src/i18n/messages/ms.json
+++ b/ui/desktop/src/i18n/messages/ms.json
@@ -3290,6 +3290,9 @@
   "scheduleDetailView.idLabel": {
     "defaultMessage": "ID:"
   },
+  "scheduleDetailView.incompleteSession": {
+    "defaultMessage": "Respons mencapai had output model. Sesi separa: {sessionId}"
+  },
   "scheduleDetailView.inspectJobError": {
     "defaultMessage": "Periksa Ralat Kerja"
   },
@@ -3370,6 +3373,9 @@
   },
   "scheduleDetailView.scheduleDetails": {
     "defaultMessage": "Butiran Jadual"
+  },
+  "scheduleDetailView.scheduleIncomplete": {
+    "defaultMessage": "Pelaksanaan tidak lengkap"
   },
   "scheduleDetailView.scheduleInformation": {
     "defaultMessage": "Maklumat Jadual"

--- a/ui/desktop/src/i18n/messages/pt.json
+++ b/ui/desktop/src/i18n/messages/pt.json
@@ -3290,6 +3290,9 @@
   "scheduleDetailView.idLabel": {
     "defaultMessage": "ID:"
   },
+  "scheduleDetailView.incompleteSession": {
+    "defaultMessage": "A resposta atingiu o limite de saída do modelo. Sessão parcial: {sessionId}"
+  },
   "scheduleDetailView.inspectJobError": {
     "defaultMessage": "Erro ao inspecionar tarefa"
   },
@@ -3370,6 +3373,9 @@
   },
   "scheduleDetailView.scheduleDetails": {
     "defaultMessage": "Detalhes do agendamento"
+  },
+  "scheduleDetailView.scheduleIncomplete": {
+    "defaultMessage": "Execução incompleta"
   },
   "scheduleDetailView.scheduleInformation": {
     "defaultMessage": "Informação do agendamento"

--- a/ui/desktop/src/i18n/messages/ru.json
+++ b/ui/desktop/src/i18n/messages/ru.json
@@ -3290,6 +3290,9 @@
   "scheduleDetailView.idLabel": {
     "defaultMessage": "ID:"
   },
+  "scheduleDetailView.incompleteSession": {
+    "defaultMessage": "Ответ достиг ограничения модели на объём вывода. Частичная сессия: {sessionId}"
+  },
   "scheduleDetailView.inspectJobError": {
     "defaultMessage": "Ошибка проверки задания"
   },
@@ -3370,6 +3373,9 @@
   },
   "scheduleDetailView.scheduleDetails": {
     "defaultMessage": "Детали расписания"
+  },
+  "scheduleDetailView.scheduleIncomplete": {
+    "defaultMessage": "Выполнение не завершено"
   },
   "scheduleDetailView.scheduleInformation": {
     "defaultMessage": "Информация о расписании"

--- a/ui/desktop/src/i18n/messages/tr.json
+++ b/ui/desktop/src/i18n/messages/tr.json
@@ -3290,6 +3290,9 @@
   "scheduleDetailView.idLabel": {
     "defaultMessage": "Kimlik:"
   },
+  "scheduleDetailView.incompleteSession": {
+    "defaultMessage": "Yanıt, modelin çıktı sınırına ulaştı. Kısmi oturum: {sessionId}"
+  },
   "scheduleDetailView.inspectJobError": {
     "defaultMessage": "İş Hatasını İnceleyin"
   },
@@ -3370,6 +3373,9 @@
   },
   "scheduleDetailView.scheduleDetails": {
     "defaultMessage": "Program Ayrıntıları"
+  },
+  "scheduleDetailView.scheduleIncomplete": {
+    "defaultMessage": "Çalıştırma tamamlanmadı"
   },
   "scheduleDetailView.scheduleInformation": {
     "defaultMessage": "Program Bilgileri"

--- a/ui/desktop/src/i18n/messages/vi.json
+++ b/ui/desktop/src/i18n/messages/vi.json
@@ -3290,6 +3290,9 @@
   "scheduleDetailView.idLabel": {
     "defaultMessage": "ID:"
   },
+  "scheduleDetailView.incompleteSession": {
+    "defaultMessage": "Phản hồi đã đạt giới hạn đầu ra của mô hình. Phiên một phần: {sessionId}"
+  },
   "scheduleDetailView.inspectJobError": {
     "defaultMessage": "Lỗi kiểm tra công việc"
   },
@@ -3370,6 +3373,9 @@
   },
   "scheduleDetailView.scheduleDetails": {
     "defaultMessage": "Chi tiết lịch trình"
+  },
+  "scheduleDetailView.scheduleIncomplete": {
+    "defaultMessage": "Lần chạy chưa hoàn tất"
   },
   "scheduleDetailView.scheduleInformation": {
     "defaultMessage": "Thông tin lịch trình"

--- a/ui/desktop/src/i18n/messages/zh-CN.json
+++ b/ui/desktop/src/i18n/messages/zh-CN.json
@@ -3290,6 +3290,9 @@
   "scheduleDetailView.idLabel": {
     "defaultMessage": "ID："
   },
+  "scheduleDetailView.incompleteSession": {
+    "defaultMessage": "响应已达到模型的输出限制。部分会话：{sessionId}"
+  },
   "scheduleDetailView.inspectJobError": {
     "defaultMessage": "检查任务错误"
   },
@@ -3370,6 +3373,9 @@
   },
   "scheduleDetailView.scheduleDetails": {
     "defaultMessage": "计划详情"
+  },
+  "scheduleDetailView.scheduleIncomplete": {
+    "defaultMessage": "运行未完成"
   },
   "scheduleDetailView.scheduleInformation": {
     "defaultMessage": "计划信息"

--- a/ui/desktop/src/i18n/messages/zh-TW.json
+++ b/ui/desktop/src/i18n/messages/zh-TW.json
@@ -3290,6 +3290,9 @@
   "scheduleDetailView.idLabel": {
     "defaultMessage": "ID："
   },
+  "scheduleDetailView.incompleteSession": {
+    "defaultMessage": "回應已達模型輸出限制。部分工作階段：{sessionId}"
+  },
   "scheduleDetailView.inspectJobError": {
     "defaultMessage": "檢查工作錯誤"
   },
@@ -3370,6 +3373,9 @@
   },
   "scheduleDetailView.scheduleDetails": {
     "defaultMessage": "排程詳細資料"
+  },
+  "scheduleDetailView.scheduleIncomplete": {
+    "defaultMessage": "執行未完成"
   },
   "scheduleDetailView.scheduleInformation": {
     "defaultMessage": "排程資訊"

--- a/ui/desktop/src/toasts.tsx
+++ b/ui/desktop/src/toasts.tsx
@@ -163,6 +163,18 @@ export function toastSuccess({ title, msg, toastOptions = {} }: ToastSuccessProp
   );
 }
 
+type ToastWarningProps = { title?: string; msg?: string; toastOptions?: ToastOptions };
+
+export function toastWarning({ title, msg, toastOptions = {} }: ToastWarningProps) {
+  return toast.warning(
+    <div>
+      {title ? <strong className="font-medium">{title}</strong> : null}
+      {title ? <div>{msg}</div> : null}
+    </div>,
+    { ...commonToastOptions, autoClose: 5000, ...toastOptions }
+  );
+}
+
 type ToastErrorProps = {
   title: string;
   msg: string;

--- a/ui/sdk/src/generated/types.gen.ts
+++ b/ui/sdk/src/generated/types.gen.ts
@@ -1849,7 +1849,7 @@ export type RunScheduleNowResponse_unstable = {
     sessionId?: string | null;
 };
 
-export type RunScheduleNowStatus = 'completed' | 'cancelled';
+export type RunScheduleNowStatus = 'completed' | 'incomplete' | 'cancelled';
 
 export type KillRunningJobRequest_unstable = {
     jobId: string;

--- a/ui/sdk/src/generated/zod.gen.ts
+++ b/ui/sdk/src/generated/zod.gen.ts
@@ -1911,7 +1911,11 @@ export const zRunScheduleNowRequest_unstable = z.object({
     scheduleId: z.string()
 });
 
-export const zRunScheduleNowStatus = z.enum(['completed', 'cancelled']);
+export const zRunScheduleNowStatus = z.enum([
+    'completed',
+    'incomplete',
+    'cancelled'
+]);
 
 export const zRunScheduleNowResponse_unstable = z.object({
     status: zRunScheduleNowStatus,


### PR DESCRIPTION
## Problem

Responses that hit a model's output token limit are currently treated as normal completions. Users can receive an answer that stops mid-sentence with no indication that it is incomplete, while ACP clients lose the terminal stop reason.

## Solution

- **Detect truncation across provider formats.** Anthropic (`max_tokens`), OpenAI Chat Completions and compatible providers (`length`), OpenAI Responses (`max_output_tokens`), and Google Gemini (`MAX_TOKENS`) map their native signals to a shared typed error. Ollama and Databricks inherit this through the shared OpenAI parsers.
- **Preserve partial output without hidden retries.** The agent keeps everything the model produced, ends the turn immediately, and does not issue automatic continuation requests. Users explicitly choose whether to continue, narrow the request, or move on.
- **Propagate the terminal stop reason.** `StopReason::MaxTokens` flows through ACP and nested ACP providers, so Goose, Claude Code, Codex, and other ACP harness paths can report truncation whenever the upstream harness supplies the standard stop reason.
- **Surface the incomplete state.** Desktop chat adds an inline, user-visible/agent-invisible message directly below the partial response. Scheduled runs use a warning toast. Gateway and interactive CLI surfaces show human-readable warnings.
- **Support structured consumers.** JSON and stream-JSON completion records report `status: "incomplete"` and `stop_reason: "max_tokens"`; stream-JSON remains valid NDJSON.
- **Protect downstream trust boundaries.** Truncated subagent and orchestrator responses return errors with preserved partial output rather than presenting incomplete work as successful.
- **Preserve toolshim output safely.** Complete tool calls and partial assistant text are retained, incomplete tool syntax is removed, and truncation still propagates.

## Harness behavior

- **Goose harness:** detects provider-native output-limit signals and emits the shared incomplete result.
- **Nested ACP harnesses:** relays `StopReason::MaxTokens` from external harnesses through Goose.
- **Direct ACP clients:** receive the standard ACP stop reason and decide how to present it; Goose Desktop renders it inline in the conversation.

An external harness must report `StopReason::MaxTokens` for its own truncated response. Goose cannot infer truncation when an adapter reports a generic end turn.

## Testing

- Provider-format regressions verify partial output and usage are emitted before `MaxTokens` for Anthropic, OpenAI Chat Completions, OpenAI Responses, and Google Gemini.
- Agent regression verifies one provider call, preserved partial output, exactly one terminal event, and no hidden continuation.
- Cancellation remains higher priority than max-token truncation.
- Nested ACP tests preserve usage and propagate the typed stop reason.
- Subagent, orchestrator, scheduler, CLI structured-output, toolshim, and desktop inline-message tests cover their respective boundaries.
- Validation performed during the rework:
  - targeted Goose max-token and cancellation tests passed
  - targeted provider-format tests passed
  - `cargo clippy -p goose-provider-types -p goose --all-targets -- -D warnings` passed
  - desktop max-token controller test passed as part of the UI suite; the unrelated full suite has existing environment failures involving a missing `turndown` dependency and recipe-schema generation
