### PR TITLE
Bundle subagent sessions and spilled tool outputs into session exports

### DIFF
--- a/crates/goose-cli/src/commands/session.rs
+++ b/crates/goose-cli/src/commands/session.rs
@@ -242,18 +242,6 @@ pub async fn handle_session_export(
         }
     };
 
-    let output = match format.as_str() {
-        "json" => serde_json::to_string_pretty(&session)?,
-        "yaml" => serde_yaml::to_string(&session)?,
-        "markdown" => {
-            let conversation = session
-                .conversation
-                .ok_or_else(|| anyhow::anyhow!("Session has no messages"))?;
-            export_session_to_markdown(conversation.user_visible_messages(), &session.name)
-        }
-        _ => return Err(anyhow::anyhow!("Unsupported format: {}", format)),
-    };
-
     #[cfg(feature = "nostr")]
     if nostr {
         if format != "json" {
@@ -268,7 +256,10 @@ pub async fn handle_session_export(
         }
 
         let relays = nostr_share::resolve_relays(relays, Config::global());
-        let share = nostr_share::publish_session_json(&output, relays).await?;
+        let data = session_manager
+            .export_session_without_artifacts(&session_id)
+            .await?;
+        let share = nostr_share::publish_session_json(&data, relays).await?;
         println!("Session published to Nostr relays:");
         for relay in &share.relays {
             println!("- {}", relay);
@@ -281,6 +272,21 @@ pub async fn handle_session_export(
     if nostr {
         return Err(anyhow::anyhow!("goose was not built with nostr support"));
     }
+
+    let output = match format.as_str() {
+        "json" => session_manager.export_session(&session_id).await?,
+        "yaml" => {
+            let bundle = session_manager.export_session(&session_id).await?;
+            serde_yaml::to_string(&serde_json::from_str::<serde_json::Value>(&bundle)?)?
+        }
+        "markdown" => {
+            let conversation = session
+                .conversation
+                .ok_or_else(|| anyhow::anyhow!("Session has no messages"))?;
+            export_session_to_markdown(conversation.user_visible_messages(), &session.name)
+        }
+        _ => return Err(anyhow::anyhow!("Unsupported format: {}", format)),
+    };
 
     if let Some(output_path) = output_path {
         fs::write(&output_path, output).with_context(|| {

--- a/crates/goose/src/acp/server/manage_sessions.rs
+++ b/crates/goose/src/acp/server/manage_sessions.rs
@@ -163,7 +163,7 @@ impl GooseAcpAgent {
     ) -> Result<ShareSessionNostrResponse, agent_client_protocol::Error> {
         let data = self
             .session_manager
-            .export_session(&req.session_id)
+            .export_session_without_artifacts(&req.session_id)
             .await
             .internal_err()?;
 

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -640,6 +640,7 @@ impl Agent {
     ) -> ToolCallResult {
         let hook_manager = self.hook_manager.clone();
         let session_id = session.id.clone();
+        let spill_dir = self.config.session_manager.session_spill_dir(&session.id);
         let working_dir = session.working_dir.to_string_lossy().to_string();
         let tool_name = tool_call.name.to_string();
         let tool_input = tool_call
@@ -651,8 +652,10 @@ impl Agent {
         let capture_message_content = gen_ai_telemetry::capture_message_content();
 
         let fut = async move {
-            let processed_result =
-                super::large_response_handler::process_tool_response(result.result.await);
+            let processed_result = super::large_response_handler::process_tool_response(
+                result.result.await,
+                &spill_dir,
+            );
             if capture_message_content {
                 let output = gen_ai_telemetry::tool_result_json(&processed_result);
                 span.record("output", output.as_str());

--- a/crates/goose/src/agents/large_response_handler.rs
+++ b/crates/goose/src/agents/large_response_handler.rs
@@ -4,15 +4,31 @@ use std::io::Write;
 
 const DEFAULT_LARGE_TEXT_THRESHOLD: usize = 200_000;
 
+pub(crate) const SPILL_MESSAGE_PREFIX: &str = "The response returned from the tool call was larger";
+pub(crate) const SPILL_FILE_PREFIX: &str = "goose_mcp_response_";
+
+/// Extract the file path from a spilled-large-response pointer message.
+pub(crate) fn spilled_file_path(text: &str) -> Option<&str> {
+    if !text.starts_with(SPILL_MESSAGE_PREFIX) {
+        return None;
+    }
+    text.rsplit_once(": ").map(|(_, path)| path.trim())
+}
+
 fn large_text_threshold() -> usize {
     Config::global()
         .get_param::<usize>("GOOSE_MAX_TOOL_RESPONSE_SIZE")
         .unwrap_or(DEFAULT_LARGE_TEXT_THRESHOLD)
 }
 
-/// Process tool response and handle large text content
+/// Process tool response and handle large text content. Large outputs are
+/// spilled into `spill_dir`, the owning session's spill directory, so a spill
+/// pointer proves which session produced the file: export uses this to reject
+/// forged pointers at other sessions' spills, and deleting the session removes
+/// the whole directory.
 pub fn process_tool_response(
     response: Result<CallToolResult, ErrorData>,
+    spill_dir: &std::path::Path,
 ) -> Result<CallToolResult, ErrorData> {
     let threshold = large_text_threshold();
     match response {
@@ -25,11 +41,11 @@ pub fn process_tool_response(
                         // Check if text exceeds threshold
                         if text_content.text.chars().count() > threshold {
                             // Write to temp file
-                            match write_large_text_to_file(&text_content.text) {
+                            match write_large_text_to_file(&text_content.text, spill_dir) {
                                 Ok(file_path) => {
                                     // Create a new text content with reference to the file
                                     let message = format!(
-                                        "The response returned from the tool call was larger ({} characters) and is stored in the file which you can use other tools to examine or search in: {}",
+                                        "{SPILL_MESSAGE_PREFIX} ({} characters) and is stored in the file which you can use other tools to examine or search in: {}",
                                         text_content.text.chars().count(),
                                         file_path
                                     );
@@ -64,12 +80,25 @@ pub fn process_tool_response(
     }
 }
 
-/// Write large text content to a temporary file
-fn write_large_text_to_file(content: &str) -> Result<String, std::io::Error> {
+/// Write large text content to a file in the session's spill directory
+fn write_large_text_to_file(
+    content: &str,
+    dir: &std::path::Path,
+) -> Result<String, std::io::Error> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::DirBuilderExt;
+        std::fs::DirBuilder::new()
+            .recursive(true)
+            .mode(0o700)
+            .create(dir)?;
+    }
+    #[cfg(not(unix))]
+    std::fs::create_dir_all(dir)?;
     let mut file = tempfile::Builder::new()
-        .prefix("goose_mcp_response_")
+        .prefix(SPILL_FILE_PREFIX)
         .suffix(".txt")
-        .tempfile()?;
+        .tempfile_in(dir)?;
     file.write_all(content.as_bytes())?;
     let (_, file_path) = file.keep()?;
 
@@ -84,6 +113,10 @@ mod tests {
     use std::fs;
     use std::path::Path;
 
+    fn spill_dir() -> tempfile::TempDir {
+        tempfile::tempdir().unwrap()
+    }
+
     #[test]
     fn test_small_text_response_passes_through() {
         // Create a small text response
@@ -93,7 +126,7 @@ mod tests {
         let response = Ok(CallToolResult::success(vec![content]));
 
         // Process the response
-        let processed = process_tool_response(response).unwrap();
+        let processed = process_tool_response(response, spill_dir().path()).unwrap();
 
         // Verify the response is unchanged
         assert_eq!(processed.content.len(), 1);
@@ -113,7 +146,8 @@ mod tests {
         let response = Ok(CallToolResult::success(vec![content]));
 
         // Process the response
-        let processed = process_tool_response(response).unwrap();
+        let dir = spill_dir();
+        let processed = process_tool_response(response, dir.path()).unwrap();
 
         // Verify the response contains a message about the file
         assert_eq!(processed.content.len(), 1);
@@ -146,7 +180,7 @@ mod tests {
         let response = Ok(CallToolResult::success(vec![image_content]));
 
         // Process the response
-        let processed = process_tool_response(response).unwrap();
+        let processed = process_tool_response(response, spill_dir().path()).unwrap();
 
         // Verify the response is unchanged
         assert_eq!(processed.content.len(), 1);
@@ -168,7 +202,8 @@ mod tests {
         let response = Ok(CallToolResult::success(vec![small_text, large_text, image]));
 
         // Process the response
-        let processed = process_tool_response(response).unwrap();
+        let dir = spill_dir();
+        let processed = process_tool_response(response, dir.path()).unwrap();
 
         // Verify each item is handled correctly
         assert_eq!(processed.content.len(), 3);
@@ -217,7 +252,7 @@ mod tests {
         let response: Result<CallToolResult, ErrorData> = Err(error);
 
         // Process the response
-        let processed = process_tool_response(response);
+        let processed = process_tool_response(response, spill_dir().path());
 
         // Verify the error is passed through unchanged
         assert!(processed.is_err());
@@ -232,8 +267,9 @@ mod tests {
 
     #[test]
     fn test_large_response_files_have_unique_paths() {
-        let first_path = write_large_text_to_file("first response").unwrap();
-        let second_path = write_large_text_to_file("second response").unwrap();
+        let dir = spill_dir();
+        let first_path = write_large_text_to_file("first response", dir.path()).unwrap();
+        let second_path = write_large_text_to_file("second response", dir.path()).unwrap();
         let paths_are_distinct = first_path != second_path;
         let first_content = fs::read_to_string(&first_path).unwrap();
         let second_content = fs::read_to_string(&second_path).unwrap();
@@ -253,7 +289,8 @@ mod tests {
     fn test_large_response_file_is_owner_only() {
         use std::os::unix::fs::PermissionsExt;
 
-        let file_path = write_large_text_to_file("sensitive response").unwrap();
+        let dir = spill_dir();
+        let file_path = write_large_text_to_file("sensitive response", dir.path()).unwrap();
         let metadata = fs::metadata(&file_path).unwrap();
         let mode = metadata.permissions().mode();
         let content = fs::read_to_string(&file_path).unwrap();

--- a/crates/goose/src/agents/mod.rs
+++ b/crates/goose/src/agents/mod.rs
@@ -6,7 +6,7 @@ pub mod extension_malware_check;
 pub mod extension_manager;
 pub mod final_output_tool;
 mod gen_ai_telemetry;
-mod large_response_handler;
+pub(crate) mod large_response_handler;
 pub mod mcp_client;
 pub mod moim;
 pub mod platform_extensions;

--- a/crates/goose/src/session/diagnostics.rs
+++ b/crates/goose/src/session/diagnostics.rs
@@ -306,7 +306,9 @@ pub async fn generate_diagnostics(
     let mut errors = Vec::new();
 
     let session = if is_full {
-        let session_data = session_manager.export_session(session_id).await?;
+        let session_data = session_manager
+            .export_session_without_artifacts(session_id)
+            .await?;
         Some(serde_json::from_str(&session_data)?)
     } else {
         None

--- a/crates/goose/src/session/export_bundle.rs
+++ b/crates/goose/src/session/export_bundle.rs
@@ -1,0 +1,261 @@
+//! The self-contained session export envelope: the session itself, the
+//! subagent sessions it spawned, and any large tool outputs that were
+//! spilled to local files. Plain `Session` JSON deserializes into it, so
+//! older exports remain importable.
+
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::path::Path;
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::agents::large_response_handler::{spilled_file_path, SPILL_FILE_PREFIX};
+use crate::conversation::message::MessageContentBlock;
+use crate::conversation::Conversation;
+use crate::session::Session;
+use rmcp::model::ContentBlock;
+
+const SUBAGENT_SESSION_META_KEY: &str = "subagent_session_id";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionExport {
+    #[serde(flatten)]
+    pub session: Session,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub child_sessions: Vec<Session>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub artifacts: Vec<SessionArtifact>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionArtifact {
+    pub path: String,
+    pub sha256: String,
+    pub content: String,
+}
+
+pub fn collect_artifacts<'a>(
+    sessions: impl Iterator<Item = &'a Session>,
+    artifacts_dir: &Path,
+    spills_dir: &Path,
+) -> Vec<SessionArtifact> {
+    let sessions: Vec<&Session> = sessions.collect();
+    let session_ids: HashSet<&str> = sessions.iter().map(|session| session.id.as_str()).collect();
+    let mut artifacts: BTreeMap<String, SessionArtifact> = BTreeMap::new();
+    for session in sessions {
+        let Some(conversation) = &session.conversation else {
+            continue;
+        };
+        for path in spilled_paths(conversation) {
+            if artifacts.contains_key(&path) {
+                continue;
+            }
+            if !is_exportable_spill_file(Path::new(&path), artifacts_dir, spills_dir, &session_ids)
+            {
+                tracing::warn!("Skipping non-goose spill pointer in export: {path}");
+                continue;
+            }
+            match std::fs::read_to_string(&path) {
+                Ok(content) => {
+                    let sha256 = sha256_hex(&content);
+                    artifacts.insert(
+                        path.clone(),
+                        SessionArtifact {
+                            path,
+                            sha256,
+                            content,
+                        },
+                    );
+                }
+                Err(e) => {
+                    tracing::warn!("Skipping unreadable spilled tool output {path}: {e}");
+                }
+            }
+        }
+    }
+    artifacts.into_values().collect()
+}
+
+/// Map each artifact's original path to its content-addressed local copy
+/// under `dir`. The hash is recomputed from the content rather than trusted
+/// from the import, so a crafted `sha256` field cannot escape `dir`.
+pub fn artifact_destinations(
+    artifacts: &[SessionArtifact],
+    dir: &Path,
+) -> BTreeMap<String, String> {
+    artifacts
+        .iter()
+        .map(|artifact| {
+            let file = dir.join(format!("{}.txt", sha256_hex(&artifact.content)));
+            (artifact.path.clone(), file.to_string_lossy().into_owned())
+        })
+        .collect()
+}
+
+/// Write bundled artifacts to their [`artifact_destinations`] under `dir`.
+pub fn write_artifacts(artifacts: &[SessionArtifact], dir: &Path) -> Result<()> {
+    if artifacts.is_empty() {
+        return Ok(());
+    }
+    std::fs::create_dir_all(dir)?;
+    for artifact in artifacts {
+        let file = dir.join(format!("{}.txt", sha256_hex(&artifact.content)));
+        let up_to_date =
+            std::fs::read_to_string(&file).is_ok_and(|existing| existing == artifact.content);
+        if !up_to_date {
+            let mut temp = tempfile::NamedTempFile::new_in(dir)?;
+            std::io::Write::write_all(&mut temp, artifact.content.as_bytes())?;
+            temp.persist(&file)?;
+        }
+    }
+    Ok(())
+}
+
+/// Point `_meta.subagent_session_id` references at the freshly created child
+/// sessions after an import assigns new ids.
+pub fn rewrite_subagent_session_ids(
+    conversation: Conversation,
+    id_map: &HashMap<String, String>,
+) -> Conversation {
+    if id_map.is_empty() {
+        return conversation;
+    }
+    let messages = conversation.into_iter().map(|mut message| {
+        for content in &mut message.content {
+            let MessageContentBlock::ToolResponse(response) = content else {
+                continue;
+            };
+            let Ok(result) = &mut response.tool_result else {
+                continue;
+            };
+            let Some(meta) = result.meta.as_mut() else {
+                continue;
+            };
+            let Some(serde_json::Value::String(id)) = meta.0.get_mut(SUBAGENT_SESSION_META_KEY)
+            else {
+                continue;
+            };
+            if let Some(new_id) = id_map.get(id.as_str()) {
+                *id = new_id.clone();
+            }
+        }
+        message
+    });
+    Conversation::new_unvalidated(messages)
+}
+
+/// Only bundle files goose itself wrote for the sessions being exported:
+/// spill files inside those sessions' own spill directories, or previously
+/// imported artifacts. A crafted pointer in a tool response must not be able
+/// to pull arbitrary local files, including another session's spills, into an
+/// export.
+fn is_exportable_spill_file(
+    path: &Path,
+    artifacts_dir: &Path,
+    spills_dir: &Path,
+    session_ids: &HashSet<&str>,
+) -> bool {
+    let Ok(canonical) = path.canonicalize() else {
+        return false;
+    };
+    let Some(name) = canonical.file_name().and_then(|n| n.to_str()) else {
+        return false;
+    };
+    if !name.ends_with(".txt") {
+        return false;
+    }
+    let within = |dir: &Path| {
+        dir.canonicalize()
+            .is_ok_and(|dir| canonical.starts_with(&dir))
+    };
+    let in_own_spill_dir = name.starts_with(SPILL_FILE_PREFIX)
+        && canonical
+            .parent()
+            .and_then(|parent| parent.file_name())
+            .and_then(|dir_name| dir_name.to_str())
+            .is_some_and(|dir_name| session_ids.contains(dir_name))
+        && within(spills_dir);
+    in_own_spill_dir || (is_sha256_file_name(name) && within(artifacts_dir))
+}
+
+/// File names of imported artifacts under `artifacts_dir` that a message's
+/// content blocks point at, used to garbage-collect artifact files once no
+/// message references them.
+pub(crate) fn artifact_file_names(content_json: &str, artifacts_dir: &Path) -> Vec<String> {
+    let Ok(blocks) = serde_json::from_str::<Vec<MessageContentBlock>>(content_json) else {
+        return Vec::new();
+    };
+    blocks
+        .iter()
+        .filter_map(|content| match content {
+            MessageContentBlock::ToolResponse(response) => response.tool_result.as_ref().ok(),
+            _ => None,
+        })
+        .flat_map(|result| &result.content)
+        .filter_map(|block| spilled_file_path(&block.as_text()?.text))
+        .filter_map(|path| {
+            let path = Path::new(path);
+            let name = path.file_name()?.to_str()?;
+            (path.parent() == Some(artifacts_dir) && is_sha256_file_name(name))
+                .then(|| name.to_string())
+        })
+        .collect()
+}
+
+fn is_sha256_file_name(name: &str) -> bool {
+    let bytes = name.as_bytes();
+    bytes.len() == 68 && bytes[..64].iter().all(|byte| byte.is_ascii_hexdigit())
+}
+
+fn sha256_hex(content: &str) -> String {
+    Sha256::digest(content.as_bytes())
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
+
+pub fn rewrite_spilled_paths(
+    conversation: Conversation,
+    paths: &BTreeMap<String, String>,
+) -> Conversation {
+    if paths.is_empty() {
+        return conversation;
+    }
+    let messages = conversation.into_iter().map(|mut message| {
+        for content in &mut message.content {
+            let MessageContentBlock::ToolResponse(response) = content else {
+                continue;
+            };
+            let Ok(result) = &mut response.tool_result else {
+                continue;
+            };
+            for block in &mut result.content {
+                let Some(replaced) = block.as_text().and_then(|text| {
+                    let old_path = spilled_file_path(&text.text)?;
+                    let new_path = paths.get(old_path)?;
+                    Some(text.text.replace(old_path, new_path))
+                }) else {
+                    continue;
+                };
+                *block = ContentBlock::text(replaced);
+            }
+        }
+        message
+    });
+    Conversation::new_unvalidated(messages)
+}
+
+pub(crate) fn spilled_paths(conversation: &Conversation) -> Vec<String> {
+    conversation
+        .messages()
+        .iter()
+        .flat_map(|message| &message.content)
+        .filter_map(|content| match content {
+            MessageContentBlock::ToolResponse(response) => response.tool_result.as_ref().ok(),
+            _ => None,
+        })
+        .flat_map(|result| &result.content)
+        .filter_map(|block| spilled_file_path(&block.as_text()?.text).map(|path| path.to_string()))
+        .collect()
+}

--- a/crates/goose/src/session/import_formats/mod.rs
+++ b/crates/goose/src/session/import_formats/mod.rs
@@ -1,6 +1,8 @@
 //! Importers for non-goose session formats.
 //!
-//! Goose's native session export is a JSON-serialized [`crate::session::Session`].
+//! Goose's native session export is a JSON-serialized
+//! [`crate::session::export_bundle::SessionExport`]: a [`crate::session::Session`]
+//! plus optional bundled subagent sessions and spilled tool-output artifacts.
 //! These submodules let users also import sessions exported by other coding
 //! agents — currently:
 //!

--- a/crates/goose/src/session/mod.rs
+++ b/crates/goose/src/session/mod.rs
@@ -1,5 +1,6 @@
 mod chat_history_search;
 mod diagnostics;
+pub mod export_bundle;
 pub mod extension_data;
 pub mod import_formats;
 mod last_message_snippet;

--- a/crates/goose/src/session/session_manager.rs
+++ b/crates/goose/src/session/session_manager.rs
@@ -5,6 +5,7 @@ use crate::conversation::Conversation;
 use crate::providers::base::CostSource;
 use crate::providers::base::Provider;
 use crate::recipe::Recipe;
+use crate::session::export_bundle;
 use crate::session::extension_data::ExtensionData;
 use crate::session::session_naming::{
     generate_session_name, MSG_COUNT_FOR_SESSION_NAME_GENERATION,
@@ -17,7 +18,7 @@ use rmcp::model::Role;
 use serde::{Deserialize, Serialize};
 use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
 use sqlx::{Pool, Sqlite};
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, LazyLock};
@@ -485,8 +486,19 @@ impl SessionManager {
             .await
     }
 
+    /// Directory that receives this session's spilled large tool outputs.
+    pub fn session_spill_dir(&self, session_id: &str) -> PathBuf {
+        self.storage.session_spill_dir(session_id)
+    }
+
     pub async fn export_session(&self, id: &str) -> Result<String> {
-        self.storage.export_session(id).await
+        self.storage.export_session(id, true).await
+    }
+
+    /// Export without bundled artifact contents, for shares that must fit
+    /// inside a single Nostr event.
+    pub async fn export_session_without_artifacts(&self, id: &str) -> Result<String> {
+        self.storage.export_session(id, false).await
     }
 
     pub async fn import_session(
@@ -2047,6 +2059,24 @@ impl SessionStorage {
             return Err(anyhow::anyhow!("Session not found"));
         }
 
+        let artifacts_dir = self.artifacts_dir();
+        let rows: Vec<(String,)> = sqlx::query_as(
+            "SELECT content_json FROM messages WHERE session_id = ? AND content_json LIKE ?",
+        )
+        .bind(session_id)
+        .bind(format!(
+            "%{}%",
+            crate::agents::large_response_handler::SPILL_MESSAGE_PREFIX
+        ))
+        .fetch_all(&mut *tx)
+        .await?;
+        let artifact_candidates: BTreeSet<String> = rows
+            .iter()
+            .flat_map(|(content_json,)| {
+                export_bundle::artifact_file_names(content_json, &artifacts_dir)
+            })
+            .collect();
+
         sqlx::query("DELETE FROM messages WHERE session_id = ?")
             .bind(session_id)
             .execute(&mut *tx)
@@ -2063,6 +2093,31 @@ impl SessionStorage {
             .await?;
 
         tx.commit().await?;
+
+        for name in artifact_candidates {
+            let referenced: bool = sqlx::query_scalar(
+                "SELECT EXISTS(SELECT 1 FROM messages WHERE content_json LIKE ?)",
+            )
+            .bind(format!("%{name}%"))
+            .fetch_one(pool)
+            .await?;
+            if !referenced {
+                if let Err(e) = std::fs::remove_file(artifacts_dir.join(&name)) {
+                    if e.kind() != std::io::ErrorKind::NotFound {
+                        tracing::warn!(
+                            "Failed to remove unreferenced session artifact {name}: {e}"
+                        );
+                    }
+                }
+            }
+        }
+
+        if let Err(e) = std::fs::remove_dir_all(self.session_spill_dir(session_id)) {
+            if e.kind() != std::io::ErrorKind::NotFound {
+                tracing::warn!("Failed to remove spilled tool outputs for {session_id}: {e}");
+            }
+        }
+
         Ok(())
     }
 
@@ -2273,9 +2328,57 @@ impl SessionStorage {
         })
     }
 
-    async fn export_session(&self, id: &str) -> Result<String> {
+    async fn descendant_session_ids(&self, id: &str) -> Result<Vec<String>> {
+        let pool = self.pool().await?;
+        let rows: Vec<(String,)> = sqlx::query_as(
+            r#"
+            WITH RECURSIVE tree(id) AS (
+                SELECT id FROM sessions WHERE parent_session_id = ?
+                UNION
+                SELECT s.id FROM sessions s JOIN tree ON s.parent_session_id = tree.id
+            )
+            SELECT id FROM tree
+            "#,
+        )
+        .bind(id)
+        .fetch_all(pool)
+        .await?;
+        Ok(rows.into_iter().map(|(id,)| id).collect())
+    }
+
+    fn artifacts_dir(&self) -> PathBuf {
+        self.session_dir.join("artifacts")
+    }
+
+    fn spills_dir(&self) -> PathBuf {
+        self.session_dir.join("spills")
+    }
+
+    fn session_spill_dir(&self, session_id: &str) -> PathBuf {
+        self.spills_dir().join(session_id)
+    }
+
+    async fn export_session(&self, id: &str, include_artifacts: bool) -> Result<String> {
         let session = self.get_session(id, true).await?;
-        serde_json::to_string_pretty(&session).map_err(Into::into)
+        let mut child_sessions = Vec::new();
+        for child_id in self.descendant_session_ids(id).await? {
+            child_sessions.push(self.get_session(&child_id, true).await?);
+        }
+        let artifacts = if include_artifacts {
+            export_bundle::collect_artifacts(
+                std::iter::once(&session).chain(&child_sessions),
+                &self.artifacts_dir(),
+                &self.spills_dir(),
+            )
+        } else {
+            Vec::new()
+        };
+        serde_json::to_string_pretty(&export_bundle::SessionExport {
+            session,
+            child_sessions,
+            artifacts,
+        })
+        .map_err(Into::into)
     }
 
     async fn import_session(
@@ -2285,7 +2388,26 @@ impl SessionStorage {
         session_type_override: Option<SessionType>,
     ) -> Result<Session> {
         let normalized = super::import_formats::convert_to_goose_session_json(json)?;
-        let import: Session = serde_json::from_str(&normalized)?;
+        let export_bundle::SessionExport {
+            session: import,
+            child_sessions,
+            mut artifacts,
+        } = serde_json::from_str(&normalized)?;
+
+        let referenced: std::collections::HashSet<String> = std::iter::once(&import)
+            .chain(&child_sessions)
+            .filter_map(|session| session.conversation.as_ref())
+            .flat_map(export_bundle::spilled_paths)
+            .collect();
+        artifacts.retain(|artifact| referenced.contains(&artifact.path));
+        // One artifact per referenced path: a crafted bundle repeating a path
+        // with different contents would otherwise persist files no rewritten
+        // pointer references, beyond the reach of the deletion GC.
+        let mut seen_paths = std::collections::HashSet::new();
+        artifacts.retain(|artifact| seen_paths.insert(artifact.path.clone()));
+
+        let artifact_paths =
+            export_bundle::artifact_destinations(&artifacts, &self.artifacts_dir());
 
         let session = self
             .create_session(
@@ -2309,15 +2431,116 @@ impl SessionStorage {
         if import.user_set_name {
             builder = builder.user_provided_name(import.name.clone());
         }
+        if let Some(provider_name) = import.provider_name {
+            builder = builder.provider_name(provider_name);
+        }
+        if let Some(model_config) = import.model_config {
+            builder = builder.model_config(model_config);
+        }
 
         builder.apply().await?;
 
+        let mut conversations = Vec::new();
         if let Some(conversation) = import.conversation {
-            self.replace_conversation(&session.id, &conversation)
-                .await?;
+            conversations.push((session.id.clone(), conversation));
         }
 
+        let id_map = self
+            .import_child_sessions(
+                session_manager,
+                &import.id,
+                &session.id,
+                child_sessions,
+                &mut conversations,
+            )
+            .await?;
+
+        for (target_id, conversation) in conversations {
+            let conversation = export_bundle::rewrite_spilled_paths(conversation, &artifact_paths);
+            let conversation = export_bundle::rewrite_subagent_session_ids(conversation, &id_map);
+            self.replace_conversation(&target_id, &conversation).await?;
+        }
+
+        // Written after the referencing messages are persisted, so a
+        // concurrent deletion's artifact GC can never observe these files
+        // without their references and remove them.
+        export_bundle::write_artifacts(&artifacts, &self.artifacts_dir())?;
+
         self.get_session(&session.id, true).await
+    }
+
+    /// Recreate exported subagent sessions under fresh ids, preserving the
+    /// parent links between them. Children whose exported parent is missing
+    /// from the bundle are attached to the imported root session. Their
+    /// conversations are pushed onto `conversations` for the caller to
+    /// persist once the full old-to-new id map is known, and that map is
+    /// returned.
+    async fn import_child_sessions(
+        &self,
+        session_manager: &SessionManager,
+        exported_root_id: &str,
+        new_root_id: &str,
+        child_sessions: Vec<Session>,
+        conversations: &mut Vec<(String, Conversation)>,
+    ) -> Result<HashMap<String, String>> {
+        let mut id_map = HashMap::new();
+        id_map.insert(exported_root_id.to_string(), new_root_id.to_string());
+
+        let mut pending = child_sessions;
+        while !pending.is_empty() {
+            let (ready, rest): (Vec<_>, Vec<_>) = pending.into_iter().partition(|child| {
+                child
+                    .parent_session_id
+                    .as_deref()
+                    .is_some_and(|parent| id_map.contains_key(parent))
+            });
+            let (batch, rest) = if ready.is_empty() {
+                (rest, Vec::new())
+            } else {
+                (ready, rest)
+            };
+            pending = rest;
+
+            for child in batch {
+                let parent_id = child
+                    .parent_session_id
+                    .as_deref()
+                    .and_then(|parent| id_map.get(parent))
+                    .unwrap_or(&id_map[exported_root_id])
+                    .clone();
+
+                let new_child = self
+                    .create_session(
+                        child.working_dir.clone(),
+                        child.name.clone(),
+                        child.session_type,
+                        child.goose_mode,
+                    )
+                    .await?;
+
+                let mut builder = session_manager
+                    .update(&new_child.id)
+                    .extension_data(child.extension_data)
+                    .usage(child.usage)
+                    .accumulated_usage(child.accumulated_usage)
+                    .accumulated_cost(child.accumulated_cost)
+                    .parent_session_id(Some(parent_id));
+                if let Some(provider_name) = child.provider_name {
+                    builder = builder.provider_name(provider_name);
+                }
+                if let Some(model_config) = child.model_config {
+                    builder = builder.model_config(model_config);
+                }
+                builder.apply().await?;
+
+                if let Some(conversation) = child.conversation {
+                    conversations.push((new_child.id.clone(), conversation));
+                }
+
+                id_map.insert(child.id, new_child.id);
+            }
+        }
+        Ok(id_map)
     }
 
     async fn copy_session(
@@ -3778,6 +4001,172 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_export_import_bundles_children_and_artifacts() {
+        use rmcp::model::{CallToolResult, ContentBlock};
+
+        let temp_dir = TempDir::new().unwrap();
+        let sm = SessionManager::new(temp_dir.path().to_path_buf());
+
+        let create = |name: &str, session_type| {
+            sm.create_session(
+                PathBuf::from("/tmp/test"),
+                name.to_string(),
+                session_type,
+                GooseMode::default(),
+            )
+        };
+
+        let root = create("Root", SessionType::User).await.unwrap();
+        let child = create("Child", SessionType::SubAgent).await.unwrap();
+        let grandchild = create("Grandchild", SessionType::SubAgent).await.unwrap();
+
+        sm.update(&root.id)
+            .provider_name("anthropic".to_string())
+            .apply()
+            .await
+            .unwrap();
+        sm.update(&child.id)
+            .parent_session_id(Some(root.id.clone()))
+            .apply()
+            .await
+            .unwrap();
+        sm.update(&grandchild.id)
+            .parent_session_id(Some(child.id.clone()))
+            .apply()
+            .await
+            .unwrap();
+
+        const SPILLED: &str = "the very large tool output";
+        let spill_dir = sm.session_spill_dir(&child.id);
+        fs::create_dir_all(&spill_dir).unwrap();
+        let spill_file = spill_dir.join("goose_mcp_response_test.txt");
+        fs::write(&spill_file, SPILLED).unwrap();
+        let secret_file = temp_dir.path().join("secret.txt");
+        fs::write(&secret_file, "must not leak").unwrap();
+        let foreign_spill_dir = sm.session_spill_dir("some-other-session");
+        fs::create_dir_all(&foreign_spill_dir).unwrap();
+        let foreign_spill_file = foreign_spill_dir.join("goose_mcp_response_foreign.txt");
+        fs::write(&foreign_spill_file, "other session's output").unwrap();
+        let pointer_to = |path: &std::path::Path| {
+            format!(
+                "The response returned from the tool call was larger (250000 characters) and is stored in the file which you can use other tools to examine or search in: {}",
+                path.display()
+            )
+        };
+        sm.add_message(
+            &child.id,
+            &Message::user().with_tool_response(
+                "call_1",
+                Ok(CallToolResult::success(vec![
+                    ContentBlock::text(pointer_to(&spill_file)),
+                    ContentBlock::text(pointer_to(&secret_file)),
+                    ContentBlock::text(pointer_to(&foreign_spill_file)),
+                ])),
+            ),
+        )
+        .await
+        .unwrap();
+
+        let mut delegate_meta = rmcp::model::MetaObject::new();
+        delegate_meta.0.insert(
+            "subagent_session_id".to_string(),
+            serde_json::Value::String(grandchild.id.clone()),
+        );
+        sm.add_message(
+            &root.id,
+            &Message::user().with_tool_response(
+                "call_2",
+                Ok(
+                    CallToolResult::success(vec![ContentBlock::text("delegated")])
+                        .with_meta(Some(delegate_meta)),
+                ),
+            ),
+        )
+        .await
+        .unwrap();
+
+        let exported = sm.export_session(&root.id).await.unwrap();
+        let unbundled = sm.export_session_without_artifacts(&root.id).await.unwrap();
+        fs::remove_file(&spill_file).unwrap();
+
+        assert!(
+            !exported.contains("must not leak"),
+            "non-goose files must not be bundled"
+        );
+        assert!(
+            !exported.contains("other session's output"),
+            "another session's spills must not be bundled"
+        );
+        assert!(exported.contains(SPILLED));
+        assert!(
+            !unbundled.contains(SPILLED),
+            "artifact contents must stay out of size-bounded exports"
+        );
+
+        let imported = sm.import_session(&exported, None).await.unwrap();
+        assert_eq!(imported.provider_name.as_deref(), Some("anthropic"));
+
+        let descendant_ids = sm
+            .storage
+            .descendant_session_ids(&imported.id)
+            .await
+            .unwrap();
+        assert_eq!(descendant_ids.len(), 2);
+
+        let mut new_child = None;
+        let mut new_grandchild = None;
+        for id in &descendant_ids {
+            let session = sm.get_session(id, true).await.unwrap();
+            match session.name.as_str() {
+                "Child" => new_child = Some(session),
+                "Grandchild" => new_grandchild = Some(session),
+                other => panic!("unexpected descendant {other}"),
+            }
+        }
+        let new_child = new_child.unwrap();
+        let new_grandchild = new_grandchild.unwrap();
+        assert_eq!(
+            new_child.parent_session_id.as_deref(),
+            Some(imported.id.as_str())
+        );
+        assert_eq!(new_child.session_type, SessionType::SubAgent);
+        assert_eq!(
+            new_grandchild.parent_session_id.as_deref(),
+            Some(new_child.id.as_str())
+        );
+
+        let conversation = new_child.conversation.unwrap();
+        let child_result = conversation.messages()[0]
+            .content
+            .iter()
+            .find_map(|c| match c {
+                MessageContent::ToolResponse(r) => r.tool_result.as_ref().ok(),
+                _ => None,
+            })
+            .unwrap();
+        let rewritten = child_result.content[0].as_text().unwrap().text.clone();
+        assert!(!rewritten.contains(&spill_file.display().to_string()));
+        let restored_path = rewritten.rsplit_once(": ").unwrap().1.trim();
+        assert_eq!(fs::read_to_string(restored_path).unwrap(), SPILLED);
+
+        let root_conversation = imported.conversation.unwrap();
+        let root_meta = root_conversation.messages()[0]
+            .content
+            .iter()
+            .find_map(|c| match c {
+                MessageContent::ToolResponse(r) => r.tool_result.as_ref().ok(),
+                _ => None,
+            })
+            .and_then(|result| result.meta.as_ref())
+            .unwrap();
+        assert_eq!(
+            root_meta.0.get("subagent_session_id"),
+            Some(&serde_json::Value::String(new_grandchild.id.clone())),
+            "subagent references must point at the recreated session"
+        );
+    }
+
+    #[tokio::test]
     async fn test_list_sessions_filters_by_type() {
         let temp_dir = TempDir::new().unwrap();
         let sm = SessionManager::new(temp_dir.path().to_path_buf());
@@ -4328,6 +4717,105 @@ mod tests {
 
         sm.delete_session(&id).await.unwrap();
         assert!(sm.get_session(&id, false).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_delete_session_removes_unreferenced_artifacts() {
+        use rmcp::model::{CallToolResult, ContentBlock};
+
+        let temp_dir = TempDir::new().unwrap();
+        let sm = SessionManager::new(temp_dir.path().to_path_buf());
+        let session = sm
+            .create_session(
+                PathBuf::from("/tmp/test"),
+                "Exporter".to_string(),
+                SessionType::User,
+                GooseMode::default(),
+            )
+            .await
+            .unwrap();
+
+        let spill_dir = sm.session_spill_dir(&session.id);
+        fs::create_dir_all(&spill_dir).unwrap();
+        let spill_file = spill_dir.join("goose_mcp_response_gc.txt");
+        fs::write(&spill_file, "spilled").unwrap();
+        sm.add_message(
+            &session.id,
+            &Message::user().with_tool_response(
+                "call_1",
+                Ok(CallToolResult::success(vec![ContentBlock::text(format!(
+                    "The response returned from the tool call was larger (250000 characters) and is stored in the file which you can use other tools to examine or search in: {}",
+                    spill_file.display()
+                ))])),
+            ),
+        )
+        .await
+        .unwrap();
+
+        let exported = sm.export_session(&session.id).await.unwrap();
+        fs::remove_file(&spill_file).unwrap();
+
+        let first = sm.import_session(&exported, None).await.unwrap();
+        let second = sm.import_session(&exported, None).await.unwrap();
+
+        let artifacts_dir = temp_dir.path().join(SESSIONS_FOLDER).join("artifacts");
+        let artifact_count = || fs::read_dir(&artifacts_dir).unwrap().count();
+        assert_eq!(artifact_count(), 1);
+
+        sm.delete_session(&first.id).await.unwrap();
+        assert_eq!(
+            artifact_count(),
+            1,
+            "artifact still referenced by the second import"
+        );
+
+        sm.delete_session(&second.id).await.unwrap();
+        assert_eq!(artifact_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_import_dedupes_artifacts_by_path() {
+        use rmcp::model::{CallToolResult, ContentBlock};
+
+        let temp_dir = TempDir::new().unwrap();
+        let sm = SessionManager::new(temp_dir.path().to_path_buf());
+        let session = sm
+            .create_session(
+                PathBuf::from("/tmp/test"),
+                "Exporter".to_string(),
+                SessionType::User,
+                GooseMode::default(),
+            )
+            .await
+            .unwrap();
+
+        let spill_dir = sm.session_spill_dir(&session.id);
+        fs::create_dir_all(&spill_dir).unwrap();
+        let spill_file = spill_dir.join("goose_mcp_response_dup.txt");
+        fs::write(&spill_file, "spilled").unwrap();
+        sm.add_message(
+            &session.id,
+            &Message::user().with_tool_response(
+                "call_1",
+                Ok(CallToolResult::success(vec![ContentBlock::text(format!(
+                    "The response returned from the tool call was larger (250000 characters) and is stored in the file which you can use other tools to examine or search in: {}",
+                    spill_file.display()
+                ))])),
+            ),
+        )
+        .await
+        .unwrap();
+
+        let exported = sm.export_session(&session.id).await.unwrap();
+        let mut bundle: serde_json::Value = serde_json::from_str(&exported).unwrap();
+        let mut smuggled = bundle["artifacts"][0].clone();
+        smuggled["content"] = serde_json::Value::String("unreferenced payload".to_string());
+        bundle["artifacts"].as_array_mut().unwrap().push(smuggled);
+
+        sm.import_session(&bundle.to_string(), None).await.unwrap();
+
+        let artifacts_dir = temp_dir.path().join(SESSIONS_FOLDER).join("artifacts");
+        assert_eq!(fs::read_dir(&artifacts_dir).unwrap().count(), 1);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What

Stacked on #10832. Makes `goose session export` self-contained:

- **Subagent sessions are bundled.** Export now includes all descendant sessions (recursive `parent_session_id` walk) under a `child_sessions` field. Import recreates the tree under fresh ids with parent links intact, rewrites `_meta.subagent_session_id` references to the new ids, and attaches children whose exported parent is missing from the bundle to the imported root.
- **Spilled large tool outputs are bundled.** Tool results over `GOOSE_MAX_TOOL_RESPONSE_SIZE` are stored as pointers to spill files, which dangle after an import on another machine. Export inlines those files as sha256-addressed artifacts; import writes them to `<data_dir>/sessions/artifacts/` and rewrites the pointers. The hash is recomputed from content on import so a crafted `sha256` field cannot escape the artifacts directory, import persists only artifacts actually referenced by a conversation in the bundle (one per referenced path, so a crafted bundle repeating a path cannot smuggle in unreferenced files), and artifact files are written only after the referencing messages are persisted so they are never on disk without their references.
- **Spill files are session-owned.** Spills previously went to flat OS temp files, so a pointer said nothing about which session produced the file. They now live under `<data_dir>/sessions/spills/<session_id>/`, and export only bundles spill files owned by a session in the exported tree, so a forged pointer in an imported transcript cannot pull another session's spills (or any other local file) into an export. Pre-existing flat temp spills are skipped with a warning. Deleting a session removes its spill directory and garbage-collects imported artifact files that no remaining message references (the reference check runs after the delete transaction commits, keyed on the plain-ASCII spill message prefix so the SQL `LIKE` filter is JSON-stable on Windows).
- **Provider settings survive import.** `provider_name` and `model_config` were silently dropped; they are now preserved (cross-provider safety is handled by the scrub in the previous PR).
- **CLI export goes through the same envelope.** `goose session export --format json|yaml` previously serialized the bare session; both now emit the full bundle.
- **Full diagnostics stay lean.** `goose session diagnostics --level full` embeds the export without artifact contents, so a session with large spilled outputs does not balloon the diagnostics JSON.
- **Nostr shares stay within relay limits.** Sharing over Nostr (ACP and CLI) exports without artifact contents, since bundled artifacts are at least 200 KB and a share is a single encrypted relay event.

The export envelope (`SessionExport`) flattens the existing `Session` JSON, so old exports import unchanged and old goose versions can still read the session fields of new exports. The Claude Code / Codex / Pi importers are unaffected.

## Known limitations (resolved by the stacked #10834)

Deleting the root of an imported tree removes only that session. The subagent children recreated by import are left behind, like every pre-existing subagent session on main; the delete cascade in #10834, stacked directly on this PR, removes the whole subtree.

## Why

An exported session should be a complete archive: the article-style test is export, revoke, continue elsewhere. Today the subagent transcripts and large tool outputs stay behind.

## Verification

- Test: a crafted bundle repeating an artifact path with different contents imports exactly one artifact file.
- Test: import the same bundle twice; deleting the first import keeps the shared artifact file, deleting the second removes it.
- Round-trip test: root + child + grandchild with a spilled tool output; the spill file is deleted before import to simulate another machine; asserts the recreated tree, rewritten pointer and subagent references, restored artifact content, preserved provider, and that neither a non-goose file pointer nor another session's spill file is bundled.
- E2E with a built binary: import a bundle, re-export as json and yaml, verify the envelope and reparented child.
- `cargo test -p goose --lib`, `cargo fmt`, `cargo clippy --all-targets -- -D warnings` on the touched crates.
