### PR TITLE
docs: document auto-injected GOOSE_SHELL flags

### DIFF
--- a/crates/goose/src/agents/platform_extensions/developer/shell.rs
+++ b/crates/goose/src/agents/platform_extensions/developer/shell.rs
@@ -84,13 +84,13 @@ fn unix_shell_command_args(command_line: &str) -> [&str; 2] {
     ["-c", command_line]
 }
 
-/// Resolve the preferred Unix shell for command execution, respecting GOOSE_SHELL.
+/// Resolve the shell used to run Developer extension commands on Windows,
+/// respecting `GOOSE_SHELL`.
 ///
-/// Auto-detected shells are returned as basenames (e.g. `"bash"`) so that
-/// `Command::new` resolves them on `PATH` at spawn time — this also keeps
-/// Flatpak happy, where absolute paths from inside the sandbox don't match
-/// the host filesystem. `GOOSE_SHELL` is passed through as-is.
-///
+/// Defaults to `cmd` when `GOOSE_SHELL` is unset. The invocation flags are
+/// chosen automatically from the executable name in `build_shell_command`,
+/// so callers only ever provide a bare executable path or name — see that
+/// function for the flag mapping.
 #[cfg(windows)]
 fn windows_shell() -> String {
     std::env::var("GOOSE_SHELL").unwrap_or_else(|_| "cmd".to_string())
@@ -624,6 +624,18 @@ async fn run_command(
     })
 }
 
+/// Build the `Command` that executes a single command line via the configured shell.
+///
+/// The invocation flags are selected automatically from the shell executable
+/// name, so setting `GOOSE_SHELL` to a bare executable is enough — users never
+/// need to supply command-style flags themselves:
+///
+/// - PowerShell (`pwsh`, `powershell`) → `-NoProfile -NonInteractive -Command`
+/// - cmd (`cmd`) → `/C`
+/// - POSIX shells (bash, zsh, … via Cygwin/MSYS2) → `-c`
+///
+/// On Unix the default shell (`bash`, falling back to `sh`) is likewise invoked
+/// as `<shell> -c <line>`.
 fn build_shell_command(
     command_line: &str,
     working_dir: Option<&std::path::Path>,

--- a/documentation/docs/guides/environment-variables.md
+++ b/documentation/docs/guides/environment-variables.md
@@ -312,6 +312,15 @@ REM Windows: use a POSIX-like shell instead of cmd.exe
 set GOOSE_SHELL=C:\cygwin64\bin\bash.exe
 ```
 
+:::note
+You only ever set `GOOSE_SHELL` to a shell executable path or name. goose injects the command-line flags automatically based on the shell, so there is no need to add them yourself:
+
+- **PowerShell** (`pwsh`, `powershell`) → `-NoProfile -NonInteractive -Command`
+- **cmd** → `/C`
+- **POSIX shells** (bash, zsh, … on Windows via Cygwin/MSYS2) → `-c`
+- On Unix the default shell (`bash`, falling back to `sh`) is invoked as `<shell> -c`
+:::
+
 ## Security and Privacy
 
 These variables control security features, credential storage, and anonymous usage data collection.


### PR DESCRIPTION
## Summary
- A merged PR (#7909) added automatic shell-flag injection in `build_shell_command` based on shell type, but this was undocumented — a reviewer noted they searched the docs expecting to add these flags manually, only to find they're injected automatically (https://github.com/aaif-goose/goose/pull/7909#discussion_r3661787143).
- Fix a misplaced doc comment on `windows_shell()` that incorrectly described *Unix* behavior (Flatpak, basename auto-detection) instead of Windows.
- Add a doc comment to `build_shell_command()` documenting the automatic flag mapping: PowerShell → `-NoProfile -NonInteractive -Command`, cmd → `/C`, POSIX shells → `-c`.
- Add a user-facing `:::note` in the environment-variables guide so the behavior is discoverable where users set `GOOSE_SHELL`.

## Review Notes
- Production-safety review passed (2 rounds).
- Doc comments + markdown only; no executable code changed. `cargo fmt` clean, clippy shows only pre-existing unrelated warnings, 21/21 shell module tests pass.

## Decision Log
**Hardest decision:** Whether to fix the misplaced `windows_shell()` doc comment in the same PR or leave it. It was describing Unix behavior (Flatpak, PATH basename resolution) on a `#[cfg(windows)]` function — clearly a copy-paste from `unix_shell()`. Since the whole point of this PR is accurate `GOOSE_SHELL` docs, leaving a wrong doc comment right next to the new one would undermine it, so I fixed it.

**Alternatives rejected:**
- Documenting the flag mapping only in the user guide (`environment-variables.md`): rejected because `cargo doc` / IDE users reading `build_shell_command` would still hit the same dead end the reviewer did. Added the rustdoc too.
- Replicating the full mapping in every helper (`windows_shell`, `shell_basename`): rejected as duplication; the single `build_shell_command` doc is the canonical source and the others point to it.

**Least confident about:** The wording "POSIX shells (bash, zsh, … via Cygwin/MSYS2) → `-c`". The Windows catch-all `_` arm matches any non-PowerShell/non-cmd shell, so something exotic (fish, csh) on Windows would also get `-c`, which is correct for bash/zsh but not for those. The original code already had this behavior unchanged by this PR; I documented the common cases rather than over-promising on the catch-all.

## Test plan
- [ ] CI passes
- [ ] `cargo doc -p goose --lib` renders the new doc comments without warnings
- [ ] The environment-variables page renders the `:::note` admonition correctly
