### PR TITLE
Scrub foreign provider-bound state when replaying conversations

### DIFF
--- a/crates/goose-provider-types/src/conversation.rs
+++ b/crates/goose-provider-types/src/conversation.rs
@@ -257,6 +257,121 @@ pub fn fix_conversation(conversation: Conversation) -> (Conversation, Vec<String
     (Conversation::new_unvalidated(final_messages), issues)
 }
 
+/// Strip provider-bound opaque state minted by a different provider or model
+/// than the one about to serve the request: thinking signatures, redacted
+/// thinking blobs, and Gemini thought signatures only validate against the
+/// model that produced them, so replaying them after a provider or model
+/// switch gets the request rejected. Readable thinking text is kept; only the
+/// opaque attachments are removed. Messages without inference provenance are
+/// left untouched. A tool response is scrubbed only when it pairs with a
+/// foreign request, where pairing follows the transcript order: a response
+/// belongs to the most recent preceding request with its id, so a later
+/// same-provider turn that reuses an id keeps its signatures.
+pub fn scrub_foreign_provider_state(
+    conversation: Conversation,
+    provider: &str,
+    model: &str,
+    resolved_model: Option<&str>,
+) -> (Conversation, Vec<String>) {
+    let mut issues = Vec::new();
+    let mut foreign_request_ids: HashSet<String> = HashSet::new();
+    let mut messages: Vec<Message> = conversation.into_iter().collect();
+
+    for message in &mut messages {
+        for content in &mut message.content {
+            if let MessageContentBlock::ToolResponse(response) = content {
+                if foreign_request_ids.remove(&response.id)
+                    && remove_thought_signature(&mut response.metadata)
+                {
+                    issues.push("Removed foreign thought signature".to_string());
+                }
+            }
+        }
+
+        let foreign = message
+            .metadata
+            .inference
+            .as_ref()
+            .is_some_and(|inference| {
+                inference.provider != provider
+                    || inference.requested_model != model
+                    || matches!(
+                        (inference.resolved_model.as_deref(), resolved_model),
+                        (Some(recorded), Some(current)) if recorded != current
+                    )
+            });
+        if !foreign {
+            for content in &message.content {
+                if let MessageContentBlock::ToolRequest(request) = content {
+                    foreign_request_ids.remove(&request.id);
+                }
+            }
+            continue;
+        }
+        message.content.retain_mut(|content| match content {
+            MessageContentBlock::Thinking(thinking) => {
+                if !thinking.signature.is_empty() {
+                    thinking.signature.clear();
+                    issues.push("Cleared foreign thinking signature".to_string());
+                }
+                true
+            }
+            MessageContentBlock::RedactedThinking(_) => {
+                issues.push("Removed foreign redacted thinking".to_string());
+                false
+            }
+            MessageContentBlock::ToolRequest(request) => {
+                foreign_request_ids.insert(request.id.clone());
+                if remove_thought_signature(&mut request.metadata) {
+                    issues.push("Removed foreign thought signature".to_string());
+                }
+                true
+            }
+            _ => true,
+        });
+    }
+
+    (Conversation::new_unvalidated(messages), issues)
+}
+
+/// Gemini thought signatures live either at the metadata top level (native
+/// Google format) or nested under `extra_content.google.thought_signature`
+/// (OpenAI-compatible endpoints); both are replayed, so both are removed.
+fn remove_thought_signature(
+    metadata: &mut Option<crate::conversation::message::ProviderMetadata>,
+) -> bool {
+    let Some(map) = metadata else { return false };
+    let mut removed = map
+        .remove(crate::formats::google::THOUGHT_SIGNATURE_KEY)
+        .is_some();
+    if let Some(google) = map
+        .get_mut("extra_content")
+        .and_then(|extra| extra.get_mut("google"))
+        .and_then(|google| google.as_object_mut())
+    {
+        removed |= google.remove("thought_signature").is_some();
+    }
+    if let Some(extra) = map
+        .get_mut("extra_content")
+        .and_then(|extra| extra.as_object_mut())
+    {
+        if extra
+            .get("google")
+            .and_then(|google| google.as_object())
+            .is_some_and(|google| google.is_empty())
+        {
+            extra.remove("google");
+        }
+        if extra.is_empty() {
+            map.remove("extra_content");
+        }
+    }
+    if map.is_empty() {
+        *metadata = None;
+    }
+    removed
+}
+
 fn fix_messages(messages: Vec<Message>) -> (Vec<Message>, Vec<String>) {
     [
         merge_text_content_items,
@@ -1878,6 +1993,208 @@ mod tests {
                 assert_eq!(c.text, "and now text");
             }
             other => panic!("unexpected content shape: {:?}", other),
+        }
+    }
+
+    mod scrub_foreign_provider_state {
+        use super::*;
+        use crate::conversation::message::InferenceMetadata;
+        use crate::conversation::scrub_foreign_provider_state;
+        use crate::formats::google::metadata_with_signature;
+        use rmcp::model::{CallToolResult, ContentBlock};
+
+        fn provenance(provider: &str, model: &str) -> InferenceMetadata {
+            InferenceMetadata {
+                provider: provider.to_string(),
+                requested_model: model.to_string(),
+                resolved_model: None,
+            }
+        }
+
+        fn conversation_with_provenance(inference: Option<InferenceMetadata>) -> Conversation {
+            let mut metadata = metadata_with_signature("gemini-sig");
+            metadata.insert(
+                "extra_content".to_string(),
+                serde_json::json!({"google": {"thought_signature": "nested-sig"}}),
+            );
+            let mut assistant = Message::assistant()
+                .with_thinking("planning the search", "anthropic-sig")
+                .with_content(MessageContentBlock::redacted_thinking("opaque-blob"))
+                .with_content(MessageContentBlock::tool_request_with_metadata(
+                    "call_1",
+                    Ok(CallToolRequestParams::new("search").with_arguments(object!({}))),
+                    Some(&metadata),
+                ));
+            if let Some(inference) = inference {
+                assistant = assistant.with_inference(inference);
+            }
+            Conversation::new_unvalidated(vec![
+                Message::user().with_text("find it"),
+                assistant,
+                Message::user().with_content(MessageContentBlock::tool_response_with_metadata(
+                    "call_1",
+                    Ok(CallToolResult::success(vec![ContentBlock::text("found")])),
+                    Some(&metadata),
+                )),
+            ])
+        }
+
+        fn opaque_state(conversation: &Conversation) -> (Vec<String>, usize, usize) {
+            let mut signatures = Vec::new();
+            let mut redacted = 0;
+            let mut thought_signatures = 0;
+            for message in conversation.messages() {
+                for content in &message.content {
+                    match content {
+                        MessageContentBlock::Thinking(t) if !t.signature.is_empty() => {
+                            signatures.push(t.signature.clone())
+                        }
+                        MessageContentBlock::RedactedThinking(_) => redacted += 1,
+                        MessageContentBlock::ToolRequest(r) if r.metadata.is_some() => {
+                            thought_signatures += 1
+                        }
+                        MessageContentBlock::ToolResponse(r) if r.metadata.is_some() => {
+                            thought_signatures += 1
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            (signatures, redacted, thought_signatures)
+        }
+
+        #[test]
+        fn foreign_provider_state_is_removed() {
+            let conversation =
+                conversation_with_provenance(Some(provenance("anthropic", "claude-opus-4-8")));
+
+            let (scrubbed, issues) =
+                scrub_foreign_provider_state(conversation, "openai", "gpt-5.2", None);
+
+            let (signatures, redacted, thought_signatures) = opaque_state(&scrubbed);
+            assert!(signatures.is_empty());
+            assert_eq!(redacted, 0);
+            assert_eq!(thought_signatures, 0);
+            assert_eq!(issues.len(), 4);
+            let thinking_text: Vec<_> = scrubbed
+                .messages()
+                .iter()
+                .flat_map(|m| m.content.iter())
+                .filter_map(|c| c.as_thinking())
+                .collect();
+            assert_eq!(thinking_text.len(), 1, "readable thinking text is kept");
+            assert_eq!(thinking_text[0].thinking, "planning the search");
+        }
+
+        #[test]
+        fn model_switch_within_provider_is_foreign() {
+            let conversation =
+                conversation_with_provenance(Some(provenance("anthropic", "claude-opus-4-8")));
+
+            let (scrubbed, issues) =
+                scrub_foreign_provider_state(conversation, "anthropic", "claude-sonnet-5", None);
+
+            let (signatures, redacted, _) = opaque_state(&scrubbed);
+            assert!(signatures.is_empty());
+            assert_eq!(redacted, 0);
+            assert!(!issues.is_empty());
+        }
+
+        #[test]
+        fn resolved_model_drift_is_foreign() {
+            let mut inference = provenance("anthropic", "claude-opus-4-8");
+            inference.resolved_model = Some("claude-opus-4-8-v1".to_string());
+            let conversation = conversation_with_provenance(Some(inference));
+
+            let (scrubbed, issues) = scrub_foreign_provider_state(
+                conversation,
+                "anthropic",
+                "claude-opus-4-8",
+                Some("claude-opus-4-8-v2"),
+            );
+
+            let (signatures, redacted, _) = opaque_state(&scrubbed);
+            assert!(signatures.is_empty());
+            assert_eq!(redacted, 0);
+            assert!(!issues.is_empty());
+        }
+
+        #[test]
+        fn matching_provenance_is_untouched() {
+            let conversation =
+                conversation_with_provenance(Some(provenance("anthropic", "claude-opus-4-8")));
+
+            let (scrubbed, issues) = scrub_foreign_provider_state(
+                conversation.clone(),
+                "anthropic",
+                "claude-opus-4-8",
+                None,
+            );
+
+            assert!(issues.is_empty());
+            assert_eq!(scrubbed.messages(), conversation.messages());
+        }
+
+        #[test]
+        fn reused_tool_id_keeps_native_response_signature() {
+            let mut metadata = metadata_with_signature("gemini-sig");
+            metadata.insert(
+                "extra_content".to_string(),
+                serde_json::json!({"google": {"thought_signature": "nested-sig"}}),
+            );
+            let tool_request = |inference: InferenceMetadata| {
+                Message::assistant()
+                    .with_content(MessageContentBlock::tool_request_with_metadata(
+                        "call_1",
+                        Ok(CallToolRequestParams::new("search").with_arguments(object!({}))),
+                        Some(&metadata),
+                    ))
+                    .with_inference(inference)
+            };
+            let tool_response = || {
+                Message::user().with_content(MessageContentBlock::tool_response_with_metadata(
+                    "call_1",
+                    Ok(CallToolResult::success(vec![ContentBlock::text("found")])),
+                    Some(&metadata),
+                ))
+            };
+            let conversation = Conversation::new_unvalidated(vec![
+                tool_request(provenance("openai", "gpt-5.2")),
+                tool_response(),
+                tool_request(provenance("google", "gemini-3-pro")),
+                tool_response(),
+            ]);
+
+            let (scrubbed, issues) =
+                scrub_foreign_provider_state(conversation, "google", "gemini-3-pro", None);
+
+            assert_eq!(issues.len(), 2, "only the foreign pair is scrubbed");
+            let with_metadata: Vec<bool> = scrubbed
+                .messages()
+                .iter()
+                .flat_map(|m| m.content.iter())
+                .map(|c| match c {
+                    MessageContentBlock::ToolRequest(r) => r.metadata.is_some(),
+                    MessageContentBlock::ToolResponse(r) => r.metadata.is_some(),
+                    _ => unreachable!(),
+                })
+                .collect();
+            assert_eq!(
+                with_metadata,
+                vec![false, false, true, true],
+                "the native pair that reuses the id keeps its signatures"
+            );
+        }
+
+        #[test]
+        fn missing_provenance_is_untouched() {
+            let conversation = conversation_with_provenance(None);
+
+            let (scrubbed, issues) =
+                scrub_foreign_provider_state(conversation.clone(), "openai", "gpt-5.2", None);
+
+            assert!(issues.is_empty());
+            assert_eq!(scrubbed.messages(), conversation.messages());
         }
     }
 }

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -37,7 +37,9 @@ use crate::conversation::message::{
     ActionRequiredData, InferenceMetadata, Message, MessageContent, MessageUsage, ProviderMetadata,
     SystemNotificationType, ToolRequest,
 };
-use crate::conversation::{debug_conversation_fix, fix_conversation, Conversation};
+use crate::conversation::{
+    debug_conversation_fix, fix_conversation, scrub_foreign_provider_state, Conversation,
+};
 use crate::mcp_utils::ToolResult;
 use crate::permission::permission_inspector::PermissionInspector;
 use crate::permission::permission_judge::PermissionCheckResult;
@@ -792,6 +794,31 @@ impl Agent {
         unfixed_conversation: Conversation,
         working_dir: &std::path::Path,
     ) -> Result<ReplyContext> {
+        let (tools, toolshim_tools, system_prompt, model_config) = self
+            .prepare_tools_and_prompt(session_id, working_dir)
+            .await?;
+
+        let unfixed_conversation = match self.provider().await {
+            Ok(provider) => {
+                let resolved_model = provider
+                    .fetch_model_info(&model_config.model_name)
+                    .await
+                    .ok()
+                    .and_then(|model_info| model_info.resolved_model);
+                let (scrubbed, issues) = scrub_foreign_provider_state(
+                    unfixed_conversation,
+                    provider.get_name(),
+                    &model_config.model_name,
+                    resolved_model.as_deref(),
+                );
+                if !issues.is_empty() {
+                    debug!("Scrubbed foreign provider state: {}", issues.join(", "));
+                }
+                scrubbed
+            }
+            Err(_) => unfixed_conversation,
+        };
+
         let unfixed_messages = unfixed_conversation.messages().clone();
         let (conversation, issues) = fix_conversation(unfixed_conversation.clone());
         if !issues.is_empty() {
@@ -805,10 +832,6 @@ impl Agent {
             );
         }
         let initial_messages = conversation.messages().clone();
-
-        let (tools, toolshim_tools, system_prompt, model_config) = self
-            .prepare_tools_and_prompt(session_id, working_dir)
-            .await?;
 
         let goose_mode = *self.current_goose_mode.lock().await;
 
@@ -1973,16 +1996,15 @@ impl Agent {
         let provider = self.provider().await?;
         let provider_name = provider.get_name().to_string();
         let requested_model = model_config.model_name.clone();
-        let inference = provider
-            .fetch_model_info(&requested_model)
-            .await
-            .ok()
-            .and_then(|model_info| model_info.resolved_model)
-            .map(|resolved_model| InferenceMetadata {
-                provider: provider_name,
-                requested_model,
-                resolved_model: Some(resolved_model),
-            });
+        let inference = InferenceMetadata {
+            provider: provider_name,
+            resolved_model: provider
+                .fetch_model_info(&requested_model)
+                .await
+                .ok()
+                .and_then(|model_info| model_info.resolved_model),
+            requested_model,
+        };
         let session_manager = self.config.session_manager.clone();
         let session_id = session_config.id.clone();
         if !self.config.disable_session_naming {
@@ -2257,16 +2279,9 @@ impl Agent {
                                     )
                                     .await;
 
-                                let filtered_response = if let Some(inference) = inference.as_ref() {
-                                    filtered_response.with_inference(inference.clone())
-                                } else {
-                                    filtered_response
-                                };
-                                let response = if let Some(inference) = inference.as_ref() {
-                                    response.with_inference(inference.clone())
-                                } else {
-                                    response
-                                };
+                                let filtered_response =
+                                    filtered_response.with_inference(inference.clone());
+                                let response = response.with_inference(inference.clone());
 
                                 surfaced_thinking_in_turn |= filtered_response.content.iter().any(
                                     |content| {
@@ -3014,15 +3029,11 @@ impl Agent {
                     yield AgentEvent::Message(message);
                 }
 
-                let mut messages_to_add = if let Some(ref inference) = inference {
-                    Conversation::new_unvalidated(
-                        messages_to_add
-                            .into_iter()
-                            .map(|message| message.with_inference_if_assistant(inference.clone())),
-                    )
-                } else {
+                let mut messages_to_add = Conversation::new_unvalidated(
                     messages_to_add
-                };
+                        .into_iter()
+                        .map(|message| message.with_inference_if_assistant(inference.clone())),
+                );
 
                 if let Some(usage) = pending_turn_usage.take() {
                     if let Some((message_id, usage)) = attach_turn_usage(


### PR DESCRIPTION
First of a three-PR session-portability stack: this PR, then #10833 (self-contained export bundles), then #10834 (cascading deletion + artifact GC).

## What

Resuming a session on a different provider or model currently replays provider-bound opaque state verbatim, and the request gets rejected:

- Anthropic/Bedrock thinking `signature`s are minted per model and fail signature validation anywhere else (`formats/anthropic.rs` sends them unconditionally whenever thinking is enabled).
- `redacted_thinking` blobs are opaque to everyone but the account+model that produced them.
- Gemini `thoughtSignature`s stored in tool request/response metadata trip Google's validator when replayed from another model. They appear both at the metadata top level (native Google format) and nested under `extra_content.google.thought_signature` (OpenAI-compatible endpoints); both are handled.

This PR adds `scrub_foreign_provider_state`, which runs before `fix_conversation` when building the reply context. For every message whose stored inference provenance does not match the active provider and model (`provider`, `requestedModel`, or a drifted `resolvedModel` when both sides report one), it:

- keeps the readable thinking text but clears the model-bound signature,
- drops `redactedThinking` blocks,
- removes thought signatures from tool request metadata and from the paired tool responses. Pairing follows transcript order (a response belongs to the most recent preceding request with its id), so a later same-provider turn that reuses a tool call id keeps its signatures.

Messages with matching provenance are untouched, so same-provider/same-model sessions behave exactly as before. Messages without provenance (older sessions) are also left untouched to avoid regressing existing same-provider resumes.

To make provenance reliable going forward, `InferenceMetadata` is now recorded on assistant messages even when the provider cannot resolve the model (previously it was only attached when `fetch_model_info` returned a `resolved_model`).

## Why

This is the main blocker for cross-provider session portability: export a session, switch provider, continue. The readable content survives; only the opaque, provider-sealed attachments are scrubbed, and only when they can no longer validate.

## Verification

- Unit tests cover the scrub matrix: foreign provider, model switch within a provider, resolved-model drift under a stable alias, matching provenance (byte-identical passthrough), and missing provenance (passthrough). The signature-removal test covers both the top-level and nested Gemini forms, and a reused-tool-id test pins that only the foreign pair is scrubbed.
- `cargo test -p goose-provider-types`, `cargo test -p goose --lib` (failures on `main` from local machine config are unchanged), `cargo fmt`, `cargo clippy --all-targets -- -D warnings` on the touched crates.
