### PR TITLE
fix: show tool inputs before approval

### DIFF
--- a/ui/desktop/src/components/ToolCallConfirmation.test.tsx
+++ b/ui/desktop/src/components/ToolCallConfirmation.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { IntlTestWrapper } from '../i18n/test-utils';
+import type { ActionRequired } from '../types/message';
+import ToolCallConfirmation from './ToolCallConfirmation';
+
+vi.mock('./ToolApprovalButtons', () => ({
+  default: () => <div data-testid="approval-buttons" />,
+}));
+
+const securityPrompt = 'This command sends a local file to a remote service.';
+
+const actionRequiredContent = {
+  type: 'actionRequired',
+  data: {
+    actionType: 'toolConfirmation',
+    id: 'request-1',
+    toolName: 'developer__shell',
+    arguments: {
+      command: 'upload /home/alice/private.txt to files.example.test',
+    },
+    prompt: securityPrompt,
+  },
+} as ActionRequired & { type: 'actionRequired' };
+
+describe('ToolCallConfirmation', () => {
+  it('shows the concrete tool arguments before approval', () => {
+    render(
+      <ToolCallConfirmation
+        sessionId="session-1"
+        isClicked={false}
+        actionRequiredContent={actionRequiredContent}
+      />,
+      { wrapper: IntlTestWrapper }
+    );
+
+    expect(screen.getByText('command')).toBeInTheDocument();
+    expect(screen.getByText(/upload \/home\/alice\/private\.txt/)).toBeInTheDocument();
+    expect(screen.getByTestId('approval-buttons')).toBeInTheDocument();
+  });
+
+  it('shows the security prompt before approval', () => {
+    render(
+      <ToolCallConfirmation
+        sessionId="session-1"
+        isClicked={false}
+        actionRequiredContent={actionRequiredContent}
+      />,
+      { wrapper: IntlTestWrapper }
+    );
+
+    expect(screen.getByText(securityPrompt)).toBeInTheDocument();
+    expect(screen.getByTestId('approval-buttons')).toBeInTheDocument();
+  });
+});

--- a/ui/desktop/src/components/ToolCallConfirmation.tsx
+++ b/ui/desktop/src/components/ToolCallConfirmation.tsx
@@ -2,6 +2,7 @@ import type { ActionRequired } from '../types/message';
 import { defineMessages, useIntl } from '../i18n';
 import { snakeToTitleCase } from '../utils';
 import ToolApprovalButtons from './ToolApprovalButtons';
+import { ToolCallArguments, type ToolCallArgumentValue } from './ToolCallArguments';
 
 const i18n = defineMessages({
   allowToolCallWithName: {
@@ -35,7 +36,7 @@ export default function ToolConfirmation({
 }: ToolConfirmationProps) {
   const intl = useIntl();
   const data = actionRequiredContent.data as ToolConfirmationData;
-  const { id, toolName, prompt } = data;
+  const { id, toolName, arguments: toolArguments, prompt } = data;
   const displayName = formatToolName(toolName);
 
   return (
@@ -45,9 +46,13 @@ export default function ToolConfirmation({
           ? intl.formatMessage(i18n.allowToolCallWithName, { toolName: displayName })
           : intl.formatMessage(i18n.gooseWouldLikeToCallWithName, { toolName: displayName })}
       </div>
-      <ToolApprovalButtons
-        data={{ id, toolName, prompt: prompt ?? undefined, sessionId, isClicked }}
-      />
+      <div className="px-4 pb-2">
+        {prompt && <div className="py-2 text-sm text-amber-600 dark:text-amber-400">{prompt}</div>}
+        <ToolCallArguments args={toolArguments as Record<string, ToolCallArgumentValue>} />
+        <ToolApprovalButtons
+          data={{ id, toolName, prompt: prompt ?? undefined, sessionId, isClicked }}
+        />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- display authoritative tool arguments in standalone ACP approval requests
- display the backend security prompt alongside those arguments
- reuse the established argument renderer used by inline tool calls
- add focused permission-only regressions for arguments and warning text

This restores the invariant that every tool approval surface presents the complete operation and security warning before the user decides. It addresses the confirmed private audit findings `project-loupe/audit-goose#691` and `project-loupe/audit-goose#175` without publishing exploit-specific content.

## Validation

- Regression proof before the fix: 2 tests failed because arguments and the security prompt were absent
- `pnpm exec vitest run src/components/ToolCallConfirmation.test.tsx` — 2 passed
- `pnpm run build-goose-sdk`
- `pnpm run typecheck`
- `pnpm test -- --run` — 64 files and 599 tests passed
- ESLint on both changed files with zero warnings
- Prettier check on both changed files

## Limitations

This changes only the standalone permission presentation. It does not alter permission resolution, saved approval policy, or ACP transport behavior.

*This finding was discovered by [Project Loupe](https://github.com/project-loupe/loupe)*
