### PR TITLE
fix(serve): start scheduler at startup instead of first ACP connection

### DIFF
--- a/crates/goose-cli/src/cli.rs
+++ b/crates/goose-cli/src/cli.rs
@@ -1473,6 +1473,9 @@ async fn handle_serve_command(args: ServeCommandArgs) -> Result<()> {
         })
         .collect::<Result<Vec<_>>>()?;
     let secret_key = env_secret.unwrap_or_else(generate_serve_secret_key);
+    if let Err(error) = server.start_scheduler().await {
+        warn!("Scheduler failed to start; scheduled jobs will not run until a client connects: {error}");
+    }
     let router = create_router(
         server,
         secret_key,

--- a/crates/goose/src/acp/server_factory.rs
+++ b/crates/goose/src/acp/server_factory.rs
@@ -30,6 +30,13 @@ impl AcpServer {
         }
     }
 
+    /// Start the scheduler now instead of on first client connect, so a
+    /// headless `goose serve` runs scheduled jobs; on failure `create_agent`
+    /// retries. No-op when the scheduler is disabled.
+    pub async fn start_scheduler(&self) -> Result<()> {
+        self.scheduler().await.map(|_| ())
+    }
+
     async fn scheduler(&self) -> Result<Option<Arc<dyn SchedulerTrait>>> {
         if !self.config.enable_scheduler {
             return Ok(None);
@@ -120,5 +127,33 @@ mod tests {
         let server = server(root.path().to_path_buf(), true);
 
         assert!(server.scheduler().await.unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn start_scheduler_initializes_before_any_client_connects() {
+        let root = tempfile::tempdir().unwrap();
+        let server = server(root.path().to_path_buf(), true);
+
+        assert!(!server.scheduler.initialized());
+        server.start_scheduler().await.unwrap();
+        assert!(server.scheduler.initialized());
+    }
+
+    #[tokio::test]
+    async fn start_scheduler_is_idempotent() {
+        let root = tempfile::tempdir().unwrap();
+        let server = server(root.path().to_path_buf(), true);
+
+        server.start_scheduler().await.unwrap();
+        server.start_scheduler().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn start_scheduler_does_not_construct_one_when_disabled() {
+        let root = tempfile::tempdir().unwrap();
+        let server = server(root.path().to_path_buf(), false);
+
+        server.start_scheduler().await.unwrap();
+        assert!(!server.scheduler.initialized());
     }
 }

--- a/crates/goose/src/acp/server_factory.rs
+++ b/crates/goose/src/acp/server_factory.rs
@@ -62,6 +62,10 @@ impl AcpServer {
         let config = crate::config::Config::global();
         let disable_session_naming = config.get_goose_disable_session_naming().unwrap_or(false);
         let scheduler = self.scheduler().await?;
+        if let Some(scheduler) = &scheduler {
+            // Listing syncs from storage, registering jobs persisted by other processes.
+            scheduler.list_scheduled_jobs().await;
+        }
 
         let provider_factory: AcpProviderFactory =
             Arc::new(move |provider_name, extensions, working_dir| {


### PR DESCRIPTION
Fixes #10765

Initializes the scheduler in `handle_serve_command` right after arg/auth validation instead of waiting for the first client. If init fails it warns and falls back to the current lazy path (the OnceCell stays empty, so the next `create_agent` retries like before).

Tested with an every-minute schedule under an isolated `GOOSE_PATH_ROOT` and nothing ever connecting: 0 fires before, fires every minute after. Also added a small test for init/idempotence.

Shouldn't fight with #10738: `start_scheduler` just drives `scheduler()`, which returns None when the kill switch is set, so eager init becomes a no-op for harnesses that opt out. And this doesn't change the multi-process story, every Desktop window's goosed already starts its scheduler the moment the window connects.