### PR TITLE
fix(streaming): skip metadata-only SSE frames instead of failing the turn

### DIFF
--- a/crates/goose-provider-types/src/formats/openai.rs
+++ b/crates/goose-provider-types/src/formats/openai.rs
@@ -1066,6 +1066,10 @@ fn strip_data_prefix(line: &str) -> Option<&str> {
 ///
 /// A frame with `"choices": []` is NOT metadata — that is the standard usage-only chunk,
 /// so it still deserializes and flows through the empty-choices paths below.
+///
+/// A choice-less frame carrying a human-readable `message`/`detail` is NOT metadata either:
+/// it is an in-stream failure, and skipping it would report a failed turn as an empty
+/// successful one. Those become `ServerError` alongside the two shapes handled above.
 fn parse_streaming_chunk(line: &str) -> Result<Option<StreamingChunk>, ProviderError> {
     let value: Value = serde_json::from_str(line).map_err(|e| {
         ProviderError::stream_decode_error(format!(
@@ -1093,6 +1097,17 @@ fn parse_streaming_chunk(line: &str) -> Result<Option<StreamingChunk>, ProviderE
         .as_object()
         .is_some_and(|o| !o.contains_key("choices"))
     {
+        // Not every gateway reports an in-stream failure with one of the two shapes above.
+        // Azure APIM, for one, rate-limits with a bare `{"statusCode": 429, "message": …}`
+        // on an HTTP 200. Classify those before skipping: swallowing one would turn a failed
+        // turn into an empty successful response and prompt the user to retry into the wall.
+        if let Some(message) = value
+            .get("message")
+            .or_else(|| value.get("detail"))
+            .and_then(|m| m.as_str())
+        {
+            return Err(ProviderError::ServerError(message.to_string()));
+        }
         return Ok(None);
     }
 
@@ -4373,10 +4388,15 @@ data: [DONE]"#;
     #[tokio::test]
     async fn test_error_frames_still_surface_as_server_error() {
         // Skipping choice-less frames must not swallow gateway error frames, which are also
-        // choice-less. Both spellings are handled ahead of the metadata check.
+        // choice-less. Every one of these is handled ahead of the metadata skip.
         for line in [
             r#"{"error":{"message":"upstream exploded"}}"#,
             r#"{"object":"error","message":"upstream exploded"}"#,
+            // No `error` key and no `object`: the shape Azure APIM rate-limits with, on an
+            // HTTP 200. Skipping this would report the failed turn as an empty success.
+            r#"{"statusCode":429,"message":"upstream exploded"}"#,
+            // FastAPI-style servers report failures under `detail`.
+            r#"{"detail":"upstream exploded"}"#,
         ] {
             match parse_streaming_chunk(line) {
                 Err(ProviderError::ServerError(msg)) => {
@@ -4385,6 +4405,27 @@ data: [DONE]"#;
                 other => panic!("expected ServerError for {line}, got {other:?}"),
             }
         }
+    }
+
+    #[tokio::test]
+    async fn test_in_stream_error_frame_aborts_rather_than_ending_empty() {
+        // End-to-end counterpart: the turn must fail, not complete with no content. A silent
+        // skip here tells the user to resend — the worst possible advice into a 429.
+        let response_lines = concat!(
+            r#"data: {"statusCode":429,"message":"rate limited"}"#,
+            "\n",
+            "data: [DONE]"
+        );
+        let lines: Vec<String> = response_lines.lines().map(|s| s.to_string()).collect();
+        let response_stream = tokio_stream::iter(lines.into_iter().map(Ok));
+        let mut messages = std::pin::pin!(response_to_streaming_message(response_stream));
+
+        let first = messages.next().await.expect("stream should yield an item");
+        let err = first.expect_err("an in-stream error frame must not be skipped");
+        assert!(
+            err.to_string().contains("rate limited"),
+            "the gateway's message must reach the caller: {err}"
+        );
     }
 
     #[test]

--- a/crates/goose-provider-types/src/formats/openai.rs
+++ b/crates/goose-provider-types/src/formats/openai.rs
@@ -1056,6 +1056,87 @@ fn strip_data_prefix(line: &str) -> Option<&str> {
         .map(|s| s.trim())
 }
 
+/// Longest error text pulled out of a stream frame, so a pathological payload cannot be
+/// pasted wholesale into a user-facing message.
+const MAX_STREAM_ERROR_LEN: usize = 500;
+
+/// Best-effort human-readable text for an error payload that may not be a plain string.
+///
+/// FastAPI reports `HTTPException` as `{"detail": "..."}` but `RequestValidationError` as
+/// `{"detail": [{"loc": [...], "msg": "field required", ...}]}`, so a string-only read would
+/// drop the commoner validation shape entirely.
+fn stream_error_text(value: &Value) -> Option<String> {
+    fn one(value: &Value) -> Option<String> {
+        match value {
+            Value::String(s) => Some(s.clone()),
+            Value::Object(_) => value
+                .get("msg")
+                .or_else(|| value.get("message"))
+                .and_then(|m| m.as_str().map(String::from))
+                .or_else(|| Some(value.to_string())),
+            Value::Null => None,
+            other => Some(other.to_string()),
+        }
+    }
+
+    let text = match value {
+        Value::Array(items) => {
+            let parts: Vec<String> = items.iter().filter_map(one).collect();
+            if parts.is_empty() {
+                return None;
+            }
+            parts.join("; ")
+        }
+        other => one(other)?,
+    };
+    if text.is_empty() {
+        return None;
+    }
+    if text.chars().count() > MAX_STREAM_ERROR_LEN {
+        let truncated: String = text.chars().take(MAX_STREAM_ERROR_LEN).collect();
+        return Some(format!("{truncated}…"));
+    }
+    Some(text)
+}
+
+/// Decide whether a choice-less SSE frame reports an in-stream failure.
+///
+/// Returns `Some(err)` when it does, `None` when it is gateway metadata that can be skipped.
+///
+/// Requires an actual error *signal* — a `status`/`statusCode`/`code` of 400 or above, a
+/// `type` of `"error"`, or a `detail` field, which has no benign meaning in this position.
+/// Mere prose is not enough: gateways also emit informational frames, and treating
+/// `{"message": "processing"}` as a failure would kill a healthy stream, which is the very
+/// bug this skip exists to avoid. The converse matters just as much — a gateway that
+/// rate-limits with a bare `{"statusCode": 429, "message": …}` on an HTTP 200 must not be
+/// silently skipped, or a failed turn is reported as an empty successful one.
+fn classify_choiceless_frame(value: &Value) -> Option<ProviderError> {
+    let status = ["status", "statusCode", "code"].iter().find_map(|key| {
+        let raw = value.get(*key)?;
+        raw.as_i64()
+            .or_else(|| raw.as_str().and_then(|s| s.parse::<i64>().ok()))
+    });
+
+    let has_error_signal = status.is_some_and(|s| s >= 400)
+        || value.get("type").and_then(|t| t.as_str()) == Some("error")
+        || value.get("detail").is_some_and(|d| !d.is_null());
+    if !has_error_signal {
+        return None;
+    }
+
+    let details = value
+        .get("message")
+        .and_then(stream_error_text)
+        .or_else(|| value.get("detail").and_then(stream_error_text))
+        .or_else(|| value.get("error").and_then(stream_error_text))
+        // A status with no recoverable text must still be loud rather than vanish.
+        .unwrap_or_else(|| match status {
+            Some(s) => format!("Gateway returned status {s} mid-stream"),
+            None => "Unknown server error".to_string(),
+        });
+    Some(ProviderError::ServerError(details))
+}
+
 /// Parse one SSE `data:` payload.
 ///
 /// Returns `Ok(None)` for a metadata-only frame — a JSON object with no `choices` key at
@@ -1067,9 +1148,8 @@ fn strip_data_prefix(line: &str) -> Option<&str> {
 /// A frame with `"choices": []` is NOT metadata — that is the standard usage-only chunk,
 /// so it still deserializes and flows through the empty-choices paths below.
 ///
-/// A choice-less frame carrying a human-readable `message`/`detail` is NOT metadata either:
-/// it is an in-stream failure, and skipping it would report a failed turn as an empty
-/// successful one. Those become `ServerError` alongside the two shapes handled above.
+/// A choice-less frame that reports an in-stream failure is NOT metadata either — see
+/// `classify_choiceless_frame`.
 fn parse_streaming_chunk(line: &str) -> Result<Option<StreamingChunk>, ProviderError> {
     let value: Value = serde_json::from_str(line).map_err(|e| {
         ProviderError::stream_decode_error(format!(
@@ -1097,16 +1177,8 @@ fn parse_streaming_chunk(line: &str) -> Result<Option<StreamingChunk>, ProviderE
         .as_object()
         .is_some_and(|o| !o.contains_key("choices"))
     {
-        // Not every gateway reports an in-stream failure with one of the two shapes above.
-        // Azure APIM, for one, rate-limits with a bare `{"statusCode": 429, "message": …}`
-        // on an HTTP 200. Classify those before skipping: swallowing one would turn a failed
-        // turn into an empty successful response and prompt the user to retry into the wall.
-        if let Some(message) = value
-            .get("message")
-            .or_else(|| value.get("detail"))
-            .and_then(|m| m.as_str())
-        {
-            return Err(ProviderError::ServerError(message.to_string()));
+        if let Some(err) = classify_choiceless_frame(&value) {
+            return Err(err);
         }
         return Ok(None);
     }
@@ -4385,8 +4457,8 @@ data: [DONE]"#;
         Ok(())
     }
 
-    #[tokio::test]
-    async fn test_error_frames_still_surface_as_server_error() {
+    #[test]
+    fn test_error_frames_still_surface_as_server_error() {
         // Skipping choice-less frames must not swallow gateway error frames, which are also
         // choice-less. Every one of these is handled ahead of the metadata skip.
         for line in [
@@ -4395,15 +4467,64 @@ data: [DONE]"#;
             // No `error` key and no `object`: the shape Azure APIM rate-limits with, on an
             // HTTP 200. Skipping this would report the failed turn as an empty success.
             r#"{"statusCode":429,"message":"upstream exploded"}"#,
-            // FastAPI-style servers report failures under `detail`.
+            // Some gateways stringify the status.
+            r#"{"status":"503","message":"upstream exploded"}"#,
+            // FastAPI's HTTPException shape.
             r#"{"detail":"upstream exploded"}"#,
+            // FastAPI's RequestValidationError shape: `detail` is a LIST, so a string-only
+            // read would drop it and silently skip the frame.
+            r#"{"detail":[{"loc":["body"],"msg":"upstream exploded","type":"value_error"}]}"#,
+            // A non-string `message` must not be dropped either.
+            r#"{"statusCode":500,"message":{"text":"upstream exploded"}}"#,
+            // `type: "error"` is a third error marker some gateways use.
+            r#"{"type":"error","message":"upstream exploded"}"#,
         ] {
             match parse_streaming_chunk(line) {
-                Err(ProviderError::ServerError(msg)) => {
-                    assert_eq!(msg, "upstream exploded", "message preserved for {line}")
-                }
+                Err(ProviderError::ServerError(msg)) => assert!(
+                    msg.contains("upstream exploded"),
+                    "message preserved for {line}, got {msg:?}"
+                ),
                 other => panic!("expected ServerError for {line}, got {other:?}"),
             }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_informational_choiceless_frame_is_still_skipped() -> anyhow::Result<()> {
+        // Prose alone is not an error signal. A keepalive/progress frame carrying a message
+        // but no status must NOT abort the turn — doing so would reintroduce exactly the bug
+        // the metadata skip exists to fix.
+        let response_lines = format!(
+            "{}\n{}\ndata: [DONE]",
+            r#"data: {"message":"processing"}"#,
+            content_chunk("hello")
+        );
+        assert_eq!(run_streaming_test(&response_lines).await?.text, "hello");
+        Ok(())
+    }
+
+    #[test]
+    fn test_status_only_error_frame_still_fails_loudly() {
+        // No message text anywhere: the frame must still surface rather than vanish.
+        match parse_streaming_chunk(r#"{"statusCode":503}"#) {
+            Err(ProviderError::ServerError(msg)) => {
+                assert!(msg.contains("503"), "status should reach the caller: {msg}")
+            }
+            other => panic!("expected ServerError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_choiceless_frame_error_text_is_capped() {
+        let long = "x".repeat(5_000);
+        let line = format!(r#"{{"statusCode":500,"message":"{long}"}}"#);
+        match parse_streaming_chunk(&line) {
+            Err(ProviderError::ServerError(msg)) => assert!(
+                msg.chars().count() <= MAX_STREAM_ERROR_LEN + 1,
+                "error text should be truncated, got {} chars",
+                msg.chars().count()
+            ),
+            other => panic!("expected ServerError, got {other:?}"),
         }
     }
 

--- a/crates/goose-provider-types/src/formats/openai.rs
+++ b/crates/goose-provider-types/src/formats/openai.rs
@@ -1089,15 +1089,11 @@ fn parse_streaming_chunk(line: &str) -> Result<Option<StreamingChunk>, ProviderE
         return Err(ProviderError::ServerError(message.to_string()));
     }
 
-    if let Some(obj) = value.as_object() {
-        if !obj.contains_key("choices") {
-            // Log the keys only — a trace frame can carry request metadata.
-            tracing::debug!(
-                keys = ?obj.keys().collect::<Vec<_>>(),
-                "skipping metadata-only streaming frame (no `choices`)"
-            );
-            return Ok(None);
-        }
+    if value
+        .as_object()
+        .is_some_and(|o| !o.contains_key("choices"))
+    {
+        return Ok(None);
     }
 
     serde_json::from_value(value).map(Some).map_err(|e| {

--- a/crates/goose-provider-types/src/formats/openai.rs
+++ b/crates/goose-provider-types/src/formats/openai.rs
@@ -1056,7 +1056,17 @@ fn strip_data_prefix(line: &str) -> Option<&str> {
         .map(|s| s.trim())
 }
 
-fn parse_streaming_chunk(line: &str) -> Result<StreamingChunk, ProviderError> {
+/// Parse one SSE `data:` payload.
+///
+/// Returns `Ok(None)` for a metadata-only frame — a JSON object with no `choices` key at
+/// all. Gateways interleave these with the real chunks: Portkey/Azure APIM and friends
+/// emit trace/guardrail objects such as `{"hook_results": {...}}` before the first token.
+/// They carry nothing this parser consumes, so they are skipped rather than failed on;
+/// treating them as decode errors kills the whole turn on an otherwise healthy stream.
+///
+/// A frame with `"choices": []` is NOT metadata — that is the standard usage-only chunk,
+/// so it still deserializes and flows through the empty-choices paths below.
+fn parse_streaming_chunk(line: &str) -> Result<Option<StreamingChunk>, ProviderError> {
     let value: Value = serde_json::from_str(line).map_err(|e| {
         ProviderError::stream_decode_error(format!(
             "Failed to parse streaming chunk: {e}: {line:?}"
@@ -1079,7 +1089,18 @@ fn parse_streaming_chunk(line: &str) -> Result<StreamingChunk, ProviderError> {
         return Err(ProviderError::ServerError(message.to_string()));
     }
 
-    serde_json::from_value(value).map_err(|e| {
+    if let Some(obj) = value.as_object() {
+        if !obj.contains_key("choices") {
+            // Log the keys only — a trace frame can carry request metadata.
+            tracing::debug!(
+                keys = ?obj.keys().collect::<Vec<_>>(),
+                "skipping metadata-only streaming frame (no `choices`)"
+            );
+            return Ok(None);
+        }
+    }
+
+    serde_json::from_value(value).map(Some).map_err(|e| {
         ProviderError::stream_decode_error(format!(
             "Failed to parse streaming chunk: {e}: {line:?}"
         ))
@@ -1131,9 +1152,11 @@ where
                 continue
             }
 
-            let chunk: StreamingChunk = parse_streaming_chunk(
+            let Some(chunk) = parse_streaming_chunk(
                 line.ok_or_else(|| anyhow!("unexpected stream format"))?
-            )?;
+            )? else {
+                continue  // metadata-only frame
+            };
             if let Some(model) = &chunk.model {
                 last_seen_model = Some(model.clone());
             }
@@ -1190,7 +1213,12 @@ where
                                     break 'outer;
                                 }
 
-                                let tool_chunk: StreamingChunk = parse_streaming_chunk(line)?;
+                                // A metadata frame here must NOT fall through to the
+                                // empty-choices branch below, which ends accumulation and
+                                // would truncate this tool call's arguments.
+                                let Some(tool_chunk) = parse_streaming_chunk(line)? else {
+                                    continue
+                                };
                                 if let Some(model) = &tool_chunk.model {
                                     last_seen_model = Some(model.clone());
                                 }
@@ -4233,6 +4261,149 @@ data: [DONE]"#;
             panic!("Expected Thinking content, got {:?}", message.content[0]);
         }
         Ok(())
+    }
+
+    // ---- metadata-only SSE frames (gateway trace/guardrail objects) -----------------------
+    //
+    // Some OpenAI-compatible gateways interleave objects that have no `choices` key at all
+    // with the real chunks. A Portkey gateway sends a `hook_results` guardrail trace as the
+    // FIRST frame whenever strict-openai-compliance is off. Failing on such a frame killed
+    // the whole turn.
+
+    /// A guardrail trace frame, in the shape a Portkey gateway emits it.
+    const METADATA_FRAME: &str = concat!(
+        r#"data: {"hook_results":{"before_request_hooks":[{"verdict":true,"#,
+        r#""id":"guardrail-1","type":"guardrail","deny":false}]}}"#
+    );
+
+    fn content_chunk(content: &str) -> String {
+        format!(
+            concat!(
+                r#"data: {{"id":"x","object":"chat.completion.chunk","created":1,"model":"m","#,
+                r#""choices":[{{"index":0,"delta":{{"content":"{}"}},"finish_reason":null}}]}}"#
+            ),
+            content
+        )
+    }
+
+    #[tokio::test]
+    async fn test_metadata_only_first_frame_does_not_abort_stream() -> anyhow::Result<()> {
+        // The reported bug: a metadata-only opening frame made the whole turn fail with
+        // "Failed to parse streaming chunk: missing field `choices`".
+        let response_lines = format!("{METADATA_FRAME}\n{}\ndata: [DONE]", content_chunk("hello"));
+        assert_eq!(run_streaming_test(&response_lines).await?.text, "hello");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_metadata_only_frame_interleaved_mid_stream_is_skipped() -> anyhow::Result<()> {
+        let response_lines = format!(
+            "{}\n{METADATA_FRAME}\n{}\ndata: [DONE]",
+            content_chunk("hel"),
+            content_chunk("lo")
+        );
+        assert_eq!(run_streaming_test(&response_lines).await?.text, "hello");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_metadata_only_frame_mid_tool_call_keeps_arguments_intact() -> anyhow::Result<()> {
+        // A metadata frame arriving between two tool_calls argument deltas must not end
+        // argument accumulation. Merely defaulting `choices` to an empty vec would route this
+        // frame into the inner loop's empty-choices branch (`done = true`) and silently
+        // truncate the arguments to `{"city":"Pa` — a quiet corruption instead of a loud error.
+        let response_lines = concat!(
+            r#"data: {"id":"x","object":"chat.completion.chunk","model":"m","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"get_weather","arguments":"{\"city\":\"Pa"}}]},"finish_reason":null}]}"#,
+            "\n",
+            r#"data: {"hook_results":{"before_request_hooks":[{"verdict":true,"type":"guardrail","deny":false}]}}"#,
+            "\n",
+            r#"data: {"id":"x","object":"chat.completion.chunk","model":"m","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"ris\"}"}}]},"finish_reason":null}]}"#,
+            "\n",
+            r#"data: {"id":"x","object":"chat.completion.chunk","model":"m","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}"#,
+            "\n",
+            "data: [DONE]"
+        );
+        let lines: Vec<String> = response_lines.lines().map(|s| s.to_string()).collect();
+        let response_stream = tokio_stream::iter(lines.into_iter().map(Ok));
+        let mut messages = std::pin::pin!(response_to_streaming_message(response_stream));
+
+        let mut tool_calls = Vec::new();
+        while let Some(result) = messages.next().await {
+            let (message, _usage) = result?;
+            if let Some(msg) = message {
+                for content in &msg.content {
+                    if let MessageContentBlock::ToolRequest(req) = content {
+                        if let Ok(call) = &req.tool_call {
+                            tool_calls.push(call.clone());
+                        }
+                    }
+                }
+            }
+        }
+
+        assert_eq!(tool_calls.len(), 1, "expected exactly one tool call");
+        assert_eq!(tool_calls[0].name, "get_weather");
+        assert_eq!(
+            tool_calls[0]
+                .arguments
+                .as_ref()
+                .and_then(|a| a.get("city"))
+                .and_then(Value::as_str),
+            Some("Paris"),
+            "arguments must survive the interleaved metadata frame intact"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_empty_choices_array_is_not_treated_as_metadata() -> anyhow::Result<()> {
+        // `"choices": []` is the standard usage-only chunk, NOT a metadata frame: it must
+        // still deserialize and still surface its usage.
+        let response_lines = concat!(
+            r#"data: {"id":"x","object":"chat.completion.chunk","model":"m","choices":[{"index":0,"delta":{"content":"hi"},"finish_reason":"stop"}]}"#,
+            "\n",
+            r#"data: {"id":"x","object":"chat.completion.chunk","model":"m","choices":[],"usage":{"prompt_tokens":7,"completion_tokens":3,"total_tokens":10}}"#,
+            "\n",
+            "data: [DONE]"
+        );
+        let result = run_streaming_test(response_lines).await?;
+        assert_eq!(result.usage_count, 1, "the usage-only chunk must be kept");
+        let usage = result.usage.expect("usage should be reported");
+        assert_eq!(usage.usage.output_tokens, Some(3));
+        assert!(result.has_text_content);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_error_frames_still_surface_as_server_error() {
+        // Skipping choice-less frames must not swallow gateway error frames, which are also
+        // choice-less. Both spellings are handled ahead of the metadata check.
+        for line in [
+            r#"{"error":{"message":"upstream exploded"}}"#,
+            r#"{"object":"error","message":"upstream exploded"}"#,
+        ] {
+            match parse_streaming_chunk(line) {
+                Err(ProviderError::ServerError(msg)) => {
+                    assert_eq!(msg, "upstream exploded", "message preserved for {line}")
+                }
+                other => panic!("expected ServerError for {line}, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn test_parse_streaming_chunk_returns_none_for_metadata_frames() {
+        // Unit-level counterpart to the streaming tests above.
+        let metadata = parse_streaming_chunk(r#"{"hook_results":{"before_request_hooks":[]}}"#)
+            .expect("metadata frame must not be an error");
+        assert!(metadata.is_none(), "metadata frame should be skipped");
+
+        let real = parse_streaming_chunk(r#"{"choices":[],"usage":{"completion_tokens":1}}"#)
+            .expect("usage-only chunk must parse");
+        assert!(
+            real.is_some(),
+            "`choices: []` is a real chunk, not metadata"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Fixes #10935 — the OpenAI-compatible SSE parser aborts the entire turn on any `data:` payload that is a JSON object with no `choices` key, because `StreamingChunk::choices` is a required serde field:

```
Stream decode error: Failed to parse streaming chunk: missing field `choices`
```

Some gateways interleave such metadata-only frames among the real chunks — a Portkey gateway sends a `hook_results` guardrail trace as the very first frame when strict-openai-compliance is off. The user loses the whole response even though everything after that frame is valid.

**This is the same class of bug as #7645**, which #8031 fixed narrowly by adding `error` / `object: "error"` early returns to `parse_streaming_chunk`. That rescues one shape of choice-less frame; this generalises it to any of them. Those early returns stay ahead of the new check, so genuine gateway error frames still surface as `ServerError`.

Note the parser already copes with `"choices": []` — there are dedicated `choices.is_empty()` branches. Only the key being *absent* was fatal, which looks like an oversight rather than deliberate strictness.

### The change

`parse_streaming_chunk` now returns `Result<Option<StreamingChunk>, ProviderError>`, yielding `Ok(None)` for a metadata frame. Both call sites — the main loop and the tool-call argument-accumulation inner loop — skip those frames.

**Why not just `#[serde(default)]` on `choices`?** It is shorter and looks equivalent, but it routes metadata frames into the *existing* empty-choices branches, and the tool-call inner loop's branch is `} else { done = true; }`. A metadata frame arriving mid-tool-call would then silently end argument accumulation and truncate the call's JSON to `{"city":"Pa` instead of `{"city":"Paris"}` — swapping a loud failure for a quiet corruption. There is a regression test covering exactly this.

**Not every choice-less frame is metadata.** `classify_choiceless_frame` inspects the frame before skipping it, and fails the turn when it carries an actual error signal:

- a `status` / `statusCode` / `code` of 400 or above (integer, or stringified as some gateways do);
- `type: "error"`;
- a `detail` field, which has no benign meaning in this position.

Prose alone is deliberately *not* an error signal. Gateways also emit informational frames, and treating `{"message": "processing"}` as a failure would kill a healthy stream — the very bug this PR exists to fix. In a genuinely ambiguous frame, skipping is the safer default: a swallowed error still surfaces as an empty response, whereas a wrongly aborted stream destroys working output. That trade is the one judgement call here and I'm happy to move it if you'd rather.

Error text is normalised rather than string-matched, because the interesting shapes are not strings. FastAPI reports `HTTPException` as `{"detail": "..."}` but `RequestValidationError` as `{"detail": [{"loc": [...], "msg": "field required"}]}` — a list — so a string-only read would drop the commoner 422 shape entirely. Strings, arrays and objects are all handled, capped at 500 chars so a pathological payload cannot be pasted wholesale into a user-facing error. A frame with a status but no recoverable text still fails loudly, with a synthesised message.

### Testing

Ten tests in `formats::openai`:

| test | covers |
|---|---|
| `test_metadata_only_first_frame_does_not_abort_stream` | the reported bug |
| `test_metadata_only_frame_interleaved_mid_stream_is_skipped` | not just the first frame |
| `test_metadata_only_frame_mid_tool_call_keeps_arguments_intact` | the `serde(default)` trap above |
| `test_empty_choices_array_is_not_treated_as_metadata` | `"choices": []` usage chunks still work |
| `test_error_frames_still_surface_as_server_error` | 8 error shapes, incl. #8031's two |
| `test_in_stream_error_frame_aborts_rather_than_ending_empty` | a 429 frame aborts, not ends empty |
| `test_informational_choiceless_frame_is_still_skipped` | `{"message":"processing"}` does **not** abort |
| `test_status_only_error_frame_still_fails_loudly` | `{"statusCode":503}` with no text |
| `test_choiceless_frame_error_text_is_capped` | truncation |
| `test_parse_streaming_chunk_returns_none_for_metadata_frames` | unit-level |

Each was verified to genuinely fail without the change it guards, rather than assumed — reverting the classification yields `expected ServerError …, got Ok(None)`, and reverting the normalisation yields `got "Unknown server error"` for the FastAPI list.

Also exercised end-to-end against a stdlib-only fake OpenAI-compatible endpoint (full script in #10935 — no gateway, proxy, credentials or real model needed), building `goose-cli` with and without the patch:

| frame | unpatched | patched |
|---|---|---|
| `hook_results` trace first | ❌ `missing field 'choices'` | ✅ prints `hello` |
| no metadata frame (control) | ✅ `hello` | ✅ `hello` |
| metadata frame with `"choices": []` | ✅ `hello` | ✅ `hello` |
| metadata frame mid tool-call arguments | ❌ `missing field 'choices'` | ✅ `get_weather` with `city: Paris` |
| `{"statusCode":429,"message":"rate limited"}` | ❌ `missing field 'choices'` | ✅ `Server error: rate limited` |
| `{"message":"processing"}` then content | ❌ `missing field 'choices'` | ✅ `hello` |
| FastAPI 422 `detail` list | ❌ `missing field 'choices'` | ✅ `Server error: field required` |
| `{"statusCode":503}` | ❌ `missing field 'choices'` | ✅ `Server error: Gateway returned status 503 mid-stream` |

Local CI gates, all clean on `06f218c`:

- `cargo test -p goose-provider-types --lib` — 479 passed
- `cargo fmt --check` (workspace)
- `cargo clippy -p goose-provider-types --all-targets` — no new warnings (the 3 remaining are pre-existing in `google.rs` / `thinking.rs`)
- `cargo check --workspace --locked --all-targets`

### Related Issues

Closes #10935
Same class as #7645, generalises the fix from #8031

### Screenshots/Demos (for UX changes)

n/a — no UI surface.

---

<sub>Review history: the `tracing::debug!` in the first commit was removed in `8ff3d50` per the Codex P1; the choice-less error-swallowing raised as P2 is addressed in `5615030`, hardened in `37c1d8e` after a further review pass caught that presence-of-a-`message` was too weak a signal.</sub>

---

### Noted but deliberately out of scope

While working on `parse_streaming_chunk` I confirmed a **pre-existing** bug from #8031, happy to send a separate PR if useful: `value.get("error")` matches `Some(Value::Null)`, so a frame carrying `"error": null` — which some gateways attach to *every* chunk — returns `ServerError("Unknown server error")`. It fires even when `choices` is present, so it aborts a healthy turn. Reproduced against `main`:

```
data: {"id":"x","object":"chat.completion.chunk","error":null,"choices":[{"index":0,"delta":{"content":"hello"},"finish_reason":null}]}
→ Ran into this error: Server error: Unknown server error.
```

A `.filter(|e| !e.is_null())` fixes it, but it is unrelated to this PR's diff so I have left it alone.
