### PR TITLE
test: stabilize compaction summary assertion

### DIFF
--- a/crates/goose/tests/compaction.rs
+++ b/crates/goose/tests/compaction.rs
@@ -245,19 +245,23 @@ fn assert_conversation_compacted(conversation: &Conversation) {
     let messages = conversation.messages();
     assert!(!messages.is_empty(), "Conversation should not be empty");
 
-    // Find the summary message (contains "mock summary")
+    // Find the actual compaction summary message. Match on both content and
+    // visibility so an ordinary visible user/assistant message that happens to
+    // mention "mock summary" is not mistaken for the summary boundary.
     let summary_index = messages
         .iter()
         .position(|msg| {
-            msg.content.iter().any(|content| {
-                if let MessageContent::Text(text) = content {
-                    text.text.contains("mock summary")
-                } else {
-                    false
-                }
-            })
+            msg.is_agent_visible()
+                && !msg.is_user_visible()
+                && msg.content.iter().any(|content| {
+                    if let MessageContent::Text(text) = content {
+                        text.text.contains("mock summary")
+                    } else {
+                        false
+                    }
+                })
         })
-        .expect("Conversation should contain the summary message");
+        .expect("Conversation should contain an agent-only summary message");
 
     let summary_msg = &messages[summary_index];
 
@@ -334,6 +338,20 @@ fn assert_conversation_compacted(conversation: &Conversation) {
             }
         }
     }
+}
+
+#[test]
+fn compacted_conversation_assertion_ignores_user_visible_mock_summary_text() {
+    let conversation = Conversation::new_unvalidated(vec![
+        Message::user()
+            .with_text("This visible user message mentions mock summary before compaction")
+            .user_only(),
+        Message::assistant()
+            .with_text("<mock summary of conversation>")
+            .with_metadata(goose::conversation::message::MessageMetadata::agent_only()),
+    ]);
+
+    assert_conversation_compacted(&conversation);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- make the compaction test helper identify the actual summary boundary by both content and visibility
- add a regression test covering an older user-visible message that mentions the mock summary text before the real agent-only summary
- keep the existing recovery compaction assertions intact while avoiding a brittle content-only boundary match

### Testing
- `RUSTUP_TOOLCHAIN=stable cargo fmt --check`
- `CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse RUSTUP_TOOLCHAIN=stable cargo test --locked -p goose --test compaction --no-default-features --features rustls-tls,code-mode -- --nocapture`
- `CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse RUSTUP_TOOLCHAIN=stable cargo test --locked -p goose --test compaction test_context_limit_recovery_compaction --no-default-features --features rustls-tls,code-mode -- --exact --quiet` repeated 20 times locally

### Related Issues
Fixes #10828

### Screenshots/Demos (for UX changes)
Before: n/a

After: n/a
