### PR TITLE
Sanitize Unicode tags in Responses output

### DIFF
--- a/crates/goose-provider-types/src/formats/openai_responses.rs
+++ b/crates/goose-provider-types/src/formats/openai_responses.rs
@@ -699,6 +699,32 @@ pub fn create_responses_request(
     Ok(payload)
 }
 
+fn sanitize_tool_arguments(value: Value) -> Value {
+    match value {
+        Value::String(text) => Value::String(sanitize_unicode_tags(&text)),
+        Value::Array(values) => {
+            Value::Array(values.into_iter().map(sanitize_tool_arguments).collect())
+        }
+        Value::Object(values) => Value::Object(
+            values
+                .into_iter()
+                .map(|(key, value)| (sanitize_unicode_tags(&key), sanitize_tool_arguments(value)))
+                .collect(),
+        ),
+        value => value,
+    }
+}
+
+fn parse_tool_arguments(arguments: &str) -> Value {
+    if arguments.is_empty() {
+        json!({})
+    } else {
+        serde_json::from_str(arguments)
+            .map(sanitize_tool_arguments)
+            .unwrap_or_else(|_| json!({}))
+    }
+}
+
 pub fn responses_api_to_message(response: &ResponsesApiResponse) -> anyhow::Result<Message> {
     let mut content = Vec::new();
 
@@ -728,8 +754,9 @@ pub fn responses_api_to_message(response: &ResponsesApiResponse) -> anyhow::Resu
                         ResponseContentBlock::ToolCall { id, name, input } => {
                             content.push(MessageContentBlock::tool_request(
                                 id.clone(),
-                                Ok(CallToolRequestParams::new(name.clone())
-                                    .with_arguments(object(input.clone()))),
+                                Ok(CallToolRequestParams::new(name.clone()).with_arguments(
+                                    object(sanitize_tool_arguments(input.clone())),
+                                )),
                             ));
                         }
                     }
@@ -745,11 +772,7 @@ pub fn responses_api_to_message(response: &ResponsesApiResponse) -> anyhow::Resu
                 let request_id = call_id.clone().or_else(|| id.clone()).ok_or_else(|| {
                     anyhow!("Responses function_call output missing call_id and id")
                 })?;
