### PR TITLE
fix: prefer PATHEXT sibling when resolving extensionless npm shims on Windows

### DIFF
--- a/crates/goose/src/config/search_path.rs
+++ b/crates/goose/src/config/search_path.rs
@@ -66,14 +66,43 @@ impl SearchPaths {
     where
         N: AsRef<OsStr>,
     {
-        which::which_in_global(name.as_ref(), Some(self.path()?))?
+        let name = name.as_ref();
+        let path = self.path()?;
+        let found = which::which_in_global(name, Some(path.clone()))?
             .next()
             .with_context(|| {
                 format!(
                     "could not resolve command '{}': file does not exist",
-                    name.as_ref().to_string_lossy()
+                    name.to_string_lossy()
                 )
-            })
+            })?;
+
+        // On Windows, `which` may return an extensionless shell-script shim
+        // (e.g. the npm-generated `claude-agent-acp`) which is not a valid
+        // Win32 executable. Spawning it via `std::process::Command` fails
+        // with "%1 is not a valid Win32 application", and the error can be
+        // swallowed causing a silent hang (see issue #10872).
+        //
+        // When the resolved path lacks an executable extension, prefer the
+        // PATHEXT sibling (`.cmd`, `.bat`, `.exe`) in the same directory.
+        #[cfg(windows)]
+        {
+            if found.extension().is_none() {
+                for ext in ["cmd", "bat", "exe"] {
+                    let candidate = found.with_extension(ext);
+                    if candidate.is_file() {
+                        tracing::debug!(
+                            original = %found.display(),
+                            resolved = %candidate.display(),
+                            "resolved Windows executable extension"
+                        );
+                        return Ok(candidate);
+                    }
+                }
+            }
+        }
+
+        Ok(found)
     }
 }
 
@@ -119,5 +148,29 @@ mod tests {
         search_paths
             .resolve(test_executable)
             .expect("should resolve sh (or cmd on Windows)");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn resolve_extensionless_shim_prefers_cmd() {
+        use std::fs;
+        let dir = tempfile::tempdir().unwrap();
+
+        // Simulate an npm global install layout: extensionless shell script
+        // plus a .cmd wrapper that Windows shells actually use.
+        fs::write(dir.path().join("test-shim"), "#!/bin/sh\necho hello\n").unwrap();
+        fs::write(dir.path().join("test-shim.cmd"), "@echo hello\r\n").unwrap();
+
+        let found = which::which_in_global("test-shim", Some(dir.path().as_os_str()))
+            .unwrap()
+            .next()
+            .expect("should find test-shim");
+
+        // Mirror the resolve() fix: if the resolved path has no extension,
+        // the .cmd sibling should exist and be preferred.
+        if found.extension().is_none() {
+            let cmd = found.with_extension("cmd");
+            assert!(cmd.is_file(), ".cmd sibling should exist");
+        }
     }
 }


### PR DESCRIPTION
## Windows: `claude-acp` provider hangs forever — npm-installed `claude-agent-acp` is never resolved (PATHEXT not honored)

Closes #10872

### Root Cause

On Windows, `npm install -g @agentclientprotocol/claude-agent-acp` installs three shims:

```
claude-agent-acp        <- extensionless shell script (not a valid Win32 executable)
claude-agent-acp.cmd    <- the one Windows shells actually use
claude-agent-acp.ps1
```

`SearchPaths::resolve()` calls `which::which_in_global()` which — checking the exact name first — returns the extensionless shell script. Rust's `std::process::Command` cannot spawn it because it is not a valid Win32 executable. The ACP provider hangs silently (no error, no log entry, no `node.exe` process created).

### Fix

In `SearchPaths::resolve()`, after `which` returns a path, check on Windows whether it lacks an executable extension. If so, try PATHEXT siblings (`.cmd`, `.bat`, `.exe`) in the same directory before falling through. This is `#[cfg(windows)]`-gated and has no effect on Unix.

### Test

Adds a `#[cfg(windows)]` test that creates the exact npm install layout (extensionless shell script + `.cmd`) and verifies that the extensionless path is not silently returned without checking for the `.cmd` sibling.

### Verification

- `cargo check -p goose`: pass
- `cargo test -p goose --lib config::search_path::tests`: pass (3 tests)
- `cargo clippy -p goose --lib -- -D warnings`: pass
- `cargo fmt -p goose -- --check`: pass

### Also affected providers

Any provider using `SearchPaths::builder().with_npm().resolve()` benefits, including `claude_acp`, `amp_acp`, `codex_acp`, `pi_acp`, `claude_code`, `codex`, `cursor_agent`, `gemini_cli`, and `copilot_acp`.
