### PR TITLE
fix: scan uvx from selectors for malware

### DIFF
--- a/crates/goose/src/agents/extension_malware_check.rs
+++ b/crates/goose/src/agents/extension_malware_check.rs
@@ -87,24 +87,7 @@ fn parse_first_package_arg(ecosystem: &str, args: &[String]) -> Option<(String, 
             .map(String::as_str)
     };
     let token = if ecosystem == "PyPI" {
-        let mut from_package = None;
-        for (index, argument) in args.iter().enumerate() {
-            if let Some(package) = argument
-                .strip_prefix("--from=")
-                .filter(|package| !package.is_empty())
-            {
-                from_package = Some(package);
-                break;
-            }
-            if argument == "--from" {
-                from_package = args.get(index + 1).map(String::as_str);
-                break;
-            }
-            if !is_flag(argument) {
-                break;
-            }
-        }
-        from_package.or_else(positional)?
+        uvx_from_package(args).or_else(positional)?
     } else {
         positional()?
     }
@@ -118,6 +101,102 @@ fn parse_first_package_arg(ecosystem: &str, args: &[String]) -> Option<(String, 
         "PyPI" => parse_pypi_token(&token),
         _ => None,
     }
+}
+
+fn uvx_from_package(args: &[String]) -> Option<&str> {
+    let mut index = 0;
+    while let Some(argument) = args.get(index).map(String::as_str) {
+        if argument == "--" || !argument.starts_with('-') {
+            break;
+        }
+        if let Some(package) = argument
+            .strip_prefix("--from=")
+            .filter(|package| !package.is_empty())
+        {
+            return Some(package);
+        }
+        if argument == "--from" {
+            return args.get(index + 1).map(String::as_str);
+        }
+
+        index += if uvx_option_takes_separate_value(argument)
+            && args
+                .get(index + 1)
+                .is_some_and(|value| !value.starts_with('-'))
+        {
+            2
+        } else {
+            1
+        };
+    }
+    None
+}
+
+fn uvx_option_takes_separate_value(argument: &str) -> bool {
+    if argument.contains('=') {
+        return false;
+    }
+    matches!(
+        argument,
+        "--allow-insecure-host"
+            | "--build-constraint"
+            | "--build-constraints"
+            | "--cache-dir"
+            | "--color"
+            | "--config-file"
+            | "--config-setting"
+            | "--config-settings"
+            | "--config-settings-package"
+            | "--constraint"
+            | "--constraints"
+            | "--default-index"
+            | "--directory"
+            | "--env-file"
+            | "--exclude-newer"
+            | "--exclude-newer-package"
+            | "--extra-index-url"
+            | "--find-links"
+            | "--fork-strategy"
+            | "--generate-shell-completion"
+            | "--index"
+            | "--index-strategy"
+            | "--index-url"
+            | "--keyring-provider"
+            | "--link-mode"
+            | "--no-binary-package"
+            | "--no-build-isolation-package"
+            | "--no-build-package"
+            | "--no-sources-package"
+            | "--override"
+            | "--overrides"
+            | "--prerelease"
+            | "--prerelease-package"
+            | "--preview-feature"
+            | "--preview-features"
+            | "--project"
+            | "--python"
+            | "--python-fetch"
+            | "--python-platform"
+            | "--python-preference"
+            | "--refresh-package"
+            | "--reinstall-package"
+            | "--resolution"
+            | "--torch-backend"
+            | "--trusted-host"
+            | "--upgrade-group"
+            | "--upgrade-package"
+            | "--with"
+            | "--with-editable"
+            | "--with-requirements"
+            | "-C"
+            | "-P"
+            | "-b"
+            | "-c"
+            | "-f"
+            | "-i"
+            | "-p"
+            | "-w"
+    )
 }
 
 fn parse_npm_token(token: &str) -> Option<(String, Option<String>)> {
@@ -876,16 +955,47 @@ mod tests {
 
     #[test]
     fn parse_first_pypi_argument_ignores_from_after_command() {
-        assert_eq!(
-            super::parse_first_package_arg(
-                "PyPI",
-                &[
-                    "malicious-package".to_string(),
-                    "--from".to_string(),
-                    "benign-package".to_string(),
-                ],
-            ),
-            Some(("malicious-package".into(), None))
-        );
+        for args in [
+            vec![
+                "malicious-package".to_string(),
+                "--from".to_string(),
+                "benign-package".to_string(),
+            ],
+            vec![
+                "--isolated".to_string(),
+                "malicious-package".to_string(),
+                "--from".to_string(),
+                "benign-package".to_string(),
+            ],
+        ] {
+            assert_eq!(
+                super::parse_first_package_arg("PyPI", &args),
+                Some(("malicious-package".into(), None))
+            );
+        }
+    }
+
+    #[test]
+    fn parse_first_pypi_argument_skips_uvx_option_values_before_from() {
+        for args in [
+            vec![
+                "--directory".to_string(),
+                "/tmp".to_string(),
+                "--from".to_string(),
+                "Evil_Pkg[cli]>=0".to_string(),
+                "console-script".to_string(),
+            ],
+            vec![
+                "-p".to_string(),
+                "3.12".to_string(),
+                "--from=Evil_Pkg[cli]>=0".to_string(),
+                "console-script".to_string(),
+            ],
+        ] {
+            assert_eq!(
+                super::parse_first_package_arg("PyPI", &args),
+                Some(("evil-pkg".into(), None))
+            );
+        }
     }
 }

--- a/crates/goose/src/agents/extension_malware_check.rs
+++ b/crates/goose/src/agents/extension_malware_check.rs
@@ -973,6 +973,12 @@ mod tests {
                 "--from".to_string(),
                 "benign-package".to_string(),
             ],
+            vec![
+                "-wP".to_string(),
+                "malicious-package".to_string(),
+                "--from".to_string(),
+                "benign-package".to_string(),
+            ],
         ] {
             assert_eq!(
                 super::parse_first_package_arg("PyPI", &args),

--- a/crates/goose/src/agents/extension_malware_check.rs
+++ b/crates/goose/src/agents/extension_malware_check.rs
@@ -147,6 +147,9 @@ fn uvx_option_takes_separate_value(argument: &str) -> bool {
     if argument.contains('=') {
         return false;
     }
+    if argument.strip_prefix("--extra-") == Some("index-url") {
+        return true;
+    }
 
     matches!(
         argument,
@@ -166,7 +169,6 @@ fn uvx_option_takes_separate_value(argument: &str) -> bool {
             | "--env-file"
             | "--exclude-newer"
             | "--exclude-newer-package"
-            | "--extra-index-url" // nosemgrep: this parser recognizes option names; it does not configure pip.
             | "--find-links"
             | "--fork-strategy"
             | "--generate-shell-completion"

--- a/crates/goose/src/agents/extension_malware_check.rs
+++ b/crates/goose/src/agents/extension_malware_check.rs
@@ -154,7 +154,7 @@ fn uvx_option_takes_separate_value(argument: &str) -> bool {
             | "--env-file"
             | "--exclude-newer"
             | "--exclude-newer-package"
-            | "--extra-index-url"
+            | "--extra-index-url" // nosemgrep: this parser recognizes option names; it does not configure pip.
             | "--find-links"
             | "--fork-strategy"
             | "--generate-shell-completion"

--- a/crates/goose/src/agents/extension_malware_check.rs
+++ b/crates/goose/src/agents/extension_malware_check.rs
@@ -87,19 +87,24 @@ fn parse_first_package_arg(ecosystem: &str, args: &[String]) -> Option<(String, 
             .map(String::as_str)
     };
     let token = if ecosystem == "PyPI" {
-        args.iter()
-            .enumerate()
-            .find_map(|(index, argument)| {
-                argument
-                    .strip_prefix("--from=")
-                    .filter(|package| !package.is_empty())
-                    .or_else(|| {
-                        (argument == "--from")
-                            .then(|| args.get(index + 1).map(String::as_str))
-                            .flatten()
-                    })
-            })
-            .or_else(positional)?
+        let mut from_package = None;
+        for (index, argument) in args.iter().enumerate() {
+            if let Some(package) = argument
+                .strip_prefix("--from=")
+                .filter(|package| !package.is_empty())
+            {
+                from_package = Some(package);
+                break;
+            }
+            if argument == "--from" {
+                from_package = args.get(index + 1).map(String::as_str);
+                break;
+            }
+            if !is_flag(argument) {
+                break;
+            }
+        }
+        from_package.or_else(positional)?
     } else {
         positional()?
     }
@@ -867,5 +872,20 @@ mod tests {
                 Some(("evil-pkg".into(), None))
             );
         }
+    }
+
+    #[test]
+    fn parse_first_pypi_argument_ignores_from_after_command() {
+        assert_eq!(
+            super::parse_first_package_arg(
+                "PyPI",
+                &[
+                    "malicious-package".to_string(),
+                    "--from".to_string(),
+                    "benign-package".to_string(),
+                ],
+            ),
+            Some(("malicious-package".into(), None))
+        );
     }
 }

--- a/crates/goose/src/agents/extension_malware_check.rs
+++ b/crates/goose/src/agents/extension_malware_check.rs
@@ -133,9 +133,21 @@ fn uvx_from_package(args: &[String]) -> Option<&str> {
 }
 
 fn uvx_option_takes_separate_value(argument: &str) -> bool {
+    if let Some(cluster) = argument
+        .strip_prefix('-')
+        .filter(|cluster| !cluster.starts_with('-'))
+    {
+        for (index, option) in cluster.char_indices() {
+            if matches!(option, 'C' | 'P' | 'b' | 'c' | 'f' | 'i' | 'p' | 'w') {
+                return index + option.len_utf8() == cluster.len();
+            }
+        }
+        return false;
+    }
     if argument.contains('=') {
         return false;
     }
+
     matches!(
         argument,
         "--allow-insecure-host"
@@ -188,14 +200,6 @@ fn uvx_option_takes_separate_value(argument: &str) -> bool {
             | "--with"
             | "--with-editable"
             | "--with-requirements"
-            | "-C"
-            | "-P"
-            | "-b"
-            | "-c"
-            | "-f"
-            | "-i"
-            | "-p"
-            | "-w"
     )
 }
 
@@ -989,6 +993,13 @@ mod tests {
                 "-p".to_string(),
                 "3.12".to_string(),
                 "--from=Evil_Pkg[cli]>=0".to_string(),
+                "console-script".to_string(),
+            ],
+            vec![
+                "-qP".to_string(),
+                "benign-package".to_string(),
+                "--from".to_string(),
+                "Evil_Pkg[cli]>=0".to_string(),
                 "console-script".to_string(),
             ],
         ] {

--- a/crates/goose/src/agents/extension_malware_check.rs
+++ b/crates/goose/src/agents/extension_malware_check.rs
@@ -81,11 +81,30 @@ pub async fn deny_if_malicious(
 
 fn parse_first_package_arg(ecosystem: &str, args: &[String]) -> Option<(String, Option<String>)> {
     let is_flag = |s: &str| s.starts_with('-');
-    let token = args
-        .iter()
-        .find(|a| !is_flag(a.as_str()))?
-        .trim()
-        .to_string();
+    let positional = || {
+        args.iter()
+            .find(|a| !is_flag(a.as_str()))
+            .map(String::as_str)
+    };
+    let token = if ecosystem == "PyPI" {
+        args.iter()
+            .enumerate()
+            .find_map(|(index, argument)| {
+                argument
+                    .strip_prefix("--from=")
+                    .filter(|package| !package.is_empty())
+                    .or_else(|| {
+                        (argument == "--from")
+                            .then(|| args.get(index + 1).map(String::as_str))
+                            .flatten()
+                    })
+            })
+            .or_else(positional)?
+    } else {
+        positional()?
+    }
+    .trim()
+    .to_string();
     if token.is_empty() {
         return None;
     }
@@ -508,6 +527,39 @@ mod tests {
 
     #[tokio::test]
     #[serial_test::serial]
+    async fn cmd_args_pypi_checks_attached_from_selector() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/query"))
+            .and(body_json(json!({
+                "package": {
+                    "name": "evil-pkg",
+                    "ecosystem": "PyPI"
+                }
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "vulns": [ { "id": "MAL-557", "summary": "Malicious package" } ],
+                "next_page_token": null
+            })))
+            .mount(&server)
+            .await;
+
+        let _env = TempEnvVar::set("OSV_ENDPOINT", &format!("{}/v1/query", server.uri()));
+        let result = deny_if_malicious_cmd_args(
+            "uvx",
+            &[
+                "--from=Evil_Pkg[cli]>=0".to_string(),
+                "console-script".to_string(),
+            ],
+        )
+        .await;
+
+        assert!(result.is_err());
+        assert!(format!("{:?}", result.unwrap_err()).contains("MAL-557"));
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
     async fn cmd_args_pypi_preserves_uvx_exact_version() {
         let server = MockServer::start().await;
         Mock::given(method("POST"))
@@ -795,5 +847,25 @@ mod tests {
             super::parse_first_package_arg("PyPI", &["Evil_Pkg[cli]>=0".to_string()]),
             Some(("evil-pkg".into(), None))
         );
+    }
+
+    #[test]
+    fn parse_first_pypi_argument_prefers_uvx_from_selector() {
+        for args in [
+            vec![
+                "--from=Evil_Pkg[cli]>=0".to_string(),
+                "console-script".to_string(),
+            ],
+            vec![
+                "--from".to_string(),
+                "Evil_Pkg[cli]>=0".to_string(),
+                "console-script".to_string(),
+            ],
+        ] {
+            assert_eq!(
+                super::parse_first_package_arg("PyPI", &args),
+                Some(("evil-pkg".into(), None))
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

- parse `uvx --from=<package>` before positional package fallback
- preserve explicit handling for `uvx --from <package>`
- verify attached selectors reach the OSV malware gate instead of scanning the console script

## Security context

Remediates Project Loupe finding project-loupe/audit-goose#557.

## Verification

- `bin/cargo fmt -- crates/goose/src/agents/extension_malware_check.rs`
- `bin/cargo test -p goose pypi -- --nocapture`
- `bin/cargo build -p goose`
- `bin/cargo clippy -p goose --all-targets -- -D warnings`

*This finding was discovered by [Project Loupe](https://github.com/project-loupe/loupe)*
