### PR TITLE
feat: soft-continue after unfinished text-only turn following tools

### DIFF
--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -2082,6 +2082,8 @@ impl Agent {
             let mut retrying_after_stop_hook_denial = false;
             let mut consecutive_stop_hook_blocks = 0u32;
             let stop_hook_block_cap = self.stop_hook_block_cap();
+            let mut tools_used_this_user_turn = false;
+            let mut soft_continue_used = false;
             let mut can_drain_pending_steers = false;
             let turn_start = chrono::Local::now();
             let turn_start_compaction_info =
@@ -2710,6 +2712,7 @@ impl Agent {
                                 }
 
                                 no_tools_called = false;
+                                tools_used_this_user_turn = true;
                                 // Agent is actively working — re-check goal when it next finishes
                                 goal_check_pending = false;
                             }
@@ -2938,6 +2941,25 @@ impl Agent {
                                 Message::assistant().with_system_notification(
                                     SystemNotificationType::InlineMessage,
                                     format!("Grind: {grind}"),
+                                )
+                            );
+                        }
+
+                        None if !soft_continue_used
+                            && tools_used_this_user_turn
+                            && super::soft_continue::continue_after_tools_enabled()
+                            && super::soft_continue::looks_unfinished(&last_assistant_text) =>
+                        {
+                            soft_continue_used = true;
+                            info!("Soft-continuing after unfinished text-only turn following tools");
+                            let message = Message::user()
+                                .with_text(super::soft_continue::SOFT_CONTINUE_MESSAGE)
+                                .with_visibility(false, true);
+                            push_message_with_id(&mut messages_to_add, message);
+                            yield AgentEvent::Message(
+                                Message::assistant().with_system_notification(
+                                    SystemNotificationType::InlineMessage,
+                                    "Continuing unfinished work…",
                                 )
                             );
                         }

--- a/crates/goose/src/agents/mod.rs
+++ b/crates/goose/src/agents/mod.rs
@@ -14,6 +14,7 @@ pub mod platform_tools;
 pub mod prompt_manager;
 pub mod reply_parts;
 pub mod retry;
+mod soft_continue;
 mod schedule_tool;
 pub mod subagent_execution_tool;
 pub(crate) mod subagent_handler;

