### PR TITLE
feat: add GOOSE_SHOW_THINKING setting to always expand thinking traces

### DIFF
--- a/ui/desktop/src/components/GooseMessage.tsx
+++ b/ui/desktop/src/components/GooseMessage.tsx
@@ -3,6 +3,7 @@ import ImagePreview from './ImagePreview';
 import { formatMessageTimestamp } from '../utils/timeUtils';
 import MarkdownContent from './MarkdownContent';
 import ThinkingContent from './ThinkingContent';
+import { useConfig } from './ConfigContext';
 import ToolCallWithResponse from './ToolCallWithResponse';
 import {
   getTextAndImageContent,
@@ -47,10 +48,13 @@ export default function GooseMessage({
   isStreaming,
   submitElicitationResponse,
 }: GooseMessageProps) {
+  const { config } = useConfig();
   const contentRef = useRef<HTMLDivElement | null>(null);
 
   const { textContent: displayText, imagePaths } = getTextAndImageContent(message);
   const thinkingContent = getThinkingContent(message);
+
+  const showThinkingByDefault = config['GOOSE_SHOW_THINKING'] === true;
 
   const timestamp = useMemo(() => formatMessageTimestamp(message.created), [message.created]);
   const toolRequests = getToolRequests(message);
@@ -126,10 +130,11 @@ export default function GooseMessage({
           <ThinkingContent
             content={thinkingContent}
             isExpanded={
-              isStreaming &&
-              !displayText.trim() &&
-              imagePaths.length === 0 &&
-              toolRequests.length === 0
+              showThinkingByDefault ||
+              (isStreaming &&
+                !displayText.trim() &&
+                imagePaths.length === 0 &&
+                toolRequests.length === 0)
             }
           />
         )}

--- a/ui/desktop/src/components/settings/chat/ShowThinkingToggle.tsx
+++ b/ui/desktop/src/components/settings/chat/ShowThinkingToggle.tsx
@@ -1,0 +1,42 @@
+import { useState, useEffect } from 'react';
+import { Switch } from '../../ui/switch';
+import { useConfig } from '../../ConfigContext';
+import { defineMessages, useIntl } from '../../../i18n';
+
+const i18n = defineMessages({
+  title: {
+    id: 'showThinkingToggle.title',
+    defaultMessage: 'Always Expand Thinking Traces',
+  },
+  description: {
+    id: 'showThinkingToggle.description',
+    defaultMessage: 'Keep thinking traces expanded by default instead of collapsed',
+  },
+});
+
+export const ShowThinkingToggle = () => {
+  const intl = useIntl();
+  const { config, upsert } = useConfig();
+  const [showThinking, setShowThinking] = useState(false);
+
+  useEffect(() => {
+    setShowThinking(config['GOOSE_SHOW_THINKING'] === true);
+  }, [config['GOOSE_SHOW_THINKING']]);
+
+  const handleToggle = async (checked: boolean) => {
+    setShowThinking(checked);
+    await upsert('GOOSE_SHOW_THINKING', checked, false);
+  };
+
+  return (
+    <div className="flex items-center justify-between py-2 px-2 hover:bg-background-secondary rounded-lg transition-all">
+      <div>
+        <h3 className="text-text-primary">{intl.formatMessage(i18n.title)}</h3>
+        <p className="text-xs text-text-secondary max-w-md mt-[2px]">
+          {intl.formatMessage(i18n.description)}
+        </p>
+      </div>
+      <Switch checked={showThinking} onCheckedChange={handleToggle} variant="mono" />
+    </div>
+  );
+};

--- a/ui/desktop/src/components/settings/response_styles/ResponseStylesSection.tsx
+++ b/ui/desktop/src/components/settings/response_styles/ResponseStylesSection.tsx
@@ -1,6 +1,7 @@
 import { AppEvents } from '../../../constants/events';
 import { useEffect, useState } from 'react';
 import { all_response_styles, ResponseStyleSelectionItem } from './ResponseStyleSelectionItem';
+import { ShowThinkingToggle } from '../chat/ShowThinkingToggle';
 
 export const ResponseStylesSection = () => {
   const [currentStyle, setCurrentStyle] = useState('concise');
@@ -40,6 +41,7 @@ export const ResponseStylesSection = () => {
           handleStyleChange={handleStyleChange}
         />
       ))}
+      <ShowThinkingToggle />
     </div>
   );
 };

--- a/ui/desktop/src/i18n/messages/de.json
+++ b/ui/desktop/src/i18n/messages/de.json
@@ -4100,6 +4100,12 @@
   "shortcutRecorder.save": {
     "defaultMessage": "Speichern"
   },
+  "showThinkingToggle.description": {
+    "defaultMessage": "Keep thinking traces expanded by default instead of collapsed"
+  },
+  "showThinkingToggle.title": {
+    "defaultMessage": "Always Expand Thinking Traces"
+  },
   "skillsView.addSkill": {
     "defaultMessage": "Skill hinzufügen"
   },

