### PR TITLE
fix: avoid following untracked review symlinks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5084,6 +5084,7 @@ dependencies = [
  "goose-mcp",
  "goose-providers",
  "indicatif",
+ "libc",
  "open",
  "rand 0.10.2",
  "regex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5085,6 +5085,7 @@ dependencies = [
  "goose-providers",
  "indicatif",
  "libc",
+ "ntapi",
  "open",
  "rand 0.10.2",
  "regex",

--- a/crates/goose-cli/Cargo.toml
+++ b/crates/goose-cli/Cargo.toml
@@ -70,6 +70,7 @@ clap_complete_nushell = { version = "4", default-features = false }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 anstream = { version = "1", default-features = false, features = ["wincon"] }
+ntapi = { version = "0.4.3", default-features = false, features = ["user"] }
 winapi = { workspace = true, features = [
     "consoleapi",
     "processenv",

--- a/crates/goose-cli/Cargo.toml
+++ b/crates/goose-cli/Cargo.toml
@@ -77,6 +77,9 @@ winapi = { workspace = true, features = [
     "wincon",
 ] }
 
+[target."cfg(unix)".dependencies]
+libc = { version = "0.2.182", default-features = false, features = ["std"] }
+
 [features]
 default = [
     "code-mode",

--- a/crates/goose-cli/src/commands/review/handler.rs
+++ b/crates/goose-cli/src/commands/review/handler.rs
@@ -97,7 +97,7 @@ pub async fn handle_review(opts: ReviewOptions) -> Result<()> {
     // Synthesize a `new file` diff for each so the main pass and the
     // checks see them.
     if let Some(untracked_root) = untracked_root.as_ref() {
-        let untracked = untracked_files(&repo_root, &opts.files)?;
+        let untracked = untracked_files(untracked_root, &opts.files)?;
         if !untracked.is_empty() {
             let untracked_diff = synthesize_untracked_diff(untracked_root, &untracked)?;
             diff.push_str(&untracked_diff);
@@ -430,8 +430,8 @@ fn collect_diff_stat(repo_root: &Path, range: Option<&str>, files: &[String]) ->
 /// List untracked-but-not-ignored files in `repo_root`. Used to expose
 /// brand-new files to the review when no `--range` is given (default
 /// `git diff HEAD` would silently drop them).
-fn untracked_files(repo_root: &Path, files: &[String]) -> Result<Vec<String>> {
-    let mut cmd = review_git_command(repo_root);
+fn untracked_files(repo_root: &UntrackedRoot, files: &[String]) -> Result<Vec<String>> {
+    let mut cmd = untracked_git_command(repo_root)?;
     cmd.args(["ls-files", "--others", "--exclude-standard"]);
     if !files.is_empty() {
         cmd.arg("--");
@@ -480,11 +480,66 @@ fn validated_relative_components(path: &Path) -> std::io::Result<Vec<&std::ffi::
     Ok(components)
 }
 
-#[cfg(any(unix, windows))]
+#[cfg(unix)]
 struct UntrackedRoot(fs::File);
 
+#[cfg(windows)]
+struct UntrackedRoot {
+    directory: fs::File,
+    path: PathBuf,
+    _anchors: Vec<fs::File>,
+}
+
 #[cfg(not(any(unix, windows)))]
-struct UntrackedRoot;
+struct UntrackedRoot(PathBuf);
+
+#[cfg(unix)]
+fn untracked_git_command(repo_root: &UntrackedRoot) -> Result<Command> {
+    use std::os::fd::AsRawFd;
+    use std::os::unix::process::CommandExt;
+
+    let directory = repo_root.0.try_clone()?;
+    let mut command = git_command();
+    command.args(["-c", "core.quotePath=off"]);
+    unsafe {
+        command.pre_exec(move || {
+            if libc::fchdir(directory.as_raw_fd()) < 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+    Ok(command)
+}
+
+#[cfg(windows)]
+fn untracked_git_command(repo_root: &UntrackedRoot) -> Result<Command> {
+    Ok(review_git_command(&repo_root.path))
+}
+
+#[cfg(not(any(unix, windows)))]
+fn untracked_git_command(repo_root: &UntrackedRoot) -> Result<Command> {
+    Ok(review_git_command(&repo_root.0))
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn directory_traversal_flags() -> libc::c_int {
+    libc::O_PATH | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC
+}
+
+#[cfg(all(unix, target_vendor = "apple"))]
+fn directory_traversal_flags() -> libc::c_int {
+    libc::O_SEARCH | libc::O_NOFOLLOW | libc::O_CLOEXEC
+}
+
+#[cfg(all(
+    unix,
+    not(any(target_os = "linux", target_os = "android")),
+    not(target_vendor = "apple")
+))]
+fn directory_traversal_flags() -> libc::c_int {
+    libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC
+}
 
 #[cfg(unix)]
 fn open_untracked_root(repo_root: &Path) -> std::io::Result<UntrackedRoot> {
@@ -501,9 +556,7 @@ fn open_untracked_root_with_hook(
     use std::path::Component;
 
     let mut options = fs::OpenOptions::new();
-    options
-        .read(true)
-        .custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC);
+    options.read(true).custom_flags(directory_traversal_flags());
     let mut directory = options.open(Path::new("/"))?;
     let mut opened_path = PathBuf::from("/");
     let mut saw_root = false;
@@ -511,11 +564,7 @@ fn open_untracked_root_with_hook(
         match component {
             Component::RootDir if !saw_root => saw_root = true,
             Component::Normal(component) if saw_root => {
-                directory = open_at(
-                    &directory,
-                    component,
-                    libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
-                )?;
+                directory = open_at(&directory, component, directory_traversal_flags())?;
                 opened_path.push(component);
                 after_opened_component(&opened_path);
             }
@@ -556,6 +605,7 @@ fn open_untracked_root_with_hook(
     use std::io::{Error, ErrorKind};
     use std::os::windows::fs::OpenOptionsExt;
     use winapi::um::winbase::{FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT};
+    use winapi::um::winnt::{FILE_SHARE_READ, FILE_SHARE_WRITE};
 
     let root_anchor = repo_root
         .ancestors()
@@ -582,6 +632,7 @@ fn open_untracked_root_with_hook(
     let mut options = fs::OpenOptions::new();
     options
         .read(true)
+        .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE)
         .custom_flags(FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT);
     let mut directory = options.open(root_anchor)?;
     let root_metadata = directory.metadata()?;
@@ -592,8 +643,11 @@ fn open_untracked_root_with_hook(
         ));
     }
     let mut opened_path = root_anchor.to_path_buf();
+    let mut anchors = Vec::new();
     for component in components {
-        directory = windows_open_at(&directory, component, true)?;
+        let next = windows_open_at(&directory, component, true, false)?;
+        anchors.push(directory);
+        directory = next;
         let metadata = directory.metadata()?;
         if windows_metadata_is_reparse_point(&metadata) || !metadata.is_dir() {
             return Err(Error::new(
@@ -610,12 +664,16 @@ fn open_untracked_root_with_hook(
             "repository root must be an absolute normalized path",
         ));
     }
-    Ok(UntrackedRoot(directory))
+    Ok(UntrackedRoot {
+        directory,
+        path: repo_root.to_path_buf(),
+        _anchors: anchors,
+    })
 }
 
 #[cfg(not(any(unix, windows)))]
 fn open_untracked_root(_repo_root: &Path) -> std::io::Result<UntrackedRoot> {
-    Ok(UntrackedRoot)
+    Ok(UntrackedRoot(_repo_root.to_path_buf()))
 }
 
 #[cfg(unix)]
@@ -641,11 +699,7 @@ fn read_untracked_content_with_hook(
     let mut opened_path = PathBuf::new();
 
     for ancestor in ancestors {
-        directory = open_at(
-            &directory,
-            ancestor,
-            libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
-        )?;
+        directory = open_at(&directory, ancestor, directory_traversal_flags())?;
         opened_path.push(ancestor);
         after_opened_ancestor(&opened_path);
     }
@@ -761,11 +815,11 @@ fn read_untracked_content_with_hook(
 
     let components = validated_relative_components(path)?;
     let (file_name, ancestors) = components.split_last().unwrap();
-    let mut directory = repo_root.0.try_clone()?;
+    let mut directory = repo_root.directory.try_clone()?;
     let mut opened_path = PathBuf::new();
 
     for ancestor in ancestors {
-        directory = windows_open_at(&directory, ancestor, true)?;
+        directory = windows_open_at(&directory, ancestor, true, true)?;
         let metadata = directory.metadata()?;
         if windows_metadata_is_reparse_point(&metadata) || !metadata.is_dir() {
             return Err(Error::new(
@@ -777,7 +831,7 @@ fn read_untracked_content_with_hook(
         after_opened_ancestor(&opened_path);
     }
 
-    let mut file = windows_open_at(&directory, file_name, false)?;
+    let mut file = windows_open_at(&directory, file_name, false, true)?;
     let metadata = file.metadata()?;
     if windows_metadata_is_reparse_point(&metadata) {
         return Ok(windows_read_symlink_target(&file)?.map(|target| ("120000", target)));
@@ -799,6 +853,7 @@ fn windows_open_at(
     directory: &fs::File,
     name: &std::ffi::OsStr,
     directory_only: bool,
+    allow_delete: bool,
 ) -> std::io::Result<fs::File> {
     use ntapi::ntioapi::{
         NtCreateFile, FILE_DIRECTORY_FILE, FILE_OPEN, FILE_OPEN_REPARSE_POINT,
@@ -845,6 +900,10 @@ fn windows_open_at(
     if directory_only {
         create_options |= FILE_DIRECTORY_FILE;
     }
+    let mut share_access = FILE_SHARE_READ | FILE_SHARE_WRITE;
+    if allow_delete {
+        share_access |= FILE_SHARE_DELETE;
+    }
     // SAFETY: all pointers reference initialized values for the duration of the synchronous call.
     let status = unsafe {
         NtCreateFile(
@@ -854,7 +913,7 @@ fn windows_open_at(
             &mut io_status,
             std::ptr::null_mut(),
             0,
-            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+            share_access,
             FILE_OPEN,
             create_options,
             std::ptr::null_mut(),
@@ -1242,6 +1301,42 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    fn untracked_enumeration_stays_in_opened_root_after_swap() {
+        let parent = tempfile::tempdir().unwrap();
+        let root_path = parent.path().join("repo");
+        let moved_root = parent.path().join("moved-repo");
+        fs::create_dir(&root_path).unwrap();
+        assert!(Command::new("git")
+            .args(["init", "--quiet"])
+            .current_dir(&root_path)
+            .status()
+            .unwrap()
+            .success());
+        fs::write(root_path.join(".gitignore"), "secret.txt\n").unwrap();
+        fs::write(root_path.join("secret.txt"), "original ignored content").unwrap();
+        let root = open_test_untracked_root(&root_path).unwrap();
+
+        fs::rename(&root_path, &moved_root).unwrap();
+        fs::create_dir(&root_path).unwrap();
+        assert!(Command::new("git")
+            .args(["init", "--quiet"])
+            .current_dir(&root_path)
+            .status()
+            .unwrap()
+            .success());
+        fs::write(
+            root_path.join("secret.txt"),
+            "replacement untracked content",
+        )
+        .unwrap();
+
+        let untracked = untracked_files(&root, &[]).unwrap();
+        assert!(untracked.contains(&".gitignore".to_string()));
+        assert!(!untracked.contains(&"secret.txt".to_string()));
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn untracked_root_rejects_symlinked_ancestor() {
         let parent = tempfile::tempdir().unwrap();
         let parent = fs::canonicalize(parent.path()).unwrap();
@@ -1323,7 +1418,7 @@ mod tests {
 
     #[cfg(windows)]
     #[test]
-    fn windows_untracked_file_reader_stays_in_opened_root_after_swap() {
+    fn windows_untracked_root_prevents_swap() {
         let parent = tempfile::tempdir().unwrap();
         let root_path = parent.path().join("repo");
         let moved_root = parent.path().join("moved-repo");
@@ -1331,9 +1426,7 @@ mod tests {
         fs::write(root_path.join("file.txt"), "safe worktree content").unwrap();
         let root = open_test_untracked_root(&root_path).unwrap();
 
-        fs::rename(&root_path, &moved_root).unwrap();
-        fs::create_dir(&root_path).unwrap();
-        fs::write(root_path.join("file.txt"), "TOPSECRET-OUTSIDE-REPO").unwrap();
+        assert!(fs::rename(&root_path, &moved_root).is_err());
 
         let (mode, content) = read_untracked_content(&root, Path::new("file.txt"))
             .unwrap()
@@ -1345,7 +1438,7 @@ mod tests {
 
     #[cfg(windows)]
     #[test]
-    fn windows_untracked_root_stays_in_opened_ancestor_after_reparse_swap() {
+    fn windows_untracked_root_prevents_ancestor_reparse_swap() {
         let parent = tempfile::tempdir().unwrap();
         let outside = tempfile::tempdir().unwrap();
         let ancestor = parent.path().join("ancestor");
@@ -1366,8 +1459,7 @@ mod tests {
 
         let root = open_untracked_root_with_hook(&root_path, |opened_path| {
             if opened_path == ancestor {
-                fs::rename(&ancestor, &moved_ancestor).unwrap();
-                fs::rename(&replacement, &ancestor).unwrap();
+                assert!(fs::rename(&ancestor, &moved_ancestor).is_err());
             }
         })
         .unwrap();

--- a/crates/goose-cli/src/commands/review/handler.rs
+++ b/crates/goose-cli/src/commands/review/handler.rs
@@ -448,6 +448,31 @@ fn untracked_files(repo_root: &Path, files: &[String]) -> Result<Vec<String>> {
         .collect())
 }
 
+#[cfg(unix)]
+fn read_untracked_regular_file(path: &Path) -> std::io::Result<String> {
+    use std::io::{Error, ErrorKind, Read};
+    use std::os::unix::fs::OpenOptionsExt;
+
+    let mut options = fs::OpenOptions::new();
+    options.read(true).custom_flags(libc::O_NOFOLLOW);
+    let mut file = options.open(path)?;
+    if !file.metadata()?.is_file() {
+        return Err(Error::new(
+            ErrorKind::InvalidInput,
+            "untracked path is not a regular file",
+        ));
+    }
+
+    let mut content = String::new();
+    file.read_to_string(&mut content)?;
+    Ok(content)
+}
+
+#[cfg(not(unix))]
+fn read_untracked_regular_file(path: &Path) -> std::io::Result<String> {
+    fs::read_to_string(path)
+}
+
 /// Synthesize a unified `new file` diff for each untracked path so
 /// downstream parsers and the review prompt can treat them as
 /// additions. Symlinks are represented by their link text, matching Git.
@@ -470,7 +495,7 @@ fn synthesize_untracked_diff(repo_root: &Path, paths: &[String]) -> Result<Strin
             };
             ("120000", target.to_string())
         } else {
-            let content = match fs::read_to_string(&abs) {
+            let content = match read_untracked_regular_file(&abs) {
                 Ok(content) => content,
                 Err(_) => continue,
             };
@@ -640,6 +665,24 @@ mod tests {
 
         assert!(diff.contains("new file mode 120000"));
         assert!(diff.contains("+../missing-target"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn untracked_regular_file_reader_rejects_symlink_swap() {
+        let dir = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let path = dir.path().join("untracked.txt");
+        let secret = outside.path().join("secret.txt");
+        fs::write(&path, "safe worktree content").unwrap();
+        fs::write(&secret, "TOPSECRET-OUTSIDE-REPO").unwrap();
+
+        assert!(fs::symlink_metadata(&path).unwrap().is_file());
+        fs::remove_file(&path).unwrap();
+        std::os::unix::fs::symlink(&secret, &path).unwrap();
+
+        let error = read_untracked_regular_file(&path).unwrap_err();
+        assert_eq!(error.raw_os_error(), Some(libc::ELOOP));
     }
 
     #[test]

--- a/crates/goose-cli/src/commands/review/handler.rs
+++ b/crates/goose-cli/src/commands/review/handler.rs
@@ -72,6 +72,11 @@ pub struct ReviewOptions {
 /// Entry point for the `goose review` subcommand.
 pub async fn handle_review(opts: ReviewOptions) -> Result<()> {
     let repo_root = find_repo_root().context("not inside a git repository")?;
+    let untracked_root = opts
+        .range
+        .is_none()
+        .then(|| open_untracked_root(&repo_root))
+        .transpose()?;
 
     // Validate `--severity` once, up front, so a bogus value fails fast
     // regardless of which orchestration path we end up taking.
@@ -91,10 +96,10 @@ pub async fn handle_review(opts: ReviewOptions) -> Result<()> {
     // files entirely — brand-new files would silently miss the review.
     // Synthesize a `new file` diff for each so the main pass and the
     // checks see them.
-    if opts.range.is_none() {
+    if let Some(untracked_root) = untracked_root.as_ref() {
         let untracked = untracked_files(&repo_root, &opts.files)?;
         if !untracked.is_empty() {
-            let untracked_diff = synthesize_untracked_diff(&repo_root, &untracked)?;
+            let untracked_diff = synthesize_untracked_diff(untracked_root, &untracked)?;
             diff.push_str(&untracked_diff);
             for u in untracked {
                 if !touched.contains(&u) {
@@ -475,9 +480,60 @@ fn validated_relative_components(path: &Path) -> std::io::Result<Vec<&std::ffi::
     Ok(components)
 }
 
+#[cfg(any(unix, windows))]
+struct UntrackedRoot(fs::File);
+
+#[cfg(not(any(unix, windows)))]
+struct UntrackedRoot;
+
+#[cfg(unix)]
+fn open_untracked_root(repo_root: &Path) -> std::io::Result<UntrackedRoot> {
+    use std::io::{Error, ErrorKind};
+    use std::os::unix::fs::OpenOptionsExt;
+
+    let mut options = fs::OpenOptions::new();
+    options
+        .read(true)
+        .custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC);
+    let directory = options.open(repo_root)?;
+    if !directory.metadata()?.is_dir() {
+        return Err(Error::new(
+            ErrorKind::InvalidInput,
+            "repository root is not a directory",
+        ));
+    }
+    Ok(UntrackedRoot(directory))
+}
+
+#[cfg(windows)]
+fn open_untracked_root(repo_root: &Path) -> std::io::Result<UntrackedRoot> {
+    use std::io::{Error, ErrorKind};
+    use std::os::windows::fs::OpenOptionsExt;
+    use winapi::um::winbase::{FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT};
+
+    let mut options = fs::OpenOptions::new();
+    options
+        .read(true)
+        .custom_flags(FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT);
+    let directory = options.open(repo_root)?;
+    let metadata = directory.metadata()?;
+    if windows_metadata_is_reparse_point(&metadata) || !metadata.is_dir() {
+        return Err(Error::new(
+            ErrorKind::InvalidInput,
+            "repository root is not a regular directory",
+        ));
+    }
+    Ok(UntrackedRoot(directory))
+}
+
+#[cfg(not(any(unix, windows)))]
+fn open_untracked_root(_repo_root: &Path) -> std::io::Result<UntrackedRoot> {
+    Ok(UntrackedRoot)
+}
+
 #[cfg(unix)]
 fn read_untracked_content(
-    repo_root: &Path,
+    repo_root: &UntrackedRoot,
     path: &Path,
 ) -> std::io::Result<Option<(&'static str, String)>> {
     read_untracked_content_with_hook(repo_root, path, |_| {})
@@ -485,21 +541,16 @@ fn read_untracked_content(
 
 #[cfg(unix)]
 fn read_untracked_content_with_hook(
-    repo_root: &Path,
+    repo_root: &UntrackedRoot,
     path: &Path,
     mut after_opened_ancestor: impl FnMut(&Path),
 ) -> std::io::Result<Option<(&'static str, String)>> {
     use std::io::{Error, ErrorKind, Read};
     use std::os::unix::ffi::OsStringExt;
-    use std::os::unix::fs::OpenOptionsExt;
 
     let components = validated_relative_components(path)?;
     let (file_name, ancestors) = components.split_last().unwrap();
-    let mut options = fs::OpenOptions::new();
-    options
-        .read(true)
-        .custom_flags(libc::O_DIRECTORY | libc::O_CLOEXEC);
-    let mut directory = options.open(repo_root)?;
+    let mut directory = repo_root.0.try_clone()?;
     let mut opened_path = PathBuf::new();
 
     for ancestor in ancestors {
@@ -607,7 +658,7 @@ fn read_link_at(directory: &fs::File, name: &std::ffi::OsStr) -> std::io::Result
 
 #[cfg(windows)]
 fn read_untracked_content(
-    repo_root: &Path,
+    repo_root: &UntrackedRoot,
     path: &Path,
 ) -> std::io::Result<Option<(&'static str, String)>> {
     read_untracked_content_with_hook(repo_root, path, |_| {})
@@ -615,19 +666,15 @@ fn read_untracked_content(
 
 #[cfg(windows)]
 fn read_untracked_content_with_hook(
-    repo_root: &Path,
+    repo_root: &UntrackedRoot,
     path: &Path,
     mut after_opened_ancestor: impl FnMut(&Path),
 ) -> std::io::Result<Option<(&'static str, String)>> {
     use std::io::{Error, ErrorKind, Read};
-    use std::os::windows::fs::OpenOptionsExt;
-    use winapi::um::winbase::FILE_FLAG_BACKUP_SEMANTICS;
 
     let components = validated_relative_components(path)?;
     let (file_name, ancestors) = components.split_last().unwrap();
-    let mut options = fs::OpenOptions::new();
-    options.read(true).custom_flags(FILE_FLAG_BACKUP_SEMANTICS);
-    let mut directory = options.open(repo_root)?;
+    let mut directory = repo_root.0.try_clone()?;
     let mut opened_path = PathBuf::new();
 
     for ancestor in ancestors {
@@ -833,7 +880,7 @@ fn windows_nt_status_error(status: winapi::shared::ntdef::NTSTATUS) -> std::io::
 
 #[cfg(not(any(unix, windows)))]
 fn read_untracked_content(
-    _repo_root: &Path,
+    _repo_root: &UntrackedRoot,
     path: &Path,
 ) -> std::io::Result<Option<(&'static str, String)>> {
     validated_relative_components(path)?;
@@ -844,7 +891,7 @@ fn read_untracked_content(
 /// downstream parsers and the review prompt can treat them as
 /// additions. Symlinks are represented by their link text, matching Git.
 /// Binary or unreadable files are skipped.
-fn synthesize_untracked_diff(repo_root: &Path, paths: &[String]) -> Result<String> {
+fn synthesize_untracked_diff(repo_root: &UntrackedRoot, paths: &[String]) -> Result<String> {
     let mut out = String::new();
     for path in paths {
         let Some((mode, content)) = (match read_untracked_content(repo_root, Path::new(path)) {
@@ -970,7 +1017,8 @@ mod tests {
         fs::create_dir_all(path.parent().unwrap()).unwrap();
         fs::write(&path, "alpha\nbeta\ngamma\n").unwrap();
 
-        let diff = synthesize_untracked_diff(root, &["new/file.txt".to_string()]).unwrap();
+        let root = open_untracked_root(root).unwrap();
+        let diff = synthesize_untracked_diff(&root, &["new/file.txt".to_string()]).unwrap();
         assert!(diff.contains("diff --git a/new/file.txt b/new/file.txt"));
         assert!(diff.contains("new file mode 100644"));
         assert!(diff.contains("--- /dev/null"));
@@ -987,7 +1035,8 @@ mod tests {
         let root = dir.path();
         fs::write(root.join("a.txt"), "no-newline").unwrap();
 
-        let diff = synthesize_untracked_diff(root, &["a.txt".to_string()]).unwrap();
+        let root = open_untracked_root(root).unwrap();
+        let diff = synthesize_untracked_diff(&root, &["a.txt".to_string()]).unwrap();
         assert!(diff.contains("@@ -0,0 +1,1 @@"));
         assert!(diff.contains("+no-newline\n"));
         assert!(diff.contains("\\ No newline at end of file"));
@@ -1002,7 +1051,8 @@ mod tests {
         fs::write(&secret, "TOPSECRET-OUTSIDE-REPO").unwrap();
         std::os::unix::fs::symlink(&secret, dir.path().join("link.txt")).unwrap();
 
-        let diff = synthesize_untracked_diff(dir.path(), &["link.txt".to_string()]).unwrap();
+        let root = open_untracked_root(dir.path()).unwrap();
+        let diff = synthesize_untracked_diff(&root, &["link.txt".to_string()]).unwrap();
 
         assert!(diff.contains("new file mode 120000"));
         assert!(diff.contains(&format!("+{}", secret.display())));
@@ -1015,7 +1065,8 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         std::os::unix::fs::symlink("../missing-target", dir.path().join("broken")).unwrap();
 
-        let diff = synthesize_untracked_diff(dir.path(), &["broken".to_string()]).unwrap();
+        let root = open_untracked_root(dir.path()).unwrap();
+        let diff = synthesize_untracked_diff(&root, &["broken".to_string()]).unwrap();
 
         assert!(diff.contains("new file mode 120000"));
         assert!(diff.contains("+../missing-target"));
@@ -1035,7 +1086,8 @@ mod tests {
         fs::remove_file(&path).unwrap();
         std::os::unix::fs::symlink(&secret, &path).unwrap();
 
-        let (mode, content) = read_untracked_content(dir.path(), Path::new("untracked.txt"))
+        let root = open_untracked_root(dir.path()).unwrap();
+        let (mode, content) = read_untracked_content(&root, Path::new("untracked.txt"))
             .unwrap()
             .unwrap();
         assert_eq!(mode, "120000");
@@ -1054,19 +1106,40 @@ mod tests {
         fs::write(ancestor.join("file.txt"), "safe worktree content").unwrap();
         fs::write(outside.path().join("file.txt"), "TOPSECRET-OUTSIDE-REPO").unwrap();
 
-        let (mode, content) = read_untracked_content_with_hook(
-            dir.path(),
-            Path::new("nested/file.txt"),
-            |opened_path| {
+        let root = open_untracked_root(dir.path()).unwrap();
+        let (mode, content) =
+            read_untracked_content_with_hook(&root, Path::new("nested/file.txt"), |opened_path| {
                 if opened_path == Path::new("nested") {
                     fs::rename(&ancestor, &moved_ancestor).unwrap();
                     std::os::unix::fs::symlink(outside.path(), &ancestor).unwrap();
                 }
-            },
-        )
-        .unwrap()
-        .unwrap();
+            })
+            .unwrap()
+            .unwrap();
 
+        assert_eq!(mode, "100644");
+        assert_eq!(content, "safe worktree content");
+        assert!(!content.contains("TOPSECRET-OUTSIDE-REPO"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn untracked_file_reader_stays_in_opened_root_after_swap() {
+        let parent = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let root_path = parent.path().join("repo");
+        let moved_root = parent.path().join("moved-repo");
+        fs::create_dir(&root_path).unwrap();
+        fs::write(root_path.join("file.txt"), "safe worktree content").unwrap();
+        fs::write(outside.path().join("file.txt"), "TOPSECRET-OUTSIDE-REPO").unwrap();
+        let root = open_untracked_root(&root_path).unwrap();
+
+        fs::rename(&root_path, &moved_root).unwrap();
+        std::os::unix::fs::symlink(outside.path(), &root_path).unwrap();
+
+        let (mode, content) = read_untracked_content(&root, Path::new("file.txt"))
+            .unwrap()
+            .unwrap();
         assert_eq!(mode, "100644");
         assert_eq!(content, "safe worktree content");
         assert!(!content.contains("TOPSECRET-OUTSIDE-REPO"));
@@ -1081,20 +1154,40 @@ mod tests {
         fs::create_dir(&ancestor).unwrap();
         fs::write(ancestor.join("file.txt"), "safe worktree content").unwrap();
 
-        let (mode, content) = read_untracked_content_with_hook(
-            dir.path(),
-            Path::new("nested/file.txt"),
-            |opened_path| {
+        let root = open_untracked_root(dir.path()).unwrap();
+        let (mode, content) =
+            read_untracked_content_with_hook(&root, Path::new("nested/file.txt"), |opened_path| {
                 if opened_path == Path::new("nested") {
                     fs::rename(&ancestor, &moved_ancestor).unwrap();
                     fs::create_dir(&ancestor).unwrap();
                     fs::write(ancestor.join("file.txt"), "TOPSECRET-OUTSIDE-REPO").unwrap();
                 }
-            },
-        )
-        .unwrap()
-        .unwrap();
+            })
+            .unwrap()
+            .unwrap();
 
+        assert_eq!(mode, "100644");
+        assert_eq!(content, "safe worktree content");
+        assert!(!content.contains("TOPSECRET-OUTSIDE-REPO"));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_untracked_file_reader_stays_in_opened_root_after_swap() {
+        let parent = tempfile::tempdir().unwrap();
+        let root_path = parent.path().join("repo");
+        let moved_root = parent.path().join("moved-repo");
+        fs::create_dir(&root_path).unwrap();
+        fs::write(root_path.join("file.txt"), "safe worktree content").unwrap();
+        let root = open_untracked_root(&root_path).unwrap();
+
+        fs::rename(&root_path, &moved_root).unwrap();
+        fs::create_dir(&root_path).unwrap();
+        fs::write(root_path.join("file.txt"), "TOPSECRET-OUTSIDE-REPO").unwrap();
+
+        let (mode, content) = read_untracked_content(&root, Path::new("file.txt"))
+            .unwrap()
+            .unwrap();
         assert_eq!(mode, "100644");
         assert_eq!(content, "safe worktree content");
         assert!(!content.contains("TOPSECRET-OUTSIDE-REPO"));
@@ -1110,7 +1203,8 @@ mod tests {
             return;
         }
 
-        let result = read_untracked_content(dir.path(), Path::new("nested/file.txt"));
+        let root = open_untracked_root(dir.path()).unwrap();
+        let result = read_untracked_content(&root, Path::new("nested/file.txt"));
 
         assert!(result.is_err());
     }
@@ -1124,7 +1218,8 @@ mod tests {
             return;
         }
 
-        let diff = synthesize_untracked_diff(dir.path(), &["link.txt".to_string()]).unwrap();
+        let root = open_untracked_root(dir.path()).unwrap();
+        let diff = synthesize_untracked_diff(&root, &["link.txt".to_string()]).unwrap();
 
         assert!(diff.contains("new file mode 120000"));
         assert!(diff.contains("+missing-target.txt"));
@@ -1163,7 +1258,8 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         fs::write(dir.path().join("ordinary.txt"), "ordinary content").unwrap();
 
-        let diff = synthesize_untracked_diff(dir.path(), &["ordinary.txt".to_string()]).unwrap();
+        let root = open_untracked_root(dir.path()).unwrap();
+        let diff = synthesize_untracked_diff(&root, &["ordinary.txt".to_string()]).unwrap();
 
         assert!(diff.is_empty());
     }

--- a/crates/goose-cli/src/commands/review/handler.rs
+++ b/crates/goose-cli/src/commands/review/handler.rs
@@ -450,18 +450,34 @@ fn untracked_files(repo_root: &Path, files: &[String]) -> Result<Vec<String>> {
 
 /// Synthesize a unified `new file` diff for each untracked path so
 /// downstream parsers and the review prompt can treat them as
-/// additions. Binary or unreadable files are skipped (we cannot
-/// produce a meaningful textual diff for them).
+/// additions. Symlinks are represented by their link text, matching Git.
+/// Binary or unreadable files are skipped.
 fn synthesize_untracked_diff(repo_root: &Path, paths: &[String]) -> Result<String> {
     let mut out = String::new();
     for path in paths {
         let abs = repo_root.join(path);
-        let content = match fs::read_to_string(&abs) {
-            Ok(c) => c,
+        let metadata = match fs::symlink_metadata(&abs) {
+            Ok(metadata) => metadata,
             Err(_) => continue,
         };
+        let (mode, content) = if metadata.file_type().is_symlink() {
+            let target = match fs::read_link(&abs) {
+                Ok(target) => target,
+                Err(_) => continue,
+            };
+            let Some(target) = target.to_str() else {
+                continue;
+            };
+            ("120000", target.to_string())
+        } else {
+            let content = match fs::read_to_string(&abs) {
+                Ok(content) => content,
+                Err(_) => continue,
+            };
+            ("100644", content)
+        };
         out.push_str(&format!("diff --git a/{path} b/{path}\n"));
-        out.push_str("new file mode 100644\n");
+        out.push_str(&format!("new file mode {mode}\n"));
         out.push_str("--- /dev/null\n");
         out.push_str(&format!("+++ b/{path}\n"));
         let trailing_newline = content.ends_with('\n');
@@ -596,6 +612,34 @@ mod tests {
         assert!(diff.contains("@@ -0,0 +1,1 @@"));
         assert!(diff.contains("+no-newline\n"));
         assert!(diff.contains("\\ No newline at end of file"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn synthesize_untracked_diff_uses_symlink_text_without_following_target() {
+        let dir = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let secret = outside.path().join("secret.txt");
+        fs::write(&secret, "TOPSECRET-OUTSIDE-REPO").unwrap();
+        std::os::unix::fs::symlink(&secret, dir.path().join("link.txt")).unwrap();
+
+        let diff = synthesize_untracked_diff(dir.path(), &["link.txt".to_string()]).unwrap();
+
+        assert!(diff.contains("new file mode 120000"));
+        assert!(diff.contains(&format!("+{}", secret.display())));
+        assert!(!diff.contains("TOPSECRET-OUTSIDE-REPO"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn synthesize_untracked_diff_includes_broken_symlink_text() {
+        let dir = tempfile::tempdir().unwrap();
+        std::os::unix::fs::symlink("../missing-target", dir.path().join("broken")).unwrap();
+
+        let diff = synthesize_untracked_diff(dir.path(), &["broken".to_string()]).unwrap();
+
+        assert!(diff.contains("new file mode 120000"));
+        assert!(diff.contains("+../missing-target"));
     }
 
     #[test]

--- a/crates/goose-cli/src/commands/review/handler.rs
+++ b/crates/goose-cli/src/commands/review/handler.rs
@@ -448,29 +448,186 @@ fn untracked_files(repo_root: &Path, files: &[String]) -> Result<Vec<String>> {
         .collect())
 }
 
-#[cfg(unix)]
-fn read_untracked_regular_file(path: &Path) -> std::io::Result<String> {
-    use std::io::{Error, ErrorKind, Read};
-    use std::os::unix::fs::OpenOptionsExt;
+fn validated_relative_components(path: &Path) -> std::io::Result<Vec<&std::ffi::OsStr>> {
+    use std::io::{Error, ErrorKind};
+    use std::path::Component;
 
-    let mut options = fs::OpenOptions::new();
-    options.read(true).custom_flags(libc::O_NOFOLLOW);
-    let mut file = options.open(path)?;
-    if !file.metadata()?.is_file() {
+    let mut components = Vec::new();
+    for component in path.components() {
+        match component {
+            Component::Normal(component) => components.push(component),
+            Component::CurDir => {}
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+                return Err(Error::new(
+                    ErrorKind::InvalidInput,
+                    "untracked path must be relative to the repository",
+                ));
+            }
+        }
+    }
+    if components.is_empty() {
         return Err(Error::new(
             ErrorKind::InvalidInput,
-            "untracked path is not a regular file",
+            "untracked path must name a file",
         ));
     }
 
-    let mut content = String::new();
-    file.read_to_string(&mut content)?;
-    Ok(content)
+    Ok(components)
+}
+
+#[cfg(unix)]
+fn read_untracked_content(
+    repo_root: &Path,
+    path: &Path,
+) -> std::io::Result<Option<(&'static str, String)>> {
+    read_untracked_content_with_hook(repo_root, path, |_| {})
+}
+
+#[cfg(unix)]
+fn read_untracked_content_with_hook(
+    repo_root: &Path,
+    path: &Path,
+    mut after_opened_ancestor: impl FnMut(&Path),
+) -> std::io::Result<Option<(&'static str, String)>> {
+    use std::io::{Error, ErrorKind, Read};
+    use std::os::unix::ffi::OsStringExt;
+    use std::os::unix::fs::OpenOptionsExt;
+
+    let components = validated_relative_components(path)?;
+    let (file_name, ancestors) = components.split_last().unwrap();
+    let mut options = fs::OpenOptions::new();
+    options
+        .read(true)
+        .custom_flags(libc::O_DIRECTORY | libc::O_CLOEXEC);
+    let mut directory = options.open(repo_root)?;
+    let mut opened_path = PathBuf::new();
+
+    for ancestor in ancestors {
+        directory = open_at(
+            &directory,
+            ancestor,
+            libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+        )?;
+        opened_path.push(ancestor);
+        after_opened_ancestor(&opened_path);
+    }
+
+    match open_at(
+        &directory,
+        file_name,
+        libc::O_RDONLY | libc::O_NONBLOCK | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+    ) {
+        Ok(mut file) => {
+            if !file.metadata()?.is_file() {
+                return Err(Error::new(
+                    ErrorKind::InvalidInput,
+                    "untracked path is not a regular file",
+                ));
+            }
+            let mut content = String::new();
+            file.read_to_string(&mut content)?;
+            Ok(Some(("100644", content)))
+        }
+        Err(error) if error.raw_os_error() == Some(libc::ELOOP) => {
+            let target = read_link_at(&directory, file_name)?;
+            let target = std::ffi::OsString::from_vec(target);
+            let Some(target) = target.to_str() else {
+                return Err(Error::new(
+                    ErrorKind::InvalidData,
+                    "untracked symlink target is not UTF-8",
+                ));
+            };
+            Ok(Some(("120000", target.to_string())))
+        }
+        Err(error) => Err(error),
+    }
+}
+
+#[cfg(unix)]
+fn open_at(
+    directory: &fs::File,
+    name: &std::ffi::OsStr,
+    flags: libc::c_int,
+) -> std::io::Result<fs::File> {
+    use std::ffi::CString;
+    use std::io::{Error, ErrorKind};
+    use std::os::fd::{AsRawFd, FromRawFd};
+    use std::os::unix::ffi::OsStrExt;
+
+    let name = CString::new(name.as_bytes()).map_err(|_| {
+        Error::new(
+            ErrorKind::InvalidInput,
+            "untracked path contains a NUL byte",
+        )
+    })?;
+    // SAFETY: openat does not retain the name pointer, and no creation flag requiring a mode is set.
+    let descriptor = unsafe { libc::openat(directory.as_raw_fd(), name.as_ptr(), flags) };
+    if descriptor < 0 {
+        return Err(Error::last_os_error());
+    }
+    // SAFETY: openat returned a new owned descriptor on success.
+    Ok(unsafe { fs::File::from_raw_fd(descriptor) })
+}
+
+#[cfg(unix)]
+fn read_link_at(directory: &fs::File, name: &std::ffi::OsStr) -> std::io::Result<Vec<u8>> {
+    use std::ffi::CString;
+    use std::io::{Error, ErrorKind};
+    use std::os::fd::AsRawFd;
+    use std::os::unix::ffi::OsStrExt;
+
+    let name = CString::new(name.as_bytes()).map_err(|_| {
+        Error::new(
+            ErrorKind::InvalidInput,
+            "untracked path contains a NUL byte",
+        )
+    })?;
+    let mut target = vec![0; 256];
+    loop {
+        // SAFETY: readlinkat does not retain either pointer and writes at most target.len() bytes.
+        let length = unsafe {
+            libc::readlinkat(
+                directory.as_raw_fd(),
+                name.as_ptr(),
+                target.as_mut_ptr().cast(),
+                target.len(),
+            )
+        };
+        if length < 0 {
+            return Err(Error::last_os_error());
+        }
+        let length = length as usize;
+        if length < target.len() {
+            target.truncate(length);
+            return Ok(target);
+        }
+        target.resize(target.len() * 2, 0);
+    }
 }
 
 #[cfg(not(unix))]
-fn read_untracked_regular_file(path: &Path) -> std::io::Result<String> {
-    fs::read_to_string(path)
+fn read_untracked_content(
+    repo_root: &Path,
+    path: &Path,
+) -> std::io::Result<Option<(&'static str, String)>> {
+    use std::io::{Error, ErrorKind};
+
+    validated_relative_components(path)?;
+    let absolute_path = repo_root.join(path);
+    let metadata = fs::symlink_metadata(&absolute_path)?;
+    if !metadata.file_type().is_symlink() {
+        // std does not expose a portable opened-handle no-follow walk. Omitting ordinary files
+        // avoids disclosing content through a link swap on supported non-Unix platforms.
+        return Ok(None);
+    }
+    let target = fs::read_link(absolute_path)?;
+    let Some(target) = target.to_str() else {
+        return Err(Error::new(
+            ErrorKind::InvalidData,
+            "untracked symlink target is not UTF-8",
+        ));
+    };
+    Ok(Some(("120000", target.to_string())))
 }
 
 /// Synthesize a unified `new file` diff for each untracked path so
@@ -480,26 +637,11 @@ fn read_untracked_regular_file(path: &Path) -> std::io::Result<String> {
 fn synthesize_untracked_diff(repo_root: &Path, paths: &[String]) -> Result<String> {
     let mut out = String::new();
     for path in paths {
-        let abs = repo_root.join(path);
-        let metadata = match fs::symlink_metadata(&abs) {
-            Ok(metadata) => metadata,
+        let Some((mode, content)) = (match read_untracked_content(repo_root, Path::new(path)) {
+            Ok(content) => content,
             Err(_) => continue,
-        };
-        let (mode, content) = if metadata.file_type().is_symlink() {
-            let target = match fs::read_link(&abs) {
-                Ok(target) => target,
-                Err(_) => continue,
-            };
-            let Some(target) = target.to_str() else {
-                continue;
-            };
-            ("120000", target.to_string())
-        } else {
-            let content = match read_untracked_regular_file(&abs) {
-                Ok(content) => content,
-                Err(_) => continue,
-            };
-            ("100644", content)
+        }) else {
+            continue;
         };
         out.push_str(&format!("diff --git a/{path} b/{path}\n"));
         out.push_str(&format!("new file mode {mode}\n"));
@@ -609,6 +751,7 @@ mod tests {
         assert!(out.ends_with("BASE"));
     }
 
+    #[cfg(unix)]
     #[test]
     fn synthesize_untracked_diff_emits_new_file_chunk_with_added_lines() {
         let dir = tempfile::tempdir().unwrap();
@@ -627,6 +770,7 @@ mod tests {
         assert!(!diff.contains("\\ No newline at end of file"));
     }
 
+    #[cfg(unix)]
     #[test]
     fn synthesize_untracked_diff_marks_missing_trailing_newline() {
         let dir = tempfile::tempdir().unwrap();
@@ -669,7 +813,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn untracked_regular_file_reader_rejects_symlink_swap() {
+    fn untracked_file_reader_preserves_link_text_after_leaf_swap() {
         let dir = tempfile::tempdir().unwrap();
         let outside = tempfile::tempdir().unwrap();
         let path = dir.path().join("untracked.txt");
@@ -681,8 +825,79 @@ mod tests {
         fs::remove_file(&path).unwrap();
         std::os::unix::fs::symlink(&secret, &path).unwrap();
 
-        let error = read_untracked_regular_file(&path).unwrap_err();
-        assert_eq!(error.raw_os_error(), Some(libc::ELOOP));
+        let (mode, content) = read_untracked_content(dir.path(), Path::new("untracked.txt"))
+            .unwrap()
+            .unwrap();
+        assert_eq!(mode, "120000");
+        assert_eq!(content, secret.to_str().unwrap());
+        assert!(!content.contains("TOPSECRET-OUTSIDE-REPO"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn untracked_file_reader_stays_in_opened_ancestor_after_swap() {
+        let dir = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let ancestor = dir.path().join("nested");
+        let moved_ancestor = dir.path().join("moved-nested");
+        fs::create_dir(&ancestor).unwrap();
+        fs::write(ancestor.join("file.txt"), "safe worktree content").unwrap();
+        fs::write(outside.path().join("file.txt"), "TOPSECRET-OUTSIDE-REPO").unwrap();
+
+        let (mode, content) = read_untracked_content_with_hook(
+            dir.path(),
+            Path::new("nested/file.txt"),
+            |opened_path| {
+                if opened_path == Path::new("nested") {
+                    fs::rename(&ancestor, &moved_ancestor).unwrap();
+                    std::os::unix::fs::symlink(outside.path(), &ancestor).unwrap();
+                }
+            },
+        )
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(mode, "100644");
+        assert_eq!(content, "safe worktree content");
+        assert!(!content.contains("TOPSECRET-OUTSIDE-REPO"));
+    }
+
+    #[test]
+    fn untracked_paths_must_be_repo_relative() {
+        for path in [
+            Path::new("/outside"),
+            Path::new("../outside"),
+            Path::new("nested/../../outside"),
+        ] {
+            let error = validated_relative_components(path).unwrap_err();
+            assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
+        }
+        assert_eq!(
+            validated_relative_components(Path::new("nested/./file.txt")).unwrap(),
+            [
+                std::ffi::OsStr::new("nested"),
+                std::ffi::OsStr::new("file.txt")
+            ]
+        );
+
+        #[cfg(windows)]
+        assert_eq!(
+            validated_relative_components(Path::new(r"C:\outside"))
+                .unwrap_err()
+                .kind(),
+            std::io::ErrorKind::InvalidInput
+        );
+    }
+
+    #[cfg(not(unix))]
+    #[test]
+    fn synthesize_untracked_diff_omits_ordinary_files_without_safe_open() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("ordinary.txt"), "ordinary content").unwrap();
+
+        let diff = synthesize_untracked_diff(dir.path(), &["ordinary.txt".to_string()]).unwrap();
+
+        assert!(diff.is_empty());
     }
 
     #[test]

--- a/crates/goose-cli/src/commands/review/handler.rs
+++ b/crates/goose-cli/src/commands/review/handler.rs
@@ -606,7 +606,9 @@ fn open_untracked_root_with_hook(
     use std::io::{Error, ErrorKind};
     use std::os::windows::fs::OpenOptionsExt;
     use winapi::um::winbase::{FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT};
-    use winapi::um::winnt::{FILE_SHARE_READ, FILE_SHARE_WRITE};
+    use winapi::um::winnt::{
+        FILE_READ_ATTRIBUTES, FILE_SHARE_READ, FILE_SHARE_WRITE, FILE_TRAVERSE, SYNCHRONIZE,
+    };
 
     let root_anchor = repo_root
         .ancestors()
@@ -632,7 +634,7 @@ fn open_untracked_root_with_hook(
 
     let mut options = fs::OpenOptions::new();
     options
-        .read(true)
+        .access_mode(FILE_TRAVERSE | FILE_READ_ATTRIBUTES | SYNCHRONIZE)
         .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE)
         .custom_flags(FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT);
     let mut directory = options.open(root_anchor)?;
@@ -867,7 +869,8 @@ fn windows_open_at(
         HANDLE, NT_SUCCESS, OBJECT_ATTRIBUTES, OBJ_CASE_INSENSITIVE, UNICODE_STRING,
     };
     use winapi::um::winnt::{
-        FILE_GENERIC_READ, FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE,
+        FILE_GENERIC_READ, FILE_READ_ATTRIBUTES, FILE_SHARE_DELETE, FILE_SHARE_READ,
+        FILE_SHARE_WRITE, FILE_TRAVERSE, SYNCHRONIZE,
     };
 
     let mut name: Vec<u16> = name.encode_wide().collect();
@@ -905,11 +908,16 @@ fn windows_open_at(
     if allow_delete {
         share_access |= FILE_SHARE_DELETE;
     }
+    let desired_access = if directory_only {
+        FILE_TRAVERSE | FILE_READ_ATTRIBUTES | SYNCHRONIZE
+    } else {
+        FILE_GENERIC_READ
+    };
     // SAFETY: all pointers reference initialized values for the duration of the synchronous call.
     let status = unsafe {
         NtCreateFile(
             &mut handle,
-            FILE_GENERIC_READ,
+            desired_access,
             &mut attributes,
             &mut io_status,
             std::ptr::null_mut(),

--- a/crates/goose-cli/src/commands/review/handler.rs
+++ b/crates/goose-cli/src/commands/review/handler.rs
@@ -545,20 +545,69 @@ fn open_untracked_root_with_hook(
 
 #[cfg(windows)]
 fn open_untracked_root(repo_root: &Path) -> std::io::Result<UntrackedRoot> {
+    open_untracked_root_with_hook(repo_root, |_| {})
+}
+
+#[cfg(windows)]
+fn open_untracked_root_with_hook(
+    repo_root: &Path,
+    mut after_opened_component: impl FnMut(&Path),
+) -> std::io::Result<UntrackedRoot> {
     use std::io::{Error, ErrorKind};
     use std::os::windows::fs::OpenOptionsExt;
     use winapi::um::winbase::{FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT};
+
+    let root_anchor = repo_root
+        .ancestors()
+        .last()
+        .filter(|path| path.has_root())
+        .ok_or_else(|| {
+            Error::new(
+                ErrorKind::InvalidInput,
+                "repository root must be an absolute normalized path",
+            )
+        })?;
+    let relative = repo_root.strip_prefix(root_anchor).map_err(|_| {
+        Error::new(
+            ErrorKind::InvalidInput,
+            "repository root must be an absolute normalized path",
+        )
+    })?;
+    let components = if relative.as_os_str().is_empty() {
+        Vec::new()
+    } else {
+        validated_relative_components(relative)?
+    };
 
     let mut options = fs::OpenOptions::new();
     options
         .read(true)
         .custom_flags(FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT);
-    let directory = options.open(repo_root)?;
-    let metadata = directory.metadata()?;
-    if windows_metadata_is_reparse_point(&metadata) || !metadata.is_dir() {
+    let mut directory = options.open(root_anchor)?;
+    let root_metadata = directory.metadata()?;
+    if windows_metadata_is_reparse_point(&root_metadata) || !root_metadata.is_dir() {
         return Err(Error::new(
             ErrorKind::InvalidInput,
             "repository root is not a regular directory",
+        ));
+    }
+    let mut opened_path = root_anchor.to_path_buf();
+    for component in components {
+        directory = windows_open_at(&directory, component, true)?;
+        let metadata = directory.metadata()?;
+        if windows_metadata_is_reparse_point(&metadata) || !metadata.is_dir() {
+            return Err(Error::new(
+                ErrorKind::InvalidInput,
+                "repository root ancestor is not a regular directory",
+            ));
+        }
+        opened_path.push(component);
+        after_opened_component(&opened_path);
+    }
+    if opened_path != repo_root {
+        return Err(Error::new(
+            ErrorKind::InvalidInput,
+            "repository root must be an absolute normalized path",
         ));
     }
     Ok(UntrackedRoot(directory))
@@ -1290,6 +1339,42 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(mode, "100644");
+        assert_eq!(content, "safe worktree content");
+        assert!(!content.contains("TOPSECRET-OUTSIDE-REPO"));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_untracked_root_stays_in_opened_ancestor_after_reparse_swap() {
+        let parent = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let ancestor = parent.path().join("ancestor");
+        let moved_ancestor = parent.path().join("moved-ancestor");
+        let replacement = parent.path().join("replacement");
+        let root_path = ancestor.join("repo");
+        fs::create_dir_all(&root_path).unwrap();
+        fs::write(root_path.join("file.txt"), "safe worktree content").unwrap();
+        fs::create_dir(outside.path().join("repo")).unwrap();
+        fs::write(
+            outside.path().join("repo/file.txt"),
+            "TOPSECRET-OUTSIDE-REPO",
+        )
+        .unwrap();
+        if std::os::windows::fs::symlink_dir(outside.path(), &replacement).is_err() {
+            return;
+        }
+
+        let root = open_untracked_root_with_hook(&root_path, |opened_path| {
+            if opened_path == ancestor {
+                fs::rename(&ancestor, &moved_ancestor).unwrap();
+                fs::rename(&replacement, &ancestor).unwrap();
+            }
+        })
+        .unwrap();
+        let (_, content) = read_untracked_content(&root, Path::new("file.txt"))
+            .unwrap()
+            .unwrap();
+
         assert_eq!(content, "safe worktree content");
         assert!(!content.contains("TOPSECRET-OUTSIDE-REPO"));
     }

--- a/crates/goose-cli/src/commands/review/handler.rs
+++ b/crates/goose-cli/src/commands/review/handler.rs
@@ -605,29 +605,239 @@ fn read_link_at(directory: &fs::File, name: &std::ffi::OsStr) -> std::io::Result
     }
 }
 
-#[cfg(not(unix))]
+#[cfg(windows)]
 fn read_untracked_content(
     repo_root: &Path,
     path: &Path,
 ) -> std::io::Result<Option<(&'static str, String)>> {
-    use std::io::{Error, ErrorKind};
+    read_untracked_content_with_hook(repo_root, path, |_| {})
+}
 
-    validated_relative_components(path)?;
-    let absolute_path = repo_root.join(path);
-    let metadata = fs::symlink_metadata(&absolute_path)?;
-    if !metadata.file_type().is_symlink() {
-        // std does not expose a portable opened-handle no-follow walk. Omitting ordinary files
-        // avoids disclosing content through a link swap on supported non-Unix platforms.
-        return Ok(None);
+#[cfg(windows)]
+fn read_untracked_content_with_hook(
+    repo_root: &Path,
+    path: &Path,
+    mut after_opened_ancestor: impl FnMut(&Path),
+) -> std::io::Result<Option<(&'static str, String)>> {
+    use std::io::{Error, ErrorKind, Read};
+    use std::os::windows::fs::OpenOptionsExt;
+    use winapi::um::winbase::FILE_FLAG_BACKUP_SEMANTICS;
+
+    let components = validated_relative_components(path)?;
+    let (file_name, ancestors) = components.split_last().unwrap();
+    let mut options = fs::OpenOptions::new();
+    options.read(true).custom_flags(FILE_FLAG_BACKUP_SEMANTICS);
+    let mut directory = options.open(repo_root)?;
+    let mut opened_path = PathBuf::new();
+
+    for ancestor in ancestors {
+        directory = windows_open_at(&directory, ancestor, true)?;
+        let metadata = directory.metadata()?;
+        if windows_metadata_is_reparse_point(&metadata) || !metadata.is_dir() {
+            return Err(Error::new(
+                ErrorKind::InvalidInput,
+                "untracked path ancestor is not a regular directory",
+            ));
+        }
+        opened_path.push(ancestor);
+        after_opened_ancestor(&opened_path);
     }
-    let target = fs::read_link(absolute_path)?;
-    let Some(target) = target.to_str() else {
+
+    let mut file = windows_open_at(&directory, file_name, false)?;
+    let metadata = file.metadata()?;
+    if windows_metadata_is_reparse_point(&metadata) {
+        return Ok(windows_read_symlink_target(&file)?.map(|target| ("120000", target)));
+    }
+    if !metadata.is_file() {
+        return Err(Error::new(
+            ErrorKind::InvalidInput,
+            "untracked path is not a regular file",
+        ));
+    }
+
+    let mut content = String::new();
+    file.read_to_string(&mut content)?;
+    Ok(Some(("100644", content)))
+}
+
+#[cfg(windows)]
+fn windows_open_at(
+    directory: &fs::File,
+    name: &std::ffi::OsStr,
+    directory_only: bool,
+) -> std::io::Result<fs::File> {
+    use ntapi::ntioapi::{
+        NtCreateFile, FILE_DIRECTORY_FILE, FILE_OPEN, FILE_OPEN_REPARSE_POINT,
+        FILE_SYNCHRONOUS_IO_NONALERT, IO_STATUS_BLOCK,
+    };
+    use std::io::{Error, ErrorKind};
+    use std::os::windows::ffi::OsStrExt;
+    use std::os::windows::io::{AsRawHandle, FromRawHandle};
+    use winapi::shared::ntdef::{
+        HANDLE, NT_SUCCESS, OBJECT_ATTRIBUTES, OBJ_CASE_INSENSITIVE, UNICODE_STRING,
+    };
+    use winapi::um::winnt::{
+        FILE_GENERIC_READ, FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE,
+    };
+
+    let mut name: Vec<u16> = name.encode_wide().collect();
+    let name_bytes = name
+        .len()
+        .checked_mul(std::mem::size_of::<u16>())
+        .and_then(|length| u16::try_from(length).ok())
+        .ok_or_else(|| {
+            Error::new(
+                ErrorKind::InvalidInput,
+                "untracked path component is too long",
+            )
+        })?;
+    let mut unicode_name = UNICODE_STRING {
+        Length: name_bytes,
+        MaximumLength: name_bytes,
+        Buffer: name.as_mut_ptr(),
+    };
+    let mut attributes = OBJECT_ATTRIBUTES {
+        Length: std::mem::size_of::<OBJECT_ATTRIBUTES>() as u32,
+        RootDirectory: directory.as_raw_handle() as HANDLE,
+        ObjectName: &mut unicode_name,
+        Attributes: OBJ_CASE_INSENSITIVE,
+        SecurityDescriptor: std::ptr::null_mut(),
+        SecurityQualityOfService: std::ptr::null_mut(),
+    };
+    let mut handle: HANDLE = std::ptr::null_mut();
+    // SAFETY: IO_STATUS_BLOCK is a plain C data structure initialized before the synchronous call.
+    let mut io_status: IO_STATUS_BLOCK = unsafe { std::mem::zeroed() };
+    let mut create_options = FILE_OPEN_REPARSE_POINT | FILE_SYNCHRONOUS_IO_NONALERT;
+    if directory_only {
+        create_options |= FILE_DIRECTORY_FILE;
+    }
+    // SAFETY: all pointers reference initialized values for the duration of the synchronous call.
+    let status = unsafe {
+        NtCreateFile(
+            &mut handle,
+            FILE_GENERIC_READ,
+            &mut attributes,
+            &mut io_status,
+            std::ptr::null_mut(),
+            0,
+            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+            FILE_OPEN,
+            create_options,
+            std::ptr::null_mut(),
+            0,
+        )
+    };
+    if !NT_SUCCESS(status) {
+        return Err(windows_nt_status_error(status));
+    }
+    // SAFETY: NtCreateFile returned a new owned handle on success.
+    Ok(unsafe { fs::File::from_raw_handle(handle.cast()) })
+}
+
+#[cfg(windows)]
+fn windows_metadata_is_reparse_point(metadata: &fs::Metadata) -> bool {
+    use std::os::windows::fs::MetadataExt;
+    use winapi::um::winnt::FILE_ATTRIBUTE_REPARSE_POINT;
+
+    metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0
+}
+
+#[cfg(windows)]
+fn windows_read_symlink_target(file: &fs::File) -> std::io::Result<Option<String>> {
+    use ntapi::ntioapi::{NtFsControlFile, IO_STATUS_BLOCK};
+    use std::io::{Error, ErrorKind};
+    use std::os::windows::io::AsRawHandle;
+    use winapi::shared::ntdef::NT_SUCCESS;
+    use winapi::um::winioctl::FSCTL_GET_REPARSE_POINT;
+    use winapi::um::winnt::{IO_REPARSE_TAG_SYMLINK, MAXIMUM_REPARSE_DATA_BUFFER_SIZE};
+
+    let mut buffer = vec![0u8; MAXIMUM_REPARSE_DATA_BUFFER_SIZE as usize];
+    // SAFETY: IO_STATUS_BLOCK is a plain C data structure initialized before the synchronous call.
+    let mut io_status: IO_STATUS_BLOCK = unsafe { std::mem::zeroed() };
+    // SAFETY: the synchronous call receives a valid handle and a writable output buffer.
+    let status = unsafe {
+        NtFsControlFile(
+            file.as_raw_handle().cast(),
+            std::ptr::null_mut(),
+            None,
+            std::ptr::null_mut(),
+            &mut io_status,
+            FSCTL_GET_REPARSE_POINT,
+            std::ptr::null_mut(),
+            0,
+            buffer.as_mut_ptr().cast(),
+            buffer.len() as u32,
+        )
+    };
+    if !NT_SUCCESS(status) {
+        return Err(windows_nt_status_error(status));
+    }
+    let returned = io_status.Information;
+    if returned < 20 || returned > buffer.len() {
         return Err(Error::new(
             ErrorKind::InvalidData,
-            "untracked symlink target is not UTF-8",
+            "invalid untracked reparse point data",
         ));
+    }
+    let buffer = &buffer[..returned];
+    let tag = u32::from_le_bytes(buffer[0..4].try_into().unwrap());
+    if tag != IO_REPARSE_TAG_SYMLINK {
+        return Ok(None);
+    }
+    let data_length = u16::from_le_bytes(buffer[4..6].try_into().unwrap()) as usize;
+    let total_length = 8usize
+        .checked_add(data_length)
+        .filter(|length| *length <= buffer.len())
+        .ok_or_else(|| Error::new(ErrorKind::InvalidData, "invalid untracked symlink data"))?;
+    let substitute_offset = u16::from_le_bytes(buffer[8..10].try_into().unwrap()) as usize;
+    let substitute_length = u16::from_le_bytes(buffer[10..12].try_into().unwrap()) as usize;
+    let print_offset = u16::from_le_bytes(buffer[12..14].try_into().unwrap()) as usize;
+    let print_length = u16::from_le_bytes(buffer[14..16].try_into().unwrap()) as usize;
+    let (offset, length) = if print_length == 0 {
+        (substitute_offset, substitute_length)
+    } else {
+        (print_offset, print_length)
     };
-    Ok(Some(("120000", target.to_string())))
+    if length % 2 != 0 {
+        return Err(Error::new(
+            ErrorKind::InvalidData,
+            "invalid untracked symlink target",
+        ));
+    }
+    let start = 20usize
+        .checked_add(offset)
+        .filter(|start| *start <= total_length)
+        .ok_or_else(|| Error::new(ErrorKind::InvalidData, "invalid untracked symlink target"))?;
+    let end = start
+        .checked_add(length)
+        .filter(|end| *end <= total_length)
+        .ok_or_else(|| Error::new(ErrorKind::InvalidData, "invalid untracked symlink target"))?;
+    let target: Vec<u16> = buffer[start..end]
+        .chunks_exact(2)
+        .map(|unit| u16::from_le_bytes([unit[0], unit[1]]))
+        .collect();
+    String::from_utf16(&target).map(Some).map_err(|_| {
+        Error::new(
+            ErrorKind::InvalidData,
+            "untracked symlink target is not UTF-16",
+        )
+    })
+}
+
+#[cfg(windows)]
+fn windows_nt_status_error(status: winapi::shared::ntdef::NTSTATUS) -> std::io::Error {
+    // SAFETY: RtlNtStatusToDosError accepts every NTSTATUS value.
+    let error = unsafe { ntapi::ntrtl::RtlNtStatusToDosError(status) };
+    std::io::Error::from_raw_os_error(error as i32)
+}
+
+#[cfg(not(any(unix, windows)))]
+fn read_untracked_content(
+    _repo_root: &Path,
+    path: &Path,
+) -> std::io::Result<Option<(&'static str, String)>> {
+    validated_relative_components(path)?;
+    Ok(None)
 }
 
 /// Synthesize a unified `new file` diff for each untracked path so
@@ -751,7 +961,7 @@ mod tests {
         assert!(out.ends_with("BASE"));
     }
 
-    #[cfg(unix)]
+    #[cfg(any(unix, windows))]
     #[test]
     fn synthesize_untracked_diff_emits_new_file_chunk_with_added_lines() {
         let dir = tempfile::tempdir().unwrap();
@@ -770,7 +980,7 @@ mod tests {
         assert!(!diff.contains("\\ No newline at end of file"));
     }
 
-    #[cfg(unix)]
+    #[cfg(any(unix, windows))]
     #[test]
     fn synthesize_untracked_diff_marks_missing_trailing_newline() {
         let dir = tempfile::tempdir().unwrap();
@@ -862,6 +1072,64 @@ mod tests {
         assert!(!content.contains("TOPSECRET-OUTSIDE-REPO"));
     }
 
+    #[cfg(windows)]
+    #[test]
+    fn windows_untracked_file_reader_stays_in_opened_ancestor_after_swap() {
+        let dir = tempfile::tempdir().unwrap();
+        let ancestor = dir.path().join("nested");
+        let moved_ancestor = dir.path().join("moved-nested");
+        fs::create_dir(&ancestor).unwrap();
+        fs::write(ancestor.join("file.txt"), "safe worktree content").unwrap();
+
+        let (mode, content) = read_untracked_content_with_hook(
+            dir.path(),
+            Path::new("nested/file.txt"),
+            |opened_path| {
+                if opened_path == Path::new("nested") {
+                    fs::rename(&ancestor, &moved_ancestor).unwrap();
+                    fs::create_dir(&ancestor).unwrap();
+                    fs::write(ancestor.join("file.txt"), "TOPSECRET-OUTSIDE-REPO").unwrap();
+                }
+            },
+        )
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(mode, "100644");
+        assert_eq!(content, "safe worktree content");
+        assert!(!content.contains("TOPSECRET-OUTSIDE-REPO"));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_untracked_file_reader_rejects_reparse_ancestor() {
+        let dir = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        fs::write(outside.path().join("file.txt"), "TOPSECRET-OUTSIDE-REPO").unwrap();
+        if std::os::windows::fs::symlink_dir(outside.path(), dir.path().join("nested")).is_err() {
+            return;
+        }
+
+        let result = read_untracked_content(dir.path(), Path::new("nested/file.txt"));
+
+        assert!(result.is_err());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_synthesize_untracked_diff_preserves_symlink_text() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = Path::new("missing-target.txt");
+        if std::os::windows::fs::symlink_file(target, dir.path().join("link.txt")).is_err() {
+            return;
+        }
+
+        let diff = synthesize_untracked_diff(dir.path(), &["link.txt".to_string()]).unwrap();
+
+        assert!(diff.contains("new file mode 120000"));
+        assert!(diff.contains("+missing-target.txt"));
+    }
+
     #[test]
     fn untracked_paths_must_be_repo_relative() {
         for path in [
@@ -889,7 +1157,7 @@ mod tests {
         );
     }
 
-    #[cfg(not(unix))]
+    #[cfg(not(any(unix, windows)))]
     #[test]
     fn synthesize_untracked_diff_omits_ordinary_files_without_safe_open() {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/goose-cli/src/commands/review/handler.rs
+++ b/crates/goose-cli/src/commands/review/handler.rs
@@ -108,6 +108,7 @@ pub async fn handle_review(opts: ReviewOptions) -> Result<()> {
             }
         }
     }
+    drop(untracked_root);
 
     if diff.trim().is_empty() {
         eprintln!("goose review: no changes to review");

--- a/crates/goose-cli/src/commands/review/handler.rs
+++ b/crates/goose-cli/src/commands/review/handler.rs
@@ -488,14 +488,52 @@ struct UntrackedRoot;
 
 #[cfg(unix)]
 fn open_untracked_root(repo_root: &Path) -> std::io::Result<UntrackedRoot> {
+    open_untracked_root_with_hook(repo_root, |_| {})
+}
+
+#[cfg(unix)]
+fn open_untracked_root_with_hook(
+    repo_root: &Path,
+    mut after_opened_component: impl FnMut(&Path),
+) -> std::io::Result<UntrackedRoot> {
     use std::io::{Error, ErrorKind};
     use std::os::unix::fs::OpenOptionsExt;
+    use std::path::Component;
 
     let mut options = fs::OpenOptions::new();
     options
         .read(true)
         .custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC);
-    let directory = options.open(repo_root)?;
+    let mut directory = options.open(Path::new("/"))?;
+    let mut opened_path = PathBuf::from("/");
+    let mut saw_root = false;
+    for component in repo_root.components() {
+        match component {
+            Component::RootDir if !saw_root => saw_root = true,
+            Component::Normal(component) if saw_root => {
+                directory = open_at(
+                    &directory,
+                    component,
+                    libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+                )?;
+                opened_path.push(component);
+                after_opened_component(&opened_path);
+            }
+            Component::CurDir if saw_root => {}
+            _ => {
+                return Err(Error::new(
+                    ErrorKind::InvalidInput,
+                    "repository root must be an absolute normalized path",
+                ));
+            }
+        }
+    }
+    if !saw_root || opened_path != repo_root {
+        return Err(Error::new(
+            ErrorKind::InvalidInput,
+            "repository root must be an absolute normalized path",
+        ));
+    }
     if !directory.metadata()?.is_dir() {
         return Err(Error::new(
             ErrorKind::InvalidInput,
@@ -962,6 +1000,14 @@ mod tests {
     use goose::checks::Check;
     use std::path::PathBuf;
 
+    fn open_test_untracked_root(path: &Path) -> std::io::Result<UntrackedRoot> {
+        #[cfg(unix)]
+        let path = fs::canonicalize(path)?;
+        #[cfg(not(unix))]
+        let path = path.to_path_buf();
+        open_untracked_root(&path)
+    }
+
     fn ck(name: &str) -> Check {
         Check {
             name: name.to_string(),
@@ -1017,7 +1063,7 @@ mod tests {
         fs::create_dir_all(path.parent().unwrap()).unwrap();
         fs::write(&path, "alpha\nbeta\ngamma\n").unwrap();
 
-        let root = open_untracked_root(root).unwrap();
+        let root = open_test_untracked_root(root).unwrap();
         let diff = synthesize_untracked_diff(&root, &["new/file.txt".to_string()]).unwrap();
         assert!(diff.contains("diff --git a/new/file.txt b/new/file.txt"));
         assert!(diff.contains("new file mode 100644"));
@@ -1035,7 +1081,7 @@ mod tests {
         let root = dir.path();
         fs::write(root.join("a.txt"), "no-newline").unwrap();
 
-        let root = open_untracked_root(root).unwrap();
+        let root = open_test_untracked_root(root).unwrap();
         let diff = synthesize_untracked_diff(&root, &["a.txt".to_string()]).unwrap();
         assert!(diff.contains("@@ -0,0 +1,1 @@"));
         assert!(diff.contains("+no-newline\n"));
@@ -1051,7 +1097,7 @@ mod tests {
         fs::write(&secret, "TOPSECRET-OUTSIDE-REPO").unwrap();
         std::os::unix::fs::symlink(&secret, dir.path().join("link.txt")).unwrap();
 
-        let root = open_untracked_root(dir.path()).unwrap();
+        let root = open_test_untracked_root(dir.path()).unwrap();
         let diff = synthesize_untracked_diff(&root, &["link.txt".to_string()]).unwrap();
 
         assert!(diff.contains("new file mode 120000"));
@@ -1065,7 +1111,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         std::os::unix::fs::symlink("../missing-target", dir.path().join("broken")).unwrap();
 
-        let root = open_untracked_root(dir.path()).unwrap();
+        let root = open_test_untracked_root(dir.path()).unwrap();
         let diff = synthesize_untracked_diff(&root, &["broken".to_string()]).unwrap();
 
         assert!(diff.contains("new file mode 120000"));
@@ -1086,7 +1132,7 @@ mod tests {
         fs::remove_file(&path).unwrap();
         std::os::unix::fs::symlink(&secret, &path).unwrap();
 
-        let root = open_untracked_root(dir.path()).unwrap();
+        let root = open_test_untracked_root(dir.path()).unwrap();
         let (mode, content) = read_untracked_content(&root, Path::new("untracked.txt"))
             .unwrap()
             .unwrap();
@@ -1106,7 +1152,7 @@ mod tests {
         fs::write(ancestor.join("file.txt"), "safe worktree content").unwrap();
         fs::write(outside.path().join("file.txt"), "TOPSECRET-OUTSIDE-REPO").unwrap();
 
-        let root = open_untracked_root(dir.path()).unwrap();
+        let root = open_test_untracked_root(dir.path()).unwrap();
         let (mode, content) =
             read_untracked_content_with_hook(&root, Path::new("nested/file.txt"), |opened_path| {
                 if opened_path == Path::new("nested") {
@@ -1132,7 +1178,7 @@ mod tests {
         fs::create_dir(&root_path).unwrap();
         fs::write(root_path.join("file.txt"), "safe worktree content").unwrap();
         fs::write(outside.path().join("file.txt"), "TOPSECRET-OUTSIDE-REPO").unwrap();
-        let root = open_untracked_root(&root_path).unwrap();
+        let root = open_test_untracked_root(&root_path).unwrap();
 
         fs::rename(&root_path, &moved_root).unwrap();
         std::os::unix::fs::symlink(outside.path(), &root_path).unwrap();
@@ -1141,6 +1187,61 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(mode, "100644");
+        assert_eq!(content, "safe worktree content");
+        assert!(!content.contains("TOPSECRET-OUTSIDE-REPO"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn untracked_root_rejects_symlinked_ancestor() {
+        let parent = tempfile::tempdir().unwrap();
+        let parent = fs::canonicalize(parent.path()).unwrap();
+        let real_parent = parent.join("real-parent");
+        let linked_parent = parent.join("linked-parent");
+        fs::create_dir(&real_parent).unwrap();
+        std::os::unix::fs::symlink(&real_parent, &linked_parent).unwrap();
+        fs::create_dir(linked_parent.join("repo")).unwrap();
+
+        let error = match open_untracked_root(&linked_parent.join("repo")) {
+            Ok(_) => panic!("symlinked ancestor was accepted"),
+            Err(error) => error,
+        };
+
+        assert!(matches!(
+            error.raw_os_error(),
+            Some(libc::ELOOP) | Some(libc::ENOTDIR)
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn untracked_root_stays_in_opened_ancestor_after_swap() {
+        let parent = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let parent = fs::canonicalize(parent.path()).unwrap();
+        let ancestor = parent.join("ancestor");
+        let moved_ancestor = parent.join("moved-ancestor");
+        let root_path = ancestor.join("repo");
+        fs::create_dir_all(&root_path).unwrap();
+        fs::write(root_path.join("file.txt"), "safe worktree content").unwrap();
+        fs::create_dir(outside.path().join("repo")).unwrap();
+        fs::write(
+            outside.path().join("repo/file.txt"),
+            "TOPSECRET-OUTSIDE-REPO",
+        )
+        .unwrap();
+
+        let root = open_untracked_root_with_hook(&root_path, |opened_path| {
+            if opened_path == ancestor {
+                fs::rename(&ancestor, &moved_ancestor).unwrap();
+                std::os::unix::fs::symlink(outside.path(), &ancestor).unwrap();
+            }
+        })
+        .unwrap();
+        let (_, content) = read_untracked_content(&root, Path::new("file.txt"))
+            .unwrap()
+            .unwrap();
+
         assert_eq!(content, "safe worktree content");
         assert!(!content.contains("TOPSECRET-OUTSIDE-REPO"));
     }
@@ -1154,7 +1255,7 @@ mod tests {
         fs::create_dir(&ancestor).unwrap();
         fs::write(ancestor.join("file.txt"), "safe worktree content").unwrap();
 
-        let root = open_untracked_root(dir.path()).unwrap();
+        let root = open_test_untracked_root(dir.path()).unwrap();
         let (mode, content) =
             read_untracked_content_with_hook(&root, Path::new("nested/file.txt"), |opened_path| {
                 if opened_path == Path::new("nested") {
@@ -1179,7 +1280,7 @@ mod tests {
         let moved_root = parent.path().join("moved-repo");
         fs::create_dir(&root_path).unwrap();
         fs::write(root_path.join("file.txt"), "safe worktree content").unwrap();
-        let root = open_untracked_root(&root_path).unwrap();
+        let root = open_test_untracked_root(&root_path).unwrap();
 
         fs::rename(&root_path, &moved_root).unwrap();
         fs::create_dir(&root_path).unwrap();
@@ -1203,7 +1304,7 @@ mod tests {
             return;
         }
 
-        let root = open_untracked_root(dir.path()).unwrap();
+        let root = open_test_untracked_root(dir.path()).unwrap();
         let result = read_untracked_content(&root, Path::new("nested/file.txt"));
 
         assert!(result.is_err());
@@ -1218,7 +1319,7 @@ mod tests {
             return;
         }
 
-        let root = open_untracked_root(dir.path()).unwrap();
+        let root = open_test_untracked_root(dir.path()).unwrap();
         let diff = synthesize_untracked_diff(&root, &["link.txt".to_string()]).unwrap();
 
         assert!(diff.contains("new file mode 120000"));
@@ -1258,7 +1359,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         fs::write(dir.path().join("ordinary.txt"), "ordinary content").unwrap();
 
-        let root = open_untracked_root(dir.path()).unwrap();
+        let root = open_test_untracked_root(dir.path()).unwrap();
         let diff = synthesize_untracked_diff(&root, &["ordinary.txt".to_string()]).unwrap();
 
         assert!(diff.is_empty());


### PR DESCRIPTION
## Summary

- open and retain a no-follow repository-root handle before enumerating untracked paths
- enumerate Unix untracked paths after `fchdir` to that retained root, binding Git classification and reads to the same directory
- use search-only root/ancestor traversal (`O_PATH` on Linux, `O_SEARCH` on Apple) without requiring directory-listing access
- resolve every Unix repository-root component from an opened filesystem root with `openat` and `O_NOFOLLOW`
- resolve every Windows repository-root component from an opened volume/share root with traverse-only access and retain no-delete handles through enumeration
- release all retained root/ancestor handles immediately after synthetic-diff collection, before agent/check dispatch
- walk every Unix and Windows untracked-path component relative to already-opened no-follow handles
- reject symlink/reparse-point ancestors and validate the final object from its opened handle
- render Unix and Windows symlinks as Git-style mode `120000` plus link text without following targets
- preserve ordinary untracked-file review on both Unix and Windows while omitting unknown Windows reparse types
- reject absolute and parent-traversing untracked paths and cover deterministic root/ancestor replacement

Addresses https://github.com/project-loupe/audit-goose/issues/114.

## Security boundary

A no-range review may include untracked worktree entries, but its synthetic diff must never copy bytes reached through a replaced repository root, symlink, or reparse-point ancestor outside the repository into provider-visible review context. Unix enumeration starts from the same retained root descriptor used for reads. Windows retains non-delete-sharing handles for each repository path component only during collection so the path cannot be replaced during enumeration; directory handles request traversal and attribute rights without requiring directory listing. Those locks are released before the potentially long review. Every untracked-path component is resolved relative to an already-opened directory handle, and final content is read only from the validated final handle.

## Verification

- `bin/cargo fmt`
- `bin/cargo test -p goose-cli commands::review::handler::tests` (17 passed on macOS; Windows-gated root/reparse regressions added)
- `bin/cargo build -p goose-cli`
- `bin/cargo clippy --all-targets -- -D warnings`
- minimal Windows access-right harness compiled for `x86_64-pc-windows-msvc` at the current head
- current full Windows workspace check attempted; unavailable MSVC SDK headers/tools stopped unrelated native dependencies before Goose CLI compilation
- `git diff --check`

_This finding was discovered by [Project Loupe](https://github.com/project-loupe/loupe)._