### PR TITLE
feat(otel): add gen_ai.* semantic convention attributes and MLflow span I/O

### DIFF
--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -1055,7 +1055,16 @@ impl Agent {
     }
 
     /// Dispatch a single tool call to the appropriate client
-    #[instrument(skip(self, tool_call, request_id, cancellation_token, session), fields(input, output, session.id = %session.id))]
+    #[instrument(
+        skip(self, tool_call, request_id, cancellation_token, session),
+        fields(
+            input,
+            output,
+            session.id = %session.id,
+            gen_ai.operation.name = "execute_tool",
+            gen_ai.tool.call.arguments = tracing::field::Empty,
+        )
+    )]
     pub async fn dispatch_tool_call(
         &self,
         tool_call: CallToolRequestParams,
@@ -1068,6 +1077,17 @@ impl Agent {
             "arguments": tool_call.arguments,
         });
         tracing::Span::current().record("input", tracing::field::display(&input_summary));
+        if let Some(ref args) = tool_call.arguments {
+            tracing::Span::current().record(
+                "gen_ai.tool.call.arguments",
+                tracing::field::display(&serde_json::Value::Object(args.clone())),
+            );
+        }
+        #[cfg(feature = "otel")]
+        {
+            use tracing_opentelemetry::OpenTelemetrySpanExt;
+            tracing::Span::current().set_attribute("mlflow.spanInputs", input_summary.to_string());
+        }
 
         self.prompt_manager
             .lock()
