### PR TITLE
fix(desktop): stop chat auto-follow snapping back on a small scroll-up

### DIFF
--- a/ui/desktop/src/components/ui/scroll-area.test.tsx
+++ b/ui/desktop/src/components/ui/scroll-area.test.tsx
@@ -75,4 +75,21 @@ describe('ScrollArea auto-follow', () => {
     scrollTo(viewport, 440);
     expect(ref.current?.isFollowing).toBe(false);
   });
+
+  it('yields once fractional upward deltas accumulate past the jitter threshold', () => {
+    const { ref, viewport } = setup();
+
+    scrollTo(viewport, 500);
+    expect(ref.current?.isFollowing).toBe(true);
+
+    // A high-resolution trackpad reports sub-pixel steps. No single event
+    // clears the 1px jitter threshold, so following may only yield once the
+    // steps have added up.
+    for (let i = 1; i <= 40; i++) {
+      scrollTo(viewport, 500 - i * 0.5);
+    }
+
+    // Cumulative movement is 20px, still well inside the 200px band.
+    expect(ref.current?.isFollowing).toBe(false);
+  });
 });

--- a/ui/desktop/src/components/ui/scroll-area.test.tsx
+++ b/ui/desktop/src/components/ui/scroll-area.test.tsx
@@ -61,4 +61,18 @@ describe('ScrollArea auto-follow', () => {
     scrollTo(viewport, 500);
     expect(ref.current?.isFollowing).toBe(true);
   });
+
+  it('stays unfollowed across consecutive upward scroll events within the threshold', () => {
+    const { ref, viewport } = setup();
+
+    scrollTo(viewport, 500);
+    // A slow scroll-up arrives as several small events, all still within the
+    // 200px band. Following must stay off for the whole gesture.
+    scrollTo(viewport, 480);
+    expect(ref.current?.isFollowing).toBe(false);
+    scrollTo(viewport, 460);
+    expect(ref.current?.isFollowing).toBe(false);
+    scrollTo(viewport, 440);
+    expect(ref.current?.isFollowing).toBe(false);
+  });
 });

