### PR TITLE
feat(mcp): add Tendem to the extensions directory

### DIFF
--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -739,6 +739,18 @@
     ]
   },
   {
+    "id": "tendem",
+    "name": "Tendem",
+    "description": "Delegate tasks to vetted human experts - research, writing, analysis, and data work",
+    "type": "streamable-http",
+    "url": "https://mcp.tendem.ai/mcp?utm_hash=b559642fe4",
+    "link": "https://github.com/Toloka/tendem-mcp",
+    "installation_notes": "Streamable HTTP extension with OAuth browser authentication to your Tendem account on first connect. No local setup and no API key required. For headless use, supply an Authorization: ApiKey <token> header with a token from https://agent.tendem.ai/tokens.",
+    "is_builtin": false,
+    "endorsed": false,
+    "environmentVariables": []
+  },
+  {
     "id": "tom",
     "name": "Top of Mind",
     "description": "Inject persistent instructions into goose's working memory every turn",


### PR DESCRIPTION
Adds **Tendem** to the goose extensions directory (`documentation/static/servers.json`).

Tendem is a hybrid AI + human task service exposed as a remote MCP server. From goose you submit a task in natural language; Tendem's orchestrator scopes it and quotes a transparent price, and after explicit approval a vetted human expert executes it and returns verified results as markdown plus files. It is useful for the work an agent alone can't reliably close out: research and competitive analysis, fact-checking, copywriting and editing, design review, presentation polish, data cleaning and list building. Data scraping is declined by policy.

- Endpoint: `https://mcp.tendem.ai/mcp` (Streamable HTTP)
- Auth: OAuth 2.0 in the browser on first connect; no API key, no env vars, no local setup. Headless callers can pass `Authorization: ApiKey <token>` with a token from https://agent.tendem.ai/tokens
- Source / docs: https://github.com/Toloka/tendem-mcp
- Also listed in the official MCP registry as `io.github.Toloka/tendem-mcp` (v1.0.1)
- Tools: `create_task`, `get_task`, `get_contract`, `approve_task`, `cancel_task`, `get_task_result`, `list_tasks`, `read_chat`, `send_message`, `get_account`, `get_file_upload_url`

The entry is inserted alphabetically, follows the existing remote-OAuth entry shape (e.g. Neon, Rube, Glif), and the JSON validates.
