### PR TITLE
fix(ui): support remote working directory for external backend

### DIFF
--- a/ui/desktop/src/components/settings/app/ExternalBackendSection.tsx
+++ b/ui/desktop/src/components/settings/app/ExternalBackendSection.tsx
@@ -34,6 +34,18 @@ const i18n = defineMessages({
     defaultMessage:
       'Enter the HTTP(S) base URL. Goose checks /status and connects to /acp under this base.',
   },
+  workingDir: {
+    id: 'externalBackendSection.workingDir',
+    defaultMessage: 'Remote Working Directory (optional)',
+  },
+  workingDirPlaceholder: {
+    id: 'externalBackendSection.workingDirPlaceholder',
+    defaultMessage: '/home/goose/workspace',
+  },
+  workingDirHelp: {
+    id: 'externalBackendSection.workingDirHelp',
+    defaultMessage: 'Path on the machine running the external backend. Leave blank to use its default.',
+  },
   secretKey: {
     id: 'externalBackendSection.secretKey',
     defaultMessage: 'Secret Key',
@@ -219,6 +231,24 @@ export default function ExternalBackendSection() {
                 )}
                 <p className="text-xs text-text-secondary">
                   {intl.formatMessage(i18n.serverUrlHelp)}
+                </p>
+              </div>
+
+              <div className="space-y-2">
+                <label htmlFor="external-working-dir" className="text-text-primary text-xs">
+                  {intl.formatMessage(i18n.workingDir)}
+                </label>
+                <Input
+                  id="external-working-dir"
+                  type="text"
+                  placeholder={intl.formatMessage(i18n.workingDirPlaceholder)}
+                  value={config.workingDir || ''}
+                  onChange={(e) => updateField('workingDir', e.target.value)}
+                  onBlur={() => saveConfig(config)}
+                  disabled={isSaving}
+                />
+                <p className="text-xs text-text-secondary">
+                  {intl.formatMessage(i18n.workingDirHelp)}
                 </p>
               </div>
 

--- a/ui/desktop/src/components/settings/app/ExternalBackendSection.tsx
+++ b/ui/desktop/src/components/settings/app/ExternalBackendSection.tsx
@@ -44,7 +44,8 @@ const i18n = defineMessages({
   },
   workingDirHelp: {
     id: 'externalBackendSection.workingDirHelp',
-    defaultMessage: 'Path on the machine running the external backend. Leave blank to use its default.',
+    defaultMessage:
+      'Absolute path on the external backend. Leave blank to send the local working directory.',
   },
   secretKey: {
     id: 'externalBackendSection.secretKey',

--- a/ui/desktop/src/i18n/messages/de.json
+++ b/ui/desktop/src/i18n/messages/de.json
@@ -1230,7 +1230,7 @@
     "defaultMessage": "Remote-Arbeitsverzeichnis (optional)"
   },
   "externalBackendSection.workingDirHelp": {
-    "defaultMessage": "Pfad auf dem Computer, auf dem das externe Backend ausgeführt wird. Leer lassen, um den Standard zu verwenden."
+    "defaultMessage": "Absoluter Pfad auf dem externen Backend. Leer lassen, um das lokale Arbeitsverzeichnis zu senden."
   },
   "externalBackendSection.workingDirPlaceholder": {
     "defaultMessage": "/home/goose/workspace"

--- a/ui/desktop/src/i18n/messages/de.json
+++ b/ui/desktop/src/i18n/messages/de.json
@@ -1226,6 +1226,15 @@
   "externalBackendSection.useExternalServerDescription": {
     "defaultMessage": "Verbindung zu einem anderswo laufenden goose-Server herstellen (erfordert Neustart der App)"
   },
+  "externalBackendSection.workingDir": {
+    "defaultMessage": "Remote-Arbeitsverzeichnis (optional)"
+  },
+  "externalBackendSection.workingDirHelp": {
+    "defaultMessage": "Pfad auf dem Computer, auf dem das externe Backend ausgeführt wird. Leer lassen, um den Standard zu verwenden."
+  },
+  "externalBackendSection.workingDirPlaceholder": {
+    "defaultMessage": "/home/goose/workspace"
+  },
   "goosehintsModal.close": {
     "defaultMessage": "Schließen"
   },

--- a/ui/desktop/src/i18n/messages/en.json
+++ b/ui/desktop/src/i18n/messages/en.json
@@ -1226,6 +1226,15 @@
   "externalBackendSection.useExternalServerDescription": {
     "defaultMessage": "Connect to an ACP-compatible backend running elsewhere."
   },
+  "externalBackendSection.workingDir": {
+    "defaultMessage": "Remote Working Directory (optional)"
+  },
+  "externalBackendSection.workingDirHelp": {
+    "defaultMessage": "Path on the machine running the external backend. Leave blank to use its default."
+  },
+  "externalBackendSection.workingDirPlaceholder": {
+    "defaultMessage": "/home/goose/workspace"
+  },
   "goosehintsModal.close": {
     "defaultMessage": "Close"
   },

--- a/ui/desktop/src/i18n/messages/en.json
+++ b/ui/desktop/src/i18n/messages/en.json
@@ -1230,7 +1230,7 @@
     "defaultMessage": "Remote Working Directory (optional)"
   },
   "externalBackendSection.workingDirHelp": {
-    "defaultMessage": "Path on the machine running the external backend. Leave blank to use its default."
+    "defaultMessage": "Absolute path on the external backend. Leave blank to send the local working directory."
   },
   "externalBackendSection.workingDirPlaceholder": {
     "defaultMessage": "/home/goose/workspace"

--- a/ui/desktop/src/i18n/messages/es.json
+++ b/ui/desktop/src/i18n/messages/es.json
@@ -1230,7 +1230,7 @@
     "defaultMessage": "Directorio de trabajo remoto (opcional)"
   },
   "externalBackendSection.workingDirHelp": {
-    "defaultMessage": "Ruta en el equipo donde se ejecuta el backend externo. Déjelo vacío para usar el valor predeterminado."
+    "defaultMessage": "Ruta absoluta en el backend externo. Déjelo vacío para enviar el directorio de trabajo local."
   },
   "externalBackendSection.workingDirPlaceholder": {
     "defaultMessage": "/home/goose/workspace"

--- a/ui/desktop/src/i18n/messages/es.json
+++ b/ui/desktop/src/i18n/messages/es.json
@@ -1226,6 +1226,15 @@
   "externalBackendSection.useExternalServerDescription": {
     "defaultMessage": "Conéctate a un servidor goose que se ejecuta en otro lugar (requiere reiniciar la app)"
   },
+  "externalBackendSection.workingDir": {
+    "defaultMessage": "Directorio de trabajo remoto (opcional)"
+  },
+  "externalBackendSection.workingDirHelp": {
+    "defaultMessage": "Ruta en el equipo donde se ejecuta el backend externo. Déjelo vacío para usar el valor predeterminado."
+  },
+  "externalBackendSection.workingDirPlaceholder": {
+    "defaultMessage": "/home/goose/workspace"
+  },
   "goosehintsModal.close": {
     "defaultMessage": "Cerrar"
   },

--- a/ui/desktop/src/i18n/messages/fr.json
+++ b/ui/desktop/src/i18n/messages/fr.json
@@ -1226,6 +1226,15 @@
   "externalBackendSection.useExternalServerDescription": {
     "defaultMessage": "Se connecter à un serveur goose exécuté ailleurs (nécessite le redémarrage de l'application)"
   },
+  "externalBackendSection.workingDir": {
+    "defaultMessage": "Répertoire de travail distant (facultatif)"
+  },
+  "externalBackendSection.workingDirHelp": {
+    "defaultMessage": "Chemin sur la machine exécutant le backend externe. Laissez vide pour utiliser la valeur par défaut."
+  },
+  "externalBackendSection.workingDirPlaceholder": {
+    "defaultMessage": "/home/goose/workspace"
+  },
   "goosehintsModal.close": {
     "defaultMessage": "Fermer"
   },

--- a/ui/desktop/src/i18n/messages/fr.json
+++ b/ui/desktop/src/i18n/messages/fr.json
@@ -1230,7 +1230,7 @@
     "defaultMessage": "Répertoire de travail distant (facultatif)"
   },
   "externalBackendSection.workingDirHelp": {
-    "defaultMessage": "Chemin sur la machine exécutant le backend externe. Laissez vide pour utiliser la valeur par défaut."
+    "defaultMessage": "Chemin absolu sur le backend externe. Laissez vide pour envoyer le répertoire de travail local."
   },
   "externalBackendSection.workingDirPlaceholder": {
     "defaultMessage": "/home/goose/workspace"

--- a/ui/desktop/src/i18n/messages/hi.json
+++ b/ui/desktop/src/i18n/messages/hi.json
@@ -1226,6 +1226,15 @@
   "externalBackendSection.useExternalServerDescription": {
     "defaultMessage": "कहीं और चल रहे goose सर्वर से कनेक्ट करें (ऐप पुनरारंभ की आवश्यकता है)"
   },
+  "externalBackendSection.workingDir": {
+    "defaultMessage": "रिमोट कार्य निर्देशिका (वैकल्पिक)"
+  },
+  "externalBackendSection.workingDirHelp": {
+    "defaultMessage": "उस मशीन पर पथ जहाँ बाहरी बैकएंड चल रहा है। डिफ़ॉल्ट का उपयोग करने के लिए खाली छोड़ दें।"
+  },
+  "externalBackendSection.workingDirPlaceholder": {
+    "defaultMessage": "/home/goose/workspace"
+  },
   "goosehintsModal.close": {
     "defaultMessage": "बंद करें"
   },

--- a/ui/desktop/src/i18n/messages/hi.json
+++ b/ui/desktop/src/i18n/messages/hi.json
@@ -1230,7 +1230,7 @@
     "defaultMessage": "रिमोट कार्य निर्देशिका (वैकल्पिक)"
   },
   "externalBackendSection.workingDirHelp": {
-    "defaultMessage": "उस मशीन पर पथ जहाँ बाहरी बैकएंड चल रहा है। डिफ़ॉल्ट का उपयोग करने के लिए खाली छोड़ दें।"
+    "defaultMessage": "बाहरी बैकएंड पर पूर्ण पथ। स्थानीय कार्य निर्देशिका भेजने के लिए खाली छोड़ दें।"
   },
   "externalBackendSection.workingDirPlaceholder": {
     "defaultMessage": "/home/goose/workspace"

--- a/ui/desktop/src/i18n/messages/id.json
+++ b/ui/desktop/src/i18n/messages/id.json
@@ -1230,7 +1230,7 @@
     "defaultMessage": "Direktori kerja jarak jauh (opsional)"
   },
   "externalBackendSection.workingDirHelp": {
-    "defaultMessage": "Jalur pada mesin yang menjalankan backend eksternal. Biarkan kosong untuk menggunakan nilai default."
+    "defaultMessage": "Jalur absolut pada backend eksternal. Biarkan kosong untuk mengirim direktori kerja lokal."
   },
   "externalBackendSection.workingDirPlaceholder": {
     "defaultMessage": "/home/goose/workspace"

--- a/ui/desktop/src/i18n/messages/id.json
+++ b/ui/desktop/src/i18n/messages/id.json
@@ -1226,6 +1226,15 @@
   "externalBackendSection.useExternalServerDescription": {
     "defaultMessage": "Terhubung ke server goose yang berjalan di tempat lain (memerlukan mulai ulang aplikasi)"
   },
+  "externalBackendSection.workingDir": {
+    "defaultMessage": "Direktori kerja jarak jauh (opsional)"
+  },
+  "externalBackendSection.workingDirHelp": {
+    "defaultMessage": "Jalur pada mesin yang menjalankan backend eksternal. Biarkan kosong untuk menggunakan nilai default."
+  },
+  "externalBackendSection.workingDirPlaceholder": {
+    "defaultMessage": "/home/goose/workspace"
+  },
   "goosehintsModal.close": {
     "defaultMessage": "Tutup"
   },

--- a/ui/desktop/src/i18n/messages/it.json
+++ b/ui/desktop/src/i18n/messages/it.json
@@ -1230,7 +1230,7 @@
     "defaultMessage": "Directory di lavoro remota (facoltativa)"
   },
   "externalBackendSection.workingDirHelp": {
-    "defaultMessage": "Percorso sul computer che esegue il backend esterno. Lascia vuoto per usare il valore predefinito."
+    "defaultMessage": "Percorso assoluto sul backend esterno. Lascia vuoto per inviare la directory di lavoro locale."
   },
   "externalBackendSection.workingDirPlaceholder": {
     "defaultMessage": "/home/goose/workspace"

--- a/ui/desktop/src/i18n/messages/it.json
+++ b/ui/desktop/src/i18n/messages/it.json
@@ -1226,6 +1226,15 @@
   "externalBackendSection.useExternalServerDescription": {
     "defaultMessage": "Connettiti a un server goose in esecuzione altrove (richiede il riavvio dell'app)"
   },
+  "externalBackendSection.workingDir": {
+    "defaultMessage": "Directory di lavoro remota (facoltativa)"
+  },
+  "externalBackendSection.workingDirHelp": {
+    "defaultMessage": "Percorso sul computer che esegue il backend esterno. Lascia vuoto per usare il valore predefinito."
+  },
+  "externalBackendSection.workingDirPlaceholder": {
+    "defaultMessage": "/home/goose/workspace"
+  },
   "goosehintsModal.close": {
     "defaultMessage": "Chiudi"
   },

--- a/ui/desktop/src/i18n/messages/ja.json
+++ b/ui/desktop/src/i18n/messages/ja.json
@@ -1226,6 +1226,15 @@
   "externalBackendSection.useExternalServerDescription": {
     "defaultMessage": "別の場所で実行中の goose サーバーに接続します（アプリの再起動が必要）"
   },
+  "externalBackendSection.workingDir": {
+    "defaultMessage": "リモート作業ディレクトリ（任意）"
+  },
+  "externalBackendSection.workingDirHelp": {
+    "defaultMessage": "外部バックエンドを実行しているマシン上のパスです。既定値を使用するには空白のままにします。"
+  },
+  "externalBackendSection.workingDirPlaceholder": {
+    "defaultMessage": "/home/goose/workspace"
+  },
   "goosehintsModal.close": {
     "defaultMessage": "閉じる"
   },

--- a/ui/desktop/src/i18n/messages/ja.json
+++ b/ui/desktop/src/i18n/messages/ja.json
@@ -1230,7 +1230,7 @@
     "defaultMessage": "リモート作業ディレクトリ（任意）"
   },
   "externalBackendSection.workingDirHelp": {
-    "defaultMessage": "外部バックエンドを実行しているマシン上のパスです。既定値を使用するには空白のままにします。"
+    "defaultMessage": "外部バックエンド上の絶対パスです。空欄の場合はローカルの作業ディレクトリを送信します。"
   },
   "externalBackendSection.workingDirPlaceholder": {
     "defaultMessage": "/home/goose/workspace"

--- a/ui/desktop/src/i18n/messages/ko.json
+++ b/ui/desktop/src/i18n/messages/ko.json
@@ -1230,7 +1230,7 @@
     "defaultMessage": "원격 작업 디렉터리(선택 사항)"
   },
   "externalBackendSection.workingDirHelp": {
-    "defaultMessage": "외부 백엔드를 실행하는 컴퓨터의 경로입니다. 기본값을 사용하려면 비워 두세요."
+    "defaultMessage": "외부 백엔드의 절대 경로입니다. 비워 두면 로컬 작업 디렉터리를 전송합니다."
   },
   "externalBackendSection.workingDirPlaceholder": {
     "defaultMessage": "/home/goose/workspace"

--- a/ui/desktop/src/i18n/messages/ko.json
+++ b/ui/desktop/src/i18n/messages/ko.json
@@ -1226,6 +1226,15 @@
   "externalBackendSection.useExternalServerDescription": {
     "defaultMessage": "다른 곳에서 실행 중인 ACP 호환 백엔드에 연결합니다."
   },
+  "externalBackendSection.workingDir": {
+    "defaultMessage": "원격 작업 디렉터리(선택 사항)"
+  },
+  "externalBackendSection.workingDirHelp": {
+    "defaultMessage": "외부 백엔드를 실행하는 컴퓨터의 경로입니다. 기본값을 사용하려면 비워 두세요."
+  },
+  "externalBackendSection.workingDirPlaceholder": {
+    "defaultMessage": "/home/goose/workspace"
+  },
   "goosehintsModal.close": {
     "defaultMessage": "닫기"
   },

--- a/ui/desktop/src/i18n/messages/ms.json
+++ b/ui/desktop/src/i18n/messages/ms.json
@@ -1230,7 +1230,7 @@
     "defaultMessage": "Direktori kerja jauh (pilihan)"
   },
   "externalBackendSection.workingDirHelp": {
-    "defaultMessage": "Laluan pada mesin yang menjalankan backend luaran. Biarkan kosong untuk menggunakan nilai lalai."
+    "defaultMessage": "Laluan mutlak pada backend luaran. Biarkan kosong untuk menghantar direktori kerja setempat."
   },
   "externalBackendSection.workingDirPlaceholder": {
     "defaultMessage": "/home/goose/workspace"

--- a/ui/desktop/src/i18n/messages/ms.json
+++ b/ui/desktop/src/i18n/messages/ms.json
@@ -1226,6 +1226,15 @@
   "externalBackendSection.useExternalServerDescription": {
     "defaultMessage": "Sambung ke pelayan goose yang berjalan di tempat lain (memerlukan memulakan semula aplikasi)"
   },
+  "externalBackendSection.workingDir": {
+    "defaultMessage": "Direktori kerja jauh (pilihan)"
+  },
+  "externalBackendSection.workingDirHelp": {
+    "defaultMessage": "Laluan pada mesin yang menjalankan backend luaran. Biarkan kosong untuk menggunakan nilai lalai."
+  },
+  "externalBackendSection.workingDirPlaceholder": {
+    "defaultMessage": "/home/goose/workspace"
+  },
   "goosehintsModal.close": {
     "defaultMessage": "Tutup"
   },

--- a/ui/desktop/src/i18n/messages/pt.json
+++ b/ui/desktop/src/i18n/messages/pt.json
@@ -1226,6 +1226,15 @@
   "externalBackendSection.useExternalServerDescription": {
     "defaultMessage": "Conecte-se a um servidor goose em execução em outro lugar (requer reinicialização do app)"
   },
+  "externalBackendSection.workingDir": {
+    "defaultMessage": "Diretório de trabalho remoto (opcional)"
+  },
+  "externalBackendSection.workingDirHelp": {
+    "defaultMessage": "Caminho na máquina que executa o backend externo. Deixe em branco para usar o padrão."
+  },
+  "externalBackendSection.workingDirPlaceholder": {
+    "defaultMessage": "/home/goose/workspace"
+  },
   "goosehintsModal.close": {
     "defaultMessage": "Fechar"
   },

--- a/ui/desktop/src/i18n/messages/pt.json
+++ b/ui/desktop/src/i18n/messages/pt.json
@@ -1230,7 +1230,7 @@
     "defaultMessage": "Diretório de trabalho remoto (opcional)"
   },
   "externalBackendSection.workingDirHelp": {
-    "defaultMessage": "Caminho na máquina que executa o backend externo. Deixe em branco para usar o padrão."
+    "defaultMessage": "Caminho absoluto no backend externo. Deixe em branco para enviar o diretório de trabalho local."
   },
   "externalBackendSection.workingDirPlaceholder": {
     "defaultMessage": "/home/goose/workspace"

--- a/ui/desktop/src/i18n/messages/ru.json
+++ b/ui/desktop/src/i18n/messages/ru.json
@@ -1226,6 +1226,15 @@
   "externalBackendSection.useExternalServerDescription": {
     "defaultMessage": "Подключиться к серверу goose, запущенному в другом месте (требуется перезапуск приложения)"
   },
+  "externalBackendSection.workingDir": {
+    "defaultMessage": "Удалённый рабочий каталог (необязательно)"
+  },
+  "externalBackendSection.workingDirHelp": {
+    "defaultMessage": "Путь на компьютере, где запущен внешний бэкенд. Оставьте пустым, чтобы использовать значение по умолчанию."
+  },
+  "externalBackendSection.workingDirPlaceholder": {
+    "defaultMessage": "/home/goose/workspace"
+  },
   "goosehintsModal.close": {
     "defaultMessage": "Закрыть"
   },

--- a/ui/desktop/src/i18n/messages/ru.json
+++ b/ui/desktop/src/i18n/messages/ru.json
@@ -1230,7 +1230,7 @@
     "defaultMessage": "Удалённый рабочий каталог (необязательно)"
   },
   "externalBackendSection.workingDirHelp": {
-    "defaultMessage": "Путь на компьютере, где запущен внешний бэкенд. Оставьте пустым, чтобы использовать значение по умолчанию."
+    "defaultMessage": "Абсолютный путь на внешнем бэкенде. Оставьте пустым, чтобы передать локальный рабочий каталог."
   },
   "externalBackendSection.workingDirPlaceholder": {
     "defaultMessage": "/home/goose/workspace"

--- a/ui/desktop/src/i18n/messages/tr.json
+++ b/ui/desktop/src/i18n/messages/tr.json
@@ -1226,6 +1226,15 @@
   "externalBackendSection.useExternalServerDescription": {
     "defaultMessage": "Başka bir yerde çalışan bir goose sunucusuna bağlanın (uygulamanın yeniden başlatılmasını gerektirir)"
   },
+  "externalBackendSection.workingDir": {
+    "defaultMessage": "Uzak çalışma dizini (isteğe bağlı)"
+  },
+  "externalBackendSection.workingDirHelp": {
+    "defaultMessage": "Harici arka ucun çalıştığı makinedeki yol. Varsayılanı kullanmak için boş bırakın."
+  },
+  "externalBackendSection.workingDirPlaceholder": {
+    "defaultMessage": "/home/goose/workspace"
+  },
   "goosehintsModal.close": {
     "defaultMessage": "Kapat"
   },

--- a/ui/desktop/src/i18n/messages/tr.json
+++ b/ui/desktop/src/i18n/messages/tr.json
@@ -1230,7 +1230,7 @@
     "defaultMessage": "Uzak çalışma dizini (isteğe bağlı)"
   },
   "externalBackendSection.workingDirHelp": {
-    "defaultMessage": "Harici arka ucun çalıştığı makinedeki yol. Varsayılanı kullanmak için boş bırakın."
+    "defaultMessage": "Harici arka uçtaki mutlak yol. Yerel çalışma dizinini göndermek için boş bırakın."
   },
   "externalBackendSection.workingDirPlaceholder": {
     "defaultMessage": "/home/goose/workspace"

--- a/ui/desktop/src/i18n/messages/vi.json
+++ b/ui/desktop/src/i18n/messages/vi.json
@@ -1226,6 +1226,15 @@
   "externalBackendSection.useExternalServerDescription": {
     "defaultMessage": "Kết nối tới một máy chủ goose đang chạy ở nơi khác (cần khởi động lại ứng dụng)"
   },
+  "externalBackendSection.workingDir": {
+    "defaultMessage": "Thư mục làm việc từ xa (tùy chọn)"
+  },
+  "externalBackendSection.workingDirHelp": {
+    "defaultMessage": "Đường dẫn trên máy đang chạy phần phụ trợ bên ngoài. Để trống để dùng giá trị mặc định."
+  },
+  "externalBackendSection.workingDirPlaceholder": {
+    "defaultMessage": "/home/goose/workspace"
+  },
   "goosehintsModal.close": {
     "defaultMessage": "Đóng"
   },

--- a/ui/desktop/src/i18n/messages/vi.json
+++ b/ui/desktop/src/i18n/messages/vi.json
@@ -1230,7 +1230,7 @@
     "defaultMessage": "Thư mục làm việc từ xa (tùy chọn)"
   },
   "externalBackendSection.workingDirHelp": {
-    "defaultMessage": "Đường dẫn trên máy đang chạy phần phụ trợ bên ngoài. Để trống để dùng giá trị mặc định."
+    "defaultMessage": "Đường dẫn tuyệt đối trên backend bên ngoài. Để trống để gửi thư mục làm việc cục bộ."
   },
   "externalBackendSection.workingDirPlaceholder": {
     "defaultMessage": "/home/goose/workspace"

--- a/ui/desktop/src/i18n/messages/zh-CN.json
+++ b/ui/desktop/src/i18n/messages/zh-CN.json
@@ -1226,6 +1226,15 @@
   "externalBackendSection.useExternalServerDescription": {
     "defaultMessage": "连接到运行在其他位置的 goose 服务器（需要重启应用）"
   },
+  "externalBackendSection.workingDir": {
+    "defaultMessage": "远程工作目录（可选）"
+  },
+  "externalBackendSection.workingDirHelp": {
+    "defaultMessage": "运行外部后端的计算机上的路径。留空以使用默认值。"
+  },
+  "externalBackendSection.workingDirPlaceholder": {
+    "defaultMessage": "/home/goose/workspace"
+  },
   "goosehintsModal.close": {
     "defaultMessage": "关闭"
   },

--- a/ui/desktop/src/i18n/messages/zh-CN.json
+++ b/ui/desktop/src/i18n/messages/zh-CN.json
@@ -1230,7 +1230,7 @@
     "defaultMessage": "远程工作目录（可选）"
   },
   "externalBackendSection.workingDirHelp": {
-    "defaultMessage": "运行外部后端的计算机上的路径。留空以使用默认值。"
+    "defaultMessage": "外部后端上的绝对路径。留空时将发送本地工作目录。"
   },
   "externalBackendSection.workingDirPlaceholder": {
     "defaultMessage": "/home/goose/workspace"

--- a/ui/desktop/src/i18n/messages/zh-TW.json
+++ b/ui/desktop/src/i18n/messages/zh-TW.json
@@ -1230,7 +1230,7 @@
     "defaultMessage": "遠端工作目錄（選用）"
   },
   "externalBackendSection.workingDirHelp": {
-    "defaultMessage": "外部後端執行所在電腦上的路徑。留空以使用預設值。"
+    "defaultMessage": "外部後端上的絕對路徑。留空時將傳送本機工作目錄。"
   },
   "externalBackendSection.workingDirPlaceholder": {
     "defaultMessage": "/home/goose/workspace"

--- a/ui/desktop/src/i18n/messages/zh-TW.json
+++ b/ui/desktop/src/i18n/messages/zh-TW.json
@@ -1226,6 +1226,15 @@
   "externalBackendSection.useExternalServerDescription": {
     "defaultMessage": "連線至在其他位置執行的 goose 伺服器（需要重新啟動應用程式）"
   },
+  "externalBackendSection.workingDir": {
+    "defaultMessage": "遠端工作目錄（選用）"
+  },
+  "externalBackendSection.workingDirHelp": {
+    "defaultMessage": "外部後端執行所在電腦上的路徑。留空以使用預設值。"
+  },
+  "externalBackendSection.workingDirPlaceholder": {
+    "defaultMessage": "/home/goose/workspace"
+  },
   "goosehintsModal.close": {
     "defaultMessage": "關閉"
   },

--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -3002,7 +3002,17 @@ async function appMain() {
         throw new Error('No backend lease found for launching window');
       }
 
-      const workingDir = app.getPath('home');
+      const launchingWorkingDir = await launchingWindow.webContents
+        .executeJavaScript(`window.appConfig ? window.appConfig.get('GOOSE_WORKING_DIR') : null`)
+        .catch((error) => {
+          console.warn('Failed to get working directory from launching window:', error);
+          return undefined;
+        });
+      const workingDir = resolveWorkingDir(
+        typeof launchingWorkingDir === 'string' ? launchingWorkingDir : undefined,
+        undefined,
+        app.getPath('home')
+      );
       const appWindow = new BrowserWindow({
         title: formatAppName(gooseApp.name),
         width: gooseApp.width ?? 800,

--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -937,7 +937,10 @@ const getServerSecret = (settings: Settings): string => {
 const getActiveExternalBackend = (settings: Settings): ExternalBackend | null => {
   const envBackend = getExternalBackendFromEnv();
   if (envBackend) {
-    return envBackend;
+    return {
+      ...envBackend,
+      workingDir: settings.externalGoosed?.workingDir,
+    };
   }
 
   if (settings.externalGoosed?.enabled && settings.externalGoosed.url) {

--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -55,6 +55,7 @@ import type { GooseApp } from './types/apps';
 import installExtension, { REACT_DEVELOPER_TOOLS } from 'electron-devtools-installer';
 import { BLOCKED_PROTOCOLS, WEB_PROTOCOLS } from './utils/urlSecurity';
 import { buildCSP } from './utils/csp';
+import { resolveWorkingDir } from './utils/workingDir';
 
 function shouldSetupUpdater(): boolean {
   // Setup updater if either the flag is enabled OR dev updates are enabled
@@ -889,6 +890,7 @@ interface ExternalBackend {
   url: string;
   secret: string;
   certFingerprint?: string;
+  workingDir?: string;
 }
 
 const getExternalBackendUrlFromEnv = (): string | null => {
@@ -944,6 +946,7 @@ const getActiveExternalBackend = (settings: Settings): ExternalBackend | null =>
       url: settings.externalGoosed.url,
       secret: getServerSecret(settings),
       certFingerprint: settings.externalGoosed.certFingerprint,
+      workingDir: settings.externalGoosed.workingDir,
     };
   }
 
@@ -1067,7 +1070,7 @@ const createChat = async (
   }
 
   const serverSecret = externalBackend ? externalBackend.secret : GENERATED_SECRET;
-  let workingDir = dir || os.homedir();
+  let workingDir = resolveWorkingDir(externalBackend?.workingDir, dir, os.homedir());
   let gooseServeLease: GooseServeLease | null = null;
 
   if (externalBackend) {

--- a/ui/desktop/src/utils/__tests__/workingDir.test.ts
+++ b/ui/desktop/src/utils/__tests__/workingDir.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { resolveWorkingDir } from '../workingDir';
+
+describe('resolveWorkingDir', () => {
+  it('uses the configured external backend directory when present', () => {
+    expect(resolveWorkingDir(' /home/goose ', 'C:\\Users\\goose', 'C:\\Users\\goose')).toBe(
+      '/home/goose'
+    );
+    expect(resolveWorkingDir(' ', 'C:\\work', 'C:\\Users\\goose')).toBe('C:\\work');
+    expect(resolveWorkingDir(undefined, undefined, 'C:\\Users\\goose')).toBe('C:\\Users\\goose');
+  });
+});

--- a/ui/desktop/src/utils/settings.ts
+++ b/ui/desktop/src/utils/settings.ts
@@ -3,6 +3,7 @@ export interface ExternalBackendConfig {
   url: string;
   secret: string;
   certFingerprint?: string;
+  workingDir?: string;
 }
 
 export interface KeyboardShortcuts {

--- a/ui/desktop/src/utils/workingDir.ts
+++ b/ui/desktop/src/utils/workingDir.ts
@@ -2,3 +2,9 @@ export const getInitialWorkingDir = (): string => {
   // Fall back to initial config from app startup
   return (window.appConfig?.get('GOOSE_WORKING_DIR') as string) ?? '';
 };
+
+export const resolveWorkingDir = (
+  externalWorkingDir: string | undefined,
+  requestedWorkingDir: string | undefined,
+  homeDir: string
+): string => externalWorkingDir?.trim() || requestedWorkingDir || homeDir;


### PR DESCRIPTION
## Summary
- Add a remote working directory field to external backend settings.
- Use the configured directory for chat and standalone app sessions, avoiding client-side paths on a remote host.
- Keep the settings labels and locale catalogs in sync.

Fixes #10822

## Validation
- Focused working-directory Vitest regression test
- ESLint on the changed component
- Prettier check on the changed component and locale catalogs
- i18n extraction and locale validation
- git diff --check