### PR TITLE
fix: keep LiteLLM default local

### DIFF
--- a/crates/goose/src/providers/litellm.rs
+++ b/crates/goose/src/providers/litellm.rs
@@ -21,6 +21,7 @@ use goose_providers::request_log::{start_log, LoggerHandleExt};
 use rmcp::model::Tool;
 
 const LITELLM_PROVIDER_NAME: &str = "litellm";
+const LITELLM_DEFAULT_HOST: &str = "http://localhost:4000";
 pub const LITELLM_DEFAULT_MODEL: &str = "gpt-4o-mini";
 pub const LITELLM_DOC_URL: &str = "https://docs.litellm.ai/docs/";
 
@@ -46,7 +47,7 @@ impl LiteLLMProvider {
         let api_key = secrets.get("LITELLM_API_KEY").cloned().unwrap_or_default();
         let host: String = config
             .get_param("LITELLM_HOST")
-            .unwrap_or_else(|_| "https://api.litellm.ai".to_string());
+            .unwrap_or_else(|_| LITELLM_DEFAULT_HOST.to_string());
         let base_path: String = config
             .get_param("LITELLM_BASE_PATH")
             .unwrap_or_else(|_| "v1/chat/completions".to_string());
@@ -176,7 +177,7 @@ impl goose_providers::base::ProviderDescriptor for LiteLLMProvider {
                     "LITELLM_HOST",
                     true,
                     false,
-                    Some("http://localhost:4000"),
+                    Some(LITELLM_DEFAULT_HOST),
                     true,
                 ),
                 ConfigKey::new(

--- a/crates/goose/tests/litellm_default_host.rs
+++ b/crates/goose/tests/litellm_default_host.rs
@@ -1,0 +1,38 @@
+use goose::providers::litellm::LiteLLMProvider;
+
+#[tokio::test]
+async fn litellm_host_follows_the_configuration_contract() {
+    let temp_dir = tempfile::tempdir().expect("tempdir");
+    let root = temp_dir.path().to_string_lossy().to_string();
+    let _guard = env_lock::lock_env([
+        ("GOOSE_PATH_ROOT", Some(root.as_str())),
+        ("GOOSE_DISABLE_KEYRING", Some("1")),
+        ("GOOSE_ADDITIONAL_CONFIG_FILES", None::<&str>),
+        ("LITELLM_API_KEY", Some("test-key")),
+        ("LITELLM_HOST", None::<&str>),
+        ("LITELLM_CUSTOM_HEADERS", None::<&str>),
+    ]);
+
+    let provider = LiteLLMProvider::from_env(None)
+        .await
+        .expect("provider should use its default host");
+    let debug = format!("{provider:?}");
+    assert!(
+        debug.contains("http://localhost:4000"),
+        "missing host should stay on the advertised local proxy: {debug}"
+    );
+    assert!(
+        !debug.contains("api.litellm.ai"),
+        "missing host should not select a remote service: {debug}"
+    );
+
+    std::env::set_var("LITELLM_HOST", "https://proxy.example.test");
+    let provider = LiteLLMProvider::from_env(None)
+        .await
+        .expect("provider should accept an explicit host");
+    let debug = format!("{provider:?}");
+    assert!(
+        debug.contains("https://proxy.example.test"),
+        "explicit host should remain unchanged: {debug}"
+    );
+}


### PR DESCRIPTION
## Summary

- use one localhost LiteLLM default for runtime construction and provider metadata
- preserve explicitly configured proxy hosts
- add a no-network regression for missing and explicit host configuration

Addresses https://github.com/project-loupe/audit-goose/issues/82.

## Security boundary

Selecting LiteLLM without an explicit host must not send bearer credentials, model inventory, or conversation data to a remote service the operator did not choose. The advertised local proxy remains the runtime default.

## Verification

- `bin/cargo fmt`
- `bin/cargo test -p goose --test litellm_default_host`
- `bin/cargo build -p goose`
- `bin/cargo clippy --all-targets -- -D warnings`

_This finding was discovered by [Project Loupe](https://github.com/project-loupe/loupe)._