@@ -1557,6 +1577,12 @@ impl Agent {
         let message_text_for_trace = agent_visible_message_text(&user_message);
         tracing::Span::current().record("user_message", message_text_for_trace.as_str());
         tracing::Span::current().record("trace_input", message_text_for_trace.as_str());
+        #[cfg(feature = "otel")]
+        {
+            use tracing_opentelemetry::OpenTelemetrySpanExt;
+            let inputs = serde_json::json!({ "message": message_text_for_trace });
+            tracing::Span::current().set_attribute("mlflow.spanInputs", inputs.to_string());
+        }
 
         for content in &user_message.content {
             if let MessageContent::ActionRequired(action_required) = content {
@@ -1928,6 +1954,16 @@ impl Agent {
             session.agent_type = "goose",
         );
         let inner = Box::pin(async_stream::try_stream! {
+            #[cfg(feature = "otel")]
+            {
+                use tracing_opentelemetry::OpenTelemetrySpanExt;
+                let input_text = conversation.messages().iter().rev()
+                    .find(|m| m.role == rmcp::model::Role::User)
+                    .map(|m| agent_visible_message_text(m))
+                    .unwrap_or_default();
+                let inputs = serde_json::json!({ "message": input_text });
+                tracing::Span::current().set_attribute("mlflow.spanInputs", inputs.to_string());
+            }
             let mut turns_taken = 0u32;
             let max_turns = session_config.max_turns.unwrap_or_else(|| {
                 Config::global()
@@ -2921,6 +2957,12 @@ impl Agent {
 
             if !last_assistant_text.is_empty() {
                 tracing::Span::current().record("trace_output", last_assistant_text.as_str());
+                #[cfg(feature = "otel")]
+                {
+                    use tracing_opentelemetry::OpenTelemetrySpanExt;
+                    let outputs = serde_json::json!({ "response": last_assistant_text });
+                    tracing::Span::current().set_attribute("mlflow.spanOutputs", outputs.to_string());
+                }
             }
 
             if !stop_hook_handled_for_exit {

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -1959,7 +1959,7 @@ impl Agent {
                 use tracing_opentelemetry::OpenTelemetrySpanExt;
                 let input_text = conversation.messages().iter().rev()
                     .find(|m| m.role == rmcp::model::Role::User)
-                    .map(|m| agent_visible_message_text(m))
+                    .map(agent_visible_message_text)
                     .unwrap_or_default();
                 let inputs = serde_json::json!({ "message": input_text });
                 tracing::Span::current().set_attribute("mlflow.spanInputs", inputs.to_string());

--- a/crates/goose/src/agents/reply_parts.rs
+++ b/crates/goose/src/agents/reply_parts.rs
@@ -306,10 +306,13 @@ impl Agent {
         span.record("gen_ai.request.model", model_config.model_name.as_str());
         span.record("gen_ai.provider.name", provider.get_name());
 
+        let projected_messages =
+            Conversation::new_unvalidated(messages.iter().cloned()).agent_visible_messages();
+
         #[cfg(feature = "otel")]
         {
             use tracing_opentelemetry::OpenTelemetrySpanExt;
-            let last_user_text = messages
+            let last_user_text = projected_messages
                 .iter()
                 .rev()
                 .find(|m| m.role == rmcp::model::Role::User)
@@ -330,9 +333,6 @@ impl Agent {
             });
             span.set_attribute("mlflow.spanInputs", inputs.to_string());
         }
-
-        let projected_messages =
-            Conversation::new_unvalidated(messages.iter().cloned()).agent_visible_messages();
         let (filtered_messages, _) =
             fix_conversation(Conversation::new_unvalidated(projected_messages));
 

--- a/crates/goose/src/agents/reply_parts.rs
+++ b/crates/goose/src/agents/reply_parts.rs
@@ -282,7 +282,15 @@ impl Agent {
 
     #[tracing::instrument(
         skip(provider, model_config, session_id, system_prompt, messages, tools, toolshim_tools),
-        fields(session.id = %session_id)
+        fields(
+            session.id = %session_id,
+            gen_ai.operation.name = "chat",
+            gen_ai.request.model = tracing::field::Empty,
+            gen_ai.response.model = tracing::field::Empty,
+            gen_ai.provider.name = tracing::field::Empty,
+            gen_ai.usage.input_tokens = tracing::field::Empty,
+            gen_ai.usage.output_tokens = tracing::field::Empty,
+        )
     )]
     pub(crate) async fn stream_response_from_provider(
         provider: Arc<dyn Provider>,
@@ -294,6 +302,34 @@ impl Agent {
         toolshim_tools: &[Tool],
     ) -> Result<MessageStream, ProviderError> {
         let config = model_config.clone();
+        let span = tracing::Span::current();
+        span.record("gen_ai.request.model", model_config.model_name.as_str());
+        span.record("gen_ai.provider.name", provider.get_name());
+
+        #[cfg(feature = "otel")]
+        {
+            use tracing_opentelemetry::OpenTelemetrySpanExt;
+            let last_user_text = messages
+                .iter()
+                .rev()
+                .find(|m| m.role == rmcp::model::Role::User)
+                .map(|m| {
+                    m.content
+                        .iter()
+                        .filter_map(|c| match c {
+                            MessageContent::Text(t) => Some(t.text.as_str()),
+                            _ => None,
+                        })
+                        .collect::<Vec<_>>()
+                        .join("\n")
+                })
+                .unwrap_or_default();
+            let inputs = json!({
+                "model": model_config.model_name,
+                "message": last_user_text,
+            });
+            span.set_attribute("mlflow.spanInputs", inputs.to_string());
+        }
 
         let projected_messages =
             Conversation::new_unvalidated(messages.iter().cloned()).agent_visible_messages();
@@ -392,9 +428,29 @@ impl Agent {
                 // The toolshim interpreter call below must not count toward elapsed time.
                 if let Some(usage) = final_usage.as_mut() {
                     fill_stream_timing(usage, request_started, first_content_at);
+                    span.record("gen_ai.response.model", usage.model.as_str());
+                    if let Some(input_tokens) = usage.usage.input_tokens {
+                        span.record("gen_ai.usage.input_tokens", input_tokens);
+                    }
+                    if let Some(output_tokens) = usage.usage.output_tokens {
+                        span.record("gen_ai.usage.output_tokens", output_tokens);
+                    }
                 }
 
                 if let Some(msg) = accumulated_message {
+                    #[cfg(feature = "otel")]
+                    {
+                        use tracing_opentelemetry::OpenTelemetrySpanExt;
+                        let response_text = msg.content.iter()
+                            .filter_map(|c| match c {
+                                MessageContent::Text(t) => Some(t.text.as_str()),
+                                _ => None,
+                            })
+                            .collect::<Vec<_>>()
+                            .join("\n");
+                        let outputs = json!({ "response": response_text });
+                        span.set_attribute("mlflow.spanOutputs", outputs.to_string());
+                    }
                     let processed = toolshim_postprocess(msg, &toolshim_tools).await?;
                     yield (Some(processed), final_usage);
                 } else if final_usage.is_some() {
@@ -403,6 +459,8 @@ impl Agent {
                 }
             } else {
                 let mut first_content_at: Option<std::time::Instant> = None;
+                #[cfg(feature = "otel")]
+                let mut otel_response_text = String::new();
                 while let Some(result) = stream.next().await {
                     let (message, mut usage) = result?;
 
@@ -411,11 +469,32 @@ impl Agent {
                     {
                         first_content_at = Some(std::time::Instant::now());
                     }
+                    #[cfg(feature = "otel")]
+                    if let Some(ref msg) = message {
+                        for content in &msg.content {
+                            if let MessageContent::Text(t) = content {
+                                otel_response_text.push_str(&t.text);
+                            }
+                        }
+                    }
                     if let Some(usage) = usage.as_mut() {
                         fill_stream_timing(usage, request_started, first_content_at);
+                        span.record("gen_ai.response.model", usage.model.as_str());
+                        if let Some(input_tokens) = usage.usage.input_tokens {
+                            span.record("gen_ai.usage.input_tokens", input_tokens);
+                        }
+                        if let Some(output_tokens) = usage.usage.output_tokens {
+                            span.record("gen_ai.usage.output_tokens", output_tokens);
+                        }
                     }
 
                     yield (message, usage);
+                }
+                #[cfg(feature = "otel")]
+                if !otel_response_text.is_empty() {
+                    use tracing_opentelemetry::OpenTelemetrySpanExt;
+                    let outputs = json!({ "response": otel_response_text });
+                    span.set_attribute("mlflow.spanOutputs", outputs.to_string());
                 }
             }
         }))


### PR DESCRIPTION
## Summary
- Add OpenTelemetry `gen_ai.*` semantic convention attributes to LLM call spans (`stream_response_from_provider`) and tool execution spans (`dispatch_tool_call`), gated behind the existing `otel` feature flag
- Add `mlflow.spanInputs`/`mlflow.spanOutputs` attributes so MLflow can populate its Request/Response columns directly from OTLP traces
- Attributes are set on both child spans (for detailed per-call data) and root spans (for MLflow top-level display)

### Attributes added
| Span | Attributes |
|------|-----------|
| `stream_response_from_provider` | `gen_ai.operation.name`, `gen_ai.request.model`, `gen_ai.response.model`, `gen_ai.provider.name`, `gen_ai.usage.input_tokens`, `gen_ai.usage.output_tokens`, `mlflow.spanInputs`, `mlflow.spanOutputs` |
| `dispatch_tool_call` | `gen_ai.operation.name`, `gen_ai.tool.call.arguments`, `mlflow.spanInputs` |
| `reply` (root) | `mlflow.spanInputs` |
| `reply_stream` | `mlflow.spanInputs`, `mlflow.spanOutputs` |

### Testing
- Tested manually against a remote MLflow instance (OpenShift-hosted) with OTLP/HTTP protobuf export
- Verified traces appear in MLflow with populated Request and Response columns
- Verified `gen_ai.*` attributes appear on spans in trace detail view
- `cargo fmt` — clean
- `cargo clippy -p goose --all-targets -- -D warnings` — clean
- `cargo test -p goose` — 1,472 passed; 5 pre-existing failures unrelated to this change

### Related Issues
Relates to #10592

🤖 Generated with [Claude Code](https://claude.com/claude-code)