### PR TITLE
docs(code-mode): clarify callback function calls

### DIFF
--- a/crates/goose/src/agents/platform_extensions/code_execution.rs
+++ b/crates/goose/src/agents/platform_extensions/code_execution.rs
@@ -635,7 +635,7 @@ fn catalog_disclosure_moim(function_count: usize) -> String {
         "No execute_typescript callback functions are currently registered.".to_string()
     } else {
         format!(
-            "{function_count} callback functions are available only from inside execute_typescript. Do not call callback function names directly as tools. Use list_functions and get_function_details to inspect signatures before writing one execute_typescript call."
+            "{function_count} callback functions are available only from inside execute_typescript. Do not call callback function names directly as tools. Use list_functions and get_function_details to inspect signatures before writing one execute_typescript call. Call callbacks as namespace.functionName(...), for example await Developer.write(...). Do not use a `functions.*` wrapper."
         )
     }
 }
@@ -896,6 +896,13 @@ mod tests {
         assert!(moim.contains("get_function_details"));
         assert!(!moim.contains("extract_relations"));
         assert!(!moim.contains("ask_heimdall"));
+    }
+    #[test]
+    fn catalog_moim_warns_against_functions_namespace() {
+        let moim = catalog_disclosure_moim(3);
+
+        assert!(moim.contains("Do not use a `functions.*` wrapper"));
+        assert!(moim.contains("namespace.functionName"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- clarify Code Mode's execute_typescript callback instructions so agents do not invent a `functions.*` wrapper
- point agents to the actual generated TypeScript calling convention: `Namespace.functionName(...)`, e.g. `Developer.write(...)`
- add a regression test for the MOIM hint that prevents the ambiguous `functions.*` guidance from returning

### Testing
- `RUSTUP_TOOLCHAIN=stable cargo fmt --check`
- `TMP=$(cygpath -w /k/tmp/rust-link) TEMP=$(cygpath -w /k/tmp/rust-link) CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse RUSTUP_TOOLCHAIN=stable cargo test --locked -p goose --lib agents::platform_extensions::code_execution::tests::catalog_moim_warns_against_functions_namespace --no-default-features --features rustls-tls,code-mode -- --exact --nocapture`
- `TMP=$(cygpath -w /k/tmp/rust-link) TEMP=$(cygpath -w /k/tmp/rust-link) CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse RUSTUP_TOOLCHAIN=stable cargo test --locked -p goose --lib agents::platform_extensions::code_execution::tests::catalog_moim_mentions_inspection_tools_without_function_names --no-default-features --features rustls-tls,code-mode -- --exact --nocapture`
- `TMP=$(cygpath -w /k/tmp/rust-link) TEMP=$(cygpath -w /k/tmp/rust-link) CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse RUSTUP_TOOLCHAIN=stable cargo test --locked -p goose --lib agents::platform_extensions::code_execution::tests --no-default-features --features rustls-tls,code-mode -- --nocapture`

### Related Issues
Refs #9853

### Screenshots/Demos (for UX changes)
Before: Code Mode told agents callback functions were available globally, which could be interpreted as `functions.write(...)`.

After: Code Mode explicitly tells agents to call callbacks as `Namespace.functionName(...)` and not to use `functions.*`.
