### PR TITLE
fix(acp): continue after rejected model option

### DIFF
--- a/crates/goose/src/acp/provider.rs
+++ b/crates/goose/src/acp/provider.rs
@@ -354,22 +354,23 @@ impl AcpProvider {
     /// differs from what was last applied. ACP agents that select their model
     /// via a config option (e.g. Copilot) need this so resumed or switched
     /// sessions actually use the requested model instead of the agent default.
-    async fn apply_model_if_changed(&self, model_name: &str) -> Result<()> {
+    /// Returns the effective model for usage attribution, or `None` when a
+    /// rejected initial selection leaves the active model unknown.
+    async fn apply_model_if_changed(&self, model_name: &str) -> Result<Option<String>> {
         let Some(config_id) = self.model_config_option_id.clone() else {
-            return Ok(());
+            return Ok(Some(model_name.to_string()));
         };
         if model_name == ACP_CURRENT_MODEL {
-            return Ok(());
+            return Ok(Some(model_name.to_string()));
         }
 
-        {
-            let applied = self
-                .applied_model
-                .lock()
-                .map_err(|_| anyhow::anyhow!("applied_model lock poisoned"))?;
-            if applied.as_deref() == Some(model_name) {
-                return Ok(());
-            }
+        let applied_model = self
+            .applied_model
+            .lock()
+            .map_err(|_| anyhow::anyhow!("applied_model lock poisoned"))?
+            .clone();
+        if applied_model.as_deref() == Some(model_name) {
+            return Ok(Some(model_name.to_string()));
         }
 
         match self
@@ -383,7 +384,7 @@ impl AcpProvider {
                     error = %error,
                     "ACP agent rejected model config option; continuing with current model"
                 );
-                return Ok(());
+                return Ok(applied_model);
             }
         }
 
@@ -392,7 +393,7 @@ impl AcpProvider {
             .lock()
             .map_err(|_| anyhow::anyhow!("applied_model lock poisoned"))?;
         *applied = Some(model_name.to_string());
-        Ok(())
+        Ok(Some(model_name.to_string()))
     }
 
     async fn prompt(
@@ -512,11 +513,13 @@ impl Provider for AcpProvider {
     ) -> Result<MessageStream, ProviderError> {
         let session_id = self.acp_session_id();
 
-        self.apply_model_if_changed(&model_config.model_name)
+        let model_name = self
+            .apply_model_if_changed(&model_config.model_name)
             .await
             .map_err(|e| {
                 ProviderError::RequestFailed(format!("Failed to set ACP model option: {e}"))
-            })?;
+            })?
+            .unwrap_or_else(|| "unknown".to_string());
 
         let current_prompt_blocks = messages_to_prompt(messages, false);
         if current_prompt_blocks.is_empty() {
@@ -553,8 +556,6 @@ impl Provider for AcpProvider {
             .map_err(|_| ProviderError::RequestFailed("goose_mode lock poisoned".into()))?;
 
         let reject_all_tools = goose_mode == GooseMode::Chat;
-        let model_name = model_config.model_name.clone();
-
         Ok(Box::pin(try_stream! {
             let mut suppress_text = false;
             let mut rejected_tool_calls: HashSet<String> = HashSet::new();
@@ -2015,11 +2016,13 @@ mod tests {
             _ => panic!("unexpected request kind"),
         }
 
-        handle.await.unwrap().unwrap();
+        assert_eq!(handle.await.unwrap().unwrap().as_deref(), Some("new-model"));
     }
 
     #[tokio::test]
     async fn stream_continues_after_model_config_rejection() {
+        use futures::StreamExt;
+
         let (tx, mut rx) = mpsc::channel(2);
         let (mut provider, model) = test_provider_with_tx(Some(tx));
         provider.model_config_option_id = Some("model".to_string());
@@ -2038,12 +2041,40 @@ mod tests {
             _ => panic!("unexpected request kind"),
         }
 
-        assert!(matches!(
-            rx.recv().await.expect("expected a Prompt request"),
-            ClientRequest::Prompt { .. }
-        ));
-        let _stream = handle.await.unwrap().unwrap();
+        let response_tx = match rx.recv().await.expect("expected a Prompt request") {
+            ClientRequest::Prompt { response_tx, .. } => response_tx,
+            _ => panic!("unexpected request kind"),
+        };
+        let mut stream = handle.await.unwrap().unwrap();
+        response_tx
+            .send(AcpUpdate::Complete(
+                StopReason::EndTurn,
+                Some(AcpUsage::new(3, 2, 1)),
+            ))
+            .await
+            .unwrap();
+
+        let (_, usage) = stream.next().await.unwrap().unwrap();
+        assert_eq!(usage.unwrap().model, "old-model");
         assert_eq!(applied_model.lock().unwrap().as_deref(), Some("old-model"));
+    }
+
+    #[tokio::test]
+    async fn apply_model_if_changed_returns_none_after_initial_rejection() {
+        let (tx, mut rx) = mpsc::channel(1);
+        let provider = test_provider_with_model_option(tx, None);
+
+        let handle =
+            tokio::spawn(async move { provider.apply_model_if_changed("new-model").await });
+
+        match rx.recv().await.expect("expected a SetConfigOption request") {
+            ClientRequest::SetConfigOption { response_tx, .. } => {
+                let _ = response_tx.send(Err(anyhow::anyhow!("unsupported model")));
+            }
+            _ => panic!("unexpected request kind"),
+        }
+
+        assert_eq!(handle.await.unwrap().unwrap(), None);
     }
 
     #[tokio::test]
@@ -2065,7 +2096,14 @@ mod tests {
         let (tx, mut rx) = mpsc::channel(1);
         let provider = test_provider_with_model_option(tx, Some("same-model".to_string()));
 
-        provider.apply_model_if_changed("same-model").await.unwrap();
+        assert_eq!(
+            provider
+                .apply_model_if_changed("same-model")
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("same-model")
+        );
 
         assert!(rx.try_recv().is_err());
     }
@@ -2075,7 +2113,14 @@ mod tests {
         let (tx, mut rx) = mpsc::channel(1);
         let (provider, _) = test_provider_with_tx(Some(tx));
 
-        provider.apply_model_if_changed("any-model").await.unwrap();
+        assert_eq!(
+            provider
+                .apply_model_if_changed("any-model")
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("any-model")
+        );
 
         assert!(rx.try_recv().is_err());
     }
@@ -2085,10 +2130,14 @@ mod tests {
         let (tx, mut rx) = mpsc::channel(1);
         let provider = test_provider_with_model_option(tx, None);
 
-        provider
-            .apply_model_if_changed(ACP_CURRENT_MODEL)
-            .await
-            .unwrap();
+        assert_eq!(
+            provider
+                .apply_model_if_changed(ACP_CURRENT_MODEL)
+                .await
+                .unwrap()
+                .as_deref(),
+            Some(ACP_CURRENT_MODEL)
+        );
 
         assert!(rx.try_recv().is_err());
     }

--- a/crates/goose/src/acp/provider.rs
+++ b/crates/goose/src/acp/provider.rs
@@ -87,6 +87,11 @@ enum ClientRequest {
     },
 }
 
+enum SetConfigOptionOutcome {
+    Applied,
+    Rejected(anyhow::Error),
+}
+
 // tokio I/O handles can't move between runtimes, so the child process must be
 // spawned inside the OS thread. This closure lets start() share all other logic.
 type ClientLoopFn = Box<
@@ -315,6 +320,17 @@ impl AcpProvider {
         config_id: String,
         value: String,
     ) -> Result<()> {
+        match self.request_set_config_option(config_id, value).await? {
+            SetConfigOptionOutcome::Applied => Ok(()),
+            SetConfigOptionOutcome::Rejected(error) => Err(error),
+        }
+    }
+
+    async fn request_set_config_option(
+        &self,
+        config_id: String,
+        value: String,
+    ) -> Result<SetConfigOptionOutcome> {
         let session_id = self.acp_session_id();
         let (response_tx, response_rx) = oneshot::channel();
         self.tx
@@ -328,7 +344,10 @@ impl AcpProvider {
             })
             .await
             .context("ACP client is unavailable")?;
-        response_rx.await.context("ACP request cancelled")?
+        match response_rx.await.context("ACP request cancelled")? {
+            Ok(()) => Ok(SetConfigOptionOutcome::Applied),
+            Err(error) => Ok(SetConfigOptionOutcome::Rejected(error)),
+        }
     }
 
     /// Re-apply the model selection config option when the active session model
@@ -353,8 +372,20 @@ impl AcpProvider {
             }
         }
 
-        self.send_set_config_option("", config_id, model_name.to_string())
-            .await?;
+        match self
+            .request_set_config_option(config_id, model_name.to_string())
+            .await?
+        {
+            SetConfigOptionOutcome::Applied => {}
+            SetConfigOptionOutcome::Rejected(error) => {
+                tracing::warn!(
+                    model = model_name,
+                    error = %error,
+                    "ACP agent rejected model config option; continuing with current model"
+                );
+                return Ok(());
+            }
+        }
 
         let mut applied = self
             .applied_model
@@ -1985,6 +2016,48 @@ mod tests {
         }
 
         handle.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn stream_continues_after_model_config_rejection() {
+        let (tx, mut rx) = mpsc::channel(2);
+        let (mut provider, model) = test_provider_with_tx(Some(tx));
+        provider.model_config_option_id = Some("model".to_string());
+        provider.applied_model = Arc::new(Mutex::new(Some("old-model".to_string())));
+        let applied_model = provider.applied_model.clone();
+        let messages = vec![Message::user().with_text("continue this turn")];
+
+        let handle = tokio::spawn(async move { provider.stream(&model, "", &messages, &[]).await });
+
+        match rx.recv().await.expect("expected a SetConfigOption request") {
+            ClientRequest::SetConfigOption { response_tx, .. } => {
+                let _ = response_tx.send(Err(anyhow::anyhow!(
+                    "Invalid value for config option model: test-model"
+                )));
+            }
+            _ => panic!("unexpected request kind"),
+        }
+
+        assert!(matches!(
+            rx.recv().await.expect("expected a Prompt request"),
+            ClientRequest::Prompt { .. }
+        ));
+        let _stream = handle.await.unwrap().unwrap();
+        assert_eq!(applied_model.lock().unwrap().as_deref(), Some("old-model"));
+    }
+
+    #[tokio::test]
+    async fn apply_model_if_changed_propagates_client_failure() {
+        let (tx, rx) = mpsc::channel(1);
+        drop(rx);
+        let provider = test_provider_with_model_option(tx, None);
+
+        let error = provider
+            .apply_model_if_changed("new-model")
+            .await
+            .unwrap_err();
+
+        assert!(error.to_string().contains("ACP client is unavailable"));
     }
 
     #[tokio::test]

--- a/crates/goose/src/acp/provider.rs
+++ b/crates/goose/src/acp/provider.rs
@@ -78,7 +78,7 @@ enum ClientRequest {
         session_id: SessionId,
         config_id: String,
         value: String,
-        response_tx: oneshot::Sender<Result<()>>,
+        response_tx: oneshot::Sender<Result<SetConfigOptionOutcome>>,
     },
     Prompt {
         session_id: SessionId,
@@ -87,6 +87,7 @@ enum ClientRequest {
     },
 }
 
+#[derive(Debug)]
 enum SetConfigOptionOutcome {
     Applied,
     Rejected(anyhow::Error),
@@ -344,10 +345,7 @@ impl AcpProvider {
             })
             .await
             .context("ACP client is unavailable")?;
-        match response_rx.await.context("ACP request cancelled")? {
-            Ok(()) => Ok(SetConfigOptionOutcome::Applied),
-            Err(error) => Ok(SetConfigOptionOutcome::Rejected(error)),
-        }
+        response_rx.await.context("ACP request cancelled")?
     }
 
     /// Re-apply the model selection config option when the active session model
@@ -1169,14 +1167,12 @@ async fn handle_requests(
             } => {
                 let value_id = agent_client_protocol::schema::v1::SessionConfigValueId::new(value);
                 let req = SetSessionConfigOptionRequest::new(session_id, config_id, value_id);
-                let result: Result<()> = cx
-                    .send_request(req)
-                    .block_task()
-                    .await
-                    .map(|_| ())
-                    .map_err(anyhow::Error::from);
+                let outcome = match cx.send_request(req).block_task().await {
+                    Ok(_) => SetConfigOptionOutcome::Applied,
+                    Err(error) => SetConfigOptionOutcome::Rejected(anyhow::Error::from(error)),
+                };
                 log_undelivered(
-                    response_tx.send(result),
+                    response_tx.send(Ok(outcome)),
                     AGENT_METHOD_NAMES.session_set_config_option,
                 );
             }
@@ -2011,7 +2007,7 @@ mod tests {
             } => {
                 assert_eq!(config_id, "model");
                 assert_eq!(value, "new-model");
-                let _ = response_tx.send(Ok(()));
+                let _ = response_tx.send(Ok(SetConfigOptionOutcome::Applied));
             }
             _ => panic!("unexpected request kind"),
         }
@@ -2034,9 +2030,9 @@ mod tests {
 
         match rx.recv().await.expect("expected a SetConfigOption request") {
             ClientRequest::SetConfigOption { response_tx, .. } => {
-                let _ = response_tx.send(Err(anyhow::anyhow!(
+                let _ = response_tx.send(Ok(SetConfigOptionOutcome::Rejected(anyhow::anyhow!(
                     "Invalid value for config option model: test-model"
-                )));
+                ))));
             }
             _ => panic!("unexpected request kind"),
         }
@@ -2069,7 +2065,9 @@ mod tests {
 
         match rx.recv().await.expect("expected a SetConfigOption request") {
             ClientRequest::SetConfigOption { response_tx, .. } => {
-                let _ = response_tx.send(Err(anyhow::anyhow!("unsupported model")));
+                let _ = response_tx.send(Ok(SetConfigOptionOutcome::Rejected(anyhow::anyhow!(
+                    "unsupported model"
+                ))));
             }
             _ => panic!("unexpected request kind"),
         }
@@ -2089,6 +2087,25 @@ mod tests {
             .unwrap_err();
 
         assert!(error.to_string().contains("ACP client is unavailable"));
+    }
+
+    #[tokio::test]
+    async fn apply_model_if_changed_propagates_cancelled_request() {
+        let (tx, mut rx) = mpsc::channel(1);
+        let provider = test_provider_with_model_option(tx, None);
+
+        let handle =
+            tokio::spawn(async move { provider.apply_model_if_changed("new-model").await });
+
+        match rx.recv().await.expect("expected a SetConfigOption request") {
+            ClientRequest::SetConfigOption { response_tx, .. } => {
+                let _ = response_tx.send(Err(anyhow::anyhow!("reply cancelled")));
+            }
+            _ => panic!("unexpected request kind"),
+        }
+
+        let error = handle.await.unwrap().unwrap_err();
+        assert!(error.to_string().contains("reply cancelled"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

ACP model selection currently flattens a completed `session/set_config_option` rejection together with client-channel failures. `stream` therefore turns an adapter rejecting an unavailable model into a fatal `ProviderError`, aborting an otherwise-valid prompt.

- distinguish a completed ACP rejection from an unavailable or cancelled client request
- warn and continue the prompt when the agent rejects the requested model
- retain the last successfully applied model so a rejected switch is not cached as active
- keep mode-option rejections and ACP client-channel failures fatal

### Testing

- `cargo fmt --all -- --check`
- `cargo test -p goose --lib stream_continues_after_model_config_rejection`
- `cargo test -p goose --lib apply_model_if_changed`
- `cargo check -p goose`
- `cargo clippy -p goose --all-targets -- -D warnings`
- `git diff --check`

### Related Issues

Fixes #10730  
Discussion: https://github.com/aaif-goose/goose/issues/10730#issuecomment-5101964801

### Screenshots/Demos (for UX changes)

Not applicable; this changes ACP error handling and adds regression coverage.
