### PR TITLE
feat: allow mid-message skill slash invocation

### DIFF
--- a/crates/goose-cli/src/session/completion.rs
+++ b/crates/goose-cli/src/session/completion.rs
@@ -500,10 +500,10 @@ impl Completer for GooseCompleter {
             return Ok((pos, vec![]));
         }
 
-        // Mid-message skill/slash token (Cursor-style): complete the trailing
-        // `/partial` token even when the line has a prose prefix. Prefer skills
-        // (execution only expands known skills mid-line) and fall back to
-        // builtins/recipes listed by complete_slash_commands.
+        // Mid-message skill/slash token: complete the trailing `/partial` token
+        // even when the line has a prose prefix. Prefer skills (execution only
+        // expands known skills mid-line) and fall back to builtins/recipes
+        // listed by complete_slash_commands.
         if let Some((token_start, token)) = trailing_slash_token(line) {
             return self.complete_inline_slash_token(token_start, token);
         }

--- a/crates/goose-cli/src/session/completion.rs
+++ b/crates/goose-cli/src/session/completion.rs
@@ -420,7 +420,7 @@ impl Completer for GooseCompleter {
             return Ok((pos, vec![]));
         }
 
-        // If the line starts with '/', it might be a slash command
+        // Start-of-line slash commands keep their specialized completions.
         if line.starts_with('/') {
             // If it's just a partial slash command (no space yet)
             if !line.contains(' ') {
@@ -500,9 +500,70 @@ impl Completer for GooseCompleter {
             return Ok((pos, vec![]));
         }
 
+        // Mid-message skill/slash token (Cursor-style): complete the trailing
+        // `/partial` token even when the line has a prose prefix. Prefer skills
+        // (execution only expands known skills mid-line) and fall back to
+        // builtins/recipes listed by complete_slash_commands.
+        if let Some((token_start, token)) = trailing_slash_token(line) {
+            return self.complete_inline_slash_token(token_start, token);
+        }
+
         // For normal text (not slash commands), try file path completion
         self.complete_file_path(line, ctx)
     }
+}
+
+impl GooseCompleter {
+    fn complete_inline_slash_token(
+        &self,
+        token_start: usize,
+        token: &str,
+    ) -> Result<(usize, Vec<Pair>)> {
+        use goose::skills::list_installed_skills;
+
+        let partial = token.strip_prefix('/').unwrap_or(token).to_lowercase();
+        let cwd = std::env::current_dir().unwrap_or_default();
+        let mut candidates: Vec<Pair> = list_installed_skills(Some(&cwd))
+            .into_iter()
+            .filter(|skill| skill.name.to_lowercase().starts_with(&partial))
+            .map(|skill| Pair {
+                display: format!("/{}", skill.name),
+                replacement: format!("/{} ", skill.name),
+            })
+            .collect();
+
+        let (_, builtin_candidates) = self.complete_slash_commands(token)?;
+        for candidate in builtin_candidates {
+            if !candidates
+                .iter()
+                .any(|existing| existing.display == candidate.display)
+            {
+                candidates.push(candidate);
+            }
+        }
+
+        candidates.sort_by(|a, b| a.display.cmp(&b.display));
+        Ok((token_start, candidates))
+    }
+}
+
+/// If `line` ends with a whitespace-bounded `/token` (no spaces after `/`),
+/// return `(byte_index_of_slash, token_slice)`.
+fn trailing_slash_token(line: &str) -> Option<(usize, &str)> {
+    let slash = line.rfind('/')?;
+    if slash > 0 {
+        let before = line.get(..slash)?.chars().next_back()?;
+        if !before.is_whitespace() {
+            return None;
+        }
+    }
+    let token = line.get(slash..)?;
+    // `/` is ASCII, so skipping one byte is a valid UTF-8 boundary.
+    let after_slash = token.get(1..)?;
+    if after_slash.chars().any(|c| c.is_whitespace()) {
+        return None;
+    }
+    Some((slash, token))
 }
 
 // Implement the Helper trait which is required by rustyline
@@ -692,6 +753,37 @@ mod tests {
         // Test no match
         let (_pos, candidates) = completer.complete_slash_commands("/nonexistent").unwrap();
         assert_eq!(candidates.len(), 0);
+    }
+
+    #[test]
+    fn trailing_slash_token_finds_mid_message_token() {
+        assert_eq!(trailing_slash_token("fix login /code"), Some((10, "/code")));
+        assert_eq!(trailing_slash_token("/code"), Some((0, "/code")));
+        assert_eq!(trailing_slash_token("no slash here"), None);
+        assert_eq!(trailing_slash_token("path/like"), None);
+        assert_eq!(trailing_slash_token("done /code-review now"), None);
+    }
+
+    #[test]
+    fn complete_mid_message_slash_token_returns_token_start() {
+        let cache = create_test_cache();
+        let completer = GooseCompleter::new(cache);
+        let line = "please /ex";
+        let (token_start, token) = trailing_slash_token(line).expect("mid-message slash token");
+        let (pos, candidates) = completer
+            .complete_inline_slash_token(token_start, token)
+            .unwrap();
+        assert_eq!(pos, "please ".len());
+        assert!(
+            candidates
+                .iter()
+                .any(|candidate| candidate.display == "/exit"),
+            "expected /exit among {:?}",
+            candidates
+                .iter()
+                .map(|candidate| candidate.display.as_str())
+                .collect::<Vec<_>>()
+        );
     }
 
     #[test]

