### PR TITLE
docs: add Brainiall TTS extension

### DIFF
--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -101,6 +101,25 @@
     "environmentVariables": []
   },
   {
+    "id": "brainiall-tts",
+    "name": "Brainiall TTS",
+    "description": "Hosted multilingual text-to-speech with Brazilian Portuguese voices",
+    "url": "https://api.brainiall.com/mcp/tts/mcp",
+    "type": "streamable-http",
+    "link": "https://github.com/fasuizu-br/brainiall-tts-mcp",
+    "installation_notes": "Connect to the remote server and provide a Brainiall API key as a Bearer token.",
+    "is_builtin": false,
+    "endorsed": false,
+    "environmentVariables": [],
+    "headers": [
+      {
+        "name": "Authorization",
+        "description": "Bearer Brainiall API key",
+        "required": true
+      }
+    ]
+  },
+  {
     "id": "browserbase-mcp",
     "name": "Browserbase",
     "description": "Browser automation and web scraping",


### PR DESCRIPTION
## Summary

- add the hosted Brainiall TTS Streamable HTTP server to the extension catalog
- prompt for the Authorization header instead of embedding credentials
- keep the entry unendorsed and link to the public server repository

## Validation

- jq empty documentation/static/servers.json
- verified unique server IDs
- production health endpoint returned ok
- anonymous MCP initialize returned HTTP 200 with protocol 2025-06-18 and server brainiall-tts 2.14.7
- git diff --check

The catalog entry does not claim endorsement, installs, customers, or revenue.