### PR TITLE
fix(acp): use stable tool name in session history

### DIFF
--- a/crates/goose-cli/src/session/output.rs
+++ b/crates/goose-cli/src/session/output.rs
@@ -540,7 +540,7 @@ fn render_tool_request(req: &ToolRequest, theme: Theme, debug: bool) {
             "subagent" => render_delegate_request(call, debug),
             "todo__write" => render_todo_request(call, debug),
             "load" => {}
-            _ => render_default_request(call, debug),
+            _ => render_default_request_with_label(call, acp_tool_label(req), debug),
         },
         Err(e) => print_markdown(&e.to_string(), theme),
     }
@@ -889,9 +889,35 @@ fn render_todo_request(call: &CallToolRequestParams, _debug: bool) {
 }
 
 fn render_default_request(call: &CallToolRequestParams, debug: bool) {
-    print_tool_header(call);
+    render_default_request_with_label(call, None, debug);
+}
+
+fn render_default_request_with_label(
+    call: &CallToolRequestParams,
+    label: Option<&str>,
+    debug: bool,
+) {
+    if let Some(label) = label {
+        print_tool_header_name(label);
+    } else {
+        print_tool_header(call);
+    }
     print_params(&call.arguments, 1, debug);
     println!();
+}
+
+fn acp_tool_label(req: &ToolRequest) -> Option<&str> {
+    let call = req.tool_call.as_ref().ok()?;
+    if call.name.as_ref() != "acp_tool" {
+        return None;
+    }
+
+    req.generated_title().or_else(|| {
+        req.tool_meta
+            .as_ref()
+            .and_then(|meta| meta.get("goose.acp.kind"))
+            .and_then(Value::as_str)
+    })
 }
 
 fn extension_display_name(name: &str) -> &str {
@@ -992,7 +1018,11 @@ fn render_subagent_tool_graph(subagent_id: &str, tool_graph: &[Value]) {
 // Helper functions
 
 fn print_tool_header(call: &CallToolRequestParams) {
-    let parts = ToolNameParts::from(call.name.as_ref());
+    print_tool_header_name(call.name.as_ref());
+}
+
+fn print_tool_header_name(name: &str) {
+    let parts = ToolNameParts::from(name);
     let tool_header = match parts.extension_name {
         Some(extension_name) => format!(
             "  {} {} {}",
@@ -1666,6 +1696,45 @@ mod tests {
             format_subagent_tool_call_message("subagent_42", "calendar__events__list"),
             "[subagent:42] events__list | calendar"
         );
+    }
+
+    #[test]
+    fn uses_saved_acp_title_for_cli_tool_labels() {
+        let request = ToolRequest {
+            id: "req_1".to_string(),
+            tool_call: Ok(CallToolRequestParams::new("acp_tool")),
+            metadata: None,
+            tool_meta: Some(json!({
+                "goose.toolSummary.title": "Read project configuration",
+                "goose.acp.kind": "read",
+            })),
+        };
+
+        assert_eq!(acp_tool_label(&request), Some("Read project configuration"));
+    }
+
+    #[test]
+    fn falls_back_to_acp_kind_for_cli_tool_labels() {
+        let request = ToolRequest {
+            id: "req_1".to_string(),
+            tool_call: Ok(CallToolRequestParams::new("acp_tool")),
+            metadata: None,
+            tool_meta: Some(json!({"goose.acp.kind": "execute"})),
+        };
+
+        assert_eq!(acp_tool_label(&request), Some("execute"));
+    }
+
+    #[test]
+    fn leaves_non_acp_cli_tool_labels_unchanged() {
+        let request = ToolRequest {
+            id: "req_1".to_string(),
+            tool_call: Ok(CallToolRequestParams::new("developer__shell")),
+            metadata: None,
+            tool_meta: Some(json!({"goose.toolSummary.title": "Run tests"})),
+        };
+
+        assert_eq!(acp_tool_label(&request), None);
     }
 
     #[test]

--- a/crates/goose/src/acp/provider.rs
+++ b/crates/goose/src/acp/provider.rs
@@ -35,7 +35,9 @@ use tokio_util::compat::{TokioAsyncReadCompatExt as _, TokioAsyncWriteCompatExt 
 use crate::acp::{map_permission_response, PermissionDecision};
 use crate::config::{ExtensionConfig, GooseMode};
 use crate::context_mgmt::format_message_for_compacting;
-use crate::conversation::message::{Message, MessageContent, TOOL_META_EXTERNAL_DISPATCH_KEY};
+use crate::conversation::message::{
+    Message, MessageContent, TOOL_META_EXTERNAL_DISPATCH_KEY, TOOL_META_TITLE_KEY,
+};
 use crate::conversation::Conversation;
 use crate::permission::permission_confirmation::PrincipalType;
 use crate::permission::{Permission, PermissionConfirmation};
@@ -105,6 +107,7 @@ enum AcpUpdate {
     Thought(String),
     ToolCallStart {
         id: String,
+        title: String,
         kind: ToolKind,
         raw_input: Option<serde_json::Value>,
     },
@@ -586,6 +589,7 @@ impl Provider for AcpProvider {
                     }
                     AcpUpdate::ToolCallStart {
                         id,
+                        title,
                         kind,
                         raw_input,
                     } => {
@@ -597,12 +601,9 @@ impl Provider for AcpProvider {
                         } else {
                             let params = acp_tool_request_params(raw_input);
                             // external_dispatch tells the agent loop not to redispatch this
-                            // call. goose.acp.kind preserves ACP's stable categorization for
-                            // downstream consumers (metrics, observability, icon selection).
-                            let tool_meta = Some(serde_json::json!({
-                                TOOL_META_EXTERNAL_DISPATCH_KEY: true,
-                                "goose.acp.kind": kind,
-                            }));
+                            // call. The ACP title remains display-only metadata while the
+                            // persisted tool name stays provider-safe and stable.
+                            let tool_meta = Some(acp_tool_meta(&title, kind));
                             let message = Message::assistant().with_tool_request_with_metadata(
                                 id,
                                 Ok(params),
@@ -903,11 +904,12 @@ impl AcpClientLoop {
                                         } else {
                                             None
                                         };
-                                    // ACP carries no canonical tool name to clients. Keep the
-                                    // display title out of persisted tool-call history and
-                                    // surface `kind` separately via tool_meta.
+                                    // ACP carries no canonical tool name to clients. Preserve
+                                    // its display title as metadata while the persisted tool
+                                    // name remains provider-safe and stable.
                                     let _ = tx.try_send(AcpUpdate::ToolCallStart {
                                         id: id.clone(),
+                                        title: tool_call.title.clone(),
                                         kind: tool_call.kind,
                                         raw_input: tool_call.raw_input.clone(),
                                     });
@@ -1532,6 +1534,14 @@ fn acp_tool_request_params(raw_input: Option<serde_json::Value>) -> CallToolRequ
     params
 }
 
+fn acp_tool_meta(title: &str, kind: ToolKind) -> serde_json::Value {
+    serde_json::json!({
+        TOOL_META_EXTERNAL_DISPATCH_KEY: true,
+        TOOL_META_TITLE_KEY: title,
+        "goose.acp.kind": kind,
+    })
+}
+
 /// Convert ACP `ToolCallContent` blocks into the rmcp `Content` shape goose's
 /// `Message::with_tool_response` consumes. Handles `Content` (text/image/other),
 /// `Diff`, and `Terminal` variants; falls back to a JSON serialization of
@@ -1983,6 +1993,7 @@ mod tests {
             response_tx
                 .send(AcpUpdate::ToolCallStart {
                     id: id.to_string(),
+                    title: "Read file".to_string(),
                     kind: ToolKind::Read,
                     raw_input: None,
                 })
@@ -2779,13 +2790,9 @@ mod tests {
         );
     }
 
-    /// Pins the tool_meta shape that the `AcpUpdate::ToolCallStart` consumer
-    /// emits onto the synthesized `ToolRequest`. ACP doesn't expose a canonical
-    /// tool name to clients, so we surface `kind` here as a stable categorization
-    /// signal alongside the `external_dispatch` marker that bypasses agent-loop
-    /// routing.
+    /// Pins the tool_meta shape emitted onto synthesized ACP tool requests.
     #[test]
-    fn tool_meta_pairs_external_dispatch_marker_with_acp_kind() {
+    fn tool_meta_preserves_display_title_and_acp_kind() {
         let cases = [
             (ToolKind::Execute, "execute"),
             (ToolKind::Read, "read"),
@@ -2793,10 +2800,7 @@ mod tests {
             (ToolKind::Other, "other"),
         ];
         for (kind, expected) in cases {
-            let tool_meta = serde_json::json!({
-                TOOL_META_EXTERNAL_DISPATCH_KEY: true,
-                "goose.acp.kind": kind,
-            });
+            let tool_meta = acp_tool_meta("Read project configuration", kind);
             assert_eq!(
                 tool_meta[TOOL_META_EXTERNAL_DISPATCH_KEY],
                 serde_json::Value::Bool(true),
@@ -2806,6 +2810,11 @@ mod tests {
                 tool_meta["goose.acp.kind"],
                 serde_json::Value::String(expected.to_string()),
                 "goose.acp.kind serialized wrong for kind={kind:?}"
+            );
+            assert_eq!(
+                tool_meta[TOOL_META_TITLE_KEY],
+                serde_json::Value::String("Read project configuration".to_string()),
+                "ACP display title missing for kind={kind:?}"
             );
         }
     }

--- a/crates/goose/src/acp/provider.rs
+++ b/crates/goose/src/acp/provider.rs
@@ -47,6 +47,7 @@ use goose_providers::model::ModelConfig;
 
 /// Sentinel: resolved to the actual model name during connect().
 pub const ACP_CURRENT_MODEL: &str = "current";
+const ACP_TOOL_NAME: &str = "acp_tool";
 
 pub struct AcpProviderConfig {
     pub command: PathBuf,
@@ -104,7 +105,6 @@ enum AcpUpdate {
     Thought(String),
     ToolCallStart {
         id: String,
-        name: String,
         kind: ToolKind,
         raw_input: Option<serde_json::Value>,
     },
@@ -584,21 +584,21 @@ impl Provider for AcpProvider {
                             .with_id(id);
                         yield (Some(message), None);
                     }
-                    AcpUpdate::ToolCallStart { id, name, kind, raw_input } => {
+                    AcpUpdate::ToolCallStart {
+                        id,
+                        kind,
+                        raw_input,
+                    } => {
                         text_run = None;
                         thought_run = None;
                         if reject_all_tools {
                             suppress_text = true;
                             rejected_tool_calls.insert(id);
                         } else {
-                            let mut params = CallToolRequestParams::new(name);
-                            if let Some(serde_json::Value::Object(map)) = raw_input {
-                                params = params.with_arguments(map);
-                            }
+                            let params = acp_tool_request_params(raw_input);
                             // external_dispatch tells the agent loop not to redispatch this
                             // call. goose.acp.kind preserves ACP's stable categorization for
-                            // downstream consumers (metrics, observability, icon selection)
-                            // independent of the display title we put in `name`.
+                            // downstream consumers (metrics, observability, icon selection).
                             let tool_meta = Some(serde_json::json!({
                                 TOOL_META_EXTERNAL_DISPATCH_KEY: true,
                                 "goose.acp.kind": kind,
@@ -903,15 +903,11 @@ impl AcpClientLoop {
                                         } else {
                                             None
                                         };
-                                    // ACP carries no canonical tool name to clients — only
-                                    // `title` (display) and `kind` (category). We pass `title`
-                                    // for renderer affordance, surface `kind` separately via
-                                    // tool_meta for stable categorization, and the
-                                    // goose.external_dispatch marker keeps `name` off the
-                                    // agent loop's routing/auth paths.
+                                    // ACP carries no canonical tool name to clients. Keep the
+                                    // display title out of persisted tool-call history and
+                                    // surface `kind` separately via tool_meta.
                                     let _ = tx.try_send(AcpUpdate::ToolCallStart {
                                         id: id.clone(),
-                                        name: tool_call.title.clone(),
                                         kind: tool_call.kind,
                                         raw_input: tool_call.raw_input.clone(),
                                     });
@@ -1528,6 +1524,14 @@ fn acp_text_update_message(text: TextContent, id: String, created: i64) -> Messa
         .with_id(id)
 }
 
+fn acp_tool_request_params(raw_input: Option<serde_json::Value>) -> CallToolRequestParams {
+    let mut params = CallToolRequestParams::new(ACP_TOOL_NAME);
+    if let Some(serde_json::Value::Object(map)) = raw_input {
+        params = params.with_arguments(map);
+    }
+    params
+}
+
 /// Convert ACP `ToolCallContent` blocks into the rmcp `Content` shape goose's
 /// `Message::with_tool_response` consumes. Handles `Content` (text/image/other),
 /// `Diff`, and `Terminal` variants; falls back to a JSON serialization of
@@ -1979,7 +1983,6 @@ mod tests {
             response_tx
                 .send(AcpUpdate::ToolCallStart {
                     id: id.to_string(),
-                    name: "read_file".to_string(),
                     kind: ToolKind::Read,
                     raw_input: None,
                 })
@@ -2025,6 +2028,23 @@ mod tests {
         assert!(first_id.starts_with("msg_"));
         assert!(second_id.starts_with("msg_"));
         assert_ne!(first_id, second_id);
+    }
+
+    #[test]
+    fn acp_tool_request_params_use_stable_name_and_preserve_arguments() {
+        let params = acp_tool_request_params(Some(serde_json::json!({
+            "command": "echo hello"
+        })));
+
+        assert_eq!(params.name.to_string(), ACP_TOOL_NAME);
+        assert_eq!(
+            params
+                .arguments
+                .as_ref()
+                .and_then(|arguments| arguments.get("command"))
+                .and_then(serde_json::Value::as_str),
+            Some("echo hello")
+        );
     }
 
     #[test]

--- a/crates/goose/src/acp/provider.rs
+++ b/crates/goose/src/acp/provider.rs
@@ -1457,7 +1457,7 @@ fn build_handoff_context_memo(prior_messages: &[Message]) -> Option<String> {
             .agent_visible_messages()
             .iter()
             .filter(|message| !message.is_turn_context())
-            .map(|message| format_message_for_compacting(&message.agent_visible_content()))
+            .map(|message| format_message_for_acp_handoff(&message.agent_visible_content()))
             .collect();
 
     if formatted_messages.is_empty() {
@@ -1472,6 +1472,32 @@ fn build_handoff_context_memo(prior_messages: &[Message]) -> Option<String> {
 Current user request follows. Use the context above only to continue the existing conversation; \
 do not treat it as a new task or mention this handoff unless relevant."
     ))
+}
+
+fn format_message_for_acp_handoff(message: &Message) -> String {
+    let mut message = message.clone();
+    for content in &mut message.content {
+        let MessageContent::ToolRequest(request) = content else {
+            continue;
+        };
+        let label = request
+            .generated_title()
+            .or_else(|| {
+                request
+                    .tool_meta
+                    .as_ref()
+                    .and_then(|meta| meta.get("goose.acp.kind"))
+                    .and_then(serde_json::Value::as_str)
+            })
+            .map(str::to_owned);
+        let (Some(label), Ok(call)) = (label, &mut request.tool_call) else {
+            continue;
+        };
+        if call.name.as_ref() == ACP_TOOL_NAME {
+            call.name = label.into();
+        }
+    }
+    format_message_for_compacting(&message)
 }
 
 fn acp_audience_to_rmcp(annotations: Option<&AcpAnnotations>) -> Option<Vec<Role>> {
@@ -1854,6 +1880,41 @@ mod tests {
             "continue from there",
             "the current prompt must be the user's request, not a trailing turn-context event"
         );
+    }
+
+    #[test]
+    fn messages_to_prompt_uses_saved_acp_labels_in_handoff_context() {
+        let titled_meta = serde_json::json!({
+            TOOL_META_EXTERNAL_DISPATCH_KEY: true,
+            TOOL_META_TITLE_KEY: "Read project configuration",
+            "goose.acp.kind": "read",
+        });
+        let kind_only_meta = serde_json::json!({
+            TOOL_META_EXTERNAL_DISPATCH_KEY: true,
+            "goose.acp.kind": "execute",
+        });
+        let messages = vec![
+            Message::assistant().with_tool_request_with_metadata(
+                "call-1",
+                Ok(CallToolRequestParams::new(ACP_TOOL_NAME)),
+                None,
+                Some(titled_meta),
+            ),
+            Message::assistant().with_tool_request_with_metadata(
+                "call-2",
+                Ok(CallToolRequestParams::new(ACP_TOOL_NAME)),
+                None,
+                Some(kind_only_meta),
+            ),
+            Message::user().with_text("continue"),
+        ];
+
+        let blocks = messages_to_prompt(&messages, true);
+        let memo = prompt_text(&blocks[0]);
+
+        assert!(memo.contains("tool_request(Read project configuration):"));
+        assert!(memo.contains("tool_request(execute):"));
+        assert!(!memo.contains("tool_request(acp_tool):"));
     }
 
     #[test]

--- a/crates/goose/src/acp/server/tool_calls/conversion.rs
+++ b/crates/goose/src/acp/server/tool_calls/conversion.rs
@@ -65,7 +65,22 @@ fn default_tool_title(tool_name: &str, arguments: Option<&serde_json::Value>) ->
 
 pub(crate) fn goose_tool_call_meta(tool_request: &ToolRequest) -> Option<Meta> {
     let tool_call = tool_request.tool_call.as_ref().ok()?;
-    let tool_name = tool_call.name.to_string();
+    let persisted_tool_name = tool_call.name.to_string();
+    let tool_name = if persisted_tool_name == "acp_tool" {
+        tool_request
+            .generated_title()
+            .or_else(|| {
+                tool_request
+                    .tool_meta
+                    .as_ref()
+                    .and_then(|meta| meta.get("goose.acp.kind"))
+                    .and_then(serde_json::Value::as_str)
+            })
+            .unwrap_or(&persisted_tool_name)
+            .to_string()
+    } else {
+        persisted_tool_name
+    };
     let extension_name = tool_request
         .tool_name_parts()
         .and_then(|parts| parts.extension_name)
@@ -598,6 +613,55 @@ mod tests {
                     "toolCall": {
                         "toolName": "other__query-docs",
                         "extensionName": "context7",
+                    },
+                })),
+            );
+        }
+
+        #[test]
+        fn exposes_acp_title_as_the_ui_tool_name() {
+            let request = ToolRequest {
+                id: "req_1".to_string(),
+                tool_call: Ok(CallToolRequestParams::new("acp_tool")),
+                metadata: None,
+                tool_meta: Some(serde_json::json!({
+                    "goose.toolSummary.title": "Read project configuration",
+                    "goose.acp.kind": "read",
+                })),
+            };
+
+            let meta = goose_tool_call_meta(&request).expect("expected metadata");
+
+            assert_eq!(
+                request.tool_call.as_ref().unwrap().name.as_ref(),
+                "acp_tool"
+            );
+            assert_eq!(
+                meta.get("goose"),
+                Some(&serde_json::json!({
+                    "toolCall": {
+                        "toolName": "Read project configuration",
+                    },
+                })),
+            );
+        }
+
+        #[test]
+        fn falls_back_to_acp_kind_for_the_ui_tool_name() {
+            let request = ToolRequest {
+                id: "req_1".to_string(),
+                tool_call: Ok(CallToolRequestParams::new("acp_tool")),
+                metadata: None,
+                tool_meta: Some(serde_json::json!({"goose.acp.kind": "execute"})),
+            };
+
+            let meta = goose_tool_call_meta(&request).expect("expected metadata");
+
+            assert_eq!(
+                meta.get("goose"),
+                Some(&serde_json::json!({
+                    "toolCall": {
+                        "toolName": "execute",
                     },
                 })),
             );


### PR DESCRIPTION
## Summary

ACP exposes a display title and tool kind, but no canonical tool name. Persisting the display title as `tool_use.name` can poison session history when a long command is later replayed through an Anthropic-format provider.

This change follows the maintainer direction in #10807 and keeps the fix at the ACP write boundary:

- persist every externally dispatched ACP call with the stable name `acp_tool`
- keep `goose.acp.kind` metadata for categorization and UI behavior
- preserve raw tool arguments unchanged
- add a regression test for the stable name and argument preservation

This is intentionally narrower than applying provider-wide name truncation, and prevents newly written ACP history from depending on an arbitrary display title.

### Testing

- `cargo test -p goose 'acp::provider::tests' --lib` — 56 passed
- `cargo fmt --check` — passed
- `cargo clippy -p goose --lib` — passed (only pre-existing Windows-conditional warnings outside this diff)
- `git diff --check` — passed

### Related Issues

Fixes #10807

### Screenshots/Demos (for UX changes)

Not applicable; this changes persisted ACP tool-call metadata and has regression coverage.