### PR TITLE
fix: shell ACP providers on desktop

### DIFF
--- a/ui/desktop/src/gooseServe.ts
+++ b/ui/desktop/src/gooseServe.ts
@@ -33,6 +33,8 @@ export interface StartGooseServeOptions extends FindGooseBinaryOptions {
   serverSecret: string;
   tls?: boolean;
   env?: Record<string, string | undefined>;
+  /** PATH from the user's login shell, prepended so goosed can find CLI providers. */
+  loginShellPath?: string | null;
   logger?: Logger;
   diagnosticsDir?: string;
   readinessFetch?: ReadinessFetch;
@@ -288,7 +290,8 @@ const withStartupDiagnosticsPath = (
 const buildGooseServeEnv = (
   serverSecret: string,
   binaryPath: string,
-  additionalEnv: Record<string, string | undefined>
+  additionalEnv: Record<string, string | undefined>,
+  loginShellPath?: string | null
 ): Record<string, string | undefined> => {
   const homeDir = process.env.HOME || os.homedir();
   const pathKey = process.platform === 'win32' ? 'Path' : 'PATH';
@@ -297,7 +300,9 @@ const buildGooseServeEnv = (
   const env: Record<string, string | undefined> = {
     ...process.env,
     HOME: homeDir,
-    [pathKey]: `${path.dirname(binaryPath)}${path.delimiter}${currentPath}`,
+    [pathKey]: [path.dirname(binaryPath), currentPath, loginShellPath]
+      .filter(Boolean)
+      .join(path.delimiter),
   };
 
   if (process.platform === 'win32') {
@@ -322,6 +327,7 @@ export const startGooseServe = async ({
   serverSecret,
   tls = false,
   env: additionalEnv = {},
+  loginShellPath,
   isPackaged,
   resourcesPath,
   logger = defaultLogger,
@@ -385,7 +391,7 @@ export const startGooseServe = async ({
   }
 
   const spawnOptions = {
-    env: buildGooseServeEnv(secretKey, goosePath, additionalEnv),
+    env: buildGooseServeEnv(secretKey, goosePath, additionalEnv, loginShellPath),
     cwd: workingDir,
     windowsHide: true,
     shell: false as const,

--- a/ui/desktop/src/gooseServe.ts
+++ b/ui/desktop/src/gooseServe.ts
@@ -33,7 +33,7 @@ export interface StartGooseServeOptions extends FindGooseBinaryOptions {
   serverSecret: string;
   tls?: boolean;
   env?: Record<string, string | undefined>;
-  /** PATH from the user's login shell, prepended so goosed can find CLI providers. */
+  /** PATH from the user's login shell, appended so goosed can find CLI providers. */
   loginShellPath?: string | null;
   logger?: Logger;
   diagnosticsDir?: string;

--- a/ui/desktop/src/loginShellPath.ts
+++ b/ui/desktop/src/loginShellPath.ts
@@ -1,0 +1,64 @@
+import { spawn } from 'child_process';
+
+import type { Logger } from './gooseServe';
+
+const RESOLVE_TIMEOUT_MS = 5000;
+
+/**
+ * Resolve the user's full PATH by running their login shell (bash/zsh).
+ *
+ * The desktop app launched from Finder/Dock inherits a minimal PATH from
+ * launchd, so goosed can't find CLI-backed providers (claude, etc.). Sourcing
+ * the user's profile via a login+interactive shell recovers the real PATH.
+ * Doing this here rather than in goosed keeps the plain `goose` CLI on the
+ * ambient PATH. Returns null on Windows, timeout, or any failure.
+ */
+const resolveLoginShellPath = (logger?: Logger): Promise<string | null> => {
+  if (process.platform === 'win32') {
+    return Promise.resolve(null);
+  }
+
+  const shell = process.env.GOOSE_SHELL || process.env.SHELL || 'bash';
+
+  return new Promise((resolve) => {
+    // detached: a new session keeps the interactive shell's job-control setup
+    // from stealing the terminal foreground and suspending the app.
+    // Use `printenv PATH` instead of `echo $PATH` so the command is
+    // shell-neutral: fish treats $PATH as a list and space-joins it under
+    // `echo`, which would corrupt the resolved PATH for fish users.
+    const child = spawn(shell, ['-l', '-i', '-c', 'printenv PATH'], {
+      stdio: ['ignore', 'pipe', 'ignore'],
+      detached: true,
+      windowsHide: true,
+    });
+
+    const timer = setTimeout(() => {
+      child.kill();
+      resolve(null);
+    }, RESOLVE_TIMEOUT_MS);
+    timer.unref?.();
+
+    let stdout = '';
+    child.stdout?.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString('utf8');
+    });
+    child.on('error', (error) => {
+      clearTimeout(timer);
+      logger?.error('Failed to resolve login shell PATH', error);
+      resolve(null);
+    });
+    child.on('close', (code) => {
+      clearTimeout(timer);
+      const path = stdout.trim().split('\n').pop()?.trim();
+      resolve(code === 0 && path ? path : null);
+    });
+  });
+};
+
+let cached: Promise<string | null> | undefined;
+
+/** Resolve the login-shell PATH once per app run, caching the result. */
+export const getLoginShellPath = (logger?: Logger): Promise<string | null> => {
+  cached ??= resolveLoginShellPath(logger);
+  return cached;
+};

--- a/ui/desktop/src/loginShellPath.ts
+++ b/ui/desktop/src/loginShellPath.ts
@@ -1,0 +1,61 @@
+import { spawn } from 'child_process';
+
+import type { Logger } from './gooseServe';
+
+const RESOLVE_TIMEOUT_MS = 5000;
+
+/**
+ * Resolve the user's full PATH by running their login shell (bash/zsh).
+ *
+ * The desktop app launched from Finder/Dock inherits a minimal PATH from
+ * launchd, so goosed can't find CLI-backed providers (claude, etc.). Sourcing
+ * the user's profile via a login+interactive shell recovers the real PATH.
+ * Doing this here rather than in goosed keeps the plain `goose` CLI on the
+ * ambient PATH. Returns null on Windows, timeout, or any failure.
+ */
+const resolveLoginShellPath = (logger?: Logger): Promise<string | null> => {
+  if (process.platform === 'win32') {
+    return Promise.resolve(null);
+  }
+
+  const shell = process.env.GOOSE_SHELL || process.env.SHELL || 'bash';
+
+  return new Promise((resolve) => {
+    // detached: a new session keeps the interactive shell's job-control setup
+    // from stealing the terminal foreground and suspending the app.
+    const child = spawn(shell, ['-l', '-i', '-c', 'echo $PATH'], {
+      stdio: ['ignore', 'pipe', 'ignore'],
+      detached: true,
+      windowsHide: true,
+    });
+
+    const timer = setTimeout(() => {
+      child.kill();
+      resolve(null);
+    }, RESOLVE_TIMEOUT_MS);
+    timer.unref?.();
+
+    let stdout = '';
+    child.stdout?.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString('utf8');
+    });
+    child.on('error', (error) => {
+      clearTimeout(timer);
+      logger?.error('Failed to resolve login shell PATH', error);
+      resolve(null);
+    });
+    child.on('close', (code) => {
+      clearTimeout(timer);
+      const path = stdout.trim().split('\n').pop()?.trim();
+      resolve(code === 0 && path ? path : null);
+    });
+  });
+};
+
+let cached: Promise<string | null> | undefined;
+
+/** Resolve the login-shell PATH once per app run, caching the result. */
+export const getLoginShellPath = (logger?: Logger): Promise<string | null> => {
+  cached ??= resolveLoginShellPath(logger);
+  return cached;
+};

--- a/ui/desktop/src/loginShellPath.ts
+++ b/ui/desktop/src/loginShellPath.ts
@@ -11,14 +11,14 @@ const RESOLVE_TIMEOUT_MS = 5000;
  * launchd, so goosed can't find CLI-backed providers (claude, etc.). Sourcing
  * the user's profile via a login+interactive shell recovers the real PATH.
  * Doing this here rather than in goosed keeps the plain `goose` CLI on the
- * ambient PATH. Returns null on Windows, timeout, or any failure.
+ * ambient PATH. Returns null on non-macOS platforms, timeout, or any failure.
  */
 const resolveLoginShellPath = (logger?: Logger): Promise<string | null> => {
-  if (process.platform === 'win32') {
+  if (process.platform !== 'darwin') {
     return Promise.resolve(null);
   }
 
-  const shell = process.env.GOOSE_SHELL || process.env.SHELL || 'bash';
+  const shell = process.env.SHELL || 'bash';
 
   return new Promise((resolve) => {
     // detached: a new session keeps the interactive shell's job-control setup

--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -28,6 +28,7 @@ import { execFileSync, spawn, execFile } from 'child_process';
 import 'dotenv/config';
 import { checkBackendStatus } from './backendStatus';
 import { startGooseServe } from './gooseServe';
+import { getLoginShellPath } from './loginShellPath';
 import { GooseServeLeaseRegistry, type GooseServeLease } from './gooseServeLeaseRegistry';
 import { acpWebSocketUrlFromHttpBase, normalizeAcpHttpBaseUrl } from './acp/url';
 import { expandTilde, sanitizeGoosePathRoot } from './utils/pathUtils';
@@ -1155,6 +1156,8 @@ const createChat = async (
   } else {
     const localCertificateTrust = trustBackendCertificate('127.0.0.1', null);
 
+    const loginShellPath = await getLoginShellPath(log);
+
     let gooseServeResult: Awaited<ReturnType<typeof startGooseServe>>;
     try {
       gooseServeResult = await startGooseServe({
@@ -1164,6 +1167,7 @@ const createChat = async (
         env: {
           GOOSE_PATH_ROOT: appConfig.GOOSE_PATH_ROOT as string | undefined,
         },
+        loginShellPath,
         isPackaged: app.isPackaged,
         resourcesPath: app.isPackaged ? process.resourcesPath : undefined,
         logger: log,


### PR DESCRIPTION
## Summary
When goose runs as a desktop app, Electron on macOS launches goosed with a minimal PATH inherited from launchd, so CLI-backed providers like claude-code can't find their binary (SearchPaths fails to resolve claude), the provider never gets built, and the agent reports "Provider not set."

### Testing
Manual usage

### Related Issues
Found this bug when working to resolve https://github.com/aaif-goose/goose/issues/10807

### Screenshots/Demos (for UX changes)
Before:  
<img width="2024" height="1146" alt="Screenshot 2026-08-03 at 1 24 00 PM" src="https://github.com/user-attachments/assets/d30cae47-707e-4337-9b78-bd29f9b0bf58" />

After:   
<img width="2024" height="1146" alt="Screenshot 2026-08-03 at 1 24 16 PM" src="https://github.com/user-attachments/assets/d27ea180-ea54-45de-88ab-7744a6bbc9df" />
