### PR TITLE
fix(docs): resolve CVE-2026-13149 in both brace-expansion copies

### DIFF
--- a/documentation/package-lock.json
+++ b/documentation/package-lock.json
@@ -6840,9 +6840,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -9629,9 +9629,9 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"

--- a/documentation/package.json
+++ b/documentation/package.json
@@ -49,10 +49,6 @@
     "typescript": "~5.6.2",
     "yaml-loader": "^0.8.1"
   },
-  "overrides": {
-    "brace-expansion@1.x": "1.1.16",
-    "brace-expansion@2.x": "2.1.2"
-  },
   "browserslist": {
     "production": [
       ">0.5%",

--- a/documentation/package.json
+++ b/documentation/package.json
@@ -49,6 +49,10 @@
     "typescript": "~5.6.2",
     "yaml-loader": "^0.8.1"
   },
+  "overrides": {
+    "brace-expansion@1.x": "1.1.16",
+    "brace-expansion@2.x": "2.1.2"
+  },
   "browserslist": {
     "production": [
       ">0.5%",


### PR DESCRIPTION
A prior approach to this added brace-expansion as a direct dependency, which only bumped the hoisted 1.x copy (1.1.12 -> 1.1.16). The nested node_modules/glob/node_modules/brace-expansion copy (pulled via tailwindcss -> sucrase -> glob) stayed at 2.0.2, which is within the advisory's vulnerable range (>=2.0.0, <2.1.2), so scanners would keep flagging CVE-2026-13149.

Use version-scoped npm overrides instead so every copy is patched:
  - brace-expansion@1.x -> 1.1.16
  - brace-expansion@2.x -> 2.1.2

This also avoids declaring a direct dependency the docs site never imports.
