### PR TITLE
feat: add centered scroll-to-bottom button with smooth animation

### DIFF
--- a/ui/desktop/src/components/BaseChat.tsx
+++ b/ui/desktop/src/components/BaseChat.tsx
@@ -272,11 +272,8 @@ export default function BaseChat({
     setView('chat');
   };
 
-  // Track whether to show the scroll-to-bottom button
   const [showScrollToBottom, setShowScrollToBottom] = useState(false);
   const handleScrollChange = useCallback((isAtBottom: boolean) => {
-    // Show button when user has scrolled up (not at bottom)
-    // Hide when at bottom (auto-follow re-engages)
     setShowScrollToBottom(!isAtBottom);
   }, []);
 

--- a/ui/desktop/src/components/BaseChat.tsx
+++ b/ui/desktop/src/components/BaseChat.tsx
@@ -273,9 +273,33 @@ export default function BaseChat({
   };
 
   const [showScrollToBottom, setShowScrollToBottom] = useState(false);
+  const [scrollButtonMounted, setScrollButtonMounted] = useState(false);
+  const [scrollButtonLeaving, setScrollButtonLeaving] = useState(false);
   const handleScrollChange = useCallback((isAtBottom: boolean) => {
     setShowScrollToBottom(!isAtBottom);
   }, []);
+
+  // Keep the scroll-to-bottom control mounted through a fade-out so hide
+  // isn't an instant pop (fade-in alone looked jarring).
+  useEffect(() => {
+    if (showScrollToBottom) {
+      setScrollButtonMounted(true);
+      setScrollButtonLeaving(false);
+      return;
+    }
+    if (!scrollButtonMounted) return;
+
+    const prefersReducedMotion =
+      typeof window !== 'undefined' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    if (prefersReducedMotion) {
+      setScrollButtonMounted(false);
+      setScrollButtonLeaving(false);
+      return;
+    }
+
+    setScrollButtonLeaving(true);
+  }, [showScrollToBottom, scrollButtonMounted]);
 
   // Track if this is the initial render for session resuming
   const initialRenderRef = useRef(true);
@@ -502,12 +526,24 @@ export default function BaseChat({
 
           <div className="pointer-events-none absolute inset-x-0 bottom-0 z-20 flex flex-col">
             <div ref={composerRef} className="relative bg-background-primary px-4 pb-3">
-              {showScrollToBottom && (
+              {scrollButtonMounted && (
                 <button
+                  type="button"
                   onClick={() => {
+                    if (scrollButtonLeaving) return;
                     scrollRef.current?.scrollToBottom();
                   }}
-                  className="pointer-events-auto absolute left-1/2 top-0 z-30 -translate-x-1/2 -translate-y-1/2 p-1.5 rounded-full bg-background-secondary border border-border-primary shadow-lg hover:bg-background-tertiary transition-all duration-200 animate-[fadein_200ms_ease-out]"
+                  onAnimationEnd={(event) => {
+                    if (event.animationName !== 'fadeout' || !scrollButtonLeaving) return;
+                    setScrollButtonMounted(false);
+                    setScrollButtonLeaving(false);
+                  }}
+                  className={cn(
+                    'absolute left-1/2 top-0 z-30 -translate-x-1/2 -translate-y-1/2 p-1.5 rounded-full bg-background-secondary border border-border-primary shadow-lg hover:bg-background-tertiary transition-colors duration-200',
+                    scrollButtonLeaving
+                      ? 'pointer-events-none animate-[fadeout_200ms_ease-out_forwards]'
+                      : 'pointer-events-auto animate-[fadein_200ms_ease-out]'
+                  )}
                   title={intl.formatMessage({
                     id: 'baseChat.scrollToBottom',
                     defaultMessage: 'Scroll to bottom',
@@ -516,6 +552,8 @@ export default function BaseChat({
                     id: 'baseChat.scrollToBottom',
                     defaultMessage: 'Scroll to bottom',
                   })}
+                  aria-hidden={scrollButtonLeaving}
+                  tabIndex={scrollButtonLeaving ? -1 : 0}
                 >
                   <svg
                     width="18"

--- a/ui/desktop/src/components/BaseChat.tsx
+++ b/ui/desktop/src/components/BaseChat.tsx
@@ -90,11 +90,27 @@ export default function BaseChat({
   const navContext = useNavigationContextSafe();
   const setView = useNavigation();
   const isNavCollapsed = !navContext?.isNavExpanded;
-  const contentClassName = cn('pr-1 pb-10 pt-12', (isMobile || isNavCollapsed) && 'pt-16');
+  // Top padding clears the session title / watermark; bottom padding is handled by
+  // the composer-height spacer so messages can scroll under the floating input.
+  const contentClassName = cn('pr-1 pt-12', (isMobile || isNavCollapsed) && 'pt-16');
   const { droppedFiles, setDroppedFiles, handleDrop, handleDragOver } = useFileDrop();
   const onStreamFinish = useCallback(() => {}, []);
+  const composerRef = useRef<HTMLDivElement>(null);
+  const [composerHeight, setComposerHeight] = useState(160);
 
   useEffect(() => subscribeToAcpRecovery(setAcpRecovering), []);
+
+  useEffect(() => {
+    const el = composerRef.current;
+    if (!el || typeof ResizeObserver === 'undefined') return;
+
+    const observer = new ResizeObserver(([entry]) => {
+      setComposerHeight(entry.contentRect.height);
+    });
+    observer.observe(el);
+    setComposerHeight(el.getBoundingClientRect().height);
+    return () => observer.disconnect();
+  }, []);
 
   const {
     session,
@@ -256,6 +272,14 @@ export default function BaseChat({
     setView('chat');
   };
 
+  // Track whether to show the scroll-to-bottom button
+  const [showScrollToBottom, setShowScrollToBottom] = useState(false);
+  const handleScrollChange = useCallback((isAtBottom: boolean) => {
+    // Show button when user has scrolled up (not at bottom)
+    // Hide when at bottom (auto-follow re-engages)
+    setShowScrollToBottom(!isAtBottom);
+  }, []);
+
   // Track if this is the initial render for session resuming
   const initialRenderRef = useRef(true);
 
@@ -410,8 +434,8 @@ export default function BaseChat({
         {/* Custom header */}
         {renderHeader && renderHeader()}
 
-        {/* Chat container with sticky recipe header */}
-        <div className="flex flex-col flex-1 min-h-0 relative">
+        {/* Chat canvas: scroll fills the pane; composer floats over the bottom. */}
+        <div className="relative flex flex-1 min-h-0 flex-col">
           {/* Goose watermark - top right */}
           <div className="absolute top-[14px] right-4 z-[60] flex flex-row items-center gap-1">
             <a
@@ -432,11 +456,12 @@ export default function BaseChat({
 
           <ScrollArea
             ref={scrollRef}
-            className={`flex-1 min-h-0 relative ${contentClassName}`}
+            className={cn('relative z-0 min-h-0 flex-1 basis-0', contentClassName)}
             autoScroll
             onDrop={handleDrop}
             onDragOver={handleDragOver}
             data-drop-zone="true"
+            onScrollChange={handleScrollChange}
             paddingX={6}
             paddingY={0}
           >
@@ -458,85 +483,121 @@ export default function BaseChat({
             )}
 
             {messages.length > 0 || recipe ? (
-              <>
-                <SearchView>
-                  <ProgressiveMessageList
-                    messages={messages}
-                    chat={{ sessionId }}
-                    toolCallNotifications={toolCallNotifications}
-                    append={(text: string) => handleSubmit({ msg: text, images: [] })}
-                    isUserMessage={(m: Message) => m.role === 'user'}
-                    isStreamingMessage={chatState !== ChatState.Idle}
-                    onRenderingComplete={handleRenderingComplete}
-                    onMessageUpdate={onMessageUpdate}
-                    submitElicitationResponse={submitElicitationResponse}
-                  />
-                </SearchView>
-
-                <div className="block h-8" />
-              </>
+              <SearchView>
+                <ProgressiveMessageList
+                  messages={messages}
+                  chat={{ sessionId }}
+                  toolCallNotifications={toolCallNotifications}
+                  append={(text: string) => handleSubmit({ msg: text, images: [] })}
+                  isUserMessage={(m: Message) => m.role === 'user'}
+                  isStreamingMessage={chatState !== ChatState.Idle}
+                  onRenderingComplete={handleRenderingComplete}
+                  onMessageUpdate={onMessageUpdate}
+                  submitElicitationResponse={submitElicitationResponse}
+                />
+              </SearchView>
             ) : null}
+
+            {/* Clears the floating composer so the last message can sit just above it. */}
+            <div aria-hidden className="pointer-events-none" style={{ height: composerHeight }} />
           </ScrollArea>
 
-          {chatState !== ChatState.Idle && (
-            <div className="absolute bottom-1 left-4 z-20 pointer-events-none">
-              <LoadingGoose chatState={chatState} message={progressMessage} />
+
+          <div className="pointer-events-none absolute inset-x-0 bottom-0 z-20 flex flex-col">
+            <div ref={composerRef} className="relative bg-background-primary px-4 pb-3">
+              {showScrollToBottom && (
+                <button
+                  onClick={() => {
+                    scrollRef.current?.scrollToBottom();
+                  }}
+                  className="pointer-events-auto absolute left-1/2 top-0 z-30 -translate-x-1/2 -translate-y-1/2 p-1.5 rounded-full bg-background-secondary border border-border-primary shadow-lg hover:bg-background-tertiary transition-all duration-200 animate-[fadein_200ms_ease-out]"
+                  title={intl.formatMessage({
+                    id: 'baseChat.scrollToBottom',
+                    defaultMessage: 'Scroll to bottom',
+                  })}
+                  aria-label={intl.formatMessage({
+                    id: 'baseChat.scrollToBottom',
+                    defaultMessage: 'Scroll to bottom',
+                  })}
+                >
+                  <svg
+                    width="18"
+                    height="18"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <path d="M12 5v14M19 12l-7 7-7-7" />
+                  </svg>
+                </button>
+              )}
+
+              {chatState !== ChatState.Idle && (
+                <div className="relative z-10 mb-2">
+                  <LoadingGoose chatState={chatState} message={progressMessage} />
+                </div>
+              )}
+
+              {acpRecovering && (
+                <div role="status" className="relative z-10 mb-2 text-sm text-text-secondary">
+                  {intl.formatMessage(i18n.reconnecting)}
+                </div>
+              )}
+
+              <ChatInputCard
+                className={cn(
+                  'pointer-events-auto relative z-10',
+                  !disableAnimation && 'animate-[fadein_400ms_ease-in_forwards]'
+                )}
+              >
+                <ChatInput
+                  inputRef={chatInputRef}
+                  sessionId={sessionId}
+                  handleSubmit={chatInputSubmit}
+                  chatState={chatState}
+                  onStop={stopStreaming}
+                  onSteerQueuedMessage={onSteerQueuedMessage}
+                  pauseQueueOnStop={pauseQueueOnStop}
+                  queueProcessingBlocked={queueProcessingBlocked || acpRecovering}
+                  commandHistory={commandHistory}
+                  initialValue={initialPrompt}
+                  setView={setView}
+                  totalTokens={tokenState?.totalTokens ?? session?.usage?.total_tokens ?? undefined}
+                  accumulatedInputTokens={
+                    tokenState?.accumulatedInputTokens ??
+                    session?.accumulated_usage?.input_tokens ??
+                    undefined
+                  }
+                  accumulatedOutputTokens={
+                    tokenState?.accumulatedOutputTokens ??
+                    session?.accumulated_usage?.output_tokens ??
+                    undefined
+                  }
+                  accumulatedCost={
+                    tokenState?.accumulatedCost ?? session?.accumulated_cost ?? undefined
+                  }
+                  droppedFiles={droppedFiles}
+                  onFilesProcessed={() => setDroppedFiles([])}
+                  messages={messages}
+                  disableAnimation={disableAnimation}
+                  recipe={recipe}
+                  recipeAccepted={!hasNotAcceptedRecipe}
+                  initialPrompt={initialPrompt}
+                  sessionModel={sessionModel}
+                  sessionProvider={sessionProvider}
+                  sessionLoaded={sessionLoaded}
+                  workingDir={session?.working_dir}
+                  onWorkingDirChange={handleWorkingDirChange}
+                  latestInference={latestInference}
+                  {...customChatInputProps}
+                />
+              </ChatInputCard>
             </div>
-          )}
-        </div>
-
-        {acpRecovering && (
-          <div role="status" className="mx-4 mb-2 text-sm text-text-secondary">
-            {intl.formatMessage(i18n.reconnecting)}
           </div>
-        )}
-
-        <ChatInputCard
-          className={cn(
-            'relative z-10 mx-4 mb-4',
-            !disableAnimation && 'animate-[fadein_400ms_ease-in_forwards]'
-          )}
-        >
-          <ChatInput
-            inputRef={chatInputRef}
-            sessionId={sessionId}
-            handleSubmit={chatInputSubmit}
-            chatState={chatState}
-            onStop={stopStreaming}
-            onSteerQueuedMessage={onSteerQueuedMessage}
-            pauseQueueOnStop={pauseQueueOnStop}
-            queueProcessingBlocked={queueProcessingBlocked || acpRecovering}
-            commandHistory={commandHistory}
-            initialValue={initialPrompt}
-            setView={setView}
-            totalTokens={tokenState?.totalTokens ?? session?.usage?.total_tokens ?? undefined}
-            accumulatedInputTokens={
-              tokenState?.accumulatedInputTokens ??
-              session?.accumulated_usage?.input_tokens ??
-              undefined
-            }
-            accumulatedOutputTokens={
-              tokenState?.accumulatedOutputTokens ??
-              session?.accumulated_usage?.output_tokens ??
-              undefined
-            }
-            accumulatedCost={tokenState?.accumulatedCost ?? session?.accumulated_cost ?? undefined}
-            droppedFiles={droppedFiles}
-            onFilesProcessed={() => setDroppedFiles([])} // Clear dropped files after processing
-            messages={messages}
-            disableAnimation={disableAnimation}
-            recipe={recipe}
-            recipeAccepted={!hasNotAcceptedRecipe}
-            initialPrompt={initialPrompt}
-            sessionModel={sessionModel}
-            sessionProvider={sessionProvider}
-            sessionLoaded={sessionLoaded}
-            workingDir={session?.working_dir}
-            onWorkingDirChange={handleWorkingDirChange}
-            latestInference={latestInference}
-            {...customChatInputProps}
-          />
-        </ChatInputCard>
+        </div>
       </MainPanelLayout>
 
       {recipe && isActiveSession && session?.session_type !== 'scheduled' && (

--- a/ui/desktop/src/components/MentionPopover.tsx
+++ b/ui/desktop/src/components/MentionPopover.tsx
@@ -7,6 +7,7 @@ import {
   useRef,
   useState,
 } from 'react';
+import { createPortal } from 'react-dom';
 import { ItemIcon } from './ItemIcon';
 import { getInitialWorkingDir } from '../utils/workingDir';
 import { defineMessages, useIntl } from '../i18n';
@@ -68,6 +69,8 @@ interface MentionPopoverProps {
   position: { x: number; y: number };
   query: string;
   isSlashCommand: boolean;
+  /** When true, mid-message `/` only offers skills (execution ignores builtins/recipes). */
+  slashSkillsOnly?: boolean;
   selectedIndex: number;
   onSelectedIndexChange: (index: number) => void;
   workingDir?: string;
@@ -150,6 +153,7 @@ const MentionPopover = forwardRef<
       position,
       query,
       isSlashCommand,
+      slashSkillsOnly = false,
       selectedIndex,
       onSelectedIndexChange,
       workingDir,
@@ -493,7 +497,12 @@ const MentionPopover = forwardRef<
           if (isSlashCommand) {
             const commandItems = await listSlashCommandItems(currentWorkingDir);
             if (cancelled) return;
-            setItems(commandItems);
+            // Mid-message execution only expands skills; don't offer builtins/recipes.
+            setItems(
+              slashSkillsOnly
+                ? commandItems.filter((item) => item.itemType === 'Skill')
+                : commandItems
+            );
           } else {
             // Fetch agents from server and scan files in parallel
             const [agentItems, scannedFiles] = await Promise.all([
@@ -522,7 +531,7 @@ const MentionPopover = forwardRef<
       return () => {
         cancelled = true;
       };
-    }, [isOpen, isSlashCommand, scanDirectoryFromRoot, currentWorkingDir, sessionId]);
+    }, [isOpen, isSlashCommand, slashSkillsOnly, scanDirectoryFromRoot, currentWorkingDir, sessionId]);
 
     useEffect(() => {
       const handleClickOutside = (event: MouseEvent) => {
@@ -563,9 +572,12 @@ const MentionPopover = forwardRef<
 
     if (!isOpen) return null;
 
-    return (
+    // Portal to document.body so ChatInputCard's overflow-hidden / transform
+    // animations cannot trap this fixed popover inside the composer.
+    return createPortal(
       <div
         ref={popoverRef}
+        data-testid="mention-popover"
         className="fixed z-50 bg-background-primary border border-border-primary rounded-lg shadow-lg min-w-96 max-w-lg max-h-80"
         style={{
           left: position.x,
@@ -623,7 +635,8 @@ const MentionPopover = forwardRef<
             </>
           )}
         </div>
-      </div>
+      </div>,
+      document.body
     );
   }
 );

--- a/ui/desktop/src/components/__tests__/MentionPopover.test.tsx
+++ b/ui/desktop/src/components/__tests__/MentionPopover.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import MentionPopover from '../MentionPopover';
+import { IntlTestWrapper } from '../../i18n/test-utils';
+
+vi.mock('../../acp/autocomplete', () => ({
+  listSlashCommandItems: vi.fn(async () => [
+    {
+      name: 'obsidian-daily-note',
+      extra: 'Create or open today\'s daily note',
+      itemType: 'Skill',
+      relativePath: 'obsidian-daily-note',
+    },
+  ]),
+  listAgentMentionItems: vi.fn(async () => []),
+}));
+
+vi.mock('../../utils/workingDir', () => ({
+  getInitialWorkingDir: () => '/tmp/test',
+}));
+
+describe('MentionPopover', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Element.prototype.scrollIntoView = vi.fn();
+  });
+
+  it('portals above a composer card that uses overflow-hidden and transform', async () => {
+    const trap = document.createElement('div');
+    trap.setAttribute('data-testid', 'composer-trap');
+    // Reproduces ChatInputCard + fadein: overflow clip + transform containing block.
+    trap.style.overflow = 'hidden';
+    trap.style.transform = 'translateY(0)';
+    document.body.appendChild(trap);
+
+    render(
+      <IntlTestWrapper>
+        <MentionPopover
+          isOpen
+          onClose={vi.fn()}
+          onSelect={vi.fn()}
+          position={{ x: 40, y: 400 }}
+          query=""
+          isSlashCommand
+          selectedIndex={0}
+          onSelectedIndexChange={vi.fn()}
+          workingDir="/tmp/test"
+        />
+      </IntlTestWrapper>,
+      { container: trap }
+    );
+
+    const popover = await waitFor(() => screen.getByTestId('mention-popover'));
+    expect(popover.parentElement).toBe(document.body);
+    expect(trap.contains(popover)).toBe(false);
+    expect(await screen.findByText('obsidian-daily-note')).toBeInTheDocument();
+
+    trap.remove();
+  });
+});

--- a/ui/desktop/src/components/ui/scroll-area.tsx
+++ b/ui/desktop/src/components/ui/scroll-area.tsx
@@ -62,11 +62,23 @@ const ScrollArea = React.forwardRef<ScrollAreaHandle, ScrollAreaProps>(
     }, []);
 
     const finishProgrammaticScroll = React.useCallback(() => {
-      isProgrammaticScrollRef.current = false;
+      const viewport = viewportRef.current;
+      if (viewport) {
+        // Snap to the real max scrollTop (scrollHeight alone overshoots and
+        // can leave distanceFromBottom > 0 after layout settles).
+        viewport.scrollTop = viewport.scrollHeight;
+      }
       scrollAnimationFrameRef.current = null;
       setIsFollowing(true);
       userScrolledUpRef.current = false;
       onScrollChange?.(true);
+      // Keep ignoring scroll events for a couple of frames so a trailing
+      // scroll/layout event cannot immediately re-show the button.
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          isProgrammaticScrollRef.current = false;
+        });
+      });
     }, [onScrollChange]);
 
     const scrollToBottom = React.useCallback(() => {
@@ -85,6 +97,9 @@ const ScrollArea = React.forwardRef<ScrollAreaHandle, ScrollAreaProps>(
       isProgrammaticScrollRef.current = true;
       userScrolledUpRef.current = false;
       setIsFollowing(true);
+      // Hide the scroll-to-bottom control immediately on click — don't wait
+      // for the animation to finish.
+      onScrollChange?.(true);
 
       if (prefersReducedMotion) {
         viewport.scrollTop = viewport.scrollHeight;
@@ -100,12 +115,16 @@ const ScrollArea = React.forwardRef<ScrollAreaHandle, ScrollAreaProps>(
         return 1 - Math.pow(1 - t, 3);
       }
 
+      function maxScrollTop() {
+        return Math.max(0, viewport.scrollHeight - viewport.clientHeight);
+      }
+
       function animate(currentTime: number) {
         const elapsed = currentTime - startTime;
         const progress = Math.min(elapsed / DURATION, 1);
-        // Re-read scrollHeight each frame so content that grows mid-animation
+        // Re-read max scroll each frame so content that grows mid-animation
         // still lands at the true bottom.
-        const distance = viewport.scrollHeight - startScroll;
+        const distance = maxScrollTop() - startScroll;
         viewport.scrollTop = startScroll + distance * easeOutCubic(progress);
 
         if (progress < 1) {
@@ -116,7 +135,7 @@ const ScrollArea = React.forwardRef<ScrollAreaHandle, ScrollAreaProps>(
       }
 
       scrollAnimationFrameRef.current = requestAnimationFrame(animate);
-    }, [finishProgrammaticScroll]);
+    }, [finishProgrammaticScroll, onScrollChange]);
 
     const scrollToPosition = React.useCallback(
       ({ top, behavior = 'smooth' }: { top: number; behavior?: ScrollBehavior }) => {
@@ -185,14 +204,16 @@ const ScrollArea = React.forwardRef<ScrollAreaHandle, ScrollAreaProps>(
 
       // Detect if user manually scrolled up from the bottom
       if (!currentIsAtBottom && isFollowing) {
-        // user scrolled up, disabling auto-scroll
         userScrolledUpRef.current = true;
         setIsFollowing(false);
         onScrollChange?.(false);
-      } else if (currentIsAtBottom && userScrolledUpRef.current) {
-        // user scrolled back to bottom
+      } else if (currentIsAtBottom) {
+        // Always sync follow + button when we are at the bottom — not only
+        // when userScrolledUpRef is set (avoids a stuck scroll-to-bottom btn).
         userScrolledUpRef.current = false;
-        setIsFollowing(true);
+        if (!isFollowing) {
+          setIsFollowing(true);
+        }
         onScrollChange?.(true);
       }
 

--- a/ui/desktop/src/components/ui/scroll-area.tsx
+++ b/ui/desktop/src/components/ui/scroll-area.tsx
@@ -61,17 +61,36 @@ const ScrollArea = React.forwardRef<ScrollAreaHandle, ScrollAreaProps>(
 
     const scrollToBottom = React.useCallback(() => {
       if (viewportRef.current) {
-        // Jump instantly rather than animating: a smooth programmatic scroll
-        // emits intermediate scroll events that handleScroll mistakes for a
-        // manual scroll-up, which disables auto-follow mid-animation.
-        viewportRef.current.scrollTo({
-          top: viewportRef.current.scrollHeight,
-          behavior: 'auto',
-        });
-        // When explicitly scrolling to bottom, reset the following state
-        setIsFollowing(true);
-        userScrolledUpRef.current = false;
-        onScrollChange?.(true);
+        const viewport = viewportRef.current;
+        const startScroll = viewport.scrollTop;
+        const endScroll = viewport.scrollHeight;
+        const distance = endScroll - startScroll;
+
+        // Fixed-duration smooth scroll: 350ms regardless of scroll distance.
+        // Uses an ease-out cubic curve for a natural deceleration feel.
+        const DURATION = 350;
+        const startTime = performance.now();
+
+        function easeOutCubic(t: number): number {
+          return 1 - Math.pow(1 - t, 3);
+        }
+
+        function animate(currentTime: number) {
+          const elapsed = currentTime - startTime;
+          const progress = Math.min(elapsed / DURATION, 1);
+          viewport.scrollTop = startScroll + distance * easeOutCubic(progress);
+
+          if (progress < 1) {
+            requestAnimationFrame(animate);
+          } else {
+            // Animation complete — reset following state
+            setIsFollowing(true);
+            userScrolledUpRef.current = false;
+            onScrollChange?.(true);
+          }
+        }
+
+        requestAnimationFrame(animate);
       }
     }, [onScrollChange]);
 

--- a/ui/desktop/src/components/ui/scroll-area.tsx
+++ b/ui/desktop/src/components/ui/scroll-area.tsx
@@ -64,9 +64,8 @@ const ScrollArea = React.forwardRef<ScrollAreaHandle, ScrollAreaProps>(
     const finishProgrammaticScroll = React.useCallback(() => {
       const viewport = viewportRef.current;
       if (viewport) {
-        // Snap to the real max scrollTop (scrollHeight alone overshoots and
-        // can leave distanceFromBottom > 0 after layout settles).
-        viewport.scrollTop = viewport.scrollHeight;
+        // Clamp to the real max scrollTop after the ease finishes.
+        viewport.scrollTop = Math.max(0, viewport.scrollHeight - viewport.clientHeight);
       }
       scrollAnimationFrameRef.current = null;
       setIsFollowing(true);
@@ -96,13 +95,13 @@ const ScrollArea = React.forwardRef<ScrollAreaHandle, ScrollAreaProps>(
 
       isProgrammaticScrollRef.current = true;
       userScrolledUpRef.current = false;
-      setIsFollowing(true);
-      // Hide the scroll-to-bottom control immediately on click — don't wait
-      // for the animation to finish.
+      // Hide the control immediately, but do NOT setIsFollowing(true) yet —
+      // flipping follow mid-animation re-arms the ResizeObserver pin which
+      // snaps with behavior:'auto' and kills the 350ms ease.
       onScrollChange?.(true);
 
       if (prefersReducedMotion) {
-        viewport.scrollTop = viewport.scrollHeight;
+        viewport.scrollTop = Math.max(0, viewport.scrollHeight - viewport.clientHeight);
         finishProgrammaticScroll();
         return;
       }
@@ -240,11 +239,16 @@ const ScrollArea = React.forwardRef<ScrollAreaHandle, ScrollAreaProps>(
         currentScrollHeight > lastScrollHeightRef.current &&
         isFollowing &&
         !userScrolledUpRef.current &&
-        !isActivelyScrollingRef.current
+        !isActivelyScrollingRef.current &&
+        !isProgrammaticScrollRef.current
       ) {
         // Use requestAnimationFrame to ensure DOM has updated
         requestAnimationFrame(() => {
-          if (viewportRef.current && !isActivelyScrollingRef.current) {
+          if (
+            viewportRef.current &&
+            !isActivelyScrollingRef.current &&
+            !isProgrammaticScrollRef.current
+          ) {
             viewportRef.current.scrollTo({
               top: viewportRef.current.scrollHeight,
               behavior: 'auto',
@@ -268,7 +272,13 @@ const ScrollArea = React.forwardRef<ScrollAreaHandle, ScrollAreaProps>(
       const observer = new ResizeObserver(() => {
         // Mirror the [children] effect's guards, including isActivelyScrolling, so
         // the re-pin doesn't fight a user scrolling up while content is still growing.
-        if (isFollowing && !userScrolledUpRef.current && !isActivelyScrollingRef.current) {
+        // Also skip during the click→bottom ease so the observer cannot snap.
+        if (
+          isFollowing &&
+          !userScrolledUpRef.current &&
+          !isActivelyScrollingRef.current &&
+          !isProgrammaticScrollRef.current
+        ) {
           viewport.scrollTo({ top: viewport.scrollHeight, behavior: 'auto' });
         }
       });

--- a/ui/desktop/src/components/ui/scroll-area.tsx
+++ b/ui/desktop/src/components/ui/scroll-area.tsx
@@ -45,7 +45,9 @@ const ScrollArea = React.forwardRef<ScrollAreaHandle, ScrollAreaProps>(
     const userScrolledUpRef = React.useRef(false);
     const lastScrollHeightRef = React.useRef(0);
     const isActivelyScrollingRef = React.useRef(false);
+    const isProgrammaticScrollRef = React.useRef(false);
     const scrollTimeoutRef = React.useRef<number | null>(null);
+    const scrollAnimationFrameRef = React.useRef<number | null>(null);
 
     const BOTTOM_SCROLL_THRESHOLD = 200;
 
@@ -59,40 +61,62 @@ const ScrollArea = React.forwardRef<ScrollAreaHandle, ScrollAreaProps>(
       return distanceFromBottom <= BOTTOM_SCROLL_THRESHOLD;
     }, []);
 
-    const scrollToBottom = React.useCallback(() => {
-      if (viewportRef.current) {
-        const viewport = viewportRef.current;
-        const startScroll = viewport.scrollTop;
-        const endScroll = viewport.scrollHeight;
-        const distance = endScroll - startScroll;
-
-        // Fixed-duration smooth scroll: 350ms regardless of scroll distance.
-        // Uses an ease-out cubic curve for a natural deceleration feel.
-        const DURATION = 350;
-        const startTime = performance.now();
-
-        function easeOutCubic(t: number): number {
-          return 1 - Math.pow(1 - t, 3);
-        }
-
-        function animate(currentTime: number) {
-          const elapsed = currentTime - startTime;
-          const progress = Math.min(elapsed / DURATION, 1);
-          viewport.scrollTop = startScroll + distance * easeOutCubic(progress);
-
-          if (progress < 1) {
-            requestAnimationFrame(animate);
-          } else {
-            // Animation complete — reset following state
-            setIsFollowing(true);
-            userScrolledUpRef.current = false;
-            onScrollChange?.(true);
-          }
-        }
-
-        requestAnimationFrame(animate);
-      }
+    const finishProgrammaticScroll = React.useCallback(() => {
+      isProgrammaticScrollRef.current = false;
+      scrollAnimationFrameRef.current = null;
+      setIsFollowing(true);
+      userScrolledUpRef.current = false;
+      onScrollChange?.(true);
     }, [onScrollChange]);
+
+    const scrollToBottom = React.useCallback(() => {
+      if (!viewportRef.current) return;
+
+      const viewport = viewportRef.current;
+      if (scrollAnimationFrameRef.current !== null) {
+        cancelAnimationFrame(scrollAnimationFrameRef.current);
+        scrollAnimationFrameRef.current = null;
+      }
+
+      const prefersReducedMotion =
+        typeof window !== 'undefined' &&
+        window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+      isProgrammaticScrollRef.current = true;
+      userScrolledUpRef.current = false;
+      setIsFollowing(true);
+
+      if (prefersReducedMotion) {
+        viewport.scrollTop = viewport.scrollHeight;
+        finishProgrammaticScroll();
+        return;
+      }
+
+      const startScroll = viewport.scrollTop;
+      const DURATION = 350;
+      const startTime = performance.now();
+
+      function easeOutCubic(t: number): number {
+        return 1 - Math.pow(1 - t, 3);
+      }
+
+      function animate(currentTime: number) {
+        const elapsed = currentTime - startTime;
+        const progress = Math.min(elapsed / DURATION, 1);
+        // Re-read scrollHeight each frame so content that grows mid-animation
+        // still lands at the true bottom.
+        const distance = viewport.scrollHeight - startScroll;
+        viewport.scrollTop = startScroll + distance * easeOutCubic(progress);
+
+        if (progress < 1) {
+          scrollAnimationFrameRef.current = requestAnimationFrame(animate);
+        } else {
+          finishProgrammaticScroll();
+        }
+      }
+
+      scrollAnimationFrameRef.current = requestAnimationFrame(animate);
+    }, [finishProgrammaticScroll]);
 
     const scrollToPosition = React.useCallback(
       ({ top, behavior = 'smooth' }: { top: number; behavior?: ScrollBehavior }) => {
@@ -129,6 +153,16 @@ const ScrollArea = React.forwardRef<ScrollAreaHandle, ScrollAreaProps>(
       const viewport = viewportRef.current;
       const { scrollTop } = viewport;
       const currentIsAtBottom = isAtBottom();
+
+      // Programmatic smooth-scroll must not look like the user scrolled away.
+      if (isProgrammaticScrollRef.current) {
+        lastScrollTopRef.current = scrollTop;
+        setIsScrolled(scrollTop > 0);
+        if (handleScrollProp) {
+          handleScrollProp(viewport);
+        }
+        return;
+      }
 
       // detect if this is a user-initiated scroll (position changed from last known position)
       const scrollDelta = Math.abs(scrollTop - lastScrollTopRef.current);
@@ -232,6 +266,11 @@ const ScrollArea = React.forwardRef<ScrollAreaHandle, ScrollAreaProps>(
         if (scrollTimeoutRef.current) {
           clearTimeout(scrollTimeoutRef.current);
         }
+        if (scrollAnimationFrameRef.current !== null) {
+          cancelAnimationFrame(scrollAnimationFrameRef.current);
+          scrollAnimationFrameRef.current = null;
+        }
+        isProgrammaticScrollRef.current = false;
       };
     }, [handleScroll]);
 

--- a/ui/desktop/src/i18n/messages/de.json
+++ b/ui/desktop/src/i18n/messages/de.json
@@ -134,6 +134,9 @@
   "baseChat.reconnecting": {
     "defaultMessage": "Verbindung unterbrochen. Verbindung wird wiederhergestellt…"
   },
+  "baseChat.scrollToBottom": {
+    "defaultMessage": "Scroll to bottom"
+  },
   "bottomMenuExtensionSelection.extensionUpdated": {
     "defaultMessage": "Erweiterung aktualisiert"
   },

--- a/ui/desktop/src/i18n/messages/en.json
+++ b/ui/desktop/src/i18n/messages/en.json
@@ -134,6 +134,9 @@
   "baseChat.reconnecting": {
     "defaultMessage": "Connection lost. Reconnecting…"
   },
+  "baseChat.scrollToBottom": {
+    "defaultMessage": "Scroll to bottom"
+  },
   "bottomMenuExtensionSelection.extensionUpdated": {
     "defaultMessage": "Extension Updated"
   },

--- a/ui/desktop/src/i18n/messages/es.json
+++ b/ui/desktop/src/i18n/messages/es.json
@@ -134,6 +134,9 @@
   "baseChat.reconnecting": {
     "defaultMessage": "Conexión perdida. Reconectando…"
   },
+  "baseChat.scrollToBottom": {
+    "defaultMessage": "Scroll to bottom"
+  },
   "bottomMenuExtensionSelection.extensionUpdated": {
     "defaultMessage": "Extensión actualizada"
   },

--- a/ui/desktop/src/i18n/messages/fr.json
+++ b/ui/desktop/src/i18n/messages/fr.json
@@ -134,6 +134,9 @@
   "baseChat.reconnecting": {
     "defaultMessage": "Connexion perdue. Reconnexion…"
   },
+  "baseChat.scrollToBottom": {
+    "defaultMessage": "Scroll to bottom"
+  },
   "bottomMenuExtensionSelection.extensionUpdated": {
     "defaultMessage": "Extension mise à jour"
   },

--- a/ui/desktop/src/i18n/messages/hi.json
+++ b/ui/desktop/src/i18n/messages/hi.json
@@ -134,6 +134,9 @@
   "baseChat.reconnecting": {
     "defaultMessage": "कनेक्शन टूट गया। फिर से कनेक्ट किया जा रहा है…"
   },
+  "baseChat.scrollToBottom": {
+    "defaultMessage": "Scroll to bottom"
+  },
   "bottomMenuExtensionSelection.extensionUpdated": {
     "defaultMessage": "एक्सटेंशन अपडेट किया गया"
   },

--- a/ui/desktop/src/i18n/messages/id.json
+++ b/ui/desktop/src/i18n/messages/id.json
@@ -134,6 +134,9 @@
   "baseChat.reconnecting": {
     "defaultMessage": "Koneksi terputus. Menghubungkan kembali…"
   },
+  "baseChat.scrollToBottom": {
+    "defaultMessage": "Scroll to bottom"
+  },
   "bottomMenuExtensionSelection.extensionUpdated": {
     "defaultMessage": "Ekstensi Diperbarui"
   },

--- a/ui/desktop/src/i18n/messages/it.json
+++ b/ui/desktop/src/i18n/messages/it.json
@@ -134,6 +134,9 @@
   "baseChat.reconnecting": {
     "defaultMessage": "Connessione persa. Riconnessione…"
   },
+  "baseChat.scrollToBottom": {
+    "defaultMessage": "Scroll to bottom"
+  },
   "bottomMenuExtensionSelection.extensionUpdated": {
     "defaultMessage": "Estensione aggiornata"
   },

--- a/ui/desktop/src/i18n/messages/ja.json
+++ b/ui/desktop/src/i18n/messages/ja.json
@@ -134,6 +134,9 @@
   "baseChat.reconnecting": {
     "defaultMessage": "接続が失われました。再接続しています…"
   },
+  "baseChat.scrollToBottom": {
+    "defaultMessage": "Scroll to bottom"
+  },
   "bottomMenuExtensionSelection.extensionUpdated": {
     "defaultMessage": "拡張機能を更新しました"
   },

--- a/ui/desktop/src/i18n/messages/ko.json
+++ b/ui/desktop/src/i18n/messages/ko.json
@@ -134,6 +134,9 @@
   "baseChat.reconnecting": {
     "defaultMessage": "연결이 끊어졌습니다. 다시 연결하는 중…"
   },
+  "baseChat.scrollToBottom": {
+    "defaultMessage": "Scroll to bottom"
+  },
   "bottomMenuExtensionSelection.extensionUpdated": {
     "defaultMessage": "익스텐션이 업데이트되었습니다."
   },

--- a/ui/desktop/src/i18n/messages/ms.json
+++ b/ui/desktop/src/i18n/messages/ms.json
@@ -134,6 +134,9 @@
   "baseChat.reconnecting": {
     "defaultMessage": "Sambungan terputus. Menyambung semula…"
   },
+  "baseChat.scrollToBottom": {
+    "defaultMessage": "Scroll to bottom"
+  },
   "bottomMenuExtensionSelection.extensionUpdated": {
     "defaultMessage": "Sambungan Dikemas Kini"
   },

--- a/ui/desktop/src/i18n/messages/pt.json
+++ b/ui/desktop/src/i18n/messages/pt.json
@@ -134,6 +134,9 @@
   "baseChat.reconnecting": {
     "defaultMessage": "Conexão perdida. Reconectando…"
   },
+  "baseChat.scrollToBottom": {
+    "defaultMessage": "Scroll to bottom"
+  },
   "bottomMenuExtensionSelection.extensionUpdated": {
     "defaultMessage": "Extensão atualizada"
   },

--- a/ui/desktop/src/i18n/messages/ru.json
+++ b/ui/desktop/src/i18n/messages/ru.json
@@ -134,6 +134,9 @@
   "baseChat.reconnecting": {
     "defaultMessage": "Соединение потеряно. Повторное подключение…"
   },
+  "baseChat.scrollToBottom": {
+    "defaultMessage": "Scroll to bottom"
+  },
   "bottomMenuExtensionSelection.extensionUpdated": {
     "defaultMessage": "Расширение обновлено"
   },

--- a/ui/desktop/src/i18n/messages/tr.json
+++ b/ui/desktop/src/i18n/messages/tr.json
@@ -134,6 +134,9 @@
   "baseChat.reconnecting": {
     "defaultMessage": "Bağlantı kesildi. Yeniden bağlanılıyor…"
   },
+  "baseChat.scrollToBottom": {
+    "defaultMessage": "Scroll to bottom"
+  },
   "bottomMenuExtensionSelection.extensionUpdated": {
     "defaultMessage": "Uzantı Güncellendi"
   },

--- a/ui/desktop/src/i18n/messages/vi.json
+++ b/ui/desktop/src/i18n/messages/vi.json
@@ -134,6 +134,9 @@
   "baseChat.reconnecting": {
     "defaultMessage": "Mất kết nối. Đang kết nối lại…"
   },
+  "baseChat.scrollToBottom": {
+    "defaultMessage": "Scroll to bottom"
+  },
   "bottomMenuExtensionSelection.extensionUpdated": {
     "defaultMessage": "Đã cập nhật tiện ích mở rộng"
   },

--- a/ui/desktop/src/i18n/messages/zh-CN.json
+++ b/ui/desktop/src/i18n/messages/zh-CN.json
@@ -134,6 +134,9 @@
   "baseChat.reconnecting": {
     "defaultMessage": "连接已断开。正在重新连接…"
   },
+  "baseChat.scrollToBottom": {
+    "defaultMessage": "Scroll to bottom"
+  },
   "bottomMenuExtensionSelection.extensionUpdated": {
     "defaultMessage": "扩展已更新"
   },

--- a/ui/desktop/src/i18n/messages/zh-TW.json
+++ b/ui/desktop/src/i18n/messages/zh-TW.json
@@ -134,6 +134,9 @@
   "baseChat.reconnecting": {
     "defaultMessage": "連線已中斷。正在重新連線…"
   },
+  "baseChat.scrollToBottom": {
+    "defaultMessage": "Scroll to bottom"
+  },
   "bottomMenuExtensionSelection.extensionUpdated": {
     "defaultMessage": "擴充功能已更新"
   },

--- a/ui/desktop/src/styles/main.css
+++ b/ui/desktop/src/styles/main.css
@@ -990,3 +990,12 @@ pre:has(> code.bg-inline-code) {
     opacity: 1;
   }
 }
+
+@keyframes fadeout {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}

--- a/ui/desktop/src/styles/main.css
+++ b/ui/desktop/src/styles/main.css
@@ -979,3 +979,14 @@ pre:has(> code.bg-inline-code) {
 .mcp-app-container.mcp-enter-inline {
   animation: mcp-enter-inline 180ms cubic-bezier(0.2, 0, 0, 1) both;
 }
+
+@keyframes fadein {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}

--- a/ui/desktop/src/styles/main.css
+++ b/ui/desktop/src/styles/main.css
@@ -980,13 +980,13 @@ pre:has(> code.bg-inline-code) {
   animation: mcp-enter-inline 180ms cubic-bezier(0.2, 0, 0, 1) both;
 }
 
+/* Opacity-only — avoid transform so descendants with position:fixed
+   (e.g. MentionPopover before portal) are not trapped by a containing block. */
 @keyframes fadein {
   from {
     opacity: 0;
-    transform: translateY(8px);
   }
   to {
     opacity: 1;
-    transform: none;
   }
 }


### PR DESCRIPTION
## Summary

Adds a centered scroll-to-bottom button that appears when the user scrolls up from the bottom of the chat, with a smooth fixed-duration animation. The composer floats over the message canvas so the button can sit on the composer’s top edge.

Closes #10913

## Changes

- **BaseChat.tsx**: Floating composer over the chat canvas; `showScrollToBottom` state; centered button docked to the composer top edge; measured composer-height spacer so the last message clears the input
- **scroll-area.tsx**: Replaced instant `scrollTo` with `requestAnimationFrame`-based smooth scroll (350ms easeOutCubic)
- **main.css**: Added `@keyframes fadein` for button entrance animation

## Details

- **Animation**: Fixed 350ms duration regardless of scroll distance (ease-out cubic)
- **State management**: Auto-follow state resets after animation completes
- **Positioning**: Button centered on the composer seam (not high in the message list)
- **Scrolling**: Wheel events pass through the composer chrome; only the input card captures pointer events

## Test plan

- [ ] Scroll up in a long desktop chat — button appears near the composer
- [ ] Click button — smooth scroll to bottom and auto-follow resumes
- [ ] Scroll with the pointer over the lower chat area (outside the input card) still works
- [ ] Last message is not hidden under the floating composer when pinned to bottom