### PR TITLE
Add Snipget remote extension

### DIFF
--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -671,6 +671,18 @@
     "environmentVariables": []
   },
   {
+    "id": "snipget",
+    "name": "Snipget",
+    "description": "317 deterministic data utilities for AI agents - validate, normalize, parse, match, and redact names, addresses, phones, emails, dates, identifiers, and healthcare/chemistry/biotech data",
+    "url": "https://mcp.snipget.ai/mcp",
+    "link": "https://snipget.ai",
+    "installation_notes": "Hosted remote MCP server (Streamable HTTP). Uses OAuth 2.0 with dynamic client registration - Goose prompts to authenticate on first use; free tier available.",
+    "is_builtin": false,
+    "endorsed": false,
+    "environmentVariables": [],
+    "type": "streamable-http"
+  },
+  {
     "id": "square-mcp",
     "name": "Square",
     "description": "Square API for payments and business management",
@@ -807,26 +819,25 @@
     "environmentVariables": []
   },
   {
-  "id": "scholar-sidekick",
-  "name": "Scholar Sidekick",
-  "description": "Resolve, format, export, and verify academic citations (DOI, PMID, ISBN, arXiv) plus retraction and open-access checks",
-  "command": "npx -y scholar-sidekick-mcp@latest",
-  "link": "https://github.com/mlava/scholar-sidekick-mcp",
-  "installation_notes": "No API key required — works anonymously on a free, rate-limited tier. Optionally set SCHOLAR_API_KEY (a free first-party ssk_ key from https://scholar-sidekick.com/account) for higher limits, or RAPIDAPI_KEY for paid tiers via RapidAPI.",
-  "is_builtin": false,
-  "endorsed": false,
-  "environmentVariables": [
-    {
-      "name": "SCHOLAR_API_KEY",
-      "description": "Optional first-party API key (ssk_) from https://scholar-sidekick.com/account; raises rate limits. Sent as Authorization: Bearer.",
-      "required": false
-    },
-    {
-      "name": "RAPIDAPI_KEY",
-      "description": "Optional RapidAPI key for paid/managed tiers; routes calls through the RapidAPI gateway.",
-      "required": false
-    }
-  ]
-}
-
+    "id": "scholar-sidekick",
+    "name": "Scholar Sidekick",
+    "description": "Resolve, format, export, and verify academic citations (DOI, PMID, ISBN, arXiv) plus retraction and open-access checks",
+    "command": "npx -y scholar-sidekick-mcp@latest",
+    "link": "https://github.com/mlava/scholar-sidekick-mcp",
+    "installation_notes": "No API key required \u2014 works anonymously on a free, rate-limited tier. Optionally set SCHOLAR_API_KEY (a free first-party ssk_ key from https://scholar-sidekick.com/account) for higher limits, or RAPIDAPI_KEY for paid tiers via RapidAPI.",
+    "is_builtin": false,
+    "endorsed": false,
+    "environmentVariables": [
+      {
+        "name": "SCHOLAR_API_KEY",
+        "description": "Optional first-party API key (ssk_) from https://scholar-sidekick.com/account; raises rate limits. Sent as Authorization: Bearer.",
+        "required": false
+      },
+      {
+        "name": "RAPIDAPI_KEY",
+        "description": "Optional RapidAPI key for paid/managed tiers; routes calls through the RapidAPI gateway.",
+        "required": false
+      }
+    ]
+  }
 ]


### PR DESCRIPTION
Adds **Snipget** to `documentation/static/servers.json` (alphabetical position) as a remote streamable-http extension.

Snipget is a hosted MCP server exposing 317 deterministic data utilities for AI agents: validation, normalization, parsing, entity matching, and PII redaction for names, addresses, phones, emails, dates, and identifiers, plus healthcare (NPI/DEA, NUCC taxonomy), chemistry, and biotech reference lookups. Pure functions (no LLM inside), consistent envelopes, batch variants, built-in catalog discovery.

- Endpoint: https://mcp.snipget.ai/mcp (Streamable HTTP; OAuth 2.0 with dynamic client registration — Goose prompts on first use; free tier available)
- Listed in the official MCP registry as `ai.snipget/snipget`
- Docs: https://snipget.ai/docs

Submitted by an automated agent on behalf of Snipget's maintainer (dave@snipget.ai).