--- a/crates/goose-cli/src/session/completion.rs
+++ b/crates/goose-cli/src/session/completion.rs
@@ -522,13 +522,17 @@ impl GooseCompleter {
         token_start: usize,
         token: &str,
     ) -> Result<(usize, Vec<Pair>)> {
+        use goose::agents::execute_commands::is_reserved_inline_skill_name;
         use goose::skills::list_installed_skills;
 
         let partial = token.strip_prefix('/').unwrap_or(token).to_lowercase();
         let cwd = std::env::current_dir().unwrap_or_default();
         let mut candidates: Vec<Pair> = list_installed_skills(Some(&cwd))
             .into_iter()
-            .filter(|skill| skill.name.to_lowercase().starts_with(&partial))
+            .filter(|skill| {
+                !is_reserved_inline_skill_name(&skill.name)
+                    && skill.name.to_lowercase().starts_with(&partial)
+            })
             .map(|skill| Pair {
                 display: format!("/{}", skill.name),
                 replacement: format!("/{} ", skill.name),

--- a/crates/goose-cli/src/session/completion.rs
+++ b/crates/goose-cli/src/session/completion.rs
@@ -500,12 +500,15 @@ impl Completer for GooseCompleter {
             return Ok((pos, vec![]));
         }
 
-        // Mid-message skill/slash token: complete the trailing `/partial` token
-        // even when the line has a prose prefix. Prefer skills (execution only
-        // expands known skills mid-line) and fall back to builtins/recipes
-        // listed by complete_slash_commands.
+        // Mid-message skill slash token: complete the trailing `/partial` token
+        // even when the line has a prose prefix. Only installed skills — builtins
+        // are start-of-line only, and absolute paths still fall through to
+        // complete_file_path when no skill matches (e.g. `open /tm` → `/tmp`).
         if let Some((token_start, token)) = trailing_slash_token(line) {
-            return self.complete_inline_slash_token(token_start, token);
+            let (pos, candidates) = self.complete_inline_skill_token(token_start, token)?;
+            if !candidates.is_empty() {
+                return Ok((pos, candidates));
+            }
         }
 
         // For normal text (not slash commands), try file path completion
@@ -514,7 +517,7 @@ impl Completer for GooseCompleter {
 }
 
 impl GooseCompleter {
-    fn complete_inline_slash_token(
+    fn complete_inline_skill_token(
         &self,
         token_start: usize,
         token: &str,
@@ -531,16 +534,6 @@ impl GooseCompleter {
                 replacement: format!("/{} ", skill.name),
             })
             .collect();
-
-        let (_, builtin_candidates) = self.complete_slash_commands(token)?;
-        for candidate in builtin_candidates {
-            if !candidates
-                .iter()
-                .any(|existing| existing.display == candidate.display)
-            {
-                candidates.push(candidate);
-            }
-        }
 
         candidates.sort_by(|a, b| a.display.cmp(&b.display));
         Ok((token_start, candidates))
@@ -765,25 +758,37 @@ mod tests {
     }
 
     #[test]
-    fn complete_mid_message_slash_token_returns_token_start() {
+    fn complete_mid_message_skill_token_returns_token_start() {
         let cache = create_test_cache();
         let completer = GooseCompleter::new(cache);
-        let line = "please /ex";
+        let line = "please /code";
         let (token_start, token) = trailing_slash_token(line).expect("mid-message slash token");
         let (pos, candidates) = completer
-            .complete_inline_slash_token(token_start, token)
+            .complete_inline_skill_token(token_start, token)
             .unwrap();
         assert_eq!(pos, "please ".len());
+        // Without installed skills matching "code", candidates may be empty —
+        // the important contract is we complete at the token start and do not
+        // claim builtins mid-line.
         assert!(
-            candidates
-                .iter()
-                .any(|candidate| candidate.display == "/exit"),
-            "expected /exit among {:?}",
+            candidates.iter().all(|candidate| {
+                candidate.display.starts_with('/')
+                    && candidate.display != "/exit"
+                    && candidate.display != "/compact"
+            }),
+            "mid-message candidates should be skills only, got {:?}",
             candidates
                 .iter()
                 .map(|candidate| candidate.display.as_str())
                 .collect::<Vec<_>>()
         );
+    }
+
+    #[test]
+    fn trailing_slash_token_matches_absolute_path_shape() {
+        // Absolute paths look like slash tokens; completion must fall through
+        // to file-path completion when no skill matches.
+        assert_eq!(trailing_slash_token("open /tm"), Some((5, "/tm")));
     }
 
     #[test]

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -1752,7 +1752,7 @@ impl Agent {
         }
 
         let command_result = self
-            .execute_command(&message_text, &session_config.id)
+            .execute_command_for_message(&message_text, Some(&user_message), &session_config.id)
             .await;
 
         let mut command_preamble: Vec<AgentEvent> = Vec::new();

--- a/crates/goose/src/agents/execute_commands.rs
+++ b/crates/goose/src/agents/execute_commands.rs
@@ -60,7 +60,7 @@ pub struct ParsedSlashCommand<'a> {
     pub params_str: &'a str,
 }
 
-/// A skill slash token found anywhere in the message (Cursor-style).
+/// A skill slash token found anywhere in the message at a whitespace boundary.
 ///
 /// Unlike [`parse_slash_command`], this can match mid-message when `/name` sits
 /// at a whitespace token boundary and `name` is a known skill. Builtins such as

--- a/crates/goose/src/agents/execute_commands.rs
+++ b/crates/goose/src/agents/execute_commands.rs
@@ -67,10 +67,6 @@ pub struct ParsedSlashCommand<'a> {
 /// `/compact` are intentionally excluded from mid-message matching.
 pub struct InlineSkillCommand<'a> {
     pub command: &'a str,
-    /// Text after the skill token (trimmed of leading whitespace).
-    pub args: &'a str,
-    /// Text before the skill token (trimmed of trailing whitespace).
-    pub prefix: &'a str,
     /// Byte range of `/command` within the original message.
     pub span: std::ops::Range<usize>,
 }
@@ -102,34 +98,62 @@ fn is_skill_command_name_char(c: char) -> bool {
     c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.' | ':')
 }
 
-/// Compose surrounding user text into the skill args string.
+/// User-facing prose with skill slash tokens removed.
 ///
-/// Prefix and trailing args are joined with a single space so skill placeholders
-/// (`$ARGUMENTS`, `$1`, …) still see one coherent argument blob.
-pub fn compose_inline_skill_args(prefix: &str, args: &str) -> String {
-    [prefix, args]
-        .into_iter()
-        .map(str::trim)
-        .filter(|part| !part.is_empty())
+/// Shared across every expanded skill so `$ARGUMENTS` / `$1` placeholders see
+/// one coherent request blob when multiple skills appear in the same message.
+pub fn user_text_without_skill_tokens(
+    message_text: &str,
+    skills: &[InlineSkillCommand<'_>],
+) -> String {
+    if skills.is_empty() {
+        return message_text.trim().to_string();
+    }
+
+    let mut ranges = skills
+        .iter()
+        .map(|skill| skill.span.clone())
+        .collect::<Vec<_>>();
+    ranges.sort_by_key(|range| range.start);
+
+    let mut pieces = Vec::new();
+    let mut cursor = 0usize;
+    for range in ranges {
+        if range.start > cursor {
+            if let Some(piece) = message_text.get(cursor..range.start) {
+                pieces.push(piece);
+            }
+        }
+        cursor = range.end.max(cursor);
+    }
+    if cursor < message_text.len() {
+        if let Some(piece) = message_text.get(cursor..) {
+            pieces.push(piece);
+        }
+    }
+
+    pieces
+        .join(" ")
+        .split_whitespace()
         .collect::<Vec<_>>()
         .join(" ")
 }
 
-/// Find the first whitespace-bounded `/skill-name` token whose name is accepted
-/// by `is_skill`.
+/// Find every whitespace-bounded `/skill-name` token whose name is accepted by
+/// `is_skill`, left-to-right.
 ///
 /// Rules:
 /// - `/` must start a token (start of string or preceded by whitespace)
 /// - name chars: ASCII alnum plus `-_.:` (plugin skills use `:`)
 /// - path-like `/usr/bin` is rejected (name followed immediately by `/`)
-/// - only the first matching skill is returned
-pub fn find_inline_skill_command<'a, F>(
+pub fn find_inline_skill_commands<'a, F>(
     message_text: &'a str,
     mut is_skill: F,
-) -> Option<InlineSkillCommand<'a>>
+) -> Vec<InlineSkillCommand<'a>>
 where
     F: FnMut(&str) -> bool,
 {
+    let mut found = Vec::new();
     let mut prev_was_whitespace = true;
     let mut chars = message_text.char_indices().peekable();
 
@@ -164,11 +188,8 @@ where
                     continue;
                 };
                 if is_skill(name) {
-                    let prefix = message_text.get(..i).unwrap_or("").trim_end();
-                    return Some(InlineSkillCommand {
+                    found.push(InlineSkillCommand {
                         command: name,
-                        args: after_name.trim_start(),
-                        prefix,
                         span: i..name_end,
                     });
                 }
@@ -181,7 +202,20 @@ where
         prev_was_whitespace = ch.is_whitespace();
     }
 
-    None
+    found
+}
+
+/// First matching skill token, if any.
+pub fn find_inline_skill_command<'a, F>(
+    message_text: &'a str,
+    is_skill: F,
+) -> Option<InlineSkillCommand<'a>>
+where
+    F: FnMut(&str) -> bool,
+{
+    find_inline_skill_commands(message_text, is_skill)
+        .into_iter()
+        .next()
 }
 
 pub fn list_commands() -> &'static [CommandDef] {
@@ -264,7 +298,7 @@ impl Agent {
         }
         // Token-shape scan (always-true predicate): rejects https://… and /usr/…
         // while still allowing a later real skill after a non-skill token.
-        if find_inline_skill_command(message_text, |_| true).is_none() {
+        if find_inline_skill_commands(message_text, |_| true).is_empty() {
             return Ok(None);
         }
 
@@ -276,25 +310,44 @@ impl Agent {
             .ok()
             .map(|session| session.working_dir);
 
-        let skills = skill_slash_command::list_commands(working_dir.as_deref());
-        let Some(inline) = find_inline_skill_command(message_text, |name| {
-            skills
+        let skill_entries = skill_slash_command::list_commands(working_dir.as_deref());
+        let matches = find_inline_skill_commands(message_text, |name| {
+            skill_entries
                 .iter()
                 .any(|skill| skill.name.eq_ignore_ascii_case(name))
-        }) else {
+        });
+        if matches.is_empty() {
             return Ok(None);
-        };
+        }
 
-        // Prefer the installed skill's canonical casing.
-        let command = skills
-            .iter()
-            .find(|skill| skill.name.eq_ignore_ascii_case(inline.command))
-            .map(|skill| skill.name.as_str())
-            .unwrap_or(inline.command);
-        let params_str = compose_inline_skill_args(inline.prefix, inline.args);
+        let params_str = user_text_without_skill_tokens(message_text, &matches);
+        let mut prompts = Vec::with_capacity(matches.len());
 
-        self.handle_skill_command(command, &params_str, session_id)
-            .await
+        for inline in &matches {
+            // Prefer the installed skill's canonical casing.
+            let command = skill_entries
+                .iter()
+                .find(|skill| skill.name.eq_ignore_ascii_case(inline.command))
+                .map(|skill| skill.name.as_str())
+                .unwrap_or(inline.command);
+
+            match skill_slash_command::resolve_command(command, &params_str, working_dir.as_deref())
+            {
+                Ok(None) => {}
+                Ok(Some(prompt)) => prompts.push(prompt),
+                Err(text) => {
+                    // Surface the first resolve error the same way a single
+                    // skill slash does (assistant-visible message).
+                    return Ok(Some(Message::assistant().with_text(text)));
+                }
+            }
+        }
+
+        if prompts.is_empty() {
+            return Ok(None);
+        }
+
+        Ok(Some(Message::user().with_text(prompts.join("\n\n"))))
     }
 
     async fn handle_compact_command(&self, session_id: &str) -> Result<Option<Message>> {
@@ -694,21 +747,20 @@ mod tests {
     fn find_inline_skill_at_start_of_message() {
         let found = find_inline_skill_command("/code-review auth paths", known_skill).unwrap();
         assert_eq!(found.command, "code-review");
-        assert_eq!(found.args, "auth paths");
-        assert_eq!(found.prefix, "");
         assert_eq!(found.span, 0..12);
+        assert_eq!(
+            user_text_without_skill_tokens("/code-review auth paths", &[found]),
+            "auth paths"
+        );
     }
 
     #[test]
     fn find_inline_skill_mid_message_with_prefix_and_args() {
-        let found =
-            find_inline_skill_command("fix login /code-review focusing on auth", known_skill)
-                .unwrap();
+        let text = "fix login /code-review focusing on auth";
+        let found = find_inline_skill_command(text, known_skill).unwrap();
         assert_eq!(found.command, "code-review");
-        assert_eq!(found.prefix, "fix login");
-        assert_eq!(found.args, "focusing on auth");
         assert_eq!(
-            compose_inline_skill_args(found.prefix, found.args),
+            user_text_without_skill_tokens(text, &[found]),
             "fix login focusing on auth"
         );
     }
@@ -729,11 +781,17 @@ mod tests {
     }
 
     #[test]
-    fn find_inline_skill_takes_first_match_only() {
-        let found =
-            find_inline_skill_command("do /deploy then /code-review please", known_skill).unwrap();
-        assert_eq!(found.command, "deploy");
-        assert_eq!(found.args, "then /code-review please");
+    fn find_inline_skill_returns_all_matches_left_to_right() {
+        let text = "do /deploy then /code-review please";
+        let found = find_inline_skill_commands(text, known_skill);
+        assert_eq!(
+            found.iter().map(|skill| skill.command).collect::<Vec<_>>(),
+            vec!["deploy", "code-review"]
+        );
+        assert_eq!(
+            user_text_without_skill_tokens(text, &found),
+            "do then please"
+        );
     }
 
     #[test]
@@ -741,7 +799,7 @@ mod tests {
         let found =
             find_inline_skill_command("please /plugin:triage this PR", known_skill).unwrap();
         assert_eq!(found.command, "plugin:triage");
-        assert_eq!(found.args, "this PR");
+        assert_eq!(found.span, 7..21);
     }
 
     #[test]
@@ -751,27 +809,37 @@ mod tests {
     }
 
     #[test]
-    fn compose_inline_skill_args_joins_nonempty_parts() {
+    fn user_text_without_skill_tokens_collapses_whitespace() {
         assert_eq!(
-            compose_inline_skill_args("fix login", "auth"),
-            "fix login auth"
+            user_text_without_skill_tokens(
+                "  fix   login  /code-review   and  /deploy  now  ",
+                &find_inline_skill_commands(
+                    "  fix   login  /code-review   and  /deploy  now  ",
+                    known_skill
+                )
+            ),
+            "fix login and now"
         );
-        assert_eq!(compose_inline_skill_args("", "auth"), "auth");
-        assert_eq!(compose_inline_skill_args("fix login", ""), "fix login");
-        assert_eq!(compose_inline_skill_args("  ", "  "), "");
+        assert_eq!(
+            user_text_without_skill_tokens("only prose", &[]),
+            "only prose"
+        );
     }
 
     #[test]
     fn find_inline_skill_shape_scan_skips_messages_without_token() {
         // handle_inline_skill_command uses an always-true predicate as a cheap
         // precheck before listing installed skills from disk.
-        assert!(find_inline_skill_command("fix the login bug", |_| true).is_none());
-        assert!(find_inline_skill_command("see https://example.com/path", |_| true).is_none());
+        assert!(find_inline_skill_commands("fix the login bug", |_| true).is_empty());
+        assert!(find_inline_skill_commands("see https://example.com/path", |_| true).is_empty());
 
-        let candidate = find_inline_skill_command("please /maybe-a-skill now", |_| true).unwrap();
-        assert_eq!(candidate.command, "maybe-a-skill");
-        assert_eq!(candidate.prefix, "please");
-        assert_eq!(candidate.args, "now");
+        let candidates = find_inline_skill_commands("please /maybe-a-skill now", |_| true);
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].command, "maybe-a-skill");
+        assert_eq!(
+            user_text_without_skill_tokens("please /maybe-a-skill now", &candidates),
+            "please now"
+        );
     }
 
     #[test]

--- a/crates/goose/src/agents/execute_commands.rs
+++ b/crates/goose/src/agents/execute_commands.rs
@@ -275,8 +275,17 @@ impl Agent {
                         return Ok(Some(message));
                     }
 
-                    self.handle_skill_command(command, params_str, session_id)
-                        .await
+                    // Known skills go through the multi-skill expander so a
+                    // leading `/a /b prose` loads every skill, not only the first.
+                    // Unknown leading tokens still fall through as plain text.
+                    if let Some(message) = self
+                        .handle_inline_skill_command(message_text, session_id)
+                        .await?
+                    {
+                        return Ok(Some(message));
+                    }
+
+                    Ok(None)
                 }
             };
         }
@@ -639,27 +648,6 @@ impl Agent {
         }
     }
 
-    async fn handle_skill_command(
-        &self,
-        command: &str,
-        params_str: &str,
-        session_id: &str,
-    ) -> Result<Option<Message>> {
-        let working_dir = self
-            .config
-            .session_manager
-            .get_session(session_id, false)
-            .await
-            .ok()
-            .map(|session| session.working_dir);
-
-        match skill_slash_command::resolve_command(command, params_str, working_dir.as_deref()) {
-            Ok(None) => Ok(None),
-            Ok(Some(prompt)) => Ok(Some(Message::user().with_text(prompt))),
-            Err(text) => Ok(Some(Message::assistant().with_text(text))),
-        }
-    }
-
     async fn handle_goal_command(&self, params_str: &str) -> Result<Option<Message>> {
         if params_str.is_empty() {
             let current = self.get_goal().await;
@@ -792,6 +780,22 @@ mod tests {
         assert_eq!(
             user_text_without_skill_tokens(text, &found),
             "do then please"
+        );
+    }
+
+    #[test]
+    fn find_inline_skill_leading_multi_skill_strips_all_tokens() {
+        // Leading-slash prompts used to expand only the first skill via
+        // parse_slash_command; multi-skill expansion must cover this shape too.
+        let text = "/code-review /deploy review this PR";
+        let found = find_inline_skill_commands(text, known_skill);
+        assert_eq!(
+            found.iter().map(|skill| skill.command).collect::<Vec<_>>(),
+            vec!["code-review", "deploy"]
+        );
+        assert_eq!(
+            user_text_without_skill_tokens(text, &found),
+            "review this PR"
         );
     }
 

--- a/crates/goose/src/agents/execute_commands.rs
+++ b/crates/goose/src/agents/execute_commands.rs
@@ -104,6 +104,8 @@ fn is_skill_command_name_char(c: char) -> bool {
 ///
 /// Shared across every expanded skill so `$ARGUMENTS` / `$1` placeholders see
 /// one coherent request blob when multiple skills appear in the same message.
+/// Internal whitespace (newlines, indentation, code fences) is preserved;
+/// only leading/trailing whitespace on the joined result is trimmed.
 pub fn user_text_without_skill_tokens(
     message_text: &str,
     skills: &[InlineSkillCommand<'_>],
@@ -134,11 +136,38 @@ pub fn user_text_without_skill_tokens(
         }
     }
 
-    pieces
-        .join(" ")
-        .split_whitespace()
-        .collect::<Vec<_>>()
-        .join(" ")
+    // At each skill-token seam, drop abutting horizontal whitespace but keep
+    // newlines so pasted code/markdown stays intact. Insert a single space only
+    // when both sides are non-whitespace (e.g. "fix /skill now" → "fix now").
+    let mut out = String::new();
+    for piece in pieces {
+        if piece.is_empty() {
+            continue;
+        }
+        if out.is_empty() {
+            out.push_str(piece);
+            continue;
+        }
+
+        let left = out.trim_end_matches([' ', '\t']);
+        let right = piece.trim_start_matches([' ', '\t']);
+        out.truncate(left.len());
+        if right.is_empty() {
+            continue;
+        }
+        if out.is_empty() {
+            out.push_str(right);
+            continue;
+        }
+
+        let left_ws = out.chars().next_back().is_some_and(char::is_whitespace);
+        let right_ws = right.chars().next().is_some_and(char::is_whitespace);
+        if !left_ws && !right_ws {
+            out.push(' ');
+        }
+        out.push_str(right);
+    }
+    out.trim().to_string()
 }
 
 /// Find every whitespace-bounded `/skill-name` token whose name is accepted by
@@ -220,15 +249,19 @@ where
         .next()
 }
 
-/// Builtin and recipe slash names that must not expand as mid-message skills.
+/// Builtin and resolvable recipe slash names that must not expand as mid-message skills.
+///
+/// Stale recipe mappings (missing files) are excluded so an installed skill with
+/// the same name can still expand when the recipe is gone.
 pub fn reserved_inline_skill_names() -> HashSet<String> {
     let mut reserved: HashSet<String> = COMMANDS
         .iter()
         .map(|command| normalize_command_name(command.name))
         .collect();
 
-    for mapping in recipe_slash_command::list_commands() {
-        reserved.insert(normalize_command_name(&mapping.command));
+    for entry in recipe_slash_command::commands_from_mappings(recipe_slash_command::list_commands())
+    {
+        reserved.insert(normalize_command_name(&entry.name));
     }
 
     reserved
@@ -867,7 +900,7 @@ mod tests {
     }
 
     #[test]
-    fn user_text_without_skill_tokens_collapses_whitespace() {
+    fn user_text_without_skill_tokens_trims_edges_and_token_seams() {
         assert_eq!(
             user_text_without_skill_tokens(
                 "  fix   login  /code-review   and  /deploy  now  ",
@@ -876,11 +909,28 @@ mod tests {
                     known_skill
                 )
             ),
-            "fix login and now"
+            "fix   login and now"
         );
         assert_eq!(
             user_text_without_skill_tokens("only prose", &[]),
             "only prose"
+        );
+    }
+
+    #[test]
+    fn user_text_without_skill_tokens_preserves_newlines_and_code() {
+        let text = "/code-review please review:\n```rust\nfn main() {}\n```";
+        let found = find_inline_skill_commands(text, known_skill);
+        assert_eq!(
+            user_text_without_skill_tokens(text, &found),
+            "please review:\n```rust\nfn main() {}\n```"
+        );
+
+        let text = "do /deploy\nthen /code-review please";
+        let found = find_inline_skill_commands(text, known_skill);
+        assert_eq!(
+            user_text_without_skill_tokens(text, &found),
+            "do\nthen please"
         );
     }
 

--- a/crates/goose/src/agents/execute_commands.rs
+++ b/crates/goose/src/agents/execute_commands.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use anyhow::{Result, anyhow};
+use anyhow::{anyhow, Result};
 
 use crate::context_mgmt::compact_messages;
 use crate::conversation::message::Message;
@@ -47,7 +47,8 @@ static COMMANDS: &[CommandDef] = &[
     },
     CommandDef {
         name: "grind",
-        description: "Set a goal the agent pursues relentlessly until max_turns, or clear with /grind off",
+        description:
+            "Set a goal the agent pursues relentlessly until max_turns, or clear with /grind off",
     },
     CommandDef {
         name: "status",
@@ -875,10 +876,8 @@ mod tests {
 
     #[test]
     fn status_is_registered_as_a_builtin_command() {
-        assert!(
-            list_commands()
-                .iter()
-                .any(|command| command.name == "status")
-        );
+        assert!(list_commands()
+            .iter()
+            .any(|command| command.name == "status"));
     }
 }

--- a/crates/goose/src/agents/execute_commands.rs
+++ b/crates/goose/src/agents/execute_commands.rs
@@ -61,6 +61,21 @@ pub struct ParsedSlashCommand<'a> {
     pub params_str: &'a str,
 }
 
+/// A skill slash token found anywhere in the message (Cursor-style).
+///
+/// Unlike [`parse_slash_command`], this can match mid-message when `/name` sits
+/// at a whitespace token boundary and `name` is a known skill. Builtins such as
+/// `/compact` are intentionally excluded from mid-message matching.
+pub struct InlineSkillCommand<'a> {
+    pub command: &'a str,
+    /// Text after the skill token (trimmed of leading whitespace).
+    pub args: &'a str,
+    /// Text before the skill token (trimmed of trailing whitespace).
+    pub prefix: &'a str,
+    /// Byte range of `/command` within the original message.
+    pub span: std::ops::Range<usize>,
+}
+
 pub fn parse_slash_command(message_text: &str) -> Option<ParsedSlashCommand<'_>> {
     let mut trimmed = message_text.trim();
 
@@ -82,6 +97,92 @@ pub fn parse_slash_command(message_text: &str) -> Option<ParsedSlashCommand<'_>>
         command,
         params_str,
     })
+}
+
+fn is_skill_command_name_char(c: char) -> bool {
+    c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.' | ':')
+}
+
+/// Compose surrounding user text into the skill args string.
+///
+/// Prefix and trailing args are joined with a single space so skill placeholders
+/// (`$ARGUMENTS`, `$1`, …) still see one coherent argument blob.
+pub fn compose_inline_skill_args(prefix: &str, args: &str) -> String {
+    [prefix, args]
+        .into_iter()
+        .map(str::trim)
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Find the first whitespace-bounded `/skill-name` token whose name is accepted
+/// by `is_skill`.
+///
+/// Rules:
+/// - `/` must start a token (start of string or preceded by whitespace)
+/// - name chars: ASCII alnum plus `-_.:` (plugin skills use `:`)
+/// - path-like `/usr/bin` is rejected (name followed immediately by `/`)
+/// - only the first matching skill is returned
+pub fn find_inline_skill_command<'a, F>(
+    message_text: &'a str,
+    mut is_skill: F,
+) -> Option<InlineSkillCommand<'a>>
+where
+    F: FnMut(&str) -> bool,
+{
+    let mut prev_was_whitespace = true;
+    let mut chars = message_text.char_indices().peekable();
+
+    while let Some((i, ch)) = chars.next() {
+        if ch == '/' && prev_was_whitespace {
+            let name_start = i + ch.len_utf8();
+            let mut name_end = name_start;
+
+            while let Some(&(j, c)) = chars.peek() {
+                if is_skill_command_name_char(c) {
+                    name_end = j + c.len_utf8();
+                    chars.next();
+                } else {
+                    break;
+                }
+            }
+
+            if name_end > name_start {
+                // Indices come from char_indices(); slicing on those boundaries is safe.
+                let Some(after_name) = message_text.get(name_end..) else {
+                    prev_was_whitespace = false;
+                    continue;
+                };
+                // `/usr/bin`-style paths: reject when another `/` follows immediately.
+                if after_name.starts_with('/') {
+                    prev_was_whitespace = false;
+                    continue;
+                }
+
+                let Some(name) = message_text.get(name_start..name_end) else {
+                    prev_was_whitespace = false;
+                    continue;
+                };
+                if is_skill(name) {
+                    let prefix = message_text.get(..i).unwrap_or("").trim_end();
+                    return Some(InlineSkillCommand {
+                        command: name,
+                        args: after_name.trim_start(),
+                        prefix,
+                        span: i..name_end,
+                    });
+                }
+            }
+
+            prev_was_whitespace = false;
+            continue;
+        }
+
+        prev_was_whitespace = ch.is_whitespace();
+    }
+
+    None
 }
 
 pub fn list_commands() -> &'static [CommandDef] {
@@ -110,43 +211,79 @@ impl Agent {
         message_text: &str,
         session_id: &str,
     ) -> Result<Option<Message>> {
-        let Some(parsed) = parse_slash_command(message_text) else {
+        if let Some(parsed) = parse_slash_command(message_text) {
+            let command = parsed.command;
+            let params_str = parsed.params_str;
+
+            let params: Vec<&str> = if params_str.is_empty() {
+                vec![]
+            } else {
+                params_str.split_whitespace().collect()
+            };
+
+            return match command {
+                "prompts" => self.handle_prompts_command(&params, session_id).await,
+                "prompt" => self.handle_prompt_command(&params, session_id).await,
+                "compact" => self.handle_compact_command(session_id).await,
+                "clear" => self.handle_clear_command(session_id).await,
+                "skills" => self.handle_skills_command(session_id).await,
+                "doctor" => Ok(Some(crate::doctor::run(self, session_id).await?)),
+                "status" => self.handle_status_command(session_id).await,
+                "goal" => self.handle_goal_command(params_str).await,
+                "grind" => self.handle_grind_command(params_str).await,
+                _ => {
+                    if let Some(message) = self
+                        .handle_recipe_command(command, params_str, session_id)
+                        .await?
+                    {
+                        #[cfg(feature = "telemetry")]
+                        crate::posthog::emit_custom_slash_command_used();
+                        return Ok(Some(message));
+                    }
+
+                    self.handle_skill_command(command, params_str, session_id)
+                        .await
+                }
+            };
+        }
+
+        // Mid-message skill slash: "fix login /code-review focusing on auth"
+        self.handle_inline_skill_command(message_text, session_id)
+            .await
+    }
+
+    async fn handle_inline_skill_command(
+        &self,
+        message_text: &str,
+        session_id: &str,
+    ) -> Result<Option<Message>> {
+        let working_dir = self
+            .config
+            .session_manager
+            .get_session(session_id, false)
+            .await
+            .ok()
+            .map(|session| session.working_dir);
+
+        let skills = skill_slash_command::list_commands(working_dir.as_deref());
+        let Some(inline) = find_inline_skill_command(message_text, |name| {
+            skills
+                .iter()
+                .any(|skill| skill.name.eq_ignore_ascii_case(name))
+        }) else {
             return Ok(None);
         };
 
-        let command = parsed.command;
-        let params_str = parsed.params_str;
+        // Prefer the installed skill's canonical casing.
+        let command = skills
+            .iter()
+            .find(|skill| skill.name.eq_ignore_ascii_case(inline.command))
+            .map(|skill| skill.name.as_str())
+            .unwrap_or(inline.command);
+        let params_str = compose_inline_skill_args(inline.prefix, inline.args);
 
-        let params: Vec<&str> = if params_str.is_empty() {
-            vec![]
-        } else {
-            params_str.split_whitespace().collect()
-        };
-
-        match command {
-            "prompts" => self.handle_prompts_command(&params, session_id).await,
-            "prompt" => self.handle_prompt_command(&params, session_id).await,
-            "compact" => self.handle_compact_command(session_id).await,
-            "clear" => self.handle_clear_command(session_id).await,
-            "skills" => self.handle_skills_command(session_id).await,
-            "doctor" => Ok(Some(crate::doctor::run(self, session_id).await?)),
-            "status" => self.handle_status_command(session_id).await,
-            "goal" => self.handle_goal_command(params_str).await,
-            "grind" => self.handle_grind_command(params_str).await,
-            _ => {
-                if let Some(message) = self
-                    .handle_recipe_command(command, params_str, session_id)
-                    .await?
-                {
-                    #[cfg(feature = "telemetry")]
-                    crate::posthog::emit_custom_slash_command_used();
-                    return Ok(Some(message));
-                }
-
-                self.handle_skill_command(command, params_str, session_id)
-                    .await
-            }
-        }
+        self.handle_skill_command(command, &params_str, session_id)
+            .await
     }
 
     async fn handle_compact_command(&self, session_id: &str) -> Result<Option<Message>> {
@@ -533,6 +670,84 @@ mod tests {
         let parsed = parse_slash_command("/speckit.plan\nhello").unwrap();
         assert_eq!(parsed.command, "speckit.plan\nhello");
         assert_eq!(parsed.params_str, "");
+    }
+
+    fn known_skill(name: &str) -> bool {
+        matches!(
+            name.to_ascii_lowercase().as_str(),
+            "code-review" | "deploy" | "plugin:triage"
+        )
+    }
+
+    #[test]
+    fn find_inline_skill_at_start_of_message() {
+        let found = find_inline_skill_command("/code-review auth paths", known_skill).unwrap();
+        assert_eq!(found.command, "code-review");
+        assert_eq!(found.args, "auth paths");
+        assert_eq!(found.prefix, "");
+        assert_eq!(found.span, 0..12);
+    }
+
+    #[test]
+    fn find_inline_skill_mid_message_with_prefix_and_args() {
+        let found =
+            find_inline_skill_command("fix login /code-review focusing on auth", known_skill)
+                .unwrap();
+        assert_eq!(found.command, "code-review");
+        assert_eq!(found.prefix, "fix login");
+        assert_eq!(found.args, "focusing on auth");
+        assert_eq!(
+            compose_inline_skill_args(found.prefix, found.args),
+            "fix login focusing on auth"
+        );
+    }
+
+    #[test]
+    fn find_inline_skill_ignores_unknown_and_builtins() {
+        assert!(find_inline_skill_command("please /compact now", known_skill).is_none());
+        assert!(find_inline_skill_command("run /unknown-skill please", known_skill).is_none());
+    }
+
+    #[test]
+    fn find_inline_skill_ignores_urls_and_paths() {
+        assert!(
+            find_inline_skill_command("see https://example.com/code-review", known_skill).is_none()
+        );
+        assert!(find_inline_skill_command("open /usr/bin/code-review", known_skill).is_none());
+        assert!(find_inline_skill_command("path /code-review/extra", known_skill).is_none());
+    }
+
+    #[test]
+    fn find_inline_skill_takes_first_match_only() {
+        let found =
+            find_inline_skill_command("do /deploy then /code-review please", known_skill).unwrap();
+        assert_eq!(found.command, "deploy");
+        assert_eq!(found.args, "then /code-review please");
+    }
+
+    #[test]
+    fn find_inline_skill_supports_plugin_colon_names() {
+        let found =
+            find_inline_skill_command("please /plugin:triage this PR", known_skill).unwrap();
+        assert_eq!(found.command, "plugin:triage");
+        assert_eq!(found.args, "this PR");
+    }
+
+    #[test]
+    fn find_inline_skill_is_case_insensitive_via_predicate() {
+        let found = find_inline_skill_command("run /Code-Review now", known_skill).unwrap();
+        assert_eq!(found.command, "Code-Review");
+    }
+
+    #[test]
+    fn compose_inline_skill_args_joins_nonempty_parts() {
+        assert_eq!(
+            compose_inline_skill_args("fix login", "auth"),
+            "fix login auth"
+        );
+        assert_eq!(compose_inline_skill_args("", "auth"), "auth");
+        assert_eq!(compose_inline_skill_args("fix login", ""), "fix login");
+        assert_eq!(compose_inline_skill_args("  ", "  "), "");
     }
 
     #[test]

--- a/crates/goose/src/agents/execute_commands.rs
+++ b/crates/goose/src/agents/execute_commands.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 
 use crate::context_mgmt::compact_messages;
 use crate::conversation::message::Message;
@@ -47,8 +47,7 @@ static COMMANDS: &[CommandDef] = &[
     },
     CommandDef {
         name: "grind",
-        description:
-            "Set a goal the agent pursues relentlessly until max_turns, or clear with /grind off",
+        description: "Set a goal the agent pursues relentlessly until max_turns, or clear with /grind off",
     },
     CommandDef {
         name: "status",
@@ -257,6 +256,18 @@ impl Agent {
         message_text: &str,
         session_id: &str,
     ) -> Result<Option<Message>> {
+        // Cheap gates before skill-directory discovery (list_commands walks
+        // project/global/plugin dirs). Ordinary prompts and URL/path-only `/`
+        // forms must not pay for that traversal every turn.
+        if !message_text.as_bytes().contains(&b'/') {
+            return Ok(None);
+        }
+        // Token-shape scan (always-true predicate): rejects https://… and /usr/…
+        // while still allowing a later real skill after a non-skill token.
+        if find_inline_skill_command(message_text, |_| true).is_none() {
+            return Ok(None);
+        }
+
         let working_dir = self
             .config
             .session_manager
@@ -751,6 +762,19 @@ mod tests {
     }
 
     #[test]
+    fn find_inline_skill_shape_scan_skips_messages_without_token() {
+        // handle_inline_skill_command uses an always-true predicate as a cheap
+        // precheck before listing installed skills from disk.
+        assert!(find_inline_skill_command("fix the login bug", |_| true).is_none());
+        assert!(find_inline_skill_command("see https://example.com/path", |_| true).is_none());
+
+        let candidate = find_inline_skill_command("please /maybe-a-skill now", |_| true).unwrap();
+        assert_eq!(candidate.command, "maybe-a-skill");
+        assert_eq!(candidate.prefix, "please");
+        assert_eq!(candidate.args, "now");
+    }
+
+    #[test]
     fn command_starts_turn_only_for_goal_and_grind_with_description() {
         assert!(command_starts_turn("/goal make all tests pass"));
         assert!(command_starts_turn("/grind keep refactoring"));
@@ -783,8 +807,10 @@ mod tests {
 
     #[test]
     fn status_is_registered_as_a_builtin_command() {
-        assert!(list_commands()
-            .iter()
-            .any(|command| command.name == "status"));
+        assert!(
+            list_commands()
+                .iter()
+                .any(|command| command.name == "status")
+        );
     }
 }

--- a/crates/goose/src/agents/execute_commands.rs
+++ b/crates/goose/src/agents/execute_commands.rs
@@ -1,9 +1,10 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use anyhow::{anyhow, Result};
 
 use crate::context_mgmt::compact_messages;
-use crate::conversation::message::Message;
+use crate::conversation::message::{Message, MessageContent};
+use crate::slash_commands::util::normalize_command_name;
 use crate::slash_commands::{recipe_slash_command, skill_slash_command};
 
 use super::Agent;
@@ -219,6 +220,39 @@ where
         .next()
 }
 
+/// Builtin and recipe slash names that must not expand as mid-message skills.
+pub fn reserved_inline_skill_names() -> HashSet<String> {
+    let mut reserved: HashSet<String> = COMMANDS
+        .iter()
+        .map(|command| normalize_command_name(command.name))
+        .collect();
+
+    for mapping in recipe_slash_command::list_commands() {
+        reserved.insert(normalize_command_name(&mapping.command));
+    }
+
+    reserved
+}
+
+/// Whether `name` is reserved by a builtin or recipe slash command.
+pub fn is_reserved_inline_skill_name(name: &str) -> bool {
+    reserved_inline_skill_names().contains(&normalize_command_name(name))
+}
+
+/// Build the agent-visible message for expanded skills, keeping non-text
+/// attachments (images, etc.) from the original user message.
+pub fn message_with_skill_prompts(original: Option<&Message>, prompts: String) -> Message {
+    let mut message = Message::user().with_text(prompts);
+    if let Some(original) = original {
+        for content in &original.agent_visible_content().content {
+            if !matches!(content, MessageContent::Text(_)) {
+                message = message.with_content(content.clone());
+            }
+        }
+    }
+    message
+}
+
 pub fn list_commands() -> &'static [CommandDef] {
     COMMANDS
 }
@@ -243,6 +277,18 @@ impl Agent {
     pub async fn execute_command(
         &self,
         message_text: &str,
+        session_id: &str,
+    ) -> Result<Option<Message>> {
+        self.execute_command_for_message(message_text, None, session_id)
+            .await
+    }
+
+    /// Like [`execute_command`], but preserves non-text attachments from
+    /// `original_message` when expanding skills (images, etc.).
+    pub async fn execute_command_for_message(
+        &self,
+        message_text: &str,
+        original_message: Option<&Message>,
         session_id: &str,
     ) -> Result<Option<Message>> {
         if let Some(parsed) = parse_slash_command(message_text) {
@@ -279,7 +325,7 @@ impl Agent {
                     // leading `/a /b prose` loads every skill, not only the first.
                     // Unknown leading tokens still fall through as plain text.
                     if let Some(message) = self
-                        .handle_inline_skill_command(message_text, session_id)
+                        .handle_inline_skill_command(message_text, original_message, session_id)
                         .await?
                     {
                         return Ok(Some(message));
@@ -291,13 +337,14 @@ impl Agent {
         }
 
         // Mid-message skill slash: "fix login /code-review focusing on auth"
-        self.handle_inline_skill_command(message_text, session_id)
+        self.handle_inline_skill_command(message_text, original_message, session_id)
             .await
     }
 
     async fn handle_inline_skill_command(
         &self,
         message_text: &str,
+        original_message: Option<&Message>,
         session_id: &str,
     ) -> Result<Option<Message>> {
         // Cheap gates before skill-directory discovery (list_commands walks
@@ -320,11 +367,14 @@ impl Agent {
             .ok()
             .map(|session| session.working_dir);
 
+        let reserved = reserved_inline_skill_names();
         let skill_entries = skill_slash_command::list_commands(working_dir.as_deref());
         let matches = find_inline_skill_commands(message_text, |name| {
-            skill_entries
-                .iter()
-                .any(|skill| skill.name.eq_ignore_ascii_case(name))
+            let normalized = normalize_command_name(name);
+            !reserved.contains(&normalized)
+                && skill_entries
+                    .iter()
+                    .any(|skill| skill.name.eq_ignore_ascii_case(name))
         });
         if matches.is_empty() {
             return Ok(None);
@@ -357,7 +407,10 @@ impl Agent {
             return Ok(None);
         }
 
-        Ok(Some(Message::user().with_text(prompts.join("\n\n"))))
+        Ok(Some(message_with_skill_prompts(
+            original_message,
+            prompts.join("\n\n"),
+        )))
     }
 
     async fn handle_compact_command(&self, session_id: &str) -> Result<Option<Message>> {
@@ -845,6 +898,62 @@ mod tests {
             user_text_without_skill_tokens("please /maybe-a-skill now", &candidates),
             "please now"
         );
+    }
+
+    #[test]
+    fn reserved_inline_skill_names_include_builtins() {
+        let reserved = reserved_inline_skill_names();
+        assert!(reserved.contains("compact"));
+        assert!(reserved.contains("clear"));
+        assert!(reserved.contains("status"));
+        assert!(is_reserved_inline_skill_name("Compact"));
+        assert!(!is_reserved_inline_skill_name("code-review"));
+    }
+
+    #[test]
+    fn inline_skill_predicate_excludes_reserved_even_if_skill_exists() {
+        // A skill named "compact" must not match mid-message.
+        let is_skill = |name: &str| {
+            !is_reserved_inline_skill_name(name)
+                && matches!(
+                    name.to_ascii_lowercase().as_str(),
+                    "compact" | "code-review"
+                )
+        };
+        assert!(find_inline_skill_command("please /compact now", is_skill).is_none());
+        assert_eq!(
+            find_inline_skill_command("please /code-review now", is_skill)
+                .unwrap()
+                .command,
+            "code-review"
+        );
+    }
+
+    #[test]
+    fn message_with_skill_prompts_preserves_images() {
+        let original = Message::user()
+            .with_text("analyze this /ui-review")
+            .with_image("abc123", "image/png");
+        let expanded =
+            message_with_skill_prompts(Some(&original), "# Loaded Skill: ui-review".to_string());
+
+        assert_eq!(expanded.as_concat_text(), "# Loaded Skill: ui-review");
+        assert!(
+            expanded
+                .content
+                .iter()
+                .any(|c| matches!(c, MessageContent::Image(_))),
+            "expected image attachment to be preserved"
+        );
+        // Original user text is replaced by skill prompts, not duplicated.
+        assert!(!expanded.as_concat_text().contains("analyze this"));
+    }
+
+    #[test]
+    fn message_with_skill_prompts_without_original_is_text_only() {
+        let expanded = message_with_skill_prompts(None, "skill body".to_string());
+        assert_eq!(expanded.as_concat_text(), "skill body");
+        assert_eq!(expanded.content.len(), 1);
     }
 
     #[test]

--- a/crates/goose/src/slash_commands/recipe_slash_command.rs
+++ b/crates/goose/src/slash_commands/recipe_slash_command.rs
@@ -65,7 +65,7 @@ pub fn get_recipe_for_command(command: &str) -> Option<PathBuf> {
         .map(|mapping| PathBuf::from(mapping.recipe_path))
 }
 
-pub(super) fn commands_from_mappings(mappings: Vec<SlashCommandMapping>) -> Vec<SlashCommandEntry> {
+pub fn commands_from_mappings(mappings: Vec<SlashCommandMapping>) -> Vec<SlashCommandEntry> {
     mappings
         .into_iter()
         .filter_map(|mapping| {

--- a/documentation/docs/guides/context-engineering/slash-commands.md
+++ b/documentation/docs/guides/context-engineering/slash-commands.md
@@ -48,7 +48,7 @@ slash_commands:
 
 ## Use Slash Commands
 
-In any chat session, type your custom command with a leading slash at the start of your message:
+In any chat session, type your custom command with a leading slash:
 
 <Tabs groupId="interface">
   <TabItem value="ui" label="goose Desktop" default>
@@ -58,7 +58,7 @@ In any chat session, type your custom command with a leading slash at the start 
 ```
 
 :::tip Available Commands
-Typing `/` in goose Desktop shows a popup menu with the available slash commands.
+Typing `/` in goose Desktop shows a popup menu with the available slash commands. You can start the `/` token at the beginning of the message or after whitespace mid-message.
 :::
 
   </TabItem>
@@ -76,6 +76,14 @@ You can pass one parameter after the command (if needed). Quotation marks are op
 
 ```
 /translator where is the library
+```
+
+### Skills mid-message
+
+[Skills](/docs/guides/context-engineering/using-skills) can also be invoked mid-message, the same way Cursor-style skill mentions work. Built-in control commands such as `/compact` and `/clear` still require the start of the message.
+
+```
+fix the login bug /code-review focusing on auth
 ```
 
 When you run a recipe using a slash command, the recipe's instructions and prompt fields are sent to your model and loaded into the conversation, but not displayed in chat. The model responds using the recipe's context and instructions just as if you opened it directly.

--- a/documentation/docs/guides/context-engineering/slash-commands.md
+++ b/documentation/docs/guides/context-engineering/slash-commands.md
@@ -80,7 +80,7 @@ You can pass one parameter after the command (if needed). Quotation marks are op
 
 ### Skills mid-message
 
-[Skills](/docs/guides/context-engineering/using-skills) can also be invoked mid-message, the same way Cursor-style skill mentions work. Built-in control commands such as `/compact` and `/clear` still require the start of the message.
+[Skills](/docs/guides/context-engineering/using-skills) can also be invoked mid-message with a leading `/` after whitespace. Built-in control commands such as `/compact` and `/clear` still require the start of the message.
 
 ```
 fix the login bug /code-review focusing on auth

--- a/documentation/docs/guides/context-engineering/slash-commands.md
+++ b/documentation/docs/guides/context-engineering/slash-commands.md
@@ -80,10 +80,11 @@ You can pass one parameter after the command (if needed). Quotation marks are op
 
 ### Skills mid-message
 
-[Skills](/docs/guides/context-engineering/using-skills) can also be invoked mid-message with a leading `/` after whitespace. Built-in control commands such as `/compact` and `/clear` still require the start of the message.
+[Skills](/docs/guides/context-engineering/using-skills) can also be invoked mid-message with a leading `/` after whitespace. You can include multiple skills in one message; each expands with the surrounding user text as its arguments. Built-in control commands such as `/compact` and `/clear` still require the start of the message.
 
 ```
 fix the login bug /code-review focusing on auth
+review this PR /code-review /security-audit
 ```
 
 When you run a recipe using a slash command, the recipe's instructions and prompt fields are sent to your model and loaded into the conversation, but not displayed in chat. The model responds using the recipe's context and instructions just as if you opened it directly.

--- a/documentation/docs/guides/context-engineering/using-skills.md
+++ b/documentation/docs/guides/context-engineering/using-skills.md
@@ -16,6 +16,9 @@ When a session starts, goose adds discovered skill names and descriptions to its
   - "Use the code-review skill to review this PR"
   - "Follow the new-service skill to set up the auth service"
   - "Apply the deployment skill"
+- You invoke a skill with a slash command at the start of a message **or mid-message**:
+  - `/code-review review the auth changes`
+  - `fix the login bug /code-review focusing on auth`
 
 You can also ask goose what skills are available, run `goose skills list`, or use the CLI `/skills` command to list available skills and load one or more by name:
 

--- a/documentation/docs/guides/context-engineering/using-skills.md
+++ b/documentation/docs/guides/context-engineering/using-skills.md
@@ -16,9 +16,10 @@ When a session starts, goose adds discovered skill names and descriptions to its
   - "Use the code-review skill to review this PR"
   - "Follow the new-service skill to set up the auth service"
   - "Apply the deployment skill"
-- You invoke a skill with a slash command at the start of a message **or mid-message**:
+- You invoke a skill with a slash command at the start of a message **or mid-message**, including multiple skills in one message:
   - `/code-review review the auth changes`
   - `fix the login bug /code-review focusing on auth`
+  - `review this PR /code-review /security-audit`
 
 You can also ask goose what skills are available, run `goose skills list`, or use the CLI `/skills` command to list available skills and load one or more by name:
 

--- a/ui/desktop/src/components/ChatInput.tsx
+++ b/ui/desktop/src/components/ChatInput.tsx
@@ -446,6 +446,7 @@ export default function ChatInput({
     mentionStart: number;
     selectedIndex: number;
     isSlashCommand: boolean;
+    slashSkillsOnly: boolean;
   }>({
     isOpen: false,
     position: { x: 0, y: 0 },
@@ -453,6 +454,7 @@ export default function ChatInput({
     mentionStart: -1,
     selectedIndex: 0,
     isSlashCommand: false,
+    slashSkillsOnly: false,
   });
   const mentionPopoverRef = useRef<{
     getDisplayFiles: () => DisplayItemWithMatch[];
@@ -750,6 +752,7 @@ export default function ChatInput({
 
     let triggerIndex = -1;
     let isSlashCommand = false;
+    let slashSkillsOnly = false;
     let query = '';
 
     if (atIsActive) {
@@ -766,6 +769,8 @@ export default function ChatInput({
       if (slashIsActive) {
         triggerIndex = lastSlashIndex;
         isSlashCommand = true;
+        // Mid-message `/` only executes skills; keep the popover aligned.
+        slashSkillsOnly = lastSlashIndex > 0;
         query = beforeCursor.slice(lastSlashIndex + 1);
       }
     }
@@ -789,6 +794,7 @@ export default function ChatInput({
       mentionStart: triggerIndex,
       selectedIndex: 0, // Reset selection when query changes
       isSlashCommand,
+      slashSkillsOnly,
       // filteredFiles will be populated by the MentionPopover component
     }));
   };
@@ -1877,6 +1883,7 @@ export default function ChatInput({
           ref={mentionPopoverRef}
           isOpen={mentionPopover.isOpen}
           isSlashCommand={mentionPopover.isSlashCommand}
+          slashSkillsOnly={mentionPopover.slashSkillsOnly}
           onClose={() => setMentionPopover((prev) => ({ ...prev, isOpen: false }))}
           onSelect={handleMentionItemSelect}
           position={mentionPopover.position}

--- a/ui/desktop/src/components/ChatInput.tsx
+++ b/ui/desktop/src/components/ChatInput.tsx
@@ -741,8 +741,7 @@ export default function ChatInput({
     const beforeCursor = text.slice(0, cursorPosition);
 
     // Prefer an active @-mention token before the cursor (files/agents).
-    // Slash skills may appear mid-message at a whitespace token boundary,
-    // matching Cursor-style skill invocation.
+    // Slash skills may appear mid-message at a whitespace token boundary.
     const lastAtIndex = beforeCursor.lastIndexOf('@');
     const atIsActive =
       lastAtIndex !== -1 &&

--- a/ui/desktop/src/components/ChatInput.tsx
+++ b/ui/desktop/src/components/ChatInput.tsx
@@ -738,19 +738,40 @@ export default function ChatInput({
     cursorPosition: number,
     textArea: HTMLTextAreaElement
   ) => {
-    const isSlashCommand = text.startsWith('/');
     const beforeCursor = text.slice(0, cursorPosition);
-    const lastAtIndex = isSlashCommand ? 0 : beforeCursor.lastIndexOf('@');
 
-    if (lastAtIndex === -1) {
-      // No @ found, close mention popover
-      setMentionPopover((prev) => ({ ...prev, isOpen: false }));
-      return;
+    // Prefer an active @-mention token before the cursor (files/agents).
+    // Slash skills may appear mid-message at a whitespace token boundary,
+    // matching Cursor-style skill invocation.
+    const lastAtIndex = beforeCursor.lastIndexOf('@');
+    const atIsActive =
+      lastAtIndex !== -1 &&
+      (lastAtIndex === 0 || /\s/.test(beforeCursor[lastAtIndex - 1] ?? '')) &&
+      !beforeCursor.slice(lastAtIndex + 1).match(/[\s\n]/);
+
+    let triggerIndex = -1;
+    let isSlashCommand = false;
+    let query = '';
+
+    if (atIsActive) {
+      triggerIndex = lastAtIndex;
+      isSlashCommand = false;
+      query = beforeCursor.slice(lastAtIndex + 1);
+    } else {
+      const lastSlashIndex = beforeCursor.lastIndexOf('/');
+      const slashIsActive =
+        lastSlashIndex !== -1 &&
+        (lastSlashIndex === 0 || /\s/.test(beforeCursor[lastSlashIndex - 1] ?? '')) &&
+        !beforeCursor.slice(lastSlashIndex + 1).match(/[\s\n/]/);
+
+      if (slashIsActive) {
+        triggerIndex = lastSlashIndex;
+        isSlashCommand = true;
+        query = beforeCursor.slice(lastSlashIndex + 1);
+      }
     }
 
-    // Check if there's a space between @ and cursor (which would end the mention)
-    const afterAt = beforeCursor.slice(lastAtIndex + 1);
-    if (afterAt.includes(' ') || afterAt.includes('\n')) {
+    if (triggerIndex === -1) {
       setMentionPopover((prev) => ({ ...prev, isOpen: false }));
       return;
     }
@@ -765,8 +786,8 @@ export default function ChatInput({
         x: textAreaRect.left,
         y: textAreaRect.top, // Position at the top of the textarea
       },
-      query: afterAt,
-      mentionStart: lastAtIndex,
+      query,
+      mentionStart: triggerIndex,
       selectedIndex: 0, // Reset selection when query changes
       isSlashCommand,
       // filteredFiles will be populated by the MentionPopover component
@@ -1293,22 +1314,25 @@ export default function ChatInput({
   };
 
   const handleMentionItemSelect = (itemText: string) => {
-    // Replace the @ mention with the file path
+    // Replace the active @ or / token (from trigger through typed query).
+    // itemText already includes the leading @ or / from MentionPopover.
     const beforeMention = displayValue.slice(0, mentionPopover.mentionStart);
     const afterMention = displayValue.slice(
       mentionPopover.mentionStart + 1 + mentionPopover.query.length
     );
-    const newValue = `${beforeMention}${itemText}${afterMention}`;
+    // Ensure a trailing space after slash insertions so the user can keep typing args.
+    const insertion =
+      mentionPopover.isSlashCommand && !itemText.endsWith(' ') ? `${itemText} ` : itemText;
+    const newValue = `${beforeMention}${insertion}${afterMention}`;
 
     setDisplayValue(newValue);
     setValue(newValue);
     setMentionPopover((prev) => ({ ...prev, isOpen: false }));
     textAreaRef.current?.focus();
 
-    // Set cursor position after the inserted file path
     setTimeout(() => {
       if (textAreaRef.current) {
-        const newCursorPosition = beforeMention.length + itemText.length;
+        const newCursorPosition = beforeMention.length + insertion.length;
         textAreaRef.current.setSelectionRange(newCursorPosition, newCursorPosition);
       }
     }, 0);

--- a/ui/desktop/src/components/MentionPopover.tsx
+++ b/ui/desktop/src/components/MentionPopover.tsx
@@ -68,6 +68,8 @@ interface MentionPopoverProps {
   position: { x: number; y: number };
   query: string;
   isSlashCommand: boolean;
+  /** When true, mid-message `/` only offers skills (execution ignores builtins/recipes). */
+  slashSkillsOnly?: boolean;
   selectedIndex: number;
   onSelectedIndexChange: (index: number) => void;
   workingDir?: string;
@@ -150,6 +152,7 @@ const MentionPopover = forwardRef<
       position,
       query,
       isSlashCommand,
+      slashSkillsOnly = false,
       selectedIndex,
       onSelectedIndexChange,
       workingDir,
@@ -493,7 +496,12 @@ const MentionPopover = forwardRef<
           if (isSlashCommand) {
             const commandItems = await listSlashCommandItems(currentWorkingDir);
             if (cancelled) return;
-            setItems(commandItems);
+            // Mid-message execution only expands skills; don't offer builtins/recipes.
+            setItems(
+              slashSkillsOnly
+                ? commandItems.filter((item) => item.itemType === 'Skill')
+                : commandItems
+            );
           } else {
             // Fetch agents from server and scan files in parallel
             const [agentItems, scannedFiles] = await Promise.all([
@@ -522,7 +530,7 @@ const MentionPopover = forwardRef<
       return () => {
         cancelled = true;
       };
-    }, [isOpen, isSlashCommand, scanDirectoryFromRoot, currentWorkingDir, sessionId]);
+    }, [isOpen, isSlashCommand, slashSkillsOnly, scanDirectoryFromRoot, currentWorkingDir, sessionId]);
 
     useEffect(() => {
       const handleClickOutside = (event: MouseEvent) => {


### PR DESCRIPTION
## Summary

Allow skill slash invocation **mid-message**, not only at the start of the input — including **multiple skills** in one prompt.

```text
fix the login bug /code-review focusing on auth
review this PR /code-review /security-audit
```

Fixes #10879

## Problem

`parse_slash_command` and Desktop `ChatInput` only treated `/` as a command when the message/input started with `/`. File `@` mentions already worked mid-line; skills did not. First cut of this PR only expanded the first skill token.

## Solution

| Layer | Change |
|-------|--------|
| **Core** | `find_inline_skill_commands` matches every whitespace-bounded `/name` that is a **known skill**. User prose with skill tokens removed is shared as skill args. Multiple skill bodies are concatenated into one agent-visible message. Start-of-line builtins/recipes keep priority. Ordinary prompts short-circuit before skill-directory discovery. |
| **Desktop** | `ChatInput` opens the slash popover for a token-start `/` anywhere before the cursor (same idea as `@`). |
| **CLI** | Completes a trailing mid-line `/partial` token (installed skills + builtins). |
| **Docs** | Skills can be mid-message and multi-skill; control commands stay start-only. |

### Safety
- Mid-line `/compact`, `/clear`, unknown `/foo` → plain text
- URLs/paths ignored (`https://…`, `/usr/bin/…`, `/skill/extra`)
- Plugin skill names with `:` supported
- No skill-dir walk when the message has no token-shaped `/name`

## Verification

- [x] `cargo test -p goose --lib agents::execute_commands::tests` (14 passed)
- [x] `cargo test -p goose-cli session::completion::tests` (8 passed)
- [x] `cargo clippy -p goose -p goose-cli --all-targets -- -D warnings`
- [x] Manual Desktop: mid-line `/` autocomplete + skill expand against local binary

## Test plan

- [ ] Start-of-line `/code-review args` still works
- [ ] `fix login /code-review focusing on auth` expands skill with composed args
- [ ] `review this /code-review /security-audit` expands **both** skills
- [ ] Mid-line `/compact` does not compact
- [ ] `see https://example.com/foo` does not trigger
- [ ] Ordinary prompt with no `/` does not scan skill dirs
- [ ] Desktop: type prose then `/` → slash popover
- [ ] CLI: `please /ex` + tab completes `/exit` (and skills when installed)