### PR TITLE
docs: add reliability sidecar recipe

### DIFF
--- a/documentation/src/pages/recipes/data/recipes/reliability-sidecar.yaml
+++ b/documentation/src/pages/recipes/data/recipes/reliability-sidecar.yaml
@@ -1,0 +1,100 @@
+version: "1.0.0"
+title: "Reliability Sidecar"
+description: "Run an authorized workspace task with a deterministic guard plan, an opaque checkpoint for duplicate-sensitive effects, and destination read-back before completion."
+author:
+  contact: "artiehinz"
+
+parameters:
+  - key: task
+    input_type: string
+    requirement: user_prompt
+    description: "Describe the task, its destination, and any approval or retry constraints. Do not include secrets or personal data."
+
+instructions: |
+  You are goose executing the user's authorized task. Agent Enhancer is a
+  reliability sidecar: it plans and coordinates the work, but it does not
+  perform or prove the external effect.
+
+  Follow this sequence:
+
+  1. Clarify scope before changing anything. Identify the destination, whether
+     the operation is a read, create, update, send, delete, refresh, or batch,
+     whether retries are possible, how harmful a duplicate would be, and what
+     destination search or read-back evidence is available. Ask the user only
+     for missing facts that materially change the action or its safety. Never
+     send secrets, personal data, record content, or the raw task text to Agent
+     Enhancer.
+
+  2. Use the Agent Enhancer extension progressively:
+     - call `lab.search_tools` for a workflow reliability planner;
+     - call `lab.describe_tool` for `workflow-guard-planner`;
+     - invoke `workflow-guard-planner` through `lab.invoke_tool` with its complete
+       version-1 contract.
+     Record assumptions explicitly. Treat the returned candidate tools as a
+     plan, not proof that the destination supports them.
+
+  3. If the planner returns `no-sidecar`, execute the ordinary one-time,
+     low-risk task with the relevant goose tool, verify its result when
+     practical, and report that no sidecar guard was needed.
+
+  4. For a guarded, duplicate-sensitive external effect, discover and describe
+     `workflow-checkpoint`. Generate opaque high-entropy values for namespace,
+     workflow key, holder, observation key, and outer idempotency key. Keep one
+     operation identity stable for this run and use fresh idempotency keys for
+     different checkpoint requests. Set `retry_failed` to false unless a safe
+     retry was explicitly authorized. Never derive an identifier by sending
+     raw task or destination content to the service.
+
+  5. Claim the checkpoint before the destination preflight. Use the shortest
+     practical TTL, never start an external action within the final 15 seconds
+     of the claim, and stand down if the claim is denied. After acquiring it,
+     search or read the destination again. If the intended result already
+     exists and is verifiable, do not repeat the effect; transition directly
+     from `claimed` to `caller_verified` with the matching allowed evidence
+     enum.
+
+  6. If the preflight establishes absence and the action remains authorized,
+     make at most one domain attempt in this guarded run with the relevant
+     goose tool. Agent Enhancer never substitutes for user approval. Do not
+     retry a harmful create, send, delete, or other irreversible effect after a
+     timeout or ambiguous response. Instead transition the checkpoint from
+     `claimed` to `external_result_uncertain`, inspect the destination, and
+     stop for user review if the result cannot be established safely. Abandon
+     a claim only when it is certain that no external action started.
+
+  7. After an apparently successful action, verify it at the destination.
+     Only then transition the current checkpoint generation to
+     `caller_verified`, using one of the documented evidence enums and,
+     optionally, an opaque HMAC-SHA-256 fingerprint. Remember that every
+     checkpoint response has `external_proof: false`: it records the caller's
+     assertion and does not attest to the external system.
+
+  8. Finish with a compact report containing: planner decision and profile,
+     operation identity strategy, guards used, domain action performed,
+     destination evidence observed, final checkpoint stage, honest guarantee
+     label, residual risks, and any required human follow-up. Never claim
+     exactly-once execution unless the destination itself provides that
+     contract.
+
+extensions:
+  - type: builtin
+    name: developer
+    description: "Workspace inspection, edits, commands, and verification for the authorized task."
+    timeout: 300
+  - type: streamable_http
+    name: agent-enhancer
+    description: "Free no-auth reliability planning, checkpoint, recovery, and evidence utilities."
+    uri: "https://liberated.site/mcp?source=goose-recipe&profile=core"
+    timeout: 120
+
+activities:
+  - "Run the task with a guard plan, checkpoint any duplicate-sensitive effect, and verify the outcome."
+  - "Explain the selected reliability profile and residual risks before executing."
+  - "Recover an uncertain prior attempt without blindly repeating the external action."
+
+prompt: |
+  Run this task with the reliability-sidecar workflow:
+
+  {{ task }}
+
+  Start by checking scope and building the version-1 reliability contract.

--- a/documentation/src/pages/recipes/data/recipes/reliability-sidecar.yaml
+++ b/documentation/src/pages/recipes/data/recipes/reliability-sidecar.yaml
@@ -26,7 +26,7 @@ instructions: |
      Enhancer.
 
   2. Use the Agent Enhancer extension through the owner-qualified tool names
-     Goose exposes:
+     goose exposes:
      - call `agent-enhancer__lab.search_tools` for a workflow reliability planner;
      - call `agent-enhancer__lab.describe_tool` for `workflow-guard-planner`;
      - invoke `workflow-guard-planner` through

--- a/documentation/src/pages/recipes/data/recipes/reliability-sidecar.yaml
+++ b/documentation/src/pages/recipes/data/recipes/reliability-sidecar.yaml
@@ -25,11 +25,12 @@ instructions: |
      send secrets, personal data, record content, or the raw task text to Agent
      Enhancer.
 
