### PR TITLE
fix: avoid double loading full conversation on session open

### DIFF
--- a/crates/goose/src/acp/server/load_session.rs
+++ b/crates/goose/src/acp/server/load_session.rs
@@ -247,7 +247,7 @@ impl GooseAcpAgent {
 
         session = self
             .session_manager
-            .get_session(&session_id_str, true)
+            .get_session(&session_id_str, false)
             .await
             .internal_err_ctx("Failed to reload session")?;
 


### PR DESCRIPTION
Fixes #10783

## Summary

handle_load_session reloads the full conversation from disk a second time after replay is complete, doubling peak memory on long sessions. The post-replay code only uses session.working_dir, session.usage, and session.recipe — none need the message history. Changing the second get_session to include_messages=false eliminates the redundant load

### Testing
manual 
