### PR TITLE
fix(flake): add cudaforge hash for git dependency

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -42,7 +42,12 @@
           version = workspaceToml.workspace.package.version;
           src = self;
 
-          cargoLock.lockFile = ./Cargo.lock;
+          cargoLock = {
+            lockFile = ./Cargo.lock;
+            outputHashes = {
+              "cudaforge-0.1.6" = "sha256-w0e/mfx08BkphDEFEWxuyxyZu/gHiG0m6RHx+3BLzDY=";
+            };
+          };
 
           LIBCLANG_PATH = "${pkgs.libclang.lib}/lib";
 


### PR DESCRIPTION
## Summary

Adds the hash for the `cudaforge` git dependency so that the flake can build. This keeps things "nix pure" which I do not think #10496 would do.

### Testing

Built locally.

### Related Issues

#9467
