### PR TITLE
test: early-exit code-exec smoke tests once tool invocation is observed

### DIFF
--- a/ui/desktop/tests/integration/test_providers_code_exec.test.ts
+++ b/ui/desktop/tests/integration/test_providers_code_exec.test.ts
@@ -22,6 +22,13 @@ beforeAll(() => {
 
 const { testAll } = providerTest(discoverTestCases({ skipAgentic: true }));
 
+// Matches: "execute_typescript | code_execution", "get_function_details | code_execution",
+//           "tool call | execute", "tool calls | execute" (old format)
+//           "▸ execute N tool call" (new format with tool_graph)
+//           "▸ execute_typescript" (plain tool name in output)
+const codeExecPattern =
+  /(execute_typescript \| code_execution)|(get_function_details \| code_execution)|(tool calls? \| execute)|(▸.*execute.*tool call)|(▸ execute_typescript)/;
+
 testAll('invokes code_execution tool', async (tc, { expect }) => {
   const testdir = fs.mkdtempSync(path.join(os.tmpdir(), 'goose-codeexec-'));
   try {
@@ -30,15 +37,10 @@ testAll('invokes code_execution tool', async (tc, { expect }) => {
       testdir,
       "Store a memory with category 'test' and data 'hello world', then retrieve all memories from category 'test'.",
       BUILTINS,
-      { GOOSE_PROVIDER: tc.provider, GOOSE_MODEL: tc.model }
+      { GOOSE_PROVIDER: tc.provider, GOOSE_MODEL: tc.model },
+      55_000,
+      (output) => codeExecPattern.test(output)
     );
-
-    // Matches: "execute_typescript | code_execution", "get_function_details | code_execution",
-    //           "tool call | execute", "tool calls | execute" (old format)
-    //           "▸ execute N tool call" (new format with tool_graph)
-    //           "▸ execute_typescript" (plain tool name in output)
-    const codeExecPattern =
-      /(execute_typescript \| code_execution)|(get_function_details \| code_execution)|(tool calls? \| execute)|(▸.*execute.*tool call)|(▸ execute_typescript)/;
 
     expect(
       codeExecPattern.test(output),


### PR DESCRIPTION
## Summary
The code_execution smoke test only checked its output pattern after the goose process exited, so models that loop extra tool calls past the 55s kill timer failed the test even though the asserted behavior (invoking the code_execution tool) had already happened.
Example: [gpt-4o-mini failure](https://github.com/aaif-goose/goose/actions/runs/30963180032/job/92172013005) - `▸ execute_typescript` appears seconds in, then the model loops until the timeout.
Fix: pass the existing `codeExecPattern` as `runGoose`'s early-exit `success` predicate, matching what the shell-tool smoke test already does.

### Testing
Ran `test_providers_code_exec.test.ts` locally against OpenAI: gpt-4o-mini went from 72s timeout-kill to passing in 1.9s; all 4 model tests pass. Typecheck clean.

### Related Issues
N/A (CI flake fix)