### PR TITLE
fix(acp): stop ACP tool titles from becoming over-long tool_use names

### DIFF
--- a/crates/goose-provider-types/src/formats/anthropic.rs
+++ b/crates/goose-provider-types/src/formats/anthropic.rs
@@ -137,6 +137,11 @@ const CACHE_CONTROL_FIELD: &str = "cache_control";
 const ID_FIELD: &str = "id";
 const NAME_FIELD: &str = "name";
 const INPUT_FIELD: &str = "input";
+/// Anthropic rejects `tool_use.name` past this length. History written by an ACP
+/// harness stores the call's display title as the name, and for shell calls that
+/// title is the whole command, so a replayed session can carry names far past the
+/// limit and 400 on every retry until it is clamped here.
+const MAX_TOOL_USE_NAME_CHARS: usize = 200;
 const TOOL_USE_ID_FIELD: &str = "tool_use_id";
 const IS_ERROR_FIELD: &str = "is_error";
 const SIGNATURE_FIELD: &str = "signature";
@@ -180,6 +185,10 @@ pub fn format_messages(messages: &[Message]) -> Vec<Value> {
     format_messages_with_options(messages, AnthropicFormatOptions::default())
 }
 
+fn clamp_tool_use_name(name: &str) -> String {
+    name.chars().take(MAX_TOOL_USE_NAME_CHARS).collect()
+}
+
 fn format_messages_with_options(
     messages: &[Message],
     options: AnthropicFormatOptions,
@@ -209,7 +218,7 @@ fn format_messages_with_options(
                             content.push(json!({
                                 TYPE_FIELD: TOOL_USE_TYPE,
                                 ID_FIELD: tool_request.id,
-                                NAME_FIELD: tool_call.name,
+                                NAME_FIELD: clamp_tool_use_name(&tool_call.name),
                                 INPUT_FIELD: args_to_input_value(tool_call.arguments.clone())
                             }));
                         }
@@ -377,7 +386,7 @@ fn format_messages_with_options(
                         content.push(json!({
                             TYPE_FIELD: TOOL_USE_TYPE,
                             ID_FIELD: tool_request.id,
-                            NAME_FIELD: tool_call.name,
+                            NAME_FIELD: clamp_tool_use_name(&tool_call.name),
                             INPUT_FIELD: args_to_input_value(tool_call.arguments.clone())
                         }));
                     }
@@ -1686,6 +1695,52 @@ mod tests {
             "Error: -32603: Tool failed"
         );
         assert_eq!(spec[1]["content"][0]["is_error"], true);
+    }
+
+    /// A session that ran on an ACP harness stores the call's display title as
+    /// the tool name, and for a shell call that title is the whole command. On
+    /// one reported machine those names reached 2143 characters, so every replay
+    /// of that history 400s on `tool_use.name` until the name is clamped.
+    #[test]
+    fn test_over_long_tool_name_is_clamped_to_the_provider_limit() {
+        let long_name = "g".repeat(2143);
+        let messages = vec![Message::assistant().with_tool_request(
+            "tool_1",
+            Ok(CallToolRequestParams::new(long_name.clone())
+                .with_arguments(object!({"command": "git commit"}))),
+        )];
+
+        let spec = format_messages(&messages);
+        let emitted = spec[0]["content"][0]["name"].as_str().unwrap();
+
+        assert_eq!(emitted.chars().count(), MAX_TOOL_USE_NAME_CHARS);
+        assert!(long_name.starts_with(emitted));
+    }
+
+    #[test]
+    fn test_tool_name_at_the_limit_is_left_alone() {
+        let exact_name = "g".repeat(MAX_TOOL_USE_NAME_CHARS);
+        let messages = vec![Message::assistant()
+            .with_tool_request("tool_1", Ok(CallToolRequestParams::new(exact_name.clone())))];
+
+        let spec = format_messages(&messages);
+
+        assert_eq!(spec[0]["content"][0]["name"], exact_name);
+    }
+
+    /// The limit counts characters, so clamping a multibyte name by bytes would
+    /// either split a code point and panic or emit a name still over the limit.
+    #[test]
+    fn test_multibyte_tool_name_is_clamped_on_a_character_boundary() {
+        let multibyte_name = "ş".repeat(300);
+        let messages = vec![Message::assistant()
+            .with_tool_request("tool_1", Ok(CallToolRequestParams::new(multibyte_name)))];
+
+        let spec = format_messages(&messages);
+        let emitted = spec[0]["content"][0]["name"].as_str().unwrap();
+
+        assert_eq!(emitted.chars().count(), MAX_TOOL_USE_NAME_CHARS);
+        assert_eq!(emitted, "ş".repeat(MAX_TOOL_USE_NAME_CHARS));
     }
 
     #[test]