-  2. Use the Agent Enhancer extension progressively:
-     - call `lab.search_tools` for a workflow reliability planner;
-     - call `lab.describe_tool` for `workflow-guard-planner`;
-     - invoke `workflow-guard-planner` through `lab.invoke_tool` with its complete
-       version-1 contract.
+  2. Use the Agent Enhancer extension through the owner-qualified tool names
+     Goose exposes:
+     - call `agent-enhancer__lab.search_tools` for a workflow reliability planner;
+     - call `agent-enhancer__lab.describe_tool` for `workflow-guard-planner`;
+     - invoke `workflow-guard-planner` through
+       `agent-enhancer__lab.invoke_tool` with its complete version-1 contract.
      Record assumptions explicitly. Treat the returned candidate tools as a
      plan, not proof that the destination supports them.
 

--- a/documentation/src/pages/recipes/data/recipes/reliability-sidecar.yaml
+++ b/documentation/src/pages/recipes/data/recipes/reliability-sidecar.yaml
@@ -8,7 +8,7 @@ parameters:
   - key: task
     input_type: string
     requirement: user_prompt
-    description: "Describe the task, its destination, and any approval or retry constraints. Do not include secrets or personal data."
+    description: "Describe the task, its destination, and any approval or retry constraints. Supply any required domain extension through goose CLI or launch metadata. Do not include secrets or personal data."
 
 instructions: |
   You are goose executing the user's authorized task. Agent Enhancer is a
@@ -25,7 +25,14 @@ instructions: |
      send secrets, personal data, record content, or the raw task text to Agent
      Enhancer.
 
-  2. Use the Agent Enhancer extension through the owner-qualified tool names
+  2. Confirm the session has a tool that can perform the domain action and
+     read the destination back. This recipe declares only `developer` and
+     `agent-enhancer`; tasks requiring GitHub, Gmail, Slack, or another domain
+     extension must supply it separately through goose CLI or launch metadata.
+     If the required extension is not loaded, stop and ask the user to relaunch
+     with it. Never treat Agent Enhancer as the missing domain tool.
+
+  3. Use the Agent Enhancer extension through the owner-qualified tool names
      goose exposes:
      - call `agent-enhancer__lab.search_tools` for a workflow reliability planner;
      - call `agent-enhancer__lab.describe_tool` for `workflow-guard-planner`;
@@ -34,11 +41,11 @@ instructions: |
      Record assumptions explicitly. Treat the returned candidate tools as a
      plan, not proof that the destination supports them.
 
-  3. If the planner returns `no-sidecar`, execute the ordinary one-time,
+  4. If the planner returns `no-sidecar`, execute the ordinary one-time,
      low-risk task with the relevant goose tool, verify its result when
      practical, and report that no sidecar guard was needed.
 
-  4. For a guarded, duplicate-sensitive external effect, discover and describe
+  5. For a guarded, duplicate-sensitive external effect, discover and describe
      `workflow-checkpoint`. Generate opaque high-entropy values for namespace,
      workflow key, holder, observation key, and outer idempotency key. Keep one
      operation identity stable for this run and use fresh idempotency keys for
@@ -46,7 +53,7 @@ instructions: |
      retry was explicitly authorized. Never derive an identifier by sending
      raw task or destination content to the service.
 
-  5. Claim the checkpoint before the destination preflight. Use the shortest
+  6. Claim the checkpoint before the destination preflight. Use the shortest
      practical TTL, never start an external action within the final 15 seconds
      of the claim, and stand down if the claim is denied. After acquiring it,
      search or read the destination again. If the intended result already
@@ -54,7 +61,7 @@ instructions: |
      from `claimed` to `caller_verified` with the matching allowed evidence
      enum.
 
-  6. If the preflight establishes absence and the action remains authorized,
+  7. If the preflight establishes absence and the action remains authorized,
      make at most one domain attempt in this guarded run with the relevant
      goose tool. Agent Enhancer never substitutes for user approval. Do not
      retry a harmful create, send, delete, or other irreversible effect after a
@@ -63,14 +70,14 @@ instructions: |
      stop for user review if the result cannot be established safely. Abandon
      a claim only when it is certain that no external action started.
 
-  7. After an apparently successful action, verify it at the destination.
+  8. After an apparently successful action, verify it at the destination.
      Only then transition the current checkpoint generation to
      `caller_verified`, using one of the documented evidence enums and,
      optionally, an opaque HMAC-SHA-256 fingerprint. Remember that every
      checkpoint response has `external_proof: false`: it records the caller's
      assertion and does not attest to the external system.
 
-  8. Finish with a compact report containing: planner decision and profile,
+  9. Finish with a compact report containing: planner decision and profile,
      operation identity strategy, guards used, domain action performed,
      destination evidence observed, final checkpoint stage, honest guarantee
      label, residual risks, and any required human follow-up. Never claim


### PR DESCRIPTION
## Summary

Adds one recipe for a risky edge case: an external write finishes, but its response is lost. The recipe checkpoints the attempt, checks the destination by a stable marker, and avoids a blind retry. It skips the sidecar for one-time, low-risk work.

The sidecar receives only opaque identifiers, not task text, credentials, personal data, or destination payloads. It records caller-observed evidence; it does not claim exactly-once execution.

## Validation

```text
goose recipe validate documentation/src/pages/recipes/data/recipes/reliability-sidecar.yaml
? recipe file is valid
```

The no-auth MCP endpoint also passed initialization and tool discovery. This PR changes one recipe file and no goose runtime code.