### PR TITLE
fix(providers): retry streaming requests dropped before first body bytes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5225,6 +5225,7 @@ dependencies = [
  "anyhow",
  "async-stream",
  "async-trait",
+ "bytes",
  "chrono",
  "env-lock",
  "futures",

--- a/crates/goose-provider-types/src/conversation/message.rs
+++ b/crates/goose-provider-types/src/conversation/message.rs
@@ -1580,7 +1580,7 @@ mod tests {
         );
         let mut result = CallToolResult::success(vec![text, image]);
         result.structured_content = Some(serde_json::json!({"safe": "世界"}));
-        result.meta = Some(rmcp::model::Meta(object!({"source": "test"})));
+        result.meta = Some(rmcp::model::MetaObject(object!({"source": "test"})));
         let expected = result.clone();
 
         let content = MessageContentBlock::tool_response("tool-1", Ok(result));

--- a/crates/goose-providers/Cargo.toml
+++ b/crates/goose-providers/Cargo.toml
@@ -54,6 +54,7 @@ pkcs1 = { version = "0.7.5", default-features = false, features = ["pkcs8", "std
 pkcs8 = { version = "0.10", default-features = false, features = ["alloc", "std"], optional = true }
 sec1 = { version = "0.7", default-features = false, features = ["der", "pkcs8", "std"], optional = true }
 include_dir = { workspace = true }
+bytes = { workspace = true }
 
 [dev-dependencies]
 test-case = { workspace = true }

--- a/crates/goose-providers/src/anthropic.rs
+++ b/crates/goose-providers/src/anthropic.rs
@@ -9,7 +9,6 @@ use async_trait::async_trait;
 use futures::TryStreamExt;
 use reqwest::StatusCode;
 use serde_json::Value;
-use std::io;
 use tokio::pin;
 use tokio_util::io::StreamReader;
 
@@ -19,7 +18,7 @@ use super::formats::anthropic::{
     create_request_for_model, response_to_streaming_message, AnthropicFormatOptions,
     ANTHROPIC_PROVIDER_NAME,
 };
-use super::openai_compatible::handle_status;
+use super::openai_compatible::{body_stream_with_prefix, first_body_chunk, handle_status};
 use super::retry::ProviderRetry;
 use crate::conversation::message::Message;
 use crate::model::ModelConfig;
@@ -182,9 +181,9 @@ impl AnthropicProvider {
         )?;
         payload["stream"] = Value::Bool(true);
         let mut log = start_log(model_config, &payload)?;
-        let response = self
+        let (response, first_chunk) = self
             .with_retry(|| async {
-                handle_status(
+                let mut response = handle_status(
                     self.api_client
                         .request("v1/messages")
                         .model_headers(model_config)?
@@ -192,13 +191,15 @@ impl AnthropicProvider {
                         .response_post(&payload)
                         .await?,
                 )
-                .await
+                .await?;
+                let first_chunk = first_body_chunk(&mut response).await?;
+                Ok((response, Some(first_chunk)))
             })
             .await
             .inspect_err(|e| {
                 let _ = log.error(e);
             })?;
-        let stream = response.bytes_stream().map_err(io::Error::other);
+        let stream = body_stream_with_prefix(response, first_chunk);
         Ok(Box::pin(try_stream! {
             let reader = StreamReader::new(stream);
             let framed = tokio_util::codec::FramedRead::new(reader, tokio_util::codec::LinesCodec::new()).map_err(anyhow::Error::from);

--- a/crates/goose-providers/src/databricks.rs
+++ b/crates/goose-providers/src/databricks.rs
@@ -24,8 +24,8 @@ pub use crate::formats::databricks::DATABRICKS_PROVIDER_NAME;
 use crate::formats::openai_responses::create_responses_request;
 use crate::model::ModelConfig;
 use crate::openai_compatible::{
-    handle_status, map_http_error_to_provider_error, sanitize_url, stream_openai_compat,
-    stream_responses_compat,
+    first_body_chunk, handle_status, map_http_error_to_provider_error, sanitize_url,
+    stream_openai_compat_with_prefix, stream_responses_compat_with_prefix,
 };
 use crate::request_log::{start_log, LoggerHandleExt};
 use crate::retry::ProviderRetry;
@@ -594,24 +594,27 @@ impl Provider for DatabricksProvider {
 
             let mut log = start_log(model_config, &payload)?;
 
-            let response = self
+            let (response, first_chunk) = self
                 .with_retry(|| async {
                     let payload_clone = payload.clone();
-                    let resp = self
-                        .api_client
-                        .request(&path)
-                        .model_headers(model_config)?
-                        .streaming(true)
-                        .response_post(&payload_clone)
-                        .await?;
-                    handle_status(resp).await
+                    let mut response = handle_status(
+                        self.api_client
+                            .request(&path)
+                            .model_headers(model_config)?
+                            .streaming(true)
+                            .response_post(&payload_clone)
+                            .await?,
+                    )
+                    .await?;
+                    let first_chunk = first_body_chunk(&mut response).await?;
+                    Ok((response, Some(first_chunk)))
                 })
                 .await
                 .inspect_err(|e| {
                     let _ = log.error(e);
                 })?;
 
-            stream_responses_compat(response, log)
+            stream_responses_compat_with_prefix(response, first_chunk, log)
         } else {
             let format_model_config;
             let request_model_config = if Self::is_claude_model(effective_model_name)
@@ -663,31 +666,7 @@ impl Provider for DatabricksProvider {
             let mut log = start_log(model_config, &payload)?;
             let response = self
                 .with_retry(|| async {
-                    let resp = self
-                        .api_client
-                        .request(&path)
-                        .model_headers(model_config)?
-                        .streaming(true)
-                        .response_post(&payload)
-                        .await?;
-                    if !resp.status().is_success() {
-                        let status = resp.status();
-                        let url = sanitize_url(resp.url().as_str());
-                        let error_text = crate::http_status::read_error_body(resp)
-                            .await
-                            .unwrap_or_default();
-
-                        let json_payload = serde_json::from_str::<Value>(&error_text).ok();
-                        return Err(map_http_error_to_provider_error(status, json_payload, &url));
-                    }
-                    Ok(resp)
-                })
-                .await;
-
-            let response = match response {
-                Err(e) if e.to_string().contains("stream_options") => {
-                    payload.as_object_mut().unwrap().remove("stream_options");
-                    self.with_retry(|| async {
+                    let mut response = {
                         let resp = self
                             .api_client
                             .request(&path)
@@ -701,6 +680,7 @@ impl Provider for DatabricksProvider {
                             let error_text = crate::http_status::read_error_body(resp)
                                 .await
                                 .unwrap_or_default();
+
                             let json_payload = serde_json::from_str::<Value>(&error_text).ok();
                             return Err(map_http_error_to_provider_error(
                                 status,
@@ -708,7 +688,42 @@ impl Provider for DatabricksProvider {
                                 &url,
                             ));
                         }
-                        Ok(resp)
+                        resp
+                    };
+                    let first_chunk = first_body_chunk(&mut response).await?;
+                    Ok((response, Some(first_chunk)))
+                })
+                .await;
+
+            let (response, first_chunk) = match response {
+                Err(e) if e.to_string().contains("stream_options") => {
+                    payload.as_object_mut().unwrap().remove("stream_options");
+                    self.with_retry(|| async {
+                        let mut response = {
+                            let resp = self
+                                .api_client
+                                .request(&path)
+                                .model_headers(model_config)?
+                                .streaming(true)
+                                .response_post(&payload)
+                                .await?;
+                            if !resp.status().is_success() {
+                                let status = resp.status();
+                                let url = sanitize_url(resp.url().as_str());
+                                let error_text = crate::http_status::read_error_body(resp)
+                                    .await
+                                    .unwrap_or_default();
+                                let json_payload = serde_json::from_str::<Value>(&error_text).ok();
+                                return Err(map_http_error_to_provider_error(
+                                    status,
+                                    json_payload,
+                                    &url,
+                                ));
+                            }
+                            resp
+                        };
+                        let first_chunk = first_body_chunk(&mut response).await?;
+                        Ok((response, Some(first_chunk)))
                     })
                     .await
                     .inspect_err(|e| {
@@ -722,7 +737,7 @@ impl Provider for DatabricksProvider {
                 Ok(resp) => resp,
             };
 
-            stream_openai_compat(response, log)
+            stream_openai_compat_with_prefix(response, first_chunk, log)
         }
     }
 

--- a/crates/goose-providers/src/databricks_v2.rs
+++ b/crates/goose-providers/src/databricks_v2.rs
@@ -25,7 +25,10 @@ use crate::errors::ProviderError;
 use crate::formats::anthropic;
 use crate::formats::openai_responses;
 use crate::model::ModelConfig;
-use crate::openai_compatible::{handle_status, stream_openai_compat, stream_responses_compat};
+use crate::openai_compatible::{
+    first_body_chunk, handle_status, stream_openai_compat_with_prefix,
+    stream_responses_compat_with_prefix,
+};
 use crate::request_log::{start_log, LoggerHandleExt};
 use crate::retry::ProviderRetry;
 use crate::retry::{
@@ -201,23 +204,26 @@ impl DatabricksV2Provider {
         payload["stream"] = Value::Bool(true);
         let mut log = start_log(model_config, &payload)?;
 
-        let response = self
+        let (response, first_chunk) = self
             .with_retry(|| async {
-                let resp = self
-                    .api_client
-                    .request("ai-gateway/openai/v1/responses")
-                    .model_headers(model_config)?
-                    .streaming(true)
-                    .response_post(&payload)
-                    .await?;
-                handle_status(resp).await
+                let mut response = handle_status(
+                    self.api_client
+                        .request("ai-gateway/openai/v1/responses")
+                        .model_headers(model_config)?
+                        .streaming(true)
+                        .response_post(&payload)
+                        .await?,
+                )
+                .await?;
+                let first_chunk = first_body_chunk(&mut response).await?;
+                Ok((response, Some(first_chunk)))
             })
             .await
             .inspect_err(|e| {
                 let _ = log.error(e);
             })?;
 
-        stream_responses_compat(response, log)
+        stream_responses_compat_with_prefix(response, first_chunk, log)
     }
 
     async fn stream_mlflow_chat_completions(
@@ -240,23 +246,26 @@ impl DatabricksV2Provider {
         }
         let mut log = start_log(model_config, &payload)?;
 
-        let response = self
+        let (response, first_chunk) = self
             .with_retry(|| async {
-                let resp = self
-                    .api_client
-                    .request("ai-gateway/mlflow/v1/chat/completions")
-                    .model_headers(model_config)?
-                    .streaming(true)
-                    .response_post(&payload)
-                    .await?;
-                handle_status(resp).await
+                let mut response = handle_status(
+                    self.api_client
+                        .request("ai-gateway/mlflow/v1/chat/completions")
+                        .model_headers(model_config)?
+                        .streaming(true)
+                        .response_post(&payload)
+                        .await?,
+                )
+                .await?;
+                let first_chunk = first_body_chunk(&mut response).await?;
+                Ok((response, Some(first_chunk)))
             })
             .await
             .inspect_err(|e| {
                 let _ = log.error(e);
             })?;
 
-        stream_openai_compat(response, log)
+        stream_openai_compat_with_prefix(response, first_chunk, log)
     }
 
     async fn stream_anthropic_messages(

--- a/crates/goose-providers/src/databricks_v2.rs
+++ b/crates/goose-providers/src/databricks_v2.rs
@@ -7,7 +7,6 @@ use async_trait::async_trait;
 use futures::TryStreamExt;
 use serde::Serialize;
 use serde_json::Value;
-use std::io;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tokio::pin;
@@ -26,7 +25,7 @@ use crate::formats::anthropic;
 use crate::formats::openai_responses;
 use crate::model::ModelConfig;
 use crate::openai_compatible::{
-    first_body_chunk, handle_status, stream_openai_compat_with_prefix,
+    body_stream_with_prefix, first_body_chunk, handle_status, stream_openai_compat_with_prefix,
     stream_responses_compat_with_prefix,
 };
 use crate::request_log::{start_log, LoggerHandleExt};
@@ -286,23 +285,26 @@ impl DatabricksV2Provider {
         payload["stream"] = Value::Bool(true);
         let mut log = start_log(model_config, &payload)?;
 
-        let response = self
+        let (response, first_chunk) = self
             .with_retry(|| async {
-                let resp = self
-                    .api_client
-                    .request("ai-gateway/anthropic/v1/messages")
-                    .model_headers(model_config)?
-                    .streaming(true)
-                    .response_post(&payload)
-                    .await?;
-                handle_status(resp).await
+                let mut response = handle_status(
+                    self.api_client
+                        .request("ai-gateway/anthropic/v1/messages")
+                        .model_headers(model_config)?
+                        .streaming(true)
+                        .response_post(&payload)
+                        .await?,
+                )
+                .await?;
+                let first_chunk = first_body_chunk(&mut response).await?;
+                Ok((response, Some(first_chunk)))
             })
             .await
             .inspect_err(|e| {
                 let _ = log.error(e);
             })?;
 
-        let stream = response.bytes_stream().map_err(io::Error::other);
+        let stream = body_stream_with_prefix(response, first_chunk);
 
         Ok(Box::pin(try_stream! {
             let stream_reader = StreamReader::new(stream);

--- a/crates/goose-providers/src/google.rs
+++ b/crates/goose-providers/src/google.rs
@@ -2,7 +2,10 @@ use crate::api_client::{ApiClient, AuthMethod};
 use crate::base::MessageStream;
 use crate::conversation::message::Message;
 use crate::errors::ProviderError;
-use crate::openai_compatible::{handle_status, map_http_error_to_provider_error, sanitize_url};
+use crate::openai_compatible::{
+    body_stream_with_prefix, first_body_chunk, handle_status, map_http_error_to_provider_error,
+    sanitize_url,
+};
 use crate::retry::ProviderRetry;
 
 use crate::base::{ConfigKey, Provider, ProviderMetadata};
@@ -15,7 +18,6 @@ use async_trait::async_trait;
 use futures::TryStreamExt;
 use rmcp::model::Tool;
 use serde_json::Value;
-use std::io;
 use tokio::pin;
 use tokio_stream::StreamExt;
 use tokio_util::codec::{FramedRead, LinesCodec};
@@ -192,14 +194,18 @@ impl Provider for GoogleProvider {
         )?;
         let mut log = start_log(model_config, &payload)?;
 
-        let response = self
-            .with_retry(|| async { self.post_stream(model_config, &payload).await })
+        let (response, first_chunk) = self
+            .with_retry(|| async {
+                let mut response = self.post_stream(model_config, &payload).await?;
+                let first_chunk = first_body_chunk(&mut response).await?;
+                Ok((response, Some(first_chunk)))
+            })
             .await
             .inspect_err(|e| {
                 let _ = log.error(e);
             })?;
 
-        let stream = response.bytes_stream().map_err(io::Error::other);
+        let stream = body_stream_with_prefix(response, first_chunk);
 
         Ok(Box::pin(try_stream! {
             let stream_reader = StreamReader::new(stream);

--- a/crates/goose-providers/src/ollama.rs
+++ b/crates/goose-providers/src/ollama.rs
@@ -1,6 +1,6 @@
 use super::api_client::ApiClient;
 use super::base::{ConfigKey, MessageStream, Provider, ProviderMetadata};
-use super::openai_compatible::handle_status;
+use super::openai_compatible::{body_stream_with_prefix, first_body_chunk, handle_status};
 use super::retry::{ProviderRetry, RetryConfig};
 use crate::api_client::{AuthMethod, TlsConfig};
 use crate::base::ProviderDescriptor;
@@ -422,22 +422,25 @@ impl Provider for OllamaProvider {
         apply_ollama_options(&mut payload, &self.options, model_config);
         let mut log = start_log(model_config, &payload)?;
 
-        let response = self
+        let (response, first_chunk) = self
             .with_retry(|| async {
-                let resp = self
-                    .api_client
-                    .request("v1/chat/completions")
-                    .model_headers(model_config)?
-                    .streaming(true)
-                    .response_post(&payload)
-                    .await?;
-                handle_status(resp).await
+                let mut response = handle_status(
+                    self.api_client
+                        .request("v1/chat/completions")
+                        .model_headers(model_config)?
+                        .streaming(true)
+                        .response_post(&payload)
+                        .await?,
+                )
+                .await?;
+                let first_chunk = first_body_chunk(&mut response).await?;
+                Ok((response, Some(first_chunk)))
             })
             .await
             .inspect_err(|e| {
                 let _ = log.error(e);
             })?;
-        stream_ollama(response, self.options.chunk_timeout_secs, log)
+        stream_ollama(response, first_chunk, self.options.chunk_timeout_secs, log)
     }
 
     async fn fetch_supported_models(&self) -> Result<Vec<String>, ProviderError> {
@@ -513,10 +516,11 @@ fn with_line_timeout(
 /// buffering inside response_to_streaming_message_ollama does not cause false stalls.
 fn stream_ollama(
     response: Response,
+    first_chunk: Option<bytes::Bytes>,
     chunk_timeout: u64,
     mut log: Option<Box<dyn RequestLogHandle>>,
 ) -> Result<MessageStream, ProviderError> {
-    let stream = response.bytes_stream().map_err(std::io::Error::other);
+    let stream = body_stream_with_prefix(response, first_chunk);
 
     Ok(Box::pin(try_stream! {
         let stream_reader = StreamReader::new(stream);

--- a/crates/goose-providers/src/openai.rs
+++ b/crates/goose-providers/src/openai.rs
@@ -17,7 +17,8 @@ use crate::formats::openai_responses::{
 };
 use crate::images::ImageFormat;
 use crate::openai_compatible::{
-    handle_response_openai_compat, handle_status, stream_openai_compat, stream_responses_compat,
+    first_body_chunk, handle_response_openai_compat, handle_status,
+    stream_openai_compat_with_prefix, stream_responses_compat_with_prefix,
 };
 use crate::request_log::{start_log, LoggerHandleExt};
 use crate::thinking::ThinkingEffort;
@@ -301,9 +302,11 @@ impl OpenAiProvider {
         payload: serde_json::Value,
     ) -> Result<MessageStream, ProviderError> {
         let mut log = start_log(model_config, &payload)?;
-        let response = self
+        // For streaming, pre-read the first body chunk inside the retry scope so a
+        // 200 OK whose connection dies before any body bytes still retries.
+        let (response, first_chunk) = self
             .with_retry(|| async {
-                handle_status(
+                let mut response = handle_status(
                     self.api_client
                         .request(&Self::map_base_path(
                             &self.base_path,
@@ -315,14 +318,20 @@ impl OpenAiProvider {
                         .response_post(&payload)
                         .await?,
                 )
-                .await
+                .await?;
+                let first_chunk = if self.supports_streaming {
+                    Some(first_body_chunk(&mut response).await?)
+                } else {
+                    None
+                };
+                Ok((response, first_chunk))
             })
             .await
             .inspect_err(|e| {
                 let _ = log.error(e);
             })?;
         if self.supports_streaming {
-            stream_responses_compat(response, log)
+            stream_responses_compat_with_prefix(response, first_chunk, log)
         } else {
             let json: serde_json::Value = response.json().await.map_err(|e| {
                 ProviderError::RequestFailed(format!("Failed to parse JSON: {}", e))
@@ -792,16 +801,25 @@ impl Provider for OpenAiProvider {
             let payload = self.sanitize_request_for_compat(payload, model_config);
             let mut log = start_log(model_config, &payload)?;
 
-            let response = self
+            // For streaming, pre-read the first body chunk inside the retry scope so a
+            // 200 OK whose connection dies before any body bytes still retries.
+            let (response, first_chunk) = self
                 .with_retry(|| async {
-                    let resp = self
-                        .api_client
-                        .request(&self.base_path)
-                        .model_headers(model_config)?
-                        .streaming(self.supports_streaming)
-                        .response_post(&payload)
-                        .await?;
-                    handle_status(resp).await
+                    let mut response = handle_status(
+                        self.api_client
+                            .request(&self.base_path)
+                            .model_headers(model_config)?
+                            .streaming(self.supports_streaming)
+                            .response_post(&payload)
+                            .await?,
+                    )
+                    .await?;
+                    let first_chunk = if self.supports_streaming {
+                        Some(first_body_chunk(&mut response).await?)
+                    } else {
+                        None
+                    };
+                    Ok((response, first_chunk))
                 })
                 .await
                 .inspect_err(|e| {
@@ -809,7 +827,7 @@ impl Provider for OpenAiProvider {
                 })?;
 
             if self.supports_streaming {
-                stream_openai_compat(response, log)
+                stream_openai_compat_with_prefix(response, first_chunk, log)
             } else {
                 let json: serde_json::Value = response.json().await.map_err(|e| {
                     ProviderError::RequestFailed(format!("Failed to parse JSON: {}", e))
@@ -1701,5 +1719,165 @@ mod tests {
         assert_eq!(payload["stream"], json!(true));
         assert_eq!(payload["stream_options"], json!({"include_usage": true}));
         assert_eq!(payload["messages"].as_array().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn stream_retries_when_connection_drops_before_first_body_bytes() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::{TcpListener, TcpStream};
+        use tokio_stream::StreamExt;
+
+        async fn read_request(socket: &mut TcpStream) {
+            let mut buf = Vec::new();
+            let mut chunk = [0u8; 4096];
+            loop {
+                let n = socket.read(&mut chunk).await.unwrap();
+                if n == 0 {
+                    break;
+                }
+                buf.extend_from_slice(&chunk[..n]);
+                if buf.windows(4).any(|w| w == b"\r\n\r\n") {
+                    break;
+                }
+            }
+        }
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let server = tokio::spawn(async move {
+            // First attempt: 200 headers promise a 1024-byte body, then the
+            // connection drops without delivering any of it — consuming the
+            // body fails with reqwest's "error decoding response body".
+            let (mut socket, _) = listener.accept().await.unwrap();
+            read_request(&mut socket).await;
+            socket
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\ncontent-length: 1024\r\n\r\n",
+                )
+                .await
+                .unwrap();
+            socket.shutdown().await.unwrap();
+
+            // Retried attempt: a complete SSE response.
+            let (mut socket, _) = listener.accept().await.unwrap();
+            read_request(&mut socket).await;
+            let body = concat!(
+                "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"created\":1,",
+                "\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,",
+                "\"delta\":{\"role\":\"assistant\",\"content\":\"hello\"},\"finish_reason\":\"stop\"}]}\n\n",
+                "data: [DONE]\n\n",
+            );
+            let response = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\ncontent-length: {}\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            socket.write_all(response.as_bytes()).await.unwrap();
+            socket.shutdown().await.unwrap();
+        });
+
+        let provider = OpenAiProvider {
+            api_client: ApiClient::new_with_tls(format!("http://{addr}"), AuthMethod::NoAuth, None)
+                .unwrap(),
+            ..make_provider("openai")
+        };
+
+        let model_config = ModelConfig::new("gpt-4o");
+        let messages = vec![Message::user().with_text("hi")];
+        let mut stream = provider
+            .stream(&model_config, "system", &messages, &[])
+            .await
+            .expect("dropped pre-body connection should be transparently retried");
+
+        let mut text = String::new();
+        while let Some(item) = stream.next().await {
+            let (message, _usage) = item.expect("stream item should be ok");
+            if let Some(message) = message {
+                text.push_str(&message.as_concat_text());
+            }
+        }
+        server.await.unwrap();
+        assert_eq!(text, "hello");
+    }
+
+    #[tokio::test]
+    async fn stream_retries_when_connection_closes_cleanly_before_first_body_bytes() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::{TcpListener, TcpStream};
+        use tokio_stream::StreamExt;
+
+        async fn read_request(socket: &mut TcpStream) {
+            let mut buf = Vec::new();
+            let mut chunk = [0u8; 4096];
+            loop {
+                let n = socket.read(&mut chunk).await.unwrap();
+                if n == 0 {
+                    break;
+                }
+                buf.extend_from_slice(&chunk[..n]);
+                if buf.windows(4).any(|w| w == b"\r\n\r\n") {
+                    break;
+                }
+            }
+        }
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let server = tokio::spawn(async move {
+            // First attempt: connection-close framing with zero body bytes —
+            // a clean EOF, so chunk() returns Ok(None) rather than an error.
+            // An empty body is not a valid streaming response and must be
+            // retried like any other pre-first-token failure.
+            let (mut socket, _) = listener.accept().await.unwrap();
+            read_request(&mut socket).await;
+            socket
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\nconnection: close\r\n\r\n",
+                )
+                .await
+                .unwrap();
+            socket.shutdown().await.unwrap();
+
+            let (mut socket, _) = listener.accept().await.unwrap();
+            read_request(&mut socket).await;
+            let body = concat!(
+                "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"created\":1,",
+                "\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,",
+                "\"delta\":{\"role\":\"assistant\",\"content\":\"hello\"},\"finish_reason\":\"stop\"}]}\n\n",
+                "data: [DONE]\n\n",
+            );
+            let response = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\ncontent-length: {}\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            socket.write_all(response.as_bytes()).await.unwrap();
+            socket.shutdown().await.unwrap();
+        });
+
+        let provider = OpenAiProvider {
+            api_client: ApiClient::new_with_tls(format!("http://{addr}"), AuthMethod::NoAuth, None)
+                .unwrap(),
+            ..make_provider("openai")
+        };
+
+        let model_config = ModelConfig::new("gpt-4o");
+        let messages = vec![Message::user().with_text("hi")];
+        let mut stream = provider
+            .stream(&model_config, "system", &messages, &[])
+            .await
+            .expect("clean pre-body EOF should be transparently retried");
+
+        let mut text = String::new();
+        while let Some(item) = stream.next().await {
+            let (message, _usage) = item.expect("stream item should be ok");
+            if let Some(message) = message {
+                text.push_str(&message.as_concat_text());
+            }
+        }
+        server.await.unwrap();
+        assert_eq!(text, "hello");
     }
 }

--- a/crates/goose-providers/src/openai_compatible.rs
+++ b/crates/goose-providers/src/openai_compatible.rs
@@ -2,11 +2,14 @@ use crate::conversation::token_usage::{CostSource, ProviderUsage};
 use crate::images::ImageFormat;
 use anyhow::Error;
 use async_stream::try_stream;
+use bytes::Bytes;
+use futures::Stream;
 use futures::TryStreamExt;
 use reqwest::Response;
 #[cfg(test)]
 use reqwest::StatusCode;
 use serde_json::Value;
+use std::pin::Pin;
 use tokio::pin;
 use tokio_stream::StreamExt;
 use tokio_util::codec::{FramedRead, LinesCodec};
@@ -106,9 +109,11 @@ impl OpenAiCompatibleProvider {
     ) -> Result<MessageStream, ProviderError> {
         let mut log = start_log(model_config, &payload)?;
         let path = format!("{}chat/completions", self.completions_prefix);
-        let response = self
+        // For streaming, pre-read the first body chunk inside the retry scope so a
+        // 200 OK whose connection dies before any body bytes still retries.
+        let (response, first_chunk) = self
             .with_retry(|| async {
-                handle_status(
+                let mut response = handle_status(
                     self.api_client
                         .request(&path)
                         .model_headers(model_config)?
@@ -116,14 +121,20 @@ impl OpenAiCompatibleProvider {
                         .response_post(&payload)
                         .await?,
                 )
-                .await
+                .await?;
+                let first_chunk = if self.supports_streaming {
+                    Some(first_body_chunk(&mut response).await?)
+                } else {
+                    None
+                };
+                Ok((response, first_chunk))
             })
             .await
             .inspect_err(|e| {
                 let _ = log.error(e);
             })?;
         if self.supports_streaming {
-            stream_openai_compat(response, log)
+            stream_openai_compat_with_prefix(response, first_chunk, log)
         } else {
             let json = response.json().await.map_err(|e| {
                 ProviderError::RequestFailed(format!("Failed to parse JSON: {}", e))
@@ -232,11 +243,53 @@ pub use super::http_status::{
 // Legacy alias kept for callers that haven't migrated their import path yet.
 pub use super::http_status::handle_response as handle_response_openai_compat;
 
+/// Reads the first chunk of a streaming response body.
+///
+/// A `200 OK` whose connection dies before delivering any body bytes only
+/// fails here, while the caller is still inside its `with_retry` scope —
+/// afterwards the failure would surface as a mid-stream item error where
+/// retry is unreachable. A clean EOF is also an error: an empty body is
+/// never a valid answer to a streaming request, and `Ok(None)` here would
+/// otherwise complete the retry scope with a stream that yields nothing.
+pub async fn first_body_chunk(response: &mut Response) -> Result<Bytes, ProviderError> {
+    response
+        .chunk()
+        .await
+        .map_err(ProviderError::stream_decode_error)?
+        .ok_or_else(|| {
+            ProviderError::stream_decode_error("stream ended before the first body chunk")
+        })
+}
+
+fn body_stream_with_prefix(
+    response: Response,
+    first_chunk: Option<Bytes>,
+) -> Pin<Box<dyn Stream<Item = std::io::Result<Bytes>> + Send>> {
+    Box::pin(async_stream::stream! {
+        if let Some(chunk) = first_chunk {
+            yield Ok(chunk);
+        }
+        let body = response.bytes_stream().map_err(std::io::Error::other);
+        tokio::pin!(body);
+        while let Some(item) = body.next().await {
+            yield item;
+        }
+    })
+}
+
 pub fn stream_openai_compat(
     response: Response,
+    log: Option<Box<dyn RequestLogHandle>>,
+) -> Result<MessageStream, ProviderError> {
+    stream_openai_compat_with_prefix(response, None, log)
+}
+
+pub fn stream_openai_compat_with_prefix(
+    response: Response,
+    first_chunk: Option<Bytes>,
     mut log: Option<Box<dyn RequestLogHandle>>,
 ) -> Result<MessageStream, ProviderError> {
-    let stream = response.bytes_stream().map_err(std::io::Error::other);
+    let stream = body_stream_with_prefix(response, first_chunk);
 
     Ok(Box::pin(try_stream! {
         let stream_reader = StreamReader::new(stream);
@@ -258,9 +311,17 @@ pub fn stream_openai_compat(
 
 pub fn stream_responses_compat(
     response: Response,
+    log: Option<Box<dyn RequestLogHandle>>,
+) -> Result<MessageStream, ProviderError> {
+    stream_responses_compat_with_prefix(response, None, log)
+}
+
+pub fn stream_responses_compat_with_prefix(
+    response: Response,
+    first_chunk: Option<Bytes>,
     mut log: Option<Box<dyn RequestLogHandle>>,
 ) -> Result<MessageStream, ProviderError> {
-    let stream = response.bytes_stream().map_err(std::io::Error::other);
+    let stream = body_stream_with_prefix(response, first_chunk);
 
     Ok(Box::pin(try_stream! {
         let stream_reader = StreamReader::new(stream);

--- a/crates/goose-providers/src/openai_compatible.rs
+++ b/crates/goose-providers/src/openai_compatible.rs
@@ -261,7 +261,7 @@ pub async fn first_body_chunk(response: &mut Response) -> Result<Bytes, Provider
         })
 }
 
-fn body_stream_with_prefix(
+pub fn body_stream_with_prefix(
     response: Response,
     first_chunk: Option<Bytes>,
 ) -> Pin<Box<dyn Stream<Item = std::io::Result<Bytes>> + Send>> {

--- a/crates/goose/Cargo.toml
+++ b/crates/goose/Cargo.toml
@@ -98,6 +98,7 @@ thiserror = { workspace = true }
 futures = { workspace = true }
 dirs = { workspace = true }
 reqwest = { workspace = true, features = ["json", "cookies", "gzip", "brotli", "deflate", "zstd", "charset", "http2", "stream", "blocking", "multipart", "system-proxy"] }
+bytes = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "sync", "time", "fs", "process", "net", "signal", "io-std", "io-util"] }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/goose/src/providers/bedrock.rs
+++ b/crates/goose/src/providers/bedrock.rs
@@ -4,7 +4,9 @@ use super::base::{
     ConfigKey, MessageStream, Provider, ProviderDef, ProviderMetadata,
     DEFAULT_CONNECT_TIMEOUT_SECS, DEFAULT_PROVIDER_TIMEOUT_SECS,
 };
-use super::openai_compatible::{handle_status, stream_responses_compat};
+use super::openai_compatible::{
+    first_body_chunk, handle_status, stream_responses_compat_with_prefix,
+};
 use super::retry::{ProviderRetry, RetryConfig};
 use crate::conversation::message::Message;
 use crate::session_context::SESSION_ID_HEADER;
@@ -244,7 +246,7 @@ impl BedrockProvider {
         &self,
         session_id: Option<&str>,
         payload: &Value,
-    ) -> Result<reqwest::Response, ProviderError> {
+    ) -> Result<(reqwest::Response, Option<bytes::Bytes>), ProviderError> {
         let region = self.region.as_deref().ok_or_else(|| {
             ProviderError::Authentication(
                 "AWS region is required for Bedrock mantle endpoint".to_string(),
@@ -284,7 +286,9 @@ impl BedrockProvider {
         )
         .await?;
 
-        handle_status(response).await
+        let mut response = handle_status(response).await?;
+        let first_chunk = first_body_chunk(&mut response).await?;
+        Ok((response, Some(first_chunk)))
     }
 
     /// Build the request inputs shared by [`Self::converse`] and
@@ -808,14 +812,14 @@ impl Provider for BedrockProvider {
             payload["stream"] = Value::Bool(true);
             let mut log = start_log(model_config, &payload).map_err(anyhow::Error::from)?;
 
-            let response = self
+            let (response, first_chunk) = self
                 .with_retry(|| self.post_mantle_streaming(session_id_opt, &payload))
                 .await
                 .inspect_err(|e| {
                     let _ = log.error(e);
                 })?;
 
-            return stream_responses_compat(response, log);
+            return stream_responses_compat_with_prefix(response, first_chunk, log);
         }
 
         let model_name = model_config.model_name.clone();

--- a/crates/goose/src/providers/chatgpt_codex.rs
+++ b/crates/goose/src/providers/chatgpt_codex.rs
@@ -5,7 +5,9 @@ use crate::providers::base::{
     ConfigKey, MessageStream, Provider, ProviderDef, ProviderMetadata,
     DEFAULT_CONNECT_TIMEOUT_SECS, DEFAULT_PROVIDER_TIMEOUT_SECS,
 };
-use crate::providers::openai_compatible::handle_status;
+use crate::providers::openai_compatible::{
+    body_stream_with_prefix, first_body_chunk, handle_status,
+};
 use crate::providers::private_file::write_private_file;
 use crate::providers::retry::ProviderRetry;
 use anyhow::{anyhow, Result};
@@ -1001,14 +1003,16 @@ impl Provider for ChatGptCodexProvider {
             .map_err(|e| ProviderError::ExecutionError(e.to_string()))?;
         payload["stream"] = serde_json::Value::Bool(true);
 
-        let response = self
+        let (response, first_chunk) = self
             .with_retry(|| async {
                 let payload_clone = payload.clone();
-                self.post_streaming(&payload_clone).await
+                let mut response = self.post_streaming(&payload_clone).await?;
+                let first_chunk = first_body_chunk(&mut response).await?;
+                Ok((response, Some(first_chunk)))
             })
             .await?;
 
-        let stream = response.bytes_stream().map_err(io::Error::other);
+        let stream = body_stream_with_prefix(response, first_chunk);
 
         Ok(Box::pin(try_stream! {
             let stream_reader = StreamReader::new(stream);

--- a/crates/goose/src/providers/gcpvertexai.rs
+++ b/crates/goose/src/providers/gcpvertexai.rs
@@ -1,4 +1,3 @@
-use std::io;
 use std::time::Duration;
 
 use anyhow::Result;
@@ -27,7 +26,9 @@ use crate::providers::formats::gcpvertexai::{
     DEFAULT_MODEL, KNOWN_MODELS,
 };
 use crate::providers::gcpauth::GcpAuth;
-use crate::providers::openai_compatible::{map_http_error_to_provider_error, sanitize_url};
+use crate::providers::openai_compatible::{
+    body_stream_with_prefix, first_body_chunk, map_http_error_to_provider_error, sanitize_url,
+};
 use crate::providers::retry::RetryConfig;
 use goose_providers::errors::ProviderError;
 use goose_providers::http_status::read_error_body;
@@ -284,7 +285,7 @@ impl GcpVertexAIProvider {
         model: &ModelConfig,
         url: Url,
         payload: &Value,
-    ) -> Result<reqwest::Response, ProviderError> {
+    ) -> Result<(reqwest::Response, Option<bytes::Bytes>), ProviderError> {
         let mut rate_limit_attempts = 0;
         let mut overloaded_attempts = 0;
         let mut last_error = None;
@@ -376,7 +377,23 @@ impl GcpVertexAIProvider {
                 });
                 sleep(self.retry_config.delay_for_attempt(overloaded_attempts)).await;
             } else if status == StatusCode::OK {
-                return Ok(response);
+                // Pre-read the first body chunk inside the retry loop so a 200
+                // whose connection dies before any body bytes still retries.
+                let mut response = response;
+                match first_body_chunk(&mut response).await {
+                    Ok(first_chunk) => return Ok((response, Some(first_chunk))),
+                    Err(e) => {
+                        rate_limit_attempts += 1;
+                        if rate_limit_attempts > max_retries {
+                            return Err(e);
+                        }
+                        tracing::warn!(
+                            "pre-body stream failure (attempt {rate_limit_attempts}/{max_retries}): {e}"
+                        );
+                        last_error = Some(e);
+                        sleep(self.retry_config.delay_for_attempt(rate_limit_attempts)).await;
+                    }
+                }
             } else if status == StatusCode::UNAUTHORIZED || status == StatusCode::FORBIDDEN {
                 if !retried_auth {
                     retried_auth = true;
@@ -407,7 +424,7 @@ impl GcpVertexAIProvider {
         payload: &Value,
         context: &RequestContext,
         location: &str,
-    ) -> Result<reqwest::Response, ProviderError> {
+    ) -> Result<(reqwest::Response, Option<bytes::Bytes>), ProviderError> {
         let url = self
             .build_request_url(model, context.provider(), location, true)
             .map_err(|e| ProviderError::RequestFailed(e.to_string()))?;
@@ -420,7 +437,7 @@ impl GcpVertexAIProvider {
         model: &ModelConfig,
         payload: &Value,
         context: &RequestContext,
-    ) -> Result<reqwest::Response, ProviderError> {
+    ) -> Result<(reqwest::Response, Option<bytes::Bytes>), ProviderError> {
         let result = self
             .post_stream_with_location(model, payload, context, &self.location)
             .await;
@@ -628,14 +645,14 @@ impl Provider for GcpVertexAIProvider {
 
         let mut log = start_log(model_config, &request)?;
 
-        let response = self
+        let (response, first_chunk) = self
             .post_stream(model_config, &request, &context)
             .await
             .inspect_err(|e| {
                 let _ = log.error(e);
             })?;
 
-        let stream = response.bytes_stream().map_err(io::Error::other);
+        let stream = body_stream_with_prefix(response, first_chunk);
 
         let context_clone = context.clone();
         Ok(Box::pin(try_stream! {

--- a/crates/goose/src/providers/gemini_oauth.rs
+++ b/crates/goose/src/providers/gemini_oauth.rs
@@ -10,6 +10,7 @@ use crate::providers::google::GOOGLE_DOC_URL;
 use crate::providers::private_file::write_private_file;
 use goose_providers::errors::ProviderError;
 use goose_providers::model::ModelConfig;
+use goose_providers::openai_compatible::{body_stream_with_prefix, first_body_chunk};
 use goose_providers::request_log::{start_log, LoggerHandleExt};
 
 const GEMINI_OAUTH_DEFAULT_MODEL: &str = "gemini-3-flash-preview";
@@ -27,7 +28,6 @@ use rmcp::model::Tool;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use sha2::Digest;
-use std::io;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::{Arc, LazyLock};
@@ -992,14 +992,18 @@ impl Provider for GeminiOAuthProvider {
         let payload = create_request(model_config, system, messages, tools)?;
         let mut log = start_log(model_config, &payload)?;
 
-        let response = self
-            .with_retry(|| async { self.post_stream(&model_config.model_name, &payload).await })
+        let (response, first_chunk) = self
+            .with_retry(|| async {
+                let mut response = self.post_stream(&model_config.model_name, &payload).await?;
+                let first_chunk = first_body_chunk(&mut response).await?;
+                Ok((response, Some(first_chunk)))
+            })
             .await
             .inspect_err(|e| {
                 let _ = log.error(e);
             })?;
 
-        let stream = response.bytes_stream().map_err(io::Error::other);
+        let stream = body_stream_with_prefix(response, first_chunk);
 
         Ok(Box::pin(try_stream! {
             let stream_reader = StreamReader::new(stream);

--- a/crates/goose/src/providers/githubcopilot.rs
+++ b/crates/goose/src/providers/githubcopilot.rs
@@ -2,7 +2,8 @@ use crate::config::paths::Paths;
 use crate::providers::api_client::{ApiClient, AuthMethod};
 use crate::providers::oauth_device_flow::{run_device_flow, DeviceFlowConfig, RequestEncoding};
 use crate::providers::openai_compatible::{
-    handle_status, stream_openai_compat, stream_responses_compat,
+    first_body_chunk, handle_status, stream_openai_compat_with_prefix,
+    stream_responses_compat_with_prefix,
 };
 use crate::providers::private_file::write_private_file;
 use anyhow::{anyhow, Result};
@@ -423,11 +424,11 @@ impl GithubCopilotProvider {
 
         let mut log = start_log(model_config, &payload)?;
 
-        let response = self
+        let (response, first_chunk) = self
             .with_retry(|| async {
                 let mut payload_clone = payload.clone();
-                let resp = self
-                    .post(
+                let mut response = handle_status(
+                    self.post(
                         model_config,
                         "responses",
                         is_user_initiated,
@@ -435,15 +436,18 @@ impl GithubCopilotProvider {
                         has_images,
                         true,
                     )
-                    .await?;
-                handle_status(resp).await
+                    .await?,
+                )
+                .await?;
+                let first_chunk = first_body_chunk(&mut response).await?;
+                Ok((response, Some(first_chunk)))
             })
             .await
             .inspect_err(|e| {
                 let _ = log.error(e);
             })?;
 
-        stream_responses_compat(response, log)
+        stream_responses_compat_with_prefix(response, first_chunk, log)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -471,11 +475,11 @@ impl GithubCopilotProvider {
             )?;
             let mut log = start_log(model_config, &payload)?;
 
-            let response = self
+            let (response, first_chunk) = self
                 .with_retry(|| async {
                     let mut payload_clone = payload.clone();
-                    let resp = self
-                        .post(
+                    let mut response = handle_status(
+                        self.post(
                             model_config,
                             "chat/completions",
                             is_user_initiated,
@@ -483,15 +487,18 @@ impl GithubCopilotProvider {
                             has_images,
                             true,
                         )
-                        .await?;
-                    handle_status(resp).await
+                        .await?,
+                    )
+                    .await?;
+                    let first_chunk = first_body_chunk(&mut response).await?;
+                    Ok((response, Some(first_chunk)))
                 })
                 .await
                 .inspect_err(|e| {
                     let _ = log.error(e);
                 })?;
 
-            stream_openai_compat(response, log)
+            stream_openai_compat_with_prefix(response, first_chunk, log)
         } else {
             let payload = create_request(
                 model_config,

--- a/crates/goose/src/providers/kimicode.rs
+++ b/crates/goose/src/providers/kimicode.rs
@@ -9,7 +9,6 @@ use reqwest::header::{HeaderMap, HeaderValue};
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::io;
 use std::time::Duration as StdDuration;
 use tokio::pin;
 use tokio_util::io::StreamReader;
@@ -25,7 +24,7 @@ use super::oauth_device_flow::{
     refresh_device_flow_token, run_device_flow, DeviceFlowConfig, DeviceFlowTokenRefreshError,
     DeviceFlowTokens, RequestEncoding,
 };
-use super::openai_compatible::handle_status;
+use super::openai_compatible::{body_stream_with_prefix, first_body_chunk, handle_status};
 use super::retry::ProviderRetry;
 use crate::conversation::message::Message;
 use futures::future::BoxFuture;
@@ -436,17 +435,18 @@ impl Provider for KimiCodeProvider {
         let mut log = start_log(model_config, &payload)
             .map_err(|e| ProviderError::RequestFailed(e.to_string()))?;
 
-        let response = self
+        let (response, first_chunk) = self
             .with_retry(|| async {
-                let resp = self.post(&payload).await?;
-                handle_status(resp).await
+                let mut response = handle_status(self.post(&payload).await?).await?;
+                let first_chunk = first_body_chunk(&mut response).await?;
+                Ok((response, Some(first_chunk)))
             })
             .await
             .inspect_err(|e| {
                 let _ = log.error(e);
             })?;
 
-        let stream = response.bytes_stream().map_err(io::Error::other);
+        let stream = body_stream_with_prefix(response, first_chunk);
 
         Ok(Box::pin(try_stream! {
             let stream_reader = StreamReader::new(stream);

--- a/crates/goose/src/providers/nanogpt.rs
+++ b/crates/goose/src/providers/nanogpt.rs
@@ -1,6 +1,6 @@
 use super::api_client::{ApiClient, AuthMethod};
 use super::base::{ConfigKey, MessageStream, Provider, ProviderDef, ProviderMetadata};
-use super::openai_compatible::{handle_status, stream_openai_compat};
+use super::openai_compatible::{first_body_chunk, handle_status, stream_openai_compat_with_prefix};
 use super::retry::ProviderRetry;
 use crate::conversation::message::Message;
 use anyhow::Result;
@@ -192,23 +192,26 @@ impl Provider for NanoGptProvider {
 
         let mut log = start_log(model_config, &payload)?;
 
-        let response = self
+        let (response, first_chunk) = self
             .with_retry(|| async {
-                let resp = self
-                    .api_client
-                    .request("chat/completions")
-                    .model_headers(model_config)?
-                    .streaming(true)
-                    .response_post(&payload)
-                    .await?;
-                handle_status(resp).await
+                let mut response = handle_status(
+                    self.api_client
+                        .request("chat/completions")
+                        .model_headers(model_config)?
+                        .streaming(true)
+                        .response_post(&payload)
+                        .await?,
+                )
+                .await?;
+                let first_chunk = first_body_chunk(&mut response).await?;
+                Ok((response, Some(first_chunk)))
             })
             .await
             .inspect_err(|e| {
                 let _ = log.error(e);
             })?;
 
-        stream_openai_compat(response, log)
+        stream_openai_compat_with_prefix(response, first_chunk, log)
     }
 }
 

--- a/crates/goose/src/providers/openrouter.rs
+++ b/crates/goose/src/providers/openrouter.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 
 use super::api_client::{ApiClient, AuthMethod};
 use super::base::{ConfigKey, MessageStream, Provider, ProviderDef, ProviderMetadata};
-use super::openai_compatible::{handle_status, stream_openai_compat};
+use super::openai_compatible::{first_body_chunk, handle_status, stream_openai_compat_with_prefix};
 use super::retry::ProviderRetry;
 use crate::conversation::message::Message;
 use crate::providers::formats::openrouter as openrouter_format;
@@ -79,16 +79,19 @@ impl OpenRouterProvider {
         &self,
         model_config: &ModelConfig,
         payload: &Value,
-    ) -> Result<reqwest::Response, ProviderError> {
+    ) -> Result<(reqwest::Response, Option<bytes::Bytes>), ProviderError> {
         self.with_retry(|| async {
-            let resp = self
-                .api_client
-                .request("api/v1/chat/completions")
-                .model_headers(model_config)?
-                .streaming(true)
-                .response_post(payload)
-                .await?;
-            handle_status(resp).await
+            let mut response = handle_status(
+                self.api_client
+                    .request("api/v1/chat/completions")
+                    .model_headers(model_config)?
+                    .streaming(true)
+                    .response_post(payload)
+                    .await?,
+            )
+            .await?;
+            let first_chunk = first_body_chunk(&mut response).await?;
+            Ok((response, Some(first_chunk)))
         })
         .await
     }
@@ -296,22 +299,23 @@ impl Provider for OpenRouterProvider {
 
         let mut log = start_log(model_config, &payload)?;
 
-        let response = match self.post_chat_completions(model_config, &payload).await {
-            // Mandatory-reasoning endpoints reject the disable request, so
-            // downgrade to the lowest effort they all accept and retry once.
-            Err(error) if sent_reasoning_disable && is_mandatory_reasoning_error(&error) => {
-                let _ = log.error(&error);
-                payload["reasoning"] = json!({ "effort": "low" });
-                log = start_log(model_config, &payload)?;
-                self.post_chat_completions(model_config, &payload).await
+        let (response, first_chunk) =
+            match self.post_chat_completions(model_config, &payload).await {
+                // Mandatory-reasoning endpoints reject the disable request, so
+                // downgrade to the lowest effort they all accept and retry once.
+                Err(error) if sent_reasoning_disable && is_mandatory_reasoning_error(&error) => {
+                    let _ = log.error(&error);
+                    payload["reasoning"] = json!({ "effort": "low" });
+                    log = start_log(model_config, &payload)?;
+                    self.post_chat_completions(model_config, &payload).await
+                }
+                result => result,
             }
-            result => result,
-        }
-        .inspect_err(|e| {
-            let _ = log.error(e);
-        })?;
+            .inspect_err(|e| {
+                let _ = log.error(e);
+            })?;
 
-        stream_openai_compat(response, log)
+        stream_openai_compat_with_prefix(response, first_chunk, log)
     }
 }
 

--- a/crates/goose/src/providers/tetrate.rs
+++ b/crates/goose/src/providers/tetrate.rs
@@ -1,8 +1,8 @@
 use super::api_client::{ApiClient, AuthMethod};
 use super::base::{ConfigKey, MessageStream, Provider, ProviderDef, ProviderMetadata};
 use super::openai_compatible::{
-    handle_response_openai_compat, handle_status, map_http_error_to_provider_error,
-    stream_openai_compat,
+    first_body_chunk, handle_response_openai_compat, handle_status,
+    map_http_error_to_provider_error, stream_openai_compat_with_prefix,
 };
 use super::retry::ProviderRetry;
 use crate::config::signup_tetrate::TETRATE_DEFAULT_MODEL;
@@ -148,20 +148,20 @@ impl Provider for TetrateProvider {
 
         let mut log = start_log(model_config, &payload)?;
 
-        let response = self
+        let (response, first_chunk) = self
             .with_retry(|| async {
-                let resp = self
-                    .api_client
-                    .request("v1/chat/completions")
-                    .model_headers(model_config)?
-                    .streaming(true)
-                    .response_post(&payload)
-                    .await?;
-                let resp = handle_status(resp)
-                    .await
-                    .map_err(Self::enrich_credits_error)?;
+                let mut response = handle_status(
+                    self.api_client
+                        .request("v1/chat/completions")
+                        .model_headers(model_config)?
+                        .streaming(true)
+                        .response_post(&payload)
+                        .await?,
+                )
+                .await
+                .map_err(Self::enrich_credits_error)?;
 
-                let is_json = resp
+                let is_json = response
                     .headers()
                     .get(reqwest::header::CONTENT_TYPE)
                     .and_then(|v| v.to_str().ok())
@@ -169,7 +169,7 @@ impl Provider for TetrateProvider {
                     .is_some_and(|v| v.contains("json"));
 
                 if is_json {
-                    let body = goose_providers::http_status::read_error_body(resp)
+                    let body = goose_providers::http_status::read_error_body(response)
                         .await
                         .unwrap_or_default();
                     if let Ok(payload) = serde_json::from_str::<serde_json::Value>(&body) {
@@ -186,14 +186,15 @@ impl Provider for TetrateProvider {
                     )));
                 }
 
-                Ok(resp)
+                let first_chunk = first_body_chunk(&mut response).await?;
+                Ok((response, Some(first_chunk)))
             })
             .await
             .inspect_err(|e| {
                 let _ = log.error(e);
             })?;
 
-        stream_openai_compat(response, log)
+        stream_openai_compat_with_prefix(response, first_chunk, log)
     }
 
     /// Fetch supported models from Tetrate Agent Router Service API


### PR DESCRIPTION
Issue: #10887 (#10926, which @DOsinga opened for this PR, was closed as a duplicate of it and #10887 now carries the agreed plan).

Rebased onto `main`. `cargo test -p goose-providers` is green (132 tests), including the new `stream_retries_when_connection_drops_before_first_body_bytes`. The rebase was not mechanical: `main` has since extracted `stream_payload` / `stream_responses_payload` helpers, so the first-chunk-inside-retry change now lives in those helpers instead of being inlined at each call site.

> [!NOTE]
> **This PR does not match the plan agreed on #10887, and I would like a steer before reworking it.**
>
> The plan there is to add first-item retry in `stream_response_from_provider` and leave stream-*creation* retries at the provider level. This PR instead stays entirely at the provider level: it pulls the first body chunk inside the provider's existing `with_retry` scope, so a connection that dies before delivering any bytes is retried as a failed request rather than surfacing as a mid-stream item error where retry is unreachable.
>
> I think these are complementary rather than competing — this one closes the window between "headers arrived" and "first byte arrived", which is below the level `stream_response_from_provider` can see, while the agreed plan covers a transient *first item* after a well-formed stream opens. But if the intent is for the agent-level handling to subsume this case, say so and I will close this in favour of an implementation of the #10887 plan.

---

## Summary
- Mid-stream network failures (`error decoding response body`) bypassed goose's provider retry entirely: `with_retry` wrapped only the HTTP request and `handle_status(resp)`, so the retry scope ended the moment response headers arrived. A cut SSE connection surfaced as a per-item `Err(NetworkError)` inside the body stream, long after any retry scope, and the agent's reply loop aborted the whole turn on the first stream error.
- Root cause: `should_retry(NetworkError) = true` was dead code for the one network error that actually occurs with SSE providers — it could only fire for pre-headers failures.
- Fix: await the first body chunk (`first_body_chunk`) inside the `with_retry` closure in `openai.rs` (chat completions + responses API paths) and `openai_compatible.rs`, then prepend it to the reconstructed body stream (`stream_openai_compat_with_prefix` / `stream_responses_compat_with_prefix`). Any failure before the first token — the common case — is now transparently retried with the existing backoff.
- Scope note: failures *after* the first token remain non-retryable (transparent resume would duplicate already-yielded partial content); that needs an agent-level turn retry and is left for a follow-up.

## Test plan
- [x] Regression test `openai::tests::stream_retries_when_connection_drops_before_first_body_bytes`: raw TCP server returns 200 headers with a promised 1024-byte body then drops the connection; retry serves a full SSE response. Verified the test fails without the fix and passes with it.
- [x] `cargo test -p goose-providers` (87 passed)
- [x] `cargo clippy -p goose-providers -p goose --all-targets -- -D warnings`
- [ ] CI passes
