### PR TITLE
create source archive as release artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,6 +115,11 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Create source code bundles
+        run: |
+          git archive --format=tar.gz --prefix="goose-${GITHUB_REF_NAME}/" --output="goose-source-${GITHUB_REF_NAME}.tar.gz" HEAD
+          git archive --format=zip --prefix="goose-${GITHUB_REF_NAME}/" --output="goose-source-${GITHUB_REF_NAME}.zip" HEAD
+
       - name: Download release artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:


### PR DESCRIPTION
GitHub does allow downloading these automatically, but they are dynamically generated and so don't publish a SHA. Adding as release artifacts means they are immutable and publish a SHA, and we can attest provenance.

### Related Issues
Discussion: https://discord.com/channels/1287729918100246654/1287729920797179957/1531628323988443157
