### PR TITLE
feat(anthropic): cache-preserving mid-conversation tool changes

### DIFF
--- a/crates/goose-provider-types/src/base.rs
+++ b/crates/goose-provider-types/src/base.rs
@@ -451,6 +451,12 @@ pub trait Provider: Send + Sync {
         false
     }
 
+    /// When true the caller keeps every tool offered during the session in `tools` and
+    /// records toggles as `ToolSetUpdate` blocks instead of rewriting the array.
+    fn supports_mid_conversation_tool_changes(&self, _model_config: &ModelConfig) -> bool {
+        false
+    }
+
     /// Fetch inventory models filtered by canonical registry and usability.
     ///
     /// When `toolshim` is true, models that lack native tool-call support are

--- a/crates/goose-provider-types/src/conversation.rs
+++ b/crates/goose-provider-types/src/conversation.rs
@@ -608,8 +608,16 @@ pub fn is_turn_context_text(text: &str) -> bool {
 
 /// Only agent-visible messages count, since those are the only ones the provider is sent,
 /// and deltas naming an undeclared tool are ignored because referencing one is a wire error.
-pub fn resolve_visible_tools(declared: &HashSet<String>, messages: &[Message]) -> HashSet<String> {
-    let mut visible = declared.clone();
+///
+/// `initially_available` is what the tool array offers on its own: a withheld tool is declared
+/// but unavailable until an addition names it, so it starts outside this set while still being
+/// nameable by a delta.
+pub fn resolve_visible_tools(
+    declared: &HashSet<String>,
+    initially_available: &HashSet<String>,
+    messages: &[Message],
+) -> HashSet<String> {
+    let mut visible = initially_available.clone();
     for update in messages
         .iter()
         .filter(|message| message.is_agent_visible())

--- a/crates/goose-provider-types/src/conversation.rs
+++ b/crates/goose-provider-types/src/conversation.rs
@@ -609,9 +609,8 @@ pub fn is_turn_context_text(text: &str) -> bool {
 /// Only agent-visible messages count, since those are the only ones the provider is sent,
 /// and deltas naming an undeclared tool are ignored because referencing one is a wire error.
 ///
-/// `initially_available` is what the tool array offers on its own: a withheld tool is declared
-/// but unavailable until an addition names it, so it starts outside this set while still being
-/// nameable by a delta.
+/// `initially_available` is what the tool array offers on its own, which excludes a withheld tool
+/// until an addition names it.
 pub fn resolve_visible_tools(
     declared: &HashSet<String>,
     initially_available: &HashSet<String>,

--- a/crates/goose-provider-types/src/conversation.rs
+++ b/crates/goose-provider-types/src/conversation.rs
@@ -606,6 +606,33 @@ pub fn is_turn_context_text(text: &str) -> bool {
         && text.trim_end().ends_with(&format!("</{TURN_CONTEXT_TAG}>"))
 }
 
+/// Only agent-visible messages count, since those are the only ones the provider is sent,
+/// and deltas naming an undeclared tool are ignored because referencing one is a wire error.
+pub fn resolve_visible_tools(declared: &HashSet<String>, messages: &[Message]) -> HashSet<String> {
+    let mut visible = declared.clone();
+    for update in messages
+        .iter()
+        .filter(|message| message.is_agent_visible())
+        .flat_map(|message| message.content.iter())
+        .filter_map(|content| match content {
+            MessageContentBlock::ToolSetUpdate(update) => Some(update),
+            _ => None,
+        })
+    {
+        for name in update
+            .removed
+            .iter()
+            .filter(|name| declared.contains(*name))
+        {
+            visible.remove(name);
+        }
+        for name in update.added.iter().filter(|name| declared.contains(*name)) {
+            visible.insert(name.clone());
+        }
+    }
+    visible
+}
+
 pub fn effective_role(message: &Message) -> String {
     if message.role == Role::User && has_tool_response(message) {
         "tool".to_string()

--- a/crates/goose-provider-types/src/conversation/message.rs
+++ b/crates/goose-provider-types/src/conversation/message.rs
@@ -203,6 +203,21 @@ pub struct SystemNotificationContent {
     pub data: Option<serde_json::Value>,
 }
 
+/// A change to the set of tools the model may call, recorded where it happened. Names are
+/// the prefixed names used in the request's `tools` array.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ToolSetUpdateContent {
+    pub added: Vec<String>,
+    pub removed: Vec<String>,
+}
+
+impl ToolSetUpdateContent {
+    pub fn is_empty(&self) -> bool {
+        self.added.is_empty() && self.removed.is_empty()
+    }
+}
+
 pub type MessageContent = MessageContentBlock;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -219,6 +234,7 @@ pub enum MessageContentBlock {
     Thinking(ThinkingContentBlock),
     RedactedThinking(RedactedThinkingContentBlock),
     SystemNotification(SystemNotificationContent),
+    ToolSetUpdate(ToolSetUpdateContent),
 }
 
 impl fmt::Display for MessageContentBlock {
@@ -260,6 +276,12 @@ impl fmt::Display for MessageContentBlock {
             MessageContentBlock::SystemNotification(r) => {
                 write!(f, "[SystemNotification: {}]", r.msg)
             }
+            MessageContentBlock::ToolSetUpdate(u) => write!(
+                f,
+                "[ToolSetUpdate: +{} -{}]",
+                u.added.len(),
+                u.removed.len()
+            ),
         }
     }
 }
@@ -350,6 +372,7 @@ impl MessageContentBlock {
             MessageContentBlock::Text(_)
             | MessageContentBlock::Image(_)
             | MessageContentBlock::ToolResponse(_) => self.filter_for_audience(Role::User),
+            MessageContentBlock::ToolSetUpdate(_) => None,
             _ => Some(self.clone()),
         }
     }

--- a/crates/goose-provider-types/src/formats/anthropic.rs
+++ b/crates/goose-provider-types/src/formats/anthropic.rs
@@ -106,6 +106,12 @@ pub fn tool_defers_loading(tool: &Tool) -> bool {
         .is_some_and(|meta| meta.0.get(DEFER_LOADING_META_KEY) == Some(&json!(true)))
 }
 
+/// An extension owns the `_meta` it returns, so a marker arriving with a listed tool is not goose's:
+/// honoring it would withhold that tool with no `tool_addition` able to reveal it.
+pub fn discard_defer_loading_marker(meta: &mut JsonObject) {
+    meta.remove(DEFER_LOADING_META_KEY);
+}
+
 /// Canonical ids, so dated names and regional or reseller aliases all resolve to one check. Mythos
 /// is absent from the generated registry, leaving it inert here until the registry carries it.
 const MID_CONVERSATION_TOOL_CHANGE_MODELS: &[&str] = &[
@@ -557,7 +563,7 @@ fn anthropic_flavored_input_schema(input_schema: Arc<JsonObject>) -> Arc<JsonObj
 }
 
 /// Convert internal Tool format to Anthropic's API tool specification
-pub fn format_tools(tools: &[Tool]) -> Vec<Value> {
+pub fn format_tools(tools: &[Tool], mid_conversation_tool_changes: bool) -> Vec<Value> {
     let mut unique_tools = HashSet::new();
     let mut tool_specs = Vec::new();
 
@@ -568,7 +574,8 @@ pub fn format_tools(tools: &[Tool]) -> Vec<Value> {
                 "description": tool.description,
                 "input_schema": anthropic_flavored_input_schema(tool.input_schema.clone())
             });
-            if tool_defers_loading(tool) {
+            // `defer_loading` is beta-only, so a request that did not opt in must not carry it.
+            if mid_conversation_tool_changes && tool_defers_loading(tool) {
                 spec[DEFER_LOADING_FIELD] = json!(true);
             }
             tool_specs.push(spec);
@@ -874,7 +881,7 @@ pub fn create_request(
         }
     }
 
-    let tool_specs = format_tools(declared_tools);
+    let tool_specs = format_tools(declared_tools, options.mid_conversation_tool_changes);
     let system_spec = format_system(system);
 
     if anthropic_messages.is_empty() {
@@ -1511,7 +1518,7 @@ mod tests {
             ),
         ];
 
-        let spec = format_tools(&tools);
+        let spec = format_tools(&tools, false);
 
         assert_eq!(spec.len(), 2);
         assert_eq!(spec[0]["name"], "calculator");
@@ -2838,6 +2845,54 @@ mod tests {
 
         assert!(!payload_needs_tool_change_beta(&payload));
         assert_eq!(payload["messages"].as_array().unwrap().len(), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn test_defer_loading_is_beta_only_and_never_shares_a_spec_with_cache_control() -> Result<()> {
+        let messages = vec![Message::user().with_text("first")];
+        let tools = [defer_tool_loading(&named_tool("a")), named_tool("b")];
+
+        let on = create_request_with_options_provider(
+            &cfg("claude-opus-5"),
+            "system",
+            &messages,
+            &tools,
+            AnthropicFormatOptions {
+                mid_conversation_tool_changes: true,
+                ..AnthropicFormatOptions::default()
+            },
+        )?;
+        let specs = on["tools"].as_array().unwrap();
+        assert_eq!(specs[0][DEFER_LOADING_FIELD], json!(true));
+        // Both fields on one spec is a 400, so the breakpoint moves to the last offered spec.
+        assert!(specs[0].get(CACHE_CONTROL_FIELD).is_none());
+        assert!(specs[1].get(CACHE_CONTROL_FIELD).is_some());
+        assert!(payload_needs_tool_change_beta(&on));
+
+        for (model, options) in [
+            ("claude-opus-5", AnthropicFormatOptions::default()),
+            (
+                "claude-sonnet-5",
+                AnthropicFormatOptions {
+                    mid_conversation_tool_changes: true,
+                    ..AnthropicFormatOptions::default()
+                },
+            ),
+        ] {
+            let off = create_request_with_options_provider(
+                &cfg(model),
+                "system",
+                &messages,
+                &tools,
+                options,
+            )?;
+            let specs = off["tools"].as_array().unwrap();
+            assert!(specs
+                .iter()
+                .all(|spec| spec.get(DEFER_LOADING_FIELD).is_none()));
+            assert!(!payload_needs_tool_change_beta(&off));
+        }
         Ok(())
     }
 

--- a/crates/goose-provider-types/src/formats/anthropic.rs
+++ b/crates/goose-provider-types/src/formats/anthropic.rs
@@ -79,9 +79,8 @@ pub const MID_CONVERSATION_TOOL_CHANGES_BETA: &str = "mid-conversation-tool-chan
 
 const DEFER_LOADING_FIELD: &str = "defer_loading";
 
-/// `_meta` marker for a declared tool the model has not been offered yet. A declared tool counts
-/// as available from the first turn unless its spec defers loading, which no later `tool_addition`
-/// can undo.
+/// `_meta` marker for a declared tool the model has not been offered yet. Without it a declared
+/// tool counts as available from the first turn, and no later `tool_addition` undoes that.
 const DEFER_LOADING_META_KEY: &str = "dev.goose/deferLoading";
 
 pub fn defer_tool_loading(tool: &Tool) -> Tool {
@@ -108,8 +107,7 @@ pub fn tool_defers_loading(tool: &Tool) -> bool {
 }
 
 /// Canonical ids, so dated names and regional or reseller aliases all resolve to one check. Mythos
-/// is restricted and absent from the generated registry, which leaves it inert here until the
-/// registry carries it rather than needing a second gate then.
+/// is absent from the generated registry, leaving it inert here until the registry carries it.
 const MID_CONVERSATION_TOOL_CHANGE_MODELS: &[&str] = &[
     "anthropic/claude-opus-5",
     "anthropic/claude-opus-4.8",

--- a/crates/goose-provider-types/src/formats/anthropic.rs
+++ b/crates/goose-provider-types/src/formats/anthropic.rs
@@ -583,8 +583,8 @@ pub fn format_tools(tools: &[Tool], mid_conversation_tool_changes: bool) -> Vec<
     }
 
     // Add "cache_control" to the last tool spec, if any. This means that all tool definitions,
-    // will be cached as a single prefix. A withheld tool is rejected outright if it also carries
-    // cache_control, so the breakpoint goes on the last spec that can hold one.
+    // will be cached as a single prefix. A withheld spec is rejected if it also carries
+    // cache_control, so the breakpoint goes on the last one that can hold it.
     if let Some(last_tool) = tool_specs
         .iter_mut()
         .rev()

--- a/crates/goose-provider-types/src/formats/anthropic.rs
+++ b/crates/goose-provider-types/src/formats/anthropic.rs
@@ -107,6 +107,9 @@ pub fn tool_defers_loading(tool: &Tool) -> bool {
         .is_some_and(|meta| meta.0.get(DEFER_LOADING_META_KEY) == Some(&json!(true)))
 }
 
+/// Canonical ids, so dated names and regional or reseller aliases all resolve to one check. Mythos
+/// is restricted and absent from the generated registry, which leaves it inert here until the
+/// registry carries it rather than needing a second gate then.
 const MID_CONVERSATION_TOOL_CHANGE_MODELS: &[&str] = &[
     "anthropic/claude-opus-5",
     "anthropic/claude-opus-4.8",

--- a/crates/goose-provider-types/src/formats/anthropic.rs
+++ b/crates/goose-provider-types/src/formats/anthropic.rs
@@ -1,6 +1,7 @@
 use crate::canonical::maybe_get_canonical_model;
 use crate::canonical::ThinkingMode;
-use crate::conversation::message::{Message, MessageContentBlock};
+use crate::conversation::message::{Message, MessageContentBlock, ToolSetUpdateContent};
+use crate::conversation::resolve_visible_tools;
 use crate::conversation::token_usage::{CostSource, ProviderUsage, Usage};
 use crate::errors::ProviderError;
 use crate::images::{convert_image, ImageFormat};
@@ -48,10 +49,12 @@ pub struct AnthropicFormatOptions {
     pub preserve_unsigned_thinking: bool,
     pub preserve_thinking_context: bool,
     pub thinking_disabled: bool,
+    /// Set only by providers that also send the beta header; without it this is a 400.
+    pub mid_conversation_tool_changes: bool,
 }
 
 impl AnthropicFormatOptions {
-    fn for_model(self, model_config: &ModelConfig) -> Self {
+    fn for_model(self, provider_name: &str, model_config: &ModelConfig) -> Self {
         let preserve_thinking_context = model_config
             .request_param::<bool>("preserve_thinking_context")
             .unwrap_or(self.preserve_thinking_context);
@@ -66,8 +69,27 @@ impl AnthropicFormatOptions {
             preserve_unsigned_thinking,
             preserve_thinking_context,
             thinking_disabled,
+            mid_conversation_tool_changes: self.mid_conversation_tool_changes
+                && model_supports_mid_conversation_tool_changes(provider_name, model_config),
         }
     }
+}
+
+pub const MID_CONVERSATION_TOOL_CHANGES_BETA: &str = "mid-conversation-tool-changes-2026-07-01";
+
+const MID_CONVERSATION_TOOL_CHANGE_MODELS: &[&str] = &[
+    "anthropic/claude-opus-5",
+    "anthropic/claude-opus-4.8",
+    "anthropic/claude-fable-5",
+    "anthropic/claude-mythos-5",
+];
+
+pub fn model_supports_mid_conversation_tool_changes(
+    provider_name: &str,
+    model_config: &ModelConfig,
+) -> bool {
+    maybe_get_canonical_model(provider_name, &model_config.model_name)
+        .is_some_and(|model| MID_CONVERSATION_TOOL_CHANGE_MODELS.contains(&model.id.as_str()))
 }
 
 fn canonical_thinking_mode(provider_name: &str, model_name: &str) -> Option<ThinkingMode> {
@@ -146,6 +168,11 @@ const EVENT_CONTENT_BLOCK_DELTA: &str = "content_block_delta";
 const EVENT_CONTENT_BLOCK_STOP: &str = "content_block_stop";
 const STOP_REASON_REFUSAL: &str = "refusal";
 const REFUSAL_FALLBACK_DETAILS: &str = "No additional details were provided.";
+const SYSTEM_ROLE: &str = "system";
+const TOOL_ADDITION_TYPE: &str = "tool_addition";
+const TOOL_REMOVAL_TYPE: &str = "tool_removal";
+const TOOL_REFERENCE_TYPE: &str = "tool_reference";
+const TOOL_FIELD: &str = "tool";
 
 /// Coerce a tool call's optional arguments into the JSON value Anthropic
 /// expects for the `input` field of a `tool_use` content block.
@@ -162,16 +189,45 @@ fn args_to_input_value(arguments: Option<JsonObject>) -> Value {
     Value::Object(arguments.unwrap_or_default())
 }
 
+fn tool_reference(name: &str) -> Value {
+    json!({ TYPE_FIELD: TOOL_REFERENCE_TYPE, NAME_FIELD: name })
+}
+
+fn tool_set_update_blocks(update: &ToolSetUpdateContent, declared: &HashSet<String>) -> Vec<Value> {
+    update
+        .removed
+        .iter()
+        .filter(|name| declared.contains(*name))
+        .map(|name| json!({ TYPE_FIELD: TOOL_REMOVAL_TYPE, TOOL_FIELD: tool_reference(name) }))
+        .chain(
+            update
+                .added
+                .iter()
+                .filter(|name| declared.contains(*name))
+                .map(|name| {
+                    json!({ TYPE_FIELD: TOOL_ADDITION_TYPE, TOOL_FIELD: tool_reference(name) })
+                }),
+        )
+        .collect()
+}
+
 /// Convert internal Message format to Anthropic's API message specification
 pub fn format_messages(messages: &[Message]) -> Vec<Value> {
-    format_messages_with_options(messages, AnthropicFormatOptions::default())
+    format_messages_with_options(messages, AnthropicFormatOptions::default()).messages
+}
+
+struct FormattedMessages {
+    messages: Vec<Value>,
+    /// `None` when the delta had no rendered predecessor, so has nowhere legal to sit.
+    tool_set_updates: Vec<(Option<usize>, ToolSetUpdateContent)>,
 }
 
 fn format_messages_with_options(
     messages: &[Message],
     options: AnthropicFormatOptions,
-) -> Vec<Value> {
+) -> FormattedMessages {
     let mut anthropic_messages = Vec::new();
+    let mut tool_set_updates: Vec<(Option<usize>, ToolSetUpdateContent)> = Vec::new();
 
     for message in messages {
         let role = match message.role {
@@ -179,6 +235,7 @@ fn format_messages_with_options(
             Role::Assistant => ASSISTANT_ROLE,
         };
 
+        let mut pending_updates: Vec<ToolSetUpdateContent> = Vec::new();
         let mut content = Vec::new();
         for msg_content in &message.content {
             match msg_content {
@@ -260,6 +317,9 @@ fn format_messages_with_options(
                 MessageContentBlock::SystemNotification(_) => {
                     // Skip
                 }
+                MessageContentBlock::ToolSetUpdate(update) => {
+                    pending_updates.push(update.clone());
+                }
                 MessageContentBlock::Thinking(thinking) => {
                     // Anthropic rejects thinking blocks sent without a matching thinking config.
                     if !options.thinking_disabled {
@@ -310,6 +370,9 @@ fn format_messages_with_options(
                 CONTENT_FIELD: content
             }));
         }
+
+        let anchor = anthropic_messages.len().checked_sub(1);
+        tool_set_updates.extend(pending_updates.into_iter().map(|update| (anchor, update)));
     }
 
     if anthropic_messages.is_empty() {
@@ -356,7 +419,55 @@ fn format_messages_with_options(
         }
     }
 
-    anthropic_messages
+    FormattedMessages {
+        messages: anthropic_messages,
+        tool_set_updates,
+    }
+}
+
+/// A `system` message is only accepted immediately after a `user` turn, and only if
+/// it ends the array or is followed by an `assistant` turn. Anything else is a 400.
+fn anchor_accepts_system_message(messages: &[Value], anchor: usize) -> bool {
+    let role_at = |index: usize| messages.get(index).and_then(|m| m.get(ROLE_FIELD));
+    role_at(anchor) == Some(&json!(USER_ROLE))
+        && match role_at(anchor + 1) {
+            Some(role) => role == &json!(ASSISTANT_ROLE),
+            None => true,
+        }
+}
+
+/// Returns false without touching `messages` if any delta cannot be placed legally. Skipping
+/// just that one would leave the model holding a tool the caller believes it withdrew, so the
+/// caller withdraws it instead by not declaring it at all.
+fn insert_tool_set_updates(
+    messages: &mut Vec<Value>,
+    updates: &[(Option<usize>, ToolSetUpdateContent)],
+    declared: &HashSet<String>,
+) -> bool {
+    let mut grouped: Vec<(usize, Vec<Value>)> = Vec::new();
+    for (anchor, update) in updates {
+        let blocks = tool_set_update_blocks(update, declared);
+        if blocks.is_empty() {
+            continue;
+        }
+        let Some(anchor) = anchor.filter(|a| anchor_accepts_system_message(messages, *a)) else {
+            return false;
+        };
+        match grouped.last_mut() {
+            Some((last_anchor, last_blocks)) if *last_anchor == anchor => {
+                last_blocks.extend(blocks)
+            }
+            _ => grouped.push((anchor, blocks)),
+        }
+    }
+
+    for (anchor, blocks) in grouped.into_iter().rev() {
+        messages.insert(
+            anchor + 1,
+            json!({ ROLE_FIELD: SYSTEM_ROLE, CONTENT_FIELD: blocks }),
+        );
+    }
+    true
 }
 
 fn relocate_turn_context_to_tail(messages: &mut [Value]) {
@@ -695,9 +806,28 @@ pub fn create_request(
     tools: &[Tool],
     options: AnthropicFormatOptions,
 ) -> Result<Value> {
-    let options = options.for_model(model_config);
-    let anthropic_messages = format_messages_with_options(messages, options);
-    let tool_specs = format_tools(tools);
+    let options = options.for_model(provider_name, model_config);
+    let FormattedMessages {
+        messages: mut anthropic_messages,
+        tool_set_updates,
+    } = format_messages_with_options(messages, options);
+
+    let mut declared_tools = tools;
+    let visible_tools;
+    if options.mid_conversation_tool_changes && !tool_set_updates.is_empty() {
+        let declared: HashSet<String> = tools.iter().map(|tool| tool.name.to_string()).collect();
+        if !insert_tool_set_updates(&mut anthropic_messages, &tool_set_updates, &declared) {
+            let visible = resolve_visible_tools(&declared, messages);
+            visible_tools = tools
+                .iter()
+                .filter(|tool| visible.contains(tool.name.as_ref()))
+                .cloned()
+                .collect::<Vec<_>>();
+            declared_tools = &visible_tools;
+        }
+    }
+
+    let tool_specs = format_tools(declared_tools);
     let system_spec = format_system(system);
 
     if anthropic_messages.is_empty() {
@@ -743,6 +873,17 @@ pub fn create_request(
     );
 
     Ok(payload)
+}
+
+pub fn payload_needs_tool_change_beta(payload: &Value) -> bool {
+    payload
+        .get("messages")
+        .and_then(Value::as_array)
+        .is_some_and(|messages| {
+            messages
+                .iter()
+                .any(|message| message.get(ROLE_FIELD).and_then(Value::as_str) == Some(SYSTEM_ROLE))
+        })
 }
 
 /// Process streaming response from Anthropic's API
@@ -1266,10 +1407,10 @@ mod tests {
             &messages,
             AnthropicFormatOptions {
                 preserve_unsigned_thinking: true,
-                preserve_thinking_context: false,
-                thinking_disabled: false,
+                ..AnthropicFormatOptions::default()
             },
-        );
+        )
+        .messages;
 
         assert_eq!(spec.len(), 2);
         assert_eq!(spec[0]["role"], "assistant");
@@ -1501,7 +1642,7 @@ mod tests {
             AnthropicFormatOptions {
                 preserve_unsigned_thinking: true,
                 preserve_thinking_context: true,
-                thinking_disabled: false,
+                ..AnthropicFormatOptions::default()
             },
         )?;
 
@@ -2566,5 +2707,112 @@ mod tests {
                  last breakpoint at {breakpoint:?}"
             );
         }
+    }
+
+    fn named_tool(name: &str) -> Tool {
+        Tool::new(name.to_string(), "test tool", object!({"type": "object"}))
+    }
+
+    fn tool_set_update(added: &[&str], removed: &[&str]) -> Message {
+        Message::user().with_content(MessageContentBlock::ToolSetUpdate(ToolSetUpdateContent {
+            added: added.iter().map(|n| n.to_string()).collect(),
+            removed: removed.iter().map(|n| n.to_string()).collect(),
+        }))
+    }
+
+    #[test]
+    fn test_tool_set_update_renders_system_message_after_its_anchor() -> Result<()> {
+        let messages = vec![
+            Message::user().with_text("first"),
+            Message::assistant().with_text("ok"),
+            Message::user().with_text("second"),
+            tool_set_update(&["b"], &["a", "never_declared"]),
+        ];
+        let tools = vec![named_tool("a"), named_tool("b")];
+
+        let payload = create_request_with_options_provider(
+            &cfg("claude-opus-5"),
+            "system",
+            &messages,
+            &tools,
+            AnthropicFormatOptions {
+                mid_conversation_tool_changes: true,
+                ..AnthropicFormatOptions::default()
+            },
+        )?;
+
+        assert!(payload_needs_tool_change_beta(&payload));
+        let messages = payload["messages"].as_array().unwrap();
+        assert_eq!(messages.len(), 4);
+        assert_eq!(messages[2]["content"][0]["text"], "second");
+        assert_eq!(messages[3]["role"], SYSTEM_ROLE);
+
+        let blocks = messages[3]["content"].as_array().unwrap();
+        assert_eq!(blocks.len(), 2);
+        assert_eq!(blocks[0]["type"], TOOL_REMOVAL_TYPE);
+        assert_eq!(blocks[0][TOOL_FIELD]["name"], "a");
+        assert_eq!(blocks[1]["type"], TOOL_ADDITION_TYPE);
+        assert_eq!(blocks[1][TOOL_FIELD]["name"], "b");
+
+        assert_eq!(payload["tools"].as_array().unwrap().len(), 2);
+        Ok(())
+    }
+
+    #[test]
+    fn test_tool_set_update_dropped_when_model_unsupported() -> Result<()> {
+        let messages = vec![
+            Message::user().with_text("first"),
+            tool_set_update(&[], &["a"]),
+        ];
+
+        let payload = create_request_with_options_provider(
+            &cfg("claude-sonnet-5"),
+            "system",
+            &messages,
+            &[named_tool("a")],
+            AnthropicFormatOptions {
+                mid_conversation_tool_changes: true,
+                ..AnthropicFormatOptions::default()
+            },
+        )?;
+
+        assert!(!payload_needs_tool_change_beta(&payload));
+        assert_eq!(payload["messages"].as_array().unwrap().len(), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn test_unplaceable_tool_set_update_withdraws_the_tool_instead() -> Result<()> {
+        let with_no_predecessor = vec![
+            tool_set_update(&[], &["a"]),
+            Message::user().with_text("first"),
+        ];
+        // Renders as `user, system, user`, which the API rejects, because the
+        // thinking-only assistant turn between them contributes no content.
+        let followed_by_a_user_turn = vec![
+            Message::user().with_text("first"),
+            tool_set_update(&[], &["a"]),
+            Message::assistant().with_content(MessageContentBlock::thinking("unsigned", "")),
+            Message::user().with_text("second"),
+        ];
+
+        for messages in [with_no_predecessor, followed_by_a_user_turn] {
+            let payload = create_request_with_options_provider(
+                &cfg("claude-opus-5"),
+                "system",
+                &messages,
+                &[named_tool("a"), named_tool("b")],
+                AnthropicFormatOptions {
+                    mid_conversation_tool_changes: true,
+                    ..AnthropicFormatOptions::default()
+                },
+            )?;
+
+            assert!(!payload_needs_tool_change_beta(&payload));
+            let tools = payload["tools"].as_array().unwrap();
+            assert_eq!(tools.len(), 1);
+            assert_eq!(tools[0]["name"], "b");
+        }
+        Ok(())
     }
 }

--- a/crates/goose-provider-types/src/formats/anthropic.rs
+++ b/crates/goose-provider-types/src/formats/anthropic.rs
@@ -93,7 +93,7 @@ pub fn defer_tool_loading(tool: &Tool) -> Tool {
     tool
 }
 
-fn offer_tool_immediately(tool: &Tool) -> Tool {
+pub fn offer_tool_immediately(tool: &Tool) -> Tool {
     let mut tool = tool.clone();
     if let Some(meta) = tool.meta.as_mut() {
         meta.0.remove(DEFER_LOADING_META_KEY);

--- a/crates/goose-provider-types/src/formats/anthropic.rs
+++ b/crates/goose-provider-types/src/formats/anthropic.rs
@@ -77,6 +77,36 @@ impl AnthropicFormatOptions {
 
 pub const MID_CONVERSATION_TOOL_CHANGES_BETA: &str = "mid-conversation-tool-changes-2026-07-01";
 
+const DEFER_LOADING_FIELD: &str = "defer_loading";
+
+/// `_meta` marker for a declared tool the model has not been offered yet. A declared tool counts
+/// as available from the first turn unless its spec defers loading, which no later `tool_addition`
+/// can undo.
+const DEFER_LOADING_META_KEY: &str = "dev.goose/deferLoading";
+
+pub fn defer_tool_loading(tool: &Tool) -> Tool {
+    let mut tool = tool.clone();
+    let mut meta = tool.meta.take().unwrap_or_default();
+    meta.0
+        .insert(DEFER_LOADING_META_KEY.to_string(), json!(true));
+    tool.meta = Some(meta);
+    tool
+}
+
+fn offer_tool_immediately(tool: &Tool) -> Tool {
+    let mut tool = tool.clone();
+    if let Some(meta) = tool.meta.as_mut() {
+        meta.0.remove(DEFER_LOADING_META_KEY);
+    }
+    tool
+}
+
+pub fn tool_defers_loading(tool: &Tool) -> bool {
+    tool.meta
+        .as_ref()
+        .is_some_and(|meta| meta.0.get(DEFER_LOADING_META_KEY) == Some(&json!(true)))
+}
+
 const MID_CONVERSATION_TOOL_CHANGE_MODELS: &[&str] = &[
     "anthropic/claude-opus-5",
     "anthropic/claude-opus-4.8",
@@ -532,17 +562,26 @@ pub fn format_tools(tools: &[Tool]) -> Vec<Value> {
 
     for tool in tools {
         if unique_tools.insert(tool.name.clone()) {
-            tool_specs.push(json!({
+            let mut spec = json!({
                 NAME_FIELD: tool.name,
                 "description": tool.description,
                 "input_schema": anthropic_flavored_input_schema(tool.input_schema.clone())
-            }));
+            });
+            if tool_defers_loading(tool) {
+                spec[DEFER_LOADING_FIELD] = json!(true);
+            }
+            tool_specs.push(spec);
         }
     }
 
     // Add "cache_control" to the last tool spec, if any. This means that all tool definitions,
-    // will be cached as a single prefix.
-    if let Some(last_tool) = tool_specs.last_mut() {
+    // will be cached as a single prefix. A withheld tool is rejected outright if it also carries
+    // cache_control, so the breakpoint goes on the last spec that can hold one.
+    if let Some(last_tool) = tool_specs
+        .iter_mut()
+        .rev()
+        .find(|spec| spec.get(DEFER_LOADING_FIELD).is_none())
+    {
         last_tool.as_object_mut().unwrap().insert(
             CACHE_CONTROL_FIELD.to_string(),
             json!({ TYPE_FIELD: "ephemeral" }),
@@ -817,11 +856,18 @@ pub fn create_request(
     if options.mid_conversation_tool_changes && !tool_set_updates.is_empty() {
         let declared: HashSet<String> = tools.iter().map(|tool| tool.name.to_string()).collect();
         if !insert_tool_set_updates(&mut anthropic_messages, &tool_set_updates, &declared) {
-            let visible = resolve_visible_tools(&declared, messages);
+            let offered: HashSet<String> = tools
+                .iter()
+                .filter(|tool| !tool_defers_loading(tool))
+                .map(|tool| tool.name.to_string())
+                .collect();
+            let visible = resolve_visible_tools(&declared, &offered, messages);
+            // Without the deltas the array is the only description of what is available, so a
+            // withheld tool has nothing left to reveal it.
             visible_tools = tools
                 .iter()
                 .filter(|tool| visible.contains(tool.name.as_ref()))
-                .cloned()
+                .map(offer_tool_immediately)
                 .collect::<Vec<_>>();
             declared_tools = &visible_tools;
         }
@@ -876,14 +922,27 @@ pub fn create_request(
 }
 
 pub fn payload_needs_tool_change_beta(payload: &Value) -> bool {
-    payload
+    let carries_delta = payload
         .get("messages")
         .and_then(Value::as_array)
         .is_some_and(|messages| {
             messages
                 .iter()
                 .any(|message| message.get(ROLE_FIELD).and_then(Value::as_str) == Some(SYSTEM_ROLE))
-        })
+        });
+
+    // A withheld tool outlives the delta that revealed it, so the header cannot depend on one
+    // still being in the request.
+    let withholds_a_tool = payload
+        .get("tools")
+        .and_then(Value::as_array)
+        .is_some_and(|tools| {
+            tools
+                .iter()
+                .any(|tool| tool.get(DEFER_LOADING_FIELD) == Some(&json!(true)))
+        });
+
+    carries_delta || withholds_a_tool
 }
 
 /// Process streaming response from Anthropic's API

--- a/crates/goose-provider-types/src/formats/databricks.rs
+++ b/crates/goose-provider-types/src/formats/databricks.rs
@@ -231,7 +231,8 @@ fn format_messages(messages: &[Message], image_format: &ImageFormat) -> Vec<Data
                 }
                 MessageContentBlock::SystemNotification(_)
                 | MessageContentBlock::ToolConfirmationRequest(_)
-                | MessageContentBlock::ActionRequired(_) => {}
+                | MessageContentBlock::ActionRequired(_)
+                | MessageContentBlock::ToolSetUpdate(_) => {}
             }
         }
 

--- a/crates/goose-provider-types/src/formats/openai.rs
+++ b/crates/goose-provider-types/src/formats/openai.rs
@@ -265,7 +265,8 @@ pub fn format_messages_with_options(
                 MessageContentBlock::RedactedThinking(_) => {
                     continue;
                 }
-                MessageContentBlock::SystemNotification(_) => {
+                MessageContentBlock::SystemNotification(_)
+                | MessageContentBlock::ToolSetUpdate(_) => {
                     continue;
                 }
                 MessageContentBlock::ToolRequest(request) => match &request.tool_call {

--- a/crates/goose-provider-types/src/formats/snowflake.rs
+++ b/crates/goose-provider-types/src/formats/snowflake.rs
@@ -64,7 +64,8 @@ pub fn format_messages(messages: &[Message]) -> Vec<Value> {
                 }
                 MessageContentBlock::ToolConfirmationRequest(_) => {}
                 MessageContentBlock::ActionRequired(_) => {}
-                MessageContentBlock::SystemNotification(_) => {
+                MessageContentBlock::SystemNotification(_)
+                | MessageContentBlock::ToolSetUpdate(_) => {
                     // Skip
                 }
                 MessageContentBlock::Thinking(_thinking) => {

--- a/crates/goose-providers/src/anthropic.rs
+++ b/crates/goose-providers/src/anthropic.rs
@@ -16,7 +16,9 @@ use tokio_util::io::StreamReader;
 use super::api_client::ApiClient;
 use super::base::{ConfigKey, MessageStream, ModelInfo, Provider, ProviderMetadata};
 use super::formats::anthropic::{
-    create_request, response_to_streaming_message, AnthropicFormatOptions, ANTHROPIC_PROVIDER_NAME,
+    create_request, model_supports_mid_conversation_tool_changes, payload_needs_tool_change_beta,
+    response_to_streaming_message, AnthropicFormatOptions, ANTHROPIC_PROVIDER_NAME,
+    MID_CONVERSATION_TOOL_CHANGES_BETA,
 };
 use super::openai_compatible::handle_status;
 use super::openai_compatible::map_http_error_to_provider_error;
@@ -89,7 +91,10 @@ impl AnthropicProviderBuilder {
             custom_models: None,
             dynamic_models: None,
             skip_canonical_filtering: false,
-            format_options: AnthropicFormatOptions::default(),
+            format_options: AnthropicFormatOptions {
+                mid_conversation_tool_changes: true,
+                ..AnthropicFormatOptions::default()
+            },
         }
     }
 
@@ -237,6 +242,11 @@ impl Provider for AnthropicProvider {
         self.skip_canonical_filtering
     }
 
+    fn supports_mid_conversation_tool_changes(&self, model_config: &ModelConfig) -> bool {
+        self.format_options.mid_conversation_tool_changes
+            && model_supports_mid_conversation_tool_changes(&self.name, model_config)
+    }
+
     async fn fetch_supported_models(&self) -> Result<Vec<String>, ProviderError> {
         if let Some(custom_models) = &self.custom_models {
             if self.dynamic_models == Some(false) {
@@ -279,14 +289,22 @@ impl Provider for AnthropicProvider {
             .unwrap()
             .insert("stream".to_string(), Value::Bool(true));
 
+        let needs_tool_change_beta = payload_needs_tool_change_beta(&payload);
+
         let mut log = start_log(model_config, &payload)?;
 
         let response = self
             .with_retry(|| async {
-                let request = self
+                let mut request = self
                     .api_client
                     .request("v1/messages")
                     .model_headers(model_config)?;
+                if needs_tool_change_beta {
+                    request = request.append_header_value(
+                        "anthropic-beta",
+                        MID_CONVERSATION_TOOL_CHANGES_BETA,
+                    )?;
+                }
                 let resp = request.response_post(&payload).await?;
                 handle_status(resp).await
             })
@@ -317,6 +335,8 @@ fn format_options_for_provider(preserves_thinking: bool) -> AnthropicFormatOptio
         preserve_unsigned_thinking: preserves_thinking,
         preserve_thinking_context: preserves_thinking,
         thinking_disabled: false,
+        // A declarative endpoint speaks this wire format but need not implement the beta.
+        mid_conversation_tool_changes: false,
     }
 }
 

--- a/crates/goose-providers/src/api_client.rs
+++ b/crates/goose-providers/src/api_client.rs
@@ -408,6 +408,25 @@ impl<'a> ApiRequestBuilder<'a> {
         self
     }
 
+    /// A per-request header replaces the client default outright, so append instead.
+    pub fn append_header_value(self, key: &str, value: &str) -> Result<Self> {
+        let header_name = HeaderName::from_bytes(key.as_bytes())?;
+        let existing = self
+            .headers
+            .get(&header_name)
+            .or_else(|| self.client.default_headers.get(&header_name))
+            .and_then(|existing| existing.to_str().ok());
+
+        let merged = match existing {
+            Some(existing) if existing.split(',').any(|part| part.trim() == value) => {
+                existing.to_string()
+            }
+            Some(existing) => format!("{existing},{value}"),
+            None => value.to_string(),
+        };
+        self.header(key, &merged)
+    }
+
     /// Apply per-request headers from a model config, overriding any static
     /// client headers on key collision.
     pub fn model_headers(self, model_config: &crate::model::ModelConfig) -> Result<Self> {

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -995,6 +995,9 @@ impl Agent {
             }
         }
 
+        // These land in the cached system prompt, and `extensions` is a HashMap.
+        instructions.sort();
+
         *self.frontend_tools.lock().await = tools;
         *self.frontend_instructions.lock().await = if instructions.is_empty() {
             None

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -2078,9 +2078,8 @@ impl Agent {
                 );
 
                 // Deltas and the tool array have to agree, so a turn sending the enabled array
-                // must not carry deltas describing the declared one. Only recording a *new*
-                // delta needs a user turn after it, which keeps the array from oscillating
-                // whenever a turn opens with an assistant message.
+                // must not carry deltas describing the declared one. Only recording a *new* delta
+                // needs a user turn after it, which keeps the array from oscillating.
                 let (provider_tools, provider_conversation) = if mid_conversation_tool_changes {
                     let (declared_tools, update) = self
                         .declared_surfaces

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -16,6 +16,9 @@ use super::mcp_client::GooseMcpHostInfo;
 use super::platform_tools;
 use super::tool_confirmation_router::ToolConfirmationRouter;
 use super::tool_execution::{ToolCallResult, CHAT_MODE_TOOL_SKIPPED_RESPONSE, DECLINED_RESPONSE};
+use super::tool_set::{
+    can_record_tool_set_update, tool_set_update_message, without_tool_set_updates, DeclaredSurfaces,
+};
 use crate::action_required_manager::ElicitationOutcome;
 use crate::agents::extension::{ExtensionConfig, ExtensionResult, ToolInfo};
 use crate::agents::extension_manager::{
@@ -262,6 +265,7 @@ pub struct Agent {
     goal: Mutex<Option<String>>,
     grind: Mutex<Option<String>>,
     pending_steers: Mutex<HashMap<String, VecDeque<Message>>>,
+    pub(crate) declared_surfaces: DeclaredSurfaces,
 }
 
 #[derive(Clone, Debug)]
@@ -421,6 +425,7 @@ impl Agent {
             goal: Mutex::new(None),
             grind: Mutex::new(None),
             pending_steers: Mutex::new(HashMap::new()),
+            declared_surfaces: DeclaredSurfaces::default(),
         }
     }
 
@@ -874,6 +879,27 @@ impl Agent {
         match &*self.provider.lock().await {
             Some(provider) => Ok(Arc::clone(provider)),
             None => Err(anyhow!("Provider not set")),
+        }
+    }
+
+    /// Toolshim moves definitions into the system prompt and sends an empty `tools`
+    /// array, leaving nothing for a delta to name.
+    pub(crate) fn provider_supports_mid_conversation_tool_changes(
+        provider: &Arc<dyn Provider>,
+        model_config: &goose_providers::model::ModelConfig,
+    ) -> bool {
+        !model_config.toolshim && provider.supports_mid_conversation_tool_changes(model_config)
+    }
+
+    pub(crate) async fn supports_mid_conversation_tool_changes(
+        &self,
+        model_config: &goose_providers::model::ModelConfig,
+    ) -> bool {
+        match self.provider().await {
+            Ok(provider) => {
+                Self::provider_supports_mid_conversation_tool_changes(&provider, model_config)
+            }
+            Err(_) => false,
         }
     }
 
@@ -2027,21 +2053,52 @@ impl Agent {
                     break;
                 }
 
+                // The capability has to come from the provider that serves this request: one
+                // swapped mid-reply would get the declared superset and ignore the deltas.
+                let turn_provider = self.provider().await?;
+                let mid_conversation_tool_changes = Self::provider_supports_mid_conversation_tool_changes(
+                    &turn_provider,
+                    &model_config,
+                );
+
+                // Deltas and the tool array have to agree, so a turn sending the enabled array
+                // must not carry deltas describing the declared one. Only recording a *new*
+                // delta needs a user turn after it, which keeps the array from oscillating
+                // whenever a turn opens with an assistant message.
+                let (provider_tools, provider_conversation) = if mid_conversation_tool_changes {
+                    let (declared_tools, update) = self
+                        .declared_surfaces
+                        .resolve(&session_config.id, &tools, &conversation)
+                        .await;
+                    match update {
+                        Some(update) if can_record_tool_set_update(&conversation) => {
+                            let message = tool_set_update_message(update);
+                            session_manager.add_message(&session_config.id, &message).await?;
+                            conversation.push(message);
+                            (declared_tools, conversation.clone())
+                        }
+                        Some(_) => (tools.clone(), without_tool_set_updates(&conversation)),
+                        None => (declared_tools, conversation.clone()),
+                    }
+                } else {
+                    (tools.clone(), without_tool_set_updates(&conversation))
+                };
+
                 let conversation_with_moim = super::moim::inject_moim(
                     &session_config.id,
-                    conversation.clone(),
+                    provider_conversation,
                     &self.extension_manager,
                     turns_taken,
                     max_turns,
                 ).await;
 
                 let mut stream = Self::stream_response_from_provider(
-                    self.provider().await?,
+                    turn_provider,
                     model_config.clone(),
                     &session_config.id,
                     &system_prompt,
                     conversation_with_moim.messages(),
-                    &tools,
+                    &provider_tools,
                     &toolshim_tools,
                 ).await?;
                 last_assistant_text.clear();

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -3375,7 +3375,9 @@ impl Agent {
             .filter(super::reply_parts::is_tool_visible_to_model)
             .collect();
 
-        messages = Conversation::new_unvalidated(messages.agent_visible_messages());
+        messages = without_tool_set_updates(&Conversation::new_unvalidated(
+            messages.agent_visible_messages(),
+        ));
         messages.push(Message::user().with_text(recipe_prompt));
 
         let (messages, issues) = fix_conversation(messages);

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -2078,8 +2078,8 @@ impl Agent {
                 );
 
                 // Deltas and the tool array have to agree, so a turn sending the enabled array
-                // must not carry deltas describing the declared one. Only recording a *new* delta
-                // needs a user turn after it, which keeps the array from oscillating.
+                // must not carry deltas describing the declared one. Only a *new* delta needs a
+                // user turn after it, which keeps the array from oscillating.
                 let (provider_tools, provider_conversation) = if mid_conversation_tool_changes {
                     let (declared_tools, update) = self
                         .declared_surfaces

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -986,6 +986,22 @@ impl Agent {
             .collect()
     }
 
+    pub(super) async fn frontend_instruction_entries(&self) -> Vec<(String, String)> {
+        self.frontend_extension_configs()
+            .await
+            .into_iter()
+            .filter_map(|config| match config {
+                ExtensionConfig::Frontend {
+                    name, instructions, ..
+                } => Some((
+                    name,
+                    instructions.unwrap_or_else(|| DEFAULT_FRONTEND_INSTRUCTIONS.to_string()),
+                )),
+                _ => None,
+            })
+            .collect()
+    }
+
     async fn rebuild_frontend_derived_state(&self, extensions: &HashMap<String, ExtensionConfig>) {
         let multiple = extensions.len() > 1;
         let mut tools = HashMap::new();

--- a/crates/goose/src/agents/extension_manager.rs
+++ b/crates/goose/src/agents/extension_manager.rs
@@ -47,6 +47,7 @@ use crate::config::search_path::SearchPaths;
 use crate::config::{get_all_extensions, Config};
 use crate::oauth::{oauth_flow, GooseCredentialStore};
 use crate::prompt_template;
+use crate::providers::formats::anthropic::discard_defer_loading_marker;
 use crate::subprocess::configure_subprocess;
 use rmcp::model::{
     CallToolRequestParams, CallToolResult, ContentBlock, ErrorCode, ErrorData, GetPromptResult,
@@ -1434,6 +1435,7 @@ impl ExtensionManager {
                                 TOOL_EXTENSION_META_KEY.to_string(),
                                 serde_json::Value::String(name.clone()),
                             );
+                            discard_defer_loading_marker(&mut meta_map);
 
                             tool.name = public_name.into();
                             tool.meta = Some(rmcp::model::Meta(meta_map));

--- a/crates/goose/src/agents/extension_manager.rs
+++ b/crates/goose/src/agents/extension_manager.rs
@@ -1482,6 +1482,9 @@ impl ExtensionManager {
             }
         }
 
+        // `extensions` is a HashMap, so prompts embedding this list would vary per process.
+        tools.sort_by(|a, b| a.name.cmp(&b.name));
+
         Ok(tools)
     }
 

--- a/crates/goose/src/agents/mod.rs
+++ b/crates/goose/src/agents/mod.rs
@@ -19,6 +19,7 @@ pub(crate) mod subagent_handler;
 pub(crate) mod subagent_task_config;
 mod tool_confirmation_router;
 mod tool_execution;
+mod tool_set;
 pub mod types;
 pub mod validate_extensions;
 

--- a/crates/goose/src/agents/moim.rs
+++ b/crates/goose/src/agents/moim.rs
@@ -95,10 +95,11 @@ pub async fn inject_moim(
     );
 
     let mut messages = conversation.messages().clone();
-    let Some(idx) = messages
-        .iter()
-        .rposition(|m| m.is_agent_visible() && effective_role(m) == "user")
-    else {
+    let Some(idx) = messages.iter().rposition(|m| {
+        m.is_agent_visible()
+            && effective_role(m) == "user"
+            && !super::tool_set::is_tool_set_update_carrier(m)
+    }) else {
         return conversation;
     };
     let insert_idx = messages[idx]
@@ -319,6 +320,45 @@ mod tests {
         assert_eq!(text_at(&msgs[0], 1), "agent visible");
         assert_eq!(text_at(&msgs[1], 0), "user only");
         assert!(!msgs[1].is_agent_visible());
+    }
+
+    #[tokio::test]
+    async fn test_moim_skips_tool_set_update_carriers() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let em = ExtensionManager::new_without_provider(temp_dir.path().to_path_buf());
+        let session = em
+            .get_context()
+            .session_manager
+            .create_session(
+                PathBuf::from("/test/dir"),
+                "test".to_string(),
+                crate::session::SessionType::User,
+                crate::config::GooseMode::Auto,
+            )
+            .await
+            .unwrap();
+
+        let conv = Conversation::new_unvalidated(vec![
+            Message::user().with_text("real turn"),
+            Message::assistant()
+                .with_tool_request("call_1", Ok(CallToolRequestParams::new("disable"))),
+            Message::user()
+                .with_tool_response("call_1", Ok(rmcp::model::CallToolResult::success(vec![]))),
+            super::super::tool_set::tool_set_update_message(
+                crate::conversation::message::ToolSetUpdateContent {
+                    added: Vec::new(),
+                    removed: vec!["gone".to_string()],
+                },
+            ),
+        ]);
+        let result = inject_moim(&session.id, conv, &em, 0, 100).await;
+        let msgs = result.messages();
+
+        assert_eq!(msgs.len(), 4);
+        assert!(is_moim(&msgs[0].content[0]));
+        assert_eq!(text_at(&msgs[0], 1), "real turn");
+        assert!(!msgs[3].content.iter().any(is_moim));
+        assert_eq!(msgs[3].content.len(), 1);
     }
 
     #[tokio::test]

--- a/crates/goose/src/agents/reply_parts.rs
+++ b/crates/goose/src/agents/reply_parts.rs
@@ -247,6 +247,7 @@ impl Agent {
             .await;
         let (mut extension_count, mut tool_count) =
             self.total_extension_and_tool_counts(session_id).await;
+        let mut frontend_instructions = self.frontend_instructions.lock().await.clone();
 
         let model_config = self.model_config_for_session(session_id).await?;
 
@@ -262,11 +263,13 @@ impl Agent {
                     session_id,
                     &tools,
                     extensions_info,
+                    self.frontend_instruction_entries().await,
                     (extension_count, tool_count),
                 )
                 .await;
             extension_count = declared.extension_count;
             tool_count = declared.tool_count;
+            frontend_instructions = declared.frontend_instructions;
             declared.extensions
         } else {
             extensions_info
@@ -282,7 +285,7 @@ impl Agent {
         let mut system_prompt = prompt_manager
             .builder()
             .with_extensions(extensions_info.into_iter())
-            .with_frontend_instructions(self.frontend_instructions.lock().await.clone())
+            .with_frontend_instructions(frontend_instructions)
             .with_extension_and_tool_counts(extension_count, tool_count)
             .with_code_execution_mode(code_execution_active)
             .with_hints(working_dir)

--- a/crates/goose/src/agents/reply_parts.rs
+++ b/crates/goose/src/agents/reply_parts.rs
@@ -245,9 +245,32 @@ impl Agent {
             .extension_manager
             .get_extensions_info(working_dir)
             .await;
-        let (extension_count, tool_count) = self.total_extension_and_tool_counts(session_id).await;
+        let (mut extension_count, mut tool_count) =
+            self.total_extension_and_tool_counts(session_id).await;
 
         let model_config = self.model_config_for_session(session_id).await?;
+
+        // The system prompt is inside the cached prefix, so it has to describe the declared
+        // surface too, or a toggle rewrites it and voids the cache anyway.
+        let extensions_info = if self
+            .supports_mid_conversation_tool_changes(&model_config)
+            .await
+        {
+            let declared = self
+                .declared_surfaces
+                .declare(
+                    session_id,
+                    &tools,
+                    extensions_info,
+                    (extension_count, tool_count),
+                )
+                .await;
+            extension_count = declared.extension_count;
+            tool_count = declared.tool_count;
+            declared.extensions
+        } else {
+            extensions_info
+        };
 
         let goose_mode = *self.current_goose_mode.lock().await;
 

--- a/crates/goose/src/agents/reply_parts.rs
+++ b/crates/goose/src/agents/reply_parts.rs
@@ -11,6 +11,7 @@ use tracing::debug;
 use super::super::agents::Agent;
 #[cfg(feature = "code-mode")]
 use crate::agents::platform_extensions::code_execution;
+use crate::agents::tool_set::EnabledSurface;
 use crate::config::{Config, GooseMode};
 use crate::conversation::message::{Message, MessageContent, MessageUsage, ToolRequest};
 use crate::conversation::{fix_conversation, Conversation};
@@ -264,10 +265,13 @@ impl Agent {
                 .declare(
                     session_id,
                     &tools,
-                    counted_tool_names,
-                    extensions_info,
-                    self.frontend_instruction_entries().await,
-                    (extension_count, tool_count),
+                    EnabledSurface {
+                        counted_tool_names,
+                        extensions: extensions_info,
+                        frontend_instructions: self.frontend_instruction_entries().await,
+                        extension_total: extension_count,
+                        tool_total: tool_count,
+                    },
                 )
                 .await;
             extension_count = declared.extension_count;

--- a/crates/goose/src/agents/reply_parts.rs
+++ b/crates/goose/src/agents/reply_parts.rs
@@ -175,6 +175,8 @@ impl Agent {
         working_dir: &std::path::Path,
     ) -> Result<(Vec<Tool>, Vec<Tool>, String, ModelConfig)> {
         let mut tools = self.list_tools(session_id, None).await;
+        let counted_tool_names: Vec<String> =
+            tools.iter().map(|tool| tool.name.to_string()).collect();
 
         #[cfg(feature = "code-mode")]
         let code_execution_active = self
@@ -262,6 +264,7 @@ impl Agent {
                 .declare(
                     session_id,
                     &tools,
+                    counted_tool_names,
                     extensions_info,
                     self.frontend_instruction_entries().await,
                     (extension_count, tool_count),

--- a/crates/goose/src/agents/tool_set.rs
+++ b/crates/goose/src/agents/tool_set.rs
@@ -22,6 +22,8 @@ pub struct DeclaredSurfaces(Mutex<HashMap<String, Surface>>);
 #[derive(Default)]
 struct Surface {
     tools: Vec<Tool>,
+    /// Names last rendered into a tool array, which is what the model's view is relative to.
+    sent: HashSet<String>,
     extensions: Vec<ExtensionInfo>,
     frontend_instructions: Vec<(String, String)>,
 }
@@ -103,7 +105,17 @@ impl DeclaredSurfaces {
         let surface = sessions.entry(session_id.to_string()).or_default();
         let declared_names = surface.declare_tools(enabled_tools);
 
-        let visible = resolve_visible_tools(&declared_names, conversation.messages());
+        // `declare` folds newly enabled tools in while building the prompt, and runs first, so the
+        // surface cannot say what the model has already been offered. Seeding from a set that
+        // already holds a brand-new tool leaves `added` empty and the array then reads as though
+        // the tool had been there from the first turn.
+        let sent = std::mem::take(&mut surface.sent);
+        let baseline = if sent.is_empty() {
+            &declared_names
+        } else {
+            &sent
+        };
+        let visible = resolve_visible_tools(baseline, conversation.messages());
         let enabled_names: HashSet<String> = enabled_tools
             .iter()
             .map(|tool| tool.name.to_string())
@@ -115,6 +127,8 @@ impl DeclaredSurfaces {
         };
         update.added.sort();
         update.removed.sort();
+
+        surface.sent = declared_names;
 
         (
             surface.tools.clone(),

--- a/crates/goose/src/agents/tool_set.rs
+++ b/crates/goose/src/agents/tool_set.rs
@@ -27,6 +27,10 @@ struct Surface {
     /// reference, so a tool the array never held still costs one rewrite of it; withholding is
     /// what stops the model reading that tool as available before it was enabled.
     deferred: HashSet<String>,
+    /// Every tool the session has held, counted before the filters that decide what the model is
+    /// offered. `tool_count` is reported in those unfiltered terms, so an adjustment measured
+    /// against `tools` would shrink whenever a hidden tool's extension went away.
+    counted: HashSet<String>,
     extensions: Vec<ExtensionInfo>,
     frontend_instructions: Vec<(String, String)>,
 }
@@ -44,6 +48,7 @@ impl DeclaredSurfaces {
         &self,
         session_id: &str,
         enabled_tools: &[Tool],
+        counted_tool_names: Vec<String>,
         enabled_extensions: Vec<ExtensionInfo>,
         enabled_frontend_instructions: Vec<(String, String)>,
         enabled_counts: (usize, usize),
@@ -51,6 +56,9 @@ impl DeclaredSurfaces {
         let mut sessions = self.0.lock().await;
         let surface = sessions.entry(session_id.to_string()).or_default();
         surface.declare_tools(enabled_tools);
+
+        let counted_enabled = counted_tool_names.len();
+        surface.counted.extend(counted_tool_names);
 
         let enabled_extension_count = enabled_extensions.len();
         for extension in enabled_extensions {
@@ -91,7 +99,7 @@ impl DeclaredSurfaces {
                     .frontend_instructions
                     .len()
                     .saturating_sub(enabled_frontend_extension_count),
-            tool_count: enabled_counts.1 + surface.tools.len().saturating_sub(enabled_tools.len()),
+            tool_count: enabled_counts.1 + surface.counted.len().saturating_sub(counted_enabled),
             extensions: surface.extensions.clone(),
             frontend_instructions: render_frontend_instructions(&surface.frontend_instructions),
         }
@@ -327,19 +335,22 @@ mod tests {
         let apps = ExtensionInfo::new("apps", "build apps", false);
         let developer = ExtensionInfo::new("developer", "write code", false);
 
+        // `apps__hidden` is counted but never offered, as an app-only tool is.
         surfaces
             .declare(
                 "s",
                 &tools(&["apps__a", "developer__b"]),
+                names(&tools(&["apps__a", "apps__hidden", "developer__b"])),
                 vec![apps, developer.clone()],
                 Vec::new(),
-                (2, 2),
+                (2, 3),
             )
             .await;
         let prompt = surfaces
             .declare(
                 "s",
                 &tools(&["developer__b"]),
+                names(&tools(&["developer__b"])),
                 vec![developer],
                 Vec::new(),
                 (1, 1),
@@ -354,14 +365,21 @@ mod tests {
                 .collect::<Vec<_>>(),
             ["apps", "developer"]
         );
-        assert_eq!((prompt.extension_count, prompt.tool_count), (2, 2));
+        assert_eq!((prompt.extension_count, prompt.tool_count), (2, 3));
 
         let other = ExtensionInfo::new("other", "do other things", false);
         let prompt = surfaces
-            .declare("s", &tools(&["other__c"]), vec![other], Vec::new(), (1, 1))
+            .declare(
+                "s",
+                &tools(&["other__c"]),
+                names(&tools(&["other__c"])),
+                vec![other],
+                Vec::new(),
+                (1, 1),
+            )
             .await;
 
-        assert_eq!((prompt.extension_count, prompt.tool_count), (3, 3));
+        assert_eq!((prompt.extension_count, prompt.tool_count), (3, 4));
     }
 
     #[tokio::test]
@@ -372,6 +390,7 @@ mod tests {
             .declare(
                 "s",
                 &tools(&["apps__a", "developer__b"]),
+                names(&tools(&["apps__a", "developer__b"])),
                 Vec::new(),
                 vec![
                     ("developer".to_string(), "write code".to_string()),
@@ -389,6 +408,7 @@ mod tests {
             .declare(
                 "s",
                 &tools(&["developer__b"]),
+                names(&tools(&["developer__b"])),
                 Vec::new(),
                 vec![("developer".to_string(), "write code".to_string())],
                 (1, 1),

--- a/crates/goose/src/agents/tool_set.rs
+++ b/crates/goose/src/agents/tool_set.rs
@@ -8,6 +8,7 @@ use crate::conversation::message::{
     Message, MessageContentBlock, MessageMetadata, ToolSetUpdateContent,
 };
 use crate::conversation::{resolve_visible_tools, Conversation};
+use crate::providers::formats::anthropic::defer_tool_loading;
 
 /// Everything goose has offered the model during a session, per session.
 ///
@@ -22,8 +23,10 @@ pub struct DeclaredSurfaces(Mutex<HashMap<String, Surface>>);
 #[derive(Default)]
 struct Surface {
     tools: Vec<Tool>,
-    /// Names last rendered into a tool array, which is what the model's view is relative to.
-    sent: HashSet<String>,
+    /// Names withheld in the array until an addition reveals them. An addition only carries a
+    /// reference, so a tool the array never held still costs one rewrite of it; withholding is
+    /// what stops the model reading that tool as available before it was enabled.
+    deferred: HashSet<String>,
     extensions: Vec<ExtensionInfo>,
     frontend_instructions: Vec<(String, String)>,
 }
@@ -105,17 +108,14 @@ impl DeclaredSurfaces {
         let surface = sessions.entry(session_id.to_string()).or_default();
         let declared_names = surface.declare_tools(enabled_tools);
 
-        // `declare` folds newly enabled tools in while building the prompt, and runs first, so the
-        // surface cannot say what the model has already been offered. Seeding from a set that
-        // already holds a brand-new tool leaves `added` empty and the array then reads as though
-        // the tool had been there from the first turn.
-        let sent = std::mem::take(&mut surface.sent);
-        let baseline = if sent.is_empty() {
-            &declared_names
-        } else {
-            &sent
-        };
-        let visible = resolve_visible_tools(baseline, conversation.messages());
+        // What the array offers by itself. A withheld tool is declared but unavailable until an
+        // addition names it, so the model's view is this set with the recorded deltas replayed:
+        // one archived by compaction simply means the addition has to be made again.
+        let offered: HashSet<String> = declared_names
+            .difference(&surface.deferred)
+            .cloned()
+            .collect();
+        let visible = resolve_visible_tools(&declared_names, &offered, conversation.messages());
         let enabled_names: HashSet<String> = enabled_tools
             .iter()
             .map(|tool| tool.name.to_string())
@@ -128,10 +128,8 @@ impl DeclaredSurfaces {
         update.added.sort();
         update.removed.sort();
 
-        surface.sent = declared_names;
-
         (
-            surface.tools.clone(),
+            surface.declared_tools(),
             (!update.is_empty()).then_some(update),
         )
     }
@@ -152,7 +150,26 @@ fn render_frontend_instructions(instructions: &[(String, String)]) -> Option<Str
 }
 
 impl Surface {
+    fn declared_tools(&self) -> Vec<Tool> {
+        self.tools
+            .iter()
+            .map(|tool| {
+                if self.deferred.contains(tool.name.as_ref()) {
+                    defer_tool_loading(tool)
+                } else {
+                    tool.clone()
+                }
+            })
+            .collect()
+    }
+
     fn declare_tools(&mut self, enabled: &[Tool]) -> HashSet<String> {
+        // Whichever of `declare` and `resolve` runs first for a turn lands here, so this is the
+        // only place that can tell a tool the model has never been offered from one it has. The
+        // first non-empty array has to be offered outright: the API rejects one whose every tool
+        // is withheld, so a session that opens with nothing model-visible cannot withhold what it
+        // gains later.
+        let opening = self.tools.is_empty();
         // A changed schema can arrive under an unchanged name, and keeping the old one would
         // have the model calling it with stale arguments.
         for tool in enabled {
@@ -162,7 +179,12 @@ impl Surface {
                 .find(|declared| declared.name == tool.name)
             {
                 Some(declared) => *declared = tool.clone(),
-                None => self.tools.push(tool.clone()),
+                None => {
+                    if !opening {
+                        self.deferred.insert(tool.name.to_string());
+                    }
+                    self.tools.push(tool.clone());
+                }
             }
         }
         // Order must not depend on when a tool was declared, so a resume rebuilds it byte-wise.
@@ -217,6 +239,7 @@ pub fn tool_set_update_message(update: ToolSetUpdateContent) -> Message {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::providers::formats::anthropic::tool_defers_loading;
     use rmcp::object;
 
     fn tools(names: &[&str]) -> Vec<Tool> {
@@ -256,6 +279,26 @@ mod tests {
         let update = update.unwrap();
         assert_eq!(update.added, ["b", "c"]);
         assert!(update.removed.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_tool_enabled_mid_session_is_withheld_until_announced() {
+        let surfaces = DeclaredSurfaces::default();
+        let conversation = Conversation::new_unvalidated(vec![Message::user().with_text("hi")]);
+
+        surfaces.resolve("s", &tools(&["a"]), &conversation).await;
+        let (declared, update) = surfaces
+            .resolve("s", &tools(&["a", "b"]), &conversation)
+            .await;
+
+        assert_eq!(update.unwrap().added, ["b"]);
+        let withheld: Vec<&str> = declared
+            .iter()
+            .filter(|tool| tool_defers_loading(tool))
+            .map(|tool| tool.name.as_ref())
+            .collect();
+        // The API rejects an array whose every tool is withheld, so the opening set stays offered.
+        assert_eq!(withheld, ["b"]);
     }
 
     #[tokio::test]

--- a/crates/goose/src/agents/tool_set.rs
+++ b/crates/goose/src/agents/tool_set.rs
@@ -23,11 +23,13 @@ pub struct DeclaredSurfaces(Mutex<HashMap<String, Surface>>);
 struct Surface {
     tools: Vec<Tool>,
     extensions: Vec<ExtensionInfo>,
+    frontend_instructions: Vec<(String, String)>,
 }
 
 /// Covers the declared surface, not only what is enabled now.
 pub struct DeclaredPrompt {
     pub extensions: Vec<ExtensionInfo>,
+    pub frontend_instructions: Option<String>,
     pub extension_count: usize,
     pub tool_count: usize,
 }
@@ -38,6 +40,7 @@ impl DeclaredSurfaces {
         session_id: &str,
         enabled_tools: &[Tool],
         enabled_extensions: Vec<ExtensionInfo>,
+        enabled_frontend_instructions: Vec<(String, String)>,
         enabled_counts: (usize, usize),
     ) -> DeclaredPrompt {
         let mut sessions = self.0.lock().await;
@@ -56,16 +59,36 @@ impl DeclaredSurfaces {
             }
         }
 
-        // `enabled_counts` covers sources the declared lists do not hold, such as frontend
-        // extensions, so add what the surface declares beyond it rather than recounting.
+        let enabled_frontend_extension_count = enabled_frontend_instructions.len();
+        for (name, instructions) in enabled_frontend_instructions {
+            match surface
+                .frontend_instructions
+                .iter_mut()
+                .find(|(declared_name, _)| declared_name == &name)
+            {
+                Some(declared) => *declared = (name, instructions),
+                None => surface.frontend_instructions.push((name, instructions)),
+            }
+        }
+        surface
+            .frontend_instructions
+            .sort_by(|(a, _), (b, _)| a.cmp(b));
+
+        // `enabled_counts` covers tool sources the declared prompt lists do not hold, so add
+        // what the surface declares beyond the currently enabled set rather than recounting.
         DeclaredPrompt {
             extension_count: enabled_counts.0
                 + surface
                     .extensions
                     .len()
-                    .saturating_sub(enabled_extension_count),
+                    .saturating_sub(enabled_extension_count)
+                + surface
+                    .frontend_instructions
+                    .len()
+                    .saturating_sub(enabled_frontend_extension_count),
             tool_count: enabled_counts.1 + surface.tools.len().saturating_sub(enabled_tools.len()),
             extensions: surface.extensions.clone(),
+            frontend_instructions: render_frontend_instructions(&surface.frontend_instructions),
         }
     }
 
@@ -97,6 +120,20 @@ impl DeclaredSurfaces {
             surface.tools.clone(),
             (!update.is_empty()).then_some(update),
         )
+    }
+}
+
+fn render_frontend_instructions(instructions: &[(String, String)]) -> Option<String> {
+    match instructions {
+        [] => None,
+        [(_, instructions)] => Some(instructions.clone()),
+        instructions => Some(
+            instructions
+                .iter()
+                .map(|(name, instructions)| format!("{name}: {instructions}"))
+                .collect::<Vec<_>>()
+                .join("\n\n"),
+        ),
     }
 }
 
@@ -238,11 +275,18 @@ mod tests {
                 "s",
                 &tools(&["apps__a", "developer__b"]),
                 vec![apps, developer.clone()],
+                Vec::new(),
                 (2, 2),
             )
             .await;
         let prompt = surfaces
-            .declare("s", &tools(&["developer__b"]), vec![developer], (1, 1))
+            .declare(
+                "s",
+                &tools(&["developer__b"]),
+                vec![developer],
+                Vec::new(),
+                (1, 1),
+            )
             .await;
 
         assert_eq!(
@@ -257,9 +301,47 @@ mod tests {
 
         let other = ExtensionInfo::new("other", "do other things", false);
         let prompt = surfaces
-            .declare("s", &tools(&["other__c"]), vec![other], (1, 1))
+            .declare("s", &tools(&["other__c"]), vec![other], Vec::new(), (1, 1))
             .await;
 
         assert_eq!((prompt.extension_count, prompt.tool_count), (3, 3));
+    }
+
+    #[tokio::test]
+    async fn test_declared_prompt_keeps_disabled_frontend_instructions() {
+        let surfaces = DeclaredSurfaces::default();
+
+        let prompt = surfaces
+            .declare(
+                "s",
+                &tools(&["apps__a", "developer__b"]),
+                Vec::new(),
+                vec![
+                    ("developer".to_string(), "write code".to_string()),
+                    ("apps".to_string(), "build apps".to_string()),
+                ],
+                (2, 2),
+            )
+            .await;
+        assert_eq!(
+            prompt.frontend_instructions.as_deref(),
+            Some("apps: build apps\n\ndeveloper: write code")
+        );
+
+        let prompt = surfaces
+            .declare(
+                "s",
+                &tools(&["developer__b"]),
+                Vec::new(),
+                vec![("developer".to_string(), "write code".to_string())],
+                (1, 1),
+            )
+            .await;
+
+        assert_eq!(
+            prompt.frontend_instructions.as_deref(),
+            Some("apps: build apps\n\ndeveloper: write code")
+        );
+        assert_eq!((prompt.extension_count, prompt.tool_count), (2, 2));
     }
 }

--- a/crates/goose/src/agents/tool_set.rs
+++ b/crates/goose/src/agents/tool_set.rs
@@ -24,12 +24,10 @@ pub struct DeclaredSurfaces(Mutex<HashMap<String, Surface>>);
 #[derive(Default)]
 struct Surface {
     tools: Vec<Tool>,
-    /// Names withheld in the array until an addition reveals them, which is what stops the model
-    /// reading a tool as available before it was enabled.
+    /// Withheld in the array until an addition reveals them, so the model does not read a tool as
+    /// available before it was enabled.
     deferred: HashSet<String>,
-    /// Every tool the session has held, counted before the filters that decide what is offered.
-    /// `tool_count` is reported in those terms, so measuring against `tools` would shrink it
-    /// whenever a hidden tool's extension went away.
+    /// Counted before the filters that decide what is offered, the unit `tool_count` is in.
     counted: HashSet<String>,
     extensions: Vec<ExtensionInfo>,
     frontend_instructions: Vec<(String, String)>,
@@ -46,8 +44,7 @@ pub struct DeclaredPrompt {
 /// What a session has enabled right now, as the prompt would describe it without a declared
 /// surface. The totals cover tool and extension sources the lists themselves do not hold.
 pub struct EnabledSurface {
-    /// Tool names taken before the filters that decide what the model is offered, which is the
-    /// unit `tool_total` is expressed in.
+    /// Taken before the filters that decide what the model is offered, the unit `tool_total` is in.
     pub counted_tool_names: Vec<String>,
     pub extensions: Vec<ExtensionInfo>,
     pub frontend_instructions: Vec<(String, String)>,
@@ -104,8 +101,6 @@ impl DeclaredSurfaces {
             .frontend_instructions
             .sort_by(|(a, _), (b, _)| a.cmp(b));
 
-        // The totals cover sources these lists do not hold, so add what the surface declares
-        // beyond the enabled set rather than recounting.
         DeclaredPrompt {
             extension_count: extension_total
                 + surface
@@ -133,8 +128,7 @@ impl DeclaredSurfaces {
         let surface = sessions.entry(session_id.to_string()).or_default();
         let declared_names = surface.declare_tools(enabled_tools);
 
-        // What the array offers by itself, which the recorded deltas then move: an addition
-        // archived by compaction simply has to be made again.
+        // An addition archived by compaction simply has to be made again.
         let offered: HashSet<String> = declared_names
             .difference(&surface.deferred)
             .cloned()
@@ -175,8 +169,7 @@ fn render_frontend_instructions(instructions: &[(String, String)]) -> Option<Str
 
 impl Surface {
     fn declared_tools(&self) -> Vec<Tool> {
-        // An extension owns its `_meta`, so the marker is only trustworthy coming from here: one
-        // arriving on an enabled tool would withhold it with no addition to reveal it.
+        // A marker on an enabled tool is not goose's, and would withhold it for good.
         self.tools
             .iter()
             .map(|tool| {
@@ -191,12 +184,11 @@ impl Surface {
 
     fn declare_tools(&mut self, enabled: &[Tool]) -> HashSet<String> {
         // Whichever of `declare` and `resolve` runs first for a turn lands here, so this is the
-        // only place that can tell a tool the model has never been offered from one it has. The
-        // first non-empty array is offered outright because the API rejects one whose every tool
-        // is withheld.
+        // only place that can tell a never-offered tool from an offered one. The opening array is
+        // offered outright because the API rejects one whose every tool is withheld.
         let opening = self.tools.is_empty();
-        // A changed schema can arrive under an unchanged name, and keeping the old one would
-        // have the model calling it with stale arguments.
+        // A changed schema can arrive under an unchanged name, and a stale one means wrong
+        // arguments.
         for tool in enabled {
             match self
                 .tools
@@ -362,25 +354,34 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_declared_prompt_keeps_disabled_extensions() {
+    async fn test_declared_prompt_keeps_what_was_disabled() {
         let surfaces = DeclaredSurfaces::default();
         let apps = ExtensionInfo::new("apps", "build apps", false);
         let developer = ExtensionInfo::new("developer", "write code", false);
 
         // `apps__hidden` is counted but never offered, as an app-only tool is.
-        surfaces
+        let prompt = surfaces
             .declare(
                 "s",
                 &tools(&["apps__a", "developer__b"]),
                 EnabledSurface {
                     counted_tool_names: names(&tools(&["apps__a", "apps__hidden", "developer__b"])),
                     extensions: vec![apps, developer.clone()],
-                    frontend_instructions: Vec::new(),
-                    extension_total: 2,
+                    frontend_instructions: vec![
+                        ("ui".to_string(), "render things".to_string()),
+                        ("chat".to_string(), "talk".to_string()),
+                    ],
+                    extension_total: 4,
                     tool_total: 3,
                 },
             )
             .await;
+        assert_eq!(
+            prompt.frontend_instructions.as_deref(),
+            Some("chat: talk\n\nui: render things")
+        );
+        assert_eq!((prompt.extension_count, prompt.tool_count), (4, 3));
+
         let prompt = surfaces
             .declare(
                 "s",
@@ -394,7 +395,6 @@ mod tests {
                 },
             )
             .await;
-
         assert_eq!(
             prompt
                 .extensions
@@ -403,16 +403,19 @@ mod tests {
                 .collect::<Vec<_>>(),
             ["apps", "developer"]
         );
-        assert_eq!((prompt.extension_count, prompt.tool_count), (2, 3));
+        assert_eq!(
+            prompt.frontend_instructions.as_deref(),
+            Some("chat: talk\n\nui: render things")
+        );
+        assert_eq!((prompt.extension_count, prompt.tool_count), (4, 3));
 
-        let other = ExtensionInfo::new("other", "do other things", false);
         let prompt = surfaces
             .declare(
                 "s",
                 &tools(&["other__c"]),
                 EnabledSurface {
                     counted_tool_names: names(&tools(&["other__c"])),
-                    extensions: vec![other],
+                    extensions: vec![ExtensionInfo::new("other", "do other things", false)],
                     frontend_instructions: Vec::new(),
                     extension_total: 1,
                     tool_total: 1,
@@ -420,55 +423,6 @@ mod tests {
             )
             .await;
 
-        assert_eq!((prompt.extension_count, prompt.tool_count), (3, 4));
-    }
-
-    #[tokio::test]
-    async fn test_declared_prompt_keeps_disabled_frontend_instructions() {
-        let surfaces = DeclaredSurfaces::default();
-
-        let prompt = surfaces
-            .declare(
-                "s",
-                &tools(&["apps__a", "developer__b"]),
-                EnabledSurface {
-                    counted_tool_names: names(&tools(&["apps__a", "developer__b"])),
-                    extensions: Vec::new(),
-                    frontend_instructions: vec![
-                        ("developer".to_string(), "write code".to_string()),
-                        ("apps".to_string(), "build apps".to_string()),
-                    ],
-                    extension_total: 2,
-                    tool_total: 2,
-                },
-            )
-            .await;
-        assert_eq!(
-            prompt.frontend_instructions.as_deref(),
-            Some("apps: build apps\n\ndeveloper: write code")
-        );
-
-        let prompt = surfaces
-            .declare(
-                "s",
-                &tools(&["developer__b"]),
-                EnabledSurface {
-                    counted_tool_names: names(&tools(&["developer__b"])),
-                    extensions: Vec::new(),
-                    frontend_instructions: vec![(
-                        "developer".to_string(),
-                        "write code".to_string(),
-                    )],
-                    extension_total: 1,
-                    tool_total: 1,
-                },
-            )
-            .await;
-
-        assert_eq!(
-            prompt.frontend_instructions.as_deref(),
-            Some("apps: build apps\n\ndeveloper: write code")
-        );
-        assert_eq!((prompt.extension_count, prompt.tool_count), (2, 2));
+        assert_eq!((prompt.extension_count, prompt.tool_count), (5, 4));
     }
 }

--- a/crates/goose/src/agents/tool_set.rs
+++ b/crates/goose/src/agents/tool_set.rs
@@ -120,6 +120,17 @@ impl Surface {
     }
 }
 
+/// A carrier only holds a delta at a wire position, so nothing else may be injected into it:
+/// that would render as the message's only block, which the Anthropic formatter cannot
+/// relocate out of the cached prefix once later messages exist.
+pub fn is_tool_set_update_carrier(message: &Message) -> bool {
+    !message.content.is_empty()
+        && message
+            .content
+            .iter()
+            .all(|content| matches!(content, MessageContentBlock::ToolSetUpdate(_)))
+}
+
 /// A delta renders as a wire-level system message, which must follow a user turn.
 pub fn can_record_tool_set_update(conversation: &Conversation) -> bool {
     conversation

--- a/crates/goose/src/agents/tool_set.rs
+++ b/crates/goose/src/agents/tool_set.rs
@@ -1,0 +1,254 @@
+use std::collections::{HashMap, HashSet};
+
+use rmcp::model::Tool;
+use tokio::sync::Mutex;
+
+use crate::agents::extension::ExtensionInfo;
+use crate::conversation::message::{
+    Message, MessageContentBlock, MessageMetadata, ToolSetUpdateContent,
+};
+use crate::conversation::{resolve_visible_tools, Conversation};
+
+/// Everything goose has offered the model during a session, per session.
+///
+/// Anthropic hashes a request prefix as `tools` -> `system` -> `messages`, so the cache only
+/// survives if both stay byte-identical for the life of the conversation. Disabling an
+/// extension therefore leaves its tools declared and hides them with a delta instead.
+///
+/// A cache, not a source of truth: it is rebuilt from what is enabled on session resume.
+#[derive(Default)]
+pub struct DeclaredSurfaces(Mutex<HashMap<String, Surface>>);
+
+#[derive(Default)]
+struct Surface {
+    tools: Vec<Tool>,
+    extensions: Vec<ExtensionInfo>,
+}
+
+/// Covers the declared surface, not only what is enabled now.
+pub struct DeclaredPrompt {
+    pub extensions: Vec<ExtensionInfo>,
+    pub extension_count: usize,
+    pub tool_count: usize,
+}
+
+impl DeclaredSurfaces {
+    pub async fn declare(
+        &self,
+        session_id: &str,
+        enabled_tools: &[Tool],
+        enabled_extensions: Vec<ExtensionInfo>,
+        enabled_counts: (usize, usize),
+    ) -> DeclaredPrompt {
+        let mut sessions = self.0.lock().await;
+        let surface = sessions.entry(session_id.to_string()).or_default();
+        surface.declare_tools(enabled_tools);
+
+        let enabled_extension_count = enabled_extensions.len();
+        for extension in enabled_extensions {
+            match surface
+                .extensions
+                .iter_mut()
+                .find(|declared| declared.name == extension.name)
+            {
+                Some(declared) => *declared = extension,
+                None => surface.extensions.push(extension),
+            }
+        }
+
+        // `enabled_counts` covers sources the declared lists do not hold, such as frontend
+        // extensions, so add what the surface declares beyond it rather than recounting.
+        DeclaredPrompt {
+            extension_count: enabled_counts.0
+                + surface
+                    .extensions
+                    .len()
+                    .saturating_sub(enabled_extension_count),
+            tool_count: enabled_counts.1 + surface.tools.len().saturating_sub(enabled_tools.len()),
+            extensions: surface.extensions.clone(),
+        }
+    }
+
+    /// The tools to send, plus the delta bringing the model's view in line with what is enabled.
+    pub async fn resolve(
+        &self,
+        session_id: &str,
+        enabled_tools: &[Tool],
+        conversation: &Conversation,
+    ) -> (Vec<Tool>, Option<ToolSetUpdateContent>) {
+        let mut sessions = self.0.lock().await;
+        let surface = sessions.entry(session_id.to_string()).or_default();
+        let declared_names = surface.declare_tools(enabled_tools);
+
+        let visible = resolve_visible_tools(&declared_names, conversation.messages());
+        let enabled_names: HashSet<String> = enabled_tools
+            .iter()
+            .map(|tool| tool.name.to_string())
+            .collect();
+
+        let mut update = ToolSetUpdateContent {
+            added: enabled_names.difference(&visible).cloned().collect(),
+            removed: visible.difference(&enabled_names).cloned().collect(),
+        };
+        update.added.sort();
+        update.removed.sort();
+
+        (
+            surface.tools.clone(),
+            (!update.is_empty()).then_some(update),
+        )
+    }
+}
+
+impl Surface {
+    fn declare_tools(&mut self, enabled: &[Tool]) -> HashSet<String> {
+        // A changed schema can arrive under an unchanged name, and keeping the old one would
+        // have the model calling it with stale arguments.
+        for tool in enabled {
+            match self
+                .tools
+                .iter_mut()
+                .find(|declared| declared.name == tool.name)
+            {
+                Some(declared) => *declared = tool.clone(),
+                None => self.tools.push(tool.clone()),
+            }
+        }
+        // Order must not depend on when a tool was declared, so a resume rebuilds it byte-wise.
+        self.tools.sort_by(|a, b| a.name.cmp(&b.name));
+        self.tools.iter().map(|t| t.name.to_string()).collect()
+    }
+}
+
+/// A delta renders as a wire-level system message, which must follow a user turn.
+pub fn can_record_tool_set_update(conversation: &Conversation) -> bool {
+    conversation
+        .messages()
+        .last()
+        .is_some_and(|message| message.role == rmcp::model::Role::User)
+}
+
+/// Deltas only mean anything against the declared surface, so a caller building its own tool
+/// array must drop them or an earlier removal hides a tool it just supplied.
+pub fn without_tool_set_updates(conversation: &Conversation) -> Conversation {
+    Conversation::new_unvalidated(
+        conversation
+            .messages()
+            .iter()
+            .filter_map(|message| {
+                let mut message = message.clone();
+                message
+                    .content
+                    .retain(|content| !matches!(content, MessageContentBlock::ToolSetUpdate(_)));
+                (!message.content.is_empty()).then_some(message)
+            })
+            .collect::<Vec<_>>(),
+    )
+}
+
+pub fn tool_set_update_message(update: ToolSetUpdateContent) -> Message {
+    Message::user()
+        .with_content(MessageContentBlock::ToolSetUpdate(update))
+        .with_metadata(MessageMetadata::agent_only())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rmcp::object;
+
+    fn tools(names: &[&str]) -> Vec<Tool> {
+        names
+            .iter()
+            .map(|name| Tool::new(name.to_string(), "test tool", object!({"type": "object"})))
+            .collect()
+    }
+
+    fn names(tools: &[Tool]) -> Vec<String> {
+        tools.iter().map(|tool| tool.name.to_string()).collect()
+    }
+
+    #[tokio::test]
+    async fn test_disable_then_reenable_replays_as_deltas() {
+        let surfaces = DeclaredSurfaces::default();
+        let mut conversation = Conversation::new_unvalidated(vec![Message::user().with_text("hi")]);
+
+        let all = tools(&["b", "a", "c"]);
+        let (declared, update) = surfaces.resolve("s", &all, &conversation).await;
+        assert_eq!(names(&declared), ["a", "b", "c"]);
+        assert!(update.is_none());
+
+        let remaining = tools(&["a"]);
+        let (declared, update) = surfaces.resolve("s", &remaining, &conversation).await;
+        assert_eq!(names(&declared), ["a", "b", "c"]);
+        let update = update.unwrap();
+        assert_eq!(update.removed, ["b", "c"]);
+        assert!(update.added.is_empty());
+        conversation.push(tool_set_update_message(update));
+
+        let (_, update) = surfaces.resolve("s", &remaining, &conversation).await;
+        assert!(update.is_none());
+
+        let (declared, update) = surfaces.resolve("s", &all, &conversation).await;
+        assert_eq!(names(&declared), ["a", "b", "c"]);
+        let update = update.unwrap();
+        assert_eq!(update.added, ["b", "c"]);
+        assert!(update.removed.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_archived_delta_is_replaced() {
+        let surfaces = DeclaredSurfaces::default();
+        let conversation = Conversation::new_unvalidated(vec![
+            Message::user().with_text("hi"),
+            tool_set_update_message(ToolSetUpdateContent {
+                added: Vec::new(),
+                removed: vec!["b".to_string()],
+            })
+            .with_metadata(MessageMetadata::user_only()),
+        ]);
+
+        surfaces
+            .resolve("s", &tools(&["a", "b"]), &conversation)
+            .await;
+        let (_, update) = surfaces.resolve("s", &tools(&["a"]), &conversation).await;
+
+        assert_eq!(update.unwrap().removed, ["b"]);
+    }
+
+    #[tokio::test]
+    async fn test_declared_prompt_keeps_disabled_extensions() {
+        let surfaces = DeclaredSurfaces::default();
+        let apps = ExtensionInfo::new("apps", "build apps", false);
+        let developer = ExtensionInfo::new("developer", "write code", false);
+
+        surfaces
+            .declare(
+                "s",
+                &tools(&["apps__a", "developer__b"]),
+                vec![apps, developer.clone()],
+                (2, 2),
+            )
+            .await;
+        let prompt = surfaces
+            .declare("s", &tools(&["developer__b"]), vec![developer], (1, 1))
+            .await;
+
+        assert_eq!(
+            prompt
+                .extensions
+                .iter()
+                .map(|extension| extension.name.as_str())
+                .collect::<Vec<_>>(),
+            ["apps", "developer"]
+        );
+        assert_eq!((prompt.extension_count, prompt.tool_count), (2, 2));
+
+        let other = ExtensionInfo::new("other", "do other things", false);
+        let prompt = surfaces
+            .declare("s", &tools(&["other__c"]), vec![other], (1, 1))
+            .await;
+
+        assert_eq!((prompt.extension_count, prompt.tool_count), (3, 3));
+    }
+}

--- a/crates/goose/src/agents/tool_set.rs
+++ b/crates/goose/src/agents/tool_set.rs
@@ -8,7 +8,7 @@ use crate::conversation::message::{
     Message, MessageContentBlock, MessageMetadata, ToolSetUpdateContent,
 };
 use crate::conversation::{resolve_visible_tools, Conversation};
-use crate::providers::formats::anthropic::defer_tool_loading;
+use crate::providers::formats::anthropic::{defer_tool_loading, offer_tool_immediately};
 
 /// Everything goose has offered the model during a session, per session.
 ///
@@ -159,13 +159,16 @@ fn render_frontend_instructions(instructions: &[(String, String)]) -> Option<Str
 
 impl Surface {
     fn declared_tools(&self) -> Vec<Tool> {
+        // An extension owns its `_meta`, so the marker is only ever trustworthy coming from here:
+        // one arriving on an enabled tool would withhold it on the wire with no addition to reveal
+        // it, and an extension whose every tool carried it would make the request illegal.
         self.tools
             .iter()
             .map(|tool| {
                 if self.deferred.contains(tool.name.as_ref()) {
                     defer_tool_loading(tool)
                 } else {
-                    tool.clone()
+                    offer_tool_immediately(tool)
                 }
             })
             .collect()
@@ -307,6 +310,21 @@ mod tests {
             .collect();
         // The API rejects an array whose every tool is withheld, so the opening set stays offered.
         assert_eq!(withheld, ["b"]);
+    }
+
+    #[tokio::test]
+    async fn test_extension_cannot_withhold_its_own_tool() {
+        let surfaces = DeclaredSurfaces::default();
+        let conversation = Conversation::new_unvalidated(vec![Message::user().with_text("hi")]);
+        let spoofed = tools(&["a"])
+            .iter()
+            .map(defer_tool_loading)
+            .collect::<Vec<_>>();
+
+        let (declared, update) = surfaces.resolve("s", &spoofed, &conversation).await;
+
+        assert!(update.is_none());
+        assert!(!tool_defers_loading(&declared[0]));
     }
 
     #[tokio::test]

--- a/crates/goose/src/agents/tool_set.rs
+++ b/crates/goose/src/agents/tool_set.rs
@@ -13,8 +13,9 @@ use crate::providers::formats::anthropic::{defer_tool_loading, offer_tool_immedi
 /// Everything goose has offered the model during a session, per session.
 ///
 /// Anthropic hashes a request prefix as `tools` -> `system` -> `messages`, so the cache only
-/// survives if both stay byte-identical for the life of the conversation. Disabling an
-/// extension therefore leaves its tools declared and hides them with a delta instead.
+/// survives if the tools and the system prompt both stay byte-identical for the life of the
+/// conversation. Disabling an extension therefore leaves its tools declared and hides them with a
+/// delta instead.
 ///
 /// A cache, not a source of truth: it is rebuilt from what is enabled on session resume.
 #[derive(Default)]
@@ -23,13 +24,12 @@ pub struct DeclaredSurfaces(Mutex<HashMap<String, Surface>>);
 #[derive(Default)]
 struct Surface {
     tools: Vec<Tool>,
-    /// Names withheld in the array until an addition reveals them. An addition only carries a
-    /// reference, so a tool the array never held still costs one rewrite of it; withholding is
-    /// what stops the model reading that tool as available before it was enabled.
+    /// Names withheld in the array until an addition reveals them, which is what stops the model
+    /// reading a tool as available before it was enabled.
     deferred: HashSet<String>,
-    /// Every tool the session has held, counted before the filters that decide what the model is
-    /// offered. `tool_count` is reported in those unfiltered terms, so an adjustment measured
-    /// against `tools` would shrink whenever a hidden tool's extension went away.
+    /// Every tool the session has held, counted before the filters that decide what is offered.
+    /// `tool_count` is reported in those terms, so measuring against `tools` would shrink it
+    /// whenever a hidden tool's extension went away.
     counted: HashSet<String>,
     extensions: Vec<ExtensionInfo>,
     frontend_instructions: Vec<(String, String)>,
@@ -87,8 +87,8 @@ impl DeclaredSurfaces {
             .frontend_instructions
             .sort_by(|(a, _), (b, _)| a.cmp(b));
 
-        // `enabled_counts` covers tool sources the declared prompt lists do not hold, so add
-        // what the surface declares beyond the currently enabled set rather than recounting.
+        // `enabled_counts` covers sources these lists do not hold, so add what the surface
+        // declares beyond the enabled set rather than recounting.
         DeclaredPrompt {
             extension_count: enabled_counts.0
                 + surface
@@ -116,9 +116,8 @@ impl DeclaredSurfaces {
         let surface = sessions.entry(session_id.to_string()).or_default();
         let declared_names = surface.declare_tools(enabled_tools);
 
-        // What the array offers by itself. A withheld tool is declared but unavailable until an
-        // addition names it, so the model's view is this set with the recorded deltas replayed:
-        // one archived by compaction simply means the addition has to be made again.
+        // What the array offers by itself, which the recorded deltas then move: an addition
+        // archived by compaction simply has to be made again.
         let offered: HashSet<String> = declared_names
             .difference(&surface.deferred)
             .cloned()
@@ -159,9 +158,8 @@ fn render_frontend_instructions(instructions: &[(String, String)]) -> Option<Str
 
 impl Surface {
     fn declared_tools(&self) -> Vec<Tool> {
-        // An extension owns its `_meta`, so the marker is only ever trustworthy coming from here:
-        // one arriving on an enabled tool would withhold it on the wire with no addition to reveal
-        // it, and an extension whose every tool carried it would make the request illegal.
+        // An extension owns its `_meta`, so the marker is only trustworthy coming from here: one
+        // arriving on an enabled tool would withhold it with no addition to reveal it.
         self.tools
             .iter()
             .map(|tool| {
@@ -177,9 +175,8 @@ impl Surface {
     fn declare_tools(&mut self, enabled: &[Tool]) -> HashSet<String> {
         // Whichever of `declare` and `resolve` runs first for a turn lands here, so this is the
         // only place that can tell a tool the model has never been offered from one it has. The
-        // first non-empty array has to be offered outright: the API rejects one whose every tool
-        // is withheld, so a session that opens with nothing model-visible cannot withhold what it
-        // gains later.
+        // first non-empty array is offered outright because the API rejects one whose every tool
+        // is withheld.
         let opening = self.tools.is_empty();
         // A changed schema can arrive under an unchanged name, and keeping the old one would
         // have the model calling it with stale arguments.

--- a/crates/goose/src/agents/tool_set.rs
+++ b/crates/goose/src/agents/tool_set.rs
@@ -43,16 +43,33 @@ pub struct DeclaredPrompt {
     pub tool_count: usize,
 }
 
+/// What a session has enabled right now, as the prompt would describe it without a declared
+/// surface. The totals cover tool and extension sources the lists themselves do not hold.
+pub struct EnabledSurface {
+    /// Tool names taken before the filters that decide what the model is offered, which is the
+    /// unit `tool_total` is expressed in.
+    pub counted_tool_names: Vec<String>,
+    pub extensions: Vec<ExtensionInfo>,
+    pub frontend_instructions: Vec<(String, String)>,
+    pub extension_total: usize,
+    pub tool_total: usize,
+}
+
 impl DeclaredSurfaces {
     pub async fn declare(
         &self,
         session_id: &str,
         enabled_tools: &[Tool],
-        counted_tool_names: Vec<String>,
-        enabled_extensions: Vec<ExtensionInfo>,
-        enabled_frontend_instructions: Vec<(String, String)>,
-        enabled_counts: (usize, usize),
+        enabled: EnabledSurface,
     ) -> DeclaredPrompt {
+        let EnabledSurface {
+            counted_tool_names,
+            extensions: enabled_extensions,
+            frontend_instructions: enabled_frontend_instructions,
+            extension_total,
+            tool_total,
+        } = enabled;
+
         let mut sessions = self.0.lock().await;
         let surface = sessions.entry(session_id.to_string()).or_default();
         surface.declare_tools(enabled_tools);
@@ -87,10 +104,10 @@ impl DeclaredSurfaces {
             .frontend_instructions
             .sort_by(|(a, _), (b, _)| a.cmp(b));
 
-        // `enabled_counts` covers sources these lists do not hold, so add what the surface
-        // declares beyond the enabled set rather than recounting.
+        // The totals cover sources these lists do not hold, so add what the surface declares
+        // beyond the enabled set rather than recounting.
         DeclaredPrompt {
-            extension_count: enabled_counts.0
+            extension_count: extension_total
                 + surface
                     .extensions
                     .len()
@@ -99,7 +116,7 @@ impl DeclaredSurfaces {
                     .frontend_instructions
                     .len()
                     .saturating_sub(enabled_frontend_extension_count),
-            tool_count: enabled_counts.1 + surface.counted.len().saturating_sub(counted_enabled),
+            tool_count: tool_total + surface.counted.len().saturating_sub(counted_enabled),
             extensions: surface.extensions.clone(),
             frontend_instructions: render_frontend_instructions(&surface.frontend_instructions),
         }
@@ -355,20 +372,26 @@ mod tests {
             .declare(
                 "s",
                 &tools(&["apps__a", "developer__b"]),
-                names(&tools(&["apps__a", "apps__hidden", "developer__b"])),
-                vec![apps, developer.clone()],
-                Vec::new(),
-                (2, 3),
+                EnabledSurface {
+                    counted_tool_names: names(&tools(&["apps__a", "apps__hidden", "developer__b"])),
+                    extensions: vec![apps, developer.clone()],
+                    frontend_instructions: Vec::new(),
+                    extension_total: 2,
+                    tool_total: 3,
+                },
             )
             .await;
         let prompt = surfaces
             .declare(
                 "s",
                 &tools(&["developer__b"]),
-                names(&tools(&["developer__b"])),
-                vec![developer],
-                Vec::new(),
-                (1, 1),
+                EnabledSurface {
+                    counted_tool_names: names(&tools(&["developer__b"])),
+                    extensions: vec![developer],
+                    frontend_instructions: Vec::new(),
+                    extension_total: 1,
+                    tool_total: 1,
+                },
             )
             .await;
 
@@ -387,10 +410,13 @@ mod tests {
             .declare(
                 "s",
                 &tools(&["other__c"]),
-                names(&tools(&["other__c"])),
-                vec![other],
-                Vec::new(),
-                (1, 1),
+                EnabledSurface {
+                    counted_tool_names: names(&tools(&["other__c"])),
+                    extensions: vec![other],
+                    frontend_instructions: Vec::new(),
+                    extension_total: 1,
+                    tool_total: 1,
+                },
             )
             .await;
 
@@ -405,13 +431,16 @@ mod tests {
             .declare(
                 "s",
                 &tools(&["apps__a", "developer__b"]),
-                names(&tools(&["apps__a", "developer__b"])),
-                Vec::new(),
-                vec![
-                    ("developer".to_string(), "write code".to_string()),
-                    ("apps".to_string(), "build apps".to_string()),
-                ],
-                (2, 2),
+                EnabledSurface {
+                    counted_tool_names: names(&tools(&["apps__a", "developer__b"])),
+                    extensions: Vec::new(),
+                    frontend_instructions: vec![
+                        ("developer".to_string(), "write code".to_string()),
+                        ("apps".to_string(), "build apps".to_string()),
+                    ],
+                    extension_total: 2,
+                    tool_total: 2,
+                },
             )
             .await;
         assert_eq!(
@@ -423,10 +452,16 @@ mod tests {
             .declare(
                 "s",
                 &tools(&["developer__b"]),
-                names(&tools(&["developer__b"])),
-                Vec::new(),
-                vec![("developer".to_string(), "write code".to_string())],
-                (1, 1),
+                EnabledSurface {
+                    counted_tool_names: names(&tools(&["developer__b"])),
+                    extensions: Vec::new(),
+                    frontend_instructions: vec![(
+                        "developer".to_string(),
+                        "write code".to_string(),
+                    )],
+                    extension_total: 1,
+                    tool_total: 1,
+                },
             )
             .await;
 

--- a/crates/goose/src/context_mgmt/mod.rs
+++ b/crates/goose/src/context_mgmt/mod.rs
@@ -482,6 +482,7 @@ pub fn format_message_for_compacting(msg: &Message) -> String {
             MessageContent::SystemNotification(notification) => {
                 Some(format!("system_notification: {}", notification.msg))
             }
+            MessageContent::ToolSetUpdate(_) => None,
         })
         .collect();
 

--- a/crates/goose/src/providers/bedrock.rs
+++ b/crates/goose/src/providers/bedrock.rs
@@ -28,7 +28,8 @@ use smithy_transport_reqwest::ReqwestHttpClient;
 
 use super::formats::bedrock::{
     bedrock_anthropic_thinking_fields, bedrock_inference_config, from_bedrock_message,
-    from_bedrock_usage, to_bedrock_message_with_caching, to_bedrock_tool_config,
+    from_bedrock_usage, has_bedrock_content, to_bedrock_message_with_caching,
+    to_bedrock_tool_config,
 };
 
 pub(crate) const BEDROCK_PROVIDER_NAME: &str = "aws_bedrock";
@@ -311,8 +312,10 @@ impl BedrockProvider {
             vec![bedrock::SystemContentBlock::Text(system.to_string())]
         };
 
-        let visible_messages: Vec<&Message> =
-            messages.iter().filter(|m| m.is_agent_visible()).collect();
+        let visible_messages: Vec<&Message> = messages
+            .iter()
+            .filter(|m| m.is_agent_visible() && has_bedrock_content(m))
+            .collect();
 
         let last_idx = visible_messages.len().saturating_sub(1);
 

--- a/crates/goose/src/providers/formats/bedrock.rs
+++ b/crates/goose/src/providers/formats/bedrock.rs
@@ -149,6 +149,15 @@ fn bedrock_model_supports_temperature(model_config: &ModelConfig) -> bool {
     }
 }
 
+fn is_bedrock_content(content: &MessageContent) -> bool {
+    !matches!(content, MessageContent::ToolSetUpdate(_))
+}
+
+/// Bedrock rejects a message with no content blocks, so drop it rather than convert it.
+pub fn has_bedrock_content(message: &Message) -> bool {
+    message.content.iter().any(is_bedrock_content)
+}
+
 pub fn to_bedrock_message_with_caching(
     message: &Message,
     enable_caching: bool,
@@ -156,6 +165,7 @@ pub fn to_bedrock_message_with_caching(
     let mut content_blocks: Vec<bedrock::ContentBlock> = message
         .content
         .iter()
+        .filter(|content| is_bedrock_content(content))
         .map(to_bedrock_message_content)
         .collect::<Result<_>>()?;
 
@@ -208,6 +218,9 @@ pub fn to_bedrock_message_content(content: &MessageContent) -> Result<bedrock::C
         }
         MessageContent::SystemNotification(_) => {
             bail!("SystemNotification should not get passed to the provider")
+        }
+        MessageContent::ToolSetUpdate(_) => {
+            bail!("ToolSetUpdate is filtered before conversion; Bedrock rejects blank content")
         }
         MessageContent::ToolRequest(tool_req) => {
             let tool_use_id = tool_req.id.to_string();

--- a/goose-self-test.yaml
+++ b/goose-self-test.yaml
@@ -172,6 +172,9 @@ prompt: |
   2. Document all available extensions
   3. Test enabling and disabling dynamic extensions (if any available)
   4. Verify extension isolation between enabled extensions
+  5. Mid-session toggles must take effect in the same turn: after disabling an extension its tools
+     must no longer be offered to you, and after enabling the builtin `memory` extension storing and
+     retrieving a memory must succeed without starting a new session
 
   Log results to: {{ workspace_dir }}/phase2_extensions.md
   {% endif %}

--- a/ui/desktop/src/types/message.ts
+++ b/ui/desktop/src/types/message.ts
@@ -192,6 +192,11 @@ export type MessageMetadata = {
   userVisible: boolean;
 };
 
+export type ToolSetUpdateContent = {
+  added: string[];
+  removed: string[];
+};
+
 export type MessageContent =
   | (TextContent & { type: 'text' })
   | (ImageContent & { type: 'image' })
@@ -202,7 +207,8 @@ export type MessageContent =
   | (FrontendToolRequest & { type: 'frontendToolRequest' })
   | (ThinkingContent & { type: 'thinking' })
   | (RedactedThinkingContent & { type: 'redactedThinking' })
-  | (SystemNotificationContent & { type: 'systemNotification' });
+  | (SystemNotificationContent & { type: 'systemNotification' })
+  | (ToolSetUpdateContent & { type: 'toolSetUpdate' });
 
 export type Message = {
   content: MessageContent[];


### PR DESCRIPTION
Uses Opus 5's `mid-conversation-tool-changes` beta so toggling an extension mid-session no longer throws away the Anthropic prompt cache: every tool offered during a session stays declared in a byte-stable `tools` array, and toggles are recorded as deltas that render as wire-level `system` messages. The system prompt is built from the same declared surface, since `system` is hashed right after `tools` and would otherwise invalidate the cache on its own.

Measured on `claude-opus-5`: disabling a 6-tool extension mid-session reads 11,876 tokens from cache where the status quo reads 0. Falls back to filtering the tool array whenever a delta cannot be placed legally, so correctness never depends on the cache optimisation.


https://www.anthropic.com/news/claude-opus-5
> Alongside Opus 5, we’re releasing two updates in beta: [Mid-conversation tool changes](https://platform.claude.com/docs/en/build-with-claude/mid-conversation-system-messages) on the Claude Platform. Within a conversation, developers can now change which tools Claude can use without invalidating the prompt cache. ...