### PR TITLE
fix: do not re-arm /goal verification after tool use

### DIFF
--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -4,9 +4,9 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 
-use anyhow::{Context, Result, anyhow};
+use anyhow::{anyhow, Context, Result};
 use futures::stream::BoxStream;
-use futures::{FutureExt, Stream, StreamExt, TryStreamExt, stream};
+use futures::{stream, FutureExt, Stream, StreamExt, TryStreamExt};
 use tracing_futures::Instrument;
 
 use super::container::Container;
@@ -15,11 +15,11 @@ use super::gen_ai_telemetry;
 use super::mcp_client::GooseMcpHostInfo;
 use super::platform_tools;
 use super::tool_confirmation_router::ToolConfirmationRouter;
-use super::tool_execution::{CHAT_MODE_TOOL_SKIPPED_RESPONSE, DECLINED_RESPONSE, ToolCallResult};
+use super::tool_execution::{ToolCallResult, CHAT_MODE_TOOL_SKIPPED_RESPONSE, DECLINED_RESPONSE};
 use crate::action_required_manager::ElicitationOutcome;
 use crate::agents::extension::{ExtensionConfig, ExtensionResult, ToolInfo};
 use crate::agents::extension_manager::{
-    ExtensionManager, ExtensionManagerCapabilities, get_parameter_names,
+    get_parameter_names, ExtensionManager, ExtensionManagerCapabilities,
 };
 use crate::agents::final_output_tool::{FINAL_OUTPUT_CONTINUATION_MESSAGE, FINAL_OUTPUT_TOOL_NAME};
 use crate::agents::platform_extensions::MANAGE_EXTENSIONS_TOOL_NAME_COMPLETE;
@@ -29,19 +29,19 @@ use crate::agents::retry::{RetryManager, RetryResult};
 use crate::agents::types::{FrontendTool, SessionConfig, SharedProvider, ToolResultReceiver};
 use crate::config::extensions::name_to_key;
 use crate::config::permission::PermissionManager;
-use crate::config::{Config, GooseMode, get_enabled_extensions};
+use crate::config::{get_enabled_extensions, Config, GooseMode};
 use crate::context_mgmt::{
-    DEFAULT_COMPACTION_THRESHOLD, check_if_compaction_needed, compact_messages,
+    check_if_compaction_needed, compact_messages, DEFAULT_COMPACTION_THRESHOLD,
 };
 use crate::conversation::message::{
     ActionRequiredData, InferenceMetadata, Message, MessageContent, MessageUsage, ProviderMetadata,
     SystemNotificationType, ToolRequest,
 };
-use crate::conversation::{Conversation, debug_conversation_fix, fix_conversation};
+use crate::conversation::{debug_conversation_fix, fix_conversation, Conversation};
 use crate::mcp_utils::ToolResult;
-use crate::permission::PermissionConfirmation;
 use crate::permission::permission_inspector::PermissionInspector;
 use crate::permission::permission_judge::PermissionCheckResult;
+use crate::permission::PermissionConfirmation;
 use crate::providers::base::{PermissionRouting, Provider};
 use crate::recipe::{Author, Recipe, Response, Settings};
 use crate::scheduler_trait::SchedulerTrait;
@@ -62,7 +62,7 @@ use rmcp::model::{
     GetPromptResult, Prompt, ServerNotification, Tool,
 };
 use serde_json::Value;
-use tokio::sync::{Mutex, mpsc};
+use tokio::sync::{mpsc, Mutex};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, instrument, warn};
 
@@ -3710,7 +3710,7 @@ mod tests {
     use crate::agents::gen_ai_telemetry::{self, test_support::SpanFieldCapture};
     use crate::permission::permission_confirmation::PrincipalType;
     use crate::plugins::discovery::{DiscoveredPlugin, PluginScope};
-    use crate::providers::base::{MessageStream, PermissionRouting, stream_from_single_message};
+    use crate::providers::base::{stream_from_single_message, MessageStream, PermissionRouting};
     use crate::recipe::Response;
     use crate::session::session_manager::SessionType;
     use goose_providers::conversation::token_usage::{ProviderUsage, Usage};

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -4,9 +4,9 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use futures::stream::BoxStream;
-use futures::{stream, FutureExt, Stream, StreamExt, TryStreamExt};
+use futures::{FutureExt, Stream, StreamExt, TryStreamExt, stream};
 use tracing_futures::Instrument;
 
 use super::container::Container;
@@ -15,11 +15,11 @@ use super::gen_ai_telemetry;
 use super::mcp_client::GooseMcpHostInfo;
 use super::platform_tools;
 use super::tool_confirmation_router::ToolConfirmationRouter;
-use super::tool_execution::{ToolCallResult, CHAT_MODE_TOOL_SKIPPED_RESPONSE, DECLINED_RESPONSE};
+use super::tool_execution::{CHAT_MODE_TOOL_SKIPPED_RESPONSE, DECLINED_RESPONSE, ToolCallResult};
 use crate::action_required_manager::ElicitationOutcome;
 use crate::agents::extension::{ExtensionConfig, ExtensionResult, ToolInfo};
 use crate::agents::extension_manager::{
-    get_parameter_names, ExtensionManager, ExtensionManagerCapabilities,
+    ExtensionManager, ExtensionManagerCapabilities, get_parameter_names,
 };
 use crate::agents::final_output_tool::{FINAL_OUTPUT_CONTINUATION_MESSAGE, FINAL_OUTPUT_TOOL_NAME};
 use crate::agents::platform_extensions::MANAGE_EXTENSIONS_TOOL_NAME_COMPLETE;
@@ -29,19 +29,19 @@ use crate::agents::retry::{RetryManager, RetryResult};
 use crate::agents::types::{FrontendTool, SessionConfig, SharedProvider, ToolResultReceiver};
 use crate::config::extensions::name_to_key;
 use crate::config::permission::PermissionManager;
-use crate::config::{get_enabled_extensions, Config, GooseMode};
+use crate::config::{Config, GooseMode, get_enabled_extensions};
 use crate::context_mgmt::{
-    check_if_compaction_needed, compact_messages, DEFAULT_COMPACTION_THRESHOLD,
+    DEFAULT_COMPACTION_THRESHOLD, check_if_compaction_needed, compact_messages,
 };
 use crate::conversation::message::{
     ActionRequiredData, InferenceMetadata, Message, MessageContent, MessageUsage, ProviderMetadata,
     SystemNotificationType, ToolRequest,
 };
-use crate::conversation::{debug_conversation_fix, fix_conversation, Conversation};
+use crate::conversation::{Conversation, debug_conversation_fix, fix_conversation};
 use crate::mcp_utils::ToolResult;
+use crate::permission::PermissionConfirmation;
 use crate::permission::permission_inspector::PermissionInspector;
 use crate::permission::permission_judge::PermissionCheckResult;
-use crate::permission::PermissionConfirmation;
 use crate::providers::base::{PermissionRouting, Provider};
 use crate::recipe::{Author, Recipe, Response, Settings};
 use crate::scheduler_trait::SchedulerTrait;
@@ -62,7 +62,7 @@ use rmcp::model::{
     GetPromptResult, Prompt, ServerNotification, Tool,
 };
 use serde_json::Value;
-use tokio::sync::{mpsc, Mutex};
+use tokio::sync::{Mutex, mpsc};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, instrument, warn};
 
