### PR TITLE
style: add dark mode inline code styling for message bubbles

### DIFF
--- a/ui/desktop/src/components/MarkdownContent.tsx
+++ b/ui/desktop/src/components/MarkdownContent.tsx
@@ -127,6 +127,7 @@ const CodeBlock = memo(function CodeBlock({
         language={language}
         PreTag="div"
         customStyle={{
+          background: 'var(--code-block-background, #282c34)',
           margin: 0,
           width: '100%',
           maxWidth: '100%',

--- a/ui/desktop/src/styles/main.css
+++ b/ui/desktop/src/styles/main.css
@@ -616,7 +616,7 @@ pre:has(> code.bg-inline-code) {
   padding: 0.625rem 1rem;
 }
 
-.dark :is(.agent-message-bubble, .user-message-bubble) .bg-inline-code {
+.dark :is(.agent-message-bubble, .user-message-bubble) :not(pre) > code.bg-inline-code {
   background-color: transparent;
   color: #8cd3d6;
   padding: 0;

--- a/ui/desktop/src/styles/main.css
+++ b/ui/desktop/src/styles/main.css
@@ -586,8 +586,13 @@ pre:has(> code.bg-inline-code) {
 }
 
 .dark .user-message-bubble {
+  --code-block-background: #0f1628;
   background-color: #171d30;
   color: #d2dae6;
+}
+
+.dark .user-message pre {
+  background-color: var(--code-block-background);
 }
 
 .dark .user-message :is(h1, h2, h3, h4, h5, h6, strong) {
@@ -619,6 +624,12 @@ pre:has(> code.bg-inline-code) {
 .dark :is(.agent-message-bubble, .user-message-bubble) :not(pre) > code.bg-inline-code {
   background-color: transparent;
   color: #8cd3d6;
+  padding: 0;
+}
+
+.dark :is(.agent-message-bubble, .user-message-bubble) pre > code.bg-inline-code {
+  background-color: transparent;
+  color: #b8c4d1;
   padding: 0;
 }
 

--- a/ui/desktop/src/styles/main.css
+++ b/ui/desktop/src/styles/main.css
@@ -616,6 +616,12 @@ pre:has(> code.bg-inline-code) {
   padding: 0.625rem 1rem;
 }
 
+.dark :is(.agent-message-bubble, .user-message-bubble) .bg-inline-code {
+  background-color: transparent;
+  color: #8cd3d6;
+  padding: 0;
+}
+
 .scrollbar-thin {
   scrollbar-width: thin;
 }


### PR DESCRIPTION
Add transparent background and teal text color (#8cd3d6) for inline code blocks inside agent and user message bubbles in dark mode.

## Summary
Refine inline code styling in dark-mode chat messages by removing the striped background and using a softer turquoise text color.

### Testing
Manually tested user prompts and agent responses on Windows 11.

### Screenshots/Demos (for UX changes)
Before:  
<img width="2211" height="854" alt="image" src="https://github.com/user-attachments/assets/b45dbf55-ece3-4914-b425-774fbdb2606f" />

After:   
<img width="2180" height="942" alt="image" src="https://github.com/user-attachments/assets/d0a6ecf8-2f82-49c8-92c0-7d26ff79ac03" />