-                let parsed_args = if arguments.is_empty() {
-                    json!({})
-                } else {
-                    serde_json::from_str(arguments).unwrap_or_else(|_| json!({}))
-                };
+                let parsed_args = parse_tool_arguments(arguments);
 
                 content.push(MessageContentBlock::tool_request(
                     request_id,
@@ -805,11 +828,7 @@ fn process_streaming_output_items(
                             name,
                             arguments,
                         } => {
-                            let parsed_args = if arguments.is_empty() {
-                                json!({})
-                            } else {
-                                serde_json::from_str(&arguments).unwrap_or_else(|_| json!({}))
-                            };
+                            let parsed_args = parse_tool_arguments(&arguments);
 
                             content.push(MessageContentBlock::tool_request(
                                 id,
@@ -830,11 +849,7 @@ fn process_streaming_output_items(
                 let request_id = call_id.or(id).ok_or_else(|| {
                     anyhow!("Responses function_call output missing call_id and id")
                 })?;
-                let parsed_args = if arguments.is_empty() {
-                    json!({})
-                } else {
-                    serde_json::from_str(&arguments).unwrap_or_else(|_| json!({}))
-                };
+                let parsed_args = parse_tool_arguments(&arguments);
 
                 content.push(MessageContentBlock::tool_request(
                     request_id,
@@ -1403,6 +1418,54 @@ mod tests {
             panic!("expected tool request content");
         };
         assert_eq!(tool_request.id, "call_abc");
+    }
+
+    #[test]
+    fn test_responses_api_to_message_sanitizes_tool_arguments() {
+        let response = ResponsesApiResponse {
+            id: "resp_1".to_string(),
+            object: "response".to_string(),
+            created_at: 0,
+            status: "completed".to_string(),
+            model: "gpt-5.3-codex".to_string(),
+            output: vec![
+                ResponseOutputItem::Message {
+                    id: Some("msg_1".to_string()),
+                    status: Some("completed".to_string()),
+                    role: "assistant".to_string(),
+                    content: vec![ResponseContentBlock::ToolCall {
+                        id: "call_1".to_string(),
+                        name: "shell".to_string(),
+                        input: json!({"prompt": "visible\u{E0041}text"}),
+                    }],
+                },
+                ResponseOutputItem::FunctionCall {
+                    id: None,
+                    status: Some("completed".to_string()),
+                    call_id: Some("call_2".to_string()),
+                    name: "shell".to_string(),
+                    arguments: serde_json::to_string(&json!({"prompt": "visible\u{E0042}text"}))
+                        .unwrap(),
+                },
+            ],
+            reasoning: None,
+            usage: None,
+        };
+
+        let message = responses_api_to_message(&response).unwrap();
+        for content in message.content {
+            let MessageContentBlock::ToolRequest(tool_request) = content else {
+                panic!("expected tool request content");
+            };
+            let tool_call = tool_request.tool_call.expect("expected valid tool call");
+            assert_eq!(
+                tool_call
+                    .arguments
+                    .expect("expected arguments")
+                    .get("prompt"),
+                Some(&json!("visibletext"))
+            );
+        }
     }
 
     #[test]
@@ -2225,6 +2288,46 @@ mod tests {
             error.to_string().contains("missing call_id and id"),
             "unexpected error: {error}"
         );
+    }
+
+    #[test]
+    fn test_streaming_output_items_sanitize_tool_arguments() -> anyhow::Result<()> {
+        let output_items = vec![
+            ResponseOutputItemInfo::Message {
+                id: Some("msg_1".to_string()),
+                status: Some("completed".to_string()),
+                role: "assistant".to_string(),
+                content: vec![ContentBlockPart::ToolCall {
+                    id: "call_1".to_string(),
+                    name: "shell".to_string(),
+                    arguments: serde_json::to_string(&json!({"prompt": "visible\u{E0041}text"}))?,
+                }],
+            },
+            ResponseOutputItemInfo::FunctionCall {
+                id: None,
+                status: Some("completed".to_string()),
+                call_id: Some("call_2".to_string()),
+                name: "shell".to_string(),
+                arguments: serde_json::to_string(&json!({"prompt": "visible\u{E0042}text"}))?,
+            },
+        ];
+
+        let content = process_streaming_output_items(output_items, false)?;
+        for content in content {
+            let MessageContentBlock::ToolRequest(tool_request) = content else {
+                panic!("expected tool request content");
+            };
+            let tool_call = tool_request.tool_call.expect("expected valid tool call");
+            assert_eq!(
+                tool_call
+                    .arguments
+                    .expect("expected arguments")
+                    .get("prompt"),
+                Some(&json!("visibletext"))
+            );
+        }
+
+        Ok(())
     }
 
     #[test]

--- a/crates/goose-provider-types/src/formats/openai_responses.rs
+++ b/crates/goose-provider-types/src/formats/openai_responses.rs
@@ -7,7 +7,7 @@ use crate::formats::openai::{
 };
 use crate::mcp_utils::extract_text_from_resource;
 use crate::model::ModelConfig;
-use crate::utils::sanitize_unicode_tags;
+use crate::utils::{sanitize_unicode_tags, strip_unicode_tags};
 use anyhow::{anyhow, Error};
 use async_stream::try_stream;
 use chrono;
@@ -906,7 +906,7 @@ where
 
                 ResponsesStreamEvent::OutputTextDelta { delta, .. } => {
                     is_text_response = true;
-                    let delta = sanitize_unicode_tags(&delta);
+                    let delta = strip_unicode_tags(&delta);
                     if !delta.is_empty() {
                         accumulated_text.push_str(&delta);
 
@@ -961,7 +961,7 @@ where
 
                 ResponsesStreamEvent::RefusalDelta { delta, .. } => {
                     is_text_response = true;
-                    let delta = sanitize_unicode_tags(&delta);
+                    let delta = strip_unicode_tags(&delta);
                     if !delta.is_empty() {
                         accumulated_text.push_str(&delta);
 
@@ -2062,14 +2062,36 @@ mod tests {
                     "item_id": "msg_1",
                     "output_index": 0,
                     "content_index": 0,
-                    "delta": "visible\u{E0041}text"
+                    "delta": "visible\u{E0041}te"
+                })
+            ),
+            format!(
+                "data: {}",
+                serde_json::json!({
+                    "type": "response.output_text.delta",
+                    "sequence_number": 3,
+                    "item_id": "msg_1",
+                    "output_index": 0,
+                    "content_index": 0,
+                    "delta": "xt e"
+                })
+            ),
+            format!(
+                "data: {}",
+                serde_json::json!({
+                    "type": "response.output_text.delta",
+                    "sequence_number": 4,
+                    "item_id": "msg_1",
+                    "output_index": 0,
+                    "content_index": 0,
+                    "delta": "\u{301}"
                 })
             ),
             format!(
                 "data: {}",
                 serde_json::json!({
                     "type": "response.refusal.delta",
-                    "sequence_number": 3,
+                    "sequence_number": 5,
                     "item_id": "msg_1",
                     "output_index": 0,
                     "content_index": 1,
@@ -2095,7 +2117,7 @@ mod tests {
             }
         }
 
-        assert_eq!(text, vec!["visibletext", "cannothelp"]);
+        assert_eq!(text.concat(), "visibletext e\u{301}cannothelp");
         Ok(())
     }
 

--- a/crates/goose-provider-types/src/formats/openai_responses.rs
+++ b/crates/goose-provider-types/src/formats/openai_responses.rs
@@ -765,9 +765,10 @@ pub fn responses_api_to_message(response: &ResponsesApiResponse) -> anyhow::Resu
                         ResponseContentBlock::ToolCall { id, name, input } => {
                             content.push(MessageContentBlock::tool_request(
                                 id.clone(),
-                                Ok(CallToolRequestParams::new(name.clone()).with_arguments(
-                                    object(sanitize_tool_arguments(input.clone())?),
-                                )),
+                                Ok(CallToolRequestParams::new(strip_unicode_tags(name))
+                                    .with_arguments(object(sanitize_tool_arguments(
+                                        input.clone(),
+                                    )?))),
                             ));
                         }
                     }
@@ -787,7 +788,7 @@ pub fn responses_api_to_message(response: &ResponsesApiResponse) -> anyhow::Resu
 
                 content.push(MessageContentBlock::tool_request(
                     request_id,
-                    Ok(CallToolRequestParams::new(name.clone())
+                    Ok(CallToolRequestParams::new(strip_unicode_tags(name))
                         .with_arguments(object(parsed_args))),
                 ));
             }
@@ -843,7 +844,7 @@ fn process_streaming_output_items(
 
                             content.push(MessageContentBlock::tool_request(
                                 id,
-                                Ok(CallToolRequestParams::new(name)
+                                Ok(CallToolRequestParams::new(strip_unicode_tags(&name))
                                     .with_arguments(object(parsed_args))),
                             ));
                         }
@@ -864,7 +865,8 @@ fn process_streaming_output_items(
 
                 content.push(MessageContentBlock::tool_request(
                     request_id,
-                    Ok(CallToolRequestParams::new(name).with_arguments(object(parsed_args))),
+                    Ok(CallToolRequestParams::new(strip_unicode_tags(&name))
+                        .with_arguments(object(parsed_args))),
                 ));
             }
         }
@@ -1446,7 +1448,7 @@ mod tests {
                     role: "assistant".to_string(),
                     content: vec![ResponseContentBlock::ToolCall {
                         id: "call_1".to_string(),
-                        name: "shell".to_string(),
+                        name: "sh\u{E0041}ell".to_string(),
                         input: json!({"prompt": "visible e\u{301}\u{E0041}text"}),
                     }],
                 },
@@ -1454,7 +1456,7 @@ mod tests {
                     id: None,
                     status: Some("completed".to_string()),
                     call_id: Some("call_2".to_string()),
-                    name: "shell".to_string(),
+                    name: "sh\u{E0042}ell".to_string(),
                     arguments: serde_json::to_string(
                         &json!({"prompt": "visible e\u{301}\u{E0042}text"}),
                     )
@@ -1471,6 +1473,7 @@ mod tests {
                 panic!("expected tool request content");
             };
             let tool_call = tool_request.tool_call.expect("expected valid tool call");
+            assert_eq!(tool_call.name, "shell");
             assert_eq!(
                 tool_call
                     .arguments
@@ -2367,7 +2370,7 @@ mod tests {
                 role: "assistant".to_string(),
                 content: vec![ContentBlockPart::ToolCall {
                     id: "call_1".to_string(),
-                    name: "shell".to_string(),
+                    name: "sh\u{E0041}ell".to_string(),
                     arguments: serde_json::to_string(
                         &json!({"prompt": "visible e\u{301}\u{E0041}text"}),
                     )?,
@@ -2377,7 +2380,7 @@ mod tests {
                 id: None,
                 status: Some("completed".to_string()),
                 call_id: Some("call_2".to_string()),
-                name: "shell".to_string(),
+                name: "sh\u{E0042}ell".to_string(),
                 arguments: serde_json::to_string(
                     &json!({"prompt": "visible e\u{301}\u{E0042}text"}),
                 )?,
@@ -2390,6 +2393,7 @@ mod tests {
                 panic!("expected tool request content");
             };
             let tool_call = tool_request.tool_call.expect("expected valid tool call");
+            assert_eq!(tool_call.name, "shell");
             assert_eq!(
                 tool_call
                     .arguments

--- a/crates/goose-provider-types/src/formats/openai_responses.rs
+++ b/crates/goose-provider-types/src/formats/openai_responses.rs
@@ -15,6 +15,7 @@ use futures::Stream;
 use rmcp::model::{object, CallToolRequestParams, ContentBlock, Role, Tool};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
+use std::collections::HashSet;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ResponsesApiResponse {
@@ -736,8 +737,19 @@ fn parse_tool_arguments(arguments: &str) -> anyhow::Result<Value> {
     }
 }
 
+fn sanitize_tool_request_id(id: &str, seen_ids: &mut HashSet<String>) -> anyhow::Result<String> {
+    let id = strip_unicode_tags(id);
+    if !seen_ids.insert(id.clone()) {
+        return Err(anyhow!(
+            "Responses tool calls contain duplicate ID after Unicode tag sanitization"
+        ));
+    }
+    Ok(id)
+}
+
 pub fn responses_api_to_message(response: &ResponsesApiResponse) -> anyhow::Result<Message> {
     let mut content = Vec::new();
+    let mut tool_request_ids = HashSet::new();
 
     for item in &response.output {
         match item {
@@ -763,8 +775,9 @@ pub fn responses_api_to_message(response: &ResponsesApiResponse) -> anyhow::Resu
                             }
                         }
                         ResponseContentBlock::ToolCall { id, name, input } => {
+                            let id = sanitize_tool_request_id(id, &mut tool_request_ids)?;
                             content.push(MessageContentBlock::tool_request(
-                                id.clone(),
+                                id,
                                 Ok(CallToolRequestParams::new(strip_unicode_tags(name))
                                     .with_arguments(object(sanitize_tool_arguments(
                                         input.clone(),
@@ -784,6 +797,7 @@ pub fn responses_api_to_message(response: &ResponsesApiResponse) -> anyhow::Resu
                 let request_id = call_id.clone().or_else(|| id.clone()).ok_or_else(|| {
                     anyhow!("Responses function_call output missing call_id and id")
                 })?;
+                let request_id = sanitize_tool_request_id(&request_id, &mut tool_request_ids)?;
                 let parsed_args = parse_tool_arguments(arguments)?;
 
                 content.push(MessageContentBlock::tool_request(
@@ -814,6 +828,7 @@ fn process_streaming_output_items(
     is_text_response: bool,
 ) -> anyhow::Result<Vec<MessageContentBlock>> {
     let mut content = Vec::new();
+    let mut tool_request_ids = HashSet::new();
 
     for item in output_items {
         match item {
@@ -840,6 +855,7 @@ fn process_streaming_output_items(
                             name,
                             arguments,
                         } => {
+                            let id = sanitize_tool_request_id(&id, &mut tool_request_ids)?;
                             let parsed_args = parse_tool_arguments(&arguments)?;
 
                             content.push(MessageContentBlock::tool_request(
@@ -861,6 +877,7 @@ fn process_streaming_output_items(
                 let request_id = call_id.or(id).ok_or_else(|| {
                     anyhow!("Responses function_call output missing call_id and id")
                 })?;
+                let request_id = sanitize_tool_request_id(&request_id, &mut tool_request_ids)?;
                 let parsed_args = parse_tool_arguments(&arguments)?;
 
                 content.push(MessageContentBlock::tool_request(
@@ -1447,7 +1464,7 @@ mod tests {
                     status: Some("completed".to_string()),
                     role: "assistant".to_string(),
                     content: vec![ResponseContentBlock::ToolCall {
-                        id: "call_1".to_string(),
+                        id: "call_\u{E0041}1".to_string(),
                         name: "sh\u{E0041}ell".to_string(),
                         input: json!({"prompt": "visible e\u{301}\u{E0041}text"}),
                     }],
@@ -1455,7 +1472,7 @@ mod tests {
                 ResponseOutputItem::FunctionCall {
                     id: None,
                     status: Some("completed".to_string()),
-                    call_id: Some("call_2".to_string()),
+                    call_id: Some("call_\u{E0042}2".to_string()),
                     name: "sh\u{E0042}ell".to_string(),
                     arguments: serde_json::to_string(
                         &json!({"prompt": "visible e\u{301}\u{E0042}text"}),
@@ -1468,10 +1485,11 @@ mod tests {
         };
 
         let message = responses_api_to_message(&response).unwrap();
-        for content in message.content {
+        for (content, expected_id) in message.content.into_iter().zip(["call_1", "call_2"]) {
             let MessageContentBlock::ToolRequest(tool_request) = content else {
                 panic!("expected tool request content");
             };
+            assert_eq!(tool_request.id, expected_id);
             let tool_call = tool_request.tool_call.expect("expected valid tool call");
             assert_eq!(tool_call.name, "shell");
             assert_eq!(
@@ -1482,6 +1500,46 @@ mod tests {
                 Some(&json!("visible e\u{301}text"))
             );
         }
+    }
+
+    #[test]
+    fn test_responses_api_to_message_rejects_sanitized_tool_request_id_collisions() {
+        let response = ResponsesApiResponse {
+            id: "resp_1".to_string(),
+            object: "response".to_string(),
+            created_at: 0,
+            status: "completed".to_string(),
+            model: "gpt-5.3-codex".to_string(),
+            output: vec![
+                ResponseOutputItem::Message {
+                    id: Some("msg_1".to_string()),
+                    status: Some("completed".to_string()),
+                    role: "assistant".to_string(),
+                    content: vec![ResponseContentBlock::ToolCall {
+                        id: "call_1".to_string(),
+                        name: "shell".to_string(),
+                        input: json!({}),
+                    }],
+                },
+                ResponseOutputItem::FunctionCall {
+                    id: None,
+                    status: Some("completed".to_string()),
+                    call_id: Some("call_\u{E0041}1".to_string()),
+                    name: "shell".to_string(),
+                    arguments: "{}".to_string(),
+                },
+            ],
+            reasoning: None,
+            usage: None,
+        };
+
+        let error = responses_api_to_message(&response).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("duplicate ID after Unicode tag sanitization"),
+            "unexpected error: {error}"
+        );
     }
 
     #[test]
@@ -2369,7 +2427,7 @@ mod tests {
                 status: Some("completed".to_string()),
                 role: "assistant".to_string(),
                 content: vec![ContentBlockPart::ToolCall {
-                    id: "call_1".to_string(),
+                    id: "call_\u{E0041}1".to_string(),
                     name: "sh\u{E0041}ell".to_string(),
                     arguments: serde_json::to_string(
                         &json!({"prompt": "visible e\u{301}\u{E0041}text"}),
@@ -2379,7 +2437,7 @@ mod tests {
             ResponseOutputItemInfo::FunctionCall {
                 id: None,
                 status: Some("completed".to_string()),
-                call_id: Some("call_2".to_string()),
+                call_id: Some("call_\u{E0042}2".to_string()),
                 name: "sh\u{E0042}ell".to_string(),
                 arguments: serde_json::to_string(
                     &json!({"prompt": "visible e\u{301}\u{E0042}text"}),
@@ -2388,10 +2446,11 @@ mod tests {
         ];
 
         let content = process_streaming_output_items(output_items, false)?;
-        for content in content {
+        for (content, expected_id) in content.into_iter().zip(["call_1", "call_2"]) {
             let MessageContentBlock::ToolRequest(tool_request) = content else {
                 panic!("expected tool request content");
             };
+            assert_eq!(tool_request.id, expected_id);
             let tool_call = tool_request.tool_call.expect("expected valid tool call");
             assert_eq!(tool_call.name, "shell");
             assert_eq!(
@@ -2402,6 +2461,40 @@ mod tests {
                 Some(&json!("visible e\u{301}text"))
             );
         }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_streaming_output_items_reject_sanitized_tool_request_id_collisions(
+    ) -> anyhow::Result<()> {
+        let output_items = vec![
+            ResponseOutputItemInfo::Message {
+                id: Some("msg_1".to_string()),
+                status: Some("completed".to_string()),
+                role: "assistant".to_string(),
+                content: vec![ContentBlockPart::ToolCall {
+                    id: "call_1".to_string(),
+                    name: "shell".to_string(),
+                    arguments: "{}".to_string(),
+                }],
+            },
+            ResponseOutputItemInfo::FunctionCall {
+                id: None,
+                status: Some("completed".to_string()),
+                call_id: Some("call_\u{E0041}1".to_string()),
+                name: "shell".to_string(),
+                arguments: "{}".to_string(),
+            },
+        ];
+
+        let error = process_streaming_output_items(output_items, false).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("duplicate ID after Unicode tag sanitization"),
+            "unexpected error: {error}"
+        );
 
         Ok(())
     }

--- a/crates/goose-provider-types/src/formats/openai_responses.rs
+++ b/crates/goose-provider-types/src/formats/openai_responses.rs
@@ -701,14 +701,14 @@ pub fn create_responses_request(
 
 fn sanitize_tool_arguments(value: Value) -> Value {
     match value {
-        Value::String(text) => Value::String(sanitize_unicode_tags(&text)),
+        Value::String(text) => Value::String(strip_unicode_tags(&text)),
         Value::Array(values) => {
             Value::Array(values.into_iter().map(sanitize_tool_arguments).collect())
         }
         Value::Object(values) => Value::Object(
             values
                 .into_iter()
-                .map(|(key, value)| (sanitize_unicode_tags(&key), sanitize_tool_arguments(value)))
+                .map(|(key, value)| (strip_unicode_tags(&key), sanitize_tool_arguments(value)))
                 .collect(),
         ),
         value => value,
@@ -1436,7 +1436,7 @@ mod tests {
                     content: vec![ResponseContentBlock::ToolCall {
                         id: "call_1".to_string(),
                         name: "shell".to_string(),
-                        input: json!({"prompt": "visible\u{E0041}text"}),
+                        input: json!({"prompt": "visible e\u{301}\u{E0041}text"}),
                     }],
                 },
                 ResponseOutputItem::FunctionCall {
@@ -1444,8 +1444,10 @@ mod tests {
                     status: Some("completed".to_string()),
                     call_id: Some("call_2".to_string()),
                     name: "shell".to_string(),
-                    arguments: serde_json::to_string(&json!({"prompt": "visible\u{E0042}text"}))
-                        .unwrap(),
+                    arguments: serde_json::to_string(
+                        &json!({"prompt": "visible e\u{301}\u{E0042}text"}),
+                    )
+                    .unwrap(),
                 },
             ],
             reasoning: None,
@@ -1463,7 +1465,7 @@ mod tests {
                     .arguments
                     .expect("expected arguments")
                     .get("prompt"),
-                Some(&json!("visibletext"))
+                Some(&json!("visible e\u{301}text"))
             );
         }
     }
@@ -2300,7 +2302,9 @@ mod tests {
                 content: vec![ContentBlockPart::ToolCall {
                     id: "call_1".to_string(),
                     name: "shell".to_string(),
-                    arguments: serde_json::to_string(&json!({"prompt": "visible\u{E0041}text"}))?,
+                    arguments: serde_json::to_string(
+                        &json!({"prompt": "visible e\u{301}\u{E0041}text"}),
+                    )?,
                 }],
             },
             ResponseOutputItemInfo::FunctionCall {
@@ -2308,7 +2312,9 @@ mod tests {
                 status: Some("completed".to_string()),
                 call_id: Some("call_2".to_string()),
                 name: "shell".to_string(),
-                arguments: serde_json::to_string(&json!({"prompt": "visible\u{E0042}text"}))?,
+                arguments: serde_json::to_string(
+                    &json!({"prompt": "visible e\u{301}\u{E0042}text"}),
+                )?,
             },
         ];
 
@@ -2323,7 +2329,7 @@ mod tests {
                     .arguments
                     .expect("expected arguments")
                     .get("prompt"),
-                Some(&json!("visibletext"))
+                Some(&json!("visible e\u{301}text"))
             );
         }
 

--- a/crates/goose-provider-types/src/formats/openai_responses.rs
+++ b/crates/goose-provider-types/src/formats/openai_responses.rs
@@ -7,6 +7,7 @@ use crate::formats::openai::{
 };
 use crate::mcp_utils::extract_text_from_resource;
 use crate::model::ModelConfig;
+use crate::utils::sanitize_unicode_tags;
 use anyhow::{anyhow, Error};
 use async_stream::try_stream;
 use chrono;
@@ -713,11 +714,13 @@ pub fn responses_api_to_message(response: &ResponsesApiResponse) -> anyhow::Resu
                 for block in msg_content {
                     match block {
                         ResponseContentBlock::OutputText { text, .. } => {
+                            let text = sanitize_unicode_tags(text);
                             if !text.is_empty() {
                                 content.push(MessageContentBlock::text(text));
                             }
                         }
                         ResponseContentBlock::Refusal { refusal } => {
+                            let refusal = sanitize_unicode_tags(refusal);
                             if !refusal.is_empty() {
                                 content.push(MessageContentBlock::text(refusal));
                             }
@@ -786,13 +789,15 @@ fn process_streaming_output_items(
                 for part in parts {
                     match part {
                         ContentBlockPart::OutputText { text, .. } => {
+                            let text = sanitize_unicode_tags(&text);
                             if !text.is_empty() && !is_text_response {
-                                content.push(MessageContentBlock::text(&text));
+                                content.push(MessageContentBlock::text(text));
                             }
                         }
                         ContentBlockPart::Refusal { refusal } => {
+                            let refusal = sanitize_unicode_tags(&refusal);
                             if !refusal.is_empty() && !is_text_response {
-                                content.push(MessageContentBlock::text(&refusal));
+                                content.push(MessageContentBlock::text(refusal));
                             }
                         }
                         ContentBlockPart::ToolCall {
@@ -901,6 +906,7 @@ where
 
                 ResponsesStreamEvent::OutputTextDelta { delta, .. } => {
                     is_text_response = true;
+                    let delta = sanitize_unicode_tags(&delta);
                     if !delta.is_empty() {
                         accumulated_text.push_str(&delta);
 
@@ -955,6 +961,7 @@ where
 
                 ResponsesStreamEvent::RefusalDelta { delta, .. } => {
                     is_text_response = true;
+                    let delta = sanitize_unicode_tags(&delta);
                     if !delta.is_empty() {
                         accumulated_text.push_str(&delta);
 
@@ -1973,6 +1980,123 @@ mod tests {
         assert_eq!(input[0]["role"], "assistant");
         assert_eq!(input[0]["content"][0]["type"], "output_text");
         assert_eq!(input[0]["content"][0]["text"], "hello");
+    }
+
+    #[test]
+    fn test_responses_api_to_message_sanitizes_unicode_tags() {
+        let response: ResponsesApiResponse = serde_json::from_value(serde_json::json!({
+            "id": "resp_1",
+            "object": "response",
+            "created_at": 0,
+            "status": "completed",
+            "model": "gpt-5.5",
+            "output": [{
+                "type": "message",
+                "id": "msg_1",
+                "status": "completed",
+                "role": "assistant",
+                "content": [
+                    {"type": "output_text", "text": "visible\u{E0041}text"},
+                    {"type": "refusal", "refusal": "cannot\u{E0042}help"}
+                ]
+            }]
+        }))
+        .unwrap();
+
+        let message = responses_api_to_message(&response).unwrap();
+        let text = message
+            .content
+            .iter()
+            .filter_map(MessageContentBlock::as_text)
+            .collect::<Vec<_>>();
+
+        assert_eq!(text, vec!["visibletext", "cannothelp"]);
+    }
+
+    #[test]
+    fn test_streaming_output_items_sanitize_unicode_tags() {
+        let item: ResponseOutputItemInfo = serde_json::from_value(serde_json::json!({
+            "type": "message",
+            "id": "msg_1",
+            "status": "completed",
+            "role": "assistant",
+            "content": [
+                {"type": "output_text", "text": "visible\u{E0041}text"},
+                {"type": "refusal", "refusal": "cannot\u{E0042}help"}
+            ]
+        }))
+        .unwrap();
+
+        let content = process_streaming_output_items(vec![item], false).unwrap();
+        let text = content
+            .iter()
+            .filter_map(MessageContentBlock::as_text)
+            .collect::<Vec<_>>();
+
+        assert_eq!(text, vec!["visibletext", "cannothelp"]);
+    }
+
+    #[tokio::test]
+    async fn test_streaming_deltas_sanitize_unicode_tags() -> anyhow::Result<()> {
+        let lines = vec![
+            format!(
+                "data: {}",
+                serde_json::json!({
+                    "type": "response.created",
+                    "sequence_number": 1,
+                    "response": {
+                        "id": "resp_1",
+                        "object": "response",
+                        "created_at": 0,
+                        "status": "in_progress",
+                        "model": "gpt-5.5",
+                        "output": []
+                    }
+                })
+            ),
+            format!(
+                "data: {}",
+                serde_json::json!({
+                    "type": "response.output_text.delta",
+                    "sequence_number": 2,
+                    "item_id": "msg_1",
+                    "output_index": 0,
+                    "content_index": 0,
+                    "delta": "visible\u{E0041}text"
+                })
+            ),
+            format!(
+                "data: {}",
+                serde_json::json!({
+                    "type": "response.refusal.delta",
+                    "sequence_number": 3,
+                    "item_id": "msg_1",
+                    "output_index": 0,
+                    "content_index": 1,
+                    "delta": "cannot\u{E0042}help"
+                })
+            ),
+            "data: [DONE]".to_string(),
+        ];
+        let response_stream = tokio_stream::iter(lines.into_iter().map(Ok));
+        let messages = responses_api_to_streaming_message(response_stream);
+        futures::pin_mut!(messages);
+
+        let mut text = Vec::new();
+        while let Some(item) = messages.next().await {
+            if let Some(message) = item?.0 {
+                text.extend(
+                    message
+                        .content
+                        .iter()
+                        .filter_map(MessageContentBlock::as_text)
+                        .map(str::to_owned),
+                );
+            }
+        }
+
+        assert_eq!(text, vec!["visibletext", "cannothelp"]);
+        Ok(())
     }
 
     #[test]

--- a/crates/goose-provider-types/src/formats/openai_responses.rs
+++ b/crates/goose-provider-types/src/formats/openai_responses.rs
@@ -699,29 +699,40 @@ pub fn create_responses_request(
     Ok(payload)
 }
 
-fn sanitize_tool_arguments(value: Value) -> Value {
+fn sanitize_tool_arguments(value: Value) -> anyhow::Result<Value> {
     match value {
-        Value::String(text) => Value::String(strip_unicode_tags(&text)),
-        Value::Array(values) => {
-            Value::Array(values.into_iter().map(sanitize_tool_arguments).collect())
-        }
-        Value::Object(values) => Value::Object(
+        Value::String(text) => Ok(Value::String(strip_unicode_tags(&text))),
+        Value::Array(values) => Ok(Value::Array(
             values
                 .into_iter()
-                .map(|(key, value)| (strip_unicode_tags(&key), sanitize_tool_arguments(value)))
-                .collect(),
-        ),
-        value => value,
+                .map(sanitize_tool_arguments)
+                .collect::<anyhow::Result<_>>()?,
+        )),
+        Value::Object(values) => {
+            let mut sanitized = serde_json::Map::new();
+            for (key, value) in values {
+                let key = strip_unicode_tags(&key);
+                if sanitized.contains_key(&key) {
+                    return Err(anyhow!(
+                        "Responses tool arguments contain duplicate key after Unicode tag sanitization"
+                    ));
+                }
+                sanitized.insert(key, sanitize_tool_arguments(value)?);
+            }
+            Ok(Value::Object(sanitized))
+        }
+        value => Ok(value),
     }
 }
 
-fn parse_tool_arguments(arguments: &str) -> Value {
+fn parse_tool_arguments(arguments: &str) -> anyhow::Result<Value> {
     if arguments.is_empty() {
-        json!({})
+        Ok(json!({}))
     } else {
-        serde_json::from_str(arguments)
-            .map(sanitize_tool_arguments)
-            .unwrap_or_else(|_| json!({}))
+        match serde_json::from_str(arguments) {
+            Ok(value) => sanitize_tool_arguments(value),
+            Err(_) => Ok(json!({})),
+        }
     }
 }
 
@@ -755,7 +766,7 @@ pub fn responses_api_to_message(response: &ResponsesApiResponse) -> anyhow::Resu
                             content.push(MessageContentBlock::tool_request(
                                 id.clone(),
                                 Ok(CallToolRequestParams::new(name.clone()).with_arguments(
-                                    object(sanitize_tool_arguments(input.clone())),
+                                    object(sanitize_tool_arguments(input.clone())?),
                                 )),
                             ));
                         }
@@ -772,7 +783,7 @@ pub fn responses_api_to_message(response: &ResponsesApiResponse) -> anyhow::Resu
                 let request_id = call_id.clone().or_else(|| id.clone()).ok_or_else(|| {
                     anyhow!("Responses function_call output missing call_id and id")
                 })?;
-                let parsed_args = parse_tool_arguments(arguments);
+                let parsed_args = parse_tool_arguments(arguments)?;
 
                 content.push(MessageContentBlock::tool_request(
                     request_id,
@@ -828,7 +839,7 @@ fn process_streaming_output_items(
                             name,
                             arguments,
                         } => {
-                            let parsed_args = parse_tool_arguments(&arguments);
+                            let parsed_args = parse_tool_arguments(&arguments)?;
 
                             content.push(MessageContentBlock::tool_request(
                                 id,
@@ -849,7 +860,7 @@ fn process_streaming_output_items(
                 let request_id = call_id.or(id).ok_or_else(|| {
                     anyhow!("Responses function_call output missing call_id and id")
                 })?;
-                let parsed_args = parse_tool_arguments(&arguments);
+                let parsed_args = parse_tool_arguments(&arguments)?;
 
                 content.push(MessageContentBlock::tool_request(
                     request_id,
@@ -1466,6 +1477,61 @@ mod tests {
                     .expect("expected arguments")
                     .get("prompt"),
                 Some(&json!("visible e\u{301}text"))
+            );
+        }
+    }
+
+    #[test]
+    fn test_responses_api_to_message_rejects_sanitized_tool_argument_key_collisions() {
+        let colliding_arguments = json!({
+            "command": "visible",
+            "comm\u{E0041}and": "hidden",
+        });
+        let responses = [
+            ResponsesApiResponse {
+                id: "resp_1".to_string(),
+                object: "response".to_string(),
+                created_at: 0,
+                status: "completed".to_string(),
+                model: "gpt-5.3-codex".to_string(),
+                output: vec![ResponseOutputItem::Message {
+                    id: Some("msg_1".to_string()),
+                    status: Some("completed".to_string()),
+                    role: "assistant".to_string(),
+                    content: vec![ResponseContentBlock::ToolCall {
+                        id: "call_1".to_string(),
+                        name: "shell".to_string(),
+                        input: colliding_arguments.clone(),
+                    }],
+                }],
+                reasoning: None,
+                usage: None,
+            },
+            ResponsesApiResponse {
+                id: "resp_2".to_string(),
+                object: "response".to_string(),
+                created_at: 0,
+                status: "completed".to_string(),
+                model: "gpt-5.3-codex".to_string(),
+                output: vec![ResponseOutputItem::FunctionCall {
+                    id: None,
+                    status: Some("completed".to_string()),
+                    call_id: Some("call_2".to_string()),
+                    name: "shell".to_string(),
+                    arguments: serde_json::to_string(&colliding_arguments).unwrap(),
+                }],
+                reasoning: None,
+                usage: None,
+            },
+        ];
+
+        for response in responses {
+            let error = responses_api_to_message(&response).unwrap_err();
+            assert!(
+                error
+                    .to_string()
+                    .contains("duplicate key after Unicode tag sanitization"),
+                "unexpected error: {error}"
             );
         }
     }
@@ -2330,6 +2396,46 @@ mod tests {
                     .expect("expected arguments")
                     .get("prompt"),
                 Some(&json!("visible e\u{301}text"))
+            );
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_streaming_output_items_reject_sanitized_tool_argument_key_collisions(
+    ) -> anyhow::Result<()> {
+        let colliding_arguments = json!({
+            "command": "visible",
+            "comm\u{E0041}and": "hidden",
+        });
+        let output_items = [
+            ResponseOutputItemInfo::Message {
+                id: Some("msg_1".to_string()),
+                status: Some("completed".to_string()),
+                role: "assistant".to_string(),
+                content: vec![ContentBlockPart::ToolCall {
+                    id: "call_1".to_string(),
+                    name: "shell".to_string(),
+                    arguments: serde_json::to_string(&colliding_arguments)?,
+                }],
+            },
+            ResponseOutputItemInfo::FunctionCall {
+                id: None,
+                status: Some("completed".to_string()),
+                call_id: Some("call_2".to_string()),
+                name: "shell".to_string(),
+                arguments: serde_json::to_string(&colliding_arguments)?,
+            },
+        ];
+
+        for output_item in output_items {
+            let error = process_streaming_output_items(vec![output_item], false).unwrap_err();
+            assert!(
+                error
+                    .to_string()
+                    .contains("duplicate key after Unicode tag sanitization"),
+                "unexpected error: {error}"
             );
         }
 

--- a/crates/goose-provider-types/src/formats/openai_responses.rs
+++ b/crates/goose-provider-types/src/formats/openai_responses.rs
@@ -39,7 +39,7 @@ pub struct SummaryText {
 fn reasoning_from_summary(summary: &[SummaryText]) -> Option<MessageContentBlock> {
     let text: String = summary
         .iter()
-        .map(|s| s.text.as_str())
+        .map(|s| sanitize_unicode_tags(&s.text))
         .collect::<Vec<_>>()
         .join("\n");
     if text.is_empty() {
@@ -1203,8 +1203,8 @@ mod tests {
                     "type": "reasoning",
                     "id": "rs_1",
                     "summary": [
-                        { "type": "summary_text", "text": "Thinking about the question..." },
-                        { "type": "summary_text", "text": "The answer is straightforward." }
+                        { "type": "summary_text", "text": "Thinking\u{E0041} about the question..." },
+                        { "type": "summary_text", "text": "The answer is\u{E0042} straightforward." }
                     ]
                 },
                 {
@@ -1240,7 +1240,7 @@ mod tests {
             "type": "reasoning",
             "id": "rs_1",
             "summary": [
-                { "type": "summary_text", "text": "Let me think step by step." }
+                { "type": "summary_text", "text": "Let me\u{E0041} think step by step." }
             ]
         });
         let message_item = serde_json::json!({

--- a/crates/goose-provider-types/src/utils.rs
+++ b/crates/goose-provider-types/src/utils.rs
@@ -6,9 +6,11 @@ fn is_in_unicode_tag_range(c: char) -> bool {
 
 pub fn sanitize_unicode_tags(text: &str) -> String {
     let normalized: String = text.nfc().collect();
+    strip_unicode_tags(&normalized)
+}
 
-    normalized
-        .chars()
+pub fn strip_unicode_tags(text: &str) -> String {
+    text.chars()
         .filter(|&c| !is_in_unicode_tag_range(c))
         .collect()
 }


### PR DESCRIPTION
## Summary

Sanitize Unicode tag characters as Responses-compatible provider output enters conversation history.

This restores the invariant that model-visible text cannot contain invisible Unicode-tag instructions absent from user-visible rendering. The fix covers non-streaming `output_text` and `refusal` blocks, completed streaming output items, live text/refusal deltas, reasoning summaries stored as thinking blocks, and tool-call IDs, names, and arguments in both streaming and non-streaming response shapes.

Complete narrative strings use the existing NFC-normalizing sanitizer. Live stream deltas strip tag characters without per-delta normalization, so arbitrary SSE boundaries cannot change visible output. Tool IDs, names, and recursively parsed arguments strip tag characters without normalization, covering nested arrays and objects, object keys, and escaped tag code points while preserving legitimate non-tag Unicode exactly. If distinct argument keys or tool request IDs collide after tag stripping, the provider response is rejected instead of silently choosing or misassociating a value.

### Testing

- `cargo fmt --all`
- `cargo test -p goose-provider-types` — 449 passed
- `cargo build -p goose-provider-types -p goose`
- `cargo clippy -p goose-provider-types -p goose --all-targets -- -D warnings`
- `git diff --check`

### Related Issues

Addresses Project Loupe audit finding 612.

### Rollout considerations

The sanitizer is the existing repository-wide Unicode-tag control and leaves legitimate non-tag Unicode unchanged. Streaming output and structured tool calls avoid normalization where transport or downstream consumers may depend on exact code-point sequences. Sanitization-induced key or request-ID ambiguity fails closed.

_This finding was discovered by [Project Loupe](https://github.com/project-loupe/loupe)._
