### PR TITLE
fix(openrouter): stop silently ignoring thinking effort off

### DIFF
--- a/crates/goose-provider-types/src/retry.rs
+++ b/crates/goose-provider-types/src/retry.rs
@@ -88,6 +88,7 @@ impl RetryConfig {
 const PERMANENT_REQUEST_FAILURE_MARKERS: &[&str] = &[
     "blocks in the latest assistant message cannot be modified",
     "must remain as they were in the original response",
+    "Reasoning is mandatory for this endpoint",
 ];
 
 fn is_permanent_request_failure(message: &str) -> bool {

--- a/crates/goose/src/providers/formats/openrouter.rs
+++ b/crates/goose/src/providers/formats/openrouter.rs
@@ -89,6 +89,31 @@ pub fn add_reasoning_details_to_request(payload: &mut Value, messages: &[Message
     }
 }
 
+// OpenRouter rejects disable requests for mandatory-reasoning endpoints
+// (e.g. gpt-5, grok-4.5), so off keeps the lowest supported effort where one
+// is known and sends enabled:false otherwise.
+fn reasoning_off_value(model_config: &ModelConfig, clamped_effort: Option<&str>) -> Value {
+    if let Some(clamped) = clamped_effort {
+        return json!({ "effort": clamped });
+    }
+    // The xAI helpers only match bare model names, so strip OpenRouter's
+    // provider prefix; grok endpoints with mandatory reasoning (e.g.
+    // x-ai/grok-4.5) reject a disable request but accept their lowest effort.
+    let bare_name = model_config
+        .model_name
+        .rsplit('/')
+        .next()
+        .unwrap_or(&model_config.model_name);
+    if openai::supports_xai_reasoning_effort(bare_name) {
+        if let Some(effort) =
+            openai::xai_reasoning_effort_for_thinking(bare_name, ThinkingEffort::Off)
+        {
+            return json!({ "effort": effort });
+        }
+    }
+    json!({ "enabled": false })
+}
+
 fn reasoning_effort_for_openrouter(effort: ThinkingEffort) -> Option<&'static str> {
     match effort {
         ThinkingEffort::Off => None,
@@ -114,6 +139,10 @@ pub fn apply_reasoning_config(payload: &mut Value, model_config: &ModelConfig) {
             .remove("reasoning_effort")
             .and_then(|value| value.as_str().map(str::to_owned));
         if effort == ThinkingEffort::Off {
+            if model_config.is_reasoning_model() {
+                let reasoning = reasoning_off_value(model_config, clamped_effort.as_deref());
+                obj.insert("reasoning".to_string(), reasoning);
+            }
             return;
         }
         if clamped_effort.is_none() && !model_config.is_reasoning_model() {
@@ -231,23 +260,6 @@ mod tests {
     }
 
     #[test]
-    fn test_apply_reasoning_config_omits_off_reasoning_capable_model() {
-        let mut payload = json!({
-            "model": "google/gemini-2.5-flash",
-            "messages": []
-        });
-        let mut model_config = ModelConfig::new("google/gemini-2.5-flash");
-        model_config.reasoning = Some(true);
-        let mut params = HashMap::new();
-        params.insert("thinking_effort".to_string(), json!("off"));
-        model_config.request_params = Some(params);
-
-        apply_reasoning_config(&mut payload, &model_config);
-
-        assert!(payload.get("reasoning").is_none());
-    }
-
-    #[test]
     fn test_apply_reasoning_config_uses_reasoning_metadata() {
         let mut payload = json!({
             "model": "x-ai/grok-4",
@@ -298,7 +310,7 @@ mod tests {
     }
 
     #[test]
-    fn test_apply_reasoning_config_off_omits_reasoning() {
+    fn test_apply_reasoning_config_off_disables_reasoning() {
         let mut payload = json!({
             "model": "x-ai/grok-4",
             "messages": []
@@ -311,11 +323,11 @@ mod tests {
 
         apply_reasoning_config(&mut payload, &model_config);
 
-        assert!(payload.get("reasoning").is_none());
+        assert_eq!(payload["reasoning"], json!({ "enabled": false }));
     }
 
     #[test]
-    fn test_apply_reasoning_config_off_ignores_clamped_effort() {
+    fn test_apply_reasoning_config_off_keeps_clamped_effort() {
         let mut payload = json!({
             "model": "openai/gpt-5",
             "messages": [],
@@ -329,7 +341,81 @@ mod tests {
 
         apply_reasoning_config(&mut payload, &model_config);
 
+        assert_eq!(payload["reasoning"], json!({ "effort": "low" }));
+        assert!(payload.get("reasoning_effort").is_none());
+    }
+
+    #[test]
+    fn test_apply_reasoning_config_off_clamps_prefixed_xai_model() {
+        let mut payload = json!({
+            "model": "x-ai/grok-4.5",
+            "messages": []
+        });
+        let mut model_config = ModelConfig::new("x-ai/grok-4.5");
+        let mut params = HashMap::new();
+        params.insert("thinking_effort".to_string(), json!("off"));
+        model_config.request_params = Some(params);
+        model_config.reasoning = Some(true);
+
+        apply_reasoning_config(&mut payload, &model_config);
+
+        assert_eq!(payload["reasoning"], json!({ "effort": "low" }));
+    }
+
+    #[test]
+    fn test_apply_reasoning_config_kimi_k3_off_disables_reasoning() {
+        let mut payload = json!({
+            "model": "moonshotai/kimi-k3",
+            "messages": []
+        });
+        let mut model_config =
+            ModelConfig::new("moonshotai/kimi-k3").with_canonical_limits("openrouter");
+        let mut params = HashMap::new();
+        params.insert("thinking_effort".to_string(), json!("off"));
+        model_config.request_params = Some(params);
+
+        apply_reasoning_config(&mut payload, &model_config);
+
+        assert_eq!(payload["reasoning"], json!({ "enabled": false }));
+    }
+
+    #[test]
+    fn test_apply_reasoning_config_off_skips_non_reasoning_model() {
+        // gpt-5.1-chat is OpenAI-shaped (the builder emits a clamped
+        // reasoning_effort) but canonically non-reasoning; off must not
+        // turn the clamp into a reasoning field.
+        let mut payload = json!({
+            "model": "openai/gpt-5.1-chat",
+            "messages": [],
+            "reasoning_effort": "low"
+        });
+        let mut model_config = ModelConfig::new("openai/gpt-5.1-chat");
+        let mut params = HashMap::new();
+        params.insert("thinking_effort".to_string(), json!("off"));
+        model_config.request_params = Some(params);
+        model_config.reasoning = Some(false);
+
+        apply_reasoning_config(&mut payload, &model_config);
+
         assert!(payload.get("reasoning").is_none());
         assert!(payload.get("reasoning_effort").is_none());
+    }
+
+    #[test]
+    fn test_apply_reasoning_config_off_preserves_user_reasoning() {
+        let mut payload = json!({
+            "model": "x-ai/grok-4",
+            "messages": [],
+            "reasoning": { "max_tokens": 2000 }
+        });
+        let mut model_config = ModelConfig::new("x-ai/grok-4");
+        let mut params = HashMap::new();
+        params.insert("thinking_effort".to_string(), json!("off"));
+        model_config.request_params = Some(params);
+        model_config.reasoning = Some(true);
+
+        apply_reasoning_config(&mut payload, &model_config);
+
+        assert_eq!(payload["reasoning"], json!({ "max_tokens": 2000 }));
     }
 }

--- a/crates/goose/src/providers/formats/openrouter.rs
+++ b/crates/goose/src/providers/formats/openrouter.rs
@@ -89,31 +89,6 @@ pub fn add_reasoning_details_to_request(payload: &mut Value, messages: &[Message
     }
 }
 
-// OpenRouter rejects disable requests for mandatory-reasoning endpoints
-// (e.g. gpt-5, grok-4.5), so off keeps the lowest supported effort where one
-// is known and sends enabled:false otherwise.
-fn reasoning_off_value(model_config: &ModelConfig, clamped_effort: Option<&str>) -> Value {
-    if let Some(clamped) = clamped_effort {
-        return json!({ "effort": clamped });
-    }
-    // The xAI helpers only match bare model names, so strip OpenRouter's
-    // provider prefix; grok endpoints with mandatory reasoning (e.g.
-    // x-ai/grok-4.5) reject a disable request but accept their lowest effort.
-    let bare_name = model_config
-        .model_name
-        .rsplit('/')
-        .next()
-        .unwrap_or(&model_config.model_name);
-    if openai::supports_xai_reasoning_effort(bare_name) {
-        if let Some(effort) =
-            openai::xai_reasoning_effort_for_thinking(bare_name, ThinkingEffort::Off)
-        {
-            return json!({ "effort": effort });
-        }
-    }
-    json!({ "enabled": false })
-}
-
 fn reasoning_effort_for_openrouter(effort: ThinkingEffort) -> Option<&'static str> {
     match effort {
         ThinkingEffort::Off => None,
@@ -124,29 +99,40 @@ fn reasoning_effort_for_openrouter(effort: ThinkingEffort) -> Option<&'static st
     }
 }
 
-pub fn apply_reasoning_config(payload: &mut Value, model_config: &ModelConfig) {
+/// Returns true when a reasoning disable request was inserted, which
+/// mandatory-reasoning endpoints reject; the provider downgrades those to
+/// the lowest effort on OpenRouter's mandatory-reasoning error.
+pub fn apply_reasoning_config(payload: &mut Value, model_config: &ModelConfig) -> bool {
     let Some(effort) = model_config.thinking_effort() else {
-        return;
+        return false;
     };
 
     if let Some(obj) = payload.as_object_mut() {
         if obj.contains_key("reasoning") {
             obj.remove("reasoning_effort");
-            return;
+            return false;
         }
 
         let clamped_effort = obj
             .remove("reasoning_effort")
             .and_then(|value| value.as_str().map(str::to_owned));
         if effort == ThinkingEffort::Off {
-            if model_config.is_reasoning_model() {
-                let reasoning = reasoning_off_value(model_config, clamped_effort.as_deref());
-                obj.insert("reasoning".to_string(), reasoning);
+            if !model_config.is_reasoning_model() {
+                return false;
             }
-            return;
+            return match clamped_effort {
+                Some(clamped) => {
+                    obj.insert("reasoning".to_string(), json!({ "effort": clamped }));
+                    false
+                }
+                None => {
+                    obj.insert("reasoning".to_string(), json!({ "enabled": false }));
+                    true
+                }
+            };
         }
         if clamped_effort.is_none() && !model_config.is_reasoning_model() {
-            return;
+            return false;
         }
 
         let effort = clamped_effort
@@ -156,6 +142,7 @@ pub fn apply_reasoning_config(payload: &mut Value, model_config: &ModelConfig) {
             obj.insert("reasoning".to_string(), json!({ "effort": effort }));
         }
     }
+    false
 }
 
 #[cfg(test)]
@@ -310,23 +297,6 @@ mod tests {
     }
 
     #[test]
-    fn test_apply_reasoning_config_off_disables_reasoning() {
-        let mut payload = json!({
-            "model": "x-ai/grok-4",
-            "messages": []
-        });
-        let mut model_config = ModelConfig::new("x-ai/grok-4");
-        let mut params = HashMap::new();
-        params.insert("thinking_effort".to_string(), json!("off"));
-        model_config.request_params = Some(params);
-        model_config.reasoning = Some(true);
-
-        apply_reasoning_config(&mut payload, &model_config);
-
-        assert_eq!(payload["reasoning"], json!({ "enabled": false }));
-    }
-
-    #[test]
     fn test_apply_reasoning_config_off_keeps_clamped_effort() {
         let mut payload = json!({
             "model": "openai/gpt-5",
@@ -339,27 +309,11 @@ mod tests {
         model_config.request_params = Some(params);
         model_config.reasoning = Some(true);
 
-        apply_reasoning_config(&mut payload, &model_config);
+        let sent_disable = apply_reasoning_config(&mut payload, &model_config);
 
+        assert!(!sent_disable);
         assert_eq!(payload["reasoning"], json!({ "effort": "low" }));
         assert!(payload.get("reasoning_effort").is_none());
-    }
-
-    #[test]
-    fn test_apply_reasoning_config_off_clamps_prefixed_xai_model() {
-        let mut payload = json!({
-            "model": "x-ai/grok-4.5",
-            "messages": []
-        });
-        let mut model_config = ModelConfig::new("x-ai/grok-4.5");
-        let mut params = HashMap::new();
-        params.insert("thinking_effort".to_string(), json!("off"));
-        model_config.request_params = Some(params);
-        model_config.reasoning = Some(true);
-
-        apply_reasoning_config(&mut payload, &model_config);
-
-        assert_eq!(payload["reasoning"], json!({ "effort": "low" }));
     }
 
     #[test]
@@ -374,16 +328,15 @@ mod tests {
         params.insert("thinking_effort".to_string(), json!("off"));
         model_config.request_params = Some(params);
 
-        apply_reasoning_config(&mut payload, &model_config);
+        let sent_disable = apply_reasoning_config(&mut payload, &model_config);
 
+        assert!(sent_disable);
         assert_eq!(payload["reasoning"], json!({ "enabled": false }));
     }
 
     #[test]
     fn test_apply_reasoning_config_off_skips_non_reasoning_model() {
-        // gpt-5.1-chat is OpenAI-shaped (the builder emits a clamped
-        // reasoning_effort) but canonically non-reasoning; off must not
-        // turn the clamp into a reasoning field.
+        // OpenAI-shaped but canonically non-reasoning; off must drop the clamp.
         let mut payload = json!({
             "model": "openai/gpt-5.1-chat",
             "messages": [],
@@ -414,8 +367,9 @@ mod tests {
         model_config.request_params = Some(params);
         model_config.reasoning = Some(true);
 
-        apply_reasoning_config(&mut payload, &model_config);
+        let sent_disable = apply_reasoning_config(&mut payload, &model_config);
 
+        assert!(!sent_disable);
         assert_eq!(payload["reasoning"], json!({ "max_tokens": 2000 }));
     }
 }

--- a/crates/goose/src/providers/openrouter.rs
+++ b/crates/goose/src/providers/openrouter.rs
@@ -74,6 +74,28 @@ impl OpenRouterProvider {
             configured_parameters,
         })
     }
+
+    async fn post_chat_completions(
+        &self,
+        model_config: &ModelConfig,
+        payload: &Value,
+    ) -> Result<reqwest::Response, ProviderError> {
+        self.with_retry(|| async {
+            let resp = self
+                .api_client
+                .request("api/v1/chat/completions")
+                .model_headers(model_config)?
+                .streaming(true)
+                .response_post(payload)
+                .await?;
+            handle_status(resp).await
+        })
+        .await
+    }
+}
+
+fn is_mandatory_reasoning_error(error: &ProviderError) -> bool {
+    matches!(error, ProviderError::RequestFailed(message) if message.contains("Reasoning is mandatory"))
 }
 
 /// Update the request when using anthropic model.
@@ -335,7 +357,8 @@ impl Provider for OpenRouterProvider {
         if is_gemini_model(&model_config.model_name) {
             openrouter_format::add_reasoning_details_to_request(&mut payload, messages);
         }
-        openrouter_format::apply_reasoning_config(&mut payload, model_config);
+        let sent_reasoning_disable =
+            openrouter_format::apply_reasoning_config(&mut payload, model_config);
 
         if let Some(obj) = payload.as_object_mut() {
             obj.insert("transforms".to_string(), json!(["middle-out"]));
@@ -344,21 +367,20 @@ impl Provider for OpenRouterProvider {
 
         let mut log = start_log(model_config, &payload)?;
 
-        let response = self
-            .with_retry(|| async {
-                let resp = self
-                    .api_client
-                    .request("api/v1/chat/completions")
-                    .model_headers(model_config)?
-                    .streaming(true)
-                    .response_post(&payload)
-                    .await?;
-                handle_status(resp).await
-            })
-            .await
-            .inspect_err(|e| {
-                let _ = log.error(e);
-            })?;
+        let response = match self.post_chat_completions(model_config, &payload).await {
+            // Mandatory-reasoning endpoints reject the disable request, so
+            // downgrade to the lowest effort they all accept and retry once.
+            Err(error) if sent_reasoning_disable && is_mandatory_reasoning_error(&error) => {
+                let _ = log.error(&error);
+                payload["reasoning"] = json!({ "effort": "low" });
+                log = start_log(model_config, &payload)?;
+                self.post_chat_completions(model_config, &payload).await
+            }
+            result => result,
+        }
+        .inspect_err(|e| {
+            let _ = log.error(e);
+        })?;
 
         stream_openai_compat(response, log)
     }
@@ -447,5 +469,61 @@ mod tests {
         let request_params = model.request_params.as_ref().unwrap();
         assert_eq!(request_params["plugins"], json!([{ "id": "web" }]));
         assert_eq!(request_params["verbosity"], json!("xhigh"));
+    }
+
+    #[tokio::test]
+    async fn stream_downgrades_reasoning_disable_on_mandatory_endpoint() {
+        use wiremock::matchers::{body_partial_json, method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/v1/chat/completions"))
+            .and(body_partial_json(
+                json!({ "reasoning": { "enabled": false } }),
+            ))
+            .respond_with(ResponseTemplate::new(400).set_body_json(json!({
+                "error": { "message": "Reasoning is mandatory for this endpoint and cannot be disabled." }
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/api/v1/chat/completions"))
+            .and(body_partial_json(
+                json!({ "reasoning": { "effort": "low" } }),
+            ))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string("data: [DONE]\n\n"),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let provider = OpenRouterProvider {
+            api_client: ApiClient::new_with_tls(
+                server.uri(),
+                AuthMethod::BearerToken("test-key".to_string()),
+                None,
+            )
+            .unwrap(),
+            supports_streaming: true,
+            name: OPENROUTER_PROVIDER_NAME.to_string(),
+            configured_parameters: None,
+        };
+
+        let mut config = model_config("google/gemini-3.5-flash");
+        config.reasoning = Some(true);
+        config.request_params = Some(HashMap::from([(
+            "thinking_effort".to_string(),
+            json!("off"),
+        )]));
+
+        let _stream = provider
+            .stream(&config, "system", &[Message::user().with_text("hi")], &[])
+            .await
+            .unwrap();
     }
 }


### PR DESCRIPTION
## Summary

`GOOSE_THINKING_EFFORT=off` was a silent no-op on the OpenRouter path: `apply_reasoning_config` returned early and sent no reasoning config, so models that reason by default (Kimi K3, DeepSeek-R, GLM) kept thinking at full default effort.
On Terminal-Bench 2.1 that unbounded thinking cost goose 0/6 on `cobol-modernization` and `build-pov-ray`; disabling reasoning at the wire level flips them to PASS and halves median output tokens.

Now `off` on reasoning-capable models sends OpenRouter's documented disable knob `{"reasoning": {"enabled": false}}`, keeping the lowest-supported-effort clamp the upstream builder already computed for OpenAI-shaped models.
Some endpoints have mandatory reasoning (gpt-5 family, gemini-3.5, gpt-oss, deepseek-r1, some grok) and deterministically reject every disable spelling with a clear 400; rather than maintaining a name list that goes stale, the provider downgrades the request to `{"reasoning": {"effort": "low"}}` and retries once when the router reports that error.
The 400 is marked permanent so the generic retry loop does not burn attempts on it first.

Unchanged: an explicit `reasoning` object from `OPENROUTER_PARAMETERS` still wins (and never triggers the downgrade), and non-reasoning models still get no reasoning field.

### Testing

- Unit tests assert the exact JSON per case: kimi-k3 off (resolved through the canonical registry), the kept gpt-5 clamp, non-reasoning models (including OpenAI-shaped chat variants like gpt-5.1-chat), and `OPENROUTER_PARAMETERS` precedence under off; a wiremock test drives the provider through the mandatory-reasoning 400 and asserts the downgraded retry.
- Live wire checks: `{"enabled": false}` yields 0 reasoning tokens on kimi-k3, glm-4.6, gemini-2.5-flash, grok-4.20, grok-4.3, claude-sonnet-4.5; mandatory endpoints (gpt-5-mini, gpt-5-pro, gemini-3.5-flash, gpt-oss-120b, grok-4.5, deepseek-r1) reject every disable spelling and all accept `effort:"low"`.
- End-to-end with the patched binary on gemini-3.5-flash: request log shows the disable, the router 400, and the successful `effort:"low"` retry.
- Terminal-Bench 2.1 (patched binary, off, K3): the three signature tasks went 9/9 at k=3 vs 0/9 in thinking-on baselines; a 7-task no-regression slice all passed.
- `cargo fmt`, `cargo clippy -D warnings`, `cargo test -p goose` green.