--- a/crates/goose/src/agents/soft_continue.rs
+++ b/crates/goose/src/agents/soft_continue.rs
@@ -1,0 +1,160 @@
+/// Heuristic used by the opt-in soft-continue path: after tools ran in a user
+/// turn, a text-only reply that still looks unfinished gets one automatic nudge
+/// instead of ending the agent loop.
+
+const UNFINISHED_PREFIXES: &[&str] = &[
+    "now i'll",
+    "now i will",
+    "now let me",
+    "let me",
+    "i'll",
+    "i will",
+    "next i'll",
+    "next i will",
+    "next,",
+    "next:",
+    "continuing",
+    "continue —",
+    "continue -",
+    "i'm going to",
+    "i am going to",
+    "first i'll",
+    "first i will",
+    "then i'll",
+    "then i will",
+];
+
+const TERMINAL_SHORT_REPLIES: &[&str] = &[
+    "done",
+    "done.",
+    "fixed",
+    "fixed.",
+    "ok",
+    "ok.",
+    "okay",
+    "okay.",
+    "all done",
+    "all done.",
+];
+
+/// Returns true when `text` looks like a mid-task pause rather than a finished reply.
+pub fn looks_unfinished(text: &str) -> bool {
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+
+    let lowercase = trimmed.to_lowercase();
+    if TERMINAL_SHORT_REPLIES
+        .iter()
+        .any(|reply| lowercase == *reply)
+    {
+        return false;
+    }
+
+    if trimmed.ends_with(':') || trimmed.ends_with('…') || trimmed.ends_with("...") {
+        return true;
+    }
+
+    if has_unclosed_fence(trimmed) {
+        return true;
+    }
+
+    let first_line = lowercase.lines().next().unwrap_or("").trim();
+    if UNFINISHED_PREFIXES
+        .iter()
+        .any(|prefix| first_line.starts_with(prefix))
+    {
+        return true;
+    }
+
+    // Very short non-terminal replies after tools are usually status, not completion.
+    if trimmed.chars().count() < 80 && !trimmed.contains('?') && !looks_terminal_summary(&lowercase)
+    {
+        return true;
+    }
+
+    false
+}
+
+fn has_unclosed_fence(text: &str) -> bool {
+    text.matches("```").count() % 2 == 1
+}
+
+fn looks_terminal_summary(lowercase: &str) -> bool {
+    lowercase.starts_with("done")
+        || lowercase.starts_with("fixed")
+        || lowercase.starts_with("here's")
+        || lowercase.starts_with("here is")
+        || lowercase.starts_with("summary")
+        || lowercase.contains("all set")
+        || lowercase.contains("you're all set")
+}
+
+pub const SOFT_CONTINUE_MESSAGE: &str = "\
+If work remains, continue with tools now. \
+If you are fully done or need input from the user, reply with a clear final message and no tool calls.";
+
+pub const CONTINUE_AFTER_TOOLS_CONFIG_KEY: &str = "GOOSE_CONTINUE_AFTER_TOOLS";
+
+pub fn continue_after_tools_enabled() -> bool {
+    crate::config::Config::global()
+        .get_param::<bool>(CONTINUE_AFTER_TOOLS_CONFIG_KEY)
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_trailing_colon_and_ellipsis() {
+        assert!(looks_unfinished("Now I'll wire the CSS:"));
+        assert!(looks_unfinished("Next up…"));
+        assert!(looks_unfinished("Working on it..."));
+    }
+
+    #[test]
+    fn detects_unfinished_prefixes() {
+        assert!(looks_unfinished("Let me check the scroll area next."));
+        assert!(looks_unfinished("Continuing — wiring the fade prop."));
+        assert!(looks_unfinished("I'll update BaseChat."));
+    }
+
+    #[test]
+    fn detects_unclosed_code_fence() {
+        assert!(looks_unfinished(
+            "Here is the change:\n```rust\nfn main() {}"
+        ));
+        assert!(!looks_unfinished(
+            "Here is the change:\n```rust\nfn main() {}\n```"
+        ));
+    }
+
+    #[test]
+    fn short_status_is_unfinished_but_done_is_not() {
+        assert!(looks_unfinished("On it."));
+        assert!(!looks_unfinished("Done."));
+        assert!(!looks_unfinished("Fixed."));
+        assert!(!looks_unfinished(
+            "Done. The Anthropic default is now `claude-opus-5`."
+        ));
+    }
+
+    #[test]
+    fn complete_answers_are_finished() {
+        assert!(!looks_unfinished(
+            "Here's what's going on — nothing was lost, the work just isn't on main yet."
+        ));
+        assert!(!looks_unfinished(
+            "I checked the config and the default model is already set correctly."
+        ));
+        assert!(!looks_unfinished("Want me to open a PR for this?"));
+    }
+
+    #[test]
+    fn empty_is_not_unfinished() {
+        assert!(!looks_unfinished(""));
+        assert!(!looks_unfinished("   "));
+    }
+}

--- a/crates/goose/src/prompts/system.md
+++ b/crates/goose/src/prompts/system.md
@@ -46,3 +46,5 @@ Consider asking if they'd like to disable some extensions to improve tool select
 # Response Guidelines
 
 Use Markdown formatting for all responses.
+
+When you use tools, finish the user's request completely before ending your turn. Do not stop after a mid-task status update such as "Now I'll…" or a trailing colon — keep going with tools until the work is done, then leave a clear final message. If you need input from the user, ask a direct question and stop.