@@ -2710,8 +2710,10 @@ impl Agent {
                                 }
 
                                 no_tools_called = false;
-                                // Agent is actively working — re-check goal when it next finishes
-                                goal_check_pending = false;
+                                // Do not reset goal_check_pending here. Once a goal
+                                // verification nudge has been injected, tool use is part of
+                                // that verification — clearing the latch would re-arm the
+                                // nudge after every tool-using turn and loop until max_turns.
                             }
                         }
                         #[allow(unused_variables)]
@@ -3708,7 +3710,7 @@ mod tests {
     use crate::agents::gen_ai_telemetry::{self, test_support::SpanFieldCapture};
     use crate::permission::permission_confirmation::PrincipalType;
     use crate::plugins::discovery::{DiscoveredPlugin, PluginScope};
-    use crate::providers::base::{stream_from_single_message, MessageStream, PermissionRouting};
+    use crate::providers::base::{MessageStream, PermissionRouting, stream_from_single_message};
     use crate::recipe::Response;
     use crate::session::session_manager::SessionType;
     use goose_providers::conversation::token_usage::{ProviderUsage, Usage};

--- a/crates/goose/tests/agent.rs
+++ b/crates/goose/tests/agent.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use anyhow::Result;
 use futures::StreamExt;
 use goose::agents::{Agent, AgentEvent, GoosePlatform};
-use goose::config::extensions::{set_extension, ExtensionEntry};
+use goose::config::extensions::{ExtensionEntry, set_extension};
 
 #[cfg(test)]
 mod tests {
@@ -14,10 +14,10 @@ mod tests {
         use super::*;
         use async_trait::async_trait;
         use chrono::{DateTime, Utc};
-        use goose::agents::platform_tools::PLATFORM_MANAGE_SCHEDULE_TOOL_NAME;
         use goose::agents::AgentConfig;
-        use goose::config::permission::PermissionManager;
+        use goose::agents::platform_tools::PLATFORM_MANAGE_SCHEDULE_TOOL_NAME;
         use goose::config::GooseMode;
+        use goose::config::permission::PermissionManager;
         use goose::scheduler::{ScheduledJob, SchedulerError, ValidatedScheduleRecipe};
         use goose::scheduler_trait::SchedulerTrait;
         use goose::session::{Session, SessionManager};
@@ -238,11 +238,12 @@ mod tests {
             assert!(schedule_tool.is_some());
 
             let tool = schedule_tool.unwrap();
-            assert!(tool
-                .description
-                .clone()
-                .unwrap_or_default()
-                .contains("Manage goose's internal scheduled recipe execution"));
+            assert!(
+                tool.description
+                    .clone()
+                    .unwrap_or_default()
+                    .contains("Manage goose's internal scheduled recipe execution")
+            );
         }
 
         #[tokio::test]
@@ -284,11 +285,12 @@ mod tests {
             assert!(schedule_tool.is_some());
 
             let tool = schedule_tool.unwrap();
-            assert!(tool
-                .description
-                .clone()
-                .unwrap_or_default()
-                .contains("Manage goose's internal scheduled recipe execution"));
+            assert!(
+                tool.description
+                    .clone()
+                    .unwrap_or_default()
+                    .contains("Manage goose's internal scheduled recipe execution")
+            );
 
             // Verify the tool has the expected actions in its schema
             if let Some(properties) = tool.input_schema.get("properties") {
@@ -345,12 +347,14 @@ mod tests {
                         session_id_prop.get("type").unwrap().as_str().unwrap(),
                         "string"
                     );
-                    assert!(session_id_prop
-                        .get("description")
-                        .unwrap()
-                        .as_str()
-                        .unwrap()
-                        .contains("Session identifier for session_content action"));
+                    assert!(
+                        session_id_prop
+                            .get("description")
+                            .unwrap()
+                            .as_str()
+                            .unwrap()
+                            .contains("Session identifier for session_content action")
+                    );
                 }
             }
         }
@@ -461,9 +465,11 @@ mod tests {
                 validation_result.is_err(),
                 "Should validate max_retries > 0"
             );
-            assert!(validation_result
-                .unwrap_err()
-                .contains("max_retries must be greater than 0"));
+            assert!(
+                validation_result
+                    .unwrap_err()
+                    .contains("max_retries must be greater than 0")
+            );
 
             Ok(())
         }
@@ -495,7 +501,7 @@ mod tests {
         use goose::config::GooseMode;
         use goose::conversation::message::{Message, MessageContent};
         use goose::providers::base::{
-            stream_from_single_message, MessageStream, Provider, ProviderDef, ProviderMetadata,
+            MessageStream, Provider, ProviderDef, ProviderMetadata, stream_from_single_message,
         };
         use goose::session::session_manager::SessionType;
         use goose_providers::conversation::token_usage::{ProviderUsage, Usage};
@@ -654,14 +660,14 @@ mod tests {
         use super::*;
         use async_trait::async_trait;
         use goose::agents::{AgentConfig, SessionConfig};
-        use goose::config::permission::PermissionManager;
         use goose::config::GooseMode;
+        use goose::config::permission::PermissionManager;
         use goose::conversation::message::{Message, MessageContent};
         use goose::providers::base::{
-            stream_from_single_message, MessageStream, Provider, ProviderDef, ProviderMetadata,
+            MessageStream, Provider, ProviderDef, ProviderMetadata, stream_from_single_message,
         };
-        use goose::session::session_manager::SessionType;
         use goose::session::SessionManager;
+        use goose::session::session_manager::SessionType;
         use goose_providers::conversation::token_usage::{ProviderUsage, Usage};
         use goose_providers::errors::ProviderError;
         use goose_providers::model::ModelConfig;
@@ -835,12 +841,12 @@ mod tests {
         use super::*;
         use async_trait::async_trait;
         use goose::agents::{AgentConfig, SessionConfig};
+        use goose::config::GooseMode;
         use goose::config::base::Config;
         use goose::config::permission::PermissionManager;
-        use goose::config::GooseMode;
         use goose::conversation::message::Message;
         use goose::providers::base::{
-            stream_from_single_message, MessageStream, Provider, ProviderDef, ProviderMetadata,
+            MessageStream, Provider, ProviderDef, ProviderMetadata, stream_from_single_message,
         };
         use goose::session::{SessionManager, SessionType};
         use goose_providers::conversation::token_usage::{ProviderUsage, Usage};
@@ -848,8 +854,8 @@ mod tests {
         use goose_providers::model::ModelConfig;
         use rmcp::model::{CallToolRequestParams, CallToolResult, ContentBlock, Tool};
         use std::path::PathBuf;
-        use std::sync::atomic::{AtomicUsize, Ordering};
         use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
 
         /// Mock provider that returns text for the main reply and summaries for
         /// summarization calls. Distinguishes by checking if tools are empty
@@ -1097,13 +1103,13 @@ mod tests {
     #[cfg(test)]
     mod extension_manager_tests {
         use super::*;
+        use goose::agents::AgentConfig;
         use goose::agents::extension::ExtensionConfig;
         use goose::agents::platform_extensions::{
             MANAGE_EXTENSIONS_TOOL_NAME, SEARCH_AVAILABLE_EXTENSIONS_TOOL_NAME,
         };
-        use goose::agents::AgentConfig;
-        use goose::config::permission::PermissionManager;
         use goose::config::GooseMode;
+        use goose::config::permission::PermissionManager;
         use goose::session::SessionManager;
 
         async fn setup_agent_with_extension_manager() -> (Agent, String) {
@@ -1196,12 +1202,12 @@ mod tests {
         use super::*;
         use async_trait::async_trait;
         use goose::agents::{AgentConfig, SessionConfig};
-        use goose::config::permission::PermissionManager;
         use goose::config::GooseMode;
+        use goose::config::permission::PermissionManager;
         use goose::conversation::message::Message;
         use goose::providers::base::{MessageStream, Provider, ProviderDef, ProviderMetadata};
-        use goose::session::session_manager::SessionType;
         use goose::session::SessionManager;
+        use goose::session::session_manager::SessionType;
         use goose_providers::conversation::token_usage::{ProviderUsage, Usage};
         use goose_providers::errors::ProviderError;
         use goose_providers::model::ModelConfig;
@@ -1466,12 +1472,12 @@ mod tests {
         use super::*;
         use async_trait::async_trait;
         use goose::agents::{AgentConfig, SessionConfig};
-        use goose::config::permission::PermissionManager;
         use goose::config::GooseMode;
+        use goose::config::permission::PermissionManager;
         use goose::conversation::message::{Message, MessageContent};
         use goose::providers::base::{MessageStream, Provider, ProviderDef, ProviderMetadata};
-        use goose::session::session_manager::SessionType;
         use goose::session::SessionManager;
+        use goose::session::session_manager::SessionType;
         use goose_providers::conversation::token_usage::{ProviderUsage, Usage};
         use goose_providers::errors::ProviderError;
         use goose_providers::model::ModelConfig;
@@ -1626,7 +1632,7 @@ mod tests {
 
         fn assert_formatter_adds_reasoning_to_tool_calls(messages: &[Message], provider: &str) {
             use goose_providers::formats::openai::{
-                format_messages_with_options, OpenAiFormatOptions,
+                OpenAiFormatOptions, format_messages_with_options,
             };
             use goose_providers::images::ImageFormat;
 
@@ -1924,10 +1930,10 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn test_multi_tool_response_preserves_reasoning_and_message_id_correlation(
-        ) -> Result<()> {
+        async fn test_multi_tool_response_preserves_reasoning_and_message_id_correlation()
+        -> Result<()> {
             use goose_providers::formats::openai::{
-                format_messages_with_options, OpenAiFormatOptions,
+                OpenAiFormatOptions, format_messages_with_options,
             };
             use goose_providers::images::ImageFormat;
 
@@ -2179,14 +2185,14 @@ mod tests {
         use async_trait::async_trait;
         use goose::agents::AgentConfig;
         use goose::agents::SessionConfig;
-        use goose::config::permission::PermissionManager;
         use goose::config::GooseMode;
+        use goose::config::permission::PermissionManager;
         use goose::conversation::message::Message;
         use goose::providers::base::{
-            stream_from_single_message, MessageStream, Provider, ProviderDef, ProviderMetadata,
+            MessageStream, Provider, ProviderDef, ProviderMetadata, stream_from_single_message,
         };
-        use goose::session::session_manager::SessionType;
         use goose::session::SessionManager;
+        use goose::session::session_manager::SessionType;
         use goose_providers::conversation::token_usage::{ProviderUsage, Usage};
         use goose_providers::errors::ProviderError;
         use goose_providers::model::ModelConfig;
@@ -2350,6 +2356,160 @@ mod tests {
                 agent.get_goal().await,
                 None,
                 "Goal should be cleared after the agent finishes with it met"
+            );
+
+            Ok(())
+        }
+
+        /// Provider that answers the goal-check nudge with a tool call, then
+        /// finishes with plain text. Reproduces the harness loop where
+        /// verifying a goal via tools re-armed the goal check forever.
+        struct GoalToolThenTextProvider {
+            call_count: AtomicU32,
+        }
+
+        impl GoalToolThenTextProvider {
+            fn new() -> Self {
+                Self {
+                    call_count: AtomicU32::new(0),
+                }
+            }
+        }
+
+        impl goose::providers::base::ProviderDescriptor for GoalToolThenTextProvider {
+            fn metadata() -> ProviderMetadata {
+                ProviderMetadata {
+                    name: "goal-tool-mock".to_string(),
+                    display_name: "Goal Tool Mock Provider".to_string(),
+                    description: "Mock provider that uses a tool during goal verification"
+                        .to_string(),
+                    default_model: "mock-model".to_string(),
+                    known_models: vec![],
+                    model_doc_link: "".to_string(),
+                    config_keys: vec![],
+                    setup_steps: vec![],
+                    model_selection_hint: None,
+                    fast_model: None,
+                }
+            }
+        }
+
+        impl ProviderDef for GoalToolThenTextProvider {
+            type Provider = Self;
+
+            fn from_env(
+                _extensions: Vec<goose::config::ExtensionConfig>,
+                _tls_config: Option<goose::providers::api_client::TlsConfig>,
+            ) -> futures::future::BoxFuture<'static, anyhow::Result<Self>> {
+                Box::pin(async { Ok(Self::new()) })
+            }
+        }
+
+        #[async_trait]
+        impl Provider for GoalToolThenTextProvider {
+            async fn stream(
+                &self,
+                _model_config: &ModelConfig,
+                _system_prompt: &str,
+                messages: &[Message],
+                _tools: &[Tool],
+            ) -> Result<MessageStream, ProviderError> {
+                use rmcp::model::CallToolRequestParams;
+
+                let count = self.call_count.fetch_add(1, Ordering::SeqCst);
+                let last_user = messages
+                    .iter()
+                    .rev()
+                    .find(|m| m.role == rmcp::model::Role::User)
+                    .map(|m| m.as_concat_text())
+                    .unwrap_or_default();
+
+                let message = if last_user.contains("check whether the following goal") {
+                    // First response to the goal-check nudge: use a tool (unknown is fine;
+                    // execution still counts as tool work for the agent loop).
+                    let tool_call = CallToolRequestParams::new("goal_verify_probe");
+                    Message::assistant()
+                        .with_tool_request(format!("goal_tool_{count}"), Ok(tool_call))
+                } else {
+                    Message::assistant().with_text(format!("Response number {count}"))
+                };
+
+                let usage = ProviderUsage::new(
+                    "mock-model".to_string(),
+                    Usage::new(Some(10), Some(5), Some(15)),
+                );
+                Ok(stream_from_single_message(message, usage))
+            }
+
+            fn get_name(&self) -> &str {
+                "goal-tool-mock"
+            }
+        }
+
+        #[tokio::test]
+        async fn test_goal_check_does_not_rearm_after_tool_use() -> Result<()> {
+            let temp_dir = TempDir::new()?;
+            let session_manager = Arc::new(SessionManager::new(temp_dir.path().to_path_buf()));
+            let agent = create_agent_with_session_naming_disabled(session_manager.clone());
+            let provider = Arc::new(GoalToolThenTextProvider::new());
+
+            let session = session_manager
+                .create_session(
+                    PathBuf::default(),
+                    "goal-tool-loop-test".to_string(),
+                    SessionType::Hidden,
+                    GooseMode::default(),
+                )
+                .await?;
+
+            agent
+                .update_provider(
+                    provider.clone(),
+                    ModelConfig::new("mock-model"),
+                    &session.id,
+                )
+                .await?;
+            agent
+                .set_goal(Some(
+                    "keep working until all pr comments are addressed".to_string(),
+                ))
+                .await;
+
+            let session_config = SessionConfig {
+                id: session.id.clone(),
+                schedule_id: None,
+                max_turns: Some(10),
+                retry_config: None,
+            };
+
+            let reply_stream = agent
+                .reply(Message::user().with_text("Hello"), session_config, None)
+                .await?;
+            tokio::pin!(reply_stream);
+
+            while let Some(event) = reply_stream.next().await {
+                match event {
+                    Ok(_) => {}
+                    Err(e) => return Err(e),
+                }
+            }
+
+            let call_count = provider.call_count.load(Ordering::SeqCst);
+            // Expected path: initial text → goal check (tool) → post-tool text → exit.
+            // Before the fix this re-armed the goal check after every tool turn and
+            // burned max_turns.
+            assert!(
+                call_count >= 2,
+                "Expected at least initial + goal-check calls, got {call_count}"
+            );
+            assert!(
+                call_count <= 4,
+                "Goal verification via tools must not re-arm forever; got {call_count} provider calls"
+            );
+            assert_eq!(
+                agent.get_goal().await,
+                None,
+                "Goal should be cleared after verification completes"
             );
 
             Ok(())
@@ -2617,12 +2777,12 @@ mod tests {
         use super::*;
         use async_trait::async_trait;
         use goose::agents::{AgentConfig, SessionConfig};
-        use goose::config::permission::PermissionManager;
         use goose::config::GooseMode;
+        use goose::config::permission::PermissionManager;
         use goose::conversation::message::Message;
-        use goose::providers::base::{stream_from_single_message, MessageStream, Provider};
-        use goose::session::session_manager::SessionType;
+        use goose::providers::base::{MessageStream, Provider, stream_from_single_message};
         use goose::session::SessionManager;
+        use goose::session::session_manager::SessionType;
         use goose_providers::conversation::token_usage::{ProviderUsage, Usage};
         use goose_providers::errors::ProviderError;
         use goose_providers::model::ModelConfig;
@@ -2731,8 +2891,8 @@ mod tests {
     mod frontend_extension_tests {
         use super::*;
         use goose::agents::{AgentConfig, ExtensionConfig};
-        use goose::config::permission::PermissionManager;
         use goose::config::GooseMode;
+        use goose::config::permission::PermissionManager;
         use goose::session::session_manager::SessionType;
         use goose::session::{
             EnabledExtensionsState, ExtensionData, ExtensionState, SessionManager,
@@ -2797,9 +2957,11 @@ mod tests {
                 .unwrap();
 
             let listed_tools = agent.list_tools(&session.id, None).await;
-            assert!(listed_tools
-                .iter()
-                .any(|tool| tool.name == "frontend__echo"));
+            assert!(
+                listed_tools
+                    .iter()
+                    .any(|tool| tool.name == "frontend__echo")
+            );
 
             let filtered_tools = agent
                 .list_tools(&session.id, Some("frontend-e2e".to_string()))
@@ -2818,9 +2980,11 @@ mod tests {
                 EnabledExtensionsState::from_extension_data(&persisted_session.extension_data)
                     .unwrap()
                     .extensions;
-            assert!(persisted_extensions
-                .iter()
-                .any(|extension| extension.name() == "frontend-e2e"));
+            assert!(
+                persisted_extensions
+                    .iter()
+                    .any(|extension| extension.name() == "frontend-e2e")
+            );
 
             agent
                 .remove_extension("frontend-e2e", &session.id)
@@ -2828,9 +2992,11 @@ mod tests {
                 .unwrap();
 
             let listed_tools = agent.list_tools(&session.id, None).await;
-            assert!(!listed_tools
-                .iter()
-                .any(|tool| tool.name == "frontend__echo"));
+            assert!(
+                !listed_tools
+                    .iter()
+                    .any(|tool| tool.name == "frontend__echo")
+            );
 
             let persisted_session = session_manager
                 .get_session(&session.id, false)
@@ -2840,9 +3006,11 @@ mod tests {
                 EnabledExtensionsState::from_extension_data(&persisted_session.extension_data)
                     .unwrap()
                     .extensions;
-            assert!(persisted_extensions
-                .iter()
-                .all(|extension| extension.name() != "frontend-e2e"));
+            assert!(
+                persisted_extensions
+                    .iter()
+                    .all(|extension| extension.name() != "frontend-e2e")
+            );
         }
 
         #[tokio::test]
@@ -2922,7 +3090,7 @@ mod tests {
         use goose::agents::{AgentConfig, SessionConfig};
         use goose::config::{ExtensionConfig, GooseMode, PermissionManager};
         use goose::conversation::message::{Message, MessageContent};
-        use goose::providers::base::{stream_from_single_message, MessageStream, Provider};
+        use goose::providers::base::{MessageStream, Provider, stream_from_single_message};
         use goose::session::{SessionManager, SessionType};
         use goose_providers::conversation::token_usage::{ProviderUsage, Usage};
         use goose_providers::errors::ProviderError;
@@ -3078,12 +3246,12 @@ mod tests {
         use async_trait::async_trait;
         use goose::agents::final_output_tool::FINAL_OUTPUT_TOOL_NAME;
         use goose::agents::{AgentConfig, AgentEvent, GoosePlatform, SessionConfig};
-        use goose::config::permission::PermissionManager;
         use goose::config::GooseMode;
-        use goose::conversation::message::{Message, MessageContent};
+        use goose::config::permission::PermissionManager;
         use goose::conversation::Conversation;
+        use goose::conversation::message::{Message, MessageContent};
         use goose::providers::base::{
-            stream_from_single_message, MessageStream, Provider, ProviderDef, ProviderMetadata,
+            MessageStream, Provider, ProviderDef, ProviderMetadata, stream_from_single_message,
         };
         use goose::session::session_manager::SessionType;
         use goose_providers::conversation::token_usage::{ProviderUsage, Usage};
@@ -3092,8 +3260,8 @@ mod tests {
         use rmcp::model::{CallToolRequestParams, Tool};
         use rmcp::object;
         use std::path::PathBuf;
-        use std::sync::atomic::{AtomicUsize, Ordering};
         use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
 
         fn usage() -> ProviderUsage {
             ProviderUsage::new(

--- a/crates/goose/tests/agent.rs
+++ b/crates/goose/tests/agent.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use anyhow::Result;
 use futures::StreamExt;
 use goose::agents::{Agent, AgentEvent, GoosePlatform};
-use goose::config::extensions::{ExtensionEntry, set_extension};
+use goose::config::extensions::{set_extension, ExtensionEntry};
 
 #[cfg(test)]
 mod tests {
@@ -14,10 +14,10 @@ mod tests {
         use super::*;
         use async_trait::async_trait;
         use chrono::{DateTime, Utc};
-        use goose::agents::AgentConfig;
         use goose::agents::platform_tools::PLATFORM_MANAGE_SCHEDULE_TOOL_NAME;
-        use goose::config::GooseMode;
+        use goose::agents::AgentConfig;
         use goose::config::permission::PermissionManager;
+        use goose::config::GooseMode;
         use goose::scheduler::{ScheduledJob, SchedulerError, ValidatedScheduleRecipe};
         use goose::scheduler_trait::SchedulerTrait;
         use goose::session::{Session, SessionManager};
@@ -238,12 +238,11 @@ mod tests {
             assert!(schedule_tool.is_some());
 
             let tool = schedule_tool.unwrap();
-            assert!(
-                tool.description
-                    .clone()
-                    .unwrap_or_default()
-                    .contains("Manage goose's internal scheduled recipe execution")
-            );
+            assert!(tool
+                .description
+                .clone()
+                .unwrap_or_default()
+                .contains("Manage goose's internal scheduled recipe execution"));
         }
 
         #[tokio::test]
@@ -285,12 +284,11 @@ mod tests {
             assert!(schedule_tool.is_some());
 
             let tool = schedule_tool.unwrap();
-            assert!(
-                tool.description
-                    .clone()
-                    .unwrap_or_default()
-                    .contains("Manage goose's internal scheduled recipe execution")
-            );
+            assert!(tool
+                .description
+                .clone()
+                .unwrap_or_default()
+                .contains("Manage goose's internal scheduled recipe execution"));
 
             // Verify the tool has the expected actions in its schema
             if let Some(properties) = tool.input_schema.get("properties") {
@@ -347,14 +345,12 @@ mod tests {
                         session_id_prop.get("type").unwrap().as_str().unwrap(),
                         "string"
                     );
-                    assert!(
-                        session_id_prop
-                            .get("description")
-                            .unwrap()
-                            .as_str()
-                            .unwrap()
-                            .contains("Session identifier for session_content action")
-                    );
+                    assert!(session_id_prop
+                        .get("description")
+                        .unwrap()
+                        .as_str()
+                        .unwrap()
+                        .contains("Session identifier for session_content action"));
                 }
             }
         }
@@ -465,11 +461,9 @@ mod tests {
                 validation_result.is_err(),
                 "Should validate max_retries > 0"
             );
-            assert!(
-                validation_result
-                    .unwrap_err()
-                    .contains("max_retries must be greater than 0")
-            );
+            assert!(validation_result
+                .unwrap_err()
+                .contains("max_retries must be greater than 0"));
 
             Ok(())
         }
@@ -501,7 +495,7 @@ mod tests {
         use goose::config::GooseMode;
         use goose::conversation::message::{Message, MessageContent};
         use goose::providers::base::{
-            MessageStream, Provider, ProviderDef, ProviderMetadata, stream_from_single_message,
+            stream_from_single_message, MessageStream, Provider, ProviderDef, ProviderMetadata,
         };
         use goose::session::session_manager::SessionType;
         use goose_providers::conversation::token_usage::{ProviderUsage, Usage};
@@ -660,14 +654,14 @@ mod tests {
         use super::*;
         use async_trait::async_trait;
         use goose::agents::{AgentConfig, SessionConfig};
-        use goose::config::GooseMode;
         use goose::config::permission::PermissionManager;
+        use goose::config::GooseMode;
         use goose::conversation::message::{Message, MessageContent};
         use goose::providers::base::{
-            MessageStream, Provider, ProviderDef, ProviderMetadata, stream_from_single_message,
+            stream_from_single_message, MessageStream, Provider, ProviderDef, ProviderMetadata,
         };
-        use goose::session::SessionManager;
         use goose::session::session_manager::SessionType;
+        use goose::session::SessionManager;
         use goose_providers::conversation::token_usage::{ProviderUsage, Usage};
         use goose_providers::errors::ProviderError;
         use goose_providers::model::ModelConfig;
@@ -841,12 +835,12 @@ mod tests {
         use super::*;
         use async_trait::async_trait;
         use goose::agents::{AgentConfig, SessionConfig};
-        use goose::config::GooseMode;
         use goose::config::base::Config;
         use goose::config::permission::PermissionManager;
+        use goose::config::GooseMode;
         use goose::conversation::message::Message;
         use goose::providers::base::{
-            MessageStream, Provider, ProviderDef, ProviderMetadata, stream_from_single_message,
+            stream_from_single_message, MessageStream, Provider, ProviderDef, ProviderMetadata,
         };
         use goose::session::{SessionManager, SessionType};
         use goose_providers::conversation::token_usage::{ProviderUsage, Usage};
@@ -854,8 +848,8 @@ mod tests {
         use goose_providers::model::ModelConfig;
         use rmcp::model::{CallToolRequestParams, CallToolResult, ContentBlock, Tool};
         use std::path::PathBuf;
-        use std::sync::Arc;
         use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::Arc;
 
         /// Mock provider that returns text for the main reply and summaries for
         /// summarization calls. Distinguishes by checking if tools are empty
@@ -1103,13 +1097,13 @@ mod tests {
     #[cfg(test)]
     mod extension_manager_tests {
         use super::*;
-        use goose::agents::AgentConfig;
         use goose::agents::extension::ExtensionConfig;
         use goose::agents::platform_extensions::{
             MANAGE_EXTENSIONS_TOOL_NAME, SEARCH_AVAILABLE_EXTENSIONS_TOOL_NAME,
         };
-        use goose::config::GooseMode;
+        use goose::agents::AgentConfig;
         use goose::config::permission::PermissionManager;
+        use goose::config::GooseMode;
         use goose::session::SessionManager;
 
         async fn setup_agent_with_extension_manager() -> (Agent, String) {
@@ -1202,12 +1196,12 @@ mod tests {
         use super::*;
         use async_trait::async_trait;
         use goose::agents::{AgentConfig, SessionConfig};
-        use goose::config::GooseMode;
         use goose::config::permission::PermissionManager;
+        use goose::config::GooseMode;
         use goose::conversation::message::Message;
         use goose::providers::base::{MessageStream, Provider, ProviderDef, ProviderMetadata};
-        use goose::session::SessionManager;
         use goose::session::session_manager::SessionType;
+        use goose::session::SessionManager;
         use goose_providers::conversation::token_usage::{ProviderUsage, Usage};
         use goose_providers::errors::ProviderError;
         use goose_providers::model::ModelConfig;
@@ -1472,12 +1466,12 @@ mod tests {
         use super::*;
         use async_trait::async_trait;
         use goose::agents::{AgentConfig, SessionConfig};
-        use goose::config::GooseMode;
         use goose::config::permission::PermissionManager;
+        use goose::config::GooseMode;
         use goose::conversation::message::{Message, MessageContent};
         use goose::providers::base::{MessageStream, Provider, ProviderDef, ProviderMetadata};
-        use goose::session::SessionManager;
         use goose::session::session_manager::SessionType;
+        use goose::session::SessionManager;
         use goose_providers::conversation::token_usage::{ProviderUsage, Usage};
         use goose_providers::errors::ProviderError;
         use goose_providers::model::ModelConfig;
@@ -1632,7 +1626,7 @@ mod tests {
 
         fn assert_formatter_adds_reasoning_to_tool_calls(messages: &[Message], provider: &str) {
             use goose_providers::formats::openai::{
-                OpenAiFormatOptions, format_messages_with_options,
+                format_messages_with_options, OpenAiFormatOptions,
             };
             use goose_providers::images::ImageFormat;
 
@@ -1930,10 +1924,10 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn test_multi_tool_response_preserves_reasoning_and_message_id_correlation()
-        -> Result<()> {
+        async fn test_multi_tool_response_preserves_reasoning_and_message_id_correlation(
+        ) -> Result<()> {
             use goose_providers::formats::openai::{
-                OpenAiFormatOptions, format_messages_with_options,
+                format_messages_with_options, OpenAiFormatOptions,
             };
             use goose_providers::images::ImageFormat;
 
@@ -2185,14 +2179,14 @@ mod tests {
         use async_trait::async_trait;
         use goose::agents::AgentConfig;
         use goose::agents::SessionConfig;
-        use goose::config::GooseMode;
         use goose::config::permission::PermissionManager;
+        use goose::config::GooseMode;
         use goose::conversation::message::Message;
         use goose::providers::base::{
-            MessageStream, Provider, ProviderDef, ProviderMetadata, stream_from_single_message,
+            stream_from_single_message, MessageStream, Provider, ProviderDef, ProviderMetadata,
         };
-        use goose::session::SessionManager;
         use goose::session::session_manager::SessionType;
+        use goose::session::SessionManager;
         use goose_providers::conversation::token_usage::{ProviderUsage, Usage};
         use goose_providers::errors::ProviderError;
         use goose_providers::model::ModelConfig;
@@ -2777,12 +2771,12 @@ mod tests {
         use super::*;
         use async_trait::async_trait;
         use goose::agents::{AgentConfig, SessionConfig};
-        use goose::config::GooseMode;
         use goose::config::permission::PermissionManager;
+        use goose::config::GooseMode;
         use goose::conversation::message::Message;
-        use goose::providers::base::{MessageStream, Provider, stream_from_single_message};
-        use goose::session::SessionManager;
+        use goose::providers::base::{stream_from_single_message, MessageStream, Provider};
         use goose::session::session_manager::SessionType;
+        use goose::session::SessionManager;
         use goose_providers::conversation::token_usage::{ProviderUsage, Usage};
         use goose_providers::errors::ProviderError;
         use goose_providers::model::ModelConfig;
@@ -2891,8 +2885,8 @@ mod tests {
     mod frontend_extension_tests {
         use super::*;
         use goose::agents::{AgentConfig, ExtensionConfig};
-        use goose::config::GooseMode;
         use goose::config::permission::PermissionManager;
+        use goose::config::GooseMode;
         use goose::session::session_manager::SessionType;
         use goose::session::{
             EnabledExtensionsState, ExtensionData, ExtensionState, SessionManager,
@@ -2957,11 +2951,9 @@ mod tests {
                 .unwrap();
 
             let listed_tools = agent.list_tools(&session.id, None).await;
-            assert!(
-                listed_tools
-                    .iter()
-                    .any(|tool| tool.name == "frontend__echo")
-            );
+            assert!(listed_tools
+                .iter()
+                .any(|tool| tool.name == "frontend__echo"));
 
             let filtered_tools = agent
                 .list_tools(&session.id, Some("frontend-e2e".to_string()))
@@ -2980,11 +2972,9 @@ mod tests {
                 EnabledExtensionsState::from_extension_data(&persisted_session.extension_data)
                     .unwrap()
                     .extensions;
-            assert!(
-                persisted_extensions
-                    .iter()
-                    .any(|extension| extension.name() == "frontend-e2e")
-            );
+            assert!(persisted_extensions
+                .iter()
+                .any(|extension| extension.name() == "frontend-e2e"));
 
             agent
                 .remove_extension("frontend-e2e", &session.id)
@@ -2992,11 +2982,9 @@ mod tests {
                 .unwrap();
 
             let listed_tools = agent.list_tools(&session.id, None).await;
-            assert!(
-                !listed_tools
-                    .iter()
-                    .any(|tool| tool.name == "frontend__echo")
-            );
+            assert!(!listed_tools
+                .iter()
+                .any(|tool| tool.name == "frontend__echo"));
 
             let persisted_session = session_manager
                 .get_session(&session.id, false)
@@ -3006,11 +2994,9 @@ mod tests {
                 EnabledExtensionsState::from_extension_data(&persisted_session.extension_data)
                     .unwrap()
                     .extensions;
-            assert!(
-                persisted_extensions
-                    .iter()
-                    .all(|extension| extension.name() != "frontend-e2e")
-            );
+            assert!(persisted_extensions
+                .iter()
+                .all(|extension| extension.name() != "frontend-e2e"));
         }
 
         #[tokio::test]
@@ -3090,7 +3076,7 @@ mod tests {
         use goose::agents::{AgentConfig, SessionConfig};
         use goose::config::{ExtensionConfig, GooseMode, PermissionManager};
         use goose::conversation::message::{Message, MessageContent};
-        use goose::providers::base::{MessageStream, Provider, stream_from_single_message};
+        use goose::providers::base::{stream_from_single_message, MessageStream, Provider};
         use goose::session::{SessionManager, SessionType};
         use goose_providers::conversation::token_usage::{ProviderUsage, Usage};
         use goose_providers::errors::ProviderError;
@@ -3246,12 +3232,12 @@ mod tests {
         use async_trait::async_trait;
         use goose::agents::final_output_tool::FINAL_OUTPUT_TOOL_NAME;
         use goose::agents::{AgentConfig, AgentEvent, GoosePlatform, SessionConfig};
-        use goose::config::GooseMode;
         use goose::config::permission::PermissionManager;
-        use goose::conversation::Conversation;
+        use goose::config::GooseMode;
         use goose::conversation::message::{Message, MessageContent};
+        use goose::conversation::Conversation;
         use goose::providers::base::{
-            MessageStream, Provider, ProviderDef, ProviderMetadata, stream_from_single_message,
+            stream_from_single_message, MessageStream, Provider, ProviderDef, ProviderMetadata,
         };
         use goose::session::session_manager::SessionType;
         use goose_providers::conversation::token_usage::{ProviderUsage, Usage};
@@ -3260,8 +3246,8 @@ mod tests {
         use rmcp::model::{CallToolRequestParams, Tool};
         use rmcp::object;
         use std::path::PathBuf;
-        use std::sync::Arc;
         use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::Arc;
 
         fn usage() -> ProviderUsage {
             ProviderUsage::new(


### PR DESCRIPTION
## Summary

`/goal` verification could loop forever when the model used tools to check the goal.

## Bug

In the agent reply loop, after injecting the hidden nudge:

> Before finishing, check whether the following goal has been fully met…

`goal_check_pending` was reset to `false` on **any** tool execution. So a verification turn that called tools (e.g. `gh`, `git`, tests) cleared the latch, and the next tool-free finish re-injected the same nudge — until `max_turns`.

That matches the thrash of repeatedly seeing the goal-check prompt after already finishing the work.

## Fix

Stop clearing `goal_check_pending` when tools run. Once verification has been requested, tool use is part of that verification. The goal still clears when the agent finishes a subsequent turn with no tools (existing `None => set_goal(None)` path).

## Test

- `test_goal_check_does_not_rearm_after_tool_use` — provider answers the goal nudge with a tool call, then text; asserts bounded provider calls and goal cleared
- Existing goal_checking tests still pass (6 total)

## Test plan

- [x] `cargo test -p goose --test agent goal_checking`
- [ ] Manual: `/goal do something that needs tools` → agent should not keep re-asking “has the goal been met?” after tool-using verification