### PR TITLE
ci: allow isolated fork recipe checkout

### DIFF
--- a/.github/workflows/recipe-security-scanner.yml
+++ b/.github/workflows/recipe-security-scanner.yml
@@ -42,6 +42,10 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
           path: pr-content
+          persist-credentials: false
+          # This checkout is untrusted data only. Scanner code and its Dockerfile
+          # come from the separate trusted base checkout above.
+          allow-unsafe-pr-checkout: true
           sparse-checkout: |
             documentation/src/pages/recipes/data/recipes/
 


### PR DESCRIPTION
## Summary

Allows the recipe security scanner to read recipe files from fork PRs with `actions/checkout@v7`.

The workflow already separates trusted scanner code from untrusted recipe data. This change explicitly opts into the isolated recipe checkout and disables credential persistence. Without it, checkout stops before the scanner runs on every fork submission.

## Validation

- YAML parse passed
- Workflow diff contains four configuration lines only
- Failure reproduced on #10780: checkout refused the fork before scanning