### PR TITLE
fix: apply custom provider context limits consistently

### DIFF
--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -948,8 +948,12 @@ impl Agent {
         let model_name = config
             .get_goose_model()
             .map_err(|_| anyhow!("Could not resolve model config: missing model"))?;
-        crate::model_config::model_config_from_user_config(&provider_name, &model_name)
-            .map_err(|e| anyhow!("Could not resolve model config: {e}"))
+        crate::model_config::model_config_from_user_config_with_provider_defaults(
+            &provider_name,
+            &model_name,
+        )
+        .await
+        .map_err(|e| anyhow!("Could not resolve model config: {e}"))
     }
 
     /// When set, all stdio extensions will be started via `docker exec` in the specified container.

--- a/crates/goose/src/doctor.rs
+++ b/crates/goose/src/doctor.rs
@@ -170,9 +170,12 @@ async fn try_create_and_test(
     provider_name: &str,
     model_name: &str,
 ) -> Result<(Arc<dyn Provider>, goose_providers::model::ModelConfig), ProviderError> {
-    let model_config =
-        crate::model_config::model_config_from_user_config(provider_name, model_name)
-            .map_err(|e| ProviderError::ExecutionError(e.to_string()))?;
+    let model_config = crate::model_config::model_config_from_user_config_with_provider_defaults(
+        provider_name,
+        model_name,
+    )
+    .await
+    .map_err(|e| ProviderError::ExecutionError(e.to_string()))?;
 
     let provider = providers::create(provider_name, vec![])
         .await
@@ -221,7 +224,12 @@ async fn try_other_providers(
         };
         let model_name = entry.metadata().default_model.clone();
         let model_config =
-            match crate::model_config::model_config_from_user_config(&meta.name, &model_name) {
+            match crate::model_config::model_config_from_user_config_with_provider_defaults(
+                &meta.name,
+                &model_name,
+            )
+            .await
+            {
                 Ok(config) => config,
                 Err(_) => continue,
             };

--- a/crates/goose/src/model_config.rs
+++ b/crates/goose/src/model_config.rs
@@ -18,6 +18,17 @@ pub fn model_config_from_user_config(
     materialize_model_config(provider_name, model)
 }
 
+pub async fn model_config_from_user_config_with_provider_defaults(
+    provider_name: &str,
+    model_name: impl AsRef<str>,
+) -> Result<ModelConfig> {
+    let model = model_config_from_user_config(provider_name, model_name)?;
+    match crate::providers::get_from_registry(provider_name).await {
+        Ok(entry) => entry.normalize_model_config(model),
+        Err(_) => Ok(model),
+    }
+}
+
 pub fn model_config_from_user_config_with_session_settings(
     provider_name: &str,
     model_name: impl AsRef<str>,

--- a/crates/goose/src/providers/init.rs
+++ b/crates/goose/src/providers/init.rs
@@ -417,6 +417,15 @@ mod tests {
             .await
             .expect("custom providers should refresh");
 
+        let resolved_config =
+            crate::model_config::model_config_from_user_config_with_provider_defaults(
+                "custom_inf",
+                "kimi-k2.5",
+            )
+            .await
+            .expect("custom_inf model config should resolve with provider defaults");
+        assert_eq!(resolved_config.context_limit, Some(256_000));
+
         let inf_entry = get_from_registry("custom_inf")
             .await
             .expect("custom_inf entry should exist");


### PR DESCRIPTION
## Summary

- resolve model configs against the active provider registry before doctor requests
- apply the same provider metadata fallback when a session has no persisted model config
- preserve existing behavior for providers that are not present in the registry

Custom/declarative providers already expose per-model `context_limit` values through `ProviderEntry::normalize_model_config`, but the doctor and session fallback paths constructed a bare `ModelConfig` and skipped that normalization. As a result, large-context custom models could silently fall back to 128k.

### Testing

- `cargo test -p goose providers::init::tests --lib -- --nocapture` (8 passed)
- `cargo clippy -p goose --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

All Rust checks ran in the repository toolchain version (Rust 1.96.1).

### Related Issues

Fixes #10805

### Screenshots/Demos (for UX changes)

Not applicable.
