### PR TITLE
feat(openrouter): forward session_id and add app category header

### DIFF
--- a/crates/goose/src/providers/openrouter.rs
+++ b/crates/goose/src/providers/openrouter.rs
@@ -65,7 +65,8 @@ impl OpenRouterProvider {
         let api_client = ApiClient::new_with_tls(host, auth, tls_config)?
             .with_request_builder(crate::session_context::session_id_request_builder())
             .with_header("HTTP-Referer", "https://goose-docs.ai")?
-            .with_header("X-Title", "goose")?;
+            .with_header("X-Title", "goose")?
+            .with_header("X-OpenRouter-Categories", "cli-agent,productivity")?;
 
         Ok(Self {
             api_client,
@@ -321,10 +322,13 @@ impl Provider for OpenRouterProvider {
             true,
         )?;
 
-        // Add user field for OpenRouter attribution/rate-limiting
         if !session_id.is_empty() {
             if let Some(obj) = payload.as_object_mut() {
                 obj.insert("user".to_string(), Value::String(session_id.to_string()));
+                obj.insert(
+                    "session_id".to_string(),
+                    Value::String(session_id.to_string()),
+                );
             }
         }
 


### PR DESCRIPTION
## Summary

OpenRouter dashboard provides per-session grouping via a non-standard `session_id` field in the request body. Goose was sending `user` (OpenAI standard end-user field) and `agent-session-id` header (goose telemetry), but neither triggers OpenRouter session grouping or sticky routing.

This PR:
- Injects `session_id` into the request JSON body top-level alongside the existing `user` field
- Adds `X-OpenRouter-Categories: cli-agent,productivity` header for marketplace category attribution
- Removes stale comment that described only the `user` field

## Background

OpenRouter's `session_id` is a proprietary extension field (not part of OpenAI Chat Completions spec). When present, OpenRouter groups requests by session in the dashboard and uses it for sticky routing to maximize prompt cache hits. Without it, only per-request view is available.

`HTTP-Referer` and `X-Title` headers were already implemented. `X-OpenRouter-Categories` was missing.

## Changes

`crates/goose/src/providers/openrouter.rs`:
1. `from_env()`: add `.with_header("X-OpenRouter-Categories", "cli-agent,productivity")`
2. `stream()`: add `obj.insert("session_id", ...)` next to existing `user` field injection

## Verification

- `cargo build -p goose` ✅
- `cargo test -p goose --lib -- openrouter` ✅ (20 passed, 0 failed)
- `cargo clippy -p goose --lib -- -D warnings` ✅
- `cargo fmt` ✅