--- a/crates/goose-provider-types/src/formats/anthropic.rs
+++ b/crates/goose-provider-types/src/formats/anthropic.rs
@@ -137,11 +137,16 @@ const CACHE_CONTROL_FIELD: &str = "cache_control";
 const ID_FIELD: &str = "id";
 const NAME_FIELD: &str = "name";
 const INPUT_FIELD: &str = "input";
-/// Anthropic rejects `tool_use.name` past this length. History written by an ACP
-/// harness stores the call's display title as the name, and for shell calls that
-/// title is the whole command, so a replayed session can carry names far past the
-/// limit and 400 on every retry until it is clamped here.
-const MAX_TOOL_USE_NAME_CHARS: usize = 200;
+/// Anthropic validates `tool_use.name` inside replayed history against
+/// `^[a-zA-Z0-9_-]{1,64}$`, so both the length and the character class are
+/// enforced. History written by an ACP harness stores the call's display title as
+/// the name, and for shell calls that title is the whole command, so a replayed
+/// session carries spaces and quotes and 400s on every retry until it is
+/// sanitized here. A gateway in front of Anthropic may report the weaker rule
+/// instead (`String should have at most 200 characters`, issue #10807); 64 is
+/// under that bound, so satisfying the pattern satisfies both.
+const MAX_TOOL_USE_NAME_CHARS: usize = 64;
+const TOOL_USE_NAME_PLACEHOLDER: &str = "unnamed_tool";
 const TOOL_USE_ID_FIELD: &str = "tool_use_id";
 const IS_ERROR_FIELD: &str = "is_error";
 const SIGNATURE_FIELD: &str = "signature";
@@ -185,8 +190,27 @@ pub fn format_messages(messages: &[Message]) -> Vec<Value> {
     format_messages_with_options(messages, AnthropicFormatOptions::default())
 }
 
