### PR TITLE
docs: update Discord invite

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -342,10 +342,10 @@ This project follows the [Conventional Commits](https://www.conventionalcommits.
 
 ## Other Ways to Contribute
 
-There are numerous ways to be an open source contributor and contribute to goose. We're here to help you on your way! Here are some suggestions to get started. If you have any questions or need help, feel free to reach out to us on [Discord](https://discord.gg/goose-oss).
+There are numerous ways to be an open source contributor and contribute to goose. We're here to help you on your way! Here are some suggestions to get started. If you have any questions or need help, feel free to reach out to us on [Discord](https://discord.gg/n8R5VaWDAn).
 
 - **Stars on GitHub:** If you resonate with our project and find it valuable, consider starring our goose on GitHub! 🌟
-- **Ask Questions:** Your questions not only help us improve but also benefit the community. If you have a question, don't hesitate to ask it on [Discord](https://discord.gg/goose-oss).
+- **Ask Questions:** Your questions not only help us improve but also benefit the community. If you have a question, don't hesitate to ask it on [Discord](https://discord.gg/n8R5VaWDAn).
 - **Give Feedback:** Have a feature you want to see or encounter an issue with goose, [click here to open an issue](https://github.com/aaif-goose/goose/issues/new/choose), [start a discussion](https://github.com/aaif-goose/goose/discussions) or tell us on Discord.
 - **Participate in Community Events:** We host a variety of community events and livestreams on Discord every month, ranging from workshops to brainstorming sessions. You can subscribe to our [events calendar](https://calget.com/c/t7jszrie) or follow us on [social media](https://linktr.ee/goose_oss) to stay in touch.
 - **Improve Documentation:** Good documentation is key to the success of any project. You can help improve the quality of our existing docs or add new pages.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ _your native open source AI agent — desktop app, CLI, and API — for code, wo
 <p align="center">
   <a href="https://opensource.org/licenses/Apache-2.0"
     ><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg"></a>
-  <a href="https://discord.gg/goose-oss"
+  <a href="https://discord.gg/n8R5VaWDAn"
     ><img src="https://img.shields.io/discord/1287729918100246654?logo=discord&logoColor=white&label=Join+Us&color=blueviolet" alt="Discord"></a>
   <a href="https://github.com/aaif-goose/goose/actions/workflows/ci.yml"
      ><img src="https://img.shields.io/github/actions/workflow/status/aaif-goose/goose/ci.yml?branch=main" alt="CI"></a>
@@ -57,7 +57,7 @@ curl -fsSL https://github.com/aaif-goose/goose/releases/download/stable/download
 > Because it always helps them "migrate" their code to production! 🚀
 
 # goose around with us
-- [Discord](https://discord.gg/goose-oss)
+- [Discord](https://discord.gg/n8R5VaWDAn)
 - [YouTube](https://www.youtube.com/@goose-oss)
 - [LinkedIn](https://www.linkedin.com/company/goose-oss)
 - [Twitter/X](https://x.com/goose_oss)

--- a/documentation/blog/2024-11-22-screenshot-driven-development/index.md
+++ b/documentation/blog/2024-11-22-screenshot-driven-development/index.md
@@ -281,7 +281,7 @@ Developing user interfaces is a blend of creativity and problem-solving. And I l
 
 Beyond prototyping, goose's ability to analyze screenshots can help developers identify and resolve UI bugs.
 
-If you're interested in learning more, check out the [goose repo](https://github.com/aaif-goose/goose) and join our [Discord community](https://discord.gg/goose-oss).
+If you're interested in learning more, check out the [goose repo](https://github.com/aaif-goose/goose) and join our [Discord community](https://discord.gg/n8R5VaWDAn).
 
 <head>
     <meta property="og:title" content="Screenshot-Driven Development" />

--- a/documentation/blog/2024-12-06-previewing-goose-v10-beta/index.md
+++ b/documentation/blog/2024-12-06-previewing-goose-v10-beta/index.md
@@ -47,7 +47,7 @@ goose now has an electron-based GUI macOS application that provides and alternat
 
 goose v1.0 Beta now uses a custom protocol, that is designed in parallel with [Anthropic’s Model Context Protocol](https://www.anthropic.com/news/model-context-protocol) (MCP) to communicate with Systems. This makes it possible for developers to create their own systems (e.g Jira, ) that Goose can integrate with. 
 
-Excited for many more feature updates and improvements? Stay tuned for more updates on Goose! Check out the [goose repo](https://github.com/aaif-goose/goose) and join our [Discord community](https://discord.gg/goose-oss).
+Excited for many more feature updates and improvements? Stay tuned for more updates on Goose! Check out the [goose repo](https://github.com/aaif-goose/goose) and join our [Discord community](https://discord.gg/n8R5VaWDAn).
 
 
 <head>

--- a/documentation/blog/2024-12-06-previewing-goose-v10-beta/index.md
+++ b/documentation/blog/2024-12-06-previewing-goose-v10-beta/index.md
@@ -47,7 +47,7 @@ goose now has an electron-based GUI macOS application that provides and alternat
 
 goose v1.0 Beta now uses a custom protocol, that is designed in parallel with [Anthropic’s Model Context Protocol](https://www.anthropic.com/news/model-context-protocol) (MCP) to communicate with Systems. This makes it possible for developers to create their own systems (e.g Jira, ) that Goose can integrate with. 
 
-Excited for many more feature updates and improvements? Stay tuned for more updates on Goose! Check out the [goose repo](https://github.com/aaif-goose/goose) and join our [Discord community](https://discord.gg/n8R5VaWDAn).
+Excited for many more feature updates and improvements? Stay tuned for more updates on goose! Check out the [goose repo](https://github.com/aaif-goose/goose) and join our [Discord community](https://discord.gg/n8R5VaWDAn).
 
 
 <head>

--- a/documentation/blog/2025-01-28-introducing-codename-goose/index.md
+++ b/documentation/blog/2025-01-28-introducing-codename-goose/index.md
@@ -53,7 +53,7 @@ You can get started using goose right away! Check out our [Quickstart](/docs/qui
 Excited for upcoming features and events? Be sure to connect with us!
 
 - [GitHub](https://github.com/aaif-goose/goose)
-- [Discord](https://discord.gg/goose-oss)
+- [Discord](https://discord.gg/n8R5VaWDAn)
 - [YouTube](https://www.youtube.com/@goose-oss)
 - [LinkedIn](https://www.linkedin.com/company/goose-oss)
 - [X](https://x.com/goose_oss)

--- a/documentation/blog/2025-02-21-gooseteam-mcp/index.md
+++ b/documentation/blog/2025-02-21-gooseteam-mcp/index.md
@@ -28,7 +28,7 @@ A goose agent with the Project Coordinator role will assign roles to other agent
 Working with a team of AI agents on a task is a game changer. Instead of getting confused as to how to improve your prompt engineering on your own or work across sessions manually, tools like Cliff's gooseTeam or Aaron's Agent Communication Protocol help us make sure AI agents like goose are doing the work for us as efficiently as possible. The possibilities feel endless!
 
 ## Get Your Contribution Featured
-Hopefully this contribution inspired you as much as it inspired our community. If you have a goose contribution or project you'd like to share with our community, join our [Discord](https://discord.gg/goose-oss) and share your work in the **#share-your-work** channel. You may just be featured on our livestream or get a cool prize. 👀 You can also star goose on GitHub or follow us on social media so you never miss an update from us. Until next time!
+Hopefully this contribution inspired you as much as it inspired our community. If you have a goose contribution or project you'd like to share with our community, join our [Discord](https://discord.gg/n8R5VaWDAn) and share your work in the **#share-your-work** channel. You may just be featured on our livestream or get a cool prize. 👀 You can also star goose on GitHub or follow us on social media so you never miss an update from us. Until next time!
 
 
 <head>

--- a/documentation/blog/2025-03-14-goose-ollama/index.md
+++ b/documentation/blog/2025-03-14-goose-ollama/index.md
@@ -19,7 +19,7 @@ Together, they create a self-contained AI agent workflow that puts advanced capa
 
 Before diving deep into various capabilities, Rizel walked us through how to set yourself up for success by integrating goose with Ollama. To follow along, you can [download goose](https://goose-docs.ai/) and follow a step-by-step walk through in the [Configure LLM Provider](https://goose-docs.ai/docs/getting-started/providers) guide.
 
-If you have any questions or get stuck, feel free to chat with us on [Discord](https://discord.gg/goose-oss) or post an issue/discussion on [GitHub](https://github.com/aaif-goose/goose/). Thanks for reading!
+If you have any questions or get stuck, feel free to chat with us on [Discord](https://discord.gg/n8R5VaWDAn) or post an issue/discussion on [GitHub](https://github.com/aaif-goose/goose/). Thanks for reading!
 
 # Why Go Local?
 Using cloud-based LLMs and providers make it so you don't need substantial computing resources, so why go local? Here's some benefits you may want to consider:

--- a/documentation/blog/2025-03-21-goose-boston-meetup/index.mdx
+++ b/documentation/blog/2025-03-21-goose-boston-meetup/index.mdx
@@ -105,7 +105,7 @@ _The Goose Team in Boston_
 
 - If you're experiencing FOMO (the Fear of Missing Out) and want to join the next meetup, follow us on [social media](https://linktr.ee/goose_oss) to stay updated.
 
-- Bring a Goose meetup to your city! If you have a venue, reach out to us on [Discord](https://discord.gg/goose-oss)—let’s make it happen!
+- Bring a Goose meetup to your city! If you have a venue, reach out to us on [Discord](https://discord.gg/n8R5VaWDAn)—let’s make it happen!
 
 <head>
   <meta property="og:title" content="Codename Goose Goes to Boston" />

--- a/documentation/blog/2025-03-21-goose-boston-meetup/index.mdx
+++ b/documentation/blog/2025-03-21-goose-boston-meetup/index.mdx
@@ -105,7 +105,7 @@ _The Goose Team in Boston_
 
 - If you're experiencing FOMO (the Fear of Missing Out) and want to join the next meetup, follow us on [social media](https://linktr.ee/goose_oss) to stay updated.
 
-- Bring a Goose meetup to your city! If you have a venue, reach out to us on [Discord](https://discord.gg/n8R5VaWDAn)—let’s make it happen!
+- Bring a goose meetup to your city! If you have a venue, reach out to us on [Discord](https://discord.gg/n8R5VaWDAn)—let’s make it happen!
 
 <head>
   <meta property="og:title" content="Codename Goose Goes to Boston" />

--- a/documentation/blog/2025-03-21-goose-vscode/index.mdx
+++ b/documentation/blog/2025-03-21-goose-vscode/index.mdx
@@ -55,7 +55,7 @@ The features don't end here. The team is actively exploring several exciting fea
 - **Potential VS Code sidebar integration for Goose chat** - Andrew showed a quick preview of an early prototype showing Goose running directly inside VS Code.
 
 # Community and Contributing
-The project is open source, and welcomes contributions from the community. If you'd like to support the project or directly contribute to it, you can check out [the VSCode MCP repo on GitHub](https://github.com/block/vscode-mcp), or [join the Block Open Source Discord](https://discord.gg/goose-oss) if you'd like to ask the team any questions or start discussions.
+The project is open source, and welcomes contributions from the community. If you'd like to support the project or directly contribute to it, you can check out [the VSCode MCP repo on GitHub](https://github.com/block/vscode-mcp), or [join the Block Open Source Discord](https://discord.gg/n8R5VaWDAn) if you'd like to ask the team any questions or start discussions.
 
 <head>
   <meta property="og:title" content="Cracking the Code in VS Code" />

--- a/documentation/blog/2025-03-28-vibe-coding-with-goose/index.md
+++ b/documentation/blog/2025-03-28-vibe-coding-with-goose/index.md
@@ -77,7 +77,7 @@ To try the Speech MCP server yourself:
 
 ## Join the Development
 
-The Speech MCP server is [open-source](https://github.com/Kvadratni/speech-mcp) and welcomes contributions. You can also connect with Max on [Discord](https://discord.gg/goose-oss) for questions and collaboration.
+The Speech MCP server is [open-source](https://github.com/Kvadratni/speech-mcp) and welcomes contributions. You can also connect with Max on [Discord](https://discord.gg/n8R5VaWDAn) for questions and collaboration.
 
 Voice interactions with AI agents like Goose with the power and tools to act on instructions provides a different kind of vibe that makes the future feel closer than ever. Whether you're interested in vibe coding, accessibility improvements, or just want to feel a bit more like Tony Stark while getting Goose to pull a J.A.R.V.I.S, the Speech MCP server offers a glimpse into the future of human-AI collaboration - and it's available today.
 

--- a/documentation/blog/2025-04-01-mcp-nondevs/index.md
+++ b/documentation/blog/2025-04-01-mcp-nondevs/index.md
@@ -73,7 +73,7 @@ While some are developed by official providers, a vast majority of MCP servers y
 
 Hopefully now, instead of spending hours manually gathering data and creating your next marketing report, or manually sorting through your todo-backlog on a Monday, you will use MCP with Goose and have it done for you in minutes.
 
-*To learn more about using MCP servers and Goose, check out the [Goose documentation](https://goose-docs.ai/docs/category/getting-started), or join the [Block Open Source Discord](https://discord.gg/goose-oss) to connect with other open source community members.*
+*To learn more about using MCP servers and Goose, check out the [Goose documentation](https://goose-docs.ai/docs/category/getting-started), or join the [Block Open Source Discord](https://discord.gg/n8R5VaWDAn) to connect with other open source community members.*
 
 <head>
   <meta property="og:title" content="MCP Explained for Non-Developers" />

--- a/documentation/blog/2025-04-01-mcp-nondevs/index.md
+++ b/documentation/blog/2025-04-01-mcp-nondevs/index.md
@@ -73,7 +73,7 @@ While some are developed by official providers, a vast majority of MCP servers y
 
 Hopefully now, instead of spending hours manually gathering data and creating your next marketing report, or manually sorting through your todo-backlog on a Monday, you will use MCP with Goose and have it done for you in minutes.
 
-*To learn more about using MCP servers and Goose, check out the [Goose documentation](https://goose-docs.ai/docs/category/getting-started), or join the [Block Open Source Discord](https://discord.gg/n8R5VaWDAn) to connect with other open source community members.*
+*To learn more about using MCP servers and goose, check out the [goose documentation](https://goose-docs.ai/docs/category/getting-started), or join the [Block Open Source Discord](https://discord.gg/n8R5VaWDAn) to connect with other open source community members.*
 
 <head>
   <meta property="og:title" content="MCP Explained for Non-Developers" />

--- a/documentation/blog/2025-04-01-top-5-mcp-servers/index.mdx
+++ b/documentation/blog/2025-04-01-top-5-mcp-servers/index.mdx
@@ -84,7 +84,7 @@ As mentioned at the beginning of this post, the best thing about these MCP serve
 
 This is a simplified example of how I use these extensions together - I may not use all of them in every session, but having them available sure makes my workflow much smoother.
 
-What are your favorite MCP servers? How do you use them together? Share your experiences with us on [Discord server](https://discord.gg/goose-oss)!
+What are your favorite MCP servers? How do you use them together? Share your experiences with us on [Discord server](https://discord.gg/n8R5VaWDAn)!
 
 <head>
   <meta property="og:title" content="Top 5 MCP Servers I Use as a Developer with Goose Extensions" />

--- a/documentation/blog/2025-04-10-visual-guide-mcp/index.md
+++ b/documentation/blog/2025-04-10-visual-guide-mcp/index.md
@@ -76,7 +76,7 @@ The [Quickstart Guide](/docs/quickstart) walks you through connecting your first
 
 And when you’re ready to explore more, head over to the [tutorials section](/docs/category/tutorials) in the docs — it has step-by-step guides and short video demos to show you how to connect to a variety of MCP servers.
 
-And don't forget to [join the community](https://discord.gg/goose-oss) to see what others are building, ask questions, or to simply connect. 
+And don't forget to [join the community](https://discord.gg/n8R5VaWDAn) to see what others are building, ask questions, or to simply connect.
 
 
 <head>

--- a/documentation/blog/2025-04-14-community-atruelight4/index.md
+++ b/documentation/blog/2025-04-14-community-atruelight4/index.md
@@ -27,7 +27,7 @@ Thank you so much for your contribution, ATrueLight4! Your work brings us one st
 To show our deep gratitude for your contribution, we've granted you the exclusive ✨Top Contributor✨ badge on the Block Open Source Discord! You'll also be one of the first contributors to receive exclusive codename goose swag. (more info on that to be announced later 👀🪿)
 
 ## Get Your Own Spotlight
-Interested in contributing to goose and having your contribution featured? Whether it's improving platform support, adding new features, or fixing bugs, we welcome all contributions from the open source community. You can [join the Block Open Source Discord](https://discord.gg/goose-oss) or [get started using codename goose](https://goose-docs.ai/) today.
+Interested in contributing to goose and having your contribution featured? Whether it's improving platform support, adding new features, or fixing bugs, we welcome all contributions from the open source community. You can [join the Block Open Source Discord](https://discord.gg/n8R5VaWDAn) or [get started using codename goose](https://goose-docs.ai/) today.
 
 <head>
   <meta property="og:title" content="How ATrueLight4 Helped Goose Navigate Windows" />

--- a/documentation/blog/2025-04-22-community-bestcodes/index.md
+++ b/documentation/blog/2025-04-22-community-bestcodes/index.md
@@ -26,7 +26,7 @@ Thank you so much for your continued support and contributions, BestCodes! Your 
 To show how grateful we are for your contributions, we've granted you the exclusive ✨Top Contributor✨ badge on the Block Open Source Discord! Plus, you'll also be receiving exclusive codename goose swag. 👀🪿
 
 ## Become A Top Contributor
-Interested in contributing to goose and having your work featured? Whether it's fixing bugs, sharing ideas, or helping others, every contribution from the open source community has the chance to help someone. You can [join the Block Open Source Discord](https://discord.gg/goose-oss) or [get started using codename goose](https://goose-docs.ai/) today.
+Interested in contributing to goose and having your work featured? Whether it's fixing bugs, sharing ideas, or helping others, every contribution from the open source community has the chance to help someone. You can [join the Block Open Source Discord](https://discord.gg/n8R5VaWDAn) or [get started using codename goose](https://goose-docs.ai/) today.
 
 <head>
   <meta property="og:title" content="How One Contribution Can Spark Many Wins" />

--- a/documentation/blog/2025-04-23-things-need-to-know/index.md
+++ b/documentation/blog/2025-04-23-things-need-to-know/index.md
@@ -73,7 +73,7 @@ To help you manage this, there is a [Handling Rate Limits Guide](https://goose-d
 
 This part matters more than most people realize.
 
-Goose has an entire community behind it—folks building, exploring, breaking things (and fixing them), and sharing everything they learn along the way. We hang out on [Discord](https://discord.gg/goose-oss), we answer questions in [GitHub Discussions](https://github.com/aaif-goose/goose/discussions), and we host livestreams every week to show off what Goose can do and how to make it do more.
+Goose has an entire community behind it—folks building, exploring, breaking things (and fixing them), and sharing everything they learn along the way. We hang out on [Discord](https://discord.gg/n8R5VaWDAn), we answer questions in [GitHub Discussions](https://github.com/aaif-goose/goose/discussions), and we host livestreams every week to show off what Goose can do and how to make it do more.
 
 There’s:
 

--- a/documentation/blog/2025-04-23-things-need-to-know/index.md
+++ b/documentation/blog/2025-04-23-things-need-to-know/index.md
@@ -73,7 +73,7 @@ To help you manage this, there is a [Handling Rate Limits Guide](https://goose-d
 
 This part matters more than most people realize.
 
-Goose has an entire community behind it—folks building, exploring, breaking things (and fixing them), and sharing everything they learn along the way. We hang out on [Discord](https://discord.gg/n8R5VaWDAn), we answer questions in [GitHub Discussions](https://github.com/aaif-goose/goose/discussions), and we host livestreams every week to show off what Goose can do and how to make it do more.
+goose has an entire community behind it—folks building, exploring, breaking things (and fixing them), and sharing everything they learn along the way. We hang out on [Discord](https://discord.gg/n8R5VaWDAn), we answer questions in [GitHub Discussions](https://github.com/aaif-goose/goose/discussions), and we host livestreams every week to show off what goose can do and how to make it do more.
 
 There’s:
 

--- a/documentation/blog/2025-05-09-developers-ai-playbook-for-team-efficiency/index.md
+++ b/documentation/blog/2025-05-09-developers-ai-playbook-for-team-efficiency/index.md
@@ -293,7 +293,7 @@ Your team can create plays for many other tasks:
 
 ## What kinds of tasks can your team automate?
 
-We'd love for you to share your ideas with us! Share your ideas by creating a recipe and posting it to the [Goose community on Discord](http://discord.gg/goose-oss).
+We'd love for you to share your ideas with us! Share your ideas by creating a recipe and posting it to the [Goose community on Discord](http://discord.gg/n8R5VaWDAn).
 
 
 

--- a/documentation/blog/2025-05-09-developers-ai-playbook-for-team-efficiency/index.md
+++ b/documentation/blog/2025-05-09-developers-ai-playbook-for-team-efficiency/index.md
@@ -293,7 +293,7 @@ Your team can create plays for many other tasks:
 
 ## What kinds of tasks can your team automate?
 
-We'd love for you to share your ideas with us! Share your ideas by creating a recipe and posting it to the [Goose community on Discord](http://discord.gg/n8R5VaWDAn).
+We'd love for you to share your ideas with us! Share your ideas by creating a recipe and posting it to the [goose community on Discord](http://discord.gg/n8R5VaWDAn).
 
 
 

--- a/documentation/blog/2025-05-20-goose-gets-a-drivers-license/index.md
+++ b/documentation/blog/2025-05-20-goose-gets-a-drivers-license/index.md
@@ -144,7 +144,7 @@ For the video recording, I used a voice modifier to narrate Goose's response in 
 
 We want to extend a huge thank you to [deemkeen](https://x.com/deemkeen) for their open-source work which inspired this project, and to the Makeblock team for creating such a fun rover to work with.
 
-We're always excited to see what the community is up to. If you're working on your own Goose-powered experiment, come share it with us on [Discord](https://discord.gg/goose-oss)!
+We're always excited to see what the community is up to. If you're working on your own Goose-powered experiment, come share it with us on [Discord](https://discord.gg/n8R5VaWDAn)!
 
 <head>
   <meta property="og:title" content="Goose Gets a Driver's License!" />

--- a/documentation/blog/2025-05-20-goose-gets-a-drivers-license/index.md
+++ b/documentation/blog/2025-05-20-goose-gets-a-drivers-license/index.md
@@ -144,7 +144,7 @@ For the video recording, I used a voice modifier to narrate Goose's response in 
 
 We want to extend a huge thank you to [deemkeen](https://x.com/deemkeen) for their open-source work which inspired this project, and to the Makeblock team for creating such a fun rover to work with.
 
-We're always excited to see what the community is up to. If you're working on your own Goose-powered experiment, come share it with us on [Discord](https://discord.gg/n8R5VaWDAn)!
+We're always excited to see what the community is up to. If you're working on your own goose-powered experiment, come share it with us on [Discord](https://discord.gg/n8R5VaWDAn)!
 
 <head>
   <meta property="og:title" content="Goose Gets a Driver's License!" />

--- a/documentation/blog/2025-06-05-whats-in-my-goosehints-file/index.md
+++ b/documentation/blog/2025-06-05-whats-in-my-goosehints-file/index.md
@@ -119,7 +119,7 @@ The first line starts with a hash `#` and a space-separated list of keywords and
 
 Since both the `.goosehints` file and the Memory Extension files are sent with every request, whether to use one or the other really comes down to how you want to manage your context. Since you can create a project-specific `.goosehints` file, you can use it to define project-wide rules and standards that you want to apply consistently across all interactions with Goose. This is useful for defining project-wide coding standards, documentation preferences, or other static rules that you want to apply consistently across all interactions. Meanwhile you can maintain a personal set of standards for writing and coding in your Memory Extension that you can update and change as needed without affecting the project-wide rules.
 
-Share your own `.goosehints` optimization stories in the [Goose community on Discord](http://discord.gg/n8R5VaWDAn)!
+Share your own `.goosehints` optimization stories in the [goose community on Discord](http://discord.gg/n8R5VaWDAn)!
 
 <head>
   <meta property="og:title" content="What's in my .goosehints file (and why it probably shouldn't be)" />

--- a/documentation/blog/2025-06-05-whats-in-my-goosehints-file/index.md
+++ b/documentation/blog/2025-06-05-whats-in-my-goosehints-file/index.md
@@ -119,7 +119,7 @@ The first line starts with a hash `#` and a space-separated list of keywords and
 
 Since both the `.goosehints` file and the Memory Extension files are sent with every request, whether to use one or the other really comes down to how you want to manage your context. Since you can create a project-specific `.goosehints` file, you can use it to define project-wide rules and standards that you want to apply consistently across all interactions with Goose. This is useful for defining project-wide coding standards, documentation preferences, or other static rules that you want to apply consistently across all interactions. Meanwhile you can maintain a personal set of standards for writing and coding in your Memory Extension that you can update and change as needed without affecting the project-wide rules.
 
-Share your own `.goosehints` optimization stories in the [Goose community on Discord](http://discord.gg/goose-oss)!
+Share your own `.goosehints` optimization stories in the [Goose community on Discord](http://discord.gg/n8R5VaWDAn)!
 
 <head>
   <meta property="og:title" content="What's in my .goosehints file (and why it probably shouldn't be)" />

--- a/documentation/blog/2025-06-16-multi-model-in-goose/index.md
+++ b/documentation/blog/2025-06-16-multi-model-in-goose/index.md
@@ -88,7 +88,7 @@ If you're curious how it all works under the hood, see the [planning guide](/doc
 
 ---
 
-If you're experimenting with multi-model setups, [share what's working and what isn't](https://discord.gg/goose-oss).
+If you're experimenting with multi-model setups, [share what's working and what isn't](https://discord.gg/n8R5VaWDAn).
 
 
 <head>

--- a/documentation/blog/2025-06-19-isolated-development-environments/index.md
+++ b/documentation/blog/2025-06-19-isolated-development-environments/index.md
@@ -102,7 +102,7 @@ extensions:
 
 ---
 
-*Questions? Join our [GitHub discussions](https://github.com/aaif-goose/goose) or [Discord](https://discord.gg/goose-oss). Learn more about Dagger at [dagger.io](https://dagger.io/).*
+*Questions? Join our [GitHub discussions](https://github.com/aaif-goose/goose) or [Discord](https://discord.gg/n8R5VaWDAn). Learn more about Dagger at [dagger.io](https://dagger.io/).*
 
 {/* Video Player */}
 <div style={{ width: '100%', maxWidth: '800px', margin: '0 auto' }}>

--- a/documentation/blog/2025-06-27-everyday-usecases-ai/index.md
+++ b/documentation/blog/2025-06-27-everyday-usecases-ai/index.md
@@ -108,7 +108,7 @@ No dead ends. No 404s. Just tidy documentation.
 Most AI posts show off what's possible. I'm focused on what was promised.
 The whole point was to offload the tedious stuff so we could focus on the work that actually matters, and that's exactly what I'm using AI for.
 
-What everyday tasks are you delegating to AI agents? Let us know in [Discord](https://discord.gg/goose-oss).
+What everyday tasks are you delegating to AI agents? Let us know in [Discord](https://discord.gg/n8R5VaWDAn).
 
 
 <head>

--- a/documentation/blog/2025-08-11-llm-tag-team-lead-worker-model/index.md
+++ b/documentation/blog/2025-08-11-llm-tag-team-lead-worker-model/index.md
@@ -110,7 +110,7 @@ Want to see it in action? Check out the full stream where we built this feature 
 
 <iframe class="aspect-ratio" width="560" height="315" src="https://www.youtube.com/embed/IbBDBv9Chvg" title="LLM Tag Team: Who Plans, Who Executes?" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-Got questions or want to share your own Lead/Worker success stories? Join us in our [Discord community](https://discord.gg/goose-oss) - we'd love to hear what you're building!
+Got questions or want to share your own Lead/Worker success stories? Join us in our [Discord community](https://discord.gg/n8R5VaWDAn) - we'd love to hear what you're building!
 
 
 <head>

--- a/documentation/blog/2025-08-25-mcp-ui-future-agentic-interfaces/index.md
+++ b/documentation/blog/2025-08-25-mcp-ui-future-agentic-interfaces/index.md
@@ -133,7 +133,7 @@ The future of interacting with AI relies on smarter interfaces. And with MCP-UI,
 
 <iframe src="https://www.youtube.com/embed/GS-kmreZDgU" title="MCP-UI: The Future of Agentic Interfaces" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen class="aspect-ratio"></iframe>
 
-*Join the conversation on [Discord](https://discord.gg/goose-oss) and follow our progress as we continue pushing the boundaries of what's possible with AI agents.*
+*Join the conversation on [Discord](https://discord.gg/n8R5VaWDAn) and follow our progress as we continue pushing the boundaries of what's possible with AI agents.*
 
 <head>
   <meta property="og:title" content="MCP-UI: The Future of Agentic Interfaces" />

--- a/documentation/blog/2025-08-27-get-started-for-free-with-tetrate/index.md
+++ b/documentation/blog/2025-08-27-get-started-for-free-with-tetrate/index.md
@@ -64,7 +64,7 @@ Thank you to Tetrate for supporting open source and making AI development more a
 
 **What are you waiting for?** [Get started with goose](/)
 
-*Got questions?* Explore our [docs](/docs/category/guides), browse the [blog](/blog), or join the conversation in our [Discord](https://discord.gg/goose-oss) and [GitHub Discussions](https://github.com/aaif-goose/goose/discussions). We’d love to have you.
+*Got questions?* Explore our [docs](/docs/category/guides), browse the [blog](/blog), or join the conversation in our [Discord](https://discord.gg/n8R5VaWDAn) and [GitHub Discussions](https://github.com/aaif-goose/goose/discussions). We’d love to have you.
 
 <head>
   <meta property="og:title" content="Your First goose Experience Is On Us" />

--- a/documentation/blog/2025-09-08-turn-any-mcp-server-mcp-ui-compatible/index.mdx
+++ b/documentation/blog/2025-09-08-turn-any-mcp-server-mcp-ui-compatible/index.mdx
@@ -329,7 +329,7 @@ Wanna see it in action?
 
 Download [goose](/docs/quickstart#install-goose), give an MCP server a UI facelift of your own, and see the magic for yourself. Boring text prompts will never hit the same again.
 
-*Got questions?* Explore our [docs](/docs/category/guides), browse the [blog](/blog), or join the conversation in our [Discord](https://discord.gg/goose-oss) and [GitHub Discussions](https://github.com/aaif-goose/goose/discussions). We’d love to have you.
+*Got questions?* Explore our [docs](/docs/category/guides), browse the [blog](/blog), or join the conversation in our [Discord](https://discord.gg/n8R5VaWDAn) and [GitHub Discussions](https://github.com/aaif-goose/goose/discussions). We’d love to have you.
 
 
 <head>

--- a/documentation/blog/2025-09-26-hacktoberfest-2025/index.md
+++ b/documentation/blog/2025-09-26-hacktoberfest-2025/index.md
@@ -74,8 +74,8 @@ You can keep an eye on your progress all month long in our Hacktoberfest 2025 Le
 When in doubt, don't stress! The goose team is here to help you make the most of your contributions. Here's where to go when you have specific questions:
 
 1. 🆘 Maintainer Help: Connect with the maintainers by commenting on the issue or chat with them directly in the #🎃┃hacktoberfest channel on Discord.
-2. 🫶 Community Support: [Join us on Discord](https://discord.gg/goose-oss) to live chat with fellow contributors and get tips for success from participants!
-3. 🎙️ Office Hours: Join us every Tuesday at 1pm Eastern Time on [Discord](https://discord.gg/goose-oss) through the month of October to get live-over-voice help with open PRs, questions you may have, and general help. Keep an eye out on the [goose events calendar](https://goose-docs.ai/community/) for future events centered around Hacktoberfest!
+2. 🫶 Community Support: [Join us on Discord](https://discord.gg/n8R5VaWDAn) to live chat with fellow contributors and get tips for success from participants!
+3. 🎙️ Office Hours: Join us every Tuesday at 1pm Eastern Time on [Discord](https://discord.gg/n8R5VaWDAn) through the month of October to get live-over-voice help with open PRs, questions you may have, and general help. Keep an eye out on the [goose events calendar](https://goose-docs.ai/community/) for future events centered around Hacktoberfest!
 
 
 Happy hacking and cheers to goose x Hacktoberfest 2025! 🎉

--- a/documentation/blog/2025-09-26-subagents-vs-subrecipes/index.md
+++ b/documentation/blog/2025-09-26-subagents-vs-subrecipes/index.md
@@ -112,7 +112,7 @@ The choice depends on your specific needs and workflow requirements. Quick tasks
 
 Your workflow requirements should drive the decision.
 
-Share your subagent prompts or subrecipe ideas with us on our [Discord community](https://discord.gg/goose-oss) or [GitHub discussions](https://github.com/aaif-goose/goose/discussions).
+Share your subagent prompts or subrecipe ideas with us on our [Discord community](https://discord.gg/n8R5VaWDAn) or [GitHub discussions](https://github.com/aaif-goose/goose/discussions).
 
 
 

--- a/documentation/blog/2025-10-24-intro-to-agent-client-protocol-acp/index.md
+++ b/documentation/blog/2025-10-24-intro-to-agent-client-protocol-acp/index.md
@@ -65,7 +65,7 @@ If you're ready to see how fast and simple this setup really is, watch the full 
 
 <iframe class="aspect-ratio" src="https://www.youtube.com/embed/Hvu5KDTb6JE" title="Vibe Code with goose: Intro to ACP" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-*Ready to integrate goose directly into your editor? Get started with our [ACP setup guide](https://goose-docs.ai/docs/guides/acp-clients) and share your experience in our [Discord community](http://discord.gg/goose-oss).*
+*Ready to integrate goose directly into your editor? Get started with our [ACP setup guide](https://goose-docs.ai/docs/guides/acp-clients) and share your experience in our [Discord community](http://discord.gg/n8R5VaWDAn).*
 
 
 <head>

--- a/documentation/blog/2025-11-17-migrate-app-with-ai-agent/index.md
+++ b/documentation/blog/2025-11-17-migrate-app-with-ai-agent/index.md
@@ -127,7 +127,7 @@ I hope this clarifies how to converse with an agent and accomplish complex tasks
 
 <iframe class="aspect-ratio" src="https://www.youtube.com/embed/zGyXfA3kKTk" title="How to Successfully Migrate Your App with an AI Agent" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-*Ready to try AI-assisted migration with goose? Get started with our [quickstart guide](/docs/quickstart) and share your experience in our [Discord community](http://discord.gg/goose-oss).*
+*Ready to try AI-assisted migration with goose? Get started with our [quickstart guide](/docs/quickstart) and share your experience in our [Discord community](http://discord.gg/n8R5VaWDAn).*
 
 
 <head>

--- a/documentation/blog/2025-12-15-code-mode-mcp/index.md
+++ b/documentation/blog/2025-12-15-code-mode-mcp/index.md
@@ -48,7 +48,7 @@ Our hope is that we improve tool calling performance and handling of large numbe
 also provide an open source implementation of this emerging approach.
 
 * Try out the feature by enabling the ["Code Mode" extension](https://github.com/aaif-goose/goose/blob/main/crates/goose/src/agents/platform_extensions/code_execution.rs) in v1.17.0 or later of goose by clicking extensions on the left side of the desktop app or running `goose configure` on cli
-* Please give us feedback on how it works for you by joining our [discord](https://discord.gg/goose-oss).
+* Please give us feedback on how it works for you by joining our [discord](https://discord.gg/n8R5VaWDAn).
 
 Kudos to my colleague [Mic Neale](https://github.com/michaelneale) for collaborating with me on the implementation!
 

--- a/documentation/blog/2025-12-19-goose-mobile-terminal/index.md
+++ b/documentation/blog/2025-12-19-goose-mobile-terminal/index.md
@@ -50,7 +50,7 @@ A session in goose from native terminal, cli, desktop, IDE and now mobile are al
 
 It doesn't matter how you use goose. Your sessions are yours, and you can use and re-use them from anywhere: desktop, terminal, or mobile (and all on your machine). 
 
-Try them out and let us know what you think in our [Discord](https://discord.gg/goose-oss)!
+Try them out and let us know what you think in our [Discord](https://discord.gg/n8R5VaWDAn)!
 
 <head>
   <meta property="og:title" content="goose Mobile Access and Native Terminal Support" />

--- a/documentation/blog/2025-12-21-code-mode-doesnt-replace-mcp/index.md
+++ b/documentation/blog/2025-12-21-code-mode-doesnt-replace-mcp/index.md
@@ -103,7 +103,7 @@ Code Mode helps us take a step forward in building agents that can scale to hand
 
 ---
 
-*Ready to try Code Mode? Enable the "Code Mode" extension in [goose](/docs/quickstart) v1.17.0 or later. Join our [Discord](https://discord.gg/goose-oss) to share your experience!*
+*Ready to try Code Mode? Enable the "Code Mode" extension in [goose](/docs/quickstart) v1.17.0 or later. Join our [Discord](https://discord.gg/n8R5VaWDAn) to share your experience!*
 
 <head>
   <meta property="og:title" content="Code Mode Doesn't Replace MCP (Here's What It Actually Does)" />

--- a/documentation/blog/2026-02-06-8-things-you-didnt-know-about-code-mode/index.md
+++ b/documentation/blog/2026-02-06-8-things-you-didnt-know-about-code-mode/index.md
@@ -218,7 +218,7 @@ If you want to experiment with Code Mode, here are some resources:
 - [Code Mode Doesn't Replace MCP](/blog/2025/12/21/code-mode-doesnt-replace-mcp) by me
 
 **Community:**
-- Join our [Discord](https://discord.gg/goose-oss) to share what you learn
+- Join our [Discord](https://discord.gg/n8R5VaWDAn) to share what you learn
 - File issues on [GitHub](https://github.com/aaif-goose/goose) if something does not work as expected
 
 Run your own experiments and let us know what you find.

--- a/documentation/blog/2026-02-24-goose-grant-goose-in-a-pond/index.md
+++ b/documentation/blog/2026-02-24-goose-grant-goose-in-a-pond/index.md
@@ -93,7 +93,7 @@ By the end, Goose In A Pond should be something anyone can install, customize, a
 
 The goose grant program exists to support projects that push goose into places we haven't imagined yet. Goose In A Pond does exactly that. It takes goose from a developer tool on your laptop to a full blown home assistant running on edge hardware - completely local, completely open, completely yours.
 
-We can't wait to see what the Jarida team builds. If you want to follow along, join the [goose community](https://discord.gg/goose-oss) and stay tuned for updates as the project progresses.
+We can't wait to see what the Jarida team builds. If you want to follow along, join the [goose community](https://discord.gg/n8R5VaWDAn) and stay tuned for updates as the project progresses.
 
 And if *you* have a wild idea for what goose could do? The **[goose grant program](/grants/)** might be for you 🪿
 

--- a/documentation/blog/2026-04-07-goose-moves-to-aaif/index.md
+++ b/documentation/blog/2026-04-07-goose-moves-to-aaif/index.md
@@ -36,7 +36,7 @@ git remote set-url origin git@github.com:aaif-goose/goose.git
 
 ## Migration in progress
 
-We're still working through some migration issues (broken links, redirects, CI, etc). If you hit anything that seems off, please reach out on [Discord](https://discord.gg/goose-oss) and let us know.
+We're still working through some migration issues (broken links, redirects, CI, etc). If you hit anything that seems off, please reach out on [Discord](https://discord.gg/n8R5VaWDAn) and let us know.
 ## Learn more
 
 Visit [aaif.io](https://aaif.io/) to learn more about the foundation and its mission.

--- a/documentation/blog/2026-04-08-goose-acp-and-new-tui/index.md
+++ b/documentation/blog/2026-04-08-goose-acp-and-new-tui/index.md
@@ -73,7 +73,7 @@ This is all happening in the open. Follow along or jump in:
 
 - **Tracking issue:** [#6642](https://github.com/aaif-goose/goose/issues/6642)
 - **Try the TUI:** `npx @aaif/goose`
-- **Discord:** Follow along and give feedback in [#goose-2-dev](https://discord.gg/goose-oss).
+- **Discord:** Follow along and give feedback in [#goose-2-dev](https://discord.gg/n8R5VaWDAn).
 - **Feedback?** Open an issue or drop a comment on #6642 — we'd love to hear from you.
 
 <head>

--- a/documentation/blog/2026-04-08-how-to-break-up-with-your-agent/index.md
+++ b/documentation/blog/2026-04-08-how-to-break-up-with-your-agent/index.md
@@ -82,7 +82,7 @@ Pick the UI you like. Pick the agent you like. They don't have to be the same th
 - [ACP clients guide](/docs/guides/acp-clients)
 - [ACP providers guide](/docs/guides/acp-providers)
 - [Goose on GitHub](https://github.com/aaif-goose/goose)
-- [Discord community](https://discord.gg/goose-oss)
+- [Discord community](https://discord.gg/n8R5VaWDAn)
 
 <head>
   <meta property="og:title" content="How to Break Up with Your Agent" />

--- a/documentation/docs/experimental/index.md
+++ b/documentation/docs/experimental/index.md
@@ -74,7 +74,7 @@ The list of experimental features may change as goose development progresses. So
     <Card 
       title="Discord Community"
       description="Join our community to discuss experimental features, share feedback, and connect with other users."
-      link="https://discord.gg/goose-oss"
+      link="https://discord.gg/n8R5VaWDAn"
     />
   </div>
 </div>

--- a/documentation/docs/getting-started/providers.md
+++ b/documentation/docs/getting-started/providers.md
@@ -1571,7 +1571,7 @@ Reasoning output can be useful for understanding how the model arrived at its an
 
 ---
 
-If you have any questions or need help with a specific provider, feel free to reach out to us on [Discord](https://discord.gg/goose-oss) or on the [goose repo](https://github.com/aaif-goose/goose).
+If you have any questions or need help with a specific provider, feel free to reach out to us on [Discord](https://discord.gg/n8R5VaWDAn) or on the [goose repo](https://github.com/aaif-goose/goose).
 
 
 [providers]: /docs/getting-started/providers

--- a/documentation/docs/mcp/cloudflare-mcp.md
+++ b/documentation/docs/mcp/cloudflare-mcp.md
@@ -274,7 +274,7 @@ If you encounter issues:
 
 1. Check the [Cloudflare MCP Server repository](https://github.com/cloudflare/mcp-server-cloudflare) for documentation
 2. Review [Cloudflare API documentation](https://developers.cloudflare.com/api/)
-3. Join our [Discord community](https://discord.gg/goose-oss) for support
+3. Join our [Discord community](https://discord.gg/n8R5VaWDAn) for support
 4. Check [Cloudflare Community](https://community.cloudflare.com/) for platform-specific help
 
 ## Next Steps

--- a/documentation/docs/mcp/tutorial-mcp.md
+++ b/documentation/docs/mcp/tutorial-mcp.md
@@ -144,4 +144,4 @@ After completing tutorials, you can:
 ### Need Further Help? 
 If you have questions, run into issues, or just need to brainstorm ideas join the [Discord Community][discord]!
 
-[discord]: https://discord.gg/goose-oss
+[discord]: https://discord.gg/n8R5VaWDAn

--- a/documentation/docs/troubleshooting/index.mdx
+++ b/documentation/docs/troubleshooting/index.mdx
@@ -44,7 +44,7 @@ import styles from '@site/src/components/Card/styles.module.css';
     <Card 
       title="Discord Community"
       description="Join our active Discord server for real-time help, discussions, and community support from goose users and maintainers."
-      link="https://discord.gg/goose-oss"
+      link="https://discord.gg/n8R5VaWDAn"
     />
     <Card 
       title="GitHub Issues"

--- a/documentation/docs/troubleshooting/known-issues.md
+++ b/documentation/docs/troubleshooting/known-issues.md
@@ -7,7 +7,7 @@ description: Comprehensive troubleshooting guide for common goose problems with 
 goose, like any system, may run into occasional issues. This guide provides solutions for common problems.
 
 :::tip Need help with an issue not listed here?
-Our [Discord community](https://discord.gg/goose-oss) is here to help! For the fastest support, consider generating a [diagnostic report](/docs/troubleshooting/diagnostics-and-reporting) - it helps us understand your setup quickly.
+Our [Discord community](https://discord.gg/n8R5VaWDAn) is here to help! For the fastest support, consider generating a [diagnostic report](/docs/troubleshooting/diagnostics-and-reporting) - it helps us understand your setup quickly.
 :::
 
 ### goose Edits Files
@@ -523,7 +523,7 @@ If you can share a [diagnostic report](/docs/troubleshooting/diagnostics-and-rep
 
 [handling-rate-limits]: /docs/guides/handling-llm-rate-limits-with-goose
 [installation]: /docs/getting-started/installation
-[discord]: https://discord.gg/goose-oss
+[discord]: https://discord.gg/n8R5VaWDAn
 [goosehints]: /docs/guides/context-engineering/using-goosehints
 [configure-llm-provider]: /docs/getting-started/providers
 [extensions-directory]: /extensions

--- a/documentation/docs/tutorials/headless-goose.md
+++ b/documentation/docs/tutorials/headless-goose.md
@@ -323,4 +323,4 @@ Whether you're looking to streamline your CI/CD pipelines, automate server maint
 3. **Test in a safe environment** before deploying to production
 4. **Integrate with your existing workflows** and watch your productivity soar
 
-Connect with us on our [Discord community](https://discord.gg/goose-oss) to share your headless mode success stories, ask questions, and collaborate with other developers who want to push the boundaries of AI automation.
+Connect with us on our [Discord community](https://discord.gg/n8R5VaWDAn) to share your headless mode success stories, ask questions, and collaborate with other developers who want to push the boundaries of AI automation.

--- a/documentation/docs/tutorials/isolated-development-environments.md
+++ b/documentation/docs/tutorials/isolated-development-environments.md
@@ -116,7 +116,7 @@ If you encounter issues:
 
 1. Check the **[Container Use GitHub repository](https://github.com/dagger/container-use)** for documentation
 2. Verify all prerequisites are installed and working
-3. Join our [Discord community](https://discord.gg/goose-oss) for support
+3. Join our [Discord community](https://discord.gg/n8R5VaWDAn) for support
 
 ## Next Steps
 

--- a/documentation/docs/tutorials/plan-feature-devcontainer-setup.md
+++ b/documentation/docs/tutorials/plan-feature-devcontainer-setup.md
@@ -451,7 +451,7 @@ The key is treating goose as a planning partner, not just a code generator. Give
 
 - Try this approach with your own complex setup challenges
 - Experiment with different types of planning prompts
-- Share your planning successes with the [goose community](https://discord.gg/goose-oss)
+- Share your planning successes with the [goose community](https://discord.gg/n8R5VaWDAn)
 - Explore how planning integrates with [Subagents](/docs/guides/context-engineering/subagents) for even more sophisticated workflows
 
 Remember, the goal is to get the right approach, in the right order, with the right safeguards. That's what makes the difference between a quick fix and a robust, maintainable solution.

--- a/documentation/docusaurus.config.ts
+++ b/documentation/docusaurus.config.ts
@@ -473,7 +473,7 @@ const config: Config = {
         },
 
         {
-          href: "https://discord.gg/goose-oss",
+          href: "https://discord.gg/n8R5VaWDAn",
           label: "Discord",
           position: "right",
         },
@@ -508,7 +508,7 @@ const config: Config = {
             },
             {
               label: "Discord",
-              href: "https://discord.gg/goose-oss",
+              href: "https://discord.gg/n8R5VaWDAn",
             },
             {
               label: "YouTube",

--- a/documentation/src/pages/community/index.tsx
+++ b/documentation/src/pages/community/index.tsx
@@ -45,7 +45,7 @@ function UpcomingEventsSection() {
       
       {/* Call to Action */}
       <p className="italic text-textStandard">
-        Have ideas for future events? Reach out to the team on <Link href="https://discord.gg/goose-oss">Discord</Link>. 
+        Have ideas for future events? Reach out to the team on <Link href="https://discord.gg/n8R5VaWDAn">Discord</Link>.
         You may also add this calendar to yours via{' '}
         <Link href="https://calendar.google.com/calendar/embed?src=c_b2b8367dac536ebf757b2745fcc5fbff2099f6c574bc13f83d16423db2dd5535%40group.calendar.google.com&ctz=America%2FNew_York">
           this link
@@ -130,7 +130,7 @@ function CommunityAllStarsSection() {
           <div className="text-sm">
             Want to be a Community All Star? Just start contributing on{' '}
             <Link href="https://github.com/aaif-goose/goose">GitHub</Link>, helping others on{' '}
-            <Link href="https://discord.gg/goose-oss">Discord</Link>, or share your 
+            <Link href="https://discord.gg/n8R5VaWDAn">Discord</Link>, or share your
             goose projects with the community! You can check out the{' '}
             <Link href="https://github.com/aaif-goose/goose/blob/main/CONTRIBUTING.md">contributing guide</Link>{' '}
             for more tips.

--- a/documentation/src/pages/index.tsx
+++ b/documentation/src/pages/index.tsx
@@ -256,7 +256,7 @@ function CommunitySection() {
         </p>
         <div className={styles.communityGrid}>
           <a
-            href="https://discord.gg/goose-oss"
+            href="https://discord.gg/n8R5VaWDAn"
             target="_blank"
             rel="noopener"
             className={styles.communityCard}

--- a/documentation/static/llms.txt
+++ b/documentation/static/llms.txt
@@ -78,7 +78,7 @@ Project-specific hints can be added via `.goosehints` and/or `AGENT.md` files.
 
 - Website: https://goose-docs.ai/
 - GitHub: https://github.com/aaif-goose/goose
-- Discord: https://discord.gg/goose-oss
+- Discord: https://discord.gg/n8R5VaWDAn
 - Extensions Registry: https://goose-docs.ai/extensions/
 - Blog: https://goose-docs.ai/blog/
 


### PR DESCRIPTION
## Summary

Replace the expired `discord.gg/goose-oss` invite throughout the README, contributing guide, website, documentation, and blog with the new permanent Goose invite.

Fixes #10862

## Verification

- Confirmed `https://discord.gg/n8R5VaWDAn` resolves through Discord's API to the Goose server (`1287729918100246654`).
- Searched the full repository and confirmed no `discord.gg/goose-oss` references remain.
- Ran `git diff --check`.

No build or test suite was run because this change only updates links.