### PR TITLE
ci: defer privileged recipe scans for forks

### DIFF
--- a/.github/workflows/recipe-security-scanner.yml
+++ b/.github/workflows/recipe-security-scanner.yml
@@ -521,7 +521,6 @@ jobs:
       - fork-review-boundary
       - origin-ai-scan
     permissions:
-      contents: read
       statuses: write
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/recipe-security-scanner.yml
+++ b/.github/workflows/recipe-security-scanner.yml
@@ -19,6 +19,8 @@ permissions:
   statuses: write
 
 jobs:
+  # Forks are evaluated from GitHub file/review metadata only; recipe content
+  # never enters this job or the secret-bearing scanner.
   fork-review-boundary:
     name: Fork recipe review boundary
     if: ${{ github.event.pull_request.head.repo.full_name != github.repository }}

--- a/.github/workflows/recipe-security-scanner.yml
+++ b/.github/workflows/recipe-security-scanner.yml
@@ -52,37 +52,23 @@ jobs:
               return;
             }
 
-            const reviews = await github.paginate(github.rest.pulls.listReviews, request);
-            const latestByReviewer = new Map();
-            for (const review of reviews) {
-              if (!review.user?.login || !review.submitted_at) continue;
-              const state = review.state?.toUpperCase();
-              if (!['APPROVED', 'CHANGES_REQUESTED', 'DISMISSED'].includes(state)) continue;
-              const current = latestByReviewer.get(review.user.login);
-              if (!current || new Date(review.submitted_at) > new Date(current.submitted_at)) {
-                latestByReviewer.set(review.user.login, review);
-              }
-            }
-
-            const allowedPermissions = new Set(['admin', 'maintain', 'write']);
-            const approvers = [];
-            for (const review of latestByReviewer.values()) {
-              if (review.state?.toUpperCase() !== 'APPROVED') continue;
-              try {
-                const response = await github.rest.repos.getCollaboratorPermissionLevel({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  username: review.user.login,
-                });
-                if (allowedPermissions.has(response.data.permission)) {
-                  approvers.push(review.user.login);
+            const reviewData = await github.graphql(
+              `query($owner: String!, $repo: String!, $number: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  pullRequest(number: $number) {
+                    reviewDecision
+                  }
                 }
-              } catch (error) {
-                if (error.status !== 404) throw error;
+              }`,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                number: pullNumber,
               }
-            }
+            );
+            const reviewDecision = reviewData.repository.pullRequest.reviewDecision;
 
-            if (approvers.length === 0) {
+            if (reviewDecision !== 'APPROVED') {
               core.setFailed(
                 'Fork recipe instructions cannot enter the secret-bearing AI scanner. ' +
                 'An approving review from a user with write access is required.'
@@ -90,12 +76,12 @@ jobs:
               return;
             }
 
-            core.notice(`Fork recipe review boundary approved by @${approvers.join(', @')}.`);
+            core.notice('GitHub reports that the fork recipe has the required approval.');
             await core.summary
               .addHeading('Fork recipe review boundary')
               .addRaw(
                 'The privileged AI scan was not run because this recipe comes from a fork. ' +
-                `Write-access approval was verified from @${approvers.join(', @')}.`
+                'GitHub reports that the repository review requirement is approved.'
               )
               .write();
 

--- a/.github/workflows/recipe-security-scanner.yml
+++ b/.github/workflows/recipe-security-scanner.yml
@@ -66,17 +66,31 @@ jobs:
 
             const allowedPermissions = new Set(['admin', 'maintain', 'write']);
             const approvers = [];
+            const blockers = [];
             for (const review of latestByReviewer.values()) {
-              if (review.state?.toUpperCase() !== 'APPROVED') continue;
               if (review.commit_id !== currentHead) continue;
+              const state = review.state?.toUpperCase();
+              if (!['APPROVED', 'CHANGES_REQUESTED'].includes(state)) continue;
               const response = await github.rest.repos.getCollaboratorPermissionLevel({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 username: review.user.login,
               });
               if (allowedPermissions.has(response.data.permission)) {
-                approvers.push(review.user.login);
+                if (state === 'CHANGES_REQUESTED') {
+                  blockers.push(review.user.login);
+                } else {
+                  approvers.push(review.user.login);
+                }
               }
+            }
+
+            if (blockers.length > 0) {
+              core.setFailed(
+                'The current fork head has changes requested by a reviewer with write access: ' +
+                `@${blockers.join(', @')}.`
+              );
+              return;
             }
 
             if (approvers.length === 0) {

--- a/.github/workflows/recipe-security-scanner.yml
+++ b/.github/workflows/recipe-security-scanner.yml
@@ -5,6 +5,8 @@ on:
     types: [opened, synchronize, reopened]
     paths:
       - 'documentation/src/pages/recipes/data/recipes/**'
+  pull_request_review:
+    types: [submitted, dismissed]
 
 concurrency:
   group: scanner-${{ github.workflow }}-${{ github.event.pull_request.number }}
@@ -20,27 +22,84 @@ jobs:
   fork-review-boundary:
     name: Fork recipe review boundary
     if: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
-    permissions: {}
+    permissions:
+      contents: read
+      pull-requests: read
     runs-on: ubuntu-latest
     steps:
-      - name: Defer privileged scan
-        run: |
-          echo "::notice title=Privileged recipe scan deferred::Fork recipe instructions are untrusted input. A reviewer with write access must inspect the change before a maintainer mirrors it to an origin branch for the secret-bearing AI scan."
-          cat >> "$GITHUB_STEP_SUMMARY" <<'EOF'
-          # Privileged recipe scan deferred
+      - name: Require write-access approval
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        with:
+          script: |
+            const recipePrefix = 'documentation/src/pages/recipes/data/recipes/';
+            const pullNumber = context.payload.pull_request.number;
+            const request = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pullNumber,
+              per_page: 100,
+            };
 
-          This recipe comes from a fork. The AI scanner has repository secrets,
-          outbound network access, and developer tooling, so it must not process
-          fork-controlled instructions in a `pull_request_target` job.
+            const files = await github.paginate(github.rest.pulls.listFiles, request);
+            const hasReviewableRecipe = files.some(
+              (file) => file.filename.startsWith(recipePrefix) && file.status !== 'removed'
+            );
 
-          A reviewer with write access must inspect the recipe. If the AI scan is
-          needed, a maintainer can mirror the approved commit to a branch in this
-          repository, where the `security-scan` job is allowed to run.
-          EOF
+            if (!hasReviewableRecipe) {
+              core.notice('No added or modified recipe requires the fork review boundary.');
+              return;
+            }
+
+            const reviews = await github.paginate(github.rest.pulls.listReviews, request);
+            const latestByReviewer = new Map();
+            for (const review of reviews) {
+              if (!review.user?.login || !review.submitted_at) continue;
+              const state = review.state?.toUpperCase();
+              if (!['APPROVED', 'CHANGES_REQUESTED', 'DISMISSED'].includes(state)) continue;
+              const current = latestByReviewer.get(review.user.login);
+              if (!current || new Date(review.submitted_at) > new Date(current.submitted_at)) {
+                latestByReviewer.set(review.user.login, review);
+              }
+            }
+
+            const allowedPermissions = new Set(['admin', 'maintain', 'write']);
+            const approvers = [];
+            for (const review of latestByReviewer.values()) {
+              if (review.state?.toUpperCase() !== 'APPROVED') continue;
+              try {
+                const response = await github.rest.repos.getCollaboratorPermissionLevel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  username: review.user.login,
+                });
+                if (allowedPermissions.has(response.data.permission)) {
+                  approvers.push(review.user.login);
+                }
+              } catch (error) {
+                if (error.status !== 404) throw error;
+              }
+            }
+
+            if (approvers.length === 0) {
+              core.setFailed(
+                'Fork recipe instructions cannot enter the secret-bearing AI scanner. ' +
+                'An approving review from a user with write access is required.'
+              );
+              return;
+            }
+
+            core.notice(`Fork recipe review boundary approved by @${approvers.join(', @')}.`);
+            await core.summary
+              .addHeading('Fork recipe review boundary')
+              .addRaw(
+                'The privileged AI scan was not run because this recipe comes from a fork. ' +
+                `Write-access approval was verified from @${approvers.join(', @')}.`
+              )
+              .write();
 
   security-scan:
     # Never load fork-controlled recipe instructions into the privileged scanner.
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    if: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner

--- a/.github/workflows/recipe-security-scanner.yml
+++ b/.github/workflows/recipe-security-scanner.yml
@@ -23,10 +23,8 @@ jobs:
     name: Fork recipe review boundary
     if: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
     permissions:
-      # getCollaboratorPermissionLevel requires push access. This job runs only
-      # pinned base-branch JavaScript against GitHub metadata and never checks
-      # out or reads fork recipe content.
-      contents: write
+      # GitHub App installation tokens can query collaborator permission with
+      # their implicit metadata read access.
       pull-requests: read
     runs-on: ubuntu-latest
     steps:
@@ -524,26 +522,43 @@ jobs:
       - origin-ai-scan
     permissions:
       contents: read
+      statuses: write
     runs-on: ubuntu-latest
     steps:
       - name: Enforce the applicable security boundary
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         env:
           IS_FORK: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
           FORK_BOUNDARY_RESULT: ${{ needs.fork-review-boundary.result }}
           ORIGIN_SCAN_RESULT: ${{ needs.origin-ai-scan.result }}
-        run: |
-          set -euo pipefail
+        with:
+          script: |
+            const isFork = process.env.IS_FORK === 'true';
+            const applicableResult = isFork
+              ? process.env.FORK_BOUNDARY_RESULT
+              : process.env.ORIGIN_SCAN_RESULT;
+            const checkName = isFork ? 'fork review boundary' : 'origin recipe AI scan';
+            const passed = applicableResult === 'success';
 
-          if [ "$IS_FORK" = "true" ]; then
-            if [ "$FORK_BOUNDARY_RESULT" != "success" ]; then
-              echo "::error::Fork review boundary result: $FORK_BOUNDARY_RESULT"
-              exit 1
-            fi
-            echo "::notice::Fork review boundary passed; privileged AI scan was not run."
-          else
-            if [ "$ORIGIN_SCAN_RESULT" != "success" ]; then
-              echo "::error::Origin recipe AI scan result: $ORIGIN_SCAN_RESULT"
-              exit 1
-            fi
-            echo "::notice::Origin recipe AI scan passed."
-          fi
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: context.payload.pull_request.head.sha,
+              state: passed ? 'success' : 'failure',
+              target_url: `${context.payload.pull_request.html_url}/checks`,
+              description: passed
+                ? `${checkName} passed`
+                : `${checkName} result: ${applicableResult}`,
+              context: 'security-scan/recipe-scanner',
+            });
+
+            if (!passed) {
+              core.setFailed(`${checkName} result: ${applicableResult}`);
+              return;
+            }
+
+            core.notice(
+              isFork
+                ? 'Fork review boundary passed; privileged AI scan was not run.'
+                : 'Origin recipe AI scan passed.'
+            );

