### PR TITLE
feat(tracing): add Langfuse generation observations

### DIFF
--- a/crates/goose-cli/src/commands/configure.rs
+++ b/crates/goose-cli/src/commands/configure.rs
@@ -1968,14 +1968,14 @@ pub async fn handle_openrouter_auth() -> anyhow::Result<()> {
 
     match create("openrouter", Vec::new()).await {
         Ok(provider) => {
-            let test_result = provider
-                .complete(
-                    &model_config,
-                    "You are goose, an AI assistant.",
-                    &[Message::user().with_text("Say 'Configuration test successful!'")],
-                    &[],
-                )
-                .await;
+            let test_result = goose::tracing::complete_provider(
+                provider.as_ref(),
+                &model_config,
+                "You are goose, an AI assistant.",
+                &[Message::user().with_text("Say 'Configuration test successful!'")],
+                &[],
+            )
+            .await;
 
             match test_result {
                 Ok(_) => {

--- a/crates/goose-cli/src/commands/info.rs
+++ b/crates/goose-cli/src/commands/info.rs
@@ -90,7 +90,13 @@ async fn check_provider(
     let start = std::time::Instant::now();
     goose::session_context::with_session_id(
         Some("check".to_string()),
-        provider_client.complete(&model_config, "", &[test_msg], &[]),
+        goose::tracing::complete_provider(
+            provider_client.as_ref(),
+            &model_config,
+            "",
+            &[test_msg],
+            &[],
+        ),
     )
     .await
     .map_err(ProviderCheckError::ProviderRequest)?;

--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -261,7 +261,8 @@ pub async fn classify_planner_response(
     let message = Message::user().with_text(&prompt);
     let (result, _usage) = goose::session_context::with_session_id(
         Some(session_id.to_string()),
-        provider.complete(
+        goose::tracing::complete_provider(
+            provider.as_ref(),
             &model_config,
             "Reply only with the classification label: \"plan\" or \"clarifying questions\"",
             &[message],
@@ -1194,7 +1195,8 @@ impl CliSession {
         output::show_thinking();
         let (plan_response, _usage) = goose::session_context::with_session_id(
             Some(self.session_id.clone()),
-            reasoner.complete(
+            goose::tracing::complete_provider(
+                reasoner.as_ref(),
                 &model_config,
                 &plan_prompt,
                 provider_messages.messages(),

--- a/crates/goose-provider-types/src/conversation/message.rs
+++ b/crates/goose-provider-types/src/conversation/message.rs
@@ -675,6 +675,8 @@ pub struct MessageMetadata {
     pub steer: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub usage: Option<Box<MessageUsage>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub observation_id: Option<String>,
 }
 
 impl Default for MessageMetadata {
@@ -686,6 +688,7 @@ impl Default for MessageMetadata {
             output_token_limit_reached: false,
             steer: false,
             usage: None,
+            observation_id: None,
         }
     }
 }
@@ -757,6 +760,11 @@ impl MessageMetadata {
 
     pub fn with_steer(mut self) -> Self {
         self.steer = true;
+        self
+    }
+
+    pub fn with_observation_id(mut self, observation_id: String) -> Self {
+        self.observation_id = Some(observation_id);
         self
     }
 }
@@ -1723,6 +1731,9 @@ mod tests {
             .with_agent_visible();
         assert!(metadata.user_visible);
         assert!(metadata.agent_visible);
+
+        let metadata = MessageMetadata::default().with_observation_id("observation-1".to_string());
+        assert_eq!(metadata.observation_id.as_deref(), Some("observation-1"));
     }
 
     #[test]

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -1626,6 +1626,7 @@ impl Agent {
         fields(
             user_message,
             trace_input,
+            trace_boundary = true,
             session.id = %session_config.id,
             gen_ai.operation.name = "invoke_agent",
             gen_ai.input.messages = tracing::field::Empty,
@@ -3558,7 +3559,13 @@ impl Agent {
         })?;
         let (result, _usage) = crate::session_context::with_session_id(
             Some(session_id.to_string()),
-            provider.complete(&model_config, &system_prompt, messages.messages(), &tools),
+            crate::tracing::complete_provider(
+                provider.as_ref(),
+                &model_config,
+                &system_prompt,
+                messages.messages(),
+                &tools,
+            ),
         )
         .await
         .map_err(|e| {

--- a/crates/goose/src/agents/mcp_client.rs
+++ b/crates/goose/src/agents/mcp_client.rs
@@ -431,7 +431,13 @@ impl ClientHandler for GooseClient {
         })?;
         let (response, usage) = crate::session_context::with_session_id(
             session_id.clone(),
-            provider.complete(&model_config, system_prompt, &provider_ready_messages, &[]),
+            crate::tracing::complete_provider(
+                provider.as_ref(),
+                &model_config,
+                system_prompt,
+                &provider_ready_messages,
+                &[],
+            ),
         )
         .await
         .map_err(|e| {

--- a/crates/goose/src/agents/platform_extensions/apps.rs
+++ b/crates/goose/src/agents/platform_extensions/apps.rs
@@ -284,7 +284,13 @@ impl AppsManagerClient {
 
         let (response, usage) = crate::session_context::with_session_id(
             Some(session_id.to_string()),
-            provider.complete(&model_config, &system_prompt, &messages, &tools),
+            crate::tracing::complete_provider(
+                provider.as_ref(),
+                &model_config,
+                &system_prompt,
+                &messages,
+                &tools,
+            ),
         )
         .await
         .map_err(|e| format!("LLM call failed: {}", e))?;
@@ -329,7 +335,13 @@ impl AppsManagerClient {
 
         let (response, usage) = crate::session_context::with_session_id(
             Some(session_id.to_string()),
-            provider.complete(&model_config, &system_prompt, &messages, &tools),
+            crate::tracing::complete_provider(
+                provider.as_ref(),
+                &model_config,
+                &system_prompt,
+                &messages,
+                &tools,
+            ),
         )
         .await
         .map_err(|e| format!("LLM call failed: {}", e))?;

--- a/crates/goose/src/agents/platform_extensions/summarize.rs
+++ b/crates/goose/src/agents/platform_extensions/summarize.rs
@@ -200,7 +200,13 @@ async fn execute_summarize(
 
     let (response, _usage) = crate::session_context::with_session_id(
         Some(session_id.to_string()),
-        provider.complete(&model_config, system, &[user_message], &[]),
+        crate::tracing::complete_provider(
+            provider.as_ref(),
+            &model_config,
+            system,
+            &[user_message],
+            &[],
+        ),
     )
     .await
     .map_err(|e| format!("LLM call failed: {}", e))?;

--- a/crates/goose/src/agents/platform_extensions/summon.rs
+++ b/crates/goose/src/agents/platform_extensions/summon.rs
@@ -31,7 +31,8 @@ use tokio::sync::{mpsc, Mutex};
 
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
-use tracing::{info, warn};
+use tracing::{info, info_span, warn};
+use tracing_futures::Instrument;
 
 pub static EXTENSION_NAME: &str = "summon";
 
@@ -1886,19 +1887,41 @@ impl SummonClient {
             Arc::clone(&notification_buffer),
         );
 
-        let handle = tokio::spawn(async move {
-            run_subagent_task(SubagentRunParams {
-                config: agent_config,
-                recipe,
-                task_config,
-                return_last_only: true,
-                session_id: subagent_session.id,
-                cancellation_token: Some(task_token_clone),
-                on_message: Some(on_message),
-                notification_tx: Some(notif_tx),
-            })
-            .await
-        });
+        let background_span = info_span!(
+            target: "goose::agents::platform_extensions::summon",
+            "async_subagent",
+            session.id = %task_id,
+            parent.session.id = %session_id,
+            input = %description,
+            output = tracing::field::Empty,
+            status_message = tracing::field::Empty,
+        );
+        let handle = tokio::spawn(
+            async move {
+                let result = run_subagent_task(SubagentRunParams {
+                    config: agent_config,
+                    recipe,
+                    task_config,
+                    return_last_only: true,
+                    session_id: subagent_session.id,
+                    cancellation_token: Some(task_token_clone),
+                    on_message: Some(on_message),
+                    notification_tx: Some(notif_tx),
+                })
+                .await;
+                match &result {
+                    Ok(output) => {
+                        tracing::Span::current().record("output", output.as_str());
+                    }
+                    Err(error) => {
+                        let error_message = error.to_string();
+                        tracing::Span::current().record("status_message", error_message.as_str());
+                    }
+                }
+                result
+            }
+            .instrument(background_span),
+        );
 
         let task = BackgroundTask {
             id: task_id.clone(),

--- a/crates/goose/src/agents/reply_parts.rs
+++ b/crates/goose/src/agents/reply_parts.rs
@@ -7,6 +7,7 @@ use async_stream::try_stream;
 use futures::stream::StreamExt;
 use serde_json::{json, Value};
 use tracing::debug;
+use tracing_futures::Instrument;
 
 use super::super::agents::Agent;
 use super::gen_ai_telemetry;
@@ -22,6 +23,7 @@ use crate::providers::toolshim::{
     augment_message_with_selected_tool_interpreter, convert_tool_messages_to_text,
     modify_system_prompt_for_tool_json, sanitize_residual_markers,
 };
+use crate::tracing::ProviderGeneration;
 use goose_providers::conversation::token_usage::{CostSource, ProviderStats, ProviderUsage, Usage};
 use goose_providers::model::ModelConfig;
 use rmcp::model::Tool;
@@ -348,10 +350,17 @@ impl Agent {
         let toolshim_tools = toolshim_tools.to_owned();
         let provider = provider.clone();
 
-        // Capture errors during stream creation and return them as part of the stream
-        // so they can be handled by the existing error handling logic in the agent
         let model_config =
             model_config.with_default_thinking_effort(Config::global().get_goose_thinking_effort());
+        let mut generation = ProviderGeneration::new(
+            provider.get_name(),
+            &model_config,
+            session_id,
+            &system_prompt,
+            messages_for_provider.messages(),
+            &tools,
+        );
+
         let request_started = std::time::Instant::now();
         debug!("WAITING_LLM_STREAM_START");
         let stream_result = crate::session_context::with_session_id(
@@ -363,23 +372,24 @@ impl Agent {
                 &tools,
             ),
         )
+        .instrument(generation.span())
         .await;
         debug!("WAITING_LLM_STREAM_END");
 
-        // If there was an error creating the stream, return a stream that yields that error
         let mut stream = match stream_result {
             Ok(s) => s,
             Err(e) => {
+                generation.record_error(&e);
+                generation.finish();
                 let enhanced_error = enhance_model_error(e, &provider, config.toolshim).await;
-                // Return a stream that immediately yields the error
-                // This allows the error to be caught by existing error handling in agent.rs
-                return Ok(Box::pin(try_stream! {
+                let error_stream = try_stream! {
                     yield Err(enhanced_error)?;
-                }));
+                };
+                return Ok(Box::pin(error_stream));
             }
         };
 
-        Ok(Box::pin(try_stream! {
+        let traced_stream = try_stream! {
             if config.toolshim {
                 // Toolshim mode: accumulate the full response before processing
                 // so that tool-use markers spanning multiple chunks are detected
@@ -388,12 +398,21 @@ impl Agent {
                 let mut final_usage: Option<ProviderUsage> = None;
                 let mut first_content_at: Option<std::time::Instant> = None;
 
-                while let Some(result) = stream.next().await {
-                    let (msg_opt, usage_opt) = result?;
+                while let Some(result) = stream.next().instrument(generation.span()).await {
+                    let (msg_opt, usage_opt) = match result {
+                        Ok(item) => item,
+                        Err(error) => {
+                            generation.record_error(&error);
+                            generation.finish();
+                            Err(error)?
+                        }
+                    };
 
                     if let Some(msg) = msg_opt {
+                        generation.record_output(&msg);
                         if first_content_at.is_none() && message_has_timing_content(&msg) {
                             first_content_at = Some(std::time::Instant::now());
+                            generation.record_completion_start();
                         }
                         accumulated_message = Some(match accumulated_message {
                             Some(mut prev) => {
@@ -417,6 +436,7 @@ impl Agent {
                     }
 
                     if let Some(usage) = usage_opt {
+                        generation.record_usage(&usage);
                         final_usage = Some(usage);
                     }
 
@@ -430,10 +450,13 @@ impl Agent {
                     gen_ai_telemetry::record_provider_usage(&span, usage);
                 }
 
+                generation.finish();
+
                 if let Some(msg) = accumulated_message {
-                    let processed = toolshim_postprocess(msg, &toolshim_tools)
+                    let mut processed = toolshim_postprocess(msg, &toolshim_tools)
                         .await?
                         .with_generated_id_if_missing();
+                    generation.attach_observation_id(&mut processed);
                     if capture_message_content {
                         let output_messages = gen_ai_telemetry::output_message_json(&processed);
                         span.record("gen_ai.output.messages", output_messages.as_str());
@@ -447,17 +470,26 @@ impl Agent {
                 let mut first_content_at: Option<std::time::Instant> = None;
                 let mut active_mergeable_assistant_id: Option<String> = None;
                 let mut output_message: Option<Message> = None;
-                while let Some(result) = stream.next().await {
-                    let (message, mut usage) = result?;
+                while let Some(result) = stream.next().instrument(generation.span()).await {
+                    let (message, mut usage) = match result {
+                        Ok(item) => item,
+                        Err(error) => {
+                            generation.record_error(&error);
+                            generation.finish();
+                            Err(error)?
+                        }
+                    };
 
                     if first_content_at.is_none()
                         && message.as_ref().is_some_and(message_has_timing_content)
                     {
                         first_content_at = Some(std::time::Instant::now());
+                        generation.record_completion_start();
                     }
                     if let Some(usage) = usage.as_mut() {
                         fill_stream_timing(usage, request_started, first_content_at);
                         gen_ai_telemetry::record_provider_usage(&span, usage);
+                        generation.record_usage(usage);
                     }
                     if capture_message_content {
                         if let Some(message) = message.as_ref() {
@@ -465,8 +497,8 @@ impl Agent {
                         }
                     }
 
-                    let message = message.map(|message| {
-                        if message.id.is_some() {
+                    let message = message.map(|mut message| {
+                        message = if message.id.is_some() {
                             active_mergeable_assistant_id = None;
                             message
                         } else if is_mergeable_assistant_chunk(&message) {
@@ -477,7 +509,10 @@ impl Agent {
                         } else {
                             active_mergeable_assistant_id = None;
                             message.with_generated_id()
-                        }
+                        };
+                        generation.attach_observation_id(&mut message);
+                        generation.record_output(&message);
+                        message
                     });
 
                     yield (message, usage);
@@ -486,8 +521,11 @@ impl Agent {
                     let output_messages = gen_ai_telemetry::output_message_json(&output_message);
                     span.record("gen_ai.output.messages", output_messages.as_str());
                 }
+                generation.finish();
             }
-        }))
+        };
+
+        Ok(Box::pin(traced_stream))
     }
 
     /// Categorize tool requests from the response into different types
@@ -754,6 +792,7 @@ mod tests {
     use crate::conversation::message::{Message, SystemNotificationType};
     use crate::providers::base::Provider;
     use crate::session::{SessionManager, SessionType};
+    use crate::tracing::test_support::{capturing_layer, wait_for_closed_generation};
     use async_trait::async_trait;
     use goose_providers::conversation::token_usage::{ProviderStats, ProviderUsage, Usage};
     use goose_providers::model::ModelConfig;
@@ -761,6 +800,7 @@ mod tests {
     use rmcp::object;
     use std::sync::Mutex;
     use std::time::{Duration, Instant};
+    use tracing_subscriber::prelude::*;
 
     #[derive(Clone)]
     struct MockProvider;
@@ -808,6 +848,63 @@ mod tests {
                 Ok((Some(Message::assistant().with_text("hello ")), None)),
                 Ok((Some(Message::assistant().with_text("world")), Some(usage))),
             ])))
+        }
+    }
+
+    #[derive(Clone)]
+    struct PartialErrorProvider;
+
+    #[async_trait]
+    impl Provider for PartialErrorProvider {
+        fn get_name(&self) -> &str {
+            "partial-error"
+        }
+
+        async fn stream(
+            &self,
+            _model_config: &ModelConfig,
+            _system: &str,
+            _messages: &[Message],
+            _tools: &[Tool],
+        ) -> Result<MessageStream, ProviderError> {
+            Ok(Box::pin(futures::stream::iter(vec![
+                Ok((Some(Message::assistant().with_text("partial ")), None)),
+                Ok((Some(Message::assistant().with_text("response")), None)),
+                Err(ProviderError::RequestFailed("stream failed".to_string())),
+            ])))
+        }
+    }
+
+    #[derive(Clone)]
+    struct ModelErrorProvider {
+        model_fetch_started_at: Arc<Mutex<Option<chrono::DateTime<chrono::Utc>>>>,
+    }
+
+    #[async_trait]
+    impl Provider for ModelErrorProvider {
+        fn get_name(&self) -> &str {
+            "model-error"
+        }
+
+        async fn stream(
+            &self,
+            _model_config: &ModelConfig,
+            _system: &str,
+            _messages: &[Message],
+            _tools: &[Tool],
+        ) -> Result<MessageStream, ProviderError> {
+            Err(ProviderError::RequestFailed(
+                "404 model not found".to_string(),
+            ))
+        }
+
+        async fn fetch_recommended_models(
+            &self,
+            _toolshim: bool,
+        ) -> Result<Vec<String>, ProviderError> {
+            *self.model_fetch_started_at.lock().unwrap() = Some(chrono::Utc::now());
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            Ok(vec!["recommended-model".to_string()])
         }
     }
 
@@ -1280,6 +1377,19 @@ mod tests {
                     .expect("streamed provider message should have an ID")
             })
             .collect::<Vec<_>>();
+        let observation_ids = messages
+            .iter()
+            .map(|message| {
+                message
+                    .metadata
+                    .observation_id
+                    .as_deref()
+                    .expect("streamed provider message should have an observation ID")
+            })
+            .collect::<Vec<_>>();
+        assert!(observation_ids
+            .iter()
+            .all(|observation_id| *observation_id == observation_ids[0]));
 
         assert_eq!(messages[0].as_concat_text(), "Hel");
         assert_eq!(messages[1].as_concat_text(), "lo");
@@ -1382,6 +1492,154 @@ mod tests {
             .as_deref()
             .expect("toolshim provider message should have an ID");
         assert!(id.starts_with("msg_"));
+        assert!(messages[0].metadata.observation_id.is_some());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn toolshim_generation_closes_before_processed_message_is_yielded() -> anyhow::Result<()>
+    {
+        let (layer, events) = capturing_layer();
+        let subscriber = tracing_subscriber::registry().with(layer);
+        let _subscriber_guard = tracing::subscriber::set_default(subscriber);
+
+        let provider = Arc::new(ToolshimMessageIdProvider {
+            messages: vec![Message::assistant().with_text("hello")],
+        });
+        let mut stream = Agent::stream_response_from_provider(
+            provider,
+            ModelConfig::new("test-model").with_toolshim(true),
+            "test-session",
+            "system",
+            &[Message::user().with_text("hi")],
+            &[],
+            &[],
+        )
+        .await?;
+
+        while let Some(item) = stream.next().await {
+            if item?.0.is_some() {
+                break;
+            }
+        }
+
+        wait_for_closed_generation(&events).await;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn generation_records_partial_output_before_stream_error() -> anyhow::Result<()> {
+        for toolshim in [false, true] {
+            let (layer, events) = capturing_layer();
+            {
+                let subscriber = tracing_subscriber::registry().with(layer);
+                let _subscriber_guard = tracing::subscriber::set_default(subscriber);
+                let mut stream = Agent::stream_response_from_provider(
+                    Arc::new(PartialErrorProvider),
+                    ModelConfig::new("test-model").with_toolshim(toolshim),
+                    "test-session",
+                    "system",
+                    &[Message::user().with_text("hi")],
+                    &[],
+                    &[],
+                )
+                .await?;
+
+                while let Some(item) = stream.next().await {
+                    if item.is_err() {
+                        break;
+                    }
+                }
+            }
+
+            let captured = wait_for_closed_generation(&events).await;
+            assert!(captured.iter().any(|(event_type, body)| {
+                event_type == "generation-update"
+                    && body["output"][0]["content"][0]["text"] == "partial response"
+            }));
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn generation_records_partial_output_when_stream_is_dropped() -> anyhow::Result<()> {
+        for toolshim in [false, true] {
+            let (layer, events) = capturing_layer();
+            {
+                let subscriber = tracing_subscriber::registry().with(layer);
+                let _subscriber_guard = tracing::subscriber::set_default(subscriber);
+                let mut stream = Agent::stream_response_from_provider(
+                    Arc::new(PartialErrorProvider),
+                    ModelConfig::new("test-model").with_toolshim(toolshim),
+                    "test-session",
+                    "system",
+                    &[Message::user().with_text("hi")],
+                    &[],
+                    &[],
+                )
+                .await?;
+
+                stream
+                    .next()
+                    .await
+                    .expect("provider should yield a partial chunk")?;
+                drop(stream);
+            }
+
+            let captured = wait_for_closed_generation(&events).await;
+            assert!(captured.iter().any(|(event_type, body)| {
+                event_type == "generation-update"
+                    && body["output"][0]["content"][0]["text"] == "partial "
+            }));
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn failed_generation_closes_before_model_list_enhancement() -> anyhow::Result<()> {
+        let (layer, events) = capturing_layer();
+        let provider = Arc::new(ModelErrorProvider {
+            model_fetch_started_at: Arc::new(Mutex::new(None)),
+        });
+        {
+            let subscriber = tracing_subscriber::registry().with(layer);
+            let _subscriber_guard = tracing::subscriber::set_default(subscriber);
+            let mut stream = Agent::stream_response_from_provider(
+                provider.clone(),
+                ModelConfig::new("test-model"),
+                "test-session",
+                "system",
+                &[Message::user().with_text("hi")],
+                &[],
+                &[],
+            )
+            .await?;
+
+            let error = stream
+                .next()
+                .await
+                .expect("failed stream creation should yield an error")
+                .expect_err("stream creation failure should surface");
+            assert!(error.to_string().contains("recommended-model"));
+        }
+
+        let end_time = wait_for_closed_generation(&events)
+            .await
+            .iter()
+            .find_map(|(_, body)| body.get("endTime")?.as_str().map(str::to_string))
+            .expect("closed generation should carry an end time");
+
+        let end_time = chrono::DateTime::parse_from_rfc3339(&end_time)?.with_timezone(&chrono::Utc);
+        let model_fetch_started_at = provider
+            .model_fetch_started_at
+            .lock()
+            .unwrap()
+            .expect("error enhancement should fetch the recommended model list");
+        assert!(end_time <= model_fetch_started_at);
 
         Ok(())
     }
@@ -1416,6 +1674,7 @@ mod tests {
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0].as_concat_text(), "hello");
         assert_eq!(messages[0].id.as_deref(), Some("provider-toolshim-id"));
+        assert!(messages[0].metadata.observation_id.is_some());
 
         Ok(())
     }

--- a/crates/goose/src/doctor.rs
+++ b/crates/goose/src/doctor.rs
@@ -155,7 +155,8 @@ async fn test_provider(
     let messages = vec![Message::user().with_text("Say 'hello' and nothing else.")];
     crate::session_context::with_session_id(
         Some("doctor-check".to_string()),
-        provider.complete(
+        crate::tracing::complete_provider(
+            provider,
             model_config,
             "Respond as briefly as possible.",
             &messages,

--- a/crates/goose/src/model_config.rs
+++ b/crates/goose/src/model_config.rs
@@ -130,7 +130,7 @@ pub async fn complete_fast(
 
     match crate::session_context::with_session_id(
         Some(session_id.to_string()),
-        provider.complete(&fast_model_config, system, messages, tools),
+        crate::tracing::complete_provider(provider, &fast_model_config, system, messages, tools),
     )
     .await
     {
@@ -147,7 +147,13 @@ pub async fn complete_fast(
                 .with_thinking_effort(ThinkingEffort::Off);
             crate::session_context::with_session_id(
                 Some(session_id.to_string()),
-                provider.complete(&fallback_config, system, messages, tools),
+                crate::tracing::complete_provider(
+                    provider,
+                    &fallback_config,
+                    system,
+                    messages,
+                    tools,
+                ),
             )
             .await
         }

--- a/crates/goose/src/permission/permission_judge.rs
+++ b/crates/goose/src/permission/permission_judge.rs
@@ -167,7 +167,8 @@ pub async fn detect_read_only_requests(
     };
     let res = crate::session_context::with_session_id(
         Some(session_id.to_string()),
-        provider.complete(
+        crate::tracing::complete_provider(
+            provider.as_ref(),
             &model_config,
             &system_prompt,
             check_messages.messages(),

--- a/crates/goose/src/providers/toolshim.rs
+++ b/crates/goose/src/providers/toolshim.rs
@@ -38,15 +38,19 @@ use crate::conversation::message::{Message, MessageContent};
 use crate::conversation::Conversation;
 use crate::model_config::model_config_from_user_config;
 use crate::providers::base::DEFAULT_PROVIDER_TIMEOUT_SECS;
+use crate::tracing::ProviderGeneration;
 use anyhow::Result;
 use futures::StreamExt;
+use goose_providers::conversation::token_usage::{ProviderUsage, Usage};
 use goose_providers::errors::ProviderError;
 use goose_providers::formats::openai::create_request;
 use goose_providers::images::ImageFormat;
+use goose_providers::model::ModelConfig;
 use reqwest::Client;
 use rmcp::model::{object, CallToolRequestParams, ContentBlock, Tool};
 use serde_json::{json, Value};
 use std::time::Duration;
+use tracing_futures::Instrument;
 use uuid::Uuid;
 
 /// Default model to use for tool interpretation
@@ -529,9 +533,43 @@ pub fn sanitize_residual_markers(mut message: Message) -> Message {
     message
 }
 
+/// The interpreter request is a model call the user waits on, so it gets its own
+/// generation observation rather than being folded into the primary one.
+fn interpreter_generation(
+    provider_name: &str,
+    model_config: &ModelConfig,
+    system_prompt: &str,
+    messages: &[Message],
+) -> ProviderGeneration {
+    ProviderGeneration::new(
+        provider_name,
+        model_config,
+        &crate::session_context::current_session_id().unwrap_or_default(),
+        system_prompt,
+        messages,
+        &[],
+    )
+}
+
+fn ollama_response_usage(model: &str, response: &Value) -> Option<ProviderUsage> {
+    let input_tokens = response["prompt_eval_count"]
+        .as_i64()
+        .map(|count| count as i32);
+    let output_tokens = response["eval_count"].as_i64().map(|count| count as i32);
+    if input_tokens.is_none() && output_tokens.is_none() {
+        return None;
+    }
+
+    Some(ProviderUsage::new(
+        model.to_string(),
+        Usage::new(input_tokens, output_tokens, None),
+    ))
+}
+
 /// Environment variables that affect behavior:
 /// - GOOSE_TOOLSHIM: When set to "true" or "1", enables using the tool shim in the standard OllamaProvider (default: false)
 /// - GOOSE_TOOLSHIM_OLLAMA_MODEL: Ollama model to use as the tool interpreter (default: DEFAULT_INTERPRETER_MODEL)
+///
 /// A trait for models that can interpret text into structured tool call JSON format
 #[async_trait::async_trait]
 pub trait ToolInterpreter {
@@ -579,14 +617,33 @@ impl LocalInterpreter {
             })?;
 
         let request_messages = vec![Message::user().with_text(format_instruction)];
-        let mut stream = provider
+        let mut generation = interpreter_generation("local", &model_config, "", &request_messages);
+        let mut stream = match provider
             .stream(&model_config, "", &request_messages, &[])
-            .await?;
+            .instrument(generation.span())
+            .await
+        {
+            Ok(stream) => stream,
+            Err(error) => {
+                generation.record_error(&error);
+                return Err(error);
+            }
+        };
 
         let mut content = String::new();
-        while let Some(chunk) = stream.next().await {
-            let (message, _) = chunk?;
+        while let Some(chunk) = stream.next().instrument(generation.span()).await {
+            let (message, usage) = match chunk {
+                Ok(chunk) => chunk,
+                Err(error) => {
+                    generation.record_error(&error);
+                    return Err(error);
+                }
+            };
+            if let Some(usage) = usage {
+                generation.record_usage(&usage);
+            }
             if let Some(message) = message {
+                generation.record_output(&message);
                 for part in message.content {
                     if let MessageContent::Text(text) = part {
                         content.push_str(&text.text);
@@ -677,19 +734,46 @@ impl OllamaInterpreter {
         format_schema: Value,
         model: &str,
     ) -> Result<Value, ProviderError> {
+        let messages = vec![Message::user().with_text(format_instruction)];
+        let model_config = model_config_from_user_config("ollama", model)?;
+        let mut generation =
+            interpreter_generation("ollama", &model_config, system_prompt, &messages);
+
+        let result = self
+            .send_structured_request(&model_config, system_prompt, &messages, format_schema)
+            .instrument(generation.span())
+            .await;
+
+        match &result {
+            Ok(response) => {
+                generation.record_output(
+                    &Message::assistant()
+                        .with_text(response["message"]["content"].as_str().unwrap_or_default()),
+                );
+                if let Some(usage) = ollama_response_usage(&model_config.model_name, response) {
+                    generation.record_usage(&usage);
+                }
+            }
+            Err(error) => generation.record_error(error),
+        }
+
+        result
+    }
+
+    async fn send_structured_request(
+        &self,
+        model_config: &ModelConfig,
+        system_prompt: &str,
+        messages: &[Message],
+        format_schema: Value,
+    ) -> Result<Value, ProviderError> {
         let base_url = self.base_url.trim_end_matches('/');
         let url = format!("{}/api/chat", base_url);
 
-        let mut messages = Vec::new();
-        let user_message = Message::user().with_text(format_instruction);
-        messages.push(user_message);
-
-        let model_config = model_config_from_user_config("ollama", model)?;
-
         let mut payload = create_request(
-            &model_config,
+            model_config,
             system_prompt,
-            &messages,
+            messages,
             &[], // No tools
             &ImageFormat::OpenAi,
             false,
@@ -1045,6 +1129,113 @@ pub async fn augment_message_with_selected_tool_interpreter(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::tracing::test_support::{capturing_layer, wait_for_closed_generation};
+    use tracing_subscriber::prelude::*;
+    use wiremock::matchers::{method, path as request_path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[tokio::test]
+    async fn ollama_interpreter_request_is_traced_as_its_own_generation() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(request_path("/api/chat"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "message": { "content": "{\"tool_calls\":[]}" },
+                "prompt_eval_count": 31,
+                "eval_count": 7
+            })))
+            .mount(&server)
+            .await;
+
+        let (layer, events) = capturing_layer();
+        let subscriber = tracing_subscriber::registry().with(layer);
+        let _subscriber_guard = tracing::subscriber::set_default(subscriber);
+
+        let interpreter = OllamaInterpreter {
+            client: Client::new(),
+            base_url: server.uri(),
+        };
+        let response = interpreter
+            .post_structured(
+                "interpreter system",
+                "interpret this",
+                OllamaInterpreter::tool_structured_output_format_schema(),
+                "interpreter-model",
+            )
+            .await
+            .expect("mocked interpreter request should succeed");
+        assert_eq!(response["message"]["content"], "{\"tool_calls\":[]}");
+
+        let captured = wait_for_closed_generation(&events).await;
+        assert!(captured.iter().any(|(event_type, body)| {
+            event_type == "generation-create" && body["model"] == "interpreter-model"
+        }));
+        assert!(captured.iter().any(|(event_type, body)| {
+            event_type == "generation-update"
+                && body["input"]["messages"][0]["content"][0]["text"] == "interpret this"
+        }));
+        assert!(captured.iter().any(|(event_type, body)| {
+            event_type == "generation-update"
+                && body["usageDetails"]["input"] == 31
+                && body["usageDetails"]["output"] == 7
+                && body["usageDetails"]["total"] == 38
+        }));
+        assert!(captured.iter().any(|(event_type, body)| {
+            event_type == "generation-update"
+                && body["output"][0]["content"][0]["text"] == "{\"tool_calls\":[]}"
+        }));
+    }
+
+    #[tokio::test]
+    async fn failed_interpreter_request_records_the_error_status() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(request_path("/api/chat"))
+            .respond_with(ResponseTemplate::new(500).set_body_string("model not loaded"))
+            .mount(&server)
+            .await;
+
+        let (layer, events) = capturing_layer();
+        let subscriber = tracing_subscriber::registry().with(layer);
+        let _subscriber_guard = tracing::subscriber::set_default(subscriber);
+
+        let interpreter = OllamaInterpreter {
+            client: Client::new(),
+            base_url: server.uri(),
+        };
+        interpreter
+            .post_structured(
+                "",
+                "interpret this",
+                OllamaInterpreter::tool_structured_output_format_schema(),
+                "interpreter-model",
+            )
+            .await
+            .expect_err("interpreter request should fail");
+
+        let captured = wait_for_closed_generation(&events).await;
+        assert!(captured.iter().any(|(event_type, body)| {
+            event_type == "generation-update"
+                && body["statusMessage"]
+                    .as_str()
+                    .is_some_and(|status| status.contains("model not loaded"))
+        }));
+    }
+
+    #[test]
+    fn ollama_response_usage_maps_eval_counts() {
+        let usage = ollama_response_usage(
+            "interpreter-model",
+            &json!({ "prompt_eval_count": 11, "eval_count": 4 }),
+        )
+        .expect("eval counts should map to usage");
+        assert_eq!(usage.model, "interpreter-model");
+        assert_eq!(usage.usage.input_tokens, Some(11));
+        assert_eq!(usage.usage.output_tokens, Some(4));
+        assert_eq!(usage.usage.total_tokens, Some(15));
+
+        assert!(ollama_response_usage("interpreter-model", &json!({})).is_none());
+    }
 
     struct FailingInterpreter;
 

--- a/crates/goose/src/security/adversary_inspector.rs
+++ b/crates/goose/src/security/adversary_inspector.rs
@@ -326,7 +326,13 @@ impl AdversaryInspector {
             .map_err(|e| anyhow::anyhow!("Could not resolve model config: {}", e))?;
         let (response, _usage) = crate::session_context::with_session_id(
             Some(session_id.to_string()),
-            provider.complete(&model_config, system_prompt, conversation.messages(), &[]),
+            crate::tracing::complete_provider(
+                provider.as_ref(),
+                &model_config,
+                system_prompt,
+                conversation.messages(),
+                &[],
+            ),
         )
         .await
         .map_err(|e| anyhow::anyhow!("Adversary LLM call failed: {}", e))?;

--- a/crates/goose/src/tool_call_labels.rs
+++ b/crates/goose/src/tool_call_labels.rs
@@ -204,7 +204,13 @@ async fn complete_label(
     for attempt in 0..LABEL_GENERATION_MAX_ATTEMPTS {
         if let Ok((response, _)) = with_session_id(
             Some(session_id.to_string()),
-            provider.complete(model_config, system_prompt, from_ref(message), &[]),
+            crate::tracing::complete_provider(
+                provider,
+                model_config,
+                system_prompt,
+                from_ref(message),
+                &[],
+            ),
         )
         .await
         {

--- a/crates/goose/src/tracing/langfuse_layer.rs
+++ b/crates/goose/src/tracing/langfuse_layer.rs
@@ -1,4 +1,4 @@
-use crate::tracing::observation_layer::{BatchManager, ObservationLayer, SpanTracker};
+use crate::tracing::observation_layer::{BatchManager, ObservationLayer};
 use chrono::Utc;
 use reqwest::{Client, StatusCode};
 use serde::{Deserialize, Serialize};
@@ -179,10 +179,7 @@ pub fn create_langfuse_observer() -> Option<ObservationLayer> {
         LangfuseBatchManager::spawn_sender(batch_manager.clone());
     }
 
-    Some(ObservationLayer {
-        batch_manager,
-        span_tracker: Arc::new(Mutex::new(SpanTracker::new())),
-    })
+    Some(ObservationLayer::new(batch_manager))
 }
 
 #[cfg(test)]

--- a/crates/goose/src/tracing/mod.rs
+++ b/crates/goose/src/tracing/mod.rs
@@ -1,11 +1,17 @@
 pub mod langfuse_layer;
 mod observation_layer;
+mod provider_generation;
 pub mod rate_limiter;
+#[cfg(test)]
+pub(crate) mod test_support;
 
 pub use langfuse_layer::{create_langfuse_observer, LangfuseBatchManager};
+pub(crate) use observation_layer::is_observation_layer_active;
 pub use observation_layer::{
     flatten_metadata, map_level, BatchManager, ObservationLayer, SpanData, SpanTracker,
 };
+pub use provider_generation::complete_provider;
+pub(crate) use provider_generation::ProviderGeneration;
 pub use rate_limiter::{
     MetricData, RateLimitedTelemetrySender, SpanData as RateLimitedSpanData, TelemetryEvent,
 };

--- a/crates/goose/src/tracing/observation_layer.rs
+++ b/crates/goose/src/tracing/observation_layer.rs
@@ -1,9 +1,10 @@
 use chrono::Utc;
-use serde_json::{json, Value};
+use serde_json::{json, Map, Value};
 use std::collections::HashMap;
 use std::fmt;
-use std::sync::Arc;
-use tokio::sync::Mutex;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex as StdMutex};
+use tokio::sync::{mpsc, Mutex};
 use tracing::field::{Field, Visit};
 use tracing::{span, Event, Id, Level, Metadata, Subscriber};
 use tracing_subscriber::layer::Context;
@@ -13,12 +14,66 @@ use uuid::Uuid;
 
 #[derive(Debug, Clone)]
 pub struct SpanData {
-    pub observation_id: String, // Langfuse requires ids to be UUID v4 strings
+    pub observation_id: String,
     pub name: String,
     pub start_time: String,
     pub level: String,
-    pub metadata: serde_json::Map<String, Value>,
+    pub metadata: Map<String, Value>,
     pub parent_span_id: Option<u64>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ObservationType {
+    Span,
+    Generation,
+}
+
+impl ObservationType {
+    fn from_value(value: Option<Value>) -> Self {
+        match value.as_ref().and_then(Value::as_str) {
+            Some(value) if value.eq_ignore_ascii_case("GENERATION") => Self::Generation,
+            _ => Self::Span,
+        }
+    }
+
+    fn create_event(self) -> &'static str {
+        match self {
+            Self::Span => "span-create",
+            Self::Generation => "generation-create",
+        }
+    }
+
+    fn update_event(self) -> &'static str {
+        match self {
+            Self::Span => "span-update",
+            Self::Generation => "generation-update",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TraceFieldTarget {
+    Trace,
+    Observation,
+}
+
+#[derive(Debug, Clone)]
+struct ObservationContext {
+    observation_id: String,
+    trace_id: String,
+    observation_type: ObservationType,
+    trace_field_target: TraceFieldTarget,
+}
+
+#[derive(Debug)]
+struct NewObservation {
+    context: ObservationContext,
+    parent_observation_id: Option<String>,
+    name: String,
+    start_time: String,
+    level: String,
+    fields: Map<String, Value>,
+    creates_trace: bool,
 }
 
 pub fn map_level(level: &Level) -> &'static str {
@@ -26,28 +81,22 @@ pub fn map_level(level: &Level) -> &'static str {
         Level::ERROR => "ERROR",
         Level::WARN => "WARNING",
         Level::INFO => "DEFAULT",
-        Level::DEBUG => "DEBUG",
-        Level::TRACE => "DEBUG",
+        Level::DEBUG | Level::TRACE => "DEBUG",
     }
 }
 
-pub fn flatten_metadata(
-    metadata: serde_json::Map<String, Value>,
-) -> serde_json::Map<String, Value> {
-    let mut flattened = serde_json::Map::new();
+pub fn flatten_metadata(metadata: Map<String, Value>) -> Map<String, Value> {
+    let mut flattened = Map::new();
     for (key, value) in metadata {
         match value {
-            Value::String(s) => {
-                flattened.insert(key, json!(s));
-            }
-            Value::Object(mut obj) => {
-                if let Some(text) = obj.remove("text") {
+            Value::Object(mut object) => {
+                if let Some(text) = object.remove("text") {
                     flattened.insert(key, text);
                 } else {
-                    flattened.insert(key, json!(obj));
+                    flattened.insert(key, Value::Object(object));
                 }
             }
-            _ => {
+            value => {
                 flattened.insert(key, value);
             }
         }
@@ -63,7 +112,7 @@ pub trait BatchManager: Send + Sync + 'static {
 
 #[derive(Debug)]
 pub struct SpanTracker {
-    active_spans: HashMap<u64, String>, // span_id -> observation_id. span_id in Tracing is u64 whereas Langfuse requires UUID v4 strings
+    active_spans: HashMap<u64, String>,
     current_trace_id: Option<String>,
 }
 
@@ -94,183 +143,380 @@ impl SpanTracker {
     }
 }
 
+type QueuedEvent = (&'static str, Value);
+static ACTIVE_OBSERVATION_LAYERS: AtomicUsize = AtomicUsize::new(0);
+
+struct ActiveObservationLayer;
+
+impl Drop for ActiveObservationLayer {
+    fn drop(&mut self) {
+        ACTIVE_OBSERVATION_LAYERS.fetch_sub(1, Ordering::Relaxed);
+    }
+}
+
+pub(crate) fn is_observation_layer_active() -> bool {
+    ACTIVE_OBSERVATION_LAYERS.load(Ordering::Relaxed) > 0
+}
+
 #[derive(Clone)]
 pub struct ObservationLayer {
     pub batch_manager: Arc<Mutex<dyn BatchManager>>,
     pub span_tracker: Arc<Mutex<SpanTracker>>,
+    event_sender: mpsc::UnboundedSender<QueuedEvent>,
+    idle_receiver: Arc<StdMutex<Option<mpsc::UnboundedReceiver<QueuedEvent>>>>,
+    _activity: Arc<ActiveObservationLayer>,
 }
 
 impl ObservationLayer {
-    pub async fn handle_span(&self, span_id: u64, span_data: SpanData) {
-        let observation_id = span_data.observation_id.clone();
+    pub fn new(batch_manager: Arc<Mutex<dyn BatchManager>>) -> Self {
+        let (event_sender, event_receiver) = mpsc::unbounded_channel::<QueuedEvent>();
+        ACTIVE_OBSERVATION_LAYERS.fetch_add(1, Ordering::Relaxed);
 
-        {
-            let mut spans = self.span_tracker.lock().await;
-            spans.add_span(span_id, observation_id.clone());
-        }
+        let layer = Self {
+            batch_manager,
+            span_tracker: Arc::new(Mutex::new(SpanTracker::new())),
+            event_sender,
+            idle_receiver: Arc::new(StdMutex::new(Some(event_receiver))),
+            _activity: Arc::new(ActiveObservationLayer),
+        };
+        layer.start_worker();
+        layer
+    }
 
-        // Get parent ID if it exists
-        let parent_id = if let Some(parent_span_id) = span_data.parent_span_id {
-            let spans = self.span_tracker.lock().await;
-            spans.get_span(parent_span_id).cloned()
-        } else {
-            None
+    /// Callers such as `create_langfuse_observer` build the layer from
+    /// synchronous logging setup, so there may be no runtime to spawn on yet.
+    /// The channel is unbounded, so events queued before the worker starts are
+    /// delivered once tracing reaches the layer from inside a runtime.
+    fn start_worker(&self) {
+        let mut idle_receiver = self.idle_receiver.lock().unwrap();
+        let Some(mut event_receiver) = idle_receiver.take() else {
+            return;
+        };
+        let Ok(handle) = tokio::runtime::Handle::try_current() else {
+            *idle_receiver = Some(event_receiver);
+            return;
         };
 
-        let trace_id = self.ensure_trace_id().await;
+        let batch_manager = self.batch_manager.clone();
+        handle.spawn(async move {
+            while let Some((event_type, body)) = event_receiver.recv().await {
+                batch_manager.lock().await.add_event(event_type, body);
+            }
+        });
+    }
 
-        // Create the span observation
-        let mut batch = self.batch_manager.lock().await;
-        batch.add_event(
-            "observation-create",
+    fn enqueue(&self, event_type: &'static str, body: Value) {
+        self.start_worker();
+        let _ = self.event_sender.send((event_type, body));
+    }
+
+    fn enqueue_new_observation(&self, mut observation: NewObservation) {
+        let trace_input = take_value(&mut observation.fields, &["trace_input"]);
+        let trace_output = take_value(&mut observation.fields, &["trace_output"]);
+
+        if observation.context.trace_field_target == TraceFieldTarget::Observation {
+            if let Some(input) = trace_input {
+                observation.fields.insert("input".to_string(), input);
+            }
+            if let Some(output) = trace_output {
+                observation.fields.insert("output".to_string(), output);
+            }
+        } else if observation.creates_trace {
+            let mut trace_body = json!({
+                "id": observation.context.trace_id,
+                "name": observation.name,
+                "timestamp": observation.start_time,
+                "metadata": {},
+                "tags": [],
+                "public": false
+            });
+
+            if let Some(session_id) = observation
+                .fields
+                .get("session.id")
+                .and_then(value_as_string)
+            {
+                trace_body["sessionId"] = Value::String(session_id);
+            }
+            if let Some(input) = trace_input {
+                trace_body["input"] = input;
+            }
+            if let Some(output) = trace_output {
+                trace_body["output"] = output;
+            }
+
+            self.enqueue("trace-create", trace_body);
+        } else if trace_input.is_some() || trace_output.is_some() {
+            let mut trace_update = json!({ "id": observation.context.trace_id });
+            if let Some(input) = trace_input {
+                trace_update["input"] = input;
+            }
+            if let Some(output) = trace_output {
+                trace_update["output"] = output;
+            }
+            self.enqueue("trace-create", trace_update);
+        }
+
+        let body = observation_body(
+            &observation.context,
+            observation.parent_observation_id,
+            observation.name,
+            observation.start_time,
+            observation.level,
+            &mut observation.fields,
+        );
+        self.enqueue(observation.context.observation_type.create_event(), body);
+    }
+
+    fn enqueue_close(&self, context: ObservationContext) {
+        self.enqueue(
+            context.observation_type.update_event(),
             json!({
-                "id": observation_id,
-                "traceId": trace_id,
-                "type": "SPAN",
-                "name": span_data.name,
-                "startTime": span_data.start_time,
-                "parentObservationId": parent_id,
-                "metadata": span_data.metadata,
-                "level": span_data.level
+                "id": context.observation_id,
+                "traceId": context.trace_id,
+                "endTime": Utc::now().to_rfc3339()
             }),
         );
     }
 
-    pub async fn handle_span_close(&self, span_id: u64) {
-        let observation_id = {
-            let mut spans = self.span_tracker.lock().await;
-            spans.remove_span(span_id)
-        };
+    fn enqueue_record(&self, context: ObservationContext, mut fields: Map<String, Value>) {
+        match context.trace_field_target {
+            TraceFieldTarget::Trace => {
+                let mut trace_update = json!({ "id": context.trace_id });
+                let mut has_trace_update = false;
 
+                if let Some(input) = take_value(&mut fields, &["trace_input"]) {
+                    trace_update["input"] = input;
+                    has_trace_update = true;
+                }
+                if let Some(output) = take_value(&mut fields, &["trace_output"]) {
+                    trace_update["output"] = output;
+                    has_trace_update = true;
+                }
+                if has_trace_update {
+                    self.enqueue("trace-create", trace_update);
+                }
+            }
+            TraceFieldTarget::Observation => {
+                if let Some(input) = take_value(&mut fields, &["trace_input"]) {
+                    fields.insert("input".to_string(), input);
+                }
+                if let Some(output) = take_value(&mut fields, &["trace_output"]) {
+                    fields.insert("output".to_string(), output);
+                }
+            }
+        }
+
+        remove_internal_fields(&mut fields);
+        if fields.is_empty() {
+            return;
+        }
+
+        let mut update = json!({
+            "id": context.observation_id,
+            "traceId": context.trace_id
+        });
+        apply_observation_fields(&mut update, &mut fields, context.observation_type);
+        if !fields.is_empty() {
+            update["metadata"] = Value::Object(flatten_metadata(fields));
+        }
+        self.enqueue(context.observation_type.update_event(), update);
+    }
+
+    pub async fn handle_span(&self, span_id: u64, mut span_data: SpanData) {
+        let observation_type =
+            ObservationType::from_value(take_value(&mut span_data.metadata, &["observation_type"]));
+        let parent_observation_id = if let Some(parent_span_id) = span_data.parent_span_id {
+            self.span_tracker
+                .lock()
+                .await
+                .get_span(parent_span_id)
+                .cloned()
+        } else {
+            None
+        };
+        self.span_tracker
+            .lock()
+            .await
+            .add_span(span_id, span_data.observation_id.clone());
+        let trace_id = self.ensure_trace_id().await;
+        let context = ObservationContext {
+            observation_id: span_data.observation_id,
+            trace_id,
+            observation_type,
+            trace_field_target: TraceFieldTarget::Trace,
+        };
+        let body = observation_body(
+            &context,
+            parent_observation_id,
+            span_data.name,
+            span_data.start_time,
+            span_data.level,
+            &mut span_data.metadata,
+        );
+        self.enqueue(observation_type.create_event(), body);
+    }
+
+    pub async fn handle_span_close(&self, span_id: u64) {
+        let observation_id = self.span_tracker.lock().await.remove_span(span_id);
         if let Some(observation_id) = observation_id {
-            let trace_id = self.ensure_trace_id().await;
-            let mut batch = self.batch_manager.lock().await;
-            batch.add_event(
-                "observation-update",
-                json!({
-                    "id": observation_id,
-                    "type": "SPAN",
-                    "traceId": trace_id,
-                    "endTime": Utc::now().to_rfc3339()
-                }),
-            );
+            self.enqueue_close(ObservationContext {
+                observation_id,
+                trace_id: self.ensure_trace_id().await,
+                observation_type: ObservationType::Span,
+                trace_field_target: TraceFieldTarget::Trace,
+            });
         }
     }
 
     pub async fn ensure_trace_id(&self) -> String {
         let mut spans = self.span_tracker.lock().await;
-        if let Some(id) = spans.current_trace_id.clone() {
-            return id;
+        if let Some(trace_id) = &spans.current_trace_id {
+            return trace_id.clone();
         }
 
         let trace_id = Uuid::new_v4().to_string();
         spans.current_trace_id = Some(trace_id.clone());
-
-        let mut batch = self.batch_manager.lock().await;
-        batch.add_event(
+        self.enqueue(
             "trace-create",
             json!({
                 "id": trace_id,
                 "name": Utc::now().timestamp().to_string(),
                 "timestamp": Utc::now().to_rfc3339(),
-                "input": {},
                 "metadata": {},
                 "tags": [],
                 "public": false
             }),
         );
-
         trace_id
     }
+}
 
-    pub async fn update_trace(&self, updates: serde_json::Map<String, Value>) {
-        let trace_id = self.ensure_trace_id().await;
-        let mut body = json!({ "id": trace_id });
-        for (k, v) in updates {
-            body[k] = v;
+fn observation_body(
+    context: &ObservationContext,
+    parent_observation_id: Option<String>,
+    name: String,
+    start_time: String,
+    level: String,
+    fields: &mut Map<String, Value>,
+) -> Value {
+    remove_internal_fields(fields);
+    let mut body = json!({
+        "id": context.observation_id,
+        "traceId": context.trace_id,
+        "name": name,
+        "startTime": start_time,
+        "level": level
+    });
+    if let Some(parent_observation_id) = parent_observation_id {
+        body["parentObservationId"] = Value::String(parent_observation_id);
+    }
+    apply_observation_fields(&mut body, fields, context.observation_type);
+    if !fields.is_empty() {
+        body["metadata"] = Value::Object(flatten_metadata(std::mem::take(fields)));
+    }
+    body
+}
+
+fn apply_observation_fields(
+    body: &mut Value,
+    fields: &mut Map<String, Value>,
+    observation_type: ObservationType,
+) {
+    for (source_names, target_name) in [
+        (&["input"][..], "input"),
+        (&["output"][..], "output"),
+        (&["status_message", "statusMessage"][..], "statusMessage"),
+    ] {
+        if let Some(value) = take_value(fields, source_names) {
+            body[target_name] = value;
         }
-        let mut batch = self.batch_manager.lock().await;
-        batch.add_event("trace-create", body);
     }
 
-    pub async fn handle_record(&self, span_id: u64, metadata: serde_json::Map<String, Value>) {
-        // Handle trace-level fields by updating the trace itself
-        let trace_fields: Vec<&str> = vec!["trace_input", "trace_output"];
-        let has_trace_fields = trace_fields.iter().any(|f| metadata.contains_key(*f));
-
-        if has_trace_fields {
-            let mut trace_updates = serde_json::Map::new();
-            if let Some(val) = metadata.get("trace_input") {
-                trace_updates.insert("input".to_string(), val.clone());
-            }
-            if let Some(val) = metadata.get("trace_output") {
-                trace_updates.insert("output".to_string(), val.clone());
-            }
-            if !trace_updates.is_empty() {
-                self.update_trace(trace_updates).await;
-            }
+    for (source_names, target_name) in [
+        (&["input_json"][..], "input"),
+        (&["output_json"][..], "output"),
+    ] {
+        if let Some(value) = take_value(fields, source_names) {
+            body[target_name] = parse_recorded_json(value);
         }
+    }
 
-        // Filter out trace-level fields from span metadata
-        let span_metadata: serde_json::Map<String, Value> = metadata
-            .into_iter()
-            .filter(|(k, _)| !trace_fields.contains(&k.as_str()))
-            .collect();
+    if observation_type != ObservationType::Generation {
+        return;
+    }
 
-        if span_metadata.is_empty() {
-            return;
+    for (source_names, target_name) in [
+        (&["model"][..], "model"),
+        (
+            &["completion_start_time", "completionStartTime"][..],
+            "completionStartTime",
+        ),
+    ] {
+        if let Some(value) = take_value(fields, source_names) {
+            body[target_name] = value;
         }
+    }
 
-        let observation_id = {
-            let spans = self.span_tracker.lock().await;
-            spans.get_span(span_id).cloned()
-        };
-
-        if let Some(observation_id) = observation_id {
-            let trace_id = self.ensure_trace_id().await;
-
-            let mut update = json!({
-                "id": observation_id,
-                "traceId": trace_id,
-                "type": "SPAN"
-            });
-
-            // Handle special fields
-            if let Some(val) = span_metadata.get("input") {
-                update["input"] = val.clone();
-            }
-
-            if let Some(val) = span_metadata.get("output") {
-                update["output"] = val.clone();
-            }
-
-            if let Some(val) = span_metadata.get("model_config") {
-                update["metadata"] = json!({ "model_config": val });
-            }
-
-            // Handle any remaining metadata
-            let remaining_metadata: serde_json::Map<String, Value> = span_metadata
-                .iter()
-                .filter(|(k, _)| !["input", "output", "model_config"].contains(&k.as_str()))
-                .map(|(k, v)| (k.clone(), v.clone()))
-                .collect();
-
-            if !remaining_metadata.is_empty() {
-                let flattened = flatten_metadata(remaining_metadata);
-                if update.get("metadata").is_some() {
-                    if let Some(obj) = update["metadata"].as_object_mut() {
-                        for (k, v) in flattened {
-                            obj.insert(k, v);
-                        }
-                    }
-                } else {
-                    update["metadata"] = json!(flattened);
-                }
-            }
-
-            let mut batch = self.batch_manager.lock().await;
-            batch.add_event("span-update", update);
+    for (source_names, target_name) in [
+        (
+            &[
+                "model_parameters_json",
+                "model_parameters",
+                "modelParameters",
+                "model_config",
+            ][..],
+            "modelParameters",
+        ),
+        (
+            &[
+                "usage_details_json",
+                "usage_details",
+                "usageDetails",
+                "usage",
+            ][..],
+            "usageDetails",
+        ),
+        (
+            &["cost_details_json", "cost_details", "costDetails"][..],
+            "costDetails",
+        ),
+    ] {
+        if let Some(value) = take_value(fields, source_names) {
+            body[target_name] = parse_recorded_json(value);
         }
+    }
+}
+
+fn remove_internal_fields(fields: &mut Map<String, Value>) {
+    for name in [
+        "observation_type",
+        "observation_id",
+        "trace_id",
+        "parent_observation_id",
+        "trace_boundary",
+        "trace_input",
+        "trace_output",
+    ] {
+        fields.remove(name);
+    }
+}
+
+fn take_value(fields: &mut Map<String, Value>, names: &[&str]) -> Option<Value> {
+    names.iter().find_map(|name| fields.remove(*name))
+}
+
+fn value_as_string(value: &Value) -> Option<String> {
+    match value {
+        Value::String(value) => Some(value.clone()),
+        _ => None,
+    }
+}
+
+fn parse_recorded_json(value: Value) -> Value {
+    match value {
+        Value::String(value) => serde_json::from_str(&value).unwrap_or(Value::String(value)),
+        value => value,
     }
 }
 
@@ -282,69 +528,126 @@ where
         metadata.target().starts_with("goose::")
     }
 
-    fn on_new_span(&self, attrs: &span::Attributes<'_>, id: &span::Id, ctx: Context<'_, S>) {
-        let span_id = id.into_u64();
-
-        let parent_span_id = ctx
+    fn on_new_span(&self, attrs: &span::Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
+        let parent_context = ctx
             .span_scope(id)
             .and_then(|mut scope| scope.nth(1))
-            .map(|parent| parent.id().into_u64());
+            .and_then(|parent| parent.extensions().get::<ObservationContext>().cloned());
 
         let mut visitor = JsonVisitor::new();
         attrs.record(&mut visitor);
+        let mut fields = visitor.recorded_fields;
 
-        let span_data = SpanData {
-            observation_id: Uuid::new_v4().to_string(),
+        let observation_type =
+            ObservationType::from_value(take_value(&mut fields, &["observation_type"]));
+        let trace_boundary = take_value(&mut fields, &["trace_boundary"])
+            .and_then(|value| value.as_bool())
+            .unwrap_or(false);
+        let observation_id = take_value(&mut fields, &["observation_id"])
+            .as_ref()
+            .and_then(value_as_string)
+            .unwrap_or_else(|| Uuid::new_v4().to_string());
+        let explicit_trace_id = take_value(&mut fields, &["trace_id"])
+            .as_ref()
+            .and_then(value_as_string);
+        let explicit_parent_id = take_value(&mut fields, &["parent_observation_id"])
+            .as_ref()
+            .and_then(value_as_string);
+
+        let trace_id = explicit_trace_id
+            .or_else(|| {
+                parent_context
+                    .as_ref()
+                    .map(|parent| parent.trace_id.clone())
+            })
+            .unwrap_or_else(|| Uuid::new_v4().to_string());
+        let parent_observation_id = explicit_parent_id.or_else(|| {
+            parent_context
+                .as_ref()
+                .map(|parent| parent.observation_id.clone())
+        });
+        let context = ObservationContext {
+            observation_id,
+            trace_id,
+            observation_type,
+            trace_field_target: if trace_boundary {
+                if parent_context.is_some() {
+                    TraceFieldTarget::Observation
+                } else {
+                    TraceFieldTarget::Trace
+                }
+            } else {
+                parent_context
+                    .as_ref()
+                    .map(|parent| parent.trace_field_target)
+                    .unwrap_or(TraceFieldTarget::Trace)
+            },
+        };
+
+        if let Some(span) = ctx.span(id) {
+            span.extensions_mut().insert(context.clone());
+        }
+
+        self.enqueue_new_observation(NewObservation {
+            context,
+            parent_observation_id,
             name: attrs.metadata().name().to_string(),
             start_time: Utc::now().to_rfc3339(),
             level: map_level(attrs.metadata().level()).to_owned(),
-            metadata: visitor.recorded_fields,
-            parent_span_id,
+            fields,
+            creates_trace: parent_context.is_none(),
+        });
+    }
+
+    fn on_close(&self, id: Id, ctx: Context<'_, S>) {
+        let context = ctx
+            .span(&id)
+            .and_then(|span| span.extensions().get::<ObservationContext>().cloned());
+        if let Some(context) = context {
+            self.enqueue_close(context);
+        }
+    }
+
+    fn on_record(&self, span: &Id, values: &span::Record<'_>, ctx: Context<'_, S>) {
+        let context = ctx
+            .span(span)
+            .and_then(|span| span.extensions().get::<ObservationContext>().cloned());
+        let Some(context) = context else {
+            return;
         };
 
-        let layer = self.clone();
-        tokio::spawn(async move { layer.handle_span(span_id, span_data).await });
-    }
-
-    fn on_close(&self, id: Id, _ctx: Context<'_, S>) {
-        let span_id = id.into_u64();
-        let layer = self.clone();
-        tokio::spawn(async move { layer.handle_span_close(span_id).await });
-    }
-
-    fn on_record(&self, span: &Id, values: &span::Record<'_>, _ctx: Context<'_, S>) {
-        let span_id = span.into_u64();
         let mut visitor = JsonVisitor::new();
         values.record(&mut visitor);
-        let metadata = visitor.recorded_fields;
-
-        if !metadata.is_empty() {
-            let layer = self.clone();
-            tokio::spawn(async move { layer.handle_record(span_id, metadata).await });
+        if !visitor.recorded_fields.is_empty() {
+            self.enqueue_record(context, visitor.recorded_fields);
         }
     }
 
     fn on_event(&self, event: &Event<'_>, ctx: Context<'_, S>) {
+        let context = ctx
+            .lookup_current()
+            .and_then(|span| span.extensions().get::<ObservationContext>().cloned());
+        let Some(context) = context else {
+            return;
+        };
+
         let mut visitor = JsonVisitor::new();
         event.record(&mut visitor);
-        let metadata = visitor.recorded_fields;
-
-        if let Some(span_id) = ctx.lookup_current().map(|span| span.id().into_u64()) {
-            let layer = self.clone();
-            tokio::spawn(async move { layer.handle_record(span_id, metadata).await });
+        if !visitor.recorded_fields.is_empty() {
+            self.enqueue_record(context, visitor.recorded_fields);
         }
     }
 }
 
 #[derive(Debug)]
 struct JsonVisitor {
-    recorded_fields: serde_json::Map<String, Value>,
+    recorded_fields: Map<String, Value>,
 }
 
 impl JsonVisitor {
     fn new() -> Self {
         Self {
-            recorded_fields: serde_json::Map::new(),
+            recorded_fields: Map::new(),
         }
     }
 
@@ -368,7 +671,7 @@ impl Visit for JsonVisitor {
     record_field!(record_str, &str);
 
     fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
-        self.insert_value(field, Value::String(format!("{:?}", value)));
+        self.insert_value(field, Value::String(format!("{value:?}")));
     }
 }
 
@@ -376,79 +679,22 @@ impl Visit for JsonVisitor {
 mod tests {
     use super::*;
     use std::time::Duration;
-    use tokio::sync::mpsc;
-    use tracing::dispatcher;
+    use tracing::dispatcher::{self, Dispatch};
+    use tracing::Instrument;
+    use tracing_subscriber::layer::SubscriberExt;
 
-    type Events = Arc<Mutex<Vec<(String, Value)>>>;
-    struct TestFixture {
-        original_subscriber: Option<dispatcher::Dispatch>,
-        events: Option<Events>,
-    }
-
-    impl TestFixture {
-        fn new() -> Self {
-            Self {
-                original_subscriber: Some(dispatcher::get_default(dispatcher::Dispatch::clone)),
-                events: None,
-            }
-        }
-
-        fn with_test_layer(mut self) -> (Self, ObservationLayer) {
-            let events = Arc::new(Mutex::new(Vec::new()));
-            let mock_manager = MockBatchManager::new(events.clone());
-
-            let layer = ObservationLayer {
-                batch_manager: Arc::new(Mutex::new(mock_manager)),
-                span_tracker: Arc::new(Mutex::new(SpanTracker::new())),
-            };
-
-            self.events = Some(events);
-            (self, layer)
-        }
-
-        async fn get_events(&self) -> Vec<(String, Value)> {
-            self.events
-                .as_ref()
-                .expect("Events not initialized")
-                .lock()
-                .await
-                .clone()
-        }
-    }
-
-    impl Drop for TestFixture {
-        fn drop(&mut self) {
-            if let Some(subscriber) = &self.original_subscriber {
-                let _ = dispatcher::set_global_default(subscriber.clone());
-            }
-        }
-    }
+    type Events = Arc<StdMutex<Vec<(String, Value)>>>;
 
     struct MockBatchManager {
-        events: Arc<Mutex<Vec<(String, Value)>>>,
-        sender: mpsc::UnboundedSender<(String, Value)>,
-    }
-
-    impl MockBatchManager {
-        fn new(events: Arc<Mutex<Vec<(String, Value)>>>) -> Self {
-            let (sender, mut receiver) = mpsc::unbounded_channel();
-            let events_clone = events.clone();
-
-            tokio::spawn(async move {
-                while let Some((event_type, body)) = receiver.recv().await {
-                    events_clone.lock().await.push((event_type, body));
-                }
-            });
-
-            Self { events, sender }
-        }
+        events: Events,
     }
 
     impl BatchManager for MockBatchManager {
         fn add_event(&mut self, event_type: &str, body: Value) {
-            self.sender
-                .send((event_type.to_string(), body))
-                .expect("Failed to send event");
+            self.events
+                .lock()
+                .unwrap()
+                .push((event_type.to_string(), body));
         }
 
         fn send(&mut self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
@@ -456,183 +702,289 @@ mod tests {
         }
 
         fn is_empty(&self) -> bool {
-            futures::executor::block_on(async { self.events.lock().await.is_empty() })
+            self.events.lock().unwrap().is_empty()
         }
     }
 
-    fn create_test_span_data() -> SpanData {
-        SpanData {
-            observation_id: Uuid::new_v4().to_string(),
-            name: "test_span".to_string(),
-            start_time: Utc::now().to_rfc3339(),
-            level: "DEFAULT".to_string(),
-            metadata: serde_json::Map::new(),
-            parent_span_id: None,
-        }
-    }
-
-    const TEST_WAIT_DURATION: Duration = Duration::from_secs(6);
-
-    #[tokio::test]
-    async fn test_span_creation() {
-        let (fixture, layer) = TestFixture::new().with_test_layer();
-        let span_id = 1u64;
-        let span_data = create_test_span_data();
-
-        layer.handle_span(span_id, span_data.clone()).await;
-        tokio::time::sleep(TEST_WAIT_DURATION).await;
-
-        let events = fixture.get_events().await;
-        assert_eq!(events.len(), 2); // trace-create and observation-create
-
-        let (event_type, body) = &events[1];
-        assert_eq!(event_type, "observation-create");
-        assert_eq!(body["id"], span_data.observation_id);
-        assert_eq!(body["name"], "test_span");
-        assert_eq!(body["type"], "SPAN");
-    }
-
-    #[tokio::test]
-    async fn test_span_close() {
-        let (fixture, layer) = TestFixture::new().with_test_layer();
-        let span_id = 1u64;
-        let span_data = create_test_span_data();
-
-        layer.handle_span(span_id, span_data.clone()).await;
-        layer.handle_span_close(span_id).await;
-        tokio::time::sleep(TEST_WAIT_DURATION).await;
-
-        let events = fixture.get_events().await;
-        assert_eq!(events.len(), 3); // trace-create, observation-create, observation-update
-
-        let (event_type, body) = &events[2];
-        assert_eq!(event_type, "observation-update");
-        assert_eq!(body["id"], span_data.observation_id);
-        assert!(body["endTime"].as_str().is_some());
-    }
-
-    #[tokio::test]
-    async fn test_record_handling() {
-        let (fixture, layer) = TestFixture::new().with_test_layer();
-        let span_id = 1u64;
-        let span_data = create_test_span_data();
-
-        layer.handle_span(span_id, span_data.clone()).await;
-
-        let mut metadata = serde_json::Map::new();
-        metadata.insert("input".to_string(), json!("test input"));
-        metadata.insert("output".to_string(), json!("test output"));
-        metadata.insert("custom_field".to_string(), json!("custom value"));
-
-        layer.handle_record(span_id, metadata).await;
-        tokio::time::sleep(TEST_WAIT_DURATION).await;
-
-        let events = fixture.get_events().await;
-        assert_eq!(events.len(), 3); // trace-create, observation-create, span-update
-
-        let (event_type, body) = &events[2];
-        assert_eq!(event_type, "span-update");
-        assert_eq!(body["input"], "test input");
-        assert_eq!(body["output"], "test output");
-        assert_eq!(body["metadata"]["custom_field"], "custom value");
-    }
-
-    #[tokio::test]
-    async fn test_trace_input_output_updates() {
-        let (fixture, layer) = TestFixture::new().with_test_layer();
-        let span_id = 1u64;
-        let span_data = create_test_span_data();
-
-        layer.handle_span(span_id, span_data).await;
-
-        let mut metadata = serde_json::Map::new();
-        metadata.insert("trace_input".to_string(), json!("hello from user"));
-        metadata.insert("trace_output".to_string(), json!("response from assistant"));
-
-        layer.handle_record(span_id, metadata).await;
-        tokio::time::sleep(TEST_WAIT_DURATION).await;
-
-        let events = fixture.get_events().await;
-        // trace-create, observation-create, trace-create (update with input/output)
-        assert!(events.len() >= 3);
-
-        let trace_update = events
-            .iter()
-            .rfind(|(t, b)| t == "trace-create" && b.get("input").is_some_and(|v| v.is_string()))
-            .expect("should have a trace update with input");
-        assert_eq!(trace_update.1["input"], "hello from user");
-        assert_eq!(trace_update.1["output"], "response from assistant");
-    }
-
-    #[tokio::test]
-    async fn test_trace_fields_not_sent_as_span_metadata() {
-        let (fixture, layer) = TestFixture::new().with_test_layer();
-        let span_id = 1u64;
-        let span_data = create_test_span_data();
-
-        layer.handle_span(span_id, span_data).await;
-
-        // Only trace-level fields, no span-level fields
-        let mut metadata = serde_json::Map::new();
-        metadata.insert("trace_input".to_string(), json!("user msg"));
-
-        layer.handle_record(span_id, metadata).await;
-        tokio::time::sleep(TEST_WAIT_DURATION).await;
-
-        let events = fixture.get_events().await;
-        // Should NOT have a span-update since there are no span-level fields
-        let span_updates: Vec<_> = events.iter().filter(|(t, _)| t == "span-update").collect();
-        assert!(
-            span_updates.is_empty(),
-            "trace-only fields should not generate span-update events"
-        );
-    }
-
-    #[tokio::test]
-    async fn test_mixed_trace_and_span_fields() {
-        let (fixture, layer) = TestFixture::new().with_test_layer();
-        let span_id = 1u64;
-        let span_data = create_test_span_data();
-
-        layer.handle_span(span_id, span_data).await;
-
-        let mut metadata = serde_json::Map::new();
-        metadata.insert("trace_input".to_string(), json!("user msg"));
-        metadata.insert("input".to_string(), json!("tool input"));
-        metadata.insert("output".to_string(), json!("tool output"));
-
-        layer.handle_record(span_id, metadata).await;
-        tokio::time::sleep(TEST_WAIT_DURATION).await;
-
-        let events = fixture.get_events().await;
-
-        // Should have both a trace update and a span-update
-        let trace_updates: Vec<_> = events
-            .iter()
-            .filter(|(t, b)| t == "trace-create" && b.get("input").is_some_and(|v| v.is_string()))
-            .collect();
-        assert_eq!(trace_updates.len(), 1);
-        assert_eq!(trace_updates[0].1["input"], "user msg");
-
-        let span_updates: Vec<_> = events.iter().filter(|(t, _)| t == "span-update").collect();
-        assert_eq!(span_updates.len(), 1);
-        assert_eq!(span_updates[0].1["input"], "tool input");
-        assert_eq!(span_updates[0].1["output"], "tool output");
+    fn test_layer() -> (ObservationLayer, Events) {
+        let events = Arc::new(StdMutex::new(Vec::new()));
+        let manager = MockBatchManager {
+            events: events.clone(),
+        };
+        (ObservationLayer::new(Arc::new(Mutex::new(manager))), events)
     }
 
     #[test]
-    fn test_flatten_metadata() {
-        let _fixture = TestFixture::new();
-        let mut metadata = serde_json::Map::new();
-        metadata.insert("simple".to_string(), json!("value"));
-        metadata.insert(
-            "complex".to_string(),
-            json!({
-                "text": "inner value"
-            }),
-        );
+    fn queues_events_when_constructed_without_a_runtime() {
+        let (layer, events) = test_layer();
+        layer.enqueue("trace-create", json!({ "id": "queued-before-runtime" }));
+        assert!(events.lock().unwrap().is_empty());
 
-        let flattened = flatten_metadata(metadata);
+        tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(async move {
+                layer.enqueue("trace-create", json!({ "id": "queued-inside-runtime" }));
+                let delivered = wait_for_events(&events, 2).await;
+                assert_eq!(delivered[0].1["id"], "queued-before-runtime");
+                assert_eq!(delivered[1].1["id"], "queued-inside-runtime");
+            });
+    }
+
+    async fn wait_for_events(events: &Events, expected: usize) -> Vec<(String, Value)> {
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                let current = events.lock().unwrap().clone();
+                if current.len() >= expected {
+                    return current;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("timed out waiting for tracing events")
+    }
+
+    #[tokio::test]
+    async fn creates_generation_with_protocol_fields_and_parent() {
+        let (layer, events) = test_layer();
+        let subscriber = tracing_subscriber::registry().with(layer);
+        let dispatch = Dispatch::new(subscriber);
+
+        dispatcher::with_default(&dispatch, || {
+            let parent = tracing::info_span!(
+                target: "goose::test",
+                "agent_reply",
+                trace_input = tracing::field::Empty,
+                session.id = "session-1"
+            );
+            let _parent_guard = parent.enter();
+            parent.record("trace_input", "hello");
+
+            let generation = tracing::info_span!(
+                target: "goose::test",
+                "provider_generation",
+                observation_type = "GENERATION",
+                model = "gpt-4o",
+                model_parameters = tracing::field::Empty,
+                usage_details = tracing::field::Empty,
+                cost_details = tracing::field::Empty,
+                completion_start_time = tracing::field::Empty,
+                input = tracing::field::Empty,
+                output = tracing::field::Empty
+            );
+            generation.record(
+                "model_parameters",
+                serde_json::to_string(&json!({"temperature": 0.2}))
+                    .unwrap()
+                    .as_str(),
+            );
+            generation.record(
+                "usage_details",
+                serde_json::to_string(&json!({"input": 12, "output": 5, "total": 17}))
+                    .unwrap()
+                    .as_str(),
+            );
+            generation.record(
+                "cost_details",
+                serde_json::to_string(&json!({"total": 0.01}))
+                    .unwrap()
+                    .as_str(),
+            );
+            generation.record("completion_start_time", "2026-01-01T00:00:01Z");
+            generation.record("output", "done");
+        });
+
+        let events = wait_for_events(&events, 11).await;
+        assert_eq!(events[0].0, "trace-create");
+        assert_eq!(events[0].1["sessionId"], "session-1");
+        assert_eq!(events[1].0, "span-create");
+        assert!(events
+            .iter()
+            .any(|(event_type, body)| event_type == "trace-create" && body["input"] == "hello"));
+        assert_eq!(events[3].0, "generation-create");
+
+        let parent_id = events[1].1["id"].as_str().unwrap();
+        let generation = &events[3].1;
+        assert_eq!(generation["parentObservationId"], parent_id);
+        assert_eq!(generation["traceId"], events[1].1["traceId"]);
+        assert_eq!(generation["model"], "gpt-4o");
+
+        let generation_updates: Vec<_> = events
+            .iter()
+            .filter(|(event_type, _)| event_type == "generation-update")
+            .collect();
+        assert!(generation_updates
+            .iter()
+            .any(|(_, body)| body["modelParameters"]["temperature"] == 0.2));
+        assert!(generation_updates
+            .iter()
+            .any(|(_, body)| body["usageDetails"]["total"] == 17));
+        assert!(generation_updates
+            .iter()
+            .any(|(_, body)| body["costDetails"]["total"] == 0.01));
+        assert!(generation_updates
+            .iter()
+            .any(|(_, body)| body["completionStartTime"] == "2026-01-01T00:00:01Z"));
+        assert!(generation_updates
+            .iter()
+            .any(|(_, body)| body["output"] == "done"));
+        assert!(generation_updates
+            .iter()
+            .any(|(_, body)| body.get("endTime").is_some()));
+    }
+
+    #[tokio::test]
+    async fn keeps_json_looking_text_fields_as_strings() {
+        let (layer, events) = test_layer();
+        let subscriber = tracing_subscriber::registry().with(layer);
+        let dispatch = Dispatch::new(subscriber);
+        let json_text = r#"{"error":"still text"}"#;
+
+        dispatcher::with_default(&dispatch, || {
+            let generation = tracing::info_span!(
+                target: "goose::test",
+                "provider_generation",
+                observation_type = "GENERATION",
+                trace_input = tracing::field::Empty,
+                input = tracing::field::Empty,
+                output = tracing::field::Empty,
+                status_message = tracing::field::Empty,
+            );
+            generation.record("trace_input", json_text);
+            generation.record("input", json_text);
+            generation.record("output", json_text);
+            generation.record("status_message", json_text);
+        });
+
+        let events = wait_for_events(&events, 7).await;
+        assert!(events.iter().any(|(event_type, body)| {
+            event_type == "trace-create" && body["input"] == json_text
+        }));
+        for field in ["input", "output", "statusMessage"] {
+            assert!(events.iter().any(|(event_type, body)| {
+                event_type == "generation-update" && body[field] == json_text
+            }));
+        }
+    }
+
+    #[tokio::test]
+    async fn creates_a_trace_per_root_span() {
+        let (layer, events) = test_layer();
+        let subscriber = tracing_subscriber::registry().with(layer);
+        let dispatch = Dispatch::new(subscriber);
+
+        dispatcher::with_default(&dispatch, || {
+            drop(tracing::info_span!(target: "goose::test", "first"));
+            drop(tracing::info_span!(target: "goose::test", "second"));
+        });
+
+        let events = wait_for_events(&events, 6).await;
+        let trace_ids: Vec<_> = events
+            .iter()
+            .filter(|(event_type, _)| event_type == "trace-create")
+            .map(|(_, body)| body["id"].as_str().unwrap())
+            .collect();
+        assert_eq!(trace_ids.len(), 2);
+        assert_ne!(trace_ids[0], trace_ids[1]);
+    }
+
+    #[tokio::test]
+    async fn nested_reply_fields_update_the_observation_not_the_parent_trace() {
+        let (layer, events) = test_layer();
+        let subscriber = tracing_subscriber::registry().with(layer);
+        let dispatch = Dispatch::new(subscriber);
+
+        dispatcher::with_default(&dispatch, || {
+            let parent = tracing::info_span!(
+                target: "goose::test",
+                "parent_reply",
+                trace_boundary = true,
+                trace_input = tracing::field::Empty
+            );
+            let _parent_guard = parent.enter();
+            parent.record("trace_input", "parent input");
+
+            let child = tracing::info_span!(
+                target: "goose::test",
+                "subagent_reply",
+                trace_boundary = true,
+                trace_input = tracing::field::Empty,
+                trace_output = tracing::field::Empty
+            );
+            child.record("trace_input", "child input");
+            child.record("trace_output", "child output");
+        });
+
+        let events = wait_for_events(&events, 8).await;
+        let trace_inputs: Vec<_> = events
+            .iter()
+            .filter(|(event_type, body)| {
+                event_type == "trace-create" && body.get("input").is_some()
+            })
+            .map(|(_, body)| &body["input"])
+            .collect();
+        assert_eq!(trace_inputs.len(), 1);
+        assert_eq!(trace_inputs[0], "parent input");
+
+        let child_updates: Vec<_> = events
+            .iter()
+            .filter(|(event_type, body)| {
+                event_type == "span-update"
+                    && (body.get("input").is_some() || body.get("output").is_some())
+            })
+            .collect();
+        assert!(child_updates
+            .iter()
+            .any(|(_, body)| body["input"] == "child input"));
+        assert!(child_updates
+            .iter()
+            .any(|(_, body)| body["output"] == "child output"));
+    }
+
+    #[tokio::test]
+    async fn instrumented_background_task_keeps_parent_trace() {
+        let (layer, events) = test_layer();
+        let subscriber = tracing_subscriber::registry().with(layer);
+        let dispatch = Dispatch::new(subscriber);
+        let background_dispatch = dispatch.clone();
+
+        let task = dispatcher::with_default(&dispatch, || {
+            let parent = tracing::info_span!(target: "goose::test", "parent");
+            let background = {
+                let _guard = parent.enter();
+                tracing::info_span!(target: "goose::test", "background_subagent")
+            };
+            tokio::spawn(
+                async move {
+                    dispatcher::with_default(&background_dispatch, || {
+                        drop(tracing::info_span!(target: "goose::test", "subagent_reply"));
+                    });
+                }
+                .instrument(background),
+            )
+        });
+        task.await.unwrap();
+
+        let events = wait_for_events(&events, 6).await;
+        let creates: Vec<_> = events
+            .iter()
+            .filter(|(event_type, _)| event_type == "span-create")
+            .map(|(_, body)| body)
+            .collect();
+        assert_eq!(creates.len(), 3);
+        assert!(creates
+            .windows(2)
+            .all(|pair| pair[0]["traceId"] == pair[1]["traceId"]));
+        assert_eq!(creates[1]["parentObservationId"], creates[0]["id"]);
+        assert_eq!(creates[2]["parentObservationId"], creates[1]["id"]);
+    }
+
+    #[test]
+    fn flattens_text_wrappers() {
+        let flattened = flatten_metadata(Map::from_iter([
+            ("simple".to_string(), json!("value")),
+            ("complex".to_string(), json!({"text": "inner value"})),
+        ]));
         assert_eq!(flattened["simple"], "value");
         assert_eq!(flattened["complex"], "inner value");
     }

--- a/crates/goose/src/tracing/provider_generation.rs
+++ b/crates/goose/src/tracing/provider_generation.rs
@@ -1,0 +1,339 @@
+use goose_providers::base::Provider;
+use goose_providers::conversation::token_usage::ProviderUsage;
+use goose_providers::errors::ProviderError;
+use goose_providers::model::ModelConfig;
+use rmcp::model::Tool;
+use serde_json::{json, Value};
+use tracing_futures::Instrument;
+
+use crate::conversation::message::{Message, MessageContent};
+
+pub async fn complete_provider(
+    provider: &dyn Provider,
+    model_config: &ModelConfig,
+    system_prompt: &str,
+    messages: &[Message],
+    tools: &[Tool],
+) -> Result<(Message, ProviderUsage), ProviderError> {
+    let session_id = crate::session_context::current_session_id().unwrap_or_default();
+    let mut generation = ProviderGeneration::new(
+        provider.get_name(),
+        model_config,
+        &session_id,
+        system_prompt,
+        messages,
+        tools,
+    );
+
+    match provider
+        .complete(model_config, system_prompt, messages, tools)
+        .instrument(generation.span())
+        .await
+    {
+        Ok((mut message, usage)) => {
+            generation.record_usage(&usage);
+            generation.attach_observation_id(&mut message);
+            generation.record_output(&message);
+            generation.finish();
+            Ok((message, usage))
+        }
+        Err(error) => {
+            generation.record_error(&error);
+            generation.finish();
+            Err(error)
+        }
+    }
+}
+
+pub(crate) struct ProviderGeneration {
+    observation_id: String,
+    provider_name: String,
+    span: Option<tracing::Span>,
+    output: Vec<Message>,
+}
+
+impl ProviderGeneration {
+    pub(crate) fn new(
+        provider_name: &str,
+        model_config: &ModelConfig,
+        session_id: &str,
+        system_prompt: &str,
+        messages: &[Message],
+        tools: &[Tool],
+    ) -> Self {
+        let observation_id = uuid::Uuid::new_v4().to_string();
+        let span = super::is_observation_layer_active().then(|| {
+            tracing::info_span!(
+                target: "goose::tracing::provider_generation",
+                "provider_generation",
+                observation_type = "GENERATION",
+                observation_id = %observation_id,
+                session.id = %session_id,
+                provider = provider_name,
+                model = %model_config.model_name,
+                model_parameters_json = tracing::field::Empty,
+                input_json = tracing::field::Empty,
+                output_json = tracing::field::Empty,
+                usage_details_json = tracing::field::Empty,
+                cost_details_json = tracing::field::Empty,
+                completion_start_time = tracing::field::Empty,
+                status_message = tracing::field::Empty,
+            )
+        });
+
+        if let Some(span) = span.as_ref() {
+            record_json(
+                span,
+                "model_parameters_json",
+                &langfuse_model_parameters(model_config),
+            );
+            record_json(
+                span,
+                "input_json",
+                &json!({
+                    "system": system_prompt,
+                    "messages": messages,
+                    "tools": tools,
+                }),
+            );
+        }
+
+        Self {
+            observation_id,
+            provider_name: provider_name.to_string(),
+            span,
+            output: Vec::new(),
+        }
+    }
+
+    pub(crate) fn span(&self) -> tracing::Span {
+        self.span
+            .as_ref()
+            .cloned()
+            .unwrap_or_else(tracing::Span::none)
+    }
+
+    pub(crate) fn record_completion_start(&self) {
+        if let Some(span) = self.span.as_ref() {
+            let completion_start_time = chrono::Utc::now().to_rfc3339();
+            span.record("completion_start_time", completion_start_time.as_str());
+        }
+    }
+
+    pub(crate) fn record_error(&self, error: &impl std::fmt::Display) {
+        if let Some(span) = self.span.as_ref() {
+            let error_message = error.to_string();
+            span.record("status_message", error_message.as_str());
+        }
+    }
+
+    pub(crate) fn record_usage(&self, usage: &ProviderUsage) {
+        let Some(span) = self.span.as_ref() else {
+            return;
+        };
+
+        span.record("model", usage.model.as_str());
+        let token_usage = &usage.usage;
+        let mut usage_details = serde_json::Map::new();
+        for (name, value) in [
+            ("input", token_usage.input_tokens),
+            ("output", token_usage.output_tokens),
+            ("total", token_usage.total_tokens),
+            (
+                "cache_read_input_tokens",
+                token_usage.cache_read_input_tokens,
+            ),
+            (
+                "cache_write_input_tokens",
+                token_usage.cache_write_input_tokens,
+            ),
+        ] {
+            if let Some(value) = value {
+                usage_details.insert(name.to_string(), json!(value));
+            }
+        }
+        if !usage_details.is_empty() {
+            record_json(span, "usage_details_json", &Value::Object(usage_details));
+        }
+
+        let cost = usage.cost.or_else(|| {
+            crate::providers::canonical::maybe_get_canonical_model(
+                &self.provider_name,
+                &usage.model,
+            )
+            .and_then(|canonical| canonical.cost.estimate_cost(&usage.usage))
+        });
+        if let Some(cost) = cost {
+            record_json(span, "cost_details_json", &json!({ "total": cost }));
+        }
+    }
+
+    pub(crate) fn attach_observation_id(&self, message: &mut Message) {
+        message.metadata = message
+            .metadata
+            .clone()
+            .with_observation_id(self.observation_id.clone());
+    }
+
+    pub(crate) fn record_output(&mut self, message: &Message) {
+        if self.span.is_some() {
+            append_output(&mut self.output, message.clone());
+        }
+    }
+
+    pub(crate) fn finish(&mut self) {
+        let Some(span) = self.span.take() else {
+            return;
+        };
+        if !self.output.is_empty() {
+            record_json(
+                &span,
+                "output_json",
+                &serde_json::to_value(&self.output).unwrap_or_default(),
+            );
+        }
+    }
+}
+
+impl Drop for ProviderGeneration {
+    fn drop(&mut self) {
+        self.finish();
+    }
+}
+
+fn record_json(span: &tracing::Span, field: &'static str, value: &Value) {
+    if let Ok(serialized) = serde_json::to_string(value) {
+        span.record(field, serialized.as_str());
+    }
+}
+
+fn langfuse_model_parameters(model_config: &ModelConfig) -> Value {
+    let Ok(Value::Object(mut parameters)) = serde_json::to_value(model_config) else {
+        return json!({});
+    };
+    parameters.remove("model_name");
+
+    let request_parameters = parameters
+        .remove("request_params")
+        .and_then(|value| value.as_object().cloned())
+        .unwrap_or_default();
+    parameters.retain(|_, value| is_langfuse_model_parameter(value));
+    for (name, value) in request_parameters {
+        if is_langfuse_model_parameter(&value) {
+            parameters.insert(name, value);
+        }
+    }
+    Value::Object(parameters)
+}
+
+fn is_langfuse_model_parameter(value: &Value) -> bool {
+    match value {
+        Value::String(_) | Value::Number(_) | Value::Bool(_) => true,
+        Value::Array(values) => values.iter().all(Value::is_string),
+        Value::Object(values) => values.values().all(Value::is_string),
+        Value::Null => false,
+    }
+}
+
+fn append_output(output: &mut Vec<Message>, message: Message) {
+    let Some(previous) = output.last_mut() else {
+        output.push(message);
+        return;
+    };
+    if previous.id != message.id || previous.role != message.role {
+        output.push(message);
+        return;
+    }
+
+    for content in message.content {
+        match (previous.content.last_mut(), content) {
+            (Some(MessageContent::Text(previous)), MessageContent::Text(next))
+                if previous
+                    .annotations
+                    .as_ref()
+                    .and_then(|annotations| annotations.audience.as_ref())
+                    == next
+                        .annotations
+                        .as_ref()
+                        .and_then(|annotations| annotations.audience.as_ref()) =>
+            {
+                previous.text.push_str(&next.text);
+            }
+            (_, content) => previous.content.push(content),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tracing::test_support::{capturing_layer, wait_for_closed_generation};
+    use goose_providers::base::{stream_from_single_message, MessageStream};
+    use goose_providers::conversation::token_usage::Usage;
+    use tracing_subscriber::prelude::*;
+
+    struct CompleteProvider;
+
+    #[async_trait::async_trait]
+    impl Provider for CompleteProvider {
+        fn get_name(&self) -> &str {
+            "complete-test"
+        }
+
+        async fn stream(
+            &self,
+            _model_config: &ModelConfig,
+            _system: &str,
+            _messages: &[Message],
+            _tools: &[Tool],
+        ) -> Result<MessageStream, ProviderError> {
+            Ok(stream_from_single_message(
+                Message::assistant().with_text("complete response"),
+                ProviderUsage::new(
+                    "complete-model".to_string(),
+                    Usage::new(Some(3), Some(2), Some(5)),
+                ),
+            ))
+        }
+    }
+
+    #[tokio::test]
+    async fn complete_provider_emits_generation_observation() {
+        let (layer, events) = capturing_layer();
+        let subscriber = tracing_subscriber::registry().with(layer);
+        let _subscriber_guard = tracing::subscriber::set_default(subscriber);
+
+        let (message, _) = crate::session_context::with_session_id(
+            Some("complete-session".to_string()),
+            complete_provider(
+                &CompleteProvider,
+                &ModelConfig::new("requested-model"),
+                "system",
+                &[Message::user().with_text("request")],
+                &[],
+            ),
+        )
+        .await
+        .unwrap();
+
+        assert!(message.metadata.observation_id.is_some());
+        let captured = wait_for_closed_generation(&events).await;
+        assert!(captured.iter().any(|(event_type, body)| {
+            event_type == "generation-create" && body["model"] == "requested-model"
+        }));
+        assert!(captured.iter().any(|(event_type, body)| {
+            event_type == "generation-update"
+                && body["input"]["messages"][0]["content"][0]["text"] == "request"
+        }));
+        assert!(captured.iter().any(|(event_type, body)| {
+            event_type == "generation-update" && body["model"] == "complete-model"
+        }));
+        assert!(captured.iter().any(|(event_type, body)| {
+            event_type == "generation-update" && body["usageDetails"]["total"] == 5
+        }));
+        assert!(captured.iter().any(|(event_type, body)| {
+            event_type == "generation-update"
+                && body["output"][0]["content"][0]["text"] == "complete response"
+        }));
+    }
+}

--- a/crates/goose/src/tracing/test_support.rs
+++ b/crates/goose/src/tracing/test_support.rs
@@ -1,0 +1,52 @@
+use serde_json::Value;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use super::{BatchManager, ObservationLayer};
+
+pub(crate) type CapturedEvents = Arc<Mutex<Vec<(String, Value)>>>;
+
+struct CapturingBatchManager {
+    events: CapturedEvents,
+}
+
+impl BatchManager for CapturingBatchManager {
+    fn add_event(&mut self, event_type: &str, body: Value) {
+        self.events
+            .lock()
+            .unwrap()
+            .push((event_type.to_string(), body));
+    }
+
+    fn send(&mut self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        Ok(())
+    }
+
+    fn is_empty(&self) -> bool {
+        self.events.lock().unwrap().is_empty()
+    }
+}
+
+pub(crate) fn capturing_layer() -> (ObservationLayer, CapturedEvents) {
+    let events: CapturedEvents = Arc::new(Mutex::new(Vec::new()));
+    let layer = ObservationLayer::new(Arc::new(tokio::sync::Mutex::new(CapturingBatchManager {
+        events: events.clone(),
+    })));
+    (layer, events)
+}
+
+pub(crate) async fn wait_for_closed_generation(events: &CapturedEvents) -> Vec<(String, Value)> {
+    tokio::time::timeout(Duration::from_secs(1), async {
+        loop {
+            let captured = events.lock().unwrap().clone();
+            if captured.iter().any(|(event_type, body)| {
+                event_type == "generation-update" && body.get("endTime").is_some()
+            }) {
+                return captured;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("generation should close")
+}

--- a/ui/desktop/src/types/message.ts
+++ b/ui/desktop/src/types/message.ts
@@ -188,6 +188,7 @@ export type MessageMetadata = {
   agentVisible: boolean;
   fallbackContent?: boolean;
   inference?: InferenceMetadata | null;
+  observationId?: string | null;
   outputTokenLimitReached?: boolean;
   steer?: boolean;
   usage?: MessageUsage | null;


### PR DESCRIPTION
## Summary

Adds first-class Langfuse `GENERATION` observations for each provider call and preserves LangGraph/LangSmith-style parentage across nested replies and asynchronous sub-agents.

- Instruments `Agent::stream_response_from_provider` at the shared provider-call boundary and emits Langfuse `generation-create` / `generation-update` events.
- Maps generation data to native Langfuse fields: `model`, `modelParameters`, `input`, `output`, `completionStartTime`, `usageDetails`, `costDetails`, and `statusMessage`.
- Creates a distinct trace for each root run instead of reusing a process-wide trace.
- Stores observation context directly on tracing spans and serializes ingestion events so parent IDs remain stable and create/update/close events stay ordered.
- Treats nested reply boundaries as child observations while keeping the outer reply input/output on the trace.
- Instruments detached summon tasks so async sub-agents inherit the originating trace and parent observation.
- Adds `observationId` to streamed message metadata, allowing downstream clients to correlate message deltas with the generation that produced them.

### Testing

- [x] `cargo fmt --check`
- [x] `cargo build -p goose`
- [x] `cargo test -p goose tracing::observation_layer --lib` — 5 passed
- [x] `cargo test -p goose agents::reply_parts --lib` — 32 passed
- [x] `cargo test -p goose-provider-types message_metadata` — 5 passed
- [x] `cargo clippy -p goose -p goose-provider-types --all-targets -- -D warnings`
- [x] `pnpm run typecheck`
- [x] GitHub CI: Rust build/tests, native-tls and rustls-tls builds, MSRV, schema validation, Electron tests/lint, Semgrep, and zizmor

### Related Issues

Fixes #10791

### Screenshots/Demos (for UX changes)

N/A — this changes tracing behavior and message metadata; it does not change the UI.