### PR TITLE
Route OpenRouter tool calls to tool-capable providers

### DIFF
--- a/crates/goose/src/providers/openrouter.rs
+++ b/crates/goose/src/providers/openrouter.rs
@@ -1,8 +1,8 @@
-use anyhow::{Result, bail};
+use anyhow::{bail, Result};
 use async_trait::async_trait;
 use futures::future::BoxFuture;
 use goose_providers::images::ImageFormat;
-use serde_json::{Value, json};
+use serde_json::{json, Value};
 use std::collections::HashMap;
 
 use super::api_client::{ApiClient, AuthMethod};
@@ -15,7 +15,7 @@ use goose_providers::cache_semantics::{apply_chat_payload_breakpoints, CacheSema
 use goose_providers::errors::ProviderError;
 use goose_providers::formats::openai::create_request;
 use goose_providers::model::ModelConfig;
-use goose_providers::request_log::{LoggerHandleExt, start_log};
+use goose_providers::request_log::{start_log, LoggerHandleExt};
 use rmcp::model::Tool;
 
 pub const OPENROUTER_PROVIDER_NAME: &str = "openrouter";
@@ -381,12 +381,10 @@ mod tests {
     fn metadata_includes_openrouter_parameters_config_key() {
         let metadata = OpenRouterProvider::metadata();
 
-        assert!(
-            metadata
-                .config_keys
-                .iter()
-                .any(|key| key.name == OPENROUTER_PARAMETERS_CONFIG_KEY)
-        );
+        assert!(metadata
+            .config_keys
+            .iter()
+            .any(|key| key.name == OPENROUTER_PARAMETERS_CONFIG_KEY));
     }
 
     #[test]
@@ -416,10 +414,9 @@ mod tests {
     fn parse_openrouter_parameters_rejects_non_object_json_string() {
         let err = parse_openrouter_parameters(json!(r#"["web"]"#)).unwrap_err();
 
-        assert!(
-            err.to_string()
-                .contains("OPENROUTER_PARAMETERS must be a JSON object")
-        );
+        assert!(err
+            .to_string()
+            .contains("OPENROUTER_PARAMETERS must be a JSON object"));
     }
 
     #[test]

--- a/crates/goose/src/providers/openrouter.rs
+++ b/crates/goose/src/providers/openrouter.rs
@@ -1,8 +1,8 @@
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use async_trait::async_trait;
 use futures::future::BoxFuture;
 use goose_providers::images::ImageFormat;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use std::collections::HashMap;
 
 use super::api_client::{ApiClient, AuthMethod};
@@ -15,7 +15,7 @@ use goose_providers::cache_semantics::{apply_chat_payload_breakpoints, CacheSema
 use goose_providers::errors::ProviderError;
 use goose_providers::formats::openai::create_request;
 use goose_providers::model::ModelConfig;
-use goose_providers::request_log::{start_log, LoggerHandleExt};
+use goose_providers::request_log::{LoggerHandleExt, start_log};
 use rmcp::model::Tool;
 
 pub const OPENROUTER_PROVIDER_NAME: &str = "openrouter";
@@ -294,6 +294,12 @@ impl Provider for OpenRouterProvider {
             obj.insert("usage".to_string(), json!({ "include": true }));
         }
 
+        // Models like thinkingmachines/inkling advertise tools at the model level, but some
+        // OpenRouter backends (e.g. DeepInfra) do not implement tool calling. Without
+        // require_parameters, OpenRouter may still route tool requests there and the model
+        // answers as plain text / ignores tools — which looks like "strange" agent behavior.
+        ensure_tool_compatible_routing(&mut payload);
+
         let mut log = start_log(model_config, &payload)?;
 
         let response = match self.post_chat_completions(model_config, &payload).await {
@@ -312,6 +318,43 @@ impl Provider for OpenRouterProvider {
         })?;
 
         stream_openai_compat(response, log)
+    }
+}
+
+/// When the request includes tools, force OpenRouter to only use providers that support every
+/// request parameter (including `tools`). Leaves an explicit user `provider` object alone if it
+/// already sets `require_parameters`.
+fn ensure_tool_compatible_routing(payload: &mut Value) {
+    let has_tools = payload
+        .get("tools")
+        .and_then(|tools| tools.as_array())
+        .is_some_and(|tools| !tools.is_empty());
+    if !has_tools {
+        return;
+    }
+
+    let Some(obj) = payload.as_object_mut() else {
+        return;
+    };
+
+    match obj.get_mut("provider") {
+        Some(Value::Object(provider)) => {
+            provider.entry("require_parameters").or_insert(json!(true));
+        }
+        Some(_) => {
+            // Non-object provider values are invalid for OpenRouter; replace with the constraint
+            // goose needs for tool-capable routing.
+            obj.insert(
+                "provider".to_string(),
+                json!({ "require_parameters": true }),
+            );
+        }
+        None => {
+            obj.insert(
+                "provider".to_string(),
+                json!({ "require_parameters": true }),
+            );
+        }
     }
 }
 
@@ -338,10 +381,12 @@ mod tests {
     fn metadata_includes_openrouter_parameters_config_key() {
         let metadata = OpenRouterProvider::metadata();
 
-        assert!(metadata
-            .config_keys
-            .iter()
-            .any(|key| key.name == OPENROUTER_PARAMETERS_CONFIG_KEY));
+        assert!(
+            metadata
+                .config_keys
+                .iter()
+                .any(|key| key.name == OPENROUTER_PARAMETERS_CONFIG_KEY)
+        );
     }
 
     #[test]
@@ -371,9 +416,10 @@ mod tests {
     fn parse_openrouter_parameters_rejects_non_object_json_string() {
         let err = parse_openrouter_parameters(json!(r#"["web"]"#)).unwrap_err();
 
-        assert!(err
-            .to_string()
-            .contains("OPENROUTER_PARAMETERS must be a JSON object"));
+        assert!(
+            err.to_string()
+                .contains("OPENROUTER_PARAMETERS must be a JSON object")
+        );
     }
 
     #[test]
@@ -448,5 +494,79 @@ mod tests {
             .stream(&config, "system", &[Message::user().with_text("hi")], &[])
             .await
             .unwrap();
+    }
+
+    #[test]
+    fn ensure_tool_compatible_routing_adds_require_parameters_when_tools_present() {
+        let mut payload = json!({
+            "model": "thinkingmachines/inkling-small",
+            "messages": [],
+            "tools": [{
+                "type": "function",
+                "function": { "name": "shell", "parameters": { "type": "object" } }
+            }]
+        });
+
+        ensure_tool_compatible_routing(&mut payload);
+
+        assert_eq!(payload["provider"], json!({ "require_parameters": true }));
+    }
+
+    #[test]
+    fn ensure_tool_compatible_routing_skips_requests_without_tools() {
+        let mut payload = json!({
+            "model": "thinkingmachines/inkling-small",
+            "messages": []
+        });
+
+        ensure_tool_compatible_routing(&mut payload);
+
+        assert!(payload.get("provider").is_none());
+    }
+
+    #[test]
+    fn ensure_tool_compatible_routing_preserves_existing_provider_fields() {
+        let mut payload = json!({
+            "model": "thinkingmachines/inkling-small",
+            "messages": [],
+            "tools": [{
+                "type": "function",
+                "function": { "name": "shell", "parameters": { "type": "object" } }
+            }],
+            "provider": {
+                "order": ["together"],
+                "allow_fallbacks": false
+            }
+        });
+
+        ensure_tool_compatible_routing(&mut payload);
+
+        assert_eq!(
+            payload["provider"],
+            json!({
+                "order": ["together"],
+                "allow_fallbacks": false,
+                "require_parameters": true
+            })
+        );
+    }
+
+    #[test]
+    fn ensure_tool_compatible_routing_does_not_override_explicit_require_parameters() {
+        let mut payload = json!({
+            "model": "thinkingmachines/inkling-small",
+            "messages": [],
+            "tools": [{
+                "type": "function",
+                "function": { "name": "shell", "parameters": { "type": "object" } }
+            }],
+            "provider": {
+                "require_parameters": false
+            }
+        });
+
+        ensure_tool_compatible_routing(&mut payload);
+
+        assert_eq!(payload["provider"], json!({ "require_parameters": false }));
     }
 }


### PR DESCRIPTION
Issue: #11054 — filed for this PR per the contribution workflow in `AGENTS.md`; not yet triaged to **Ready**, so this PR is a proposal attached to it rather than agreed work.

Rebased onto `main`.

**Verification after rebase**
- Conflict resolved by hand: `main` removed `supports_cache_control`, so it was **not** reintroduced — only `ensure_tool_compatible_routing` is added.
- `cargo test -p goose --lib providers::openrouter` — 10 passed.
- `cargo clippy -p goose --lib --tests -- -D warnings` — clean.

---

## Summary
- OpenRouter models such as `thinkingmachines/inkling-small` advertise `tools` at the model level, but some backends (notably DeepInfra) do not implement tool calling.
- Goose agent requests always include tools, so OpenRouter could still route to a non-tool host; the model then answers as plain text / ignores tools, which looks like "strange" behavior.
- When a chat request includes tools, set `provider.require_parameters: true` so OpenRouter only uses backends that support every parameter in the request (including `tools`). Preserve an explicit user `require_parameters` value and other `provider` fields from `OPENROUTER_PARAMETERS`.

## Test plan
- [x] `cargo test -p goose --lib providers::openrouter::tests`
- [x] `cargo clippy -p goose --lib -- -D warnings`
- [ ] Manual: open a Goose session with OpenRouter `thinkingmachines/inkling-small`, run a tool-using prompt, confirm responses use tools instead of free-form/weird answers