--- a/documentation/docs/guides/environment-variables.md
+++ b/documentation/docs/guides/environment-variables.md
@@ -155,6 +155,7 @@ These variables control how goose manages conversation sessions and context.
 | Variable | Purpose | Values | Default |
 |----------|---------|---------|---------|
 | `GOOSE_MAX_TURNS` | [Maximum number of turns](/docs/guides/sessions/smart-context-management#maximum-turns) allowed without user input | Integer (e.g., 10, 50, 100) | 1000 |
+| `GOOSE_CONTINUE_AFTER_TOOLS` | When enabled, if goose used tools in the current user turn and then replies with text that still looks unfinished (for example a trailing colon or "Now I'll…"), goose nudges itself once to keep going instead of ending the turn. Also available in Desktop Settings → Chat. | `true` / `false` | `false` |
 | `GOOSE_GATEWAY_MAX_TURNS` | Maximum number of turns for gateway sessions (e.g., Telegram). Overrides `GOOSE_MAX_TURNS` for gateway traffic only, so chat platforms can keep a stricter cap than CLI/desktop sessions. | Integer (e.g., 5, 10, 25) | Falls back to `GOOSE_MAX_TURNS`, then 5 |
 | `GOOSE_SUBAGENT_MAX_TURNS` | Sets the maximum turns allowed for a [subagent](/docs/guides/context-engineering/subagents) to complete before timeout. Can be overridden by [`settings.max_turns`](/docs/guides/recipes/recipe-reference#settings) in recipes or subagent tool calls. | Integer (e.g., 25) | 25 |
 | `GOOSE_MAX_BACKGROUND_TASKS` | Sets the maximum number of concurrent background [subagent](/docs/guides/context-engineering/subagents) tasks goose can run at once | Integer (e.g., 1, 5, 10) | 5 |

--- a/ui/desktop/src/components/settings/chat/ContinueAfterToolsToggle.tsx
+++ b/ui/desktop/src/components/settings/chat/ContinueAfterToolsToggle.tsx
@@ -1,0 +1,45 @@
+import { Switch } from '../../ui/switch';
+import { useConfig } from '../../ConfigContext';
+import { defineMessages, useIntl } from '../../../i18n';
+
+const CONFIG_KEY = 'GOOSE_CONTINUE_AFTER_TOOLS';
+
+const i18n = defineMessages({
+  title: {
+    id: 'continueAfterToolsToggle.title',
+    defaultMessage: 'Continue After Tools',
+  },
+  description: {
+    id: 'continueAfterToolsToggle.description',
+    defaultMessage:
+      'When Goose stops mid-task after using tools, nudge it once to keep going. Off by default.',
+  },
+});
+
+export const ContinueAfterToolsToggle = () => {
+  const intl = useIntl();
+  const { config, upsert } = useConfig();
+  const enabled = Boolean(config[CONFIG_KEY]);
+
+  const handleToggle = async (checked: boolean) => {
+    try {
+      await upsert(CONFIG_KEY, checked, false);
+    } catch (error) {
+      console.error('Error updating continue-after-tools setting:', error);
+    }
+  };
+
+  return (
+    <div className="flex items-center justify-between py-2 px-2 hover:bg-background-secondary rounded-lg transition-all">
+      <div>
+        <h3 className="text-text-primary">{intl.formatMessage(i18n.title)}</h3>
+        <p className="text-xs text-text-secondary max-w-md mt-[2px]">
+          {intl.formatMessage(i18n.description)}
+        </p>
+      </div>
+      <div className="flex items-center">
+        <Switch checked={enabled} onCheckedChange={handleToggle} variant="mono" />
+      </div>
+    </div>
+  );
+};

--- a/ui/desktop/src/components/settings/mode/ModeSection.tsx
+++ b/ui/desktop/src/components/settings/mode/ModeSection.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState, useCallback } from 'react';
 import { all_goose_modes, ModeSelectionItem } from './ModeSelectionItem';
 import { useConfig } from '../../ConfigContext';
 import { ConversationLimitsDropdown } from './ConversationLimitsDropdown';
+import { ContinueAfterToolsToggle } from '../chat/ContinueAfterToolsToggle';
 
 export const ModeSection = () => {
   const [currentMode, setCurrentMode] = useState('auto');
@@ -62,6 +63,8 @@ export const ModeSection = () => {
           handleModeChange={handleModeChange}
         />
       ))}
