### PR TITLE
Add DialMCP remote phone-call MCP extension

### DIFF
--- a/documentation/docs/mcp/dialmcp-mcp.md
+++ b/documentation/docs/mcp/dialmcp-mcp.md
@@ -1,0 +1,66 @@
+---
+title: DialMCP Extension
+description: Add DialMCP as a goose Extension
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import GooseDesktopInstaller from '@site/src/components/GooseDesktopInstaller';
+import CLIExtensionInstructions from '@site/src/components/CLIExtensionInstructions';
+
+DialMCP is a hosted remote MCP server that lets AI agents place real phone calls from your own SMS-verified number. Every call returns a transcript, a recording, and a structured outcome. US & Canada only.
+
+## Quick Install
+
+:::tip
+<Tabs groupId="interface">
+  <TabItem value="ui" label="goose Desktop" default>
+  [Install DialMCP extension](goose://extension?type=streamable_http&url=https%3A%2F%2Fmcp.dialmcp.com%2Fmcp&id=dialmcp&name=DialMCP&description=Place%20real%20phone%20calls%20from%20your%20verified%20number%20with%20transcripts%20and%20recordings)
+  </TabItem>
+  <TabItem value="cli" label="goose CLI">
+  Use `goose configure` to add a `Remote Extension (Streamable HTTP)` with:
+
+  **Endpoint URL**
+
+  ```
+  https://mcp.dialmcp.com/mcp
+  ```
+  </TabItem>
+</Tabs>
+:::
+
+## Configuration
+
+<Tabs groupId="interface">
+  <TabItem value="ui" label="goose Desktop" default>
+    <GooseDesktopInstaller
+      extensionId="dialmcp"
+      extensionName="DialMCP"
+      description="Place real phone calls from your verified number, with transcripts and recordings"
+      type="streamable_http"
+      url="https://mcp.dialmcp.com/mcp"
+    />
+  </TabItem>
+  <TabItem value="cli" label="goose CLI">
+    <CLIExtensionInstructions
+      name="dialmcp"
+      type="streamable_http"
+      url="https://mcp.dialmcp.com/mcp"
+      description="Place real phone calls from your verified number, with transcripts and recordings"
+    />
+  </TabItem>
+</Tabs>
+
+## Example Usage
+
+- "Call the restaurant at +1-415-555-0100 and ask if they have a table for 2 at 7pm tonight."
+- "Phone my dentist's office and confirm my appointment on Thursday."
+- "Call this vendor and get a status update on order 1842; summarize any commitments they make."
+
+## Notes
+
+- Auth is OAuth 2.1 (phone number + SMS). No API keys.
+- Calls present your own verified caller ID.
+- Scope: US & Canada, 8:00–21:00 local time; rate-limited.
+- Website: https://dialmcp.com
+- Connector / docs: https://github.com/SkillfulAgents/dialmcp-connector

--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -36,7 +36,7 @@
   {
     "id": "apify",
     "name": "Apify",
-    "description": "Extract data from any website with thousands of scrapers, crawlers, and automations on Apify Store \u26a1",
+    "description": "Extract data from any website with thousands of scrapers, crawlers, and automations on Apify Store ⚡",
     "command": "npx -y @apify/actors-mcp-server",
     "link": "https://github.com/apify/apify-mcp-server",
     "installation_notes": "Install using npx. Requires an Apify API token.",
@@ -128,6 +128,18 @@
     ]
   },
   {
+    "id": "cash-app",
+    "name": "Cash App",
+    "description": "Cash App brings local food ordering into the AI era. Discover nearby sellers, browse menus with calories and allergen info, customize orders, and complete checkout—all conversationally.",
+    "type": "streamable-http",
+    "url": "https://connect.squareup.com/v2/mcp/cash-app",
+    "link": "",
+    "installation_notes": "No local setup required. This extension connects to a remote service. Use the install button or run the command below.",
+    "is_builtin": false,
+    "endorsed": true,
+    "environmentVariables": []
+  },
+  {
     "id": "chrome-devtools-mcp",
     "name": "Chrome DevTools",
     "description": "Control and inspect a live Chrome browser",
@@ -154,6 +166,17 @@
         "required": true
       }
     ]
