### PR TITLE
docs: point agents at issue templates in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@ The issue is the source of truth for work intended for an upstream pull request.
 - Keep the implementation within the issue's agreed scope.
 - If implementation reveals a material design change, return to the issue before continuing.
 - Every external pull request must link the Ready issue it implements and explain how the verification plan was performed.
+- Structure new issues on the matching template in `.github/ISSUE_TEMPLATE/` and set the issue type (e.g. Bug, Feature). `gh issue create` does not apply templates automatically.
 
 Maintainer-directed work, urgent security fixes, release automation, and local or exploratory changes do not require a Ready issue.
 


### PR DESCRIPTION
Adds one line to the Contribution Workflow section of AGENTS.md telling agents to structure new issues on the matching template in `.github/ISSUE_TEMPLATE/` and set the issue type.

The templates and `blank_issues_enabled: false` are only enforced in the GitHub web UI; `gh issue create` and the REST API bypass both, so agents filing issues via `gh` were unknowingly skipping repo policy.