+
+      <ContinueAfterToolsToggle />
 
       {/* Conversation Limits Dropdown */}
       <ConversationLimitsDropdown maxTurns={maxTurns} onMaxTurnsChange={handleMaxTurnsChange} />

--- a/ui/desktop/src/i18n/messages/de.json
+++ b/ui/desktop/src/i18n/messages/de.json
@@ -317,6 +317,12 @@
   "confirmationModal.processing": {
     "defaultMessage": "Wird verarbeitet..."
   },
+  "continueAfterToolsToggle.description": {
+    "defaultMessage": "When Goose stops mid-task after using tools, nudge it once to keep going. Off by default."
+  },
+  "continueAfterToolsToggle.title": {
+    "defaultMessage": "Continue After Tools"
+  },
   "conversationLimitsDropdown.conversationLimits": {
     "defaultMessage": "Konversationslimits"
   },

--- a/ui/desktop/src/i18n/messages/en.json
+++ b/ui/desktop/src/i18n/messages/en.json
@@ -317,6 +317,12 @@
   "confirmationModal.processing": {
     "defaultMessage": "Processing..."
   },
+  "continueAfterToolsToggle.description": {
+    "defaultMessage": "When Goose stops mid-task after using tools, nudge it once to keep going. Off by default."
+  },
+  "continueAfterToolsToggle.title": {
+    "defaultMessage": "Continue After Tools"
+  },
   "conversationLimitsDropdown.conversationLimits": {
     "defaultMessage": "Conversation Limits"
   },

--- a/ui/desktop/src/i18n/messages/es.json
+++ b/ui/desktop/src/i18n/messages/es.json
@@ -317,6 +317,12 @@
   "confirmationModal.processing": {
     "defaultMessage": "Procesando..."
   },
+  "continueAfterToolsToggle.description": {
+    "defaultMessage": "When Goose stops mid-task after using tools, nudge it once to keep going. Off by default."
+  },
+  "continueAfterToolsToggle.title": {
+    "defaultMessage": "Continue After Tools"
+  },
   "conversationLimitsDropdown.conversationLimits": {
     "defaultMessage": "Límites de conversación"
   },

--- a/ui/desktop/src/i18n/messages/fr.json
+++ b/ui/desktop/src/i18n/messages/fr.json
@@ -317,6 +317,12 @@
   "confirmationModal.processing": {
     "defaultMessage": "Traitement en cours..."
   },
+  "continueAfterToolsToggle.description": {
+    "defaultMessage": "When Goose stops mid-task after using tools, nudge it once to keep going. Off by default."
+  },
+  "continueAfterToolsToggle.title": {
+    "defaultMessage": "Continue After Tools"
+  },
   "conversationLimitsDropdown.conversationLimits": {
     "defaultMessage": "Limites de conversation"
   },

--- a/ui/desktop/src/i18n/messages/hi.json
+++ b/ui/desktop/src/i18n/messages/hi.json
@@ -317,6 +317,12 @@
   "confirmationModal.processing": {
     "defaultMessage": "प्रसंस्करण..."
   },
+  "continueAfterToolsToggle.description": {
+    "defaultMessage": "When Goose stops mid-task after using tools, nudge it once to keep going. Off by default."
+  },
+  "continueAfterToolsToggle.title": {
+    "defaultMessage": "Continue After Tools"
+  },
   "conversationLimitsDropdown.conversationLimits": {
     "defaultMessage": "बातचीत की सीमाएँ"
   },

--- a/ui/desktop/src/i18n/messages/id.json
+++ b/ui/desktop/src/i18n/messages/id.json
@@ -317,6 +317,12 @@
   "confirmationModal.processing": {
     "defaultMessage": "Memproses..."
   },
