### PR TITLE
fix(cli): clarify Copilot ACP auth failures

### DIFF
--- a/crates/goose-cli/src/commands/configure.rs
+++ b/crates/goose-cli/src/commands/configure.rs
@@ -917,7 +917,15 @@ pub async fn configure_provider_dialog() -> anyhow::Result<bool> {
 
     let spin = spinner();
     spin.start("Attempting to fetch supported models...");
-    let temp_provider = create(&provider_name, Vec::new()).await?;
+    let temp_provider = match create(&provider_name, Vec::new()).await {
+        Ok(provider) => provider,
+        Err(e) => {
+            let message = provider_creation_error_message(&provider_name, &e);
+            spin.stop(style(&message).red());
+            cliclack::outro(style(message).on_red().white())?;
+            return Ok(false);
+        }
+    };
     let models_res = retry_operation(&RetryConfig::default(), || async {
         temp_provider
             .fetch_recommended_models(goose::model_config::global_toolshim())
@@ -1013,6 +1021,10 @@ GitHub Copilot CLI authentication is required. Run `copilot login` and retry `go
     } else {
         message
     }
+}
+
+fn provider_creation_error_message(provider_name: &str, error: impl std::fmt::Display) -> String {
+    provider_configuration_error_message(provider_name, error)
 }
 
 /// Configure extensions that can be used with goose
@@ -2403,6 +2415,17 @@ mod tests {
         let error = anyhow::anyhow!("ACP session/new failed: Authentication required");
 
         let message = provider_configuration_error_message("copilot-acp", &error);
+
+        assert!(message.contains("ACP session/new failed: Authentication required"));
+        assert!(message.contains("GitHub Copilot CLI authentication is required"));
+        assert!(message.contains("copilot login"));
+    }
+
+    #[test]
+    fn copilot_acp_provider_creation_errors_include_login_hint() {
+        let error = anyhow::anyhow!("ACP session/new failed: Authentication required");
+
+        let message = provider_creation_error_message("copilot-acp", &error);
 
         assert!(message.contains("ACP session/new failed: Authentication required"));
         assert!(message.contains("GitHub Copilot CLI authentication is required"));

--- a/crates/goose-cli/src/commands/configure.rs
+++ b/crates/goose-cli/src/commands/configure.rs
@@ -930,7 +930,11 @@ pub async fn configure_provider_dialog() -> anyhow::Result<bool> {
     let model: String = match models_res {
         Err(e) => {
             // Provider hook error
-            cliclack::outro(style(e.to_string()).on_red().white())?;
+            cliclack::outro(
+                style(provider_configuration_error_message(&provider_name, &e))
+                    .on_red()
+                    .white(),
+            )?;
             return Ok(false);
         }
         Ok(models) if !models.is_empty() => select_model_from_list(&models, provider_meta)?,
@@ -982,14 +986,32 @@ pub async fn configure_provider_dialog() -> anyhow::Result<bool> {
             Ok(true)
         }
         Err(e) => {
-            spin.stop(style(e.to_string()).red());
+            let message = provider_configuration_error_message(&provider_name, &e);
+            spin.stop(style(&message).red());
             cliclack::outro(
-                style(format!("Failed to configure provider: {e}"))
+                style(format!("Failed to configure provider: {message}"))
                     .on_red()
                     .white(),
             )?;
             Ok(false)
         }
+    }
+}
+
+fn provider_configuration_error_message(
+    provider_name: &str,
+    error: impl std::fmt::Display,
+) -> String {
+    let message = error.to_string();
+    if provider_name == "copilot-acp" && message.to_lowercase().contains("authentication required")
+    {
+        format!(
+            "{message}
+
+GitHub Copilot CLI authentication is required. Run `copilot login` and retry `goose configure`. If the Copilot CLI opens an interactive prompt, run `/login` there."
+        )
+    } else {
+        message
     }
 }
 
@@ -2375,5 +2397,24 @@ mod tests {
         let filtered = fuzzy_filter_provider_items(&items, "open ai");
 
         assert_eq!(filtered.first().map(|item| item.0.as_str()), Some("openai"));
+    }
+    #[test]
+    fn copilot_acp_auth_errors_include_login_hint() {
+        let error = anyhow::anyhow!("ACP session/new failed: Authentication required");
+
+        let message = provider_configuration_error_message("copilot-acp", &error);
+
+        assert!(message.contains("ACP session/new failed: Authentication required"));
+        assert!(message.contains("GitHub Copilot CLI authentication is required"));
+        assert!(message.contains("copilot login"));
+    }
+
+    #[test]
+    fn generic_auth_errors_do_not_get_copilot_hint() {
+        let error = anyhow::anyhow!("Authentication required");
+
+        let message = provider_configuration_error_message("other-provider", &error);
+
+        assert_eq!(message, "Authentication required");
     }
 }


### PR DESCRIPTION
## Summary
- add a provider-specific hint when `copilot-acp` configuration fails with `Authentication required`
- surface the hint in both the model-fetch and final configuration-test failure paths
- keep generic provider authentication errors unchanged

### Testing
- `RUSTUP_TOOLCHAIN=stable cargo fmt --check`
- `TMP=$(cygpath -w /k/tmp/rust-link) TEMP=$(cygpath -w /k/tmp/rust-link) CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse RUSTUP_TOOLCHAIN=stable cargo test --locked -p goose-cli commands::configure::tests::copilot_acp_auth_errors_include_login_hint --no-default-features --features rustls-tls,code-mode -- --exact --nocapture`
- `TMP=$(cygpath -w /k/tmp/rust-link) TEMP=$(cygpath -w /k/tmp/rust-link) CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse RUSTUP_TOOLCHAIN=stable cargo test --locked -p goose-cli commands::configure::tests::generic_auth_errors_do_not_get_copilot_hint --no-default-features --features rustls-tls,code-mode -- --exact --nocapture`
- `TMP=$(cygpath -w /k/tmp/rust-link) TEMP=$(cygpath -w /k/tmp/rust-link) CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse RUSTUP_TOOLCHAIN=stable cargo test --locked -p goose-cli commands::configure::tests --no-default-features --features rustls-tls,code-mode -- --nocapture`

### Related Issues
Refs #9978

### Screenshots/Demos (for UX changes)
Before: `ACP session/new failed: Authentication required` did not identify the Copilot CLI login step.

After: the same failure now tells users that GitHub Copilot CLI authentication is required and points them to the Copilot login flow before retrying `goose configure`.