--- a/.github/workflows/recipe-security-scanner.yml
+++ b/.github/workflows/recipe-security-scanner.yml
@@ -5,8 +5,6 @@ on:
     types: [opened, synchronize, reopened]
     paths:
       - 'documentation/src/pages/recipes/data/recipes/**'
-  pull_request_review:
-    types: [submitted, dismissed]
 
 concurrency:
   group: scanner-${{ github.workflow }}-${{ github.event.pull_request.number }}
@@ -25,7 +23,10 @@ jobs:
     name: Fork recipe review boundary
     if: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
     permissions:
-      contents: read
+      # getCollaboratorPermissionLevel requires push access. This job runs only
+      # pinned base-branch JavaScript against GitHub metadata and never checks
+      # out or reads fork recipe content.
+      contents: write
       pull-requests: read
     runs-on: ubuntu-latest
     steps:
@@ -52,42 +53,55 @@ jobs:
               return;
             }
 
-            const reviewData = await github.graphql(
-              `query($owner: String!, $repo: String!, $number: Int!) {
-                repository(owner: $owner, name: $repo) {
-                  pullRequest(number: $number) {
-                    reviewDecision
-                  }
-                }
-              }`,
-              {
+            const currentHead = context.payload.pull_request.head.sha;
+            const reviews = await github.paginate(github.rest.pulls.listReviews, request);
+            const latestByReviewer = new Map();
+            for (const review of reviews) {
+              if (!review.user?.login || !review.submitted_at) continue;
+              const state = review.state?.toUpperCase();
+              if (!['APPROVED', 'CHANGES_REQUESTED', 'DISMISSED'].includes(state)) continue;
+              const current = latestByReviewer.get(review.user.login);
+              if (!current || new Date(review.submitted_at) > new Date(current.submitted_at)) {
+                latestByReviewer.set(review.user.login, review);
+              }
+            }
+
+            const allowedPermissions = new Set(['admin', 'maintain', 'write']);
+            const approvers = [];
+            for (const review of latestByReviewer.values()) {
+              if (review.state?.toUpperCase() !== 'APPROVED') continue;
+              if (review.commit_id !== currentHead) continue;
+              const response = await github.rest.repos.getCollaboratorPermissionLevel({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                number: pullNumber,
+                username: review.user.login,
+              });
+              if (allowedPermissions.has(response.data.permission)) {
+                approvers.push(review.user.login);
               }
-            );
-            const reviewDecision = reviewData.repository.pullRequest.reviewDecision;
+            }
 
-            if (reviewDecision !== 'APPROVED') {
+            if (approvers.length === 0) {
               core.setFailed(
                 'Fork recipe instructions cannot enter the secret-bearing AI scanner. ' +
-                'An approving review from a user with write access is required.'
+                'The current head requires an approving review from a user with write access. ' +
+                'After approval, rerun this failed job.'
               );
               return;
             }
 
-            core.notice('GitHub reports that the fork recipe has the required approval.');
+            core.notice(`Current fork head approved by @${approvers.join(', @')}.`);
             await core.summary
               .addHeading('Fork recipe review boundary')
               .addRaw(
                 'The privileged AI scan was not run because this recipe comes from a fork. ' +
-                'GitHub reports that the repository review requirement is approved.'
+                `Write-access approval of the current head was verified from @${approvers.join(', @')}.`
               )
               .write();
 
   security-scan:
     # Never load fork-controlled recipe instructions into the privileged scanner.
-    if: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.repository }}
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner

