### PR TITLE
Add Groundhog to the extension directory

### DIFF
--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -386,6 +386,23 @@
     "environmentVariables": []
   },
   {
+    "id": "groundhog",
+    "name": "Groundhog",
+    "description": "Web search, read and research through a real stealth-patched Chrome, with text hidden from human readers stripped and reported",
+    "command": "uvx groundhog-mcp",
+    "link": "https://github.com/dmytrome/groundhog",
+    "installation_notes": "Install using uvx. Requires Docker or Podman \u2014 the server pulls and starts a stealth Chrome container on first fetch. To use a browser you already run instead, set CDP_URL and GROUNDHOG_AUTO_START_BROWSER=false.",
+    "is_builtin": false,
+    "endorsed": false,
+    "environmentVariables": [
+      {
+        "name": "CDP_URL",
+        "description": "CDP endpoint of a stealth browser you already run; leave unset to auto-start the container",
+        "required": false
+      }
+    ]
+  },
+  {
     "id": "jetbrains",
     "name": "JetBrains",
     "description": "Integrate with any JetBrains IDE (requires local setup, dependent on your IDE version)",


### PR DESCRIPTION
Adds Groundhog to `documentation/static/servers.json` so it appears in the Extension Manager's discoverable list.

## About Groundhog

An MCP server for reading the web through a real, stealth-patched Chrome driven over raw CDP. It searches, reads and researches, returning markdown plus a SHA-256 provenance receipt per source.

Its distinguishing behaviour is defensive: because it renders a real DOM it can evaluate computed styles to judge what a human would actually see, and it strips what they could not — `display:none`, near-zero opacity, off-screen positioning, sub-pixel `.sr-only` boxes, colour-on-colour text, invisible Unicode — before the content reaches the model, reporting what was removed and why. A heuristic rather than a proof; the README documents the limits.

MIT, Python, stdio. Published to PyPI as `groundhog-mcp` and listed in the official MCP registry.

## Note on setup

It needs a container runtime: on the first fetch it pulls and starts a stealth Chrome image itself, so there is no manual step, but Docker or Podman must be present. Users who already run a browser can point `CDP_URL` at it and set `GROUNDHOG_AUTO_START_BROWSER=false`. That is covered in `installation_notes` and the `CDP_URL` environment variable is declared.

`endorsed` is left `false` — that is the maintainers' call.