--- a/ui/desktop/src/components/ui/scroll-area.test.tsx
+++ b/ui/desktop/src/components/ui/scroll-area.test.tsx
@@ -19,8 +19,8 @@ function scrollTo(el: HTMLElement, top: number) {
 describe('ScrollArea auto-follow', () => {
   beforeAll(() => {
     // jsdom does not implement Element.prototype.scrollTo
-    if (!Element.prototype.scrollTo) {
-      Element.prototype.scrollTo = vi.fn();
+    if (!window.Element.prototype.scrollTo) {
+      window.Element.prototype.scrollTo = vi.fn();
     }
   });
 

--- a/ui/desktop/src/components/ui/scroll-area.test.tsx
+++ b/ui/desktop/src/components/ui/scroll-area.test.tsx
@@ -1,0 +1,64 @@
+import { render, act } from '@testing-library/react';
+import { createRef } from 'react';
+import { describe, it, expect, beforeAll, vi } from 'vitest';
+
+import { ScrollArea, ScrollAreaHandle } from './scroll-area';
+
+function mockGeometry(el: HTMLElement, scrollHeight: number, clientHeight: number) {
+  Object.defineProperty(el, 'scrollHeight', { configurable: true, get: () => scrollHeight });
+  Object.defineProperty(el, 'clientHeight', { configurable: true, get: () => clientHeight });
+}
+
+function scrollTo(el: HTMLElement, top: number) {
+  el.scrollTop = top;
+  act(() => {
+    el.dispatchEvent(new Event('scroll'));
+  });
+}
+
+describe('ScrollArea auto-follow', () => {
+  beforeAll(() => {
+    // jsdom does not implement Element.prototype.scrollTo
+    if (!Element.prototype.scrollTo) {
+      Element.prototype.scrollTo = vi.fn();
+    }
+  });
+
+  function setup() {
+    const ref = createRef<ScrollAreaHandle>();
+    const { container } = render(
+      <ScrollArea autoScroll ref={ref}>
+        <div style={{ height: 1000 }}>content</div>
+      </ScrollArea>
+    );
+    const viewport = container.querySelector('[data-radix-scroll-area-viewport]') as HTMLElement;
+    // scrollHeight 1000, clientHeight 500 -> bottom is scrollTop === 500
+    mockGeometry(viewport, 1000, 500);
+    return { ref, viewport };
+  }
+
+  it('stops following when the user scrolls up within the near-bottom threshold', () => {
+    const { ref, viewport } = setup();
+
+    // Anchor at the bottom.
+    scrollTo(viewport, 500);
+    expect(ref.current?.isFollowing).toBe(true);
+
+    // Scroll up 100px: distanceFromBottom (100) is still within the 200px
+    // threshold, so isAtBottom() stays true, but the user clearly scrolled up.
+    scrollTo(viewport, 400);
+    expect(ref.current?.isFollowing).toBe(false);
+  });
+
+  it('resumes following once the user returns to the bottom', () => {
+    const { ref, viewport } = setup();
+
+    scrollTo(viewport, 500);
+    scrollTo(viewport, 400);
+    expect(ref.current?.isFollowing).toBe(false);
+
+    // Back to the bottom.
+    scrollTo(viewport, 500);
+    expect(ref.current?.isFollowing).toBe(true);
+  });
+});

--- a/ui/desktop/src/components/ui/scroll-area.tsx
+++ b/ui/desktop/src/components/ui/scroll-area.tsx
@@ -141,8 +141,10 @@ const ScrollArea = React.forwardRef<ScrollAreaHandle, ScrollAreaProps>(
         userScrolledUpRef.current = true;
         setIsFollowing(false);
         onScrollChange?.(false);
-      } else if (currentIsAtBottom && userScrolledUpRef.current) {
-        // user scrolled back to bottom
+      } else if (currentIsAtBottom && !isScrollingUp && userScrolledUpRef.current) {
+        // user scrolled back down to the bottom: only resume when the scroll is
+        // no longer moving up, so a multi-event upward scroll within the
+        // threshold does not immediately re-enable following.
         userScrolledUpRef.current = false;
         setIsFollowing(true);
         onScrollChange?.(true);

--- a/ui/desktop/src/components/ui/scroll-area.tsx
+++ b/ui/desktop/src/components/ui/scroll-area.tsx
@@ -128,10 +128,15 @@ const ScrollArea = React.forwardRef<ScrollAreaHandle, ScrollAreaProps>(
         }, 100);
       }
 
+      // An upward move larger than sub-pixel jitter means the user is
+      // deliberately reading back, so auto-follow should yield even while the
+      // viewport is still within BOTTOM_SCROLL_THRESHOLD of the bottom.
+      const isScrollingUp = lastScrollTopRef.current - scrollTop > 1;
+
       lastScrollTopRef.current = scrollTop;
 
       // Detect if user manually scrolled up from the bottom
-      if (!currentIsAtBottom && isFollowing) {
+      if ((!currentIsAtBottom || isScrollingUp) && isFollowing) {
         // user scrolled up, disabling auto-scroll
         userScrolledUpRef.current = true;
         setIsFollowing(false);

--- a/ui/desktop/src/components/ui/scroll-area.tsx
+++ b/ui/desktop/src/components/ui/scroll-area.tsx
@@ -131,9 +131,17 @@ const ScrollArea = React.forwardRef<ScrollAreaHandle, ScrollAreaProps>(
       // An upward move larger than sub-pixel jitter means the user is
       // deliberately reading back, so auto-follow should yield even while the
       // viewport is still within BOTTOM_SCROLL_THRESHOLD of the bottom.
-      const isScrollingUp = lastScrollTopRef.current - scrollTop > 1;
+      const movement = lastScrollTopRef.current - scrollTop;
+      const isScrollingUp = movement > 1;
+      const isScrollingDown = movement < -1;
 
-      lastScrollTopRef.current = scrollTop;
+      // Only advance the baseline once movement clears the jitter threshold.
+      // High-resolution trackpads and browser zoom deliver fractional deltas;
+      // committing every one of them would reset the baseline each event so a
+      // slow drag of many sub-pixel steps could never add up to a scroll-up.
+      if (Math.abs(movement) > 1) {
+        lastScrollTopRef.current = scrollTop;
+      }
 
       // Detect if user manually scrolled up from the bottom
       if ((!currentIsAtBottom || isScrollingUp) && isFollowing) {
@@ -141,10 +149,11 @@ const ScrollArea = React.forwardRef<ScrollAreaHandle, ScrollAreaProps>(
         userScrolledUpRef.current = true;
         setIsFollowing(false);
         onScrollChange?.(false);
-      } else if (currentIsAtBottom && !isScrollingUp && userScrolledUpRef.current) {
-        // user scrolled back down to the bottom: only resume when the scroll is
-        // no longer moving up, so a multi-event upward scroll within the
-        // threshold does not immediately re-enable following.
+      } else if (currentIsAtBottom && isScrollingDown && userScrolledUpRef.current) {
+        // user scrolled back down to the bottom: require a deliberate downward
+        // move rather than merely "not moving up", otherwise the sub-pixel
+        // events in the middle of an upward drag re-enable following while the
+        // viewport is still inside the threshold.
         userScrolledUpRef.current = false;
         setIsFollowing(true);
         onScrollChange?.(true);


### PR DESCRIPTION
Fixes #10915

## Problem

While a response is streaming, scrolling up by a small margin snaps the chat viewport back to the bottom, fighting the user's attempt to read back.

## Root cause

`ScrollArea.handleScroll` (`ui/desktop/src/components/ui/scroll-area.tsx`) only disables auto-follow once the viewport is more than `BOTTOM_SCROLL_THRESHOLD` (200px) from the bottom. A scroll-up that stays within that 200px band keeps `isAtBottom()` true, so `isFollowing` stays true and the next streamed chunk re-pins to the bottom — the "snap."

## Fix

Also treat a deliberate upward move (more than 1px, to ignore sub-pixel jitter) as leaving the bottom, so auto-follow yields immediately when the user scrolls up — even within the near-bottom threshold. Resume-on-return-to-bottom is unchanged.

## Verification plan performed

- Added `scroll-area.test.tsx` (jsdom, mocked scroll geometry):
  - *"stops following when the user scrolls up within the near-bottom threshold"* — **fails on `main`** (`isFollowing` stays `true`), passes with this change.
  - *"resumes following once the user returns to the bottom."*
- `cd ui/desktop && pnpm run typecheck` — clean.
- `pnpm test` (full ui/desktop suite) — 588 passing incl. the two new tests. The only 2 failing files (`RecipeFormFields`, `ExtensionModal`) do not import `ScrollArea` and **pass in isolation** — pre-existing parallel-run flakiness, unrelated to this change.
- `prettier --check` on the changed files — clean.
