### PR TITLE
feat(desktop): option to make Enter insert a newline instead of sending

### DIFF
--- a/ui/desktop/src/components/ChatInput.tsx
+++ b/ui/desktop/src/components/ChatInput.tsx
@@ -547,8 +547,15 @@ export default function ChatInput({
       setEnterInsertsNewline(value === true);
     };
     loadEnterInsertsNewline();
-    window.addEventListener('enterInsertsNewlineChanged', loadEnterInsertsNewline);
-    return () => window.removeEventListener('enterInsertsNewlineChanged', loadEnterInsertsNewline);
+    // settings-changed is broadcast from the main process to every window,
+    // so toggling the setting in one window updates chat inputs in all of them
+    const handleSettingsChanged = (_event: unknown, payload: unknown) => {
+      if ((payload as { key?: string })?.key === 'enterInsertsNewline') {
+        loadEnterInsertsNewline();
+      }
+    };
+    window.electron.on('settings-changed', handleSettingsChanged);
+    return () => window.electron.off('settings-changed', handleSettingsChanged);
   }, []);
 
   // Use shared file drop hook for ChatInput

--- a/ui/desktop/src/components/ChatInput.tsx
+++ b/ui/desktop/src/components/ChatInput.tsx
@@ -539,6 +539,17 @@ export default function ChatInput({
   const [savedInput, setSavedInput] = useState('');
   const [isInGlobalHistory, setIsInGlobalHistory] = useState(false);
   const [hasUserTyped, setHasUserTyped] = useState(false);
+  const [enterInsertsNewline, setEnterInsertsNewline] = useState(false);
+
+  useEffect(() => {
+    const loadEnterInsertsNewline = async () => {
+      const value = await window.electron.getSetting('enterInsertsNewline');
+      setEnterInsertsNewline(value === true);
+    };
+    loadEnterInsertsNewline();
+    window.addEventListener('enterInsertsNewlineChanged', loadEnterInsertsNewline);
+    return () => window.removeEventListener('enterInsertsNewlineChanged', loadEnterInsertsNewline);
+  }, []);
 
   // Use shared file drop hook for ChatInput
   const {
@@ -1171,17 +1182,28 @@ export default function ChatInput({
     handleHistoryNavigation(evt);
 
     if (evt.key === 'Enter') {
-      // should not trigger submit on Enter if it's composing (IME input in progress) or shift/alt(option) is pressed
-      if (evt.shiftKey || isComposing) {
-        // Allow line break for Shift+Enter, or during IME composition
+      // Never submit while IME composition is in progress
+      if (isComposing) {
         return;
       }
 
-      if (evt.altKey) {
-        const newValue = displayValue + '\n';
-        setDisplayValue(newValue);
-        setValue(newValue);
-        return;
+      if (enterInsertsNewline) {
+        // Inverted mode: plain Enter inserts a newline; Shift/Cmd/Ctrl+Enter sends
+        if (!evt.shiftKey && !evt.metaKey && !evt.ctrlKey) {
+          return;
+        }
+      } else {
+        if (evt.shiftKey) {
+          // Allow line break for Shift+Enter
+          return;
+        }
+
+        if (evt.altKey) {
+          const newValue = displayValue + '\n';
+          setDisplayValue(newValue);
+          setValue(newValue);
+          return;
+        }
       }
 
       evt.preventDefault();

--- a/ui/desktop/src/components/settings/chat/ChatSettingsSection.tsx
+++ b/ui/desktop/src/components/settings/chat/ChatSettingsSection.tsx
@@ -4,6 +4,7 @@ import { SecurityToggle } from '../security/SecurityToggle';
 import { ResponseStylesSection } from '../response_styles/ResponseStylesSection';
 import { GoosehintsSection } from './GoosehintsSection';
 import { SpellcheckToggle } from './SpellcheckToggle';
+import { EnterInsertsNewlineToggle } from './EnterInsertsNewlineToggle';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../../ui/card';
 import { defineMessages, useIntl } from '../../../i18n';
 
@@ -52,6 +53,7 @@ export default function ChatSettingsSection() {
         <CardContent className="px-2">
           <DictationSettings />
           <SpellcheckToggle />
+          <EnterInsertsNewlineToggle />
         </CardContent>
       </Card>
 

--- a/ui/desktop/src/components/settings/chat/EnterInsertsNewlineToggle.tsx
+++ b/ui/desktop/src/components/settings/chat/EnterInsertsNewlineToggle.tsx
@@ -29,7 +29,6 @@ export const EnterInsertsNewlineToggle = () => {
   const handleToggle = async (checked: boolean) => {
     setEnabled(checked);
     await window.electron.setSetting('enterInsertsNewline', checked);
-    window.dispatchEvent(new CustomEvent('enterInsertsNewlineChanged'));
   };
 
   const sendShortcut = window.electron?.platform === 'darwin' ? '⌘+Enter' : 'Ctrl+Enter';

--- a/ui/desktop/src/components/settings/chat/EnterInsertsNewlineToggle.tsx
+++ b/ui/desktop/src/components/settings/chat/EnterInsertsNewlineToggle.tsx
@@ -1,0 +1,50 @@
+import { useState, useEffect } from 'react';
+import { Switch } from '../../ui/switch';
+import { defineMessages, useIntl } from '../../../i18n';
+
+const i18n = defineMessages({
+  title: {
+    id: 'enterInsertsNewlineToggle.title',
+    defaultMessage: 'Enter Inserts Newline',
+  },
+  description: {
+    id: 'enterInsertsNewlineToggle.description',
+    defaultMessage:
+      'Pressing Enter starts a new line instead of sending. Send with Shift+Enter or {sendShortcut}.',
+  },
+});
+
+export const EnterInsertsNewlineToggle = () => {
+  const intl = useIntl();
+  const [enabled, setEnabled] = useState(false);
+
+  useEffect(() => {
+    const loadState = async () => {
+      const state = await window.electron.getSetting('enterInsertsNewline');
+      setEnabled(state === true);
+    };
+    loadState();
+  }, []);
+
+  const handleToggle = async (checked: boolean) => {
+    setEnabled(checked);
+    await window.electron.setSetting('enterInsertsNewline', checked);
+    window.dispatchEvent(new CustomEvent('enterInsertsNewlineChanged'));
+  };
+
+  const sendShortcut = window.electron?.platform === 'darwin' ? '⌘+Enter' : 'Ctrl+Enter';
+
+  return (
+    <div className="flex items-center justify-between py-2 px-2 hover:bg-background-secondary rounded-lg transition-all">
+      <div>
+        <h3 className="text-text-primary">{intl.formatMessage(i18n.title)}</h3>
+        <p className="text-xs text-text-secondary max-w-md mt-[2px]">
+          {intl.formatMessage(i18n.description, { sendShortcut })}
+        </p>
+      </div>
+      <div className="flex items-center">
+        <Switch checked={enabled} onCheckedChange={handleToggle} variant="mono" />
+      </div>
+    </div>
+  );
+};

--- a/ui/desktop/src/i18n/messages/de.json
+++ b/ui/desktop/src/i18n/messages/de.json
@@ -953,6 +953,12 @@
   "elicitationRequest.waitingForResponse": {
     "defaultMessage": "Warten auf Ihre Antwort ({timeRemaining} verbleibend)"
   },
+  "enterInsertsNewlineToggle.description": {
+    "defaultMessage": "Mit der Eingabetaste wird eine neue Zeile begonnen, statt zu senden. Senden mit Shift+Enter oder {sendShortcut}."
+  },
+  "enterInsertsNewlineToggle.title": {
+    "defaultMessage": "Enter fügt Zeilenumbruch ein"
+  },
   "envVarsSection.add": {
     "defaultMessage": "Hinzufügen"
   },

--- a/ui/desktop/src/i18n/messages/en.json
+++ b/ui/desktop/src/i18n/messages/en.json
@@ -953,6 +953,12 @@
   "elicitationRequest.waitingForResponse": {
     "defaultMessage": "Waiting for your response ({timeRemaining} remaining)"
   },
+  "enterInsertsNewlineToggle.description": {
+    "defaultMessage": "Pressing Enter starts a new line instead of sending. Send with Shift+Enter or {sendShortcut}."
+  },
+  "enterInsertsNewlineToggle.title": {
+    "defaultMessage": "Enter Inserts Newline"
+  },
   "envVarsSection.add": {
     "defaultMessage": "Add"
   },

--- a/ui/desktop/src/i18n/messages/es.json
+++ b/ui/desktop/src/i18n/messages/es.json
@@ -953,6 +953,12 @@
   "elicitationRequest.waitingForResponse": {
     "defaultMessage": "Esperando tu respuesta ({timeRemaining} restantes)"
   },
+  "enterInsertsNewlineToggle.description": {
+    "defaultMessage": "Al pulsar Enter se inserta una nueva línea en lugar de enviar. Envía con Shift+Enter o {sendShortcut}."
+  },
+  "enterInsertsNewlineToggle.title": {
+    "defaultMessage": "Enter inserta salto de línea"
+  },
   "envVarsSection.add": {
     "defaultMessage": "Añadir"
   },

--- a/ui/desktop/src/i18n/messages/fr.json
+++ b/ui/desktop/src/i18n/messages/fr.json
@@ -953,6 +953,12 @@
   "elicitationRequest.waitingForResponse": {
     "defaultMessage": "En attente de votre réponse ({timeRemaining} restant)"
   },
+  "enterInsertsNewlineToggle.description": {
+    "defaultMessage": "Appuyer sur Entrée insère une nouvelle ligne au lieu d'envoyer. Envoyez avec Maj+Entrée ou {sendShortcut}."
+  },
+  "enterInsertsNewlineToggle.title": {
+    "defaultMessage": "Entrée insère un saut de ligne"
+  },
   "envVarsSection.add": {
     "defaultMessage": "Ajouter"
   },

--- a/ui/desktop/src/i18n/messages/hi.json
+++ b/ui/desktop/src/i18n/messages/hi.json
@@ -953,6 +953,12 @@
   "elicitationRequest.waitingForResponse": {
     "defaultMessage": "आपकी प्रतिक्रिया की प्रतीक्षा में ({timeRemaining} शेष)"
   },
+  "enterInsertsNewlineToggle.description": {
+    "defaultMessage": "Enter दबाने पर संदेश भेजने के बजाय नई पंक्ति शुरू होती है। Shift+Enter या {sendShortcut} से भेजें।"
+  },
+  "enterInsertsNewlineToggle.title": {
+    "defaultMessage": "Enter नई पंक्ति जोड़ता है"
+  },
   "envVarsSection.add": {
     "defaultMessage": "जोड़ें"
   },

--- a/ui/desktop/src/i18n/messages/id.json
+++ b/ui/desktop/src/i18n/messages/id.json
@@ -953,6 +953,12 @@
   "elicitationRequest.waitingForResponse": {
     "defaultMessage": "Menunggu respons Anda ({timeRemaining} tersisa)"
   },
+  "enterInsertsNewlineToggle.description": {
+    "defaultMessage": "Menekan Enter memulai baris baru alih-alih mengirim. Kirim dengan Shift+Enter atau {sendShortcut}."
+  },
+  "enterInsertsNewlineToggle.title": {
+    "defaultMessage": "Enter menyisipkan baris baru"
+  },
   "envVarsSection.add": {
     "defaultMessage": "Tambah"
   },

--- a/ui/desktop/src/i18n/messages/it.json
+++ b/ui/desktop/src/i18n/messages/it.json
@@ -953,6 +953,12 @@
   "elicitationRequest.waitingForResponse": {
     "defaultMessage": "In attesa della tua risposta ({timeRemaining} rimanenti)"
   },
+  "enterInsertsNewlineToggle.description": {
+    "defaultMessage": "Premendo Invio si inizia una nuova riga invece di inviare. Invia con Shift+Invio o {sendShortcut}."
+  },
+  "enterInsertsNewlineToggle.title": {
+    "defaultMessage": "Invio inserisce una nuova riga"
+  },
   "envVarsSection.add": {
     "defaultMessage": "Aggiungi"
   },

--- a/ui/desktop/src/i18n/messages/ja.json
+++ b/ui/desktop/src/i18n/messages/ja.json
@@ -953,6 +953,12 @@
   "elicitationRequest.waitingForResponse": {
     "defaultMessage": "あなたの応答を待っています（残り{timeRemaining}）"
   },
+  "enterInsertsNewlineToggle.description": {
+    "defaultMessage": "Enterキーで送信せずに改行します。Shift+Enterまたは{sendShortcut}で送信します。"
+  },
+  "enterInsertsNewlineToggle.title": {
+    "defaultMessage": "Enterで改行を挿入"
+  },
   "envVarsSection.add": {
     "defaultMessage": "追加"
   },

--- a/ui/desktop/src/i18n/messages/ko.json
+++ b/ui/desktop/src/i18n/messages/ko.json
@@ -953,6 +953,12 @@
   "elicitationRequest.waitingForResponse": {
     "defaultMessage": "답변을 기다리는 중입니다. ({timeRemaining} 남음)"
   },
+  "enterInsertsNewlineToggle.description": {
+    "defaultMessage": "Enter 키를 누르면 전송하지 않고 새 줄을 시작합니다. Shift+Enter 또는 {sendShortcut}로 전송하세요."
+  },
+  "enterInsertsNewlineToggle.title": {
+    "defaultMessage": "Enter로 줄바꿈 삽입"
+  },
   "envVarsSection.add": {
     "defaultMessage": "추가"
   },

--- a/ui/desktop/src/i18n/messages/ms.json
+++ b/ui/desktop/src/i18n/messages/ms.json
@@ -953,6 +953,12 @@
   "elicitationRequest.waitingForResponse": {
     "defaultMessage": "Menunggu respons anda ({timeRemaining} lagi)"
   },
+  "enterInsertsNewlineToggle.description": {
+    "defaultMessage": "Menekan Enter memulakan baris baharu dan bukannya menghantar. Hantar dengan Shift+Enter atau {sendShortcut}."
+  },
+  "enterInsertsNewlineToggle.title": {
+    "defaultMessage": "Enter memasukkan baris baharu"
+  },
   "envVarsSection.add": {
     "defaultMessage": "Tambah"
   },

--- a/ui/desktop/src/i18n/messages/pt.json
+++ b/ui/desktop/src/i18n/messages/pt.json
@@ -953,6 +953,12 @@
   "elicitationRequest.waitingForResponse": {
     "defaultMessage": "Aguardando sua resposta ({timeRemaining} restante)"
   },
+  "enterInsertsNewlineToggle.description": {
+    "defaultMessage": "Pressionar Enter inicia uma nova linha em vez de enviar. Envie com Shift+Enter ou {sendShortcut}."
+  },
+  "enterInsertsNewlineToggle.title": {
+    "defaultMessage": "Enter insere nova linha"
+  },
   "envVarsSection.add": {
     "defaultMessage": "Adicionar"
   },

--- a/ui/desktop/src/i18n/messages/ru.json
+++ b/ui/desktop/src/i18n/messages/ru.json
@@ -953,6 +953,12 @@
   "elicitationRequest.waitingForResponse": {
     "defaultMessage": "Ожидание вашего ответа (осталось {timeRemaining})"
   },
+  "enterInsertsNewlineToggle.description": {
+    "defaultMessage": "Нажатие Enter начинает новую строку вместо отправки. Отправляйте с помощью Shift+Enter или {sendShortcut}."
+  },
+  "enterInsertsNewlineToggle.title": {
+    "defaultMessage": "Enter вставляет новую строку"
+  },
   "envVarsSection.add": {
     "defaultMessage": "Добавить"
   },

--- a/ui/desktop/src/i18n/messages/tr.json
+++ b/ui/desktop/src/i18n/messages/tr.json
@@ -953,6 +953,12 @@
   "elicitationRequest.waitingForResponse": {
     "defaultMessage": "Yanıtınızı bekliyorum ({timeRemaining} kaldı)"
   },
+  "enterInsertsNewlineToggle.description": {
+    "defaultMessage": "Enter tuşuna basmak göndermek yerine yeni bir satır başlatır. Shift+Enter veya {sendShortcut} ile gönderin."
+  },
+  "enterInsertsNewlineToggle.title": {
+    "defaultMessage": "Enter yeni satır ekler"
+  },
   "envVarsSection.add": {
     "defaultMessage": "Ekle"
   },

--- a/ui/desktop/src/i18n/messages/vi.json
+++ b/ui/desktop/src/i18n/messages/vi.json
@@ -953,6 +953,12 @@
   "elicitationRequest.waitingForResponse": {
     "defaultMessage": "Đang chờ phản hồi của bạn (còn {timeRemaining})"
   },
+  "enterInsertsNewlineToggle.description": {
+    "defaultMessage": "Nhấn Enter sẽ bắt đầu dòng mới thay vì gửi. Gửi bằng Shift+Enter hoặc {sendShortcut}."
+  },
+  "enterInsertsNewlineToggle.title": {
+    "defaultMessage": "Enter chèn dòng mới"
+  },
   "envVarsSection.add": {
     "defaultMessage": "Thêm"
   },

--- a/ui/desktop/src/i18n/messages/zh-CN.json
+++ b/ui/desktop/src/i18n/messages/zh-CN.json
@@ -953,6 +953,12 @@
   "elicitationRequest.waitingForResponse": {
     "defaultMessage": "正在等待你的回复（剩余 {timeRemaining}）"
   },
+  "enterInsertsNewlineToggle.description": {
+    "defaultMessage": "按 Enter 键换行而不发送。使用 Shift+Enter 或 {sendShortcut} 发送。"
+  },
+  "enterInsertsNewlineToggle.title": {
+    "defaultMessage": "Enter 键插入换行"
+  },
   "envVarsSection.add": {
     "defaultMessage": "添加"
   },

--- a/ui/desktop/src/i18n/messages/zh-TW.json
+++ b/ui/desktop/src/i18n/messages/zh-TW.json
@@ -953,6 +953,12 @@
   "elicitationRequest.waitingForResponse": {
     "defaultMessage": "正在等待您的回應（剩餘 {timeRemaining}）"
   },
+  "enterInsertsNewlineToggle.description": {
+    "defaultMessage": "按 Enter 鍵換行而不傳送。使用 Shift+Enter 或 {sendShortcut} 傳送。"
+  },
+  "enterInsertsNewlineToggle.title": {
+    "defaultMessage": "Enter 鍵插入換行"
+  },
   "envVarsSection.add": {
     "defaultMessage": "新增"
   },

--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -1940,6 +1940,7 @@ const validSettingKeys: Set<string> = new Set([
   'language',
   'responseStyle',
   'showPricing',
+  'enterInsertsNewline',
   'seenAnnouncementIds',
   'disableAutoDownload',
 ]);

--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -1974,6 +1974,13 @@ ipcMain.handle('set-setting', (_event, key: SettingKey, value: unknown) => {
   if (key === 'disableAutoDownload') {
     setAutoDownloadDisabled(value as boolean);
   }
+
+  // Notify every window (including the sender) so open views pick up the change
+  for (const window of BrowserWindow.getAllWindows()) {
+    if (!window.isDestroyed()) {
+      window.webContents.send('settings-changed', { key });
+    }
+  }
 });
 
 ipcMain.handle('get-secret-key', (event) => {

--- a/ui/desktop/src/test/setup.ts
+++ b/ui/desktop/src/test/setup.ts
@@ -70,6 +70,7 @@ const mockSettings: Record<string, unknown> = {
   language: 'system',
   responseStyle: 'concise',
   showPricing: true,
+  enterInsertsNewline: false,
   seenAnnouncementIds: [],
 };
 

--- a/ui/desktop/src/utils/settings.ts
+++ b/ui/desktop/src/utils/settings.ts
@@ -47,6 +47,7 @@ export interface Settings {
   language: LanguageSetting;
   responseStyle: string;
   showPricing: boolean;
+  enterInsertsNewline: boolean;
   seenAnnouncementIds: string[];
 }
 
@@ -87,6 +88,7 @@ export const defaultSettings: Settings = {
   language: 'system',
   responseStyle: 'concise',
   showPricing: true,
+  enterInsertsNewline: false,
   seenAnnouncementIds: [],
 };
 


### PR DESCRIPTION
Fixes #10824

Adds an **Enter Inserts Newline** toggle to Settings → Chat (default off, so existing behavior is unchanged).

- **On:** Enter inserts a newline; Shift+Enter or Cmd+Enter (Ctrl+Enter on Windows/Linux) sends.
- **Off (default):** unchanged — Enter sends, Shift+Enter/Option+Enter insert a newline.

The setting is stored in the Electron settings store (`enterInsertsNewline`) and applies live to open chat windows via a window event, following the existing `showPricing` pattern. IME composition handling is preserved, as is Enter selection in the @-mention popover. Locale catalogs updated for all supported languages.