### PR TITLE
fix(acp): honor explicit context limit

### DIFF
--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -2794,6 +2794,7 @@ mod tests {
         let current_model_config = goose_providers::model::ModelConfig {
             model_name: "gpt-4o".to_string(),
             context_limit: Some(128_000),
+            context_limit_explicit: false,
             temperature: Some(0.25),
             max_tokens: Some(16_384),
             toolshim: true,

--- a/crates/goose-provider-types/src/formats/databricks.rs
+++ b/crates/goose-provider-types/src/formats/databricks.rs
@@ -1064,6 +1064,7 @@ mod tests {
         let model_config = ModelConfig {
             model_name: "gpt-4o".to_string(),
             context_limit: Some(4096),
+            context_limit_explicit: false,
             temperature: None,
             max_tokens: Some(1024),
             toolshim: false,
@@ -1099,6 +1100,7 @@ mod tests {
         let model_config = ModelConfig {
             model_name: "o3-mini".to_string(),
             context_limit: Some(4096),
+            context_limit_explicit: false,
             temperature: None,
             max_tokens: Some(1024),
             toolshim: false,
@@ -1119,6 +1121,7 @@ mod tests {
         let model_config = ModelConfig {
             model_name: "databricks-o3-mini".to_string(),
             context_limit: Some(4096),
+            context_limit_explicit: false,
             temperature: None,
             max_tokens: Some(1024),
             toolshim: false,
@@ -1140,6 +1143,7 @@ mod tests {
         let model_config = ModelConfig {
             model_name: "databricks-gpt-5.2-pro".to_string(),
             context_limit: Some(4096),
+            context_limit_explicit: false,
             temperature: None,
             max_tokens: Some(1024),
             toolshim: false,
@@ -1159,6 +1163,7 @@ mod tests {
         let model_config = ModelConfig {
             model_name: "o3-xhigh".to_string(),
             context_limit: Some(4096),
+            context_limit_explicit: false,
             temperature: None,
             max_tokens: Some(1024),
             toolshim: false,
@@ -1178,6 +1183,7 @@ mod tests {
         let model_config = ModelConfig {
             model_name: "o3-none".to_string(),
             context_limit: Some(4096),
+            context_limit_explicit: false,
             temperature: None,
             max_tokens: Some(1024),
             toolshim: false,
@@ -1197,6 +1203,7 @@ mod tests {
         let model_config = ModelConfig {
             model_name: "databricks-gpt-5.4-high".to_string(),
             context_limit: Some(4096),
+            context_limit_explicit: false,
             temperature: None,
             max_tokens: Some(1024),
             toolshim: false,
@@ -1687,6 +1694,7 @@ mod tests {
         let model_config = ModelConfig {
             model_name: "databricks-claude-sonnet-4".to_string(),
             context_limit: Some(200000),
+            context_limit_explicit: false,
             temperature: None,
             max_tokens: Some(8192),
             toolshim: false,
@@ -1740,6 +1748,7 @@ mod tests {
         let model_config = ModelConfig {
             model_name: "gpt-4o".to_string(),
             context_limit: Some(128000),
+            context_limit_explicit: false,
             temperature: None,
             max_tokens: Some(4096),
             toolshim: false,

--- a/crates/goose-provider-types/src/formats/openai_responses.rs
+++ b/crates/goose-provider-types/src/formats/openai_responses.rs
@@ -1351,6 +1351,7 @@ mod tests {
         let model_config = ModelConfig {
             model_name: "gpt-5.2-codex".to_string(),
             context_limit: None,
+            context_limit_explicit: false,
             temperature: None,
             max_tokens: None,
             toolshim: false,
@@ -1439,6 +1440,7 @@ mod tests {
         let model_config = ModelConfig {
             model_name: "gpt-5.4".to_string(),
             context_limit: None,
+            context_limit_explicit: false,
             temperature: None,
             max_tokens: None,
             toolshim: false,
@@ -1483,6 +1485,7 @@ mod tests {
             let model_config = ModelConfig {
                 model_name: model_name.to_string(),
                 context_limit: None,
+                context_limit_explicit: false,
                 temperature: None,
                 max_tokens: None,
                 toolshim: false,
@@ -1564,6 +1567,7 @@ mod tests {
             let model_config = ModelConfig {
                 model_name: model_name.to_string(),
                 context_limit: None,
+                context_limit_explicit: false,
                 temperature: None,
                 max_tokens: None,
                 toolshim: false,
@@ -1615,6 +1619,7 @@ mod tests {
         let model_config = ModelConfig {
             model_name: "gpt-4o".to_string(),
             context_limit: None,
+            context_limit_explicit: false,
             temperature: None,
             max_tokens: None,
             toolshim: false,
@@ -1638,6 +1643,7 @@ mod tests {
         let model_config = ModelConfig {
             model_name: "o3".to_string(),
             context_limit: None,
+            context_limit_explicit: false,
             temperature: None,
             max_tokens: None,
             toolshim: false,
@@ -1666,6 +1672,7 @@ mod tests {
         let model_config = ModelConfig {
             model_name: "gpt-5.5".to_string(),
             context_limit: None,
+            context_limit_explicit: false,
             temperature: None,
             max_tokens: None,
             toolshim: false,
@@ -1715,6 +1722,7 @@ mod tests {
         let model_config = ModelConfig {
             model_name: "gpt-5.5".to_string(),
             context_limit: None,
+            context_limit_explicit: false,
             temperature: None,
             max_tokens: None,
             toolshim: false,
@@ -1752,6 +1760,7 @@ mod tests {
         let model_config = ModelConfig {
             model_name: "gpt-5.5".to_string(),
             context_limit: None,
+            context_limit_explicit: false,
             temperature: None,
             max_tokens: None,
             toolshim: false,
@@ -1784,6 +1793,7 @@ mod tests {
         let model_config = ModelConfig {
             model_name: "gpt-5.5".to_string(),
             context_limit: None,
+            context_limit_explicit: false,
             temperature: None,
             max_tokens: None,
             toolshim: false,
@@ -1815,6 +1825,7 @@ mod tests {
         let model_config = ModelConfig {
             model_name: "gpt-5.5".to_string(),
             context_limit: None,
+            context_limit_explicit: false,
             temperature: None,
             max_tokens: None,
             toolshim: false,
@@ -1849,6 +1860,7 @@ mod tests {
         let model_config = ModelConfig {
             model_name: "gpt-5.5".to_string(),
             context_limit: None,
+            context_limit_explicit: false,
             temperature: None,
             max_tokens: None,
             toolshim: false,
@@ -1888,6 +1900,7 @@ mod tests {
         let model_config = ModelConfig {
             model_name: "gpt-5.5".to_string(),
             context_limit: None,
+            context_limit_explicit: false,
             temperature: None,
             max_tokens: None,
             toolshim: false,
@@ -1914,6 +1927,7 @@ mod tests {
         let model_config = ModelConfig {
             model_name: "gpt-5.5".to_string(),
             context_limit: None,
+            context_limit_explicit: false,
             temperature: None,
             max_tokens: None,
             toolshim: false,
@@ -1946,6 +1960,7 @@ mod tests {
         let model_config = ModelConfig {
             model_name: "gpt-5.5".to_string(),
             context_limit: None,
+            context_limit_explicit: false,
             temperature: None,
             max_tokens: None,
             toolshim: false,
@@ -1978,6 +1993,7 @@ mod tests {
         let model_config = ModelConfig {
             model_name: "gpt-5.5".to_string(),
             context_limit: None,
+            context_limit_explicit: false,
             temperature: None,
             max_tokens: None,
             toolshim: false,
@@ -2121,6 +2137,7 @@ mod tests {
         let model_config = ModelConfig {
             model_name: "gpt-5.5".to_string(),
             context_limit: None,
+            context_limit_explicit: false,
             temperature: None,
             max_tokens: None,
             toolshim: false,
@@ -2162,6 +2179,7 @@ mod tests {
         let model_config = ModelConfig {
             model_name: "gpt-5.5".to_string(),
             context_limit: None,
+            context_limit_explicit: false,
             temperature: None,
             max_tokens: None,
             toolshim: false,
@@ -2194,6 +2212,7 @@ mod tests {
         let model_config = ModelConfig {
             model_name: "gpt-5.5".to_string(),
             context_limit: None,
+            context_limit_explicit: false,
             temperature: None,
             max_tokens: None,
             toolshim: false,
@@ -2226,6 +2245,7 @@ mod tests {
         let model_config = ModelConfig {
             model_name: "gpt-5.5".to_string(),
             context_limit: None,
+            context_limit_explicit: false,
             temperature: None,
             max_tokens: None,
             toolshim: false,
@@ -2264,6 +2284,7 @@ mod tests {
         let model_config = ModelConfig {
             model_name: "gpt-5.5".to_string(),
             context_limit: None,
+            context_limit_explicit: false,
             temperature: None,
             max_tokens: None,
             toolshim: false,

--- a/crates/goose-provider-types/src/model.rs
+++ b/crates/goose-provider-types/src/model.rs
@@ -27,6 +27,10 @@ const INHERITED_SESSION_PARAM_KEYS: &[&str] = &[
 pub struct ModelConfig {
     pub model_name: String,
     pub context_limit: Option<usize>,
+    /// True when `context_limit` came from an explicit user/request override
+    /// rather than canonical model metadata or a provider default.
+    #[serde(default)]
+    pub context_limit_explicit: bool,
     pub temperature: Option<f32>,
     pub max_tokens: Option<i32>,
     pub toolshim: bool,
@@ -51,6 +55,8 @@ impl<'de> Deserialize<'de> for ModelConfig {
         struct RawModelConfig {
             model_name: String,
             context_limit: Option<usize>,
+            #[serde(default)]
+            context_limit_explicit: bool,
             temperature: Option<f32>,
             max_tokens: Option<i32>,
             toolshim: bool,
@@ -65,6 +71,7 @@ impl<'de> Deserialize<'de> for ModelConfig {
         let mut config = Self {
             model_name: raw.model_name,
             context_limit: raw.context_limit,
+            context_limit_explicit: raw.context_limit_explicit,
             temperature: raw.temperature,
             max_tokens: raw.max_tokens,
             toolshim: raw.toolshim,
@@ -83,6 +90,7 @@ impl ModelConfig {
         let mut config = Self {
             model_name: model_name.as_ref().to_string(),
             context_limit: None,
+            context_limit_explicit: false,
             temperature: None,
             max_tokens: None,
             toolshim: false,
@@ -133,8 +141,13 @@ impl ModelConfig {
     pub fn with_context_limit(mut self, limit: Option<usize>) -> Self {
         if limit.is_some() {
             self.context_limit = limit;
+            self.context_limit_explicit = true;
         }
         self
+    }
+
+    pub fn has_explicit_context_limit(&self) -> bool {
+        self.context_limit.is_some() && self.context_limit_explicit
     }
 
     pub fn with_temperature(mut self, temp: Option<f32>) -> Self {

--- a/crates/goose/src/acp/provider.rs
+++ b/crates/goose/src/acp/provider.rs
@@ -414,6 +414,10 @@ impl Provider for AcpProvider {
     }
 
     async fn get_context_limit(&self, model_config: &ModelConfig) -> Result<usize, ProviderError> {
+        if let Some(context_limit) = model_config.context_limit {
+            return Ok(context_limit);
+        }
+
         let size = self.context_size.load(Ordering::Relaxed);
         if size > 0 {
             return Ok(size as usize);
@@ -2001,6 +2005,16 @@ mod tests {
 
         provider.context_size.store(200_000, Ordering::Relaxed);
         assert_eq!(provider.get_context_limit(&model).await.unwrap(), 200_000);
+    }
+
+    #[tokio::test]
+    async fn explicit_context_limit_overrides_captured_context_size() {
+        let (provider, model) = test_provider();
+        let model = model.with_context_limit(Some(64_000));
+
+        provider.context_size.store(200_000, Ordering::Relaxed);
+
+        assert_eq!(provider.get_context_limit(&model).await.unwrap(), 64_000);
     }
 
     #[tokio::test]

--- a/crates/goose/src/acp/provider.rs
+++ b/crates/goose/src/acp/provider.rs
@@ -414,8 +414,10 @@ impl Provider for AcpProvider {
     }
 
     async fn get_context_limit(&self, model_config: &ModelConfig) -> Result<usize, ProviderError> {
-        if let Some(context_limit) = model_config.context_limit {
-            return Ok(context_limit);
+        if model_config.has_explicit_context_limit() {
+            if let Some(context_limit) = model_config.context_limit {
+                return Ok(context_limit);
+            }
         }
 
         let size = self.context_size.load(Ordering::Relaxed);
@@ -2018,10 +2020,21 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn derived_context_limit_does_not_override_captured_context_size() {
+        let (provider, mut model) = test_provider();
+        model.context_limit = Some(128_000);
+
+        provider.context_size.store(200_000, Ordering::Relaxed);
+
+        assert_eq!(provider.get_context_limit(&model).await.unwrap(), 200_000);
+    }
+
+    #[tokio::test]
     async fn failed_first_prompt_send_rolls_back_handoff_context_claim() {
         let (tx, rx) = mpsc::channel(1);
         drop(rx);
         let (provider, model) = test_provider_with_tx(Some(tx));
+
         let messages = vec![
             Message::assistant().with_text("prior answer"),
             Message::user().with_text("current request"),

--- a/crates/goose/src/context_mgmt/mod.rs
+++ b/crates/goose/src/context_mgmt/mod.rs
@@ -706,6 +706,7 @@ mod tests {
                 config: ModelConfig {
                     model_name: "test".to_string(),
                     context_limit: Some(context_limit),
+                    context_limit_explicit: false,
                     temperature: None,
                     max_tokens: None,
                     toolshim: false,

--- a/crates/goose/src/model_config.rs
+++ b/crates/goose/src/model_config.rs
@@ -64,7 +64,9 @@ fn materialize_model_config_inner(
     }
 
     if let Some(context_limit) = config.get_goose_context_limit()? {
-        model = model.with_context_limit(Some(context_limit));
+        if !model.has_explicit_context_limit() {
+            model = model.with_context_limit(Some(context_limit));
+        }
     }
     model = model.with_default_max_tokens(config.get_goose_max_tokens()?);
 

--- a/crates/goose/src/model_config.rs
+++ b/crates/goose/src/model_config.rs
@@ -63,9 +63,10 @@ fn materialize_model_config_inner(
         model = model.with_toolshim_model(get_goose_toolshim_model(config)?);
     }
 
-    model = model
-        .with_default_context_limit(config.get_goose_context_limit()?)
-        .with_default_max_tokens(config.get_goose_max_tokens()?);
+    if let Some(context_limit) = config.get_goose_context_limit()? {
+        model = model.with_context_limit(Some(context_limit));
+    }
+    model = model.with_default_max_tokens(config.get_goose_max_tokens()?);
 
     if include_default_thinking_effort {
         model = model.with_default_thinking_effort(config.get_goose_thinking_effort());
@@ -185,6 +186,7 @@ fn base_model_config_from_user_config(
     let mut model = ModelConfig {
         model_name: model_name.to_string(),
         context_limit: None,
+        context_limit_explicit: false,
         temperature: get_goose_temperature(config)?,
         max_tokens: None,
         toolshim: get_goose_toolshim(config)?.unwrap_or(false),

--- a/crates/goose/src/providers/bedrock.rs
+++ b/crates/goose/src/providers/bedrock.rs
@@ -935,6 +935,7 @@ mod tests {
             ModelConfig {
                 model_name: model_name.to_string(),
                 context_limit: None,
+                context_limit_explicit: false,
                 temperature: None,
                 max_tokens: None,
                 toolshim: false,

--- a/crates/goose/src/providers/init.rs
+++ b/crates/goose/src/providers/init.rs
@@ -507,6 +507,31 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_goose_context_limit_preserves_explicit_model_limit() {
+        let _guard = env_lock::lock_env([
+            ("GOOSE_PATH_ROOT", None::<&str>),
+            ("GOOSE_CONTEXT_LIMIT", Some("1000000")),
+            ("GOOSE_MAX_TOKENS", None::<&str>),
+            ("GOOSE_TEMPERATURE", None::<&str>),
+            ("GOOSE_TOOLSHIM", None::<&str>),
+            ("GOOSE_TOOLSHIM_OLLAMA_MODEL", None::<&str>),
+            ("GOOSE_THINKING_EFFORT", None::<&str>),
+        ]);
+
+        let openai = get_from_registry("openai")
+            .await
+            .expect("openai provider should be registered");
+        let explicit = openai
+            .normalize_model_config(
+                ModelConfig::new("totally-unknown-model").with_context_limit(Some(64_000)),
+            )
+            .expect("explicit model config should normalize");
+
+        assert_eq!(explicit.context_limit(), 64_000);
+        assert!(explicit.has_explicit_context_limit());
+    }
+
+    #[tokio::test]
     async fn test_litellm_supports_inventory_refresh() {
         let entry = get_from_registry("litellm")
             .await

--- a/crates/goose/src/providers/openrouter.rs
+++ b/crates/goose/src/providers/openrouter.rs
@@ -378,6 +378,7 @@ mod tests {
         ModelConfig {
             model_name: model_name.to_string(),
             context_limit: None,
+            context_limit_explicit: false,
             temperature: None,
             max_tokens: None,
             toolshim: false,

--- a/crates/goose/src/session/session_manager.rs
+++ b/crates/goose/src/session/session_manager.rs
@@ -2616,6 +2616,7 @@ mod tests {
         let json = serde_json::to_string(&ModelConfig {
             model_name: "gpt-5-high".to_string(),
             context_limit: None,
+            context_limit_explicit: false,
             temperature: None,
             max_tokens: None,
             toolshim: false,


### PR DESCRIPTION
## Summary
- make an explicit ACP model context limit take precedence over the context size later reported by the agent
- preserve the current behavior where the captured ACP context size is used when no explicit context limit is configured
- add a regression test for the explicit-limit precedence case

### Testing
- `RUSTUP_TOOLCHAIN=stable cargo fmt --check`
- `TMP=$(cygpath -w /k/tmp/rust-link) TEMP=$(cygpath -w /k/tmp/rust-link) CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse RUSTUP_TOOLCHAIN=stable cargo test --locked -p goose --lib acp::provider::tests::explicit_context_limit_overrides_captured_context_size --no-default-features --features rustls-tls,code-mode -- --exact --nocapture`
- `TMP=$(cygpath -w /k/tmp/rust-link) TEMP=$(cygpath -w /k/tmp/rust-link) CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse RUSTUP_TOOLCHAIN=stable cargo test --locked -p goose --lib acp::provider::tests::get_context_limit_surfaces_captured_context_size --no-default-features --features rustls-tls,code-mode -- --exact --nocapture`
- `TMP=$(cygpath -w /k/tmp/rust-link) TEMP=$(cygpath -w /k/tmp/rust-link) CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse RUSTUP_TOOLCHAIN=stable cargo test --locked -p goose --lib acp::provider::tests --no-default-features --features rustls-tls,code-mode -- --nocapture`

### Related Issues
Fixes #10776

### Screenshots/Demos (for UX changes)
Before: n/a

After: n/a
