### PR TITLE
fix(deep-link): route extension/session deep links to regular windows not standalone app windows

### DIFF
--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -507,6 +507,12 @@ if (process.platform !== 'darwin') {
           mainWindow.restore();
         }
         mainWindow.focus();
+      } else if (!protocolUrl) {
+        app.whenReady().then(async () => {
+          const recentDirs = loadRecentDirs();
+          const openDir = recentDirs.length > 0 ? recentDirs[0] : null;
+          await createChat(app, { dir: openDir || undefined });
+        });
       }
     });
   }

--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -499,10 +499,10 @@ if (process.platform !== 'darwin') {
         handleProtocolUrl(protocolUrl, parsedUrl);
       }
 
-      // Only focus existing windows for non-bot/recipe URLs
-      const existingWindows = BrowserWindow.getAllWindows();
-      if (existingWindows.length > 0) {
-        const mainWindow = existingWindows[0];
+      // Only focus existing regular windows for non-bot/recipe URLs
+      const regularWindows = getRegularWindows();
+      if (regularWindows.length > 0) {
+        const mainWindow = regularWindows[0];
         if (mainWindow.isMinimized()) {
           mainWindow.restore();
         }
@@ -644,10 +644,10 @@ async function handleProtocolUrl(url: string, parsedUrl: URL) {
     if (!targetWindow) return;
     await processProtocolUrl(url, parsedUrl, targetWindow);
   } else {
-    const existingWindows = BrowserWindow.getAllWindows();
+    const regularWindows = getRegularWindows();
     let targetWindow: BrowserWindow | undefined;
-    if (existingWindows.length > 0) {
-      targetWindow = existingWindows[0];
+    if (regularWindows.length > 0) {
+      targetWindow = regularWindows[0];
       if (targetWindow.isMinimized()) {
         targetWindow.restore();
       }
@@ -742,10 +742,10 @@ app.on('open-url', async (_event, url) => {
       return;
     }
 
-    // For extension/session URLs, send to existing window or store pending for new one
-    const existingWindows = BrowserWindow.getAllWindows();
-    if (existingWindows.length > 0) {
-      const targetWindow = existingWindows[0];
+    // For extension/session URLs, send to an existing regular window or open one
+    const regularWindows = getRegularWindows();
+    if (regularWindows.length > 0) {
+      const targetWindow = regularWindows[0];
       if (targetWindow.isMinimized()) targetWindow.restore();
       targetWindow.focus();
       if (parsedUrl.hostname === 'extension' || parsedUrl.hostname === 'sessions') {
@@ -979,6 +979,10 @@ let appConfig = {
 
 const windowMap = new Map<number, BrowserWindow>();
 const appWindows = new Map<string, BrowserWindow>();
+
+function getRegularWindows(): BrowserWindow[] {
+  return [...windowMap.values()].filter((w) => !w.isDestroyed());
+}
 
 const gooseServeLeases = new GooseServeLeaseRegistry(log);
 


### PR DESCRIPTION
Fixes : #10684

## Summary

Deep links for extension installs and shared sessions were landing in standalone goose App windows instead of regular chat windows because BrowserWindow.getAllWindows() returns everything. Switched to a getRegularWindows() helper backed by the existing windowMap which only tracks regular chat windows. Also fixed a Windows/Linux edge case where relaunching with only a standalone App window open would silently do nothing

### Testing
manual