--- a/.github/workflows/recipe-security-scanner.yml
+++ b/.github/workflows/recipe-security-scanner.yml
@@ -17,7 +17,30 @@ permissions:
   statuses: write
 
 jobs:
+  fork-review-boundary:
+    name: Fork recipe review boundary
+    if: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
+    permissions: {}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Defer privileged scan
+        run: |
+          echo "::notice title=Privileged recipe scan deferred::Fork recipe instructions are untrusted input. A reviewer with write access must inspect the change before a maintainer mirrors it to an origin branch for the secret-bearing AI scan."
+          cat >> "$GITHUB_STEP_SUMMARY" <<'EOF'
+          # Privileged recipe scan deferred
+
+          This recipe comes from a fork. The AI scanner has repository secrets,
+          outbound network access, and developer tooling, so it must not process
+          fork-controlled instructions in a `pull_request_target` job.
+
+          A reviewer with write access must inspect the recipe. If the AI scan is
+          needed, a maintainer can mirror the approved commit to a branch in this
+          repository, where the `security-scan` job is allowed to run.
+          EOF
+
   security-scan:
+    # Never load fork-controlled recipe instructions into the privileged scanner.
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner

--- a/.github/workflows/recipe-security-scanner.yml
+++ b/.github/workflows/recipe-security-scanner.yml
@@ -99,7 +99,8 @@ jobs:
               )
               .write();
 