+  },
+  {
+    "id": "code_execution",
+    "name": "Code Mode",
+    "description": "Execute JavaScript code to interact with MCP tools efficiently",
+    "command": "",
+    "link": "https://github.com/aaif-goose/goose/tree/main/crates/goose/src/agents/platform_extensions/code_execution.rs",
+    "installation_notes": "This is a built-in platform extension that comes with goose. No installation required.",
+    "is_builtin": true,
+    "endorsed": true,
+    "environmentVariables": []
   },
   {
     "id": "computercontroller",
@@ -222,15 +245,16 @@
     ]
   },
   {
-    "id": "code_execution",
-    "name": "Code Mode",
-    "description": "Execute JavaScript code to interact with MCP tools efficiently",
-    "command": "",
-    "link": "https://github.com/aaif-goose/goose/tree/main/crates/goose/src/agents/platform_extensions/code_execution.rs",
-    "installation_notes": "This is a built-in platform extension that comes with goose. No installation required.",
-    "is_builtin": true,
-    "endorsed": true,
-    "environmentVariables": []
+    "id": "dev.to",
+    "name": "Dev.to",
+    "description": "Access Dev.to articles and content (requires local server setup)",
+    "url": "http://localhost:3000/mcp",
+    "link": "https://github.com/nickytonline/dev-to-mcp",
+    "installation_notes": "This is a local extension. You must first clone, install, and run the Dev.to MCP server locally before adding this extension.",
+    "is_builtin": false,
+    "endorsed": false,
+    "environmentVariables": [],
+    "type": "streamable-http"
   },
   {
     "id": "developer",
@@ -244,16 +268,16 @@
     "environmentVariables": []
   },
   {
-    "id": "dev.to",
-    "name": "Dev.to",
-    "description": "Access Dev.to articles and content (requires local server setup)",
-    "url": "http://localhost:3000/mcp",
-    "link": "https://github.com/nickytonline/dev-to-mcp",
-    "installation_notes": "This is a local extension. You must first clone, install, and run the Dev.to MCP server locally before adding this extension.",
+    "id": "dialmcp",
+    "name": "DialMCP",
+    "description": "Let AI agents place real phone calls from your verified number, with transcripts and recordings. US & Canada.",
+    "type": "streamable-http",
+    "url": "https://mcp.dialmcp.com/mcp",
+    "link": "https://dialmcp.com",
+    "installation_notes": "Streamable HTTP extension with OAuth browser authentication (phone SMS sign-in). No API keys. US & Canada only; calling hours 8:00–21:00 local.",
     "is_builtin": false,
     "endorsed": false,
-    "environmentVariables": [],
-    "type": "streamable-http"
+    "environmentVariables": []
   },
   {
     "id": "elevenlabs-mcp",
@@ -464,6 +488,18 @@
     ]
   },
   {
+    "id": "neighborhood",
+    "name": "Neighborhood",
+    "description": "Discover nearby restaurants, browse menus, and place takeout orders through natural conversation. Sellers are US-based.",
+    "type": "streamable-http",
+    "url": "https://connect.squareup.com/v2/mcp/neighborhood",
+    "link": "",
+    "installation_notes": "No local setup required. This extension connects to a remote service. Use the install button or run the command below.",
+    "is_builtin": false,
+    "endorsed": true,
+    "environmentVariables": []
+  },
+  {
     "id": "neon",
     "name": "Neon",
     "description": "Manage Neon Postgres databases, projects, and branches",
@@ -637,6 +673,28 @@
     "environmentVariables": []
   },
   {
+    "id": "scholar-sidekick",
+    "name": "Scholar Sidekick",
+    "description": "Resolve, format, export, and verify academic citations (DOI, PMID, ISBN, arXiv) plus retraction and open-access checks",
+    "command": "npx -y scholar-sidekick-mcp@latest",
+    "link": "https://github.com/mlava/scholar-sidekick-mcp",
+    "installation_notes": "No API key required — works anonymously on a free, rate-limited tier. Optionally set SCHOLAR_API_KEY (a free first-party ssk_ key from https://scholar-sidekick.com/account) for higher limits, or RAPIDAPI_KEY for paid tiers via RapidAPI.",
+    "is_builtin": false,
+    "endorsed": false,
+    "environmentVariables": [
+      {
+        "name": "SCHOLAR_API_KEY",
+        "description": "Optional first-party API key (ssk_) from https://scholar-sidekick.com/account; raises rate limits. Sent as Authorization: Bearer.",
+        "required": false
+      },
+      {
+        "name": "RAPIDAPI_KEY",
+        "description": "Optional RapidAPI key for paid/managed tiers; routes calls through the RapidAPI gateway.",
+        "required": false
+      }
+    ]
+  },
+  {
     "id": "selenium-mcp",
     "name": "Selenium",
     "description": "Web browser automation and testing",
@@ -758,52 +816,5 @@
     "is_builtin": false,
     "endorsed": false,
     "environmentVariables": []
-  },
-  {
-    "id": "neighborhood",
-    "name": "Neighborhood",
-    "description": "Discover nearby restaurants, browse menus, and place takeout orders through natural conversation. Sellers are US-based.",
-    "type": "streamable-http",
-    "url": "https://connect.squareup.com/v2/mcp/neighborhood",
-    "link": "",
-    "installation_notes": "No local setup required. This extension connects to a remote service. Use the install button or run the command below.",
-    "is_builtin": false,
-    "endorsed": true,
-    "environmentVariables": []
-  },
-  {
-    "id": "cash-app",
-    "name": "Cash App",
-    "description": "Cash App brings local food ordering into the AI era. Discover nearby sellers, browse menus with calories and allergen info, customize orders, and complete checkout\u2014all conversationally.",
-    "type": "streamable-http",
-    "url": "https://connect.squareup.com/v2/mcp/cash-app",
-    "link": "",
-    "installation_notes": "No local setup required. This extension connects to a remote service. Use the install button or run the command below.",
-    "is_builtin": false,
-    "endorsed": true,
-    "environmentVariables": []
-  },
-  {
-  "id": "scholar-sidekick",
-  "name": "Scholar Sidekick",
-  "description": "Resolve, format, export, and verify academic citations (DOI, PMID, ISBN, arXiv) plus retraction and open-access checks",
-  "command": "npx -y scholar-sidekick-mcp@latest",
-  "link": "https://github.com/mlava/scholar-sidekick-mcp",
-  "installation_notes": "No API key required — works anonymously on a free, rate-limited tier. Optionally set SCHOLAR_API_KEY (a free first-party ssk_ key from https://scholar-sidekick.com/account) for higher limits, or RAPIDAPI_KEY for paid tiers via RapidAPI.",
-  "is_builtin": false,
-  "endorsed": false,
-  "environmentVariables": [
-    {
-      "name": "SCHOLAR_API_KEY",
-      "description": "Optional first-party API key (ssk_) from https://scholar-sidekick.com/account; raises rate limits. Sent as Authorization: Bearer.",
-      "required": false
-    },
-    {
-      "name": "RAPIDAPI_KEY",
-      "description": "Optional RapidAPI key for paid/managed tiers; routes calls through the RapidAPI gateway.",
-      "required": false
-    }
-  ]
-}
-
+  }
 ]


### PR DESCRIPTION
## Add DialMCP extension

Adds **DialMCP** as a remote Streamable HTTP extension.

| Field | Value |
|---|---|
| Type | `streamable-http` |
| URL | `https://mcp.dialmcp.com/mcp` |
| Auth | OAuth 2.1 (phone SMS), RFC 7591 DCR |
| Website | https://dialmcp.com |
| Registry | `com.dialmcp/dialmcp` |
| Docs | `documentation/docs/mcp/dialmcp-mcp.md` |
| Catalog | `documentation/static/servers.json` |

Modeled after existing remote OAuth entries (Neon, Rube, Neighborhood). Free during pilot. US & Canada only.
