### PR TITLE
fix(acp): make /clear reach the agent and reject /compact it can't do

### DIFF
--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -1043,8 +1043,11 @@ impl CliSession {
 
     async fn handle_clear(&mut self) -> Result<()> {
         let provider = self.agent.provider().await?;
-        let provider_reset = provider.reset_context().await;
 
+        // Clear locally before asking the provider to reset: a provider-side
+        // reset cannot be undone, so a failed local clear must leave both
+        // histories in place rather than handing the old transcript to a
+        // freshly reset agent-side session on the next prompt.
         if let Err(e) = self
             .agent
             .config
@@ -1055,9 +1058,9 @@ impl CliSession {
             output::render_error(&format!("Failed to clear session: {}", e));
             return Ok(());
         }
+        self.messages.clear();
 
-        if let Err(e) = provider_reset {
-            self.messages.clear();
+        if let Err(e) = provider.reset_context().await {
             tracing::warn!(provider = provider.get_name(), error = %e, "provider-side context reset failed");
             output::render_error(&stale_provider_context_message(
                 provider.get_name(),
@@ -1083,7 +1086,6 @@ impl CliSession {
             return Ok(());
         }
 
-        self.messages.clear();
         tracing::info!("Chat context cleared by user.");
         output::render_message(
             &Message::assistant().with_text("Chat context cleared.\n"),

--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -39,7 +39,10 @@ use anyhow::{Context, Result};
 use completion::GooseCompleter;
 use goose::agents::extension::{Envs, ExtensionConfig, PLATFORM_EXTENSIONS};
 use goose::agents::types::RetryConfig;
-use goose::agents::{Agent, SessionConfig, COMPACT_TRIGGERS};
+use goose::agents::{
+    compaction_unsupported_message, stale_provider_context_message, Agent, SessionConfig,
+    COMPACT_TRIGGERS,
+};
 use goose::config::extensions::name_to_key;
 use goose::config::{Config, GooseMode};
 use input::InputResult;
@@ -1039,6 +1042,9 @@ impl CliSession {
     }
 
     async fn handle_clear(&mut self) -> Result<()> {
+        let provider = self.agent.provider().await?;
+        let provider_reset = provider.reset_context().await;
+
         if let Err(e) = self
             .agent
             .config
@@ -1047,6 +1053,16 @@ impl CliSession {
             .await
         {
             output::render_error(&format!("Failed to clear session: {}", e));
+            return Ok(());
+        }
+
+        if let Err(e) = provider_reset {
+            self.messages.clear();
+            tracing::warn!(provider = provider.get_name(), error = %e, "provider-side context reset failed");
+            output::render_error(&stale_provider_context_message(
+                provider.get_name(),
+                &e.to_string(),
+            ));
             return Ok(());
         }
 
@@ -1169,6 +1185,12 @@ impl CliSession {
     }
 
     async fn handle_compact(&mut self) -> Result<()> {
+        let provider = self.agent.provider().await?;
+        if provider.manages_own_context() {
+            output::render_error(&compaction_unsupported_message(provider.get_name()));
+            return Ok(());
+        }
+
         let prompt = "Are you sure you want to compact this conversation? This will condense the message history.";
         let should_summarize = match cliclack::confirm(prompt).initial_value(true).interact() {
             Ok(choice) => choice,

--- a/crates/goose-provider-types/src/base.rs
+++ b/crates/goose-provider-types/src/base.rs
@@ -554,6 +554,24 @@ pub trait Provider: Send + Sync {
         false
     }
 
+    /// Discard the provider-side conversation context, so that a `/clear` the
+    /// user sees is also a clear the model sees.
+    ///
+    /// The default is derived from [`Self::manages_own_context`] rather than
+    /// being unconditionally `Ok`: a provider holding the authoritative history
+    /// has to opt in to claiming it can drop it. Otherwise a new context-owning
+    /// provider would inherit a silent success and `/clear` would go back to
+    /// emptying goose's copy while the model kept everything.
+    async fn reset_context(&self) -> Result<(), ProviderError> {
+        if self.manages_own_context() {
+            return Err(ProviderError::NotImplemented(format!(
+                "'{}' has no way to discard the conversation it is holding",
+                self.get_name()
+            )));
+        }
+        Ok(())
+    }
+
     /// Configure OAuth authentication for this provider
     ///
     /// This method is called when a provider has configuration keys marked with oauth_flow = true.

--- a/crates/goose/src/acp/provider.rs
+++ b/crates/goose/src/acp/provider.rs
@@ -390,6 +390,32 @@ impl AcpProvider {
             .is_some_and(|opts| opts.iter().any(|o| o.category.as_ref() == Some(&category)))
     }
 
+    /// `session/new` carries the current mode over only for agents that expose
+    /// `session.modes`. Agents that expose mode as a config option need it
+    /// re-sent, or a session opened by `reset_context` quietly reverts to the
+    /// agent default while goose still reports the previously selected mode.
+    async fn reapply_mode_config_option(&self) {
+        if !self.session_has_config_option(SessionConfigOptionCategory::Mode) {
+            return;
+        }
+        let Some(mode) = self.goose_mode.lock().ok().map(|mode| *mode) else {
+            return;
+        };
+        let Some(candidates) = self.mode_mapping.get(&mode) else {
+            return;
+        };
+        let Some(mode_id) = select_mode_id(candidates, self.session().response.modes.as_ref())
+        else {
+            return;
+        };
+        if let Err(e) = self
+            .send_set_config_option("", "mode".into(), mode_id)
+            .await
+        {
+            tracing::warn!(error = %e, "failed to reapply mode to the reset ACP session");
+        }
+    }
+
     fn claim_handoff_context(&self, messages: &[Message]) -> HandoffContextClaim {
         let first_prompt = !self.handoff_context_sent.swap(true, Ordering::AcqRel);
         HandoffContextClaim {
@@ -702,6 +728,7 @@ impl Provider for AcpProvider {
             .applied_model
             .lock()
             .expect("applied_model lock poisoned") = None;
+        self.reapply_mode_config_option().await;
 
         Ok(())
     }
@@ -721,6 +748,15 @@ async fn open_session(tx: &mpsc::Sender<ClientRequest>) -> Result<AcpSession> {
         id: response.session_id.clone(),
         response,
     })
+}
+
+/// Updates arriving before any session exists cannot be attributed, so they are
+/// accepted; once a session is known, only that session's updates are.
+fn is_active_session(active: &Arc<Mutex<Option<SessionId>>>, incoming: &SessionId) -> bool {
+    match active.lock() {
+        Ok(guard) => guard.as_ref().is_none_or(|active| active == incoming),
+        Err(_) => true,
+    }
 }
 
 /// Best-effort release of a session goose no longer prompts against. Failures
@@ -748,6 +784,10 @@ struct AcpClientLoop {
     prompt_response_tx: Arc<Mutex<Option<mpsc::Sender<AcpUpdate>>>>,
     pending_tool_updates: Arc<Mutex<HashMap<String, AccumulatedToolCall>>>,
     context_size: Arc<AtomicU64>,
+    /// Session the notification handler will accept updates for. `reset_context`
+    /// leaves a superseded session that may still emit trailing usage and mode
+    /// updates; without this those would overwrite the fresh session's state.
+    active_session: Arc<Mutex<Option<SessionId>>>,
 }
 
 impl AcpClientLoop {
@@ -763,6 +803,7 @@ impl AcpClientLoop {
             prompt_response_tx: Arc::new(Mutex::new(None)),
             pending_tool_updates,
             context_size,
+            active_session: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -817,6 +858,7 @@ impl AcpClientLoop {
             prompt_response_tx,
             pending_tool_updates,
             context_size,
+            active_session,
         } = self;
         let notification_callback = config.notification_callback.clone();
         let reverse_modes = reverse_mode_mapping(&config.mode_mapping);
@@ -830,7 +872,15 @@ impl AcpClientLoop {
                     let goose_mode = goose_mode.clone();
                     let pending_tool_updates = pending_tool_updates.clone();
                     let context_size = context_size.clone();
+                    let active_session = active_session.clone();
                     async move |notification: SessionNotification, _cx| {
+                        if !is_active_session(&active_session, &notification.session_id) {
+                            tracing::debug!(
+                                session_id = %notification.session_id,
+                                "ignoring update for superseded ACP session"
+                            );
+                            return Ok(());
+                        }
                         if let Some(ref cb) = notification_callback {
                             cb(notification.clone());
                         }
@@ -1024,7 +1074,16 @@ impl AcpClientLoop {
                 agent_client_protocol::on_receive_request!(),
             )
             .connect_with(transport, async move |cx: ConnectionTo<Agent>| {
-                handle_requests(config, goose_mode, cx, rx, prompt_response_tx, init_tx).await
+                handle_requests(
+                    config,
+                    goose_mode,
+                    cx,
+                    rx,
+                    prompt_response_tx,
+                    active_session,
+                    init_tx,
+                )
+                .await
             })
             .await?;
 
@@ -1108,6 +1167,7 @@ async fn handle_requests(
     cx: ConnectionTo<Agent>,
     rx: &mut mpsc::Receiver<ClientRequest>,
     prompt_response_tx: Arc<Mutex<Option<mpsc::Sender<AcpUpdate>>>>,
+    active_session: Arc<Mutex<Option<SessionId>>>,
     init_tx: oneshot::Sender<Result<InitializeResponse>>,
 ) -> Result<(), agent_client_protocol::Error> {
     let mut init_tx = Some(init_tx);
@@ -1153,6 +1213,9 @@ async fn handle_requests(
                 let result = match session {
                     Ok(session) => {
                         session_ids.push(session.session_id.clone());
+                        if let Ok(mut guard) = active_session.lock() {
+                            *guard = Some(session.session_id.clone());
+                        }
                         apply_session_config_options(&config, &cx, session.session_id.clone())
                             .await?;
                         apply_session_mode(&config, &goose_mode, &cx, session).await
@@ -2370,6 +2433,74 @@ mod tests {
         assert!(!provider.handoff_context_sent.load(Ordering::Acquire));
         assert_eq!(provider.context_size.load(Ordering::Relaxed), 0);
         assert!(provider.applied_model.lock().unwrap().is_none());
+        assert!(
+            rx.try_recv().is_err(),
+            "an agent without a mode config option must not be sent one"
+        );
+    }
+
+    #[tokio::test]
+    async fn reset_context_reapplies_mode_to_a_config_option_agent() {
+        let (tx, mut rx) = mpsc::channel(4);
+        let (mut provider, _) = test_provider_with_tx(Some(tx));
+        provider.mode_mapping = HashMap::from([(GooseMode::Auto, vec!["full-access".to_string()])]);
+
+        let handle = tokio::spawn(async move {
+            provider.reset_context().await.unwrap();
+            provider
+        });
+
+        match rx.recv().await.expect("expected a NewSession request") {
+            ClientRequest::NewSession { response_tx } => {
+                let _ = response_tx.send(Ok(NewSessionResponse::new("fresh-session")
+                    .config_options(vec![SessionConfigOption::select(
+                        "mode",
+                        "Mode",
+                        "read-only",
+                        vec![
+                            SessionConfigSelectOption::new("read-only", "Read only"),
+                            SessionConfigSelectOption::new("full-access", "Full access"),
+                        ],
+                    )
+                    .category(SessionConfigOptionCategory::Mode)])));
+            }
+            _ => panic!("unexpected request kind"),
+        }
+        match rx.recv().await.expect("expected a CloseSession request") {
+            ClientRequest::CloseSession { session_id } => {
+                assert_eq!(session_id, SessionId::new("test-session"));
+            }
+            _ => panic!("unexpected request kind"),
+        }
+        match rx.recv().await.expect("expected a SetConfigOption request") {
+            ClientRequest::SetConfigOption {
+                session_id,
+                config_id,
+                value,
+                response_tx,
+            } => {
+                assert_eq!(session_id, SessionId::new("fresh-session"));
+                assert_eq!(config_id, "mode");
+                assert_eq!(value, "full-access");
+                let _ = response_tx.send(Ok(()));
+            }
+            _ => panic!("unexpected request kind"),
+        }
+
+        handle.await.unwrap();
+    }
+
+    #[test]
+    fn updates_for_a_superseded_session_are_ignored() {
+        let active = Arc::new(Mutex::new(None));
+        assert!(
+            is_active_session(&active, &SessionId::new("anything")),
+            "updates arriving before a session exists cannot be attributed"
+        );
+
+        *active.lock().unwrap() = Some(SessionId::new("fresh-session"));
+        assert!(is_active_session(&active, &SessionId::new("fresh-session")));
+        assert!(!is_active_session(&active, &SessionId::new("old-session")));
     }
 
     #[tokio::test]

--- a/crates/goose/src/acp/provider.rs
+++ b/crates/goose/src/acp/provider.rs
@@ -1213,9 +1213,14 @@ async fn handle_requests(
                 let result = match session {
                     Ok(session) => {
                         session_ids.push(session.session_id.clone());
-                        apply_session_config_options(&config, &cx, session.session_id.clone())
-                            .await?;
-                        apply_session_mode(&config, &goose_mode, &cx, session).await
+                        // A `?` here would tear down the whole client loop instead of
+                        // reporting the failure to the caller through response_tx.
+                        match apply_session_config_options(&config, &cx, session.session_id.clone())
+                            .await
+                        {
+                            Ok(()) => apply_session_mode(&config, &goose_mode, &cx, session).await,
+                            Err(err) => Err(err),
+                        }
                     }
                     Err(err) => Err(anyhow::anyhow!(
                         "ACP {} failed: {err}",

--- a/crates/goose/src/acp/provider.rs
+++ b/crates/goose/src/acp/provider.rs
@@ -69,6 +69,9 @@ enum ClientRequest {
     NewSession {
         response_tx: oneshot::Sender<Result<NewSessionResponse>>,
     },
+    CloseSession {
+        session_id: SessionId,
+    },
     SetMode {
         session_id: SessionId,
         mode_id: String,
@@ -147,7 +150,9 @@ pub struct AcpProvider {
     goose_mode: Arc<Mutex<GooseMode>>,
     mode_mapping: HashMap<GooseMode, Vec<String>>,
 
-    session: AcpSession,
+    /// Replaced wholesale by `reset_context()`, which starts a fresh agent-side
+    /// session so `/clear` discards the history the agent is holding.
+    session: Arc<Mutex<AcpSession>>,
 
     pending_confirmations:
         Arc<TokioMutex<HashMap<String, oneshot::Sender<PermissionConfirmation>>>>,
@@ -258,26 +263,13 @@ impl AcpProvider {
             .context("ACP client initialization cancelled")??;
 
         // Create the ACP session eagerly during connect.
-        let (session_tx, session_rx) = oneshot::channel();
-        tx.send(ClientRequest::NewSession {
-            response_tx: session_tx,
-        })
-        .await
-        .context("ACP client is unavailable")?;
-        let response = session_rx
-            .await
-            .context("ACP session creation cancelled")??;
-
-        let session = AcpSession {
-            id: response.session_id.clone(),
-            response,
-        };
+        let session = open_session(&tx).await?;
 
         Ok(Self {
             name,
             goose_mode: goose_mode_shared,
             mode_mapping,
-            session,
+            session: Arc::new(Mutex::new(session)),
             pending_confirmations: Arc::new(TokioMutex::new(HashMap::new())),
             pending_tool_updates,
             handoff_context_sent: AtomicBool::new(false),
@@ -290,7 +282,14 @@ impl AcpProvider {
     }
 
     fn acp_session_id(&self) -> SessionId {
-        self.session.id.clone()
+        self.session().id
+    }
+
+    fn session(&self) -> AcpSession {
+        self.session
+            .lock()
+            .expect("ACP session lock poisoned")
+            .clone()
     }
 
     pub(crate) async fn send_set_mode(&self, _goose_id: &str, mode_id: String) -> Result<()> {
@@ -384,7 +383,7 @@ impl AcpProvider {
     }
 
     fn session_has_config_option(&self, category: SessionConfigOptionCategory) -> bool {
-        self.session
+        self.session()
             .response
             .config_options
             .as_ref()
@@ -423,7 +422,7 @@ impl Provider for AcpProvider {
 
     async fn update_mode(&self, session_id: &str, mode: GooseMode) -> Result<(), ProviderError> {
         if let Some(candidates) = self.mode_mapping.get(&mode) {
-            let mode_str = select_mode_id(candidates, self.session.response.modes.as_ref())
+            let mode_str = select_mode_id(candidates, self.session().response.modes.as_ref())
                 .ok_or_else(|| {
                     ProviderError::RequestFailed(format!(
                         "None of the mode ids [{}] are offered by the agent",
@@ -676,8 +675,59 @@ impl Provider for AcpProvider {
     }
 
     async fn fetch_supported_models(&self) -> Result<Vec<String>, ProviderError> {
-        let (_, available) = resolve_model_info(&self.name, &self.session.response)?;
+        let (_, available) = resolve_model_info(&self.name, &self.session().response)?;
         Ok(available)
+    }
+
+    async fn reset_context(&self) -> Result<(), ProviderError> {
+        let tx = self.tx.as_ref().ok_or_else(|| {
+            ProviderError::ExecutionError("ACP client is unavailable".to_string())
+        })?;
+
+        let session = open_session(tx).await.map_err(|e| {
+            ProviderError::ExecutionError(format!(
+                "ACP {} failed: {e}",
+                AGENT_METHOD_NAMES.session_new
+            ))
+        })?;
+
+        let previous = std::mem::replace(
+            &mut *self.session.lock().expect("ACP session lock poisoned"),
+            session,
+        );
+        close_session(tx, previous.id).await;
+        self.handoff_context_sent.store(false, Ordering::Release);
+        self.context_size.store(0, Ordering::Relaxed);
+        *self
+            .applied_model
+            .lock()
+            .expect("applied_model lock poisoned") = None;
+
+        Ok(())
+    }
+}
+
+/// Ask the client loop for a fresh agent-side session.
+async fn open_session(tx: &mpsc::Sender<ClientRequest>) -> Result<AcpSession> {
+    let (response_tx, response_rx) = oneshot::channel();
+    tx.send(ClientRequest::NewSession { response_tx })
+        .await
+        .context("ACP client is unavailable")?;
+    let response = response_rx
+        .await
+        .context("ACP session creation cancelled")??;
+
+    Ok(AcpSession {
+        id: response.session_id.clone(),
+        response,
+    })
+}
+
+/// Best-effort release of a session goose no longer prompts against. Failures
+/// only leak an idle agent-side session, which shutdown cleans up anyway.
+async fn close_session(tx: &mpsc::Sender<ClientRequest>, session_id: SessionId) {
+    if let Err(e) = tx.send(ClientRequest::CloseSession { session_id }).await {
+        tracing::debug!(method = AGENT_METHOD_NAMES.session_close, error = %e, "failed to queue close");
     }
 }
 
@@ -1113,6 +1163,18 @@ async fn handle_requests(
                     )),
                 };
                 log_undelivered(response_tx.send(result), AGENT_METHOD_NAMES.session_new);
+            }
+            ClientRequest::CloseSession { session_id } => {
+                session_ids.retain(|id| id != &session_id);
+                if supports_close {
+                    if let Err(e) = cx
+                        .send_request(CloseSessionRequest::new(session_id.clone()))
+                        .block_task()
+                        .await
+                    {
+                        tracing::debug!(method = AGENT_METHOD_NAMES.session_close, session_id = %session_id, error = %e, "failed to close superseded session");
+                    }
+                }
             }
             ClientRequest::SetMode {
                 session_id,
@@ -1694,10 +1756,10 @@ mod tests {
                 name: "acp-test".to_string(),
                 goose_mode: Arc::new(Mutex::new(GooseMode::Auto)),
                 mode_mapping: HashMap::new(),
-                session: AcpSession {
+                session: Arc::new(Mutex::new(AcpSession {
                     id: SessionId::new("test-session"),
                     response: NewSessionResponse::new("test-session"),
-                },
+                })),
                 pending_confirmations: Arc::new(TokioMutex::new(HashMap::new())),
                 pending_tool_updates: Arc::new(Mutex::new(HashMap::new())),
                 handoff_context_sent: AtomicBool::new(false),
@@ -2234,10 +2296,9 @@ mod tests {
             GooseMode::Auto,
             vec!["full-access".to_string(), "agent-full-access".to_string()],
         )]);
-        provider.session.response = NewSessionResponse::new("test-session").modes(mode_state(
-            "read-only",
-            &["read-only", "agent", "agent-full-access"],
-        ));
+        provider.session.lock().unwrap().response = NewSessionResponse::new("test-session").modes(
+            mode_state("read-only", &["read-only", "agent", "agent-full-access"]),
+        );
 
         let handle = tokio::spawn(async move {
             provider
@@ -2268,7 +2329,7 @@ mod tests {
         let (tx, mut rx) = mpsc::channel(1);
         let (mut provider, _) = test_provider_with_tx(Some(tx));
         provider.mode_mapping = HashMap::from([(GooseMode::Chat, vec!["read-only".to_string()])]);
-        provider.session.response = NewSessionResponse::new("test-session")
+        provider.session.lock().unwrap().response = NewSessionResponse::new("test-session")
             .modes(mode_state("agent", &["agent", "agent-full-access"]));
 
         let result = provider.update_mode("session", GooseMode::Chat).await;
@@ -2276,6 +2337,62 @@ mod tests {
         assert!(result.is_err());
         assert!(rx.try_recv().is_err());
         assert_eq!(*provider.goose_mode.lock().unwrap(), GooseMode::Auto);
+    }
+
+    #[tokio::test]
+    async fn reset_context_opens_a_fresh_session_and_closes_the_old_one() {
+        let (tx, mut rx) = mpsc::channel(4);
+        let (provider, _) = test_provider_with_tx(Some(tx));
+        provider.handoff_context_sent.store(true, Ordering::Release);
+        provider.context_size.store(120_000, Ordering::Relaxed);
+        *provider.applied_model.lock().unwrap() = Some("stale-model".to_string());
+
+        let handle = tokio::spawn(async move {
+            provider.reset_context().await.unwrap();
+            provider
+        });
+
+        match rx.recv().await.expect("expected a NewSession request") {
+            ClientRequest::NewSession { response_tx } => {
+                let _ = response_tx.send(Ok(NewSessionResponse::new("fresh-session")));
+            }
+            _ => panic!("unexpected request kind"),
+        }
+        match rx.recv().await.expect("expected a CloseSession request") {
+            ClientRequest::CloseSession { session_id } => {
+                assert_eq!(session_id, SessionId::new("test-session"));
+            }
+            _ => panic!("unexpected request kind"),
+        }
+
+        let provider = handle.await.unwrap();
+        assert_eq!(provider.acp_session_id(), SessionId::new("fresh-session"));
+        assert!(!provider.handoff_context_sent.load(Ordering::Acquire));
+        assert_eq!(provider.context_size.load(Ordering::Relaxed), 0);
+        assert!(provider.applied_model.lock().unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn reset_context_leaves_the_session_in_place_when_the_agent_refuses() {
+        let (tx, mut rx) = mpsc::channel(4);
+        let (provider, _) = test_provider_with_tx(Some(tx));
+
+        let handle = tokio::spawn(async move {
+            let result = provider.reset_context().await;
+            (provider, result)
+        });
+
+        match rx.recv().await.expect("expected a NewSession request") {
+            ClientRequest::NewSession { response_tx } => {
+                let _ = response_tx.send(Err(anyhow::anyhow!("agent said no")));
+            }
+            _ => panic!("unexpected request kind"),
+        }
+
+        let (provider, result) = handle.await.unwrap();
+        assert!(result.is_err());
+        assert_eq!(provider.acp_session_id(), SessionId::new("test-session"));
+        assert!(rx.try_recv().is_err(), "the old session must not be closed");
     }
 
     #[test]

--- a/crates/goose/src/acp/provider.rs
+++ b/crates/goose/src/acp/provider.rs
@@ -1213,9 +1213,6 @@ async fn handle_requests(
                 let result = match session {
                     Ok(session) => {
                         session_ids.push(session.session_id.clone());
-                        if let Ok(mut guard) = active_session.lock() {
-                            *guard = Some(session.session_id.clone());
-                        }
                         apply_session_config_options(&config, &cx, session.session_id.clone())
                             .await?;
                         apply_session_mode(&config, &goose_mode, &cx, session).await
@@ -1225,6 +1222,13 @@ async fn handle_requests(
                         AGENT_METHOD_NAMES.session_new
                     )),
                 };
+                // A session that failed setup is never returned to the caller, so it
+                // never becomes the session goose prompts against.
+                if let Ok(session) = result.as_ref() {
+                    if let Ok(mut guard) = active_session.lock() {
+                        *guard = Some(session.session_id.clone());
+                    }
+                }
                 log_undelivered(response_tx.send(result), AGENT_METHOD_NAMES.session_new);
             }
             ClientRequest::CloseSession { session_id } => {

--- a/crates/goose/src/acp/provider.rs
+++ b/crates/goose/src/acp/provider.rs
@@ -390,32 +390,6 @@ impl AcpProvider {
             .is_some_and(|opts| opts.iter().any(|o| o.category.as_ref() == Some(&category)))
     }
 
-    /// `session/new` carries the current mode over only for agents that expose
-    /// `session.modes`. Agents that expose mode as a config option need it
-    /// re-sent, or a session opened by `reset_context` quietly reverts to the
-    /// agent default while goose still reports the previously selected mode.
-    async fn reapply_mode_config_option(&self) {
-        if !self.session_has_config_option(SessionConfigOptionCategory::Mode) {
-            return;
-        }
-        let Some(mode) = self.goose_mode.lock().ok().map(|mode| *mode) else {
-            return;
-        };
-        let Some(candidates) = self.mode_mapping.get(&mode) else {
-            return;
-        };
-        let Some(mode_id) = select_mode_id(candidates, self.session().response.modes.as_ref())
-        else {
-            return;
-        };
-        if let Err(e) = self
-            .send_set_config_option("", "mode".into(), mode_id)
-            .await
-        {
-            tracing::warn!(error = %e, "failed to reapply mode to the reset ACP session");
-        }
-    }
-
     fn claim_handoff_context(&self, messages: &[Message]) -> HandoffContextClaim {
         let first_prompt = !self.handoff_context_sent.swap(true, Ordering::AcqRel);
         HandoffContextClaim {
@@ -728,7 +702,6 @@ impl Provider for AcpProvider {
             .applied_model
             .lock()
             .expect("applied_model lock poisoned") = None;
-        self.reapply_mode_config_option().await;
 
         Ok(())
     }
@@ -1364,39 +1337,99 @@ async fn apply_session_mode(
     let current_mode = goose_mode.lock().ok().map(|mode| *mode);
     let candidates = initial_mode_candidates(config, current_mode);
 
-    if let Some(modes) = session.modes.as_ref() {
-        if !candidates.is_empty() {
-            let Some(mode_id) = select_mode_id(&candidates, Some(modes)) else {
-                let available: Vec<String> = modes
-                    .available_modes
-                    .iter()
-                    .map(|mode| mode.id.0.to_string())
-                    .collect();
-                return Err(anyhow::anyhow!(
-                    "Requested mode(s) [{}] not offered by agent. Available modes: {}",
-                    candidates.join(", "),
-                    available.join(", ")
-                ));
-            };
-            if modes.current_mode_id.0.as_ref() != mode_id.as_str() {
-                let _: SetSessionModeResponse = cx
-                    .send_request(SetSessionModeRequest::new(
-                        session.session_id.clone(),
-                        mode_id,
-                    ))
-                    .block_task()
-                    .await
-                    .map_err(|err| {
-                        anyhow::anyhow!(
-                            "ACP agent rejected {}: {err}",
-                            AGENT_METHOD_NAMES.session_set_mode
-                        )
-                    })?;
-            }
+    match initial_session_mode(&session, &candidates)? {
+        InitialSessionMode::ConfigOption(mode_id) => {
+            let value_id = agent_client_protocol::schema::v1::SessionConfigValueId::new(mode_id);
+            cx.send_request(SetSessionConfigOptionRequest::new(
+                session.session_id.clone(),
+                "mode",
+                value_id,
+            ))
+            .block_task()
+            .await
+            .map_err(|err| {
+                anyhow::anyhow!(
+                    "ACP agent rejected {} for 'mode': {err}",
+                    AGENT_METHOD_NAMES.session_set_config_option
+                )
+            })?;
         }
+        InitialSessionMode::Mode(mode_id) => {
+            let _: SetSessionModeResponse = cx
+                .send_request(SetSessionModeRequest::new(
+                    session.session_id.clone(),
+                    mode_id,
+                ))
+                .block_task()
+                .await
+                .map_err(|err| {
+                    anyhow::anyhow!(
+                        "ACP agent rejected {}: {err}",
+                        AGENT_METHOD_NAMES.session_set_mode
+                    )
+                })?;
+        }
+        InitialSessionMode::Unchanged => {}
     }
 
     Ok(session)
+}
+
+#[derive(Debug, PartialEq)]
+enum InitialSessionMode {
+    ConfigOption(String),
+    Mode(String),
+    Unchanged,
+}
+
+/// Decide how the current goose mode reaches a freshly opened session. Agents
+/// that expose mode as a config option (rather than `session.modes`) start
+/// every new session in their own default, so the mode must be re-sent or a
+/// session opened by `reset_context` quietly reverts while goose still reports
+/// the previously selected mode. Running as part of session setup means a
+/// refusal fails the whole `session/new`: the caller keeps its old session
+/// instead of adopting one whose permission mode is unknown.
+fn initial_session_mode(
+    session: &NewSessionResponse,
+    candidates: &[String],
+) -> Result<InitialSessionMode> {
+    if candidates.is_empty() {
+        return Ok(InitialSessionMode::Unchanged);
+    }
+
+    if session_advertises_mode_config_option(session) {
+        return Ok(match select_mode_id(candidates, session.modes.as_ref()) {
+            Some(mode_id) => InitialSessionMode::ConfigOption(mode_id),
+            None => InitialSessionMode::Unchanged,
+        });
+    }
+
+    let Some(modes) = session.modes.as_ref() else {
+        return Ok(InitialSessionMode::Unchanged);
+    };
+    let Some(mode_id) = select_mode_id(candidates, Some(modes)) else {
+        let available: Vec<String> = modes
+            .available_modes
+            .iter()
+            .map(|mode| mode.id.0.to_string())
+            .collect();
+        return Err(anyhow::anyhow!(
+            "Requested mode(s) [{}] not offered by agent. Available modes: {}",
+            candidates.join(", "),
+            available.join(", ")
+        ));
+    };
+    if modes.current_mode_id.0.as_ref() == mode_id.as_str() {
+        return Ok(InitialSessionMode::Unchanged);
+    }
+    Ok(InitialSessionMode::Mode(mode_id))
+}
+
+fn session_advertises_mode_config_option(session: &NewSessionResponse) -> bool {
+    session.config_options.as_ref().is_some_and(|opts| {
+        opts.iter()
+            .any(|o| o.category.as_ref() == Some(&SessionConfigOptionCategory::Mode))
+    })
 }
 
 fn initial_mode_candidates(
@@ -2444,59 +2477,70 @@ mod tests {
         assert!(provider.applied_model.lock().unwrap().is_none());
         assert!(
             rx.try_recv().is_err(),
-            "an agent without a mode config option must not be sent one"
+            "session setup (mode, config options) belongs to the client loop; reset_context must send nothing beyond the swap"
         );
     }
 
-    #[tokio::test]
-    async fn reset_context_reapplies_mode_to_a_config_option_agent() {
-        let (tx, mut rx) = mpsc::channel(4);
-        let (mut provider, _) = test_provider_with_tx(Some(tx));
-        provider.mode_mapping = HashMap::from([(GooseMode::Auto, vec!["full-access".to_string()])]);
+    fn mode_config_option_session() -> NewSessionResponse {
+        NewSessionResponse::new("fresh-session").config_options(vec![SessionConfigOption::select(
+            "mode",
+            "Mode",
+            "read-only",
+            vec![
+                SessionConfigSelectOption::new("read-only", "Read only"),
+                SessionConfigSelectOption::new("full-access", "Full access"),
+            ],
+        )
+        .category(SessionConfigOptionCategory::Mode)])
+    }
 
-        let handle = tokio::spawn(async move {
-            provider.reset_context().await.unwrap();
-            provider
-        });
+    #[test]
+    fn a_new_session_sends_the_mode_to_a_config_option_agent() {
+        let session = mode_config_option_session();
+        let action = initial_session_mode(&session, &["full-access".to_string()]).unwrap();
+        assert_eq!(
+            action,
+            InitialSessionMode::ConfigOption("full-access".to_string())
+        );
+    }
 
-        match rx.recv().await.expect("expected a NewSession request") {
-            ClientRequest::NewSession { response_tx } => {
-                let _ = response_tx.send(Ok(NewSessionResponse::new("fresh-session")
-                    .config_options(vec![SessionConfigOption::select(
-                        "mode",
-                        "Mode",
-                        "read-only",
-                        vec![
-                            SessionConfigSelectOption::new("read-only", "Read only"),
-                            SessionConfigSelectOption::new("full-access", "Full access"),
-                        ],
-                    )
-                    .category(SessionConfigOptionCategory::Mode)])));
-            }
-            _ => panic!("unexpected request kind"),
-        }
-        match rx.recv().await.expect("expected a CloseSession request") {
-            ClientRequest::CloseSession { session_id } => {
-                assert_eq!(session_id, SessionId::new("test-session"));
-            }
-            _ => panic!("unexpected request kind"),
-        }
-        match rx.recv().await.expect("expected a SetConfigOption request") {
-            ClientRequest::SetConfigOption {
-                session_id,
-                config_id,
-                value,
-                response_tx,
-            } => {
-                assert_eq!(session_id, SessionId::new("fresh-session"));
-                assert_eq!(config_id, "mode");
-                assert_eq!(value, "full-access");
-                let _ = response_tx.send(Ok(()));
-            }
-            _ => panic!("unexpected request kind"),
-        }
+    #[test]
+    fn a_config_option_agent_is_preferred_over_session_modes() {
+        let session = mode_config_option_session()
+            .modes(mode_state("read-only", &["read-only", "full-access"]));
+        let action = initial_session_mode(&session, &["full-access".to_string()]).unwrap();
+        assert_eq!(
+            action,
+            InitialSessionMode::ConfigOption("full-access".to_string())
+        );
+    }
 
-        handle.await.unwrap();
+    #[test]
+    fn an_agent_without_mode_surfaces_is_not_sent_a_mode() {
+        let session = NewSessionResponse::new("fresh-session");
+        let action = initial_session_mode(&session, &["full-access".to_string()]).unwrap();
+        assert_eq!(action, InitialSessionMode::Unchanged);
+    }
+
+    #[test]
+    fn a_session_modes_agent_gets_set_mode_only_when_it_differs() {
+        let session = NewSessionResponse::new("fresh-session")
+            .modes(mode_state("read-only", &["read-only", "agent"]));
+        let action = initial_session_mode(&session, &["agent".to_string()]).unwrap();
+        assert_eq!(action, InitialSessionMode::Mode("agent".to_string()));
+
+        let session = NewSessionResponse::new("fresh-session")
+            .modes(mode_state("agent", &["read-only", "agent"]));
+        let action = initial_session_mode(&session, &["agent".to_string()]).unwrap();
+        assert_eq!(action, InitialSessionMode::Unchanged);
+    }
+
+    #[test]
+    fn a_session_modes_agent_offering_no_candidate_fails_setup() {
+        let session = NewSessionResponse::new("fresh-session")
+            .modes(mode_state("agent", &["agent", "agent-full-access"]));
+        let result = initial_session_mode(&session, &["read-only".to_string()]);
+        assert!(result.is_err());
     }
 
     #[test]

--- a/crates/goose/src/agents/execute_commands.rs
+++ b/crates/goose/src/agents/execute_commands.rs
@@ -191,15 +191,18 @@ impl Agent {
     async fn handle_clear_command(&self, session_id: &str) -> Result<Option<Message>> {
         use crate::conversation::Conversation;
 
-        let provider = self.provider().await?;
-        let provider_reset = provider.reset_context().await;
+        let provider = self.provider().await.ok();
+        let provider_reset = match &provider {
+            Some(provider) => provider.reset_context().await,
+            None => Ok(()),
+        };
 
         let manager = self.config.session_manager.clone();
         manager
             .replace_conversation(session_id, &Conversation::default())
             .await?;
 
-        if let Err(e) = provider_reset {
+        if let (Some(provider), Err(e)) = (&provider, provider_reset) {
             tracing::warn!(provider = provider.get_name(), error = %e, "provider-side context reset failed");
             return Ok(Some(user_only_assistant_text(
                 stale_provider_context_message(provider.get_name(), &e.to_string()),

--- a/crates/goose/src/agents/execute_commands.rs
+++ b/crates/goose/src/agents/execute_commands.rs
@@ -537,7 +537,9 @@ pub fn stale_provider_context_message(provider_name: &str, error: &str) -> Strin
 pub fn compaction_unsupported_message(provider_name: &str) -> String {
     format!(
         "Compaction is not supported with '{provider_name}' because it manages its own \
-         conversation context. Use /clear to start the conversation over."
+         conversation context. Try /clear, which starts the agent's conversation over for \
+         providers that can reset it; if it reports that the previous conversation is still \
+         held, start a new session instead."
     )
 }
 

--- a/crates/goose/src/agents/execute_commands.rs
+++ b/crates/goose/src/agents/execute_commands.rs
@@ -150,6 +150,13 @@ impl Agent {
     }
 
     async fn handle_compact_command(&self, session_id: &str) -> Result<Option<Message>> {
+        let provider = self.provider().await?;
+        if provider.manages_own_context() {
+            return Ok(Some(user_only_assistant_text(
+                compaction_unsupported_message(provider.get_name()),
+            )));
+        }
+
         let manager = self.config.session_manager.clone();
         let session = manager.get_session(session_id, true).await?;
         let conversation = session
@@ -158,7 +165,7 @@ impl Agent {
 
         let model_config = self.model_config_for_session(session_id).await?;
         let compaction = compact_messages(
-            self.provider().await?.as_ref(),
+            provider.as_ref(),
             &model_config,
             session_id,
             &conversation,
@@ -184,10 +191,20 @@ impl Agent {
     async fn handle_clear_command(&self, session_id: &str) -> Result<Option<Message>> {
         use crate::conversation::Conversation;
 
+        let provider = self.provider().await?;
+        let provider_reset = provider.reset_context().await;
+
         let manager = self.config.session_manager.clone();
         manager
             .replace_conversation(session_id, &Conversation::default())
             .await?;
+
+        if let Err(e) = provider_reset {
+            tracing::warn!(provider = provider.get_name(), error = %e, "provider-side context reset failed");
+            return Ok(Some(user_only_assistant_text(
+                stale_provider_context_message(provider.get_name(), &e.to_string()),
+            )));
+        }
 
         manager
             .update(session_id)
@@ -505,6 +522,23 @@ impl Agent {
             "Grind goal set. The agent will keep working until max_turns is reached:\n\n> {goal}"
         ))))
     }
+}
+
+/// Shown when `/clear` emptied goose's transcript but the provider still holds
+/// the real conversation. The token counters are deliberately left alone in that
+/// case, so the meter keeps reflecting what the model can still see.
+pub fn stale_provider_context_message(provider_name: &str, error: &str) -> String {
+    format!(
+        "Cleared goose's transcript, but '{provider_name}' still holds the previous conversation \
+         and will keep sending it to the model: {error}. Start a new session for a full reset."
+    )
+}
+
+pub fn compaction_unsupported_message(provider_name: &str) -> String {
+    format!(
+        "Compaction is not supported with '{provider_name}' because it manages its own \
+         conversation context. Use /clear to start the conversation over."
+    )
 }
 
 fn user_only_assistant_text(text: impl Into<String>) -> Message {

--- a/crates/goose/src/agents/execute_commands.rs
+++ b/crates/goose/src/agents/execute_commands.rs
@@ -191,22 +191,22 @@ impl Agent {
     async fn handle_clear_command(&self, session_id: &str) -> Result<Option<Message>> {
         use crate::conversation::Conversation;
 
-        let provider = self.provider().await.ok();
-        let provider_reset = match &provider {
-            Some(provider) => provider.reset_context().await,
-            None => Ok(()),
-        };
-
+        // Clear locally before asking the provider to reset: a provider-side
+        // reset cannot be undone, so a failed local clear must leave both
+        // histories in place rather than only goose's.
         let manager = self.config.session_manager.clone();
         manager
             .replace_conversation(session_id, &Conversation::default())
             .await?;
 
-        if let (Some(provider), Err(e)) = (&provider, provider_reset) {
-            tracing::warn!(provider = provider.get_name(), error = %e, "provider-side context reset failed");
-            return Ok(Some(user_only_assistant_text(
-                stale_provider_context_message(provider.get_name(), &e.to_string()),
-            )));
+        // No provider means nothing agent-side to reset: a local-only clear.
+        if let Ok(provider) = self.provider().await {
+            if let Err(e) = provider.reset_context().await {
+                tracing::warn!(provider = provider.get_name(), error = %e, "provider-side context reset failed");
+                return Ok(Some(user_only_assistant_text(
+                    stale_provider_context_message(provider.get_name(), &e.to_string()),
+                )));
+            }
         }
 
         manager

--- a/crates/goose/src/agents/mod.rs
+++ b/crates/goose/src/agents/mod.rs
@@ -26,7 +26,9 @@ pub mod validate_extensions;
 
 pub use agent::{Agent, AgentConfig, AgentEvent, ExtensionLoadResult, GoosePlatform};
 pub use container::Container;
-pub use execute_commands::COMPACT_TRIGGERS;
+pub use execute_commands::{
+    compaction_unsupported_message, stale_provider_context_message, COMPACT_TRIGGERS,
+};
 pub use extension::{ExtensionConfig, ExtensionError};
 pub use extension_manager::ExtensionManager;
 pub use prompt_manager::PromptManager;

--- a/crates/goose/tests/clear_command.rs
+++ b/crates/goose/tests/clear_command.rs
@@ -271,6 +271,36 @@ async fn a_context_owning_provider_does_not_inherit_a_silent_reset() -> anyhow::
     Ok(())
 }
 
+/// A resumed session whose provider restore failed leaves the agent with no
+/// provider at all. There is still a local transcript to clear, and no
+/// provider-side context to go stale.
+#[tokio::test]
+async fn clear_falls_back_to_a_local_clear_without_a_provider() -> anyhow::Result<()> {
+    let temp_dir = TempDir::new()?;
+    let agent = Agent::new();
+    let session = setup_session(&agent, &temp_dir, "clear-no-provider").await?;
+
+    let result = agent
+        .execute_command("/clear", &session.id)
+        .await?
+        .expect("/clear returns a message");
+    assert_eq!(message_text(&result), "Conversation cleared");
+
+    let updated = agent
+        .config
+        .session_manager
+        .get_session(&session.id, true)
+        .await?;
+    assert!(updated
+        .conversation
+        .expect("session has a conversation")
+        .messages()
+        .is_empty());
+    assert_eq!(updated.usage.total_tokens, Some(0));
+
+    Ok(())
+}
+
 #[tokio::test]
 async fn compact_is_rejected_for_providers_that_own_their_context() -> anyhow::Result<()> {
     let temp_dir = TempDir::new()?;

--- a/crates/goose/tests/clear_command.rs
+++ b/crates/goose/tests/clear_command.rs
@@ -19,7 +19,7 @@ use goose_providers::conversation::token_usage::{ProviderUsage, Usage};
 use goose_providers::errors::ProviderError;
 use goose_providers::model::ModelConfig;
 use rmcp::model::Tool;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 use tempfile::TempDir;
 
@@ -297,6 +297,87 @@ async fn clear_falls_back_to_a_local_clear_without_a_provider() -> anyhow::Resul
         .messages()
         .is_empty());
     assert_eq!(updated.usage.total_tokens, Some(0));
+
+    Ok(())
+}
+
+/// A provider whose `reset_context` records whether goose's transcript was
+/// already empty when the reset arrived.
+struct ResetOrderProbe {
+    session_manager: Arc<goose::session::SessionManager>,
+    session_id: String,
+    local_already_cleared: AtomicBool,
+}
+
+#[async_trait]
+impl Provider for ResetOrderProbe {
+    async fn stream(
+        &self,
+        _model_config: &ModelConfig,
+        _system_prompt: &str,
+        _messages: &[Message],
+        _tools: &[Tool],
+    ) -> Result<MessageStream, ProviderError> {
+        let usage = ProviderUsage::new(
+            "mock-model".to_string(),
+            Usage::new(Some(10), Some(10), Some(20)),
+        );
+        Ok(stream_from_single_message(
+            Message::assistant().with_text("ok"),
+            usage,
+        ))
+    }
+
+    fn get_name(&self) -> &str {
+        "reset-order-probe"
+    }
+
+    fn manages_own_context(&self) -> bool {
+        true
+    }
+
+    async fn reset_context(&self) -> Result<(), ProviderError> {
+        let cleared = self
+            .session_manager
+            .get_session(&self.session_id, true)
+            .await
+            .ok()
+            .and_then(|session| session.conversation)
+            .map(|conversation| conversation.messages().is_empty())
+            .unwrap_or(false);
+        self.local_already_cleared.store(cleared, Ordering::SeqCst);
+        Ok(())
+    }
+}
+
+/// The provider may only be reset after the local clear succeeds: a
+/// provider-side reset cannot be undone, so a failed local clear must leave
+/// both histories in place rather than only goose's.
+#[tokio::test]
+async fn clear_empties_the_local_transcript_before_resetting_the_provider() -> anyhow::Result<()> {
+    let temp_dir = TempDir::new()?;
+    let agent = Agent::new();
+    let session = setup_session(&agent, &temp_dir, "clear-ordering").await?;
+
+    let provider = Arc::new(ResetOrderProbe {
+        session_manager: agent.config.session_manager.clone(),
+        session_id: session.id.clone(),
+        local_already_cleared: AtomicBool::new(false),
+    });
+    agent
+        .update_provider(
+            provider.clone(),
+            ModelConfig::new("mock-model"),
+            &session.id,
+        )
+        .await?;
+
+    agent.execute_command("/clear", &session.id).await?;
+
+    assert!(
+        provider.local_already_cleared.load(Ordering::SeqCst),
+        "the local transcript must already be empty when the provider reset runs"
+    );
 
     Ok(())
 }

--- a/crates/goose/tests/clear_command.rs
+++ b/crates/goose/tests/clear_command.rs
@@ -1,0 +1,311 @@
+//! `/clear` and `/compact` against a provider that owns the conversation.
+//!
+//! For such providers goose's transcript is a display copy: the model sees the
+//! provider's own history. Clearing only the copy leaves the real context in
+//! place while the token meter reads zero. See issue #10763.
+
+use async_trait::async_trait;
+use goose::agents::execute_commands::{
+    compaction_unsupported_message, stale_provider_context_message,
+};
+use goose::agents::Agent;
+use goose::config::GooseMode;
+use goose::conversation::message::{Message, MessageContent};
+use goose::conversation::Conversation;
+use goose::providers::base::{stream_from_single_message, MessageStream, Provider};
+use goose::session::session_manager::SessionType;
+use goose::session::Session;
+use goose_providers::conversation::token_usage::{ProviderUsage, Usage};
+use goose_providers::errors::ProviderError;
+use goose_providers::model::ModelConfig;
+use rmcp::model::Tool;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use tempfile::TempDir;
+
+const PROVIDER_NAME: &str = "mock-owns-context";
+
+struct MockOwnContextProvider {
+    resets: AtomicUsize,
+    reset_error: Option<String>,
+}
+
+impl MockOwnContextProvider {
+    fn resettable() -> Self {
+        Self {
+            resets: AtomicUsize::new(0),
+            reset_error: None,
+        }
+    }
+
+    fn unresettable(error: &str) -> Self {
+        Self {
+            resets: AtomicUsize::new(0),
+            reset_error: Some(error.to_string()),
+        }
+    }
+}
+
+/// A context-owning provider that never overrides `reset_context`, standing in
+/// for one added later by someone unaware of `/clear`.
+struct ForgetfulProvider;
+
+#[async_trait]
+impl Provider for ForgetfulProvider {
+    async fn stream(
+        &self,
+        _model_config: &ModelConfig,
+        _system_prompt: &str,
+        _messages: &[Message],
+        _tools: &[Tool],
+    ) -> Result<MessageStream, ProviderError> {
+        let usage = ProviderUsage::new(
+            "mock-model".to_string(),
+            Usage::new(Some(10), Some(10), Some(20)),
+        );
+        Ok(stream_from_single_message(
+            Message::assistant().with_text("ok"),
+            usage,
+        ))
+    }
+
+    fn get_name(&self) -> &str {
+        "forgetful"
+    }
+
+    fn manages_own_context(&self) -> bool {
+        true
+    }
+}
+
+#[async_trait]
+impl Provider for MockOwnContextProvider {
+    async fn stream(
+        &self,
+        _model_config: &ModelConfig,
+        _system_prompt: &str,
+        _messages: &[Message],
+        _tools: &[Tool],
+    ) -> Result<MessageStream, ProviderError> {
+        let usage = ProviderUsage::new(
+            "mock-model".to_string(),
+            Usage::new(Some(10), Some(10), Some(20)),
+        );
+        Ok(stream_from_single_message(
+            Message::assistant().with_text("ok"),
+            usage,
+        ))
+    }
+
+    fn get_name(&self) -> &str {
+        PROVIDER_NAME
+    }
+
+    fn manages_own_context(&self) -> bool {
+        true
+    }
+
+    async fn reset_context(&self) -> Result<(), ProviderError> {
+        self.resets.fetch_add(1, Ordering::SeqCst);
+        match &self.reset_error {
+            Some(error) => Err(ProviderError::NotImplemented(error.clone())),
+            None => Ok(()),
+        }
+    }
+}
+
+async fn setup_session(agent: &Agent, temp_dir: &TempDir, name: &str) -> anyhow::Result<Session> {
+    let session = agent
+        .config
+        .session_manager
+        .create_session(
+            temp_dir.path().to_path_buf(),
+            name.to_string(),
+            SessionType::Hidden,
+            GooseMode::default(),
+        )
+        .await?;
+
+    let conversation = Conversation::new_unvalidated(vec![
+        Message::user().with_text("Hello"),
+        Message::assistant().with_text("Hi there!"),
+    ]);
+    agent
+        .config
+        .session_manager
+        .replace_conversation(&session.id, &conversation)
+        .await?;
+    agent
+        .config
+        .session_manager
+        .update(&session.id)
+        .usage(Usage::new(Some(6000), Some(400), Some(6400)))
+        .apply()
+        .await?;
+
+    Ok(session)
+}
+
+fn message_text(message: &Message) -> String {
+    message
+        .content
+        .iter()
+        .filter_map(|content| match content {
+            MessageContent::Text(text) => Some(text.text.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
+#[tokio::test]
+async fn clear_resets_provider_context_and_zeroes_usage() -> anyhow::Result<()> {
+    let temp_dir = TempDir::new()?;
+    let agent = Agent::new();
+    let session = setup_session(&agent, &temp_dir, "clear-resettable").await?;
+
+    let provider = Arc::new(MockOwnContextProvider::resettable());
+    agent
+        .update_provider(
+            provider.clone(),
+            ModelConfig::new("mock-model"),
+            &session.id,
+        )
+        .await?;
+
+    let result = agent
+        .execute_command("/clear", &session.id)
+        .await?
+        .expect("/clear returns a message");
+    assert_eq!(message_text(&result), "Conversation cleared");
+    assert_eq!(provider.resets.load(Ordering::SeqCst), 1);
+
+    let updated = agent
+        .config
+        .session_manager
+        .get_session(&session.id, true)
+        .await?;
+    assert!(updated
+        .conversation
+        .expect("session has a conversation")
+        .messages()
+        .is_empty());
+    assert_eq!(updated.usage.total_tokens, Some(0));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn clear_keeps_usage_when_the_provider_cannot_reset() -> anyhow::Result<()> {
+    let temp_dir = TempDir::new()?;
+    let agent = Agent::new();
+    let session = setup_session(&agent, &temp_dir, "clear-unresettable").await?;
+
+    let provider = Arc::new(MockOwnContextProvider::unresettable("no reset for you"));
+    agent
+        .update_provider(
+            provider.clone(),
+            ModelConfig::new("mock-model"),
+            &session.id,
+        )
+        .await?;
+
+    let result = agent
+        .execute_command("/clear", &session.id)
+        .await?
+        .expect("/clear returns a message");
+    assert_eq!(
+        message_text(&result),
+        stale_provider_context_message(PROVIDER_NAME, "Unsupported operation: no reset for you")
+    );
+
+    let updated = agent
+        .config
+        .session_manager
+        .get_session(&session.id, true)
+        .await?;
+    assert!(updated
+        .conversation
+        .expect("session has a conversation")
+        .messages()
+        .is_empty());
+    assert_eq!(
+        updated.usage.total_tokens,
+        Some(6400),
+        "the meter must keep reflecting the context the model still holds"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn a_context_owning_provider_does_not_inherit_a_silent_reset() -> anyhow::Result<()> {
+    let temp_dir = TempDir::new()?;
+    let agent = Agent::new();
+    let session = setup_session(&agent, &temp_dir, "clear-forgetful").await?;
+
+    agent
+        .update_provider(
+            Arc::new(ForgetfulProvider),
+            ModelConfig::new("mock-model"),
+            &session.id,
+        )
+        .await?;
+
+    let result = agent
+        .execute_command("/clear", &session.id)
+        .await?
+        .expect("/clear returns a message");
+    assert!(
+        message_text(&result).contains("still holds the previous conversation"),
+        "the default reset_context must refuse for providers that own their context, got: {}",
+        message_text(&result)
+    );
+
+    let updated = agent
+        .config
+        .session_manager
+        .get_session(&session.id, true)
+        .await?;
+    assert_eq!(updated.usage.total_tokens, Some(6400));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn compact_is_rejected_for_providers_that_own_their_context() -> anyhow::Result<()> {
+    let temp_dir = TempDir::new()?;
+    let agent = Agent::new();
+    let session = setup_session(&agent, &temp_dir, "compact-own-context").await?;
+
+    let provider = Arc::new(MockOwnContextProvider::resettable());
+    agent
+        .update_provider(provider, ModelConfig::new("mock-model"), &session.id)
+        .await?;
+
+    let result = agent
+        .execute_command("/compact", &session.id)
+        .await?
+        .expect("/compact returns a message");
+    assert_eq!(
+        message_text(&result),
+        compaction_unsupported_message(PROVIDER_NAME)
+    );
+
+    let updated = agent
+        .config
+        .session_manager
+        .get_session(&session.id, true)
+        .await?;
+    assert_eq!(
+        updated
+            .conversation
+            .expect("session has a conversation")
+            .messages()
+            .len(),
+        2,
+        "a rejected /compact must leave the transcript alone"
+    );
+    assert_eq!(updated.usage.total_tokens, Some(6400));
+
+    Ok(())
+}

--- a/documentation/docs/guides/goose-cli-commands.md
+++ b/documentation/docs/guides/goose-cli-commands.md
@@ -821,7 +821,7 @@ Once you're in an interactive session (via `goose session` or `goose run --inter
 - **`/prompt <n> [--info] [key=value...]`** - Get prompt info or execute a prompt
 - **`/prompts [--extension <name>]`** - List all available prompts, optionally filtered by extension
 - **`/recipe [filepath]`** - Generate a recipe from the current conversation and save it to the specified filepath (must end with .yaml). If no filepath is provided, it will be saved to ./recipe.yaml
-- **`/compact`** - Compact and summarize the current conversation to reduce context length while preserving key information. Not available with providers that manage their own context, since goose cannot summarize a history it does not hold — use `/clear` instead
+- **`/compact`** - Compact and summarize the current conversation to reduce context length while preserving key information. Not available with providers that manage their own context, since goose cannot summarize a history it does not hold. Use `/clear` instead where the provider can reset its conversation, and start a new session where it cannot
 - **`/r`** - Toggle full tool output display (show complete tool parameters without truncation)
 - **`/skills [<name>...]`** - List available skills, or load one or more skills by name
 - **`/t`** - Toggle between `light`, `dark`, and `ansi` themes. [More info](#themes).

--- a/documentation/docs/guides/goose-cli-commands.md
+++ b/documentation/docs/guides/goose-cli-commands.md
@@ -812,7 +812,7 @@ Once you're in an interactive session (via `goose session` or `goose run --inter
 **Available Commands:**
 - **`/?` or `/help`** - Display the help menu
 - **`/builtin <names>`** - Add builtin extensions by name (comma-separated)
-- **`/clear`** - Clear the current chat history
+- **`/clear`** - Clear the current chat history. With providers that keep their own conversation (ACP agents, Claude Code, Gemini CLI) this also starts the agent-side conversation over, so the model forgets what you just cleared
 - **`/endplan`** - Exit plan mode and return to 'normal' goose mode
 - **`/exit` or `/quit`** - Exit the session
 - **`/extension <command>`** - Add a stdio extension (format: ENV1=val1 command args...)
@@ -821,7 +821,7 @@ Once you're in an interactive session (via `goose session` or `goose run --inter
 - **`/prompt <n> [--info] [key=value...]`** - Get prompt info or execute a prompt
 - **`/prompts [--extension <name>]`** - List all available prompts, optionally filtered by extension
 - **`/recipe [filepath]`** - Generate a recipe from the current conversation and save it to the specified filepath (must end with .yaml). If no filepath is provided, it will be saved to ./recipe.yaml
-- **`/compact`** - Compact and summarize the current conversation to reduce context length while preserving key information
+- **`/compact`** - Compact and summarize the current conversation to reduce context length while preserving key information. Not available with providers that manage their own context, since goose cannot summarize a history it does not hold — use `/clear` instead
 - **`/r`** - Toggle full tool output display (show complete tool parameters without truncation)
 - **`/skills [<name>...]`** - List available skills, or load one or more skills by name
 - **`/t`** - Toggle between `light`, `dark`, and `ansi` themes. [More info](#themes).

--- a/documentation/docs/guides/goose-cli-commands.md
+++ b/documentation/docs/guides/goose-cli-commands.md
@@ -812,7 +812,7 @@ Once you're in an interactive session (via `goose session` or `goose run --inter
 **Available Commands:**
 - **`/?` or `/help`** - Display the help menu
 - **`/builtin <names>`** - Add builtin extensions by name (comma-separated)
-- **`/clear`** - Clear the current chat history. With providers that keep their own conversation (ACP agents, Claude Code, Gemini CLI) this also starts the agent-side conversation over, so the model forgets what you just cleared
+- **`/clear`** - Clear the current chat history. With ACP agents, which keep their own conversation, this also starts the agent-side conversation over, so the model forgets what you just cleared. The Claude Code and Gemini CLI providers cannot yet be reset this way; there `/clear` empties goose's transcript, warns you that the model still holds the previous conversation, and leaves the token counter reflecting what the model can still see
 - **`/endplan`** - Exit plan mode and return to 'normal' goose mode
 - **`/exit` or `/quit`** - Exit the session
 - **`/extension <command>`** - Add a stdio extension (format: ENV1=val1 command args...)


### PR DESCRIPTION
Fixes #10763.

## Problem

For providers that manage their own context, goose's transcript is a display copy — `AcpProvider::stream()` sends only the trailing user message and relies on the agent to hold history. `/clear` replaced that copy with an empty conversation and zeroed the token counters without telling the provider anything, so the model kept the full window while the UI reported an empty session. The next prompt could fail with `Prompt is too long` and the session was unrecoverable.

`/compact` had the same shape: it summarized a conversation the model never sees, spending a summarization call to no effect.

## Change

`Provider::reset_context()`, whose default is derived from `manages_own_context()` rather than being unconditionally `Ok`. A provider holding the authoritative history has to *opt in* to claiming it can drop it — so a context-owning provider added later can't inherit a silent success and quietly reintroduce this bug. That addresses @reuvenneumann's point that the hook should hang off `manages_own_context()` rather than any provider-specific path.

- `AcpProvider` implements it: opens a fresh `session/new`, swaps it in, closes the superseded session, and clears the handoff-context latch, the agent-reported context size, and the applied-model cache so the new session is configured from scratch. This covers **every** `*-acp` provider — `claude-acp`, `codex-acp`, `amp-acp`, `copilot-acp` and `pi-acp` all resolve to `type Provider = AcpProvider` — which matches the independent `codex-acp` reproduction in the issue thread.
- Both `/clear` entry points call it: the agent command and the CLI's separate `handle_clear`, which as noted in the thread the agent path never reaches.
- The current goose mode is re-sent to the new session for agents that expose mode as a config option rather than `session.modes`, which `session/new` alone does not carry over. Best-effort: the reset has already succeeded at that point, so a failure warns rather than reporting a reset that did happen as failed.
- The client loop tracks the active ACP session id and drops `session/update` notifications for a superseded session, so a trailing usage or mode update can't overwrite the freshly reset state.
- When a provider owns its context but cannot reset it (the Claude Code and Gemini CLI wrappers), `/clear` says so and **leaves the token counters alone**, so the meter keeps reflecting what the model can still see rather than reporting zero.
- `/compact` is rejected wherever `manages_own_context()` is true, in both the agent command and the CLI (which skips its confirmation prompt rather than asking and then refusing).

The Desktop path needs no change: its `/clear` forwards to the backend, which routes through `handle_clear_command` and emits `HistoryReplaced`.

## Tests

`crates/goose/tests/clear_command.rs`:
- `/clear` resets provider context and zeroes usage
- `/clear` preserves usage and warns when the provider cannot reset
- a context-owning provider that never overrides `reset_context` does **not** inherit a silent success (guards the default)
- `/compact` is rejected and leaves the transcript untouched

`acp/provider.rs`:
- `reset_context` opens a fresh session, closes the old one, and resets the latches
- a refused `session/new` leaves the current session in place and does not close it
- `reset_context` re-sends the mode to a config-option agent, and sends nothing to an agent without a mode config option
- updates for a superseded session id are ignored; updates predating any session are still accepted

`cargo clippy --all-targets -D warnings` clean. Pre-existing failures on `main` (`gcpauth` ×3, `chatgpt_codex` JWT, `prompt_manager` snapshot) are unchanged.

## Not addressed here

- The Claude Code and Gemini CLI wrappers now report honestly instead of resetting. Both are fixable — Gemini CLI just needs its `cli_session_id` `OnceLock` to become resettable, Claude Code needs its persistent process recycled — but neither is on the reported path and I can't exercise them end-to-end. Happy to file or fold in.
- @reuvenneumann's adjacent observation that `GOOSE_CONTEXT_LIMIT` only affects the display until the agent reports a `context_size` is a separate concern and unchanged by this PR.