-  security-scan:
+  origin-ai-scan:
+    name: Origin recipe AI scan
     # Never load fork-controlled recipe instructions into the privileged scanner.
     if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
@@ -510,4 +511,39 @@ jobs:
           else
             echo "::error::No scan summary found - scan may have failed completely"
             exit 1
+          fi
+
+  # Preserve the existing required job context. This job always runs and
+  # reflects the applicable isolated check instead of allowing a skipped
+  # privileged scanner to satisfy branch protection for a fork.
+  security-scan:
+    name: security-scan
+    if: ${{ always() }}
+    needs:
+      - fork-review-boundary
+      - origin-ai-scan
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enforce the applicable security boundary
+        env:
+          IS_FORK: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
+          FORK_BOUNDARY_RESULT: ${{ needs.fork-review-boundary.result }}
+          ORIGIN_SCAN_RESULT: ${{ needs.origin-ai-scan.result }}
+        run: |
+          set -euo pipefail
+
+          if [ "$IS_FORK" = "true" ]; then
+            if [ "$FORK_BOUNDARY_RESULT" != "success" ]; then
+              echo "::error::Fork review boundary result: $FORK_BOUNDARY_RESULT"
+              exit 1
+            fi
+            echo "::notice::Fork review boundary passed; privileged AI scan was not run."
+          else
+            if [ "$ORIGIN_SCAN_RESULT" != "success" ]; then
+              echo "::error::Origin recipe AI scan result: $ORIGIN_SCAN_RESULT"
+              exit 1
+            fi
+            echo "::notice::Origin recipe AI scan passed."
           fi