--- a/ui/desktop/src/i18n/messages/en.json
+++ b/ui/desktop/src/i18n/messages/en.json
@@ -4100,6 +4100,12 @@
   "shortcutRecorder.save": {
     "defaultMessage": "Save"
   },
+  "showThinkingToggle.description": {
+    "defaultMessage": "Keep thinking traces expanded by default instead of collapsed"
+  },
+  "showThinkingToggle.title": {
+    "defaultMessage": "Always Expand Thinking Traces"
+  },
   "skillsView.addSkill": {
     "defaultMessage": "Add Skill"
   },

--- a/ui/desktop/src/i18n/messages/es.json
+++ b/ui/desktop/src/i18n/messages/es.json
@@ -4100,6 +4100,12 @@
   "shortcutRecorder.save": {
     "defaultMessage": "Guardar"
   },
+  "showThinkingToggle.description": {
+    "defaultMessage": "Keep thinking traces expanded by default instead of collapsed"
+  },
+  "showThinkingToggle.title": {
+    "defaultMessage": "Always Expand Thinking Traces"
+  },
   "skillsView.addSkill": {
     "defaultMessage": "Agregar Skill"
   },

--- a/ui/desktop/src/i18n/messages/fr.json
+++ b/ui/desktop/src/i18n/messages/fr.json
@@ -4100,6 +4100,12 @@
   "shortcutRecorder.save": {
     "defaultMessage": "Enregistrer"
   },
+  "showThinkingToggle.description": {
+    "defaultMessage": "Keep thinking traces expanded by default instead of collapsed"
+  },
+  "showThinkingToggle.title": {
+    "defaultMessage": "Always Expand Thinking Traces"
+  },
   "skillsView.addSkill": {
     "defaultMessage": "Ajouter une compétence"
   },

--- a/ui/desktop/src/i18n/messages/hi.json
+++ b/ui/desktop/src/i18n/messages/hi.json
@@ -4100,6 +4100,12 @@
   "shortcutRecorder.save": {
     "defaultMessage": "सहेजें"
   },
+  "showThinkingToggle.description": {
+    "defaultMessage": "Keep thinking traces expanded by default instead of collapsed"
+  },
+  "showThinkingToggle.title": {
+    "defaultMessage": "Always Expand Thinking Traces"
+  },
   "skillsView.addSkill": {
     "defaultMessage": "कौशल जोड़ें"
   },

--- a/ui/desktop/src/i18n/messages/id.json
+++ b/ui/desktop/src/i18n/messages/id.json
@@ -4100,6 +4100,12 @@
   "shortcutRecorder.save": {
     "defaultMessage": "Simpan"
   },
+  "showThinkingToggle.description": {
+    "defaultMessage": "Keep thinking traces expanded by default instead of collapsed"
+  },
+  "showThinkingToggle.title": {
+    "defaultMessage": "Always Expand Thinking Traces"
+  },
   "skillsView.addSkill": {
     "defaultMessage": "Tambah Keterampilan"
   },

--- a/ui/desktop/src/i18n/messages/it.json
+++ b/ui/desktop/src/i18n/messages/it.json
@@ -4100,6 +4100,12 @@
   "shortcutRecorder.save": {
     "defaultMessage": "Salva"
   },
+  "showThinkingToggle.description": {
+    "defaultMessage": "Keep thinking traces expanded by default instead of collapsed"
+  },
+  "showThinkingToggle.title": {
+    "defaultMessage": "Always Expand Thinking Traces"
+  },
   "skillsView.addSkill": {
     "defaultMessage": "Aggiungi competenza"
   },

--- a/ui/desktop/src/i18n/messages/ja.json
+++ b/ui/desktop/src/i18n/messages/ja.json
@@ -4100,6 +4100,12 @@
   "shortcutRecorder.save": {
     "defaultMessage": "保存"
   },
+  "showThinkingToggle.description": {
+    "defaultMessage": "Keep thinking traces expanded by default instead of collapsed"
+  },
+  "showThinkingToggle.title": {
+    "defaultMessage": "Always Expand Thinking Traces"
+  },
   "skillsView.addSkill": {
     "defaultMessage": "スキルを追加"
   },

--- a/ui/desktop/src/i18n/messages/ko.json
+++ b/ui/desktop/src/i18n/messages/ko.json
@@ -4100,6 +4100,12 @@
   "shortcutRecorder.save": {
     "defaultMessage": "저장"
   },
+  "showThinkingToggle.description": {
+    "defaultMessage": "Keep thinking traces expanded by default instead of collapsed"
+  },
+  "showThinkingToggle.title": {
+    "defaultMessage": "Always Expand Thinking Traces"
+  },
   "skillsView.addSkill": {
     "defaultMessage": "스킬 추가"
   },

--- a/ui/desktop/src/i18n/messages/ms.json
+++ b/ui/desktop/src/i18n/messages/ms.json
@@ -4100,6 +4100,12 @@
   "shortcutRecorder.save": {
     "defaultMessage": "Simpan"
   },