+  "continueAfterToolsToggle.description": {
+    "defaultMessage": "When Goose stops mid-task after using tools, nudge it once to keep going. Off by default."
+  },
+  "continueAfterToolsToggle.title": {
+    "defaultMessage": "Continue After Tools"
+  },
   "conversationLimitsDropdown.conversationLimits": {
     "defaultMessage": "Batas Percakapan"
   },

--- a/ui/desktop/src/i18n/messages/it.json
+++ b/ui/desktop/src/i18n/messages/it.json
@@ -317,6 +317,12 @@
   "confirmationModal.processing": {
     "defaultMessage": "Elaborazione in corso..."
   },
+  "continueAfterToolsToggle.description": {
+    "defaultMessage": "When Goose stops mid-task after using tools, nudge it once to keep going. Off by default."
+  },
+  "continueAfterToolsToggle.title": {
+    "defaultMessage": "Continue After Tools"
+  },
   "conversationLimitsDropdown.conversationLimits": {
     "defaultMessage": "Limiti della conversazione"
   },

--- a/ui/desktop/src/i18n/messages/ja.json
+++ b/ui/desktop/src/i18n/messages/ja.json
@@ -317,6 +317,12 @@
   "confirmationModal.processing": {
     "defaultMessage": "処理中..."
   },
+  "continueAfterToolsToggle.description": {
+    "defaultMessage": "When Goose stops mid-task after using tools, nudge it once to keep going. Off by default."
+  },
+  "continueAfterToolsToggle.title": {
+    "defaultMessage": "Continue After Tools"
+  },
   "conversationLimitsDropdown.conversationLimits": {
     "defaultMessage": "会話制限"
   },

--- a/ui/desktop/src/i18n/messages/ko.json
+++ b/ui/desktop/src/i18n/messages/ko.json
@@ -317,6 +317,12 @@
   "confirmationModal.processing": {
     "defaultMessage": "처리 중..."
   },
+  "continueAfterToolsToggle.description": {
+    "defaultMessage": "When Goose stops mid-task after using tools, nudge it once to keep going. Off by default."
+  },
+  "continueAfterToolsToggle.title": {
+    "defaultMessage": "Continue After Tools"
+  },
   "conversationLimitsDropdown.conversationLimits": {
     "defaultMessage": "대화 제한"
   },

--- a/ui/desktop/src/i18n/messages/ms.json
+++ b/ui/desktop/src/i18n/messages/ms.json
@@ -317,6 +317,12 @@
   "confirmationModal.processing": {
     "defaultMessage": "Memproses..."
   },
+  "continueAfterToolsToggle.description": {
+    "defaultMessage": "When Goose stops mid-task after using tools, nudge it once to keep going. Off by default."
+  },
+  "continueAfterToolsToggle.title": {
+    "defaultMessage": "Continue After Tools"
+  },
   "conversationLimitsDropdown.conversationLimits": {
     "defaultMessage": "Had Perbualan"
   },

--- a/ui/desktop/src/i18n/messages/pt.json
+++ b/ui/desktop/src/i18n/messages/pt.json
@@ -317,6 +317,12 @@
   "confirmationModal.processing": {
     "defaultMessage": "A processar..."
   },
+  "continueAfterToolsToggle.description": {
+    "defaultMessage": "When Goose stops mid-task after using tools, nudge it once to keep going. Off by default."
+  },
+  "continueAfterToolsToggle.title": {
+    "defaultMessage": "Continue After Tools"
+  },
   "conversationLimitsDropdown.conversationLimits": {
     "defaultMessage": "Limites da conversa"
   },

--- a/ui/desktop/src/i18n/messages/ru.json
+++ b/ui/desktop/src/i18n/messages/ru.json
@@ -317,6 +317,12 @@
   "confirmationModal.processing": {
     "defaultMessage": "Обработка..."
   },