### PR DESCRIPTION
## Summary

- keep the secret-bearing recipe AI scanner limited to branches in `aaif-goose/goose`;
- block fork recipe PRs until an approving review of the exact current head is verified from a user with `write`, `maintain`, or `admin` permission; and
- preserve both the existing required `security-scan` job context and legacy `security-scan/recipe-scanner` commit status from an always-running final gate.

Same-repository recipe scan behavior is unchanged. Removed-only recipe changes exit the fork boundary without enforcement.

### Why

Fork recipe PRs currently fail before scanning because `actions/checkout` correctly refuses their head SHA in this `pull_request_target` workflow. #10780 reproduces the failure.

The scanner later runs goose with the `developer` extension, outbound network access, passwordless download tooling, `OPENAI_API_KEY`, and private training-data secrets. The prior #10782 proposal to opt out of checkout protection was therefore unsafe and was withdrawn after review.

This change does not load or process fork-controlled recipe instructions in the privileged job:

- `fork-review-boundary` uses GitHub file/review metadata only, requires an authorized approval of the exact current head SHA, fails on any active current-head change request from an authorized reviewer, and otherwise fails with rerun instructions;
- `origin-ai-scan` retains the existing scanner implementation but runs only for same-repository branches; and
- `security-scan` always runs under the existing required job name, publishes the legacy commit status, and fails unless the applicable dependency succeeds. A skipped privileged scanner therefore cannot satisfy branch protection or leave an approved fork pending.

The fork boundary has only `pull-requests: read`; `getCollaboratorPermissionLevel` uses the installation token's implicit metadata read permission. It runs pinned base-branch `github-script`, performs no checkout, does not read recipe contents, and executes no fork-controlled value. The final result job has only `statuses: write`.

GitHub's security guidance recommends avoiding fork checkout or other processing of untrusted PR content in `pull_request_target`:

- https://docs.github.com/en/actions/reference/security/secure-use

### Testing

- workflow YAML parsed successfully, including least-privilege and required-context assertions;
- `actionlint` v1.7.12 passed;
- both embedded `github-script` blocks passed Node syntax checking;
- a deterministic mocked approval harness passed current-head write approval, stale approval, later changes-requested, read-only reviewer, removed-recipe, and separate authorized approver-plus-blocker cases;
- a four-case result matrix passed fork/origin success and failure propagation through the required job and legacy status contexts; and
- `git diff --check` passed.

### Related Issues

Urgent security-workflow repair; no Ready issue. Unblocks #10780 and supersedes the withdrawn #10782 approach.