+  "showThinkingToggle.description": {
+    "defaultMessage": "Keep thinking traces expanded by default instead of collapsed"
+  },
+  "showThinkingToggle.title": {
+    "defaultMessage": "Always Expand Thinking Traces"
+  },
   "skillsView.addSkill": {
     "defaultMessage": "Tambah Kemahiran"
   },

--- a/ui/desktop/src/i18n/messages/pt.json
+++ b/ui/desktop/src/i18n/messages/pt.json
@@ -4100,6 +4100,12 @@
   "shortcutRecorder.save": {
     "defaultMessage": "Guardar"
   },
+  "showThinkingToggle.description": {
+    "defaultMessage": "Keep thinking traces expanded by default instead of collapsed"
+  },
+  "showThinkingToggle.title": {
+    "defaultMessage": "Always Expand Thinking Traces"
+  },
   "skillsView.addSkill": {
     "defaultMessage": "Adicionar Competência"
   },

--- a/ui/desktop/src/i18n/messages/ru.json
+++ b/ui/desktop/src/i18n/messages/ru.json
@@ -4100,6 +4100,12 @@
   "shortcutRecorder.save": {
     "defaultMessage": "Сохранить"
   },
+  "showThinkingToggle.description": {
+    "defaultMessage": "Keep thinking traces expanded by default instead of collapsed"
+  },
+  "showThinkingToggle.title": {
+    "defaultMessage": "Always Expand Thinking Traces"
+  },
   "skillsView.addSkill": {
     "defaultMessage": "Добавить навык"
   },

--- a/ui/desktop/src/i18n/messages/tr.json
+++ b/ui/desktop/src/i18n/messages/tr.json
@@ -4100,6 +4100,12 @@
   "shortcutRecorder.save": {
     "defaultMessage": "Kaydet"
   },
+  "showThinkingToggle.description": {
+    "defaultMessage": "Keep thinking traces expanded by default instead of collapsed"
+  },
+  "showThinkingToggle.title": {
+    "defaultMessage": "Always Expand Thinking Traces"
+  },
   "skillsView.addSkill": {
     "defaultMessage": "Beceri Ekle"
   },

--- a/ui/desktop/src/i18n/messages/vi.json
+++ b/ui/desktop/src/i18n/messages/vi.json
@@ -4100,6 +4100,12 @@
   "shortcutRecorder.save": {
     "defaultMessage": "Lưu"
   },
+  "showThinkingToggle.description": {
+    "defaultMessage": "Keep thinking traces expanded by default instead of collapsed"
+  },
+  "showThinkingToggle.title": {
+    "defaultMessage": "Always Expand Thinking Traces"
+  },
   "skillsView.addSkill": {
     "defaultMessage": "Thêm kỹ năng"
   },

--- a/ui/desktop/src/i18n/messages/zh-CN.json
+++ b/ui/desktop/src/i18n/messages/zh-CN.json
@@ -4100,6 +4100,12 @@
   "shortcutRecorder.save": {
     "defaultMessage": "保存"
   },
+  "showThinkingToggle.description": {
+    "defaultMessage": "Keep thinking traces expanded by default instead of collapsed"
+  },
+  "showThinkingToggle.title": {
+    "defaultMessage": "Always Expand Thinking Traces"
+  },
   "skillsView.addSkill": {
     "defaultMessage": "添加技能"
   },

--- a/ui/desktop/src/i18n/messages/zh-TW.json
+++ b/ui/desktop/src/i18n/messages/zh-TW.json
@@ -4100,6 +4100,12 @@
   "shortcutRecorder.save": {
     "defaultMessage": "儲存"
   },
+  "showThinkingToggle.description": {
+    "defaultMessage": "Keep thinking traces expanded by default instead of collapsed"
+  },
+  "showThinkingToggle.title": {
+    "defaultMessage": "Always Expand Thinking Traces"
+  },
   "skillsView.addSkill": {
     "defaultMessage": "新增技能"
   },


### PR DESCRIPTION
## Summary

Adds a new `GOOSE_SHOW_THINKING` setting that lets users keep thinking traces expanded by default instead of only during streaming.

## Changes

- **ShowThinkingToggle.tsx** (new): Toggle component in Settings → Response Styles
  - Reads/writes `GOOSE_SHOW_THINKING` config key
  - Styled to match other settings (h3 title, p description, mono variant Switch)
- **GooseMessage.tsx**: Reads `config['GOOSE_SHOW_THINKING']` and passes it to `ThinkingContent` — when true, expands by default
- **ResponseStylesSection.tsx**: Includes `ShowThinkingToggle` after the Concise/Detailed style options

## How it works

When `GOOSE_SHOW_THINKING=true`, `ThinkingContent` starts expanded regardless of streaming state. When false (default), behavior is unchanged — thinking traces only expand during streaming.