+  "continueAfterToolsToggle.description": {
+    "defaultMessage": "When Goose stops mid-task after using tools, nudge it once to keep going. Off by default."
+  },
+  "continueAfterToolsToggle.title": {
+    "defaultMessage": "Continue After Tools"
+  },
   "conversationLimitsDropdown.conversationLimits": {
     "defaultMessage": "Ограничения разговора"
   },

--- a/ui/desktop/src/i18n/messages/tr.json
+++ b/ui/desktop/src/i18n/messages/tr.json
@@ -317,6 +317,12 @@
   "confirmationModal.processing": {
     "defaultMessage": "İşleniyor..."
   },
+  "continueAfterToolsToggle.description": {
+    "defaultMessage": "When Goose stops mid-task after using tools, nudge it once to keep going. Off by default."
+  },
+  "continueAfterToolsToggle.title": {
+    "defaultMessage": "Continue After Tools"
+  },
   "conversationLimitsDropdown.conversationLimits": {
     "defaultMessage": "Konuşma Sınırları"
   },

--- a/ui/desktop/src/i18n/messages/vi.json
+++ b/ui/desktop/src/i18n/messages/vi.json
@@ -317,6 +317,12 @@
   "confirmationModal.processing": {
     "defaultMessage": "Đang xử lý..."
   },
+  "continueAfterToolsToggle.description": {
+    "defaultMessage": "When Goose stops mid-task after using tools, nudge it once to keep going. Off by default."
+  },
+  "continueAfterToolsToggle.title": {
+    "defaultMessage": "Continue After Tools"
+  },
   "conversationLimitsDropdown.conversationLimits": {
     "defaultMessage": "Giới hạn cuộc trò chuyện"
   },

--- a/ui/desktop/src/i18n/messages/zh-CN.json
+++ b/ui/desktop/src/i18n/messages/zh-CN.json
@@ -317,6 +317,12 @@
   "confirmationModal.processing": {
     "defaultMessage": "处理中…"
   },
+  "continueAfterToolsToggle.description": {
+    "defaultMessage": "When Goose stops mid-task after using tools, nudge it once to keep going. Off by default."
+  },
+  "continueAfterToolsToggle.title": {
+    "defaultMessage": "Continue After Tools"
+  },
   "conversationLimitsDropdown.conversationLimits": {
     "defaultMessage": "对话限制"
   },

--- a/ui/desktop/src/i18n/messages/zh-TW.json
+++ b/ui/desktop/src/i18n/messages/zh-TW.json
@@ -317,6 +317,12 @@
   "confirmationModal.processing": {
     "defaultMessage": "正在處理…"
   },
+  "continueAfterToolsToggle.description": {
+    "defaultMessage": "When Goose stops mid-task after using tools, nudge it once to keep going. Off by default."
+  },
+  "continueAfterToolsToggle.title": {
+    "defaultMessage": "Continue After Tools"
+  },
   "conversationLimitsDropdown.conversationLimits": {
     "defaultMessage": "對話限制"
   },


### PR DESCRIPTION
## Summary

- Opt-in `GOOSE_CONTINUE_AFTER_TOOLS` (default off): after tools ran in a user turn, if the model ends with unfinished-looking text and no tool call, inject one hidden continue nudge
- Desktop Settings → Chat toggle + i18n
- Response Guidelines prompt line so the model prefers finishing with tools instead of mid-task pauses
- Heuristic unit tests in `soft_continue.rs`

Closes #10918

## Test plan

- [ ] Enable Continue After Tools in Desktop Settings → Chat
- [ ] Reproduce a mid-task text pause after tools (e.g. trailing `:` / "Now I'll…") — expect one auto-continue + inline "Continuing unfinished work…"
- [ ] Complete answer after tools — expect no nudge
- [ ] Second text-only reply after a nudge — expect stop (cap 1)
- [ ] `cargo test -p goose soft_continue`


Made with [Cursor](https://cursor.com)