### PR TITLE
feat(providers): add OpenCode Zen gateway as a declarative provider

### DIFF
--- a/crates/goose-provider-types/src/canonical/name_builder.rs
+++ b/crates/goose-provider-types/src/canonical/name_builder.rs
@@ -53,6 +53,7 @@ pub fn map_provider_name(provider: &str) -> &str {
         "zhipu" => "zhipuai",
         "novita" => "novita-ai",
         "opencode_go" => "opencode-go",
+        "opencode_zen" => "opencode",
         "ollama_cloud" => "ollama-cloud",
         "kimi_code" => "kimi-for-coding",
         _ => provider,
@@ -344,6 +345,10 @@ mod tests {
         assert_eq!(
             map_to_canonical_model("opencode_go", "kimi-k2.6", r),
             Some("opencode-go/kimi-k2.6".to_string())
+        );
+        assert_eq!(
+            map_to_canonical_model("opencode_zen", "kimi-k3", r),
+            Some("opencode/kimi-k3".to_string())
         );
 
         // === OpenRouter ===

--- a/crates/goose-providers/src/declarative.rs
+++ b/crates/goose-providers/src/declarative.rs
@@ -39,6 +39,7 @@ pub(crate) mod declarative_providers {
         ollama_cloud,
         omlx,
         opencode_go,
+        opencode_zen,
         orcarouter,
         ovhcloud,
         perplexity,

--- a/crates/goose-providers/src/declarative/definitions/opencode_zen.json
+++ b/crates/goose-providers/src/declarative/definitions/opencode_zen.json
@@ -1,0 +1,28 @@
+{
+  "name": "opencode_zen",
+  "engine": "openai",
+  "display_name": "OpenCode Zen",
+  "description": "OpenCode Zen gateway — curated, benchmarked models through the OpenAI-compatible API.",
+  "api_key_env": "OPENCODE_API_KEY",
+  "base_url": "https://opencode.ai/zen/v1",
+  "catalog_provider_id": "opencode",
+  "dynamic_models": false,
+  "model_doc_link": "https://opencode.ai/docs/zen",
+  "preserves_thinking": true,
+  "models": [
+    {"name": "kimi-k3", "context_limit": 262144},
+    {"name": "kimi-k2.7-code", "context_limit": 262144},
+    {"name": "kimi-k2.6", "context_limit": 262144},
+    {"name": "kimi-k2.5", "context_limit": 262144},
+    {"name": "glm-5.2", "context_limit": 204800},
+    {"name": "glm-5.1", "context_limit": 204800},
+    {"name": "deepseek-v4-pro", "context_limit": 1000000},
+    {"name": "deepseek-v4-flash", "context_limit": 1000000},
+    {"name": "deepseek-v4-flash-free", "context_limit": 1000000},
+    {"name": "minimax-m3", "context_limit": 204800},
+    {"name": "minimax-m2.7", "context_limit": 204800},
+    {"name": "minimax-m2.5", "context_limit": 204800},
+    {"name": "mimo-v2.5-free", "context_limit": 262144}
+  ],
+  "supports_streaming": true
+}


### PR DESCRIPTION
## Summary
- Adds the main **OpenCode Zen** gateway (`https://opencode.ai/zen/v1`) as a bundled declarative provider — `opencode_zen` — alongside the existing `opencode_go`.
- Mirrors the `opencode_go.json` pattern; `catalog_provider_id: "opencode"` matches the canonical registry entry.
- Model list is the curated set of models Zen serves over the OpenAI-compatible `/chat/completions` endpoint.

## Context
Issue #8381 ("Add OpenCode Go/OpenCode Zen to provider configuration") was closed stating both shipped in #6934, but only **OpenCode Go** (`/zen/go/v1`) ever received a bundled declarative definition (`opencode_go.json`). The main Zen gateway never got one, so it was only reachable via manual custom-provider setup. This fills that gap.

## Design choice: static curated model list (`dynamic_models: false`)
The Zen gateway serves models over **multiple wire formats**:
- `/chat/completions` — DeepSeek, MiniMax, GLM, Kimi, MiMo (OpenAI-compatible) ✓ included
- `/responses` — GPT, Grok
- `/messages` — Claude, Qwen
- Google wire format — Gemini

The declarative `openai` engine only speaks `/chat/completions`. With `dynamic_models: true`, `fetch_supported_models` would hit `/v1/models` and surface all 85 models — including GPT/Claude/Gemini — which would then fail with a wire-format mismatch. So this lists only the documented `/chat/completions` models. (If maintainers confirm Zen's `/chat/completions` normalizes all models, this can be flipped to `dynamic_models: true`.)

## Verification
- `cargo test -p goose-providers --lib declarative` → 10 passed, incl. `expose_declarative_providers_enumerates_all_bundled_json_files` and `all_bundled_providers_are_valid`
- `cargo clippy -p goose-providers --all-targets -- -D warnings` → clean

Maintainer-directed; no separate Ready issue (context issue #8381 is closed).
