### PR TITLE
chore: remove the extension and tool count suggestion

### DIFF
--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -1057,18 +1057,6 @@ impl Agent {
         extension_configs
     }
 
-    pub(crate) async fn total_extension_and_tool_counts(&self, session_id: &str) -> (usize, usize) {
-        let (extension_count, tool_count) = self
-            .extension_manager
-            .get_extension_and_tool_counts(session_id)
-            .await;
-
-        (
-            extension_count + self.frontend_extensions.lock().await.len(),
-            tool_count + self.frontend_tools.lock().await.len(),
-        )
-    }
-
     pub async fn add_final_output_tool(&self, response: Response) {
         let mut final_output_tool = self.final_output_tool.lock().await;
         let created_final_output_tool = FinalOutputTool::new(response);
@@ -3711,7 +3699,6 @@ impl Agent {
             .get_extensions_info(&session.working_dir)
             .await;
         tracing::debug!("Retrieved {} extensions info", extensions_info.len());
-        let (extension_count, tool_count) = self.total_extension_and_tool_counts(session_id).await;
 
         let model_config = self.model_config_for_session(session_id).await?;
         let model_name = &model_config.model_name;
@@ -3723,7 +3710,6 @@ impl Agent {
             .builder()
             .with_extensions(extensions_info.into_iter())
             .with_frontend_instructions(self.frontend_instructions.lock().await.clone())
-            .with_extension_and_tool_counts(extension_count, tool_count)
             .with_goose_mode(goose_mode)
             .build();
 

--- a/crates/goose/src/agents/extension_manager.rs
+++ b/crates/goose/src/agents/extension_manager.rs
@@ -1291,18 +1291,6 @@ impl ExtensionManager {
         }
     }
 
-    pub async fn get_extension_and_tool_counts(&self, session_id: &str) -> (usize, usize) {
-        let enabled_extensions_count = self.extensions.lock().await.len();
-
-        let total_tools = self
-            .get_prefixed_tools(session_id, None)
-            .await
-            .map(|tools| tools.len())
-            .unwrap_or(0);
-
-        (enabled_extensions_count, total_tools)
-    }
-
     pub async fn list_extensions(&self) -> ExtensionResult<Vec<String>> {
         Ok(self.extensions.lock().await.keys().cloned().collect())
     }

--- a/crates/goose/src/agents/prompt_manager.rs
+++ b/crates/goose/src/agents/prompt_manager.rs
@@ -16,9 +16,6 @@ use crate::{
 };
 use std::path::Path;
 
-const MAX_EXTENSIONS: usize = 5;
-const MAX_TOOLS: usize = 50;
-
 pub struct PromptManager {
     system_prompt_override: Option<String>,
     system_prompt_extras: IndexMap<String, String>,
@@ -36,13 +33,9 @@ impl Default for PromptManager {
 struct SystemPromptContext {
     extensions: Vec<ExtensionInfo>,
     current_date_time: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    extension_tool_limits: Option<(usize, usize)>,
     goose_mode: GooseMode,
     is_autonomous: bool,
     enable_subagents: bool,
-    max_extensions: usize,
-    max_tools: usize,
     code_execution_mode: bool,
     include_extensions: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -55,7 +48,6 @@ pub struct SystemPromptBuilder<'a, M> {
     extensions_info: Vec<ExtensionInfo>,
     frontend_instructions: Option<String>,
     prompt_extras: IndexMap<String, String>,
-    extension_tool_count: Option<(usize, usize)>,
     subagents_enabled: bool,
     hints: Option<String>,
     code_execution_mode: bool,
@@ -86,15 +78,6 @@ impl<'a> SystemPromptBuilder<'a, PromptManager> {
         extras: impl IntoIterator<Item = (String, String)>,
     ) -> Self {
         self.prompt_extras.extend(extras);
-        self
-    }
-
-    pub fn with_extension_and_tool_counts(
-        mut self,
-        extension_count: usize,
-        tool_count: usize,
-    ) -> Self {
-        self.extension_tool_count = Some((extension_count, tool_count));
         self
     }
 
@@ -156,19 +139,12 @@ impl<'a> SystemPromptBuilder<'a, PromptManager> {
             .goose_mode
             .unwrap_or_else(|| Config::global().get_goose_mode().unwrap_or_default());
 
-        let extension_tool_limits = self
-            .extension_tool_count
-            .filter(|(extensions, tools)| *extensions > MAX_EXTENSIONS || *tools > MAX_TOOLS);
-
         let context = SystemPromptContext {
             extensions: sanitized_extensions_info,
             current_date_time: self.manager.current_date_timestamp.clone(),
-            extension_tool_limits,
             goose_mode,
             is_autonomous: goose_mode == GooseMode::Auto,
             enable_subagents: self.subagents_enabled,
-            max_extensions: MAX_EXTENSIONS,
-            max_tools: MAX_TOOLS,
             code_execution_mode: self.code_execution_mode,
             include_extensions: self.include_extensions,
             moim_system_prompt_block: moim::system_prompt_block(),
@@ -298,7 +274,6 @@ impl PromptManager {
             extensions_info: vec![],
             frontend_instructions: None,
             prompt_extras: IndexMap::new(),
-            extension_tool_count: None,
             subagents_enabled: false,
             hints: None,
             code_execution_mode: false,
@@ -514,7 +489,6 @@ mod tests {
                 "<instructions on how to use extension B (no resources)>",
                 false,
             ))
-            .with_extension_and_tool_counts(MAX_EXTENSIONS + 1, MAX_TOOLS + 1)
             .build();
 
         assert_snapshot!(system_prompt)

--- a/crates/goose/src/agents/reply_parts.rs
+++ b/crates/goose/src/agents/reply_parts.rs
@@ -205,8 +205,6 @@ impl Agent {
             .extension_manager
             .get_extensions_info(working_dir)
             .await;
-        let (extension_count, tool_count) = self.total_extension_and_tool_counts(session_id).await;
-
         let model_config = self.model_config_for_session(session_id).await?;
 
         let goose_mode = *self.current_goose_mode.lock().await;
@@ -220,7 +218,6 @@ impl Agent {
             .builder()
             .with_extensions(extensions_info.into_iter())
             .with_frontend_instructions(self.frontend_instructions.lock().await.clone())
-            .with_extension_and_tool_counts(extension_count, tool_count)
             .with_code_execution_mode(code_execution_active)
             .with_hints(working_dir)
             .with_goose_mode(goose_mode)

--- a/crates/goose/src/agents/snapshots/goose__agents__prompt_manager__tests__all_platform_extensions.snap
+++ b/crates/goose/src/agents/snapshots/goose__agents__prompt_manager__tests__all_platform_extensions.snap
@@ -156,7 +156,6 @@ Template:
 
 
 
-
 # Response Guidelines
 
 Use Markdown formatting for all responses.

--- a/crates/goose/src/agents/snapshots/goose__agents__prompt_manager__tests__basic.snap
+++ b/crates/goose/src/agents/snapshots/goose__agents__prompt_manager__tests__basic.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/goose/src/agents/prompt_manager.rs
+assertion_line: 457
 expression: system_prompt
 ---
 You are a general-purpose AI agent called goose, created by AAIF (Agentic AI Foundation).
@@ -29,7 +30,6 @@ Extensions provide additional tools and context from different data sources and 
 You can dynamically enable or disable extensions as needed to help complete tasks.
 
 No extensions are defined. You should let the user know that they should add extensions.
-
 
 # Response Guidelines
 

--- a/crates/goose/src/agents/snapshots/goose__agents__prompt_manager__tests__one_extension.snap
+++ b/crates/goose/src/agents/snapshots/goose__agents__prompt_manager__tests__one_extension.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/goose/src/agents/prompt_manager.rs
+assertion_line: 473
 expression: system_prompt
 ---
 You are a general-purpose AI agent called goose, created by AAIF (Agentic AI Foundation).
@@ -39,7 +40,6 @@ in your tool specification.
 test supports resources.
 ### Instructions
 how to use this extension
-
 
 # Response Guidelines
 

--- a/crates/goose/src/agents/snapshots/goose__agents__prompt_manager__tests__typical_setup.snap
+++ b/crates/goose/src/agents/snapshots/goose__agents__prompt_manager__tests__typical_setup.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/goose/src/agents/prompt_manager.rs
+assertion_line: 494
 expression: system_prompt
 ---
 You are a general-purpose AI agent called goose, created by AAIF (Agentic AI Foundation).
@@ -43,11 +44,6 @@ extension_A supports resources.
 
 ### Instructions
 <instructions on how to use extension B (no resources)>
-
-# Suggestion
-
-The user has 6 extensions with 51 tools enabled, exceeding recommended limits (5 extensions or 50 tools).
-Consider asking if they'd like to disable some extensions to improve tool selection accuracy.
 
 # Response Guidelines
 

--- a/crates/goose/src/prompts/system.md
+++ b/crates/goose/src/prompts/system.md
@@ -34,15 +34,6 @@ No extensions are defined. You should let the user know that they should add ext
 {% endif %}
 {% endif %}
 
-{% if include_extensions and extension_tool_limits is defined and not code_execution_mode %}
-{% with (extension_count, tool_count) = extension_tool_limits  %}
-# Suggestion
-
-The user has {{extension_count}} extensions with {{tool_count}} tools enabled, exceeding recommended limits ({{max_extensions}} extensions or {{max_tools}} tools).
-Consider asking if they'd like to disable some extensions to improve tool selection accuracy.
-{% endwith %}
-{% endif %}
-
 # Response Guidelines
 
 Use Markdown formatting for all responses.


### PR DESCRIPTION
## Summary

Closes #10841.

The system prompt appended a `# Suggestion` block when the user had more than 5 extensions or 50 tools enabled, asking the model to suggest disabling some. As noted in the issue, frontier models handle large tool sets fine now, and the threshold was low enough that the block fired with just the default extensions we ship.

Removes the prompt block together with everything that fed it: the `MAX_EXTENSIONS` / `MAX_TOOLS` thresholds, the `extension_tool_limits` context field, `with_extension_and_tool_counts`, and the two counting helpers (`total_extension_and_tool_counts`, `get_extension_and_tool_counts`) that no other caller uses.

Three snapshots are updated: `typical_setup` loses the suggestion block, `basic` and `one_extension` lose the blank line the template block left behind.

## Testing

Verified on Windows only, against the `x86_64-pc-windows-gnu` target — CI will be the first run on msvc and Linux.

- `cargo test -p goose --lib prompt_manager` — 11 passed, 1 failed, which is the same result as on an unmodified tree.
- The one failure is `test_all_platform_extensions`, and it already fails on a clean checkout on Windows: the prompt there substitutes `findstr` / `Get-Content` for the unix commands, so the snapshot recorded on Linux cannot match. I left that snapshot untouched.
- `cargo fmt --check` — clean.
- `cargo clippy -p goose --all-targets` — no new warnings. The few that do appear are pre-existing `#[cfg(unix)]` artifacts on Windows and are unrelated to this change.