-fn clamp_tool_use_name(name: &str) -> String {
-    name.chars().take(MAX_TOOL_USE_NAME_CHARS).collect()
+/// Rewrite a stored tool name into one Anthropic accepts in replayed history.
+/// Mapping the character class before the length cut keeps the result ASCII, so
+/// the cut can never land inside a multibyte code point.
+fn sanitize_tool_use_name(name: &str) -> String {
+    let sanitized: String = name
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '_' || c == '-' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .take(MAX_TOOL_USE_NAME_CHARS)
+        .collect();
+
+    if sanitized.is_empty() {
+        return TOOL_USE_NAME_PLACEHOLDER.to_string();
+    }
+
+    sanitized
 }
 
 fn format_messages_with_options(
@@ -218,7 +242,7 @@ fn format_messages_with_options(
                             content.push(json!({
                                 TYPE_FIELD: TOOL_USE_TYPE,
                                 ID_FIELD: tool_request.id,
-                                NAME_FIELD: clamp_tool_use_name(&tool_call.name),
+                                NAME_FIELD: sanitize_tool_use_name(&tool_call.name),
                                 INPUT_FIELD: args_to_input_value(tool_call.arguments.clone())
                             }));
                         }
@@ -386,7 +410,7 @@ fn format_messages_with_options(
                         content.push(json!({
                             TYPE_FIELD: TOOL_USE_TYPE,
                             ID_FIELD: tool_request.id,
-                            NAME_FIELD: clamp_tool_use_name(&tool_call.name),
+                            NAME_FIELD: sanitize_tool_use_name(&tool_call.name),
                             INPUT_FIELD: args_to_input_value(tool_call.arguments.clone())
                         }));
                     }
@@ -1697,50 +1721,86 @@ mod tests {
         assert_eq!(spec[1]["content"][0]["is_error"], true);
     }
 
-    /// A session that ran on an ACP harness stores the call's display title as
-    /// the tool name, and for a shell call that title is the whole command. On
-    /// one reported machine those names reached 2143 characters, so every replay
-    /// of that history 400s on `tool_use.name` until the name is clamped.
+    /// Anthropic validates `tool_use.name` inside replayed history, not just the
+    /// names declared in `tools`. Reported verbatim as
+    /// `messages.3.content.1.tool_use.name: String should match pattern
+    /// '^[a-zA-Z0-9_-]{1,64}$'` in drorm/vmpilot#17 and langchain-ai/langsmith-sdk#899.
+    fn assert_valid_tool_use_name(name: &str) {
+        assert!(!name.is_empty(), "empty name violates the {{1,64}} pattern");
+        assert!(
+            name.chars().count() <= MAX_TOOL_USE_NAME_CHARS,
+            "{name:?} is longer than {MAX_TOOL_USE_NAME_CHARS} characters"
+        );
+        assert!(
+            name.chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-'),
+            "{name:?} carries characters outside [a-zA-Z0-9_-]"
+        );
+    }
+
+    fn emitted_tool_name(name: &str) -> String {
+        let messages = vec![Message::assistant()
+            .with_tool_request("tool_1", Ok(CallToolRequestParams::new(name.to_string())))];
+
+        format_messages(&messages)[0]["content"][0]["name"]
+            .as_str()
+            .unwrap()
+            .to_string()
+    }
+
+    /// An ACP harness stores the shell command as the tool name, so a replayed
+    /// name carries spaces and quotes while sitting well under any length limit.
+    /// Truncation never touches it and the session 400s forever.
     #[test]
-    fn test_over_long_tool_name_is_clamped_to_the_provider_limit() {
-        let long_name = "g".repeat(2143);
-        let messages = vec![Message::assistant().with_tool_request(
-            "tool_1",
-            Ok(CallToolRequestParams::new(long_name.clone())
-                .with_arguments(object!({"command": "git commit"}))),
-        )];
+    fn test_tool_name_with_invalid_characters_is_sanitized() {
+        let emitted = emitted_tool_name(r#"git commit -m "fix""#);
 
-        let spec = format_messages(&messages);
-        let emitted = spec[0]["content"][0]["name"].as_str().unwrap();
+        assert_valid_tool_use_name(&emitted);
+        assert_eq!(emitted, "git_commit_-m__fix_");
+    }
 
-        assert_eq!(emitted.chars().count(), MAX_TOOL_USE_NAME_CHARS);
-        assert!(long_name.starts_with(emitted));
+    /// Twin of the case above: a name that already satisfies the pattern must
+    /// survive untouched, otherwise sanitizing breaks every ordinary tool call.
+    #[test]
+    fn test_valid_tool_name_is_left_untouched() {
+        let valid_name = "developer__shell-2";
+
+        assert_eq!(emitted_tool_name(valid_name), valid_name);
+        assert_valid_tool_use_name(valid_name);
     }
 
     #[test]
-    fn test_tool_name_at_the_limit_is_left_alone() {
+    fn test_over_long_tool_name_is_clamped_to_the_pattern_limit() {
+        let emitted = emitted_tool_name(&"g".repeat(2143));
+
+        assert_valid_tool_use_name(&emitted);
+        assert_eq!(emitted, "g".repeat(MAX_TOOL_USE_NAME_CHARS));
+    }
+
+    /// Twin: a name at the limit is not shortened.
+    #[test]
+    fn test_tool_name_at_the_limit_is_not_shortened() {
         let exact_name = "g".repeat(MAX_TOOL_USE_NAME_CHARS);
-        let messages = vec![Message::assistant()
-            .with_tool_request("tool_1", Ok(CallToolRequestParams::new(exact_name.clone())))];
 
-        let spec = format_messages(&messages);
-
-        assert_eq!(spec[0]["content"][0]["name"], exact_name);
+        assert_eq!(emitted_tool_name(&exact_name), exact_name);
     }
 
-    /// The limit counts characters, so clamping a multibyte name by bytes would
-    /// either split a code point and panic or emit a name still over the limit.
+    /// Clamping a multibyte name by characters kept it inside the length rule and
+    /// still produced a name the pattern rejects, so the emitted bytes must be
+    /// ASCII before the limit is applied at all.
     #[test]
-    fn test_multibyte_tool_name_is_clamped_on_a_character_boundary() {
-        let multibyte_name = "ş".repeat(300);
-        let messages = vec![Message::assistant()
-            .with_tool_request("tool_1", Ok(CallToolRequestParams::new(multibyte_name)))];
+    fn test_multibyte_tool_name_is_replaced_not_just_shortened() {
+        let emitted = emitted_tool_name(&"ş".repeat(300));
 
-        let spec = format_messages(&messages);
-        let emitted = spec[0]["content"][0]["name"].as_str().unwrap();
+        assert_valid_tool_use_name(&emitted);
+        assert_eq!(emitted, "_".repeat(MAX_TOOL_USE_NAME_CHARS));
+    }
 
-        assert_eq!(emitted.chars().count(), MAX_TOOL_USE_NAME_CHARS);
-        assert_eq!(emitted, "ş".repeat(MAX_TOOL_USE_NAME_CHARS));
+    /// The pattern requires at least one character, so an empty name is as
+    /// invalid as an over-long one and needs a placeholder.
+    #[test]
+    fn test_empty_tool_name_gets_a_placeholder() {
+        assert_valid_tool_use_name(&emitted_tool_name(""));
     }
 
     #[test]

--- a/crates/goose/src/acp/provider.rs
+++ b/crates/goose/src/acp/provider.rs
@@ -35,7 +35,9 @@ use tokio_util::compat::{TokioAsyncReadCompatExt as _, TokioAsyncWriteCompatExt 
 use crate::acp::{map_permission_response, PermissionDecision};
 use crate::config::{ExtensionConfig, GooseMode};
 use crate::context_mgmt::format_message_for_compacting;
-use crate::conversation::message::{Message, MessageContent, TOOL_META_EXTERNAL_DISPATCH_KEY};
+use crate::conversation::message::{
+    Message, MessageContent, TOOL_META_EXTERNAL_DISPATCH_KEY, TOOL_META_TITLE_KEY,
+};
 use crate::conversation::Conversation;
 use crate::permission::permission_confirmation::PrincipalType;
 use crate::permission::{Permission, PermissionConfirmation};
@@ -53,9 +55,9 @@ pub const ACP_CURRENT_MODEL: &str = "current";
 /// the tool name puts it on the wire whenever the session is later replayed to a
 /// provider, and Anthropic rejects a `tool_use.name` past 200 characters, which
 /// leaves the session permanently unable to send. The name is a wire identifier,
-/// so it is fixed here and the title travels in tool_meta for the renderer.
+/// so it is fixed here and the title travels under the tool_meta title key the ACP
+/// renderer already reads.
 const ACP_TOOL_NAME: &str = "acp_tool";
-const TOOL_META_ACP_TITLE_KEY: &str = "goose.acp.title";
 
 pub struct AcpProviderConfig {
     pub command: PathBuf,
@@ -575,11 +577,12 @@ impl Provider for AcpProvider {
                             // external_dispatch tells the agent loop not to redispatch this
                             // call. goose.acp.kind preserves ACP's stable categorization for
                             // downstream consumers (metrics, observability, icon selection),
-                            // and goose.acp.title carries what the harness wants shown.
+                            // and the shared title key carries what the harness wants shown, which is
+                            // the key the ACP renderer already reads.
                             let tool_meta = Some(serde_json::json!({
                                 TOOL_META_EXTERNAL_DISPATCH_KEY: true,
                                 "goose.acp.kind": kind,
-                                TOOL_META_ACP_TITLE_KEY: name,
+                                TOOL_META_TITLE_KEY: name,
                             }));
                             let message = Message::assistant().with_tool_request_with_metadata(
                                 id,
@@ -1927,10 +1930,10 @@ mod tests {
         let request = &requests[0];
         let call = request.tool_call.as_ref().expect("tool call must parse");
         assert_eq!(call.name, ACP_TOOL_NAME);
-        assert_eq!(
-            request.tool_meta.as_ref().unwrap()[TOOL_META_ACP_TITLE_KEY],
-            serde_json::Value::String(long_title)
-        );
+        // generated_title() is what the ACP renderer calls, so asserting on it
+        // rather than on the raw key is the difference between the title being
+        // stored and the title being shown.
+        assert_eq!(request.generated_title(), Some(long_title.as_str()));
     }
 
     #[tokio::test]
@@ -2750,10 +2753,10 @@ mod tests {
             let tool_meta = serde_json::json!({
                 TOOL_META_EXTERNAL_DISPATCH_KEY: true,
                 "goose.acp.kind": kind,
-                TOOL_META_ACP_TITLE_KEY: "git commit -m 'a very long title'",
+                TOOL_META_TITLE_KEY: "git commit -m 'a very long title'",
             });
             assert_eq!(
-                tool_meta[TOOL_META_ACP_TITLE_KEY],
+                tool_meta[TOOL_META_TITLE_KEY],
                 serde_json::Value::String("git commit -m 'a very long title'".to_string()),
                 "the display title must survive in tool_meta for kind={kind:?}"
             );

--- a/crates/goose/src/acp/provider.rs
+++ b/crates/goose/src/acp/provider.rs
@@ -48,6 +48,15 @@ use goose_providers::model::ModelConfig;
 /// Sentinel: resolved to the actual model name during connect().
 pub const ACP_CURRENT_MODEL: &str = "current";
 
+/// ACP exposes no canonical tool name to clients, and the display title it does
+/// expose is the whole shell command for an execute call. Storing that title as
+/// the tool name puts it on the wire whenever the session is later replayed to a
+/// provider, and Anthropic rejects a `tool_use.name` past 200 characters, which
+/// leaves the session permanently unable to send. The name is a wire identifier,
+/// so it is fixed here and the title travels in tool_meta for the renderer.
+const ACP_TOOL_NAME: &str = "acp_tool";
+const TOOL_META_ACP_TITLE_KEY: &str = "goose.acp.title";
+
 pub struct AcpProviderConfig {
     pub command: PathBuf,
     pub args: Vec<String>,
@@ -559,17 +568,18 @@ impl Provider for AcpProvider {
                             suppress_text = true;
                             rejected_tool_calls.insert(id);
                         } else {
-                            let mut params = CallToolRequestParams::new(name);
+                            let mut params = CallToolRequestParams::new(ACP_TOOL_NAME);
                             if let Some(serde_json::Value::Object(map)) = raw_input {
                                 params = params.with_arguments(map);
                             }
                             // external_dispatch tells the agent loop not to redispatch this
                             // call. goose.acp.kind preserves ACP's stable categorization for
-                            // downstream consumers (metrics, observability, icon selection)
-                            // independent of the display title we put in `name`.
+                            // downstream consumers (metrics, observability, icon selection),
+                            // and goose.acp.title carries what the harness wants shown.
                             let tool_meta = Some(serde_json::json!({
                                 TOOL_META_EXTERNAL_DISPATCH_KEY: true,
                                 "goose.acp.kind": kind,
+                                TOOL_META_ACP_TITLE_KEY: name,
                             }));
                             let message = Message::assistant().with_tool_request_with_metadata(
                                 id,
@@ -862,11 +872,10 @@ impl AcpClientLoop {
                                             None
                                         };
                                     // ACP carries no canonical tool name to clients — only
-                                    // `title` (display) and `kind` (category). We pass `title`
-                                    // for renderer affordance, surface `kind` separately via
-                                    // tool_meta for stable categorization, and the
-                                    // goose.external_dispatch marker keeps `name` off the
-                                    // agent loop's routing/auth paths.
+                                    // `title` (display) and `kind` (category). `name` here is
+                                    // that display title; the consumer stores it in tool_meta
+                                    // and puts a fixed identifier on the wire, so an execute
+                                    // call's whole command never becomes a tool name.
                                     let _ = tx.try_send(AcpUpdate::ToolCallStart {
                                         id: id.clone(),
                                         name: tool_call.title.clone(),
@@ -1869,6 +1878,61 @@ mod tests {
         assert!(!provider.handoff_context_sent.load(Ordering::Acquire));
     }
 
+    /// A harness sets `title` to the whole command for an execute call, so a
+    /// tool name taken from it can run to thousands of characters and the
+    /// session stops being sendable once it is replayed to a provider that caps
+    /// the field. The wire name must stay fixed and the title must survive in
+    /// tool_meta, or the renderer loses what the harness wanted shown.
+    #[tokio::test]
+    async fn acp_tool_call_stores_a_fixed_wire_name_and_keeps_the_title_in_meta() {
+        use futures::StreamExt;
+
+        let long_title = format!("git commit -m '{}'", "x".repeat(2143));
+        let (tx, mut rx) = mpsc::channel(1);
+        let (provider, model) = test_provider_with_tx(Some(tx));
+
+        let messages = vec![Message::user().with_text("commit it")];
+        let mut stream = provider.stream(&model, "", &messages, &[]).await.unwrap();
+
+        let response_tx = match rx.recv().await.expect("expected ACP prompt request") {
+            ClientRequest::Prompt { response_tx, .. } => response_tx,
+            _ => panic!("expected ACP prompt request"),
+        };
+        response_tx
+            .send(AcpUpdate::ToolCallStart {
+                id: "call-1".to_string(),
+                name: long_title.clone(),
+                kind: ToolKind::Execute,
+                raw_input: None,
+            })
+            .await
+            .unwrap();
+        response_tx
+            .send(AcpUpdate::Complete(StopReason::EndTurn, None))
+            .await
+            .unwrap();
+
+        let mut requests = Vec::new();
+        while let Some(item) = stream.next().await {
+            let (message, _usage) = item.unwrap();
+            let Some(message) = message else { continue };
+            for content in message.content {
+                if let MessageContent::ToolRequest(request) = content {
+                    requests.push(request);
+                }
+            }
+        }
+
+        assert_eq!(requests.len(), 1);
+        let request = &requests[0];
+        let call = request.tool_call.as_ref().expect("tool call must parse");
+        assert_eq!(call.name, ACP_TOOL_NAME);
+        assert_eq!(
+            request.tool_meta.as_ref().unwrap()[TOOL_META_ACP_TITLE_KEY],
+            serde_json::Value::String(long_title)
+        );
+    }
+
     #[tokio::test]
     async fn chat_mode_denied_tool_messages_get_distinct_provider_ids() {
         use futures::StreamExt;
@@ -2673,7 +2737,7 @@ mod tests {
     /// emits onto the synthesized `ToolRequest`. ACP doesn't expose a canonical
     /// tool name to clients, so we surface `kind` here as a stable categorization
     /// signal alongside the `external_dispatch` marker that bypasses agent-loop
-    /// routing.
+    /// routing, and the display title the harness sent.
     #[test]
     fn tool_meta_pairs_external_dispatch_marker_with_acp_kind() {
         let cases = [
@@ -2686,7 +2750,13 @@ mod tests {
             let tool_meta = serde_json::json!({
                 TOOL_META_EXTERNAL_DISPATCH_KEY: true,
                 "goose.acp.kind": kind,
+                TOOL_META_ACP_TITLE_KEY: "git commit -m 'a very long title'",
             });
+            assert_eq!(
+                tool_meta[TOOL_META_ACP_TITLE_KEY],
+                serde_json::Value::String("git commit -m 'a very long title'".to_string()),
+                "the display title must survive in tool_meta for kind={kind:?}"
+            );
             assert_eq!(
                 tool_meta[TOOL_META_EXTERNAL_DISPATCH_KEY],
                 serde_json::Value::Bool(true),

--- a/crates/goose/src/acp/server/tool_calls/conversion.rs
+++ b/crates/goose/src/acp/server/tool_calls/conversion.rs
@@ -63,7 +63,9 @@ pub(crate) fn goose_tool_call_meta(tool_request: &ToolRequest) -> Option<Meta> {
         .map(ToString::to_string);
 
     let mut tool_call_meta = serde_json::Map::new();
-    tool_call_meta.insert("toolName".to_string(), serde_json::Value::String(tool_name));
+    if !tool_request.was_executed_externally() {
+        tool_call_meta.insert("toolName".to_string(), serde_json::Value::String(tool_name));
+    }
     if let Some(extension_name) = extension_name {
         tool_call_meta.insert(
             "extensionName".to_string(),
@@ -508,6 +510,61 @@ mod tests {
                     "toolCall": {
                         "toolName": "other__query-docs",
                         "extensionName": "context7",
+                    },
+                })),
+            );
+        }
+
+        /// A call the ACP provider already executed has no goose-side tool, so
+        /// the wire name is a placeholder. Clients treat `toolName` as the
+        /// tool's identity and prefer it over the title when labelling the
+        /// call, so publishing the placeholder makes every such call render as
+        /// the placeholder instead of what the harness asked to be shown.
+        #[test]
+        fn omits_the_placeholder_name_of_an_externally_executed_call() {
+            use crate::conversation::message::{
+                TOOL_META_EXTERNAL_DISPATCH_KEY, TOOL_META_TITLE_KEY,
+            };
+
+            let request = ToolRequest {
+                id: "req_1".to_string(),
+                tool_call: Ok(CallToolRequestParams::new("acp_tool")),
+                metadata: None,
+                tool_meta: Some(serde_json::json!({
+                    TOOL_META_EXTERNAL_DISPATCH_KEY: true,
+                    (TOOL_META_TITLE_KEY): "git commit -m 'add the parser'",
+                })),
+            };
+
+            let meta = goose_tool_call_meta(&request).expect("expected metadata");
+
+            assert_eq!(
+                meta.get("goose"),
+                Some(&serde_json::json!({"toolCall": {}}))
+            );
+        }
+
+        #[test]
+        fn keeps_the_name_of_a_call_goose_dispatches_itself() {
+            use crate::conversation::message::TOOL_META_TITLE_KEY;
+
+            let request = ToolRequest {
+                id: "req_1".to_string(),
+                tool_call: Ok(CallToolRequestParams::new("developer__shell")),
+                metadata: None,
+                tool_meta: Some(serde_json::json!({
+                    (TOOL_META_TITLE_KEY): "running focused tests",
+                })),
+            };
+
+            let meta = goose_tool_call_meta(&request).expect("expected metadata");
+
+            assert_eq!(
+                meta.get("goose"),
+                Some(&serde_json::json!({
+                    "toolCall": {
+                        "toolName": "developer__shell",
+                        "extensionName": "developer",
                     },
                 })),
             );


### PR DESCRIPTION
Refs #10807

## What

A session that ran on an ACP harness stores the call's display title as the tool name. For a shell call that title is the whole command. Anthropic rejects `tool_use.name` past 200 characters, so once such a session is replayed to an Anthropic-format provider every prompt fails with the same 400 and no retry can succeed. The issue reports 13 affected sessions on one machine with stored names up to 2143 characters.

Two commits, one per layer.

**Read time** (`crates/goose-provider-types/src/formats/anthropic.rs`) clamps `tool_use.name` to 200 characters when formatting history, at both emission sites. This half also heals sessions that already carry the long names, which a write-time fix alone cannot do. The count is characters, not bytes, so a multibyte name is cut on a character boundary. `chars().take()` rather than a slice, because the crate denies `clippy::string_slice`.

**Write time** (`crates/goose/src/acp/provider.rs`) stores a fixed wire name, `acp_tool`, and carries the harness's display title in `tool_meta` under `goose.acp.title` so the renderer keeps what it was given. This follows the direction stated on the issue.

## Verification

Both changes were shown red before they were written.

- read side, before: a 2143-character name and a 300-character multibyte name both fail; the exactly-200 twin passes before and after, so the test measures the bug rather than the code
- read side, after: `cargo test -p goose-provider-types` 461 passed, 0 failed
- write side, before: the new end-to-end test fails with the full 2143-character title as the wire name
- write side, after: `cargo test -p goose --lib acp::provider` 56 passed, 0 failed
- `cargo clippy -p goose -p goose-provider-types --all-targets -- -D warnings` clean
- `cargo fmt --check` clean

Not covered: the Bedrock converter builds `tool_use` blocks too and is untouched here, as the issue notes.

## AI disclosure

Written with AI assistance. I understand the change and can discuss it without AI help.
