### PR TITLE
fix: restrict provider request log permissions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4994,6 +4994,7 @@ dependencies = [
  "reqwest 0.13.4",
  "rmcp 3.0.0",
  "rubato",
+ "rustix 1.1.4",
  "rustls",
  "schemars 1.2.1",
  "serde",

--- a/crates/goose/Cargo.toml
+++ b/crates/goose/Cargo.toml
@@ -243,6 +243,7 @@ keyring = { workspace = true, features = ["sync-secret-service"], optional = tru
 
 [target."cfg(unix)".dependencies]
 libc = { version = "0.2.182", default-features = false, features = ["std"] }
+rustix = { version = "1.1.4", default-features = false, features = ["fs", "std"] }
 
 [dev-dependencies]
 serial_test = { workspace = true }

--- a/crates/goose/src/providers/utils.rs
+++ b/crates/goose/src/providers/utils.rs
@@ -224,6 +224,8 @@ pub fn init_goose_request_log() -> Result<()> {
 
 pub struct RequestLog {
     logs_to_keep: usize,
+    #[cfg(unix)]
+    logs_directory: std::fs::File,
 }
 
 impl RequestLog {
@@ -235,21 +237,29 @@ impl RequestLog {
             .ok_or_else(|| anyhow!("request log state directory has no parent"))?;
         fs_err::create_dir_all(state_parent)?;
         #[cfg(unix)]
-        create_and_restrict_request_log_state_directory(&state_dir)?;
-        #[cfg(not(unix))]
-        fs_err::create_dir_all(&state_dir)?;
-        fs_err::create_dir_all(&logs_dir)?;
-        #[cfg(unix)]
-        {
-            restrict_request_log_directory(&logs_dir)?;
+        let logs_directory = {
+            let state_directory = create_and_restrict_request_log_state_directory(&state_dir)?;
+            let logs_directory = create_and_restrict_request_log_logs_directory(&state_directory)?;
             restrict_existing_request_logs(&logs_dir)?;
+            logs_directory
+        };
+        #[cfg(not(unix))]
+        {
+            fs_err::create_dir_all(&state_dir)?;
+            fs_err::create_dir_all(&logs_dir)?;
         }
-        Ok(Self { logs_to_keep })
+        Ok(Self {
+            logs_to_keep,
+            #[cfg(unix)]
+            logs_directory,
+        })
     }
 }
 
 #[cfg(unix)]
-fn create_and_restrict_request_log_state_directory(state_dir: &std::path::Path) -> Result<()> {
+fn create_and_restrict_request_log_state_directory(
+    state_dir: &std::path::Path,
+) -> Result<std::fs::File> {
     use std::ffi::CString;
     use std::io::{Error, ErrorKind};
     use std::os::fd::{AsRawFd, FromRawFd};
@@ -381,10 +391,129 @@ fn create_and_restrict_request_log_state_directory(state_dir: &std::path::Path) 
         .into());
     }
 
-    Ok(())
+    Ok(state_directory)
 }
 
 #[cfg(unix)]
+fn create_and_restrict_request_log_logs_directory(
+    state_directory: &std::fs::File,
+) -> Result<std::fs::File> {
+    use std::ffi::CString;
+    use std::io::{Error, ErrorKind};
+    use std::os::fd::{AsRawFd, FromRawFd};
+    use std::os::unix::fs::MetadataExt;
+
+    let file_name = CString::new("logs").unwrap();
+    // SAFETY: the name pointer is valid for the synchronous call and the state fd is retained.
+    if unsafe { libc::mkdirat(state_directory.as_raw_fd(), file_name.as_ptr(), 0o700) } < 0 {
+        let error = Error::last_os_error();
+        if error.kind() != ErrorKind::AlreadyExists {
+            return Err(error.into());
+        }
+    }
+
+    // SAFETY: libc::stat is initialized before fstatat writes it.
+    let mut entry: libc::stat = unsafe { std::mem::zeroed() };
+    // SAFETY: pointers remain valid for the call and the state fd is retained.
+    if unsafe {
+        libc::fstatat(
+            state_directory.as_raw_fd(),
+            file_name.as_ptr(),
+            &mut entry,
+            libc::AT_SYMLINK_NOFOLLOW,
+        )
+    } < 0
+    {
+        return Err(Error::last_os_error().into());
+    }
+
+    let entry_type = entry.st_mode & libc::S_IFMT;
+    let entry_is_symlink = entry_type == libc::S_IFLNK;
+    if entry_is_symlink {
+        if !request_log_directory_link_owner_is_trusted(entry.st_uid, current_effective_uid()) {
+            return Err(Error::new(
+                ErrorKind::PermissionDenied,
+                "request log directory symlink is owned by another user",
+            )
+            .into());
+        }
+    } else if entry_type != libc::S_IFDIR {
+        return Err(Error::new(
+            ErrorKind::InvalidInput,
+            "request log path is not a directory",
+        )
+        .into());
+    }
+
+    let flags = directory_search_flags()
+        | if entry_is_symlink {
+            0
+        } else {
+            libc::O_NOFOLLOW
+        };
+    // SAFETY: the name pointer is valid for the synchronous call and the state fd is retained.
+    let logs_fd = unsafe { libc::openat(state_directory.as_raw_fd(), file_name.as_ptr(), flags) };
+    if logs_fd < 0 {
+        return Err(Error::last_os_error().into());
+    }
+    // SAFETY: openat returned a new owned descriptor.
+    let logs_directory = unsafe { std::fs::File::from_raw_fd(logs_fd) };
+    let metadata = logs_directory.metadata()?;
+    if !metadata.is_dir() || metadata.uid() != current_effective_uid() {
+        return Err(Error::new(
+            ErrorKind::PermissionDenied,
+            "request log directory is not owned by the current user",
+        )
+        .into());
+    }
+
+    let current_directory = CString::new(".").unwrap();
+    // SAFETY: resolving `.` relative to the retained logs descriptor binds chmod to it.
+    if unsafe {
+        libc::fchmodat(
+            logs_directory.as_raw_fd(),
+            current_directory.as_ptr(),
+            0o700,
+            0,
+        )
+    } < 0
+    {
+        return Err(Error::last_os_error().into());
+    }
+
+    // SAFETY: libc::stat is initialized before fstatat writes it.
+    let mut current: libc::stat = unsafe { std::mem::zeroed() };
+    // SAFETY: pointers remain valid for the call and the state fd is retained.
+    if unsafe {
+        libc::fstatat(
+            state_directory.as_raw_fd(),
+            file_name.as_ptr(),
+            &mut current,
+            0,
+        )
+    } < 0
+    {
+        return Err(Error::last_os_error().into());
+    }
+    let updated = logs_directory.metadata()?;
+    if metadata.dev() != updated.dev()
+        || metadata.ino() != updated.ino()
+        || metadata.dev() != current.st_dev as u64
+        || metadata.ino() != current.st_ino as u64
+        || !updated.is_dir()
+        || updated.uid() != current_effective_uid()
+    {
+        return Err(Error::new(
+            ErrorKind::PermissionDenied,
+            "request log directory changed while permissions were restricted",
+        )
+        .into());
+    }
+
+    Ok(logs_directory)
+}
+
+#[cfg(test)]
 fn restrict_request_log_directory(logs_dir: &std::path::Path) -> Result<()> {
     restrict_request_log_directory_with_hook(logs_dir, || {})
 }
@@ -447,7 +576,7 @@ fn open_search_only_directory(path: &std::path::Path) -> std::io::Result<std::fs
     options.open(path)
 }
 
-#[cfg(unix)]
+#[cfg(test)]
 fn validate_request_log_directory_link_owner(
     path: &std::path::Path,
     expected_uid: libc::uid_t,
@@ -475,26 +604,7 @@ fn request_log_directory_link_owner_is_trusted(
     actual_uid == expected_uid || actual_uid == 0
 }
 
-#[cfg(any(
-    test,
-    all(
-        unix,
-        not(any(
-            target_os = "aix",
-            target_os = "android",
-            target_os = "emscripten",
-            target_os = "freebsd",
-            target_os = "hurd",
-            target_os = "illumos",
-            target_os = "linux",
-            target_os = "netbsd",
-            target_os = "nto",
-            target_os = "redox",
-            target_os = "solaris",
-            target_vendor = "apple"
-        ))
-    )
-))]
+#[cfg(test)]
 fn repair_request_log_directory_for_read(path: &std::path::Path) -> std::io::Result<()> {
     use std::io::{Error, ErrorKind};
     use std::os::unix::fs::{MetadataExt, PermissionsExt};
@@ -527,25 +637,29 @@ fn repair_request_log_directory_for_read(path: &std::path::Path) -> std::io::Res
     Ok(())
 }
 
-#[cfg(any(
-    target_os = "aix",
-    target_os = "android",
-    target_os = "emscripten",
-    target_os = "freebsd",
-    target_os = "hurd",
-    target_os = "illumos",
-    target_os = "linux",
-    target_os = "netbsd",
-    target_os = "nto",
-    target_os = "redox",
-    target_os = "solaris",
-    all(unix, target_vendor = "apple")
+#[cfg(all(
+    test,
+    any(
+        target_os = "aix",
+        target_os = "android",
+        target_os = "emscripten",
+        target_os = "freebsd",
+        target_os = "hurd",
+        target_os = "illumos",
+        target_os = "linux",
+        target_os = "netbsd",
+        target_os = "nto",
+        target_os = "redox",
+        target_os = "solaris",
+        target_vendor = "apple"
+    )
 ))]
 fn prepare_request_log_directory_for_open(_path: &std::path::Path) -> std::io::Result<()> {
     Ok(())
 }
 
 #[cfg(all(
+    test,
     unix,
     not(any(
         target_os = "aix",
@@ -566,7 +680,7 @@ fn prepare_request_log_directory_for_open(path: &std::path::Path) -> std::io::Re
     repair_request_log_directory_for_read(path)
 }
 
-#[cfg(unix)]
+#[cfg(test)]
 fn restrict_request_log_directory_with_hook(
     logs_dir: &std::path::Path,
     after_metadata: impl FnOnce(),
@@ -661,6 +775,14 @@ enum RestrictionOutcome {
 
 #[cfg(unix)]
 fn restrict_existing_request_log(path: &std::path::Path) -> Result<RestrictionOutcome> {
+    restrict_existing_request_log_with_hook(path, || {})
+}
+
+#[cfg(unix)]
+fn restrict_existing_request_log_with_hook(
+    path: &std::path::Path,
+    after_metadata: impl FnOnce(),
+) -> Result<RestrictionOutcome> {
     use std::io::ErrorKind;
     use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
 
@@ -706,7 +828,18 @@ fn restrict_existing_request_log(path: &std::path::Path) -> Result<RestrictionOu
     };
     let metadata = file.metadata()?;
     if metadata.is_file() && metadata.uid() == current_effective_uid() {
+        after_metadata();
         file.set_permissions(std::fs::Permissions::from_mode(0o600))?;
+        let current = match std::fs::symlink_metadata(path) {
+            Ok(metadata) => metadata,
+            Err(error) if error.kind() == ErrorKind::NotFound => {
+                return Ok(RestrictionOutcome::Retry)
+            }
+            Err(error) => return Err(error.into()),
+        };
+        if metadata.dev() != current.dev() || metadata.ino() != current.ino() {
+            return Ok(RestrictionOutcome::Retry);
+        }
     }
 
     Ok(RestrictionOutcome::Complete)
@@ -838,36 +971,70 @@ struct FileLogHandle {
     writer: Option<BufWriter<File>>,
     temp_path: PathBuf,
     logs_to_keep: usize,
+    #[cfg(unix)]
+    logs_directory: std::fs::File,
 }
 
 impl RequestLogger for RequestLog {
     fn start(&self) -> Result<Box<dyn RequestLogHandle>, Box<dyn Error + Send + Sync>> {
+        #[cfg(not(unix))]
         let logs_dir = Paths::in_state_dir("logs");
+        #[cfg(not(unix))]
         fs_err::create_dir_all(&logs_dir)?;
 
         let request_id = Uuid::new_v4();
         let temp_name = format!("llm_request.{request_id}.jsonl");
-        let temp_path = logs_dir.join(PathBuf::from(temp_name));
+        #[cfg(unix)]
+        let temp_path = PathBuf::from(&temp_name);
+        #[cfg(not(unix))]
+        let temp_path = logs_dir.join(PathBuf::from(&temp_name));
 
-        let mut options = File::options();
-        options.write(true).create(true).truncate(true);
         #[cfg(unix)]
-        {
-            use fs_err::os::unix::fs::OpenOptionsExt;
-            options.mode(0o600);
-        }
-        let file = options.open(&temp_path)?;
-        #[cfg(unix)]
-        {
+        let file = {
+            use std::ffi::CString;
+            use std::io::{Error, ErrorKind};
+            use std::os::fd::{AsRawFd, FromRawFd};
             use std::os::unix::fs::PermissionsExt;
+
+            let temp_name = CString::new(temp_name).map_err(|_| {
+                Error::new(ErrorKind::InvalidInput, "request log name contains NUL")
+            })?;
+            // SAFETY: the name pointer is valid for the call and the retained logs fd is open.
+            let fd = unsafe {
+                libc::openat(
+                    self.logs_directory.as_raw_fd(),
+                    temp_name.as_ptr(),
+                    libc::O_WRONLY
+                        | libc::O_CREAT
+                        | libc::O_TRUNC
+                        | libc::O_CLOEXEC
+                        | libc::O_NOFOLLOW,
+                    0o600,
+                )
+            };
+            if fd < 0 {
+                return Err(Error::last_os_error().into());
+            }
+            // SAFETY: openat returned a new owned descriptor.
+            let raw_file = unsafe { std::fs::File::from_raw_fd(fd) };
+            let file = File::from_parts(raw_file, temp_path.clone());
             file.set_permissions(std::fs::Permissions::from_mode(0o600))?;
-        }
+            file
+        };
+        #[cfg(not(unix))]
+        let file = {
+            let mut options = File::options();
+            options.write(true).create(true).truncate(true);
+            options.open(&temp_path)?
+        };
         let writer = BufWriter::new(file);
 
         Ok(Box::new(FileLogHandle {
             writer: Some(writer),
             temp_path,
             logs_to_keep: self.logs_to_keep,
+            #[cfg(unix)]
+            logs_directory: self.logs_directory.try_clone()?,
         }))
     }
 }
@@ -887,19 +1054,72 @@ impl FileLogHandle {
     fn finish(&mut self) -> Result<()> {
         if let Some(mut writer) = self.writer.take() {
             writer.flush()?;
-            let logs_dir = Paths::in_state_dir("logs");
-            let log_path = |i| logs_dir.join(format!("llm_request.{}.jsonl", i));
+            #[cfg(unix)]
+            {
+                use std::ffi::CString;
+                use std::io::{Error, ErrorKind};
+                use std::os::fd::AsRawFd;
+                use std::os::unix::ffi::OsStrExt;
 
-            if self.logs_to_keep == 0 {
-                fs_err::remove_file(&self.temp_path)?;
+                let temp_name =
+                    CString::new(self.temp_path.as_os_str().as_bytes()).map_err(|_| {
+                        Error::new(ErrorKind::InvalidInput, "request log name contains NUL")
+                    })?;
+                let directory_fd = self.logs_directory.as_raw_fd();
+                if self.logs_to_keep == 0 {
+                    // SAFETY: the name pointer is valid for the call and the logs fd is retained.
+                    if unsafe { libc::unlinkat(directory_fd, temp_name.as_ptr(), 0) } < 0 {
+                        return Err(Error::last_os_error().into());
+                    }
+                    return Ok(());
+                }
+
+                for i in (0..self.logs_to_keep.saturating_sub(1)).rev() {
+                    let source = CString::new(format!("llm_request.{i}.jsonl")).unwrap();
+                    let destination = CString::new(format!("llm_request.{}.jsonl", i + 1)).unwrap();
+                    // SAFETY: name pointers and the retained directory fd are valid for the call.
+                    let _ = unsafe {
+                        libc::renameat(
+                            directory_fd,
+                            source.as_ptr(),
+                            directory_fd,
+                            destination.as_ptr(),
+                        )
+                    };
+                }
+
+                let destination = CString::new("llm_request.0.jsonl").unwrap();
+                // SAFETY: name pointers and the retained directory fd are valid for the call.
+                if unsafe {
+                    libc::renameat(
+                        directory_fd,
+                        temp_name.as_ptr(),
+                        directory_fd,
+                        destination.as_ptr(),
+                    )
+                } < 0
+                {
+                    return Err(Error::last_os_error().into());
+                }
                 return Ok(());
             }
 
-            for i in (0..self.logs_to_keep.saturating_sub(1)).rev() {
-                let _ = fs_err::rename(log_path(i), log_path(i + 1));
-            }
+            #[cfg(not(unix))]
+            {
+                let logs_dir = Paths::in_state_dir("logs");
+                let log_path = |i| logs_dir.join(format!("llm_request.{}.jsonl", i));
 
-            fs_err::rename(&self.temp_path, log_path(0))?;
+                if self.logs_to_keep == 0 {
+                    fs_err::remove_file(&self.temp_path)?;
+                    return Ok(());
+                }
+
+                for i in (0..self.logs_to_keep.saturating_sub(1)).rev() {
+                    let _ = fs_err::rename(log_path(i), log_path(i + 1));
+                }
+
+                fs_err::rename(&self.temp_path, log_path(0))?;
+            }
         }
         Ok(())
     }
@@ -972,11 +1192,16 @@ mod tests {
         }
 
         let log = RequestLog::new(1).unwrap();
+        let state_dir = Paths::state_dir();
+        let moved_state_dir = state_dir.with_file_name("moved-state");
+        std::fs::rename(&state_dir, &moved_state_dir).unwrap();
+        let replacement_logs_dir = state_dir.join("logs");
+        std::fs::create_dir_all(&replacement_logs_dir).unwrap();
         unsafe {
             libc::umask(0o600);
         }
         let mut handle = log.start().unwrap();
-        let logs_dir = Paths::in_state_dir("logs");
+        let logs_dir = moved_state_dir.join("logs");
         let active_path = std::fs::read_dir(&logs_dir)
             .unwrap()
             .map(|entry| entry.unwrap().path())
@@ -999,6 +1224,10 @@ mod tests {
             std::fs::read_to_string(rotated_path).unwrap(),
             "sensitive request and response\n"
         );
+        assert!(std::fs::read_dir(replacement_logs_dir)
+            .unwrap()
+            .next()
+            .is_none());
     }
 
     #[test]
@@ -1046,6 +1275,32 @@ mod tests {
         }
 
         let outcome = restrict_inaccessible_request_log_with_hook(&original, || {
+            std::fs::rename(&original, &moved).unwrap();
+            std::fs::rename(&replacement, &original).unwrap();
+        })
+        .unwrap();
+        assert!(outcome == RestrictionOutcome::Retry);
+
+        restrict_existing_request_logs(root.path()).unwrap();
+        assert_owner_only(&original);
+        assert_owner_only(&moved);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn request_log_permission_upgrade_retries_replaced_accessible_entry() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = tempfile::tempdir().unwrap();
+        let original = root.path().join("llm_request.0.jsonl");
+        let moved = root.path().join("llm_request.1.jsonl");
+        let replacement = root.path().join("replacement");
+        for path in [&original, &replacement] {
+            std::fs::write(path, "legacy sensitive request").unwrap();
+            std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o644)).unwrap();
+        }
+
+        let outcome = restrict_existing_request_log_with_hook(&original, || {
             std::fs::rename(&original, &moved).unwrap();
             std::fs::rename(&replacement, &original).unwrap();
         })

--- a/crates/goose/src/providers/utils.rs
+++ b/crates/goose/src/providers/utils.rs
@@ -238,21 +238,39 @@ impl RequestLog {
 
 #[cfg(unix)]
 fn restrict_existing_request_logs(logs_dir: &std::path::Path) -> Result<()> {
-    use std::os::unix::fs::PermissionsExt;
-
     for entry in fs_err::read_dir(logs_dir)? {
         let entry = entry?;
-        if !entry.file_type()?.is_file() {
-            continue;
-        }
-
         let file_name = entry.file_name();
         let Some(file_name) = file_name.to_str() else {
             continue;
         };
         if is_request_log_file_name(file_name) {
-            fs_err::set_permissions(entry.path(), std::fs::Permissions::from_mode(0o600))?;
+            restrict_existing_request_log(&entry.path())?;
         }
+    }
+
+    Ok(())
+}
+
+#[cfg(unix)]
+fn restrict_existing_request_log(path: &std::path::Path) -> Result<()> {
+    use fs_err::os::unix::fs::OpenOptionsExt;
+    use std::io::ErrorKind;
+    use std::os::unix::fs::PermissionsExt;
+
+    let mut options = File::options();
+    options.read(true).custom_flags(libc::O_NOFOLLOW);
+    let file = match options.open(path) {
+        Ok(file) => file,
+        Err(error)
+            if error.kind() == ErrorKind::NotFound || error.raw_os_error() == Some(libc::ELOOP) =>
+        {
+            return Ok(())
+        }
+        Err(error) => return Err(error.into()),
+    };
+    if file.metadata()?.is_file() {
+        file.set_permissions(std::fs::Permissions::from_mode(0o600))?;
     }
 
     Ok(())
@@ -449,6 +467,15 @@ mod tests {
         ] {
             assert!(!is_request_log_file_name(file_name), "{file_name}");
         }
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn request_log_permission_upgrade_tolerates_vanished_entry() {
+        let root = tempfile::tempdir().unwrap();
+        let vanished = root.path().join("llm_request.0.jsonl");
+
+        restrict_existing_request_log(&vanished).unwrap();
     }
 
     #[test]

--- a/crates/goose/src/providers/utils.rs
+++ b/crates/goose/src/providers/utils.rs
@@ -791,7 +791,7 @@ mod tests {
     #[test]
     #[cfg(unix)]
     fn request_log_directories_may_be_symlinked() {
-        use std::os::unix::fs::{PermissionsExt, symlink};
+        use std::os::unix::fs::{symlink, PermissionsExt};
 
         let root = tempfile::tempdir().unwrap();
         let state_target = root.path().join("state-target");
@@ -823,18 +823,14 @@ mod tests {
                 & 0o777,
             0o700
         );
-        assert!(
-            std::fs::symlink_metadata(&state_dir)
-                .unwrap()
-                .file_type()
-                .is_symlink()
-        );
-        assert!(
-            std::fs::symlink_metadata(state_target.join("logs"))
-                .unwrap()
-                .file_type()
-                .is_symlink()
-        );
+        assert!(std::fs::symlink_metadata(&state_dir)
+            .unwrap()
+            .file_type()
+            .is_symlink());
+        assert!(std::fs::symlink_metadata(state_target.join("logs"))
+            .unwrap()
+            .file_type()
+            .is_symlink());
     }
 
     #[test]

--- a/crates/goose/src/providers/utils.rs
+++ b/crates/goose/src/providers/utils.rs
@@ -263,7 +263,9 @@ fn restrict_existing_request_log(path: &std::path::Path) -> Result<()> {
     let file = match read_options.open(path) {
         Ok(file) => file,
         Err(error)
-            if error.kind() == ErrorKind::NotFound || error.raw_os_error() == Some(libc::ELOOP) =>
+            if error.kind() == ErrorKind::NotFound
+                || error.raw_os_error() == Some(libc::ELOOP)
+                || error.raw_os_error() == Some(libc::ENXIO) =>
         {
             return Ok(())
         }
@@ -279,6 +281,10 @@ fn restrict_existing_request_log(path: &std::path::Path) -> Result<()> {
                 {
                     return Ok(())
                 }
+                Err(error) if error.kind() == ErrorKind::PermissionDenied => {
+                    restrict_inaccessible_request_log(path)?;
+                    return Ok(());
+                }
                 Err(error) => return Err(error.into()),
             }
         }
@@ -286,6 +292,63 @@ fn restrict_existing_request_log(path: &std::path::Path) -> Result<()> {
     };
     if file.metadata()?.is_file() {
         file.set_permissions(std::fs::Permissions::from_mode(0o600))?;
+    }
+
+    Ok(())
+}
+
+#[cfg(unix)]
+fn restrict_inaccessible_request_log(path: &std::path::Path) -> Result<()> {
+    use std::ffi::CString;
+    use std::io::{Error, ErrorKind};
+    use std::os::fd::AsRawFd;
+    use std::os::unix::ffi::OsStrExt;
+
+    let parent = path
+        .parent()
+        .ok_or_else(|| Error::new(ErrorKind::InvalidInput, "request log has no parent"))?;
+    let file_name = path
+        .file_name()
+        .ok_or_else(|| Error::new(ErrorKind::InvalidInput, "request log has no file name"))?;
+    let file_name = CString::new(file_name.as_bytes())
+        .map_err(|_| Error::new(ErrorKind::InvalidInput, "request log name contains NUL"))?;
+    let directory = std::fs::File::open(parent)?;
+    // SAFETY: libc::stat is a plain C data structure initialized before fstatat writes it.
+    let mut metadata: libc::stat = unsafe { std::mem::zeroed() };
+    // SAFETY: pointers remain valid for the synchronous call and the directory fd is open.
+    let result = unsafe {
+        libc::fstatat(
+            directory.as_raw_fd(),
+            file_name.as_ptr(),
+            &mut metadata,
+            libc::AT_SYMLINK_NOFOLLOW,
+        )
+    };
+    if result < 0 {
+        let error = Error::last_os_error();
+        if error.kind() == ErrorKind::NotFound || error.raw_os_error() == Some(libc::ELOOP) {
+            return Ok(());
+        }
+        return Err(error.into());
+    }
+    if metadata.st_mode & libc::S_IFMT != libc::S_IFREG {
+        return Ok(());
+    }
+    // SAFETY: fchmodat does not retain the name pointer and is anchored at the open directory.
+    let result = unsafe {
+        libc::fchmodat(
+            directory.as_raw_fd(),
+            file_name.as_ptr(),
+            0o600,
+            libc::AT_SYMLINK_NOFOLLOW,
+        )
+    };
+    if result < 0 {
+        let error = Error::last_os_error();
+        if error.kind() == ErrorKind::NotFound || error.raw_os_error() == Some(libc::ELOOP) {
+            return Ok(());
+        }
+        return Err(error.into());
     }
 
     Ok(())
@@ -528,6 +591,7 @@ mod tests {
     fn request_log_upgrade_permissions_child() {
         use std::os::unix::ffi::OsStrExt;
         use std::os::unix::fs::{symlink, FileTypeExt, PermissionsExt};
+        use std::os::unix::net::UnixListener;
 
         if std::env::var_os(REQUEST_LOG_UPGRADE_PERMISSIONS_CHILD).is_none() {
             return;
@@ -543,6 +607,8 @@ mod tests {
         let matching_symlink = logs_dir.join("llm_request.9.jsonl");
         let owner_write_only_log = logs_dir.join("llm_request.10.jsonl");
         let matching_fifo = logs_dir.join("llm_request.11.jsonl");
+        let owner_without_access_log = logs_dir.join("llm_request.12.jsonl");
+        let matching_socket = logs_dir.join("llm_request.13.jsonl");
 
         for path in [&numbered_log, &uuid_log, &unrelated_file, &symlink_target] {
             std::fs::write(path, "sensitive request and response").unwrap();
@@ -554,18 +620,26 @@ mod tests {
             std::fs::Permissions::from_mode(0o266),
         )
         .unwrap();
+        std::fs::write(&owner_without_access_log, "legacy sensitive request").unwrap();
+        std::fs::set_permissions(
+            &owner_without_access_log,
+            std::fs::Permissions::from_mode(0o066),
+        )
+        .unwrap();
         std::fs::create_dir(&matching_directory).unwrap();
         std::fs::set_permissions(&matching_directory, std::fs::Permissions::from_mode(0o755))
             .unwrap();
         symlink(&symlink_target, &matching_symlink).unwrap();
         let fifo_path = std::ffi::CString::new(matching_fifo.as_os_str().as_bytes()).unwrap();
         assert_eq!(unsafe { libc::mkfifo(fifo_path.as_ptr(), 0o666) }, 0);
+        let _socket = UnixListener::bind(&matching_socket).unwrap();
 
         RequestLog::new(1).unwrap();
 
         assert_owner_only(&numbered_log);
         assert_owner_only(&uuid_log);
         assert_owner_only(&owner_write_only_log);
+        assert_owner_only(&owner_without_access_log);
         assert_eq!(
             std::fs::metadata(&unrelated_file)
                 .unwrap()
@@ -591,6 +665,10 @@ mod tests {
             .unwrap()
             .file_type()
             .is_fifo());
+        assert!(std::fs::symlink_metadata(&matching_socket)
+            .unwrap()
+            .file_type()
+            .is_socket());
         assert_eq!(
             std::fs::metadata(&symlink_target)
                 .unwrap()

--- a/crates/goose/src/providers/utils.rs
+++ b/crates/goose/src/providers/utils.rs
@@ -238,14 +238,22 @@ impl RequestLog {
 
 #[cfg(unix)]
 fn restrict_existing_request_logs(logs_dir: &std::path::Path) -> Result<()> {
-    for entry in fs_err::read_dir(logs_dir)? {
-        let entry = entry?;
-        let file_name = entry.file_name();
-        let Some(file_name) = file_name.to_str() else {
-            continue;
-        };
-        if is_request_log_file_name(file_name) {
-            restrict_existing_request_log(&entry.path())?;
+    for _ in 0..3 {
+        let mut retry = false;
+        for entry in fs_err::read_dir(logs_dir)? {
+            let entry = entry?;
+            let file_name = entry.file_name();
+            let Some(file_name) = file_name.to_str() else {
+                continue;
+            };
+            if is_request_log_file_name(file_name)
+                && restrict_existing_request_log(&entry.path())? == RestrictionOutcome::Retry
+            {
+                retry = true;
+            }
+        }
+        if !retry {
+            break;
         }
     }
 
@@ -253,56 +261,73 @@ fn restrict_existing_request_logs(logs_dir: &std::path::Path) -> Result<()> {
 }
 
 #[cfg(unix)]
-fn restrict_existing_request_log(path: &std::path::Path) -> Result<()> {
+#[derive(PartialEq)]
+enum RestrictionOutcome {
+    Complete,
+    Retry,
+}
+
+#[cfg(unix)]
+fn restrict_existing_request_log(path: &std::path::Path) -> Result<RestrictionOutcome> {
     use std::io::ErrorKind;
-    use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+    use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
 
     let flags = libc::O_NONBLOCK | libc::O_NOFOLLOW | libc::O_CLOEXEC;
     let mut read_options = std::fs::OpenOptions::new();
     read_options.read(true).custom_flags(flags);
     let file = match read_options.open(path) {
         Ok(file) => file,
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(RestrictionOutcome::Retry),
         Err(error)
-            if error.kind() == ErrorKind::NotFound
-                || error.raw_os_error() == Some(libc::ELOOP)
+            if error.raw_os_error() == Some(libc::ELOOP)
                 || error.raw_os_error() == Some(libc::ENXIO) =>
         {
-            return Ok(())
+            return Ok(RestrictionOutcome::Complete)
         }
         Err(error) if error.kind() == ErrorKind::PermissionDenied => {
             let mut write_options = std::fs::OpenOptions::new();
             write_options.write(true).custom_flags(flags);
             match write_options.open(path) {
                 Ok(file) => file,
+                Err(error) if error.kind() == ErrorKind::NotFound => {
+                    return Ok(RestrictionOutcome::Retry)
+                }
                 Err(error)
-                    if error.kind() == ErrorKind::NotFound
-                        || error.raw_os_error() == Some(libc::ELOOP)
+                    if error.raw_os_error() == Some(libc::ELOOP)
                         || error.raw_os_error() == Some(libc::ENXIO) =>
                 {
-                    return Ok(())
+                    return Ok(RestrictionOutcome::Complete)
                 }
                 Err(error)
                     if error.kind() == ErrorKind::PermissionDenied
                         || error.raw_os_error() == Some(libc::EISDIR)
                         || error.raw_os_error() == Some(libc::ENXIO) =>
                 {
-                    restrict_inaccessible_request_log(path)?;
-                    return Ok(());
+                    return restrict_inaccessible_request_log(path);
                 }
                 Err(error) => return Err(error.into()),
             }
         }
         Err(error) => return Err(error.into()),
     };
-    if file.metadata()?.is_file() {
+    let metadata = file.metadata()?;
+    if metadata.is_file() && metadata.uid() == current_effective_uid() {
         file.set_permissions(std::fs::Permissions::from_mode(0o600))?;
     }
 
-    Ok(())
+    Ok(RestrictionOutcome::Complete)
 }
 
 #[cfg(unix)]
-fn restrict_inaccessible_request_log(path: &std::path::Path) -> Result<()> {
+fn restrict_inaccessible_request_log(path: &std::path::Path) -> Result<RestrictionOutcome> {
+    restrict_inaccessible_request_log_with_hook(path, || {})
+}
+
+#[cfg(unix)]
+fn restrict_inaccessible_request_log_with_hook(
+    path: &std::path::Path,
+    after_metadata: impl FnOnce(),
+) -> Result<RestrictionOutcome> {
     use std::ffi::CString;
     use std::io::{Error, ErrorKind};
     use std::os::fd::AsRawFd;
@@ -330,14 +355,20 @@ fn restrict_inaccessible_request_log(path: &std::path::Path) -> Result<()> {
     };
     if result < 0 {
         let error = Error::last_os_error();
-        if error.kind() == ErrorKind::NotFound || error.raw_os_error() == Some(libc::ELOOP) {
-            return Ok(());
+        if error.kind() == ErrorKind::NotFound {
+            return Ok(RestrictionOutcome::Retry);
+        }
+        if error.raw_os_error() == Some(libc::ELOOP) {
+            return Ok(RestrictionOutcome::Complete);
         }
         return Err(error.into());
     }
-    if metadata.st_mode & libc::S_IFMT != libc::S_IFREG {
-        return Ok(());
+    if metadata.st_mode & libc::S_IFMT != libc::S_IFREG
+        || metadata.st_uid != current_effective_uid()
+    {
+        return Ok(RestrictionOutcome::Complete);
     }
+    after_metadata();
     // SAFETY: fchmodat does not retain the name pointer and is anchored at the open directory.
     let result = unsafe {
         libc::fchmodat(
@@ -350,12 +381,39 @@ fn restrict_inaccessible_request_log(path: &std::path::Path) -> Result<()> {
     if result < 0 {
         let error = Error::last_os_error();
         if error.kind() == ErrorKind::NotFound || error.raw_os_error() == Some(libc::ELOOP) {
-            return Ok(());
+            return Ok(RestrictionOutcome::Retry);
         }
         return Err(error.into());
     }
 
-    Ok(())
+    // SAFETY: pointers remain valid for the synchronous call and the directory fd is open.
+    let mut updated: libc::stat = unsafe { std::mem::zeroed() };
+    let result = unsafe {
+        libc::fstatat(
+            directory.as_raw_fd(),
+            file_name.as_ptr(),
+            &mut updated,
+            libc::AT_SYMLINK_NOFOLLOW,
+        )
+    };
+    if result < 0 {
+        let error = Error::last_os_error();
+        if error.kind() == ErrorKind::NotFound {
+            return Ok(RestrictionOutcome::Retry);
+        }
+        return Err(error.into());
+    }
+    if metadata.st_dev != updated.st_dev || metadata.st_ino != updated.st_ino {
+        return Ok(RestrictionOutcome::Retry);
+    }
+
+    Ok(RestrictionOutcome::Complete)
+}
+
+#[cfg(unix)]
+fn current_effective_uid() -> libc::uid_t {
+    // SAFETY: geteuid has no preconditions.
+    unsafe { libc::geteuid() }
 }
 
 #[cfg(unix)]
@@ -558,6 +616,32 @@ mod tests {
         let vanished = root.path().join("llm_request.0.jsonl");
 
         restrict_existing_request_log(&vanished).unwrap();
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn request_log_permission_upgrade_retries_replaced_inaccessible_entry() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = tempfile::tempdir().unwrap();
+        let original = root.path().join("llm_request.0.jsonl");
+        let moved = root.path().join("llm_request.1.jsonl");
+        let replacement = root.path().join("replacement");
+        for path in [&original, &replacement] {
+            std::fs::write(path, "legacy sensitive request").unwrap();
+            std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o066)).unwrap();
+        }
+
+        let outcome = restrict_inaccessible_request_log_with_hook(&original, || {
+            std::fs::rename(&original, &moved).unwrap();
+            std::fs::rename(&replacement, &original).unwrap();
+        })
+        .unwrap();
+        assert!(outcome == RestrictionOutcome::Retry);
+
+        restrict_existing_request_logs(root.path()).unwrap();
+        assert_owner_only(&original);
+        assert_owner_only(&moved);
     }
 
     #[test]

--- a/crates/goose/src/providers/utils.rs
+++ b/crates/goose/src/providers/utils.rs
@@ -232,6 +232,7 @@ impl RequestLog {
         fs_err::create_dir_all(&logs_dir)?;
         #[cfg(unix)]
         {
+            restrict_request_log_directory(&Paths::state_dir())?;
             restrict_request_log_directory(&logs_dir)?;
             restrict_existing_request_logs(&logs_dir)?;
         }
@@ -241,83 +242,76 @@ impl RequestLog {
 
 #[cfg(unix)]
 fn restrict_request_log_directory(logs_dir: &std::path::Path) -> Result<()> {
+    restrict_request_log_directory_with_hook(logs_dir, || {})
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn directory_search_flags() -> libc::c_int {
+    libc::O_PATH | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC
+}
+
+#[cfg(all(unix, target_vendor = "apple"))]
+fn directory_search_flags() -> libc::c_int {
+    libc::O_SEARCH | libc::O_NOFOLLOW | libc::O_CLOEXEC
+}
+
+#[cfg(all(
+    unix,
+    not(any(target_os = "linux", target_os = "android")),
+    not(target_vendor = "apple")
+))]
+fn directory_search_flags() -> libc::c_int {
+    libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC
+}
+
+#[cfg(unix)]
+fn open_search_only_directory(path: &std::path::Path) -> std::io::Result<std::fs::File> {
+    use std::os::unix::fs::OpenOptionsExt;
+
+    let mut options = std::fs::OpenOptions::new();
+    options.read(true).custom_flags(directory_search_flags());
+    options.open(path)
+}
+
+#[cfg(unix)]
+fn restrict_request_log_directory_with_hook(
+    logs_dir: &std::path::Path,
+    after_metadata: impl FnOnce(),
+) -> Result<()> {
     use std::ffi::CString;
     use std::io::{Error, ErrorKind};
     use std::os::fd::AsRawFd;
-    use std::os::unix::ffi::OsStrExt;
+    use std::os::unix::fs::MetadataExt;
 
-    let (metadata, directory, file_name) = {
-        let parent = logs_dir
-            .parent()
-            .ok_or_else(|| Error::new(ErrorKind::InvalidInput, "logs path has no parent"))?;
-        let file_name = logs_dir
-            .file_name()
-            .ok_or_else(|| Error::new(ErrorKind::InvalidInput, "logs path has no file name"))?;
-        let file_name = CString::new(file_name.as_bytes())
-            .map_err(|_| Error::new(ErrorKind::InvalidInput, "logs path contains NUL"))?;
-        let directory = std::fs::File::open(parent)?;
-        // SAFETY: libc::stat is initialized before fstatat writes it.
-        let mut metadata: libc::stat = unsafe { std::mem::zeroed() };
-        // SAFETY: pointers remain valid for the synchronous call and the directory fd is open.
-        if unsafe {
-            libc::fstatat(
-                directory.as_raw_fd(),
-                file_name.as_ptr(),
-                &mut metadata,
-                libc::AT_SYMLINK_NOFOLLOW,
-            )
-        } < 0
-        {
-            return Err(Error::last_os_error().into());
-        }
-        (metadata, directory, file_name)
-    };
+    let directory = open_search_only_directory(logs_dir)?;
+    let metadata = directory.metadata()?;
 
-    if metadata.st_mode & libc::S_IFMT != libc::S_IFDIR {
+    if !metadata.is_dir() {
         return Err(Error::new(ErrorKind::InvalidInput, "logs path is not a directory").into());
     }
-    if metadata.st_uid != current_effective_uid() {
+    if metadata.uid() != current_effective_uid() {
         return Err(Error::new(
             ErrorKind::PermissionDenied,
             "logs directory is owned by another user",
         )
         .into());
     }
+    after_metadata();
 
-    #[cfg(target_os = "linux")]
-    let chmod_flags = 0;
-    #[cfg(not(target_os = "linux"))]
-    let chmod_flags = libc::AT_SYMLINK_NOFOLLOW;
-    // SAFETY: fchmodat does not retain the name pointer and is anchored at the open parent.
-    if unsafe {
-        libc::fchmodat(
-            directory.as_raw_fd(),
-            file_name.as_ptr(),
-            0o700,
-            chmod_flags,
-        )
-    } < 0
-    {
+    let current_directory = CString::new(".").unwrap();
+    // SAFETY: resolving `.` relative to the retained directory descriptor binds chmod to it.
+    if unsafe { libc::fchmodat(directory.as_raw_fd(), current_directory.as_ptr(), 0o700, 0) } < 0 {
         return Err(Error::last_os_error().into());
     }
 
-    // SAFETY: pointers remain valid for the synchronous call and the parent fd is open.
-    let mut updated: libc::stat = unsafe { std::mem::zeroed() };
-    if unsafe {
-        libc::fstatat(
-            directory.as_raw_fd(),
-            file_name.as_ptr(),
-            &mut updated,
-            libc::AT_SYMLINK_NOFOLLOW,
-        )
-    } < 0
-    {
-        return Err(Error::last_os_error().into());
-    }
-    if metadata.st_dev != updated.st_dev
-        || metadata.st_ino != updated.st_ino
-        || updated.st_mode & libc::S_IFMT != libc::S_IFDIR
-        || updated.st_uid != current_effective_uid()
+    let updated = directory.metadata()?;
+    let current = open_search_only_directory(logs_dir)?.metadata()?;
+    if metadata.dev() != updated.dev()
+        || metadata.ino() != updated.ino()
+        || metadata.dev() != current.dev()
+        || metadata.ino() != current.ino()
+        || !updated.is_dir()
+        || updated.uid() != current_effective_uid()
     {
         return Err(Error::new(
             ErrorKind::PermissionDenied,
@@ -758,6 +752,44 @@ mod tests {
 
     #[test]
     #[cfg(unix)]
+    fn request_log_directory_repair_is_bound_to_opened_directory() {
+        use std::os::unix::fs::{symlink, PermissionsExt};
+
+        let parent = tempfile::tempdir().unwrap();
+        let logs_dir = parent.path().join("logs");
+        let moved_logs_dir = parent.path().join("moved-logs");
+        let outside = parent.path().join("outside");
+        std::fs::create_dir(&logs_dir).unwrap();
+        std::fs::create_dir(&outside).unwrap();
+        std::fs::set_permissions(&logs_dir, std::fs::Permissions::from_mode(0o377)).unwrap();
+        std::fs::set_permissions(&outside, std::fs::Permissions::from_mode(0o777)).unwrap();
+
+        let result = restrict_request_log_directory_with_hook(&logs_dir, || {
+            std::fs::rename(&logs_dir, &moved_logs_dir).unwrap();
+            symlink(&outside, &logs_dir).unwrap();
+        });
+
+        assert!(result.is_err());
+        assert_eq!(
+            std::fs::metadata(&moved_logs_dir)
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o700
+        );
+        assert_eq!(
+            std::fs::metadata(&outside).unwrap().permissions().mode() & 0o777,
+            0o777
+        );
+        assert!(std::fs::symlink_metadata(&logs_dir)
+            .unwrap()
+            .file_type()
+            .is_symlink());
+    }
+
+    #[test]
+    #[cfg(unix)]
     fn existing_request_logs_are_restricted_on_upgrade() {
         use std::os::unix::process::CommandExt;
         use std::process::Command;
@@ -798,6 +830,7 @@ mod tests {
         }
 
         let logs_dir = Paths::in_state_dir("logs");
+        let state_dir = Paths::state_dir();
         std::fs::create_dir_all(&logs_dir).unwrap();
         let numbered_log = logs_dir.join("llm_request.7.jsonl");
         let uuid_log = logs_dir.join("llm_request.550e8400-e29b-41d4-a716-446655440000.jsonl");
@@ -833,10 +866,15 @@ mod tests {
         let fifo_path = std::ffi::CString::new(matching_fifo.as_os_str().as_bytes()).unwrap();
         assert_eq!(unsafe { libc::mkfifo(fifo_path.as_ptr(), 0o666) }, 0);
         let _socket = UnixListener::bind(&matching_socket).unwrap();
+        std::fs::set_permissions(&state_dir, std::fs::Permissions::from_mode(0o377)).unwrap();
         std::fs::set_permissions(&logs_dir, std::fs::Permissions::from_mode(0o377)).unwrap();
 
         RequestLog::new(1).unwrap();
 
+        assert_eq!(
+            std::fs::metadata(&state_dir).unwrap().permissions().mode() & 0o777,
+            0o700
+        );
         assert_eq!(
             std::fs::metadata(&logs_dir).unwrap().permissions().mode() & 0o777,
             0o700

--- a/crates/goose/src/providers/utils.rs
+++ b/crates/goose/src/providers/utils.rs
@@ -231,9 +231,103 @@ impl RequestLog {
         let logs_dir = Paths::in_state_dir("logs");
         fs_err::create_dir_all(&logs_dir)?;
         #[cfg(unix)]
-        restrict_existing_request_logs(&logs_dir)?;
+        {
+            restrict_request_log_directory(&logs_dir)?;
+            restrict_existing_request_logs(&logs_dir)?;
+        }
         Ok(Self { logs_to_keep })
     }
+}
+
+#[cfg(unix)]
+fn restrict_request_log_directory(logs_dir: &std::path::Path) -> Result<()> {
+    use std::ffi::CString;
+    use std::io::{Error, ErrorKind};
+    use std::os::fd::AsRawFd;
+    #[cfg(target_os = "linux")]
+    use std::os::fd::FromRawFd;
+    use std::os::unix::ffi::OsStrExt;
+
+    #[cfg(target_os = "linux")]
+    let (metadata, descriptor) = {
+        let path = CString::new(logs_dir.as_os_str().as_bytes())
+            .map_err(|_| Error::new(ErrorKind::InvalidInput, "logs path contains NUL"))?;
+        let flags = libc::O_PATH | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC;
+        // SAFETY: open does not retain the path pointer and no creation mode is required.
+        let raw_descriptor = unsafe { libc::open(path.as_ptr(), flags) };
+        if raw_descriptor < 0 {
+            return Err(Error::last_os_error().into());
+        }
+        // SAFETY: open returned a new owned descriptor.
+        let descriptor = unsafe { std::fs::File::from_raw_fd(raw_descriptor) };
+        // SAFETY: libc::stat is initialized before fstat writes it.
+        let mut metadata: libc::stat = unsafe { std::mem::zeroed() };
+        // SAFETY: the descriptor remains open for the synchronous call.
+        if unsafe { libc::fstat(descriptor.as_raw_fd(), &mut metadata) } < 0 {
+            return Err(Error::last_os_error().into());
+        }
+        (metadata, descriptor)
+    };
+
+    #[cfg(not(target_os = "linux"))]
+    let (metadata, directory, file_name) = {
+        let parent = logs_dir
+            .parent()
+            .ok_or_else(|| Error::new(ErrorKind::InvalidInput, "logs path has no parent"))?;
+        let file_name = logs_dir
+            .file_name()
+            .ok_or_else(|| Error::new(ErrorKind::InvalidInput, "logs path has no file name"))?;
+        let file_name = CString::new(file_name.as_bytes())
+            .map_err(|_| Error::new(ErrorKind::InvalidInput, "logs path contains NUL"))?;
+        let directory = std::fs::File::open(parent)?;
+        // SAFETY: libc::stat is initialized before fstatat writes it.
+        let mut metadata: libc::stat = unsafe { std::mem::zeroed() };
+        // SAFETY: pointers remain valid for the synchronous call and the directory fd is open.
+        if unsafe {
+            libc::fstatat(
+                directory.as_raw_fd(),
+                file_name.as_ptr(),
+                &mut metadata,
+                libc::AT_SYMLINK_NOFOLLOW,
+            )
+        } < 0
+        {
+            return Err(Error::last_os_error().into());
+        }
+        (metadata, directory, file_name)
+    };
+
+    if metadata.st_mode & libc::S_IFMT != libc::S_IFDIR {
+        return Err(Error::new(ErrorKind::InvalidInput, "logs path is not a directory").into());
+    }
+    if metadata.st_uid != current_effective_uid() {
+        return Err(Error::new(
+            ErrorKind::PermissionDenied,
+            "logs directory is owned by another user",
+        )
+        .into());
+    }
+
+    #[cfg(target_os = "linux")]
+    chmod_open_path_descriptor(&descriptor, 0o700)?;
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        // SAFETY: fchmodat does not retain the name pointer and is anchored at the open parent.
+        if unsafe {
+            libc::fchmodat(
+                directory.as_raw_fd(),
+                file_name.as_ptr(),
+                0o700,
+                libc::AT_SYMLINK_NOFOLLOW,
+            )
+        } < 0
+        {
+            return Err(Error::last_os_error().into());
+        }
+    }
+
+    Ok(())
 }
 
 #[cfg(unix)]
@@ -406,14 +500,7 @@ fn restrict_inaccessible_request_log_with_hook(
     after_metadata();
 
     #[cfg(target_os = "linux")]
-    {
-        let descriptor_path =
-            CString::new(format!("/proc/self/fd/{}", descriptor.as_raw_fd())).unwrap();
-        // SAFETY: chmod does not retain the path pointer, which names the retained descriptor.
-        if unsafe { libc::chmod(descriptor_path.as_ptr(), 0o600) } < 0 {
-            return Err(Error::last_os_error().into());
-        }
-    }
+    chmod_open_path_descriptor(&descriptor, 0o600)?;
 
     #[cfg(not(target_os = "linux"))]
     {
@@ -457,6 +544,21 @@ fn restrict_inaccessible_request_log_with_hook(
     }
 
     Ok(RestrictionOutcome::Complete)
+}
+
+#[cfg(target_os = "linux")]
+fn chmod_open_path_descriptor(descriptor: &std::fs::File, mode: libc::mode_t) -> Result<()> {
+    use std::ffi::CString;
+    use std::io::Error;
+    use std::os::fd::AsRawFd;
+
+    let descriptor_path =
+        CString::new(format!("/proc/self/fd/{}", descriptor.as_raw_fd())).unwrap();
+    // SAFETY: chmod does not retain the path pointer, which names the retained descriptor.
+    if unsafe { libc::chmod(descriptor_path.as_ptr(), mode) } < 0 {
+        return Err(Error::last_os_error().into());
+    }
+    Ok(())
 }
 
 #[cfg(unix)]
@@ -770,9 +872,14 @@ mod tests {
         let fifo_path = std::ffi::CString::new(matching_fifo.as_os_str().as_bytes()).unwrap();
         assert_eq!(unsafe { libc::mkfifo(fifo_path.as_ptr(), 0o666) }, 0);
         let _socket = UnixListener::bind(&matching_socket).unwrap();
+        std::fs::set_permissions(&logs_dir, std::fs::Permissions::from_mode(0o377)).unwrap();
 
         RequestLog::new(1).unwrap();
 
+        assert_eq!(
+            std::fs::metadata(&logs_dir).unwrap().permissions().mode() & 0o777,
+            0o700
+        );
         assert_owner_only(&numbered_log);
         assert_owner_only(&uuid_log);
         assert_owner_only(&owner_write_only_log);

--- a/crates/goose/src/providers/utils.rs
+++ b/crates/goose/src/providers/utils.rs
@@ -235,10 +235,9 @@ impl RequestLog {
             .ok_or_else(|| anyhow!("request log state directory has no parent"))?;
         fs_err::create_dir_all(state_parent)?;
         #[cfg(unix)]
-        validate_request_log_parent(state_parent)?;
+        create_and_restrict_request_log_state_directory(&state_dir)?;
+        #[cfg(not(unix))]
         fs_err::create_dir_all(&state_dir)?;
-        #[cfg(unix)]
-        restrict_request_log_directory(&state_dir)?;
         fs_err::create_dir_all(&logs_dir)?;
         #[cfg(unix)]
         {
@@ -250,14 +249,25 @@ impl RequestLog {
 }
 
 #[cfg(unix)]
-fn validate_request_log_parent(parent: &std::path::Path) -> Result<()> {
+fn create_and_restrict_request_log_state_directory(state_dir: &std::path::Path) -> Result<()> {
+    use std::ffi::CString;
     use std::io::{Error, ErrorKind};
+    use std::os::fd::{AsRawFd, FromRawFd};
+    use std::os::unix::ffi::OsStrExt;
     use std::os::unix::fs::{MetadataExt, PermissionsExt};
 
-    validate_request_log_directory_link_owner(parent, current_effective_uid())?;
+    let parent = state_dir
+        .parent()
+        .ok_or_else(|| Error::new(ErrorKind::InvalidInput, "state directory has no parent"))?;
+    let file_name = state_dir
+        .file_name()
+        .ok_or_else(|| Error::new(ErrorKind::InvalidInput, "state directory has no file name"))?;
+    let file_name = CString::new(file_name.as_bytes())
+        .map_err(|_| Error::new(ErrorKind::InvalidInput, "state directory name contains NUL"))?;
+
     let directory = open_search_only_directory(parent)?;
-    let metadata = directory.metadata()?;
-    if !metadata.is_dir() {
+    let parent_metadata = directory.metadata()?;
+    if !parent_metadata.is_dir() {
         return Err(Error::new(
             ErrorKind::InvalidInput,
             "request log state parent is not a directory",
@@ -265,20 +275,108 @@ fn validate_request_log_parent(parent: &std::path::Path) -> Result<()> {
         .into());
     }
 
-    let mode = metadata.permissions().mode();
-    if mode & 0o022 != 0 && mode & 0o1000 == 0 {
+    // SAFETY: the name pointer is valid for the synchronous call and the parent fd is retained.
+    if unsafe { libc::mkdirat(directory.as_raw_fd(), file_name.as_ptr(), 0o700) } < 0 {
+        let error = Error::last_os_error();
+        if error.kind() != ErrorKind::AlreadyExists {
+            return Err(error.into());
+        }
+    }
+
+    // SAFETY: libc::stat is initialized before fstatat writes it.
+    let mut entry: libc::stat = unsafe { std::mem::zeroed() };
+    // SAFETY: pointers remain valid for the call and the parent fd is retained.
+    if unsafe {
+        libc::fstatat(
+            directory.as_raw_fd(),
+            file_name.as_ptr(),
+            &mut entry,
+            libc::AT_SYMLINK_NOFOLLOW,
+        )
+    } < 0
+    {
+        return Err(Error::last_os_error().into());
+    }
+
+    let entry_type = entry.st_mode & libc::S_IFMT;
+    let entry_is_symlink = entry_type == libc::S_IFLNK;
+    if entry_is_symlink {
+        if !request_log_directory_link_owner_is_trusted(entry.st_uid, current_effective_uid()) {
+            return Err(Error::new(
+                ErrorKind::PermissionDenied,
+                "request log state directory symlink is owned by another user",
+            )
+            .into());
+        }
+        let parent_mode = parent_metadata.permissions().mode();
+        if parent_mode & 0o022 != 0 && parent_mode & 0o1000 == 0 {
+            return Err(Error::new(
+                ErrorKind::PermissionDenied,
+                "request log state directory symlink is replaceable by another user",
+            )
+            .into());
+        }
+    } else if entry_type != libc::S_IFDIR {
         return Err(Error::new(
-            ErrorKind::PermissionDenied,
-            "request log state parent is writable by other users without the sticky bit",
+            ErrorKind::InvalidInput,
+            "request log state path is not a directory",
         )
         .into());
     }
 
-    let current = open_search_only_directory(parent)?.metadata()?;
-    if metadata.dev() != current.dev() || metadata.ino() != current.ino() {
+    let flags = directory_search_flags()
+        | if entry_is_symlink {
+            0
+        } else {
+            libc::O_NOFOLLOW
+        };
+    // SAFETY: the name pointer is valid for the synchronous call and the parent fd is retained.
+    let state_fd = unsafe { libc::openat(directory.as_raw_fd(), file_name.as_ptr(), flags) };
+    if state_fd < 0 {
+        return Err(Error::last_os_error().into());
+    }
+    // SAFETY: openat returned a new owned descriptor.
+    let state_directory = unsafe { std::fs::File::from_raw_fd(state_fd) };
+    let metadata = state_directory.metadata()?;
+    if !metadata.is_dir() || metadata.uid() != current_effective_uid() {
         return Err(Error::new(
             ErrorKind::PermissionDenied,
-            "request log state parent changed while it was validated",
+            "request log state directory is not owned by the current user",
+        )
+        .into());
+    }
+
+    let current_directory = CString::new(".").unwrap();
+    // SAFETY: resolving `.` relative to the retained state descriptor binds chmod to it.
+    if unsafe {
+        libc::fchmodat(
+            state_directory.as_raw_fd(),
+            current_directory.as_ptr(),
+            0o700,
+            0,
+        )
+    } < 0
+    {
+        return Err(Error::last_os_error().into());
+    }
+
+    // SAFETY: libc::stat is initialized before fstatat writes it.
+    let mut current: libc::stat = unsafe { std::mem::zeroed() };
+    // SAFETY: pointers remain valid for the call and the parent fd is retained.
+    if unsafe { libc::fstatat(directory.as_raw_fd(), file_name.as_ptr(), &mut current, 0) } < 0 {
+        return Err(Error::last_os_error().into());
+    }
+    let updated = state_directory.metadata()?;
+    if metadata.dev() != updated.dev()
+        || metadata.ino() != updated.ino()
+        || metadata.dev() != current.st_dev as u64
+        || metadata.ino() != current.st_ino as u64
+        || !updated.is_dir()
+        || updated.uid() != current_effective_uid()
+    {
+        return Err(Error::new(
+            ErrorKind::PermissionDenied,
+            "request log state directory changed while permissions were restricted",
         )
         .into());
     }
@@ -1036,20 +1134,22 @@ mod tests {
 
     #[test]
     #[cfg(unix)]
-    fn request_log_state_parent_must_prevent_entry_replacement() {
+    fn request_log_state_directory_is_anchored_in_writable_parent() {
         use std::os::unix::fs::PermissionsExt;
 
         let root = tempfile::tempdir().unwrap();
         std::fs::set_permissions(root.path(), std::fs::Permissions::from_mode(0o777)).unwrap();
+        let state_dir = root.path().join("state");
 
-        let error = validate_request_log_parent(root.path()).unwrap_err();
+        create_and_restrict_request_log_state_directory(&state_dir).unwrap();
         assert_eq!(
             std::fs::metadata(root.path()).unwrap().permissions().mode() & 0o7777,
             0o777
         );
-        assert!(error
-            .to_string()
-            .contains("writable by other users without the sticky bit"));
+        assert_eq!(
+            std::fs::metadata(state_dir).unwrap().permissions().mode() & 0o777,
+            0o700
+        );
     }
 
     #[test]
@@ -1195,7 +1295,7 @@ mod tests {
         std::fs::set_permissions(&state_dir, std::fs::Permissions::from_mode(0o377)).unwrap();
         std::fs::set_permissions(&logs_dir, std::fs::Permissions::from_mode(0o377)).unwrap();
         let state_parent = state_dir.parent().unwrap();
-        std::fs::set_permissions(state_parent, std::fs::Permissions::from_mode(0o1777)).unwrap();
+        std::fs::set_permissions(state_parent, std::fs::Permissions::from_mode(0o377)).unwrap();
 
         RequestLog::new(1).unwrap();
 
@@ -1204,8 +1304,8 @@ mod tests {
                 .unwrap()
                 .permissions()
                 .mode()
-                & 0o7777,
-            0o1777
+                & 0o777,
+            0o377
         );
         assert_eq!(
             std::fs::metadata(&state_dir).unwrap().permissions().mode() & 0o777,

--- a/crates/goose/src/providers/utils.rs
+++ b/crates/goose/src/providers/utils.rs
@@ -249,13 +249,14 @@ impl RequestLogger for RequestLog {
         let temp_name = format!("llm_request.{request_id}.jsonl");
         let temp_path = logs_dir.join(PathBuf::from(temp_name));
 
-        let writer = BufWriter::new(
-            File::options()
-                .write(true)
-                .create(true)
-                .truncate(true)
-                .open(&temp_path)?,
-        );
+        let mut options = File::options();
+        options.write(true).create(true).truncate(true);
+        #[cfg(unix)]
+        {
+            use fs_err::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        let writer = BufWriter::new(options.open(&temp_path)?);
 
         Ok(Box::new(FileLogHandle {
             writer: Some(writer),
@@ -311,6 +312,81 @@ impl Drop for FileLogHandle {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[cfg(unix)]
+    const REQUEST_LOG_PERMISSIONS_CHILD: &str = "GOOSE_REQUEST_LOG_PERMISSIONS_CHILD";
+
+    #[cfg(unix)]
+    fn assert_owner_only(path: &std::path::Path) {
+        use std::os::unix::fs::PermissionsExt;
+
+        let mode = std::fs::metadata(path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode & 0o077, 0, "{} has mode {mode:o}", path.display());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn request_log_files_are_owner_only() {
+        use std::os::unix::process::CommandExt;
+        use std::process::Command;
+
+        let root = tempfile::tempdir().unwrap();
+        let mut command = Command::new(std::env::current_exe().unwrap());
+        command
+            .arg("--exact")
+            .arg("providers::utils::tests::request_log_permissions_child")
+            .arg("--nocapture")
+            .env(REQUEST_LOG_PERMISSIONS_CHILD, "1")
+            .env("GOOSE_PATH_ROOT", root.path());
+        unsafe {
+            command.pre_exec(|| {
+                libc::umask(0o022);
+                Ok(())
+            });
+        }
+
+        let output = command.output().unwrap();
+        assert!(
+            output.status.success(),
+            "permission test subprocess failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn request_log_permissions_child() {
+        if std::env::var_os(REQUEST_LOG_PERMISSIONS_CHILD).is_none() {
+            return;
+        }
+
+        let log = RequestLog::new(1).unwrap();
+        let mut handle = log.start().unwrap();
+        let logs_dir = Paths::in_state_dir("logs");
+        let active_path = std::fs::read_dir(&logs_dir)
+            .unwrap()
+            .map(|entry| entry.unwrap().path())
+            .find(|path| {
+                path.file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| {
+                        name.starts_with("llm_request.") && name != "llm_request.0.jsonl"
+                    })
+            })
+            .unwrap();
+
+        assert_owner_only(&active_path);
+        handle.write("sensitive request and response").unwrap();
+        drop(handle);
+
+        let rotated_path = logs_dir.join("llm_request.0.jsonl");
+        assert_owner_only(&rotated_path);
+        assert_eq!(
+            std::fs::read_to_string(rotated_path).unwrap(),
+            "sensitive request and response\n"
+        );
+    }
 
     #[test]
     fn unescape_json_values_with_object() {

--- a/crates/goose/src/providers/utils.rs
+++ b/crates/goose/src/providers/utils.rs
@@ -230,6 +230,12 @@ impl RequestLog {
     pub fn new(logs_to_keep: usize) -> Result<Self> {
         let state_dir = Paths::state_dir();
         let logs_dir = Paths::in_state_dir("logs");
+        let state_parent = state_dir
+            .parent()
+            .ok_or_else(|| anyhow!("request log state directory has no parent"))?;
+        fs_err::create_dir_all(state_parent)?;
+        #[cfg(unix)]
+        secure_request_log_parent(state_parent)?;
         fs_err::create_dir_all(&state_dir)?;
         #[cfg(unix)]
         restrict_request_log_directory(&state_dir)?;
@@ -241,6 +247,60 @@ impl RequestLog {
         }
         Ok(Self { logs_to_keep })
     }
+}
+
+#[cfg(unix)]
+fn secure_request_log_parent(parent: &std::path::Path) -> Result<()> {
+    use std::ffi::CString;
+    use std::io::{Error, ErrorKind};
+    use std::os::fd::AsRawFd;
+    use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+    validate_request_log_directory_link_owner(parent, current_effective_uid())?;
+    let directory = open_search_only_directory(parent)?;
+    let metadata = directory.metadata()?;
+    if !metadata.is_dir() {
+        return Err(Error::new(
+            ErrorKind::InvalidInput,
+            "request log state parent is not a directory",
+        )
+        .into());
+    }
+
+    if metadata.permissions().mode() & 0o022 != 0 {
+        if metadata.uid() != current_effective_uid() {
+            return Err(Error::new(
+                ErrorKind::PermissionDenied,
+                "writable request log state parent is owned by another user",
+            )
+            .into());
+        }
+        let current_directory = CString::new(".").unwrap();
+        // SAFETY: resolving `.` relative to the retained directory descriptor binds chmod to it.
+        if unsafe { libc::fchmodat(directory.as_raw_fd(), current_directory.as_ptr(), 0o700, 0) }
+            < 0
+        {
+            return Err(Error::last_os_error().into());
+        }
+    }
+
+    let updated = directory.metadata()?;
+    let current = open_search_only_directory(parent)?.metadata()?;
+    if metadata.dev() != updated.dev()
+        || metadata.ino() != updated.ino()
+        || metadata.dev() != current.dev()
+        || metadata.ino() != current.ino()
+        || !updated.is_dir()
+        || updated.permissions().mode() & 0o022 != 0
+    {
+        return Err(Error::new(
+            ErrorKind::PermissionDenied,
+            "request log state parent changed while permissions were restricted",
+        )
+        .into());
+    }
+
+    Ok(())
 }
 
 #[cfg(unix)]
@@ -1092,9 +1152,19 @@ mod tests {
         let _socket = UnixListener::bind(&matching_socket).unwrap();
         std::fs::set_permissions(&state_dir, std::fs::Permissions::from_mode(0o377)).unwrap();
         std::fs::set_permissions(&logs_dir, std::fs::Permissions::from_mode(0o377)).unwrap();
+        let state_parent = state_dir.parent().unwrap();
+        std::fs::set_permissions(state_parent, std::fs::Permissions::from_mode(0o377)).unwrap();
 
         RequestLog::new(1).unwrap();
 
+        assert_eq!(
+            std::fs::metadata(state_parent)
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o700
+        );
         assert_eq!(
             std::fs::metadata(&state_dir).unwrap().permissions().mode() & 0o777,
             0o700

--- a/crates/goose/src/providers/utils.rs
+++ b/crates/goose/src/providers/utils.rs
@@ -254,18 +254,33 @@ fn restrict_existing_request_logs(logs_dir: &std::path::Path) -> Result<()> {
 
 #[cfg(unix)]
 fn restrict_existing_request_log(path: &std::path::Path) -> Result<()> {
-    use fs_err::os::unix::fs::OpenOptionsExt;
     use std::io::ErrorKind;
-    use std::os::unix::fs::PermissionsExt;
+    use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 
-    let mut options = File::options();
-    options.read(true).custom_flags(libc::O_NOFOLLOW);
-    let file = match options.open(path) {
+    let flags = libc::O_NONBLOCK | libc::O_NOFOLLOW | libc::O_CLOEXEC;
+    let mut read_options = std::fs::OpenOptions::new();
+    read_options.read(true).custom_flags(flags);
+    let file = match read_options.open(path) {
         Ok(file) => file,
         Err(error)
             if error.kind() == ErrorKind::NotFound || error.raw_os_error() == Some(libc::ELOOP) =>
         {
             return Ok(())
+        }
+        Err(error) if error.kind() == ErrorKind::PermissionDenied => {
+            let mut write_options = std::fs::OpenOptions::new();
+            write_options.write(true).custom_flags(flags);
+            match write_options.open(path) {
+                Ok(file) => file,
+                Err(error)
+                    if error.kind() == ErrorKind::NotFound
+                        || error.raw_os_error() == Some(libc::ELOOP)
+                        || error.raw_os_error() == Some(libc::ENXIO) =>
+                {
+                    return Ok(())
+                }
+                Err(error) => return Err(error.into()),
+            }
         }
         Err(error) => return Err(error.into()),
     };
@@ -511,7 +526,8 @@ mod tests {
     #[test]
     #[cfg(unix)]
     fn request_log_upgrade_permissions_child() {
-        use std::os::unix::fs::{symlink, PermissionsExt};
+        use std::os::unix::ffi::OsStrExt;
+        use std::os::unix::fs::{symlink, FileTypeExt, PermissionsExt};
 
         if std::env::var_os(REQUEST_LOG_UPGRADE_PERMISSIONS_CHILD).is_none() {
             return;
@@ -525,20 +541,31 @@ mod tests {
         let matching_directory = logs_dir.join("llm_request.8.jsonl");
         let symlink_target = logs_dir.join("symlink-target.jsonl");
         let matching_symlink = logs_dir.join("llm_request.9.jsonl");
+        let owner_write_only_log = logs_dir.join("llm_request.10.jsonl");
+        let matching_fifo = logs_dir.join("llm_request.11.jsonl");
 
         for path in [&numbered_log, &uuid_log, &unrelated_file, &symlink_target] {
             std::fs::write(path, "sensitive request and response").unwrap();
             std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o644)).unwrap();
         }
+        std::fs::write(&owner_write_only_log, "legacy sensitive request").unwrap();
+        std::fs::set_permissions(
+            &owner_write_only_log,
+            std::fs::Permissions::from_mode(0o266),
+        )
+        .unwrap();
         std::fs::create_dir(&matching_directory).unwrap();
         std::fs::set_permissions(&matching_directory, std::fs::Permissions::from_mode(0o755))
             .unwrap();
         symlink(&symlink_target, &matching_symlink).unwrap();
+        let fifo_path = std::ffi::CString::new(matching_fifo.as_os_str().as_bytes()).unwrap();
+        assert_eq!(unsafe { libc::mkfifo(fifo_path.as_ptr(), 0o666) }, 0);
 
         RequestLog::new(1).unwrap();
 
         assert_owner_only(&numbered_log);
         assert_owner_only(&uuid_log);
+        assert_owner_only(&owner_write_only_log);
         assert_eq!(
             std::fs::metadata(&unrelated_file)
                 .unwrap()
@@ -560,6 +587,10 @@ mod tests {
             .unwrap()
             .file_type()
             .is_symlink());
+        assert!(std::fs::symlink_metadata(&matching_fifo)
+            .unwrap()
+            .file_type()
+            .is_fifo());
         assert_eq!(
             std::fs::metadata(&symlink_target)
                 .unwrap()

--- a/crates/goose/src/providers/utils.rs
+++ b/crates/goose/src/providers/utils.rs
@@ -247,12 +247,12 @@ fn restrict_request_log_directory(logs_dir: &std::path::Path) -> Result<()> {
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
 fn directory_search_flags() -> libc::c_int {
-    libc::O_PATH | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC
+    libc::O_PATH | libc::O_DIRECTORY | libc::O_CLOEXEC
 }
 
 #[cfg(all(unix, target_vendor = "apple"))]
 fn directory_search_flags() -> libc::c_int {
-    libc::O_SEARCH | libc::O_NOFOLLOW | libc::O_CLOEXEC
+    libc::O_SEARCH | libc::O_CLOEXEC
 }
 
 #[cfg(all(
@@ -261,7 +261,7 @@ fn directory_search_flags() -> libc::c_int {
     not(target_vendor = "apple")
 ))]
 fn directory_search_flags() -> libc::c_int {
-    libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC
+    libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC
 }
 
 #[cfg(unix)]
@@ -786,6 +786,55 @@ mod tests {
             .unwrap()
             .file_type()
             .is_symlink());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn request_log_directories_may_be_symlinked() {
+        use std::os::unix::fs::{PermissionsExt, symlink};
+
+        let root = tempfile::tempdir().unwrap();
+        let state_target = root.path().join("state-target");
+        let state_dir = root.path().join("state");
+        let logs_target = root.path().join("logs-target");
+        std::fs::create_dir(&state_target).unwrap();
+        std::fs::create_dir(&logs_target).unwrap();
+        symlink(&state_target, &state_dir).unwrap();
+        symlink(&logs_target, state_target.join("logs")).unwrap();
+        std::fs::set_permissions(&state_target, std::fs::Permissions::from_mode(0o377)).unwrap();
+        std::fs::set_permissions(&logs_target, std::fs::Permissions::from_mode(0o377)).unwrap();
+
+        restrict_request_log_directory(&state_dir).unwrap();
+        restrict_request_log_directory(&state_dir.join("logs")).unwrap();
+
+        assert_eq!(
+            std::fs::metadata(&state_target)
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o700
+        );
+        assert_eq!(
+            std::fs::metadata(&logs_target)
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o700
+        );
+        assert!(
+            std::fs::symlink_metadata(&state_dir)
+                .unwrap()
+                .file_type()
+                .is_symlink()
+        );
+        assert!(
+            std::fs::symlink_metadata(state_target.join("logs"))
+                .unwrap()
+                .file_type()
+                .is_symlink()
+        );
     }
 
     #[test]

--- a/crates/goose/src/providers/utils.rs
+++ b/crates/goose/src/providers/utils.rs
@@ -331,6 +331,8 @@ fn restrict_inaccessible_request_log_with_hook(
     use std::ffi::CString;
     use std::io::{Error, ErrorKind};
     use std::os::fd::AsRawFd;
+    #[cfg(target_os = "linux")]
+    use std::os::fd::FromRawFd;
     use std::os::unix::ffi::OsStrExt;
 
     let parent = path
@@ -342,48 +344,95 @@ fn restrict_inaccessible_request_log_with_hook(
     let file_name = CString::new(file_name.as_bytes())
         .map_err(|_| Error::new(ErrorKind::InvalidInput, "request log name contains NUL"))?;
     let directory = std::fs::File::open(parent)?;
-    // SAFETY: libc::stat is a plain C data structure initialized before fstatat writes it.
-    let mut metadata: libc::stat = unsafe { std::mem::zeroed() };
-    // SAFETY: pointers remain valid for the synchronous call and the directory fd is open.
-    let result = unsafe {
-        libc::fstatat(
-            directory.as_raw_fd(),
-            file_name.as_ptr(),
-            &mut metadata,
-            libc::AT_SYMLINK_NOFOLLOW,
-        )
+
+    #[cfg(target_os = "linux")]
+    let (metadata, descriptor) = {
+        let flags = libc::O_PATH | libc::O_NOFOLLOW | libc::O_CLOEXEC;
+        // SAFETY: openat does not retain the name pointer and no creation mode is required.
+        let raw_descriptor =
+            unsafe { libc::openat(directory.as_raw_fd(), file_name.as_ptr(), flags) };
+        if raw_descriptor < 0 {
+            let error = Error::last_os_error();
+            if error.kind() == ErrorKind::NotFound {
+                return Ok(RestrictionOutcome::Retry);
+            }
+            if error.raw_os_error() == Some(libc::ELOOP) {
+                return Ok(RestrictionOutcome::Complete);
+            }
+            return Err(error.into());
+        }
+        // SAFETY: openat returned a new owned descriptor.
+        let descriptor = unsafe { std::fs::File::from_raw_fd(raw_descriptor) };
+        // SAFETY: libc::stat is initialized before fstat writes it.
+        let mut metadata: libc::stat = unsafe { std::mem::zeroed() };
+        // SAFETY: the descriptor remains open for the synchronous call.
+        if unsafe { libc::fstat(descriptor.as_raw_fd(), &mut metadata) } < 0 {
+            return Err(Error::last_os_error().into());
+        }
+        (metadata, descriptor)
     };
-    if result < 0 {
-        let error = Error::last_os_error();
-        if error.kind() == ErrorKind::NotFound {
-            return Ok(RestrictionOutcome::Retry);
+
+    #[cfg(not(target_os = "linux"))]
+    let metadata = {
+        // SAFETY: libc::stat is a plain C data structure initialized before fstatat writes it.
+        let mut metadata: libc::stat = unsafe { std::mem::zeroed() };
+        // SAFETY: pointers remain valid for the synchronous call and the directory fd is open.
+        let result = unsafe {
+            libc::fstatat(
+                directory.as_raw_fd(),
+                file_name.as_ptr(),
+                &mut metadata,
+                libc::AT_SYMLINK_NOFOLLOW,
+            )
+        };
+        if result < 0 {
+            let error = Error::last_os_error();
+            if error.kind() == ErrorKind::NotFound {
+                return Ok(RestrictionOutcome::Retry);
+            }
+            if error.raw_os_error() == Some(libc::ELOOP) {
+                return Ok(RestrictionOutcome::Complete);
+            }
+            return Err(error.into());
         }
-        if error.raw_os_error() == Some(libc::ELOOP) {
-            return Ok(RestrictionOutcome::Complete);
-        }
-        return Err(error.into());
-    }
+        metadata
+    };
+
     if metadata.st_mode & libc::S_IFMT != libc::S_IFREG
         || metadata.st_uid != current_effective_uid()
     {
         return Ok(RestrictionOutcome::Complete);
     }
     after_metadata();
-    // SAFETY: fchmodat does not retain the name pointer and is anchored at the open directory.
-    let result = unsafe {
-        libc::fchmodat(
-            directory.as_raw_fd(),
-            file_name.as_ptr(),
-            0o600,
-            libc::AT_SYMLINK_NOFOLLOW,
-        )
-    };
-    if result < 0 {
-        let error = Error::last_os_error();
-        if error.kind() == ErrorKind::NotFound || error.raw_os_error() == Some(libc::ELOOP) {
-            return Ok(RestrictionOutcome::Retry);
+
+    #[cfg(target_os = "linux")]
+    {
+        let descriptor_path =
+            CString::new(format!("/proc/self/fd/{}", descriptor.as_raw_fd())).unwrap();
+        // SAFETY: chmod does not retain the path pointer, which names the retained descriptor.
+        if unsafe { libc::chmod(descriptor_path.as_ptr(), 0o600) } < 0 {
+            return Err(Error::last_os_error().into());
         }
-        return Err(error.into());
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        // SAFETY: fchmodat does not retain the name pointer and is anchored at the open directory.
+        let result = unsafe {
+            libc::fchmodat(
+                directory.as_raw_fd(),
+                file_name.as_ptr(),
+                0o600,
+                libc::AT_SYMLINK_NOFOLLOW,
+            )
+        };
+        if result < 0 {
+            let error = Error::last_os_error();
+            if error.kind() == ErrorKind::NotFound || error.raw_os_error() == Some(libc::ELOOP) {
+                return Ok(RestrictionOutcome::Retry);
+            }
+            return Err(error.into());
+        }
     }
 
     // SAFETY: pointers remain valid for the synchronous call and the directory fd is open.

--- a/crates/goose/src/providers/utils.rs
+++ b/crates/goose/src/providers/utils.rs
@@ -230,8 +230,46 @@ impl RequestLog {
     pub fn new(logs_to_keep: usize) -> Result<Self> {
         let logs_dir = Paths::in_state_dir("logs");
         fs_err::create_dir_all(&logs_dir)?;
+        #[cfg(unix)]
+        restrict_existing_request_logs(&logs_dir)?;
         Ok(Self { logs_to_keep })
     }
+}
+
+#[cfg(unix)]
+fn restrict_existing_request_logs(logs_dir: &std::path::Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    for entry in fs_err::read_dir(logs_dir)? {
+        let entry = entry?;
+        if !entry.file_type()?.is_file() {
+            continue;
+        }
+
+        let file_name = entry.file_name();
+        let Some(file_name) = file_name.to_str() else {
+            continue;
+        };
+        if is_request_log_file_name(file_name) {
+            fs_err::set_permissions(entry.path(), std::fs::Permissions::from_mode(0o600))?;
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(unix)]
+fn is_request_log_file_name(file_name: &str) -> bool {
+    let Some(identifier) = file_name
+        .strip_prefix("llm_request.")
+        .and_then(|name| name.strip_suffix(".jsonl"))
+    else {
+        return false;
+    };
+
+    !identifier.is_empty()
+        && (identifier.bytes().all(|byte| byte.is_ascii_digit())
+            || (identifier.len() == 36 && Uuid::parse_str(identifier).is_ok()))
 }
 
 struct FileLogHandle {
@@ -317,6 +355,10 @@ mod tests {
     const REQUEST_LOG_PERMISSIONS_CHILD: &str = "GOOSE_REQUEST_LOG_PERMISSIONS_CHILD";
 
     #[cfg(unix)]
+    const REQUEST_LOG_UPGRADE_PERMISSIONS_CHILD: &str =
+        "GOOSE_REQUEST_LOG_UPGRADE_PERMISSIONS_CHILD";
+
+    #[cfg(unix)]
     fn assert_owner_only(path: &std::path::Path) {
         use std::os::unix::fs::PermissionsExt;
 
@@ -385,6 +427,119 @@ mod tests {
         assert_eq!(
             std::fs::read_to_string(rotated_path).unwrap(),
             "sensitive request and response\n"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn request_log_file_name_matching_is_exact() {
+        assert!(is_request_log_file_name("llm_request.0.jsonl"));
+        assert!(is_request_log_file_name("llm_request.123.jsonl"));
+        assert!(is_request_log_file_name(
+            "llm_request.550e8400-e29b-41d4-a716-446655440000.jsonl"
+        ));
+
+        for file_name in [
+            "llm_request.jsonl",
+            "llm_request..jsonl",
+            "llm_request.notes.jsonl",
+            "llm_request.-1.jsonl",
+            "llm_request.0.jsonl.bak",
+            "other.0.jsonl",
+        ] {
+            assert!(!is_request_log_file_name(file_name), "{file_name}");
+        }
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn existing_request_logs_are_restricted_on_upgrade() {
+        use std::os::unix::process::CommandExt;
+        use std::process::Command;
+
+        let root = tempfile::tempdir().unwrap();
+        let mut command = Command::new(std::env::current_exe().unwrap());
+        command
+            .arg("--exact")
+            .arg("providers::utils::tests::request_log_upgrade_permissions_child")
+            .arg("--nocapture")
+            .env(REQUEST_LOG_UPGRADE_PERMISSIONS_CHILD, "1")
+            .env("GOOSE_PATH_ROOT", root.path());
+        unsafe {
+            command.pre_exec(|| {
+                libc::umask(0o022);
+                Ok(())
+            });
+        }
+
+        let output = command.output().unwrap();
+        assert!(
+            output.status.success(),
+            "upgrade permission test subprocess failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn request_log_upgrade_permissions_child() {
+        use std::os::unix::fs::{symlink, PermissionsExt};
+
+        if std::env::var_os(REQUEST_LOG_UPGRADE_PERMISSIONS_CHILD).is_none() {
+            return;
+        }
+
+        let logs_dir = Paths::in_state_dir("logs");
+        std::fs::create_dir_all(&logs_dir).unwrap();
+        let numbered_log = logs_dir.join("llm_request.7.jsonl");
+        let uuid_log = logs_dir.join("llm_request.550e8400-e29b-41d4-a716-446655440000.jsonl");
+        let unrelated_file = logs_dir.join("llm_request.notes.jsonl");
+        let matching_directory = logs_dir.join("llm_request.8.jsonl");
+        let symlink_target = logs_dir.join("symlink-target.jsonl");
+        let matching_symlink = logs_dir.join("llm_request.9.jsonl");
+
+        for path in [&numbered_log, &uuid_log, &unrelated_file, &symlink_target] {
+            std::fs::write(path, "sensitive request and response").unwrap();
+            std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o644)).unwrap();
+        }
+        std::fs::create_dir(&matching_directory).unwrap();
+        std::fs::set_permissions(&matching_directory, std::fs::Permissions::from_mode(0o755))
+            .unwrap();
+        symlink(&symlink_target, &matching_symlink).unwrap();
+
+        RequestLog::new(1).unwrap();
+
+        assert_owner_only(&numbered_log);
+        assert_owner_only(&uuid_log);
+        assert_eq!(
+            std::fs::metadata(&unrelated_file)
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o644
+        );
+        assert!(matching_directory.is_dir());
+        assert_eq!(
+            std::fs::metadata(&matching_directory)
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o755
+        );
+        assert!(std::fs::symlink_metadata(&matching_symlink)
+            .unwrap()
+            .file_type()
+            .is_symlink());
+        assert_eq!(
+            std::fs::metadata(&symlink_target)
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o644
         );
     }
 

--- a/crates/goose/src/providers/utils.rs
+++ b/crates/goose/src/providers/utils.rs
@@ -281,7 +281,11 @@ fn restrict_existing_request_log(path: &std::path::Path) -> Result<()> {
                 {
                     return Ok(())
                 }
-                Err(error) if error.kind() == ErrorKind::PermissionDenied => {
+                Err(error)
+                    if error.kind() == ErrorKind::PermissionDenied
+                        || error.raw_os_error() == Some(libc::EISDIR)
+                        || error.raw_os_error() == Some(libc::ENXIO) =>
+                {
                     restrict_inaccessible_request_log(path)?;
                     return Ok(());
                 }
@@ -627,7 +631,7 @@ mod tests {
         )
         .unwrap();
         std::fs::create_dir(&matching_directory).unwrap();
-        std::fs::set_permissions(&matching_directory, std::fs::Permissions::from_mode(0o755))
+        std::fs::set_permissions(&matching_directory, std::fs::Permissions::from_mode(0o000))
             .unwrap();
         symlink(&symlink_target, &matching_symlink).unwrap();
         let fifo_path = std::ffi::CString::new(matching_fifo.as_os_str().as_bytes()).unwrap();
@@ -655,7 +659,7 @@ mod tests {
                 .permissions()
                 .mode()
                 & 0o777,
-            0o755
+            0o000
         );
         assert!(std::fs::symlink_metadata(&matching_symlink)
             .unwrap()

--- a/crates/goose/src/providers/utils.rs
+++ b/crates/goose/src/providers/utils.rs
@@ -228,11 +228,14 @@ pub struct RequestLog {
 
 impl RequestLog {
     pub fn new(logs_to_keep: usize) -> Result<Self> {
+        let state_dir = Paths::state_dir();
         let logs_dir = Paths::in_state_dir("logs");
+        fs_err::create_dir_all(&state_dir)?;
+        #[cfg(unix)]
+        restrict_request_log_directory(&state_dir)?;
         fs_err::create_dir_all(&logs_dir)?;
         #[cfg(unix)]
         {
-            restrict_request_log_directory(&Paths::state_dir())?;
             restrict_request_log_directory(&logs_dir)?;
             restrict_existing_request_logs(&logs_dir)?;
         }
@@ -274,6 +277,24 @@ fn open_search_only_directory(path: &std::path::Path) -> std::io::Result<std::fs
 }
 
 #[cfg(unix)]
+fn validate_request_log_directory_link_owner(
+    path: &std::path::Path,
+    expected_uid: libc::uid_t,
+) -> std::io::Result<()> {
+    use std::io::{Error, ErrorKind};
+    use std::os::unix::fs::MetadataExt;
+
+    let metadata = std::fs::symlink_metadata(path)?;
+    if metadata.file_type().is_symlink() && metadata.uid() != expected_uid {
+        return Err(Error::new(
+            ErrorKind::PermissionDenied,
+            "request log directory symlink is owned by another user",
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
 fn restrict_request_log_directory_with_hook(
     logs_dir: &std::path::Path,
     after_metadata: impl FnOnce(),
@@ -283,6 +304,7 @@ fn restrict_request_log_directory_with_hook(
     use std::os::fd::AsRawFd;
     use std::os::unix::fs::MetadataExt;
 
+    validate_request_log_directory_link_owner(logs_dir, current_effective_uid())?;
     let directory = open_search_only_directory(logs_dir)?;
     let metadata = directory.metadata()?;
 
@@ -786,6 +808,24 @@ mod tests {
             .unwrap()
             .file_type()
             .is_symlink());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn request_log_directory_symlink_requires_owner() {
+        use std::io::ErrorKind;
+        use std::os::unix::fs::symlink;
+
+        let root = tempfile::tempdir().unwrap();
+        let target = root.path().join("target");
+        let link = root.path().join("link");
+        std::fs::create_dir(&target).unwrap();
+        symlink(&target, &link).unwrap();
+
+        validate_request_log_directory_link_owner(&link, current_effective_uid()).unwrap();
+        let foreign_uid = if current_effective_uid() == 0 { 1 } else { 0 };
+        let error = validate_request_log_directory_link_owner(&link, foreign_uid).unwrap_err();
+        assert_eq!(error.kind(), ErrorKind::PermissionDenied);
     }
 
     #[test]

--- a/crates/goose/src/providers/utils.rs
+++ b/crates/goose/src/providers/utils.rs
@@ -244,32 +244,8 @@ fn restrict_request_log_directory(logs_dir: &std::path::Path) -> Result<()> {
     use std::ffi::CString;
     use std::io::{Error, ErrorKind};
     use std::os::fd::AsRawFd;
-    #[cfg(target_os = "linux")]
-    use std::os::fd::FromRawFd;
     use std::os::unix::ffi::OsStrExt;
 
-    #[cfg(target_os = "linux")]
-    let (metadata, descriptor) = {
-        let path = CString::new(logs_dir.as_os_str().as_bytes())
-            .map_err(|_| Error::new(ErrorKind::InvalidInput, "logs path contains NUL"))?;
-        let flags = libc::O_PATH | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC;
-        // SAFETY: open does not retain the path pointer and no creation mode is required.
-        let raw_descriptor = unsafe { libc::open(path.as_ptr(), flags) };
-        if raw_descriptor < 0 {
-            return Err(Error::last_os_error().into());
-        }
-        // SAFETY: open returned a new owned descriptor.
-        let descriptor = unsafe { std::fs::File::from_raw_fd(raw_descriptor) };
-        // SAFETY: libc::stat is initialized before fstat writes it.
-        let mut metadata: libc::stat = unsafe { std::mem::zeroed() };
-        // SAFETY: the descriptor remains open for the synchronous call.
-        if unsafe { libc::fstat(descriptor.as_raw_fd(), &mut metadata) } < 0 {
-            return Err(Error::last_os_error().into());
-        }
-        (metadata, descriptor)
-    };
-
-    #[cfg(not(target_os = "linux"))]
     let (metadata, directory, file_name) = {
         let parent = logs_dir
             .parent()
@@ -309,22 +285,45 @@ fn restrict_request_log_directory(logs_dir: &std::path::Path) -> Result<()> {
     }
 
     #[cfg(target_os = "linux")]
-    chmod_open_path_descriptor(&descriptor, 0o700)?;
-
+    let chmod_flags = 0;
     #[cfg(not(target_os = "linux"))]
+    let chmod_flags = libc::AT_SYMLINK_NOFOLLOW;
+    // SAFETY: fchmodat does not retain the name pointer and is anchored at the open parent.
+    if unsafe {
+        libc::fchmodat(
+            directory.as_raw_fd(),
+            file_name.as_ptr(),
+            0o700,
+            chmod_flags,
+        )
+    } < 0
     {
-        // SAFETY: fchmodat does not retain the name pointer and is anchored at the open parent.
-        if unsafe {
-            libc::fchmodat(
-                directory.as_raw_fd(),
-                file_name.as_ptr(),
-                0o700,
-                libc::AT_SYMLINK_NOFOLLOW,
-            )
-        } < 0
-        {
-            return Err(Error::last_os_error().into());
-        }
+        return Err(Error::last_os_error().into());
+    }
+
+    // SAFETY: pointers remain valid for the synchronous call and the parent fd is open.
+    let mut updated: libc::stat = unsafe { std::mem::zeroed() };
+    if unsafe {
+        libc::fstatat(
+            directory.as_raw_fd(),
+            file_name.as_ptr(),
+            &mut updated,
+            libc::AT_SYMLINK_NOFOLLOW,
+        )
+    } < 0
+    {
+        return Err(Error::last_os_error().into());
+    }
+    if metadata.st_dev != updated.st_dev
+        || metadata.st_ino != updated.st_ino
+        || updated.st_mode & libc::S_IFMT != libc::S_IFDIR
+        || updated.st_uid != current_effective_uid()
+    {
+        return Err(Error::new(
+            ErrorKind::PermissionDenied,
+            "logs directory changed while permissions were restricted",
+        )
+        .into());
     }
 
     Ok(())
@@ -425,8 +424,6 @@ fn restrict_inaccessible_request_log_with_hook(
     use std::ffi::CString;
     use std::io::{Error, ErrorKind};
     use std::os::fd::AsRawFd;
-    #[cfg(target_os = "linux")]
-    use std::os::fd::FromRawFd;
     use std::os::unix::ffi::OsStrExt;
 
     let parent = path
@@ -439,34 +436,6 @@ fn restrict_inaccessible_request_log_with_hook(
         .map_err(|_| Error::new(ErrorKind::InvalidInput, "request log name contains NUL"))?;
     let directory = std::fs::File::open(parent)?;
 
-    #[cfg(target_os = "linux")]
-    let (metadata, descriptor) = {
-        let flags = libc::O_PATH | libc::O_NOFOLLOW | libc::O_CLOEXEC;
-        // SAFETY: openat does not retain the name pointer and no creation mode is required.
-        let raw_descriptor =
-            unsafe { libc::openat(directory.as_raw_fd(), file_name.as_ptr(), flags) };
-        if raw_descriptor < 0 {
-            let error = Error::last_os_error();
-            if error.kind() == ErrorKind::NotFound {
-                return Ok(RestrictionOutcome::Retry);
-            }
-            if error.raw_os_error() == Some(libc::ELOOP) {
-                return Ok(RestrictionOutcome::Complete);
-            }
-            return Err(error.into());
-        }
-        // SAFETY: openat returned a new owned descriptor.
-        let descriptor = unsafe { std::fs::File::from_raw_fd(raw_descriptor) };
-        // SAFETY: libc::stat is initialized before fstat writes it.
-        let mut metadata: libc::stat = unsafe { std::mem::zeroed() };
-        // SAFETY: the descriptor remains open for the synchronous call.
-        if unsafe { libc::fstat(descriptor.as_raw_fd(), &mut metadata) } < 0 {
-            return Err(Error::last_os_error().into());
-        }
-        (metadata, descriptor)
-    };
-
-    #[cfg(not(target_os = "linux"))]
     let metadata = {
         // SAFETY: libc::stat is a plain C data structure initialized before fstatat writes it.
         let mut metadata: libc::stat = unsafe { std::mem::zeroed() };
@@ -500,26 +469,24 @@ fn restrict_inaccessible_request_log_with_hook(
     after_metadata();
 
     #[cfg(target_os = "linux")]
-    chmod_open_path_descriptor(&descriptor, 0o600)?;
-
+    let chmod_flags = 0;
     #[cfg(not(target_os = "linux"))]
-    {
-        // SAFETY: fchmodat does not retain the name pointer and is anchored at the open directory.
-        let result = unsafe {
-            libc::fchmodat(
-                directory.as_raw_fd(),
-                file_name.as_ptr(),
-                0o600,
-                libc::AT_SYMLINK_NOFOLLOW,
-            )
-        };
-        if result < 0 {
-            let error = Error::last_os_error();
-            if error.kind() == ErrorKind::NotFound || error.raw_os_error() == Some(libc::ELOOP) {
-                return Ok(RestrictionOutcome::Retry);
-            }
-            return Err(error.into());
+    let chmod_flags = libc::AT_SYMLINK_NOFOLLOW;
+    // SAFETY: fchmodat does not retain the name pointer and is anchored at the open directory.
+    let result = unsafe {
+        libc::fchmodat(
+            directory.as_raw_fd(),
+            file_name.as_ptr(),
+            0o600,
+            chmod_flags,
+        )
+    };
+    if result < 0 {
+        let error = Error::last_os_error();
+        if error.kind() == ErrorKind::NotFound || error.raw_os_error() == Some(libc::ELOOP) {
+            return Ok(RestrictionOutcome::Retry);
         }
+        return Err(error.into());
     }
 
     // SAFETY: pointers remain valid for the synchronous call and the directory fd is open.
@@ -544,21 +511,6 @@ fn restrict_inaccessible_request_log_with_hook(
     }
 
     Ok(RestrictionOutcome::Complete)
-}
-
-#[cfg(target_os = "linux")]
-fn chmod_open_path_descriptor(descriptor: &std::fs::File, mode: libc::mode_t) -> Result<()> {
-    use std::ffi::CString;
-    use std::io::Error;
-    use std::os::fd::AsRawFd;
-
-    let descriptor_path =
-        CString::new(format!("/proc/self/fd/{}", descriptor.as_raw_fd())).unwrap();
-    // SAFETY: chmod does not retain the path pointer, which names the retained descriptor.
-    if unsafe { libc::chmod(descriptor_path.as_ptr(), mode) } < 0 {
-        return Err(Error::last_os_error().into());
-    }
-    Ok(())
 }
 
 #[cfg(unix)]
@@ -603,7 +555,13 @@ impl RequestLogger for RequestLog {
             use fs_err::os::unix::fs::OpenOptionsExt;
             options.mode(0o600);
         }
-        let writer = BufWriter::new(options.open(&temp_path)?);
+        let file = options.open(&temp_path)?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            file.set_permissions(std::fs::Permissions::from_mode(0o600))?;
+        }
+        let writer = BufWriter::new(file);
 
         Ok(Box::new(FileLogHandle {
             writer: Some(writer),
@@ -672,7 +630,7 @@ mod tests {
         use std::os::unix::fs::PermissionsExt;
 
         let mode = std::fs::metadata(path).unwrap().permissions().mode() & 0o777;
-        assert_eq!(mode & 0o077, 0, "{} has mode {mode:o}", path.display());
+        assert_eq!(mode, 0o600, "{} has mode {mode:o}", path.display());
     }
 
     #[test]
@@ -713,6 +671,9 @@ mod tests {
         }
 
         let log = RequestLog::new(1).unwrap();
+        unsafe {
+            libc::umask(0o600);
+        }
         let mut handle = log.start().unwrap();
         let logs_dir = Paths::in_state_dir("logs");
         let active_path = std::fs::read_dir(&logs_dir)

--- a/crates/goose/src/providers/utils.rs
+++ b/crates/goose/src/providers/utils.rs
@@ -253,15 +253,45 @@ fn directory_search_flags() -> libc::c_int {
     libc::O_PATH | libc::O_DIRECTORY | libc::O_CLOEXEC
 }
 
-#[cfg(all(unix, target_vendor = "apple"))]
+#[cfg(any(
+    all(unix, target_vendor = "apple"),
+    target_os = "aix",
+    target_os = "emscripten",
+    target_os = "freebsd",
+    target_os = "illumos",
+    target_os = "netbsd",
+    target_os = "solaris"
+))]
 fn directory_search_flags() -> libc::c_int {
-    libc::O_SEARCH | libc::O_CLOEXEC
+    libc::O_SEARCH | libc::O_DIRECTORY | libc::O_CLOEXEC
+}
+
+#[cfg(target_os = "redox")]
+fn directory_search_flags() -> libc::c_int {
+    libc::O_PATH | libc::O_DIRECTORY | libc::O_CLOEXEC
+}
+
+#[cfg(any(target_os = "hurd", target_os = "nto"))]
+fn directory_search_flags() -> libc::c_int {
+    libc::O_EXEC | libc::O_DIRECTORY | libc::O_CLOEXEC
 }
 
 #[cfg(all(
     unix,
-    not(any(target_os = "linux", target_os = "android")),
-    not(target_vendor = "apple")
+    not(any(
+        target_os = "aix",
+        target_os = "android",
+        target_os = "emscripten",
+        target_os = "freebsd",
+        target_os = "hurd",
+        target_os = "illumos",
+        target_os = "linux",
+        target_os = "netbsd",
+        target_os = "nto",
+        target_os = "redox",
+        target_os = "solaris",
+        target_vendor = "apple"
+    ))
 ))]
 fn directory_search_flags() -> libc::c_int {
     libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC
@@ -294,6 +324,97 @@ fn validate_request_log_directory_link_owner(
     Ok(())
 }
 
+#[cfg(any(
+    test,
+    all(
+        unix,
+        not(any(
+            target_os = "aix",
+            target_os = "android",
+            target_os = "emscripten",
+            target_os = "freebsd",
+            target_os = "hurd",
+            target_os = "illumos",
+            target_os = "linux",
+            target_os = "netbsd",
+            target_os = "nto",
+            target_os = "redox",
+            target_os = "solaris",
+            target_vendor = "apple"
+        ))
+    )
+))]
+fn repair_request_log_directory_for_read(path: &std::path::Path) -> std::io::Result<()> {
+    use std::io::{Error, ErrorKind};
+    use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+    let metadata = std::fs::metadata(path)?;
+    if !metadata.is_dir() {
+        return Err(Error::new(
+            ErrorKind::InvalidInput,
+            "logs path is not a directory",
+        ));
+    }
+    if metadata.uid() != current_effective_uid() {
+        return Err(Error::new(
+            ErrorKind::PermissionDenied,
+            "logs directory is owned by another user",
+        ));
+    }
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700))?;
+    let updated = std::fs::metadata(path)?;
+    if metadata.dev() != updated.dev()
+        || metadata.ino() != updated.ino()
+        || !updated.is_dir()
+        || updated.uid() != current_effective_uid()
+    {
+        return Err(Error::new(
+            ErrorKind::PermissionDenied,
+            "logs directory changed while permissions were restricted",
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(any(
+    target_os = "aix",
+    target_os = "android",
+    target_os = "emscripten",
+    target_os = "freebsd",
+    target_os = "hurd",
+    target_os = "illumos",
+    target_os = "linux",
+    target_os = "netbsd",
+    target_os = "nto",
+    target_os = "redox",
+    target_os = "solaris",
+    all(unix, target_vendor = "apple")
+))]
+fn prepare_request_log_directory_for_open(_path: &std::path::Path) -> std::io::Result<()> {
+    Ok(())
+}
+
+#[cfg(all(
+    unix,
+    not(any(
+        target_os = "aix",
+        target_os = "android",
+        target_os = "emscripten",
+        target_os = "freebsd",
+        target_os = "hurd",
+        target_os = "illumos",
+        target_os = "linux",
+        target_os = "netbsd",
+        target_os = "nto",
+        target_os = "redox",
+        target_os = "solaris",
+        target_vendor = "apple"
+    ))
+))]
+fn prepare_request_log_directory_for_open(path: &std::path::Path) -> std::io::Result<()> {
+    repair_request_log_directory_for_read(path)
+}
+
 #[cfg(unix)]
 fn restrict_request_log_directory_with_hook(
     logs_dir: &std::path::Path,
@@ -305,6 +426,7 @@ fn restrict_request_log_directory_with_hook(
     use std::os::unix::fs::MetadataExt;
 
     validate_request_log_directory_link_owner(logs_dir, current_effective_uid())?;
+    prepare_request_log_directory_for_open(logs_dir)?;
     let directory = open_search_only_directory(logs_dir)?;
     let metadata = directory.metadata()?;
 
@@ -826,6 +948,23 @@ mod tests {
         let foreign_uid = if current_effective_uid() == 0 { 1 } else { 0 };
         let error = validate_request_log_directory_link_owner(&link, foreign_uid).unwrap_err();
         assert_eq!(error.kind(), ErrorKind::PermissionDenied);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn request_log_directory_fallback_repairs_without_owner_read() {
+        use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+        let root = tempfile::tempdir().unwrap();
+        let directory = root.path().join("logs");
+        std::fs::create_dir(&directory).unwrap();
+        std::fs::set_permissions(&directory, std::fs::Permissions::from_mode(0o377)).unwrap();
+
+        repair_request_log_directory_for_read(&directory).unwrap();
+
+        let metadata = std::fs::metadata(&directory).unwrap();
+        assert_eq!(metadata.uid(), current_effective_uid());
+        assert_eq!(metadata.permissions().mode() & 0o777, 0o700);
     }
 
     #[test]

--- a/crates/goose/src/providers/utils.rs
+++ b/crates/goose/src/providers/utils.rs
@@ -235,7 +235,7 @@ impl RequestLog {
             .ok_or_else(|| anyhow!("request log state directory has no parent"))?;
         fs_err::create_dir_all(state_parent)?;
         #[cfg(unix)]
-        secure_request_log_parent(state_parent)?;
+        validate_request_log_parent(state_parent)?;
         fs_err::create_dir_all(&state_dir)?;
         #[cfg(unix)]
         restrict_request_log_directory(&state_dir)?;
@@ -250,10 +250,8 @@ impl RequestLog {
 }
 
 #[cfg(unix)]
-fn secure_request_log_parent(parent: &std::path::Path) -> Result<()> {
-    use std::ffi::CString;
+fn validate_request_log_parent(parent: &std::path::Path) -> Result<()> {
     use std::io::{Error, ErrorKind};
-    use std::os::fd::AsRawFd;
     use std::os::unix::fs::{MetadataExt, PermissionsExt};
 
     validate_request_log_directory_link_owner(parent, current_effective_uid())?;
@@ -267,35 +265,20 @@ fn secure_request_log_parent(parent: &std::path::Path) -> Result<()> {
         .into());
     }
 
-    if metadata.permissions().mode() & 0o022 != 0 {
-        if metadata.uid() != current_effective_uid() {
-            return Err(Error::new(
-                ErrorKind::PermissionDenied,
-                "writable request log state parent is owned by another user",
-            )
-            .into());
-        }
-        let current_directory = CString::new(".").unwrap();
-        // SAFETY: resolving `.` relative to the retained directory descriptor binds chmod to it.
-        if unsafe { libc::fchmodat(directory.as_raw_fd(), current_directory.as_ptr(), 0o700, 0) }
-            < 0
-        {
-            return Err(Error::last_os_error().into());
-        }
-    }
-
-    let updated = directory.metadata()?;
-    let current = open_search_only_directory(parent)?.metadata()?;
-    if metadata.dev() != updated.dev()
-        || metadata.ino() != updated.ino()
-        || metadata.dev() != current.dev()
-        || metadata.ino() != current.ino()
-        || !updated.is_dir()
-        || updated.permissions().mode() & 0o022 != 0
-    {
+    let mode = metadata.permissions().mode();
+    if mode & 0o022 != 0 && mode & 0o1000 == 0 {
         return Err(Error::new(
             ErrorKind::PermissionDenied,
-            "request log state parent changed while permissions were restricted",
+            "request log state parent is writable by other users without the sticky bit",
+        )
+        .into());
+    }
+
+    let current = open_search_only_directory(parent)?.metadata()?;
+    if metadata.dev() != current.dev() || metadata.ino() != current.ino() {
+        return Err(Error::new(
+            ErrorKind::PermissionDenied,
+            "request log state parent changed while it was validated",
         )
         .into());
     }
@@ -539,6 +522,14 @@ fn restrict_request_log_directory_with_hook(
 
 #[cfg(unix)]
 fn restrict_existing_request_logs(logs_dir: &std::path::Path) -> Result<()> {
+    restrict_existing_request_logs_with(logs_dir, restrict_existing_request_log)
+}
+
+#[cfg(unix)]
+fn restrict_existing_request_logs_with(
+    logs_dir: &std::path::Path,
+    mut restrict: impl FnMut(&std::path::Path) -> Result<RestrictionOutcome>,
+) -> Result<()> {
     for _ in 0..3 {
         let mut retry = false;
         for entry in fs_err::read_dir(logs_dir)? {
@@ -548,17 +539,19 @@ fn restrict_existing_request_logs(logs_dir: &std::path::Path) -> Result<()> {
                 continue;
             };
             if is_request_log_file_name(file_name)
-                && restrict_existing_request_log(&entry.path())? == RestrictionOutcome::Retry
+                && restrict(&entry.path())? == RestrictionOutcome::Retry
             {
                 retry = true;
             }
         }
         if !retry {
-            break;
+            return Ok(());
         }
     }
 
-    Ok(())
+    Err(anyhow!(
+        "request logs kept changing during permission restriction"
+    ))
 }
 
 #[cfg(unix)]
@@ -581,7 +574,8 @@ fn restrict_existing_request_log(path: &std::path::Path) -> Result<RestrictionOu
         Err(error) if error.kind() == ErrorKind::NotFound => return Ok(RestrictionOutcome::Retry),
         Err(error)
             if error.raw_os_error() == Some(libc::ELOOP)
-                || error.raw_os_error() == Some(libc::ENXIO) =>
+                || error.raw_os_error() == Some(libc::ENXIO)
+                || error.raw_os_error() == Some(libc::EOPNOTSUPP) =>
         {
             return Ok(RestrictionOutcome::Complete)
         }
@@ -595,7 +589,8 @@ fn restrict_existing_request_log(path: &std::path::Path) -> Result<RestrictionOu
                 }
                 Err(error)
                     if error.raw_os_error() == Some(libc::ELOOP)
-                        || error.raw_os_error() == Some(libc::ENXIO) =>
+                        || error.raw_os_error() == Some(libc::ENXIO)
+                        || error.raw_os_error() == Some(libc::EOPNOTSUPP) =>
                 {
                     return Ok(RestrictionOutcome::Complete)
                 }
@@ -966,6 +961,20 @@ mod tests {
 
     #[test]
     #[cfg(unix)]
+    fn request_log_permission_upgrade_reports_retry_exhaustion() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("llm_request.0.jsonl"), "sensitive request").unwrap();
+
+        let error =
+            restrict_existing_request_logs_with(root.path(), |_| Ok(RestrictionOutcome::Retry))
+                .unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("request logs kept changing during permission restriction"));
+    }
+
+    #[test]
+    #[cfg(unix)]
     fn request_log_directory_repair_is_bound_to_opened_directory() {
         use std::os::unix::fs::{symlink, PermissionsExt};
 
@@ -1023,6 +1032,24 @@ mod tests {
             foreign_uid,
             current_effective_uid()
         ));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn request_log_state_parent_must_prevent_entry_replacement() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = tempfile::tempdir().unwrap();
+        std::fs::set_permissions(root.path(), std::fs::Permissions::from_mode(0o777)).unwrap();
+
+        let error = validate_request_log_parent(root.path()).unwrap_err();
+        assert_eq!(
+            std::fs::metadata(root.path()).unwrap().permissions().mode() & 0o7777,
+            0o777
+        );
+        assert!(error
+            .to_string()
+            .contains("writable by other users without the sticky bit"));
     }
 
     #[test]
@@ -1089,7 +1116,7 @@ mod tests {
 
     #[test]
     #[cfg(unix)]
-    fn existing_request_logs_are_restricted_on_upgrade() {
+    fn request_logs_existing_files_are_restricted_on_upgrade() {
         use std::os::unix::process::CommandExt;
         use std::process::Command;
 
@@ -1168,7 +1195,7 @@ mod tests {
         std::fs::set_permissions(&state_dir, std::fs::Permissions::from_mode(0o377)).unwrap();
         std::fs::set_permissions(&logs_dir, std::fs::Permissions::from_mode(0o377)).unwrap();
         let state_parent = state_dir.parent().unwrap();
-        std::fs::set_permissions(state_parent, std::fs::Permissions::from_mode(0o377)).unwrap();
+        std::fs::set_permissions(state_parent, std::fs::Permissions::from_mode(0o1777)).unwrap();
 
         RequestLog::new(1).unwrap();
 
@@ -1177,8 +1204,8 @@ mod tests {
                 .unwrap()
                 .permissions()
                 .mode()
-                & 0o777,
-            0o700
+                & 0o7777,
+            0o1777
         );
         assert_eq!(
             std::fs::metadata(&state_dir).unwrap().permissions().mode() & 0o777,

--- a/crates/goose/src/providers/utils.rs
+++ b/crates/goose/src/providers/utils.rs
@@ -375,13 +375,23 @@ fn validate_request_log_directory_link_owner(
     use std::os::unix::fs::MetadataExt;
 
     let metadata = std::fs::symlink_metadata(path)?;
-    if metadata.file_type().is_symlink() && metadata.uid() != expected_uid {
+    if metadata.file_type().is_symlink()
+        && !request_log_directory_link_owner_is_trusted(metadata.uid(), expected_uid)
+    {
         return Err(Error::new(
             ErrorKind::PermissionDenied,
             "request log directory symlink is owned by another user",
         ));
     }
     Ok(())
+}
+
+#[cfg(unix)]
+fn request_log_directory_link_owner_is_trusted(
+    actual_uid: libc::uid_t,
+    expected_uid: libc::uid_t,
+) -> bool {
+    actual_uid == expected_uid || actual_uid == 0
 }
 
 #[cfg(any(
@@ -995,7 +1005,6 @@ mod tests {
     #[test]
     #[cfg(unix)]
     fn request_log_directory_symlink_requires_owner() {
-        use std::io::ErrorKind;
         use std::os::unix::fs::symlink;
 
         let root = tempfile::tempdir().unwrap();
@@ -1005,9 +1014,15 @@ mod tests {
         symlink(&target, &link).unwrap();
 
         validate_request_log_directory_link_owner(&link, current_effective_uid()).unwrap();
-        let foreign_uid = if current_effective_uid() == 0 { 1 } else { 0 };
-        let error = validate_request_log_directory_link_owner(&link, foreign_uid).unwrap_err();
-        assert_eq!(error.kind(), ErrorKind::PermissionDenied);
+        assert!(request_log_directory_link_owner_is_trusted(
+            0,
+            current_effective_uid()
+        ));
+        let foreign_uid = if current_effective_uid() == 1 { 2 } else { 1 };
+        assert!(!request_log_directory_link_owner_is_trusted(
+            foreign_uid,
+            current_effective_uid()
+        ));
     }
 
     #[test]

--- a/crates/goose/src/providers/utils.rs
+++ b/crates/goose/src/providers/utils.rs
@@ -257,6 +257,132 @@ impl RequestLog {
     }
 }
 
+#[cfg(target_os = "macos")]
+fn restrict_request_log_descriptor(fd: std::os::fd::RawFd, mode: libc::mode_t) -> Result<()> {
+    use std::io::{Error, ErrorKind};
+
+    mod apple {
+        use libc::{c_int, c_void, mode_t};
+
+        pub(super) type FileSec = *mut c_void;
+        pub(super) type Acl = *mut c_void;
+        pub(super) type AclEntry = *mut c_void;
+
+        pub(super) const FILESEC_MODE: c_int = 4;
+        pub(super) const FILESEC_ACL: c_int = 5;
+        pub(super) const ACL_TYPE_EXTENDED: c_int = 0x100;
+        pub(super) const ACL_FIRST_ENTRY: c_int = 0;
+
+        unsafe extern "C" {
+            pub(super) fn filesec_init() -> FileSec;
+            pub(super) fn filesec_free(filesec: FileSec);
+            pub(super) fn filesec_set_property(
+                filesec: FileSec,
+                property: c_int,
+                value: *const c_void,
+            ) -> c_int;
+            pub(super) fn fchmodx_np(fd: c_int, filesec: FileSec) -> c_int;
+            pub(super) fn acl_get_fd_np(fd: c_int, acl_type: c_int) -> Acl;
+            pub(super) fn acl_get_entry(acl: Acl, entry_id: c_int, entry: *mut AclEntry) -> c_int;
+            pub(super) fn acl_free(object: *mut c_void) -> c_int;
+        }
+
+        pub(super) struct OwnedFileSec(pub(super) FileSec);
+
+        impl Drop for OwnedFileSec {
+            fn drop(&mut self) {
+                unsafe { filesec_free(self.0) };
+            }
+        }
+
+        pub(super) struct OwnedAcl(pub(super) Acl);
+
+        impl Drop for OwnedAcl {
+            fn drop(&mut self) {
+                unsafe { acl_free(self.0) };
+            }
+        }
+
+        pub(super) fn mode_pointer(mode: &mode_t) -> *const c_void {
+            std::ptr::from_ref(mode).cast()
+        }
+
+        pub(super) fn remove_acl_pointer() -> *const c_void {
+            std::ptr::dangling()
+        }
+    }
+
+    let filesec = unsafe { apple::filesec_init() };
+    if filesec.is_null() {
+        return Err(Error::last_os_error().into());
+    }
+    let filesec = apple::OwnedFileSec(filesec);
+    if unsafe {
+        apple::filesec_set_property(filesec.0, apple::FILESEC_MODE, apple::mode_pointer(&mode))
+    } < 0
+    {
+        return Err(Error::last_os_error().into());
+    }
+    if unsafe {
+        apple::filesec_set_property(filesec.0, apple::FILESEC_ACL, apple::remove_acl_pointer())
+    } < 0
+    {
+        return Err(Error::last_os_error().into());
+    }
+
+    if unsafe { apple::fchmodx_np(fd, filesec.0) } < 0 {
+        let error = Error::last_os_error();
+        if error.raw_os_error() != Some(libc::EOPNOTSUPP) {
+            return Err(error.into());
+        }
+        if unsafe { libc::fchmod(fd, mode) } < 0 {
+            return Err(Error::last_os_error().into());
+        }
+    }
+
+    let mut metadata: libc::stat = unsafe { std::mem::zeroed() };
+    if unsafe { libc::fstat(fd, &mut metadata) } < 0 {
+        return Err(Error::last_os_error().into());
+    }
+    if metadata.st_mode & 0o7777 != mode {
+        return Err(Error::new(
+            ErrorKind::PermissionDenied,
+            "request log permissions were not restricted",
+        )
+        .into());
+    }
+
+    let acl = unsafe { apple::acl_get_fd_np(fd, apple::ACL_TYPE_EXTENDED) };
+    if acl.is_null() {
+        let error = Error::last_os_error();
+        if matches!(
+            error.raw_os_error(),
+            Some(libc::EOPNOTSUPP) | Some(libc::ENOENT)
+        ) {
+            return Ok(());
+        }
+        return Err(error.into());
+    }
+    let acl = apple::OwnedAcl(acl);
+    let mut entry = std::ptr::null_mut();
+    if unsafe { apple::acl_get_entry(acl.0, apple::ACL_FIRST_ENTRY, &mut entry) } == 0 {
+        return Err(Error::new(
+            ErrorKind::PermissionDenied,
+            "request log extended ACL was not removed",
+        )
+        .into());
+    }
+    let error = Error::last_os_error();
+    if !matches!(
+        error.raw_os_error(),
+        Some(libc::EINVAL) | Some(libc::ENOENT)
+    ) {
+        return Err(error.into());
+    }
+
+    Ok(())
+}
+
 #[cfg(unix)]
 fn create_and_restrict_request_log_state_directory(
     state_dir: &std::path::Path,
@@ -386,18 +512,23 @@ fn create_and_restrict_request_log_state_directory_with_hook(
     }
 
     if should_restrict == Some(true) {
-        let current_directory = CString::new(".").unwrap();
-        // SAFETY: resolving `.` relative to the retained state descriptor binds chmod to it.
-        if unsafe {
-            libc::fchmodat(
-                state_directory.as_raw_fd(),
-                current_directory.as_ptr(),
-                0o700,
-                0,
-            )
-        } < 0
+        #[cfg(target_os = "macos")]
+        restrict_request_log_descriptor(state_directory.as_raw_fd(), 0o700)?;
+        #[cfg(not(target_os = "macos"))]
         {
-            return Err(Error::last_os_error().into());
+            let current_directory = CString::new(".").unwrap();
+            // SAFETY: resolving `.` relative to the retained state descriptor binds chmod to it.
+            if unsafe {
+                libc::fchmodat(
+                    state_directory.as_raw_fd(),
+                    current_directory.as_ptr(),
+                    0o700,
+                    0,
+                )
+            } < 0
+            {
+                return Err(Error::last_os_error().into());
+            }
         }
     }
 
@@ -527,18 +658,23 @@ fn create_and_restrict_request_log_logs_directory(
         .into());
     }
 
-    let current_directory = CString::new(".").unwrap();
-    // SAFETY: resolving `.` relative to the retained logs descriptor binds chmod to it.
-    if unsafe {
-        libc::fchmodat(
-            logs_directory.as_raw_fd(),
-            current_directory.as_ptr(),
-            0o700,
-            0,
-        )
-    } < 0
+    #[cfg(target_os = "macos")]
+    restrict_request_log_descriptor(logs_directory.as_raw_fd(), 0o700)?;
+    #[cfg(not(target_os = "macos"))]
     {
-        return Err(Error::last_os_error().into());
+        let current_directory = CString::new(".").unwrap();
+        // SAFETY: resolving `.` relative to the retained logs descriptor binds chmod to it.
+        if unsafe {
+            libc::fchmodat(
+                logs_directory.as_raw_fd(),
+                current_directory.as_ptr(),
+                0o700,
+                0,
+            )
+        } < 0
+        {
+            return Err(Error::last_os_error().into());
+        }
     }
 
     // SAFETY: libc::stat is initialized before fstatat writes it.
@@ -881,7 +1017,9 @@ fn restrict_existing_request_log_with_hook(
 ) -> Result<RestrictionOutcome> {
     use std::io::ErrorKind;
     use std::os::fd::{AsRawFd, FromRawFd};
-    use std::os::unix::fs::{MetadataExt, PermissionsExt};
+    use std::os::unix::fs::MetadataExt;
+    #[cfg(not(target_os = "macos"))]
+    use std::os::unix::fs::PermissionsExt;
 
     let flags = libc::O_NONBLOCK | libc::O_NOFOLLOW | libc::O_CLOEXEC;
     // SAFETY: the name pointer is valid for the synchronous call and the retained logs fd is open.
@@ -950,6 +1088,9 @@ fn restrict_existing_request_log_with_hook(
     let metadata = file.metadata()?;
     if metadata.is_file() && metadata.uid() == current_effective_uid() && metadata.nlink() == 1 {
         after_metadata();
+        #[cfg(target_os = "macos")]
+        restrict_request_log_descriptor(file.as_raw_fd(), 0o600)?;
+        #[cfg(not(target_os = "macos"))]
         file.set_permissions(std::fs::Permissions::from_mode(0o600))?;
         let current = match request_log_entry_metadata(logs_directory, file_name) {
             Ok(metadata) => metadata,
@@ -1032,6 +1173,10 @@ fn restrict_inaccessible_request_log_with_hook(
         return Ok(RestrictionOutcome::Retry);
     }
 
+    #[cfg(target_os = "macos")]
+    return Ok(RestrictionOutcome::Retry);
+
+    #[cfg(not(target_os = "macos"))]
     Ok(RestrictionOutcome::Complete)
 }
 
@@ -1109,6 +1254,7 @@ impl RequestLogger for RequestLog {
             use std::ffi::CString;
             use std::io::{Error, ErrorKind};
             use std::os::fd::{AsRawFd, FromRawFd};
+            #[cfg(not(target_os = "macos"))]
             use std::os::unix::fs::PermissionsExt;
 
             let temp_name = CString::new(temp_name).map_err(|_| {
@@ -1132,7 +1278,10 @@ impl RequestLogger for RequestLog {
             }
             // SAFETY: openat returned a new owned descriptor.
             let raw_file = unsafe { std::fs::File::from_raw_fd(fd) };
+            #[cfg(target_os = "macos")]
+            restrict_request_log_descriptor(raw_file.as_raw_fd(), 0o600)?;
             let file = File::from_parts(raw_file, temp_path.clone());
+            #[cfg(not(target_os = "macos"))]
             file.set_permissions(std::fs::Permissions::from_mode(0o600))?;
             file
         };
@@ -1254,12 +1403,105 @@ mod tests {
     use super::*;
     use serde_json::json;
 
+    #[cfg(target_os = "macos")]
+    fn add_extended_acl(path: &std::path::Path, rule: &str) {
+        let status = std::process::Command::new("/bin/chmod")
+            .arg("+a")
+            .arg(rule)
+            .arg(path)
+            .status()
+            .unwrap();
+        assert!(status.success());
+    }
+
+    #[cfg(target_os = "macos")]
+    fn remove_extended_acl(path: &std::path::Path) {
+        let status = std::process::Command::new("/bin/chmod")
+            .arg("-N")
+            .arg(path)
+            .status()
+            .unwrap();
+        assert!(status.success());
+    }
+
+    #[cfg(target_os = "macos")]
+    fn descriptor_has_extended_acl(file: &std::fs::File) -> bool {
+        use libc::{c_int, c_void};
+        use std::os::fd::AsRawFd;
+
+        unsafe extern "C" {
+            fn acl_get_fd_np(fd: c_int, acl_type: c_int) -> *mut c_void;
+            fn acl_get_entry(acl: *mut c_void, entry_id: c_int, entry: *mut *mut c_void) -> c_int;
+            fn acl_free(object: *mut c_void) -> c_int;
+        }
+
+        let acl = unsafe { acl_get_fd_np(file.as_raw_fd(), 0x100) };
+        if acl.is_null() {
+            let error = std::io::Error::last_os_error();
+            assert!(matches!(
+                error.raw_os_error(),
+                Some(libc::ENOENT) | Some(libc::EOPNOTSUPP)
+            ));
+            return false;
+        }
+        let mut entry = std::ptr::null_mut();
+        let has_entry = unsafe { acl_get_entry(acl, 0, &mut entry) } == 0;
+        unsafe { acl_free(acl) };
+        has_entry
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn request_log_descriptor_restriction_removes_extended_acls() {
+        use std::os::fd::AsRawFd;
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = tempfile::tempdir().unwrap();
+        for mode in [0o600, 0o644] {
+            let path = root.path().join(format!("request-{mode:o}.jsonl"));
+            let file = std::fs::File::create(&path).unwrap();
+            file.set_permissions(std::fs::Permissions::from_mode(mode))
+                .unwrap();
+            add_extended_acl(&path, "everyone allow read");
+            assert!(descriptor_has_extended_acl(&file));
+
+            restrict_request_log_descriptor(file.as_raw_fd(), 0o600).unwrap();
+
+            assert!(!descriptor_has_extended_acl(&file));
+            assert_eq!(
+                file.metadata().unwrap().permissions().mode() & 0o7777,
+                0o600
+            );
+        }
+
+        let directory = root.path().join("logs");
+        std::fs::create_dir(&directory).unwrap();
+        std::fs::set_permissions(&directory, std::fs::Permissions::from_mode(0o700)).unwrap();
+        add_extended_acl(
+            &directory,
+            "everyone allow list,search,file_inherit,directory_inherit",
+        );
+        let directory = open_search_only_directory(&directory).unwrap();
+        assert!(descriptor_has_extended_acl(&directory));
+
+        restrict_request_log_descriptor(directory.as_raw_fd(), 0o700).unwrap();
+
+        assert!(!descriptor_has_extended_acl(&directory));
+        assert_eq!(
+            directory.metadata().unwrap().permissions().mode() & 0o7777,
+            0o700
+        );
+    }
+
     #[cfg(unix)]
     const REQUEST_LOG_PERMISSIONS_CHILD: &str = "GOOSE_REQUEST_LOG_PERMISSIONS_CHILD";
 
     #[cfg(unix)]
     const REQUEST_LOG_UPGRADE_PERMISSIONS_CHILD: &str =
         "GOOSE_REQUEST_LOG_UPGRADE_PERMISSIONS_CHILD";
+
+    #[cfg(target_os = "macos")]
+    const REQUEST_LOG_ACL_LIFECYCLE_CHILD: &str = "GOOSE_REQUEST_LOG_ACL_LIFECYCLE_CHILD";
 
     #[cfg(unix)]
     fn assert_owner_only(path: &std::path::Path) {
@@ -1296,6 +1538,152 @@ mod tests {
             "permission test subprocess failed\nstdout:\n{}\nstderr:\n{}",
             String::from_utf8_lossy(&output.stdout),
             String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn request_log_lifecycle_removes_inherited_extended_acls() {
+        use std::process::Command;
+
+        let root = tempfile::tempdir().unwrap();
+        let output = Command::new(std::env::current_exe().unwrap())
+            .arg("--exact")
+            .arg("providers::utils::tests::request_log_acl_lifecycle_child")
+            .arg("--nocapture")
+            .env(REQUEST_LOG_ACL_LIFECYCLE_CHILD, "1")
+            .env("GOOSE_PATH_ROOT", root.path())
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "ACL lifecycle test subprocess failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn request_log_acl_lifecycle_child() {
+        use std::io::Write;
+        use std::os::unix::fs::PermissionsExt;
+
+        if std::env::var_os(REQUEST_LOG_ACL_LIFECYCLE_CHILD).is_none() {
+            return;
+        }
+
+        let state_dir = Paths::state_dir();
+        std::fs::create_dir_all(&state_dir).unwrap();
+        std::fs::set_permissions(&state_dir, std::fs::Permissions::from_mode(0o700)).unwrap();
+        add_extended_acl(
+            &state_dir,
+            "everyone allow list,search,file_inherit,directory_inherit",
+        );
+
+        let logs_dir = state_dir.join("logs");
+        std::fs::create_dir(&logs_dir).unwrap();
+        std::fs::set_permissions(&logs_dir, std::fs::Permissions::from_mode(0o700)).unwrap();
+        add_extended_acl(
+            &logs_dir,
+            "everyone allow list,search,file_inherit,directory_inherit",
+        );
+
+        let accessible_path = logs_dir.join("llm_request.7.jsonl");
+        std::fs::write(&accessible_path, b"accessible retained log").unwrap();
+        std::fs::set_permissions(&accessible_path, std::fs::Permissions::from_mode(0o644)).unwrap();
+        add_extended_acl(&accessible_path, "everyone allow read");
+
+        let inaccessible_path = logs_dir.join("llm_request.8.jsonl");
+        let mut inaccessible = std::fs::File::create(&inaccessible_path).unwrap();
+        inaccessible
+            .write_all(b"inaccessible retained log")
+            .unwrap();
+        inaccessible
+            .set_permissions(std::fs::Permissions::from_mode(0o066))
+            .unwrap();
+        remove_extended_acl(&inaccessible_path);
+        add_extended_acl(&inaccessible_path, "everyone allow readsecurity");
+
+        assert!(descriptor_has_extended_acl(
+            &std::fs::File::open(&state_dir).unwrap()
+        ));
+        assert!(descriptor_has_extended_acl(
+            &std::fs::File::open(&logs_dir).unwrap()
+        ));
+        assert!(descriptor_has_extended_acl(
+            &std::fs::File::open(&accessible_path).unwrap()
+        ));
+        assert!(descriptor_has_extended_acl(&inaccessible));
+        drop(inaccessible);
+        assert!(std::fs::File::open(&inaccessible_path).is_err());
+        assert!(std::fs::OpenOptions::new()
+            .write(true)
+            .open(&inaccessible_path)
+            .is_err());
+
+        let log = RequestLog::new(2).unwrap();
+
+        for directory in [&state_dir, &logs_dir] {
+            let file = std::fs::File::open(directory).unwrap();
+            assert!(!descriptor_has_extended_acl(&file));
+            assert_eq!(
+                file.metadata().unwrap().permissions().mode() & 0o7777,
+                0o700
+            );
+        }
+        for (path, expected) in [
+            (&accessible_path, "accessible retained log"),
+            (&inaccessible_path, "inaccessible retained log"),
+        ] {
+            let file = std::fs::File::open(path).unwrap();
+            assert!(!descriptor_has_extended_acl(&file));
+            assert_eq!(
+                file.metadata().unwrap().permissions().mode() & 0o7777,
+                0o600
+            );
+            assert_eq!(std::fs::read_to_string(path).unwrap(), expected);
+        }
+
+        add_extended_acl(&logs_dir, "everyone allow read,file_inherit");
+        assert!(descriptor_has_extended_acl(
+            &std::fs::File::open(&logs_dir).unwrap()
+        ));
+
+        let mut handle = log.start().unwrap();
+        let active_path = std::fs::read_dir(&logs_dir)
+            .unwrap()
+            .map(|entry| entry.unwrap().path())
+            .find(|path| {
+                path.file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| {
+                        name.starts_with("llm_request.")
+                            && name != "llm_request.7.jsonl"
+                            && name != "llm_request.8.jsonl"
+                    })
+            })
+            .unwrap();
+        let active = std::fs::File::open(&active_path).unwrap();
+        assert!(!descriptor_has_extended_acl(&active));
+        assert_eq!(
+            active.metadata().unwrap().permissions().mode() & 0o7777,
+            0o600
+        );
+
+        handle.write("new request and response").unwrap();
+        drop(handle);
+
+        let rotated_path = logs_dir.join("llm_request.0.jsonl");
+        let rotated = std::fs::File::open(&rotated_path).unwrap();
+        assert!(!descriptor_has_extended_acl(&rotated));
+        assert_eq!(
+            rotated.metadata().unwrap().permissions().mode() & 0o7777,
+            0o600
+        );
+        assert_eq!(
+            std::fs::read_to_string(rotated_path).unwrap(),
+            "new request and response\n"
         );
     }
 

--- a/crates/goose/src/providers/utils.rs
+++ b/crates/goose/src/providers/utils.rs
@@ -349,26 +349,34 @@ fn create_and_restrict_request_log_state_directory(
     // SAFETY: openat returned a new owned descriptor.
     let state_directory = unsafe { std::fs::File::from_raw_fd(state_fd) };
     let metadata = state_directory.metadata()?;
-    if !metadata.is_dir() || metadata.uid() != current_effective_uid() {
+    let current_uid = current_effective_uid();
+    let should_restrict = request_log_state_directory_needs_restriction(
+        metadata.uid(),
+        metadata.permissions().mode(),
+        current_uid,
+    );
+    if !metadata.is_dir() || should_restrict.is_none() {
         return Err(Error::new(
             ErrorKind::PermissionDenied,
-            "request log state directory is not owned by the current user",
+            "request log state directory ownership or permissions are not trusted",
         )
         .into());
     }
 
-    let current_directory = CString::new(".").unwrap();
-    // SAFETY: resolving `.` relative to the retained state descriptor binds chmod to it.
-    if unsafe {
-        libc::fchmodat(
-            state_directory.as_raw_fd(),
-            current_directory.as_ptr(),
-            0o700,
-            0,
-        )
-    } < 0
-    {
-        return Err(Error::last_os_error().into());
+    if should_restrict == Some(true) {
+        let current_directory = CString::new(".").unwrap();
+        // SAFETY: resolving `.` relative to the retained state descriptor binds chmod to it.
+        if unsafe {
+            libc::fchmodat(
+                state_directory.as_raw_fd(),
+                current_directory.as_ptr(),
+                0o700,
+                0,
+            )
+        } < 0
+        {
+            return Err(Error::last_os_error().into());
+        }
     }
 
     // SAFETY: libc::stat is initialized before fstatat writes it.
@@ -383,7 +391,11 @@ fn create_and_restrict_request_log_state_directory(
         || metadata.dev() != current.st_dev as u64
         || metadata.ino() != current.st_ino as u64
         || !updated.is_dir()
-        || updated.uid() != current_effective_uid()
+        || request_log_state_directory_needs_restriction(
+            updated.uid(),
+            updated.permissions().mode(),
+            current_uid,
+        ) != should_restrict
     {
         return Err(Error::new(
             ErrorKind::PermissionDenied,
@@ -393,6 +405,21 @@ fn create_and_restrict_request_log_state_directory(
     }
 
     Ok(state_directory)
+}
+
+#[cfg(unix)]
+fn request_log_state_directory_needs_restriction(
+    owner_uid: libc::uid_t,
+    mode: u32,
+    effective_uid: libc::uid_t,
+) -> Option<bool> {
+    if owner_uid == effective_uid {
+        Some(true)
+    } else if owner_uid == 0 && mode & 0o022 == 0 {
+        Some(false)
+    } else {
+        None
+    }
 }
 
 #[cfg(unix)]
@@ -889,7 +916,7 @@ fn restrict_existing_request_log_with_hook(
         Err(error) => return Err(error.into()),
     };
     let metadata = file.metadata()?;
-    if metadata.is_file() && metadata.uid() == current_effective_uid() {
+    if metadata.is_file() && metadata.uid() == current_effective_uid() && metadata.nlink() == 1 {
         after_metadata();
         file.set_permissions(std::fs::Permissions::from_mode(0o600))?;
         let current = match request_log_entry_metadata(logs_directory, file_name) {
@@ -935,6 +962,7 @@ fn restrict_inaccessible_request_log_with_hook(
 
     if metadata.st_mode & libc::S_IFMT != libc::S_IFREG
         || metadata.st_uid != current_effective_uid()
+        || metadata.st_nlink != 1
     {
         return Ok(RestrictionOutcome::Complete);
     }
@@ -1422,6 +1450,65 @@ mod tests {
 
     #[test]
     #[cfg(unix)]
+    fn request_log_permission_upgrade_skips_accessible_hard_links() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = tempfile::tempdir().unwrap();
+        let outside = root.path().join("shared-output");
+        let alias = root.path().join("llm_request.14.jsonl");
+        std::fs::write(&outside, "unrelated application data").unwrap();
+        std::fs::set_permissions(&outside, std::fs::Permissions::from_mode(0o644)).unwrap();
+        std::fs::hard_link(&outside, &alias).unwrap();
+        let directory = open_search_only_directory(root.path()).unwrap();
+
+        restrict_existing_request_logs(&directory).unwrap();
+
+        assert_eq!(
+            std::fs::metadata(&outside).unwrap().permissions().mode() & 0o777,
+            0o644
+        );
+        assert_eq!(
+            std::fs::metadata(&alias).unwrap().permissions().mode() & 0o777,
+            0o644
+        );
+        assert_eq!(
+            std::fs::read_to_string(&outside).unwrap(),
+            "unrelated application data"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn request_log_permission_upgrade_skips_inaccessible_hard_links() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = tempfile::tempdir().unwrap();
+        let outside = root.path().join("shared-output");
+        let alias = root.path().join("llm_request.15.jsonl");
+        std::fs::write(&outside, "unrelated application data").unwrap();
+        std::fs::hard_link(&outside, &alias).unwrap();
+        std::fs::set_permissions(&outside, std::fs::Permissions::from_mode(0o066)).unwrap();
+        let directory = open_search_only_directory(root.path()).unwrap();
+
+        restrict_existing_request_logs(&directory).unwrap();
+
+        assert_eq!(
+            std::fs::metadata(&outside).unwrap().permissions().mode() & 0o777,
+            0o066
+        );
+        assert_eq!(
+            std::fs::metadata(&alias).unwrap().permissions().mode() & 0o777,
+            0o066
+        );
+        std::fs::set_permissions(&outside, std::fs::Permissions::from_mode(0o600)).unwrap();
+        assert_eq!(
+            std::fs::read_to_string(&outside).unwrap(),
+            "unrelated application data"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
     fn request_log_directory_repair_is_bound_to_opened_directory() {
         use std::os::unix::fs::{symlink, PermissionsExt};
 
@@ -1498,6 +1585,37 @@ mod tests {
         assert_eq!(
             std::fs::metadata(state_dir).unwrap().permissions().mode() & 0o777,
             0o700
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn request_log_state_directory_ownership_policy() {
+        let user_uid = 501;
+
+        assert_eq!(
+            request_log_state_directory_needs_restriction(user_uid, 0o777, user_uid),
+            Some(true)
+        );
+        assert_eq!(
+            request_log_state_directory_needs_restriction(0, 0o755, user_uid),
+            Some(false)
+        );
+        assert_eq!(
+            request_log_state_directory_needs_restriction(0, 0o711, user_uid),
+            Some(false)
+        );
+        assert_eq!(
+            request_log_state_directory_needs_restriction(0, 0o775, user_uid),
+            None
+        );
+        assert_eq!(
+            request_log_state_directory_needs_restriction(0, 0o777, user_uid),
+            None
+        );
+        assert_eq!(
+            request_log_state_directory_needs_restriction(502, 0o700, user_uid),
+            None
         );
     }
 

--- a/crates/goose/src/providers/utils.rs
+++ b/crates/goose/src/providers/utils.rs
@@ -327,11 +327,14 @@ fn create_and_restrict_request_log_state_directory_with_hook(
             )
             .into());
         }
-        let parent_mode = parent_metadata.permissions().mode();
-        if parent_mode & 0o022 != 0 && parent_mode & 0o1000 == 0 {
+        if !request_log_state_symlink_parent_is_trusted(
+            parent_metadata.uid(),
+            parent_metadata.permissions().mode(),
+            current_effective_uid(),
+        ) {
             return Err(Error::new(
                 ErrorKind::PermissionDenied,
-                "request log state directory symlink is replaceable by another user",
+                "request log state directory symlink parent is not trusted",
             )
             .into());
         }
@@ -439,6 +442,16 @@ fn request_log_state_directory_needs_restriction(
     } else {
         None
     }
+}
+
+#[cfg(unix)]
+fn request_log_state_symlink_parent_is_trusted(
+    owner_uid: libc::uid_t,
+    mode: u32,
+    effective_uid: libc::uid_t,
+) -> bool {
+    request_log_directory_link_owner_is_trusted(owner_uid, effective_uid)
+        && (mode & 0o022 == 0 || mode & 0o1000 != 0)
 }
 
 #[cfg(unix)]
@@ -1663,6 +1676,53 @@ mod tests {
             request_log_state_directory_needs_restriction(502, 0o700, user_uid),
             None
         );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn request_log_state_symlink_parent_policy() {
+        let user_uid = 501;
+
+        for owner_uid in [user_uid, 0] {
+            assert!(request_log_state_symlink_parent_is_trusted(
+                owner_uid, 0o755, user_uid
+            ));
+            assert!(request_log_state_symlink_parent_is_trusted(
+                owner_uid, 0o1777, user_uid
+            ));
+            assert!(!request_log_state_symlink_parent_is_trusted(
+                owner_uid, 0o777, user_uid
+            ));
+        }
+        for mode in [0o555, 0o755, 0o1777] {
+            assert!(!request_log_state_symlink_parent_is_trusted(
+                502, mode, user_uid
+            ));
+        }
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn request_log_state_directory_symlink_in_user_parent_is_supported() {
+        use std::os::unix::fs::{symlink, PermissionsExt};
+
+        let root = tempfile::tempdir().unwrap();
+        let target = root.path().join("state-target");
+        let state_dir = root.path().join("state");
+        std::fs::create_dir(&target).unwrap();
+        std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o377)).unwrap();
+        symlink(&target, &state_dir).unwrap();
+
+        create_and_restrict_request_log_state_directory(&state_dir).unwrap();
+
+        assert_eq!(
+            std::fs::metadata(&target).unwrap().permissions().mode() & 0o777,
+            0o700
+        );
+        assert!(std::fs::symlink_metadata(&state_dir)
+            .unwrap()
+            .file_type()
+            .is_symlink());
     }
 
     #[test]

--- a/crates/goose/src/providers/utils.rs
+++ b/crates/goose/src/providers/utils.rs
@@ -231,6 +231,7 @@ pub struct RequestLog {
 impl RequestLog {
     pub fn new(logs_to_keep: usize) -> Result<Self> {
         let state_dir = Paths::state_dir();
+        #[cfg(not(unix))]
         let logs_dir = Paths::in_state_dir("logs");
         let state_parent = state_dir
             .parent()
@@ -240,7 +241,7 @@ impl RequestLog {
         let logs_directory = {
             let state_directory = create_and_restrict_request_log_state_directory(&state_dir)?;
             let logs_directory = create_and_restrict_request_log_logs_directory(&state_directory)?;
-            restrict_existing_request_logs(&logs_dir)?;
+            restrict_existing_request_logs(&logs_directory)?;
             logs_directory
         };
         #[cfg(not(unix))]
@@ -733,26 +734,19 @@ fn restrict_request_log_directory_with_hook(
 }
 
 #[cfg(unix)]
-fn restrict_existing_request_logs(logs_dir: &std::path::Path) -> Result<()> {
-    restrict_existing_request_logs_with(logs_dir, restrict_existing_request_log)
+fn restrict_existing_request_logs(logs_directory: &std::fs::File) -> Result<()> {
+    restrict_existing_request_logs_with(logs_directory, restrict_existing_request_log)
 }
 
 #[cfg(unix)]
 fn restrict_existing_request_logs_with(
-    logs_dir: &std::path::Path,
-    mut restrict: impl FnMut(&std::path::Path) -> Result<RestrictionOutcome>,
+    logs_directory: &std::fs::File,
+    mut restrict: impl FnMut(&std::fs::File, &std::ffi::CStr) -> Result<RestrictionOutcome>,
 ) -> Result<()> {
     for _ in 0..3 {
         let mut retry = false;
-        for entry in fs_err::read_dir(logs_dir)? {
-            let entry = entry?;
-            let file_name = entry.file_name();
-            let Some(file_name) = file_name.to_str() else {
-                continue;
-            };
-            if is_request_log_file_name(file_name)
-                && restrict(&entry.path())? == RestrictionOutcome::Retry
-            {
+        for file_name in request_log_file_names(logs_directory)? {
+            if restrict(logs_directory, &file_name)? == RestrictionOutcome::Retry {
                 retry = true;
             }
         }
@@ -766,6 +760,45 @@ fn restrict_existing_request_logs_with(
     ))
 }
 
+#[cfg(all(unix, not(any(target_os = "espidf", target_os = "redox"))))]
+fn request_log_file_names(logs_directory: &std::fs::File) -> Result<Vec<std::ffi::CString>> {
+    use std::ffi::CString;
+    use std::io::Error;
+    use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+
+    let current_directory = c".";
+    // SAFETY: the name pointer is valid for the synchronous call and the retained logs fd is open.
+    let fd = unsafe {
+        libc::openat(
+            logs_directory.as_raw_fd(),
+            current_directory.as_ptr(),
+            libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC,
+        )
+    };
+    if fd < 0 {
+        return Err(Error::last_os_error().into());
+    }
+    // SAFETY: openat returned a new owned descriptor.
+    let directory = rustix::fs::Dir::new(unsafe { OwnedFd::from_raw_fd(fd) })?;
+    let mut file_names = Vec::new();
+    for entry in directory {
+        let entry = entry?;
+        if is_request_log_file_name(entry.file_name()) {
+            file_names.push(CString::from(entry.file_name()));
+        }
+    }
+    Ok(file_names)
+}
+
+#[cfg(any(target_os = "espidf", target_os = "redox"))]
+fn request_log_file_names(_logs_directory: &std::fs::File) -> Result<Vec<std::ffi::CString>> {
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "request log directory enumeration is unavailable on this target",
+    )
+    .into())
+}
+
 #[cfg(unix)]
 #[derive(PartialEq)]
 enum RestrictionOutcome {
@@ -774,22 +807,39 @@ enum RestrictionOutcome {
 }
 
 #[cfg(unix)]
-fn restrict_existing_request_log(path: &std::path::Path) -> Result<RestrictionOutcome> {
-    restrict_existing_request_log_with_hook(path, || {})
+fn restrict_existing_request_log(
+    logs_directory: &std::fs::File,
+    file_name: &std::ffi::CStr,
+) -> Result<RestrictionOutcome> {
+    restrict_existing_request_log_with_hook(logs_directory, file_name, || {})
 }
 
 #[cfg(unix)]
 fn restrict_existing_request_log_with_hook(
-    path: &std::path::Path,
+    logs_directory: &std::fs::File,
+    file_name: &std::ffi::CStr,
     after_metadata: impl FnOnce(),
 ) -> Result<RestrictionOutcome> {
     use std::io::ErrorKind;
-    use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
+    use std::os::fd::{AsRawFd, FromRawFd};
+    use std::os::unix::fs::{MetadataExt, PermissionsExt};
 
     let flags = libc::O_NONBLOCK | libc::O_NOFOLLOW | libc::O_CLOEXEC;
-    let mut read_options = std::fs::OpenOptions::new();
-    read_options.read(true).custom_flags(flags);
-    let file = match read_options.open(path) {
+    // SAFETY: the name pointer is valid for the synchronous call and the retained logs fd is open.
+    let read_fd = unsafe {
+        libc::openat(
+            logs_directory.as_raw_fd(),
+            file_name.as_ptr(),
+            libc::O_RDONLY | flags,
+        )
+    };
+    let read_result = if read_fd < 0 {
+        Err(std::io::Error::last_os_error())
+    } else {
+        // SAFETY: openat returned a new owned descriptor.
+        Ok(unsafe { std::fs::File::from_raw_fd(read_fd) })
+    };
+    let file = match read_result {
         Ok(file) => file,
         Err(error) if error.kind() == ErrorKind::NotFound => return Ok(RestrictionOutcome::Retry),
         Err(error)
@@ -800,9 +850,21 @@ fn restrict_existing_request_log_with_hook(
             return Ok(RestrictionOutcome::Complete)
         }
         Err(error) if error.kind() == ErrorKind::PermissionDenied => {
-            let mut write_options = std::fs::OpenOptions::new();
-            write_options.write(true).custom_flags(flags);
-            match write_options.open(path) {
+            // SAFETY: the name pointer is valid for the synchronous call and the retained logs fd is open.
+            let write_fd = unsafe {
+                libc::openat(
+                    logs_directory.as_raw_fd(),
+                    file_name.as_ptr(),
+                    libc::O_WRONLY | flags,
+                )
+            };
+            let write_result = if write_fd < 0 {
+                Err(std::io::Error::last_os_error())
+            } else {
+                // SAFETY: openat returned a new owned descriptor.
+                Ok(unsafe { std::fs::File::from_raw_fd(write_fd) })
+            };
+            match write_result {
                 Ok(file) => file,
                 Err(error) if error.kind() == ErrorKind::NotFound => {
                     return Ok(RestrictionOutcome::Retry)
@@ -819,7 +881,7 @@ fn restrict_existing_request_log_with_hook(
                         || error.raw_os_error() == Some(libc::EISDIR)
                         || error.raw_os_error() == Some(libc::ENXIO) =>
                 {
-                    return restrict_inaccessible_request_log(path);
+                    return restrict_inaccessible_request_log(logs_directory, file_name);
                 }
                 Err(error) => return Err(error.into()),
             }
@@ -830,14 +892,14 @@ fn restrict_existing_request_log_with_hook(
     if metadata.is_file() && metadata.uid() == current_effective_uid() {
         after_metadata();
         file.set_permissions(std::fs::Permissions::from_mode(0o600))?;
-        let current = match std::fs::symlink_metadata(path) {
+        let current = match request_log_entry_metadata(logs_directory, file_name) {
             Ok(metadata) => metadata,
             Err(error) if error.kind() == ErrorKind::NotFound => {
                 return Ok(RestrictionOutcome::Retry)
             }
             Err(error) => return Err(error.into()),
         };
-        if metadata.dev() != current.dev() || metadata.ino() != current.ino() {
+        if metadata.dev() != current.st_dev as u64 || metadata.ino() != current.st_ino as u64 {
             return Ok(RestrictionOutcome::Retry);
         }
     }
@@ -846,53 +908,29 @@ fn restrict_existing_request_log_with_hook(
 }
 
 #[cfg(unix)]
-fn restrict_inaccessible_request_log(path: &std::path::Path) -> Result<RestrictionOutcome> {
-    restrict_inaccessible_request_log_with_hook(path, || {})
+fn restrict_inaccessible_request_log(
+    logs_directory: &std::fs::File,
+    file_name: &std::ffi::CStr,
+) -> Result<RestrictionOutcome> {
+    restrict_inaccessible_request_log_with_hook(logs_directory, file_name, || {})
 }
 
 #[cfg(unix)]
 fn restrict_inaccessible_request_log_with_hook(
-    path: &std::path::Path,
+    logs_directory: &std::fs::File,
+    file_name: &std::ffi::CStr,
     after_metadata: impl FnOnce(),
 ) -> Result<RestrictionOutcome> {
-    use std::ffi::CString;
     use std::io::{Error, ErrorKind};
     use std::os::fd::AsRawFd;
-    use std::os::unix::ffi::OsStrExt;
 
-    let parent = path
-        .parent()
-        .ok_or_else(|| Error::new(ErrorKind::InvalidInput, "request log has no parent"))?;
-    let file_name = path
-        .file_name()
-        .ok_or_else(|| Error::new(ErrorKind::InvalidInput, "request log has no file name"))?;
-    let file_name = CString::new(file_name.as_bytes())
-        .map_err(|_| Error::new(ErrorKind::InvalidInput, "request log name contains NUL"))?;
-    let directory = std::fs::File::open(parent)?;
-
-    let metadata = {
-        // SAFETY: libc::stat is a plain C data structure initialized before fstatat writes it.
-        let mut metadata: libc::stat = unsafe { std::mem::zeroed() };
-        // SAFETY: pointers remain valid for the synchronous call and the directory fd is open.
-        let result = unsafe {
-            libc::fstatat(
-                directory.as_raw_fd(),
-                file_name.as_ptr(),
-                &mut metadata,
-                libc::AT_SYMLINK_NOFOLLOW,
-            )
-        };
-        if result < 0 {
-            let error = Error::last_os_error();
-            if error.kind() == ErrorKind::NotFound {
-                return Ok(RestrictionOutcome::Retry);
-            }
-            if error.raw_os_error() == Some(libc::ELOOP) {
-                return Ok(RestrictionOutcome::Complete);
-            }
-            return Err(error.into());
+    let metadata = match request_log_entry_metadata(logs_directory, file_name) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(RestrictionOutcome::Retry),
+        Err(error) if error.raw_os_error() == Some(libc::ELOOP) => {
+            return Ok(RestrictionOutcome::Complete)
         }
-        metadata
+        Err(error) => return Err(error.into()),
     };
 
     if metadata.st_mode & libc::S_IFMT != libc::S_IFREG
@@ -909,7 +947,7 @@ fn restrict_inaccessible_request_log_with_hook(
     // SAFETY: fchmodat does not retain the name pointer and is anchored at the open directory.
     let result = unsafe {
         libc::fchmodat(
-            directory.as_raw_fd(),
+            logs_directory.as_raw_fd(),
             file_name.as_ptr(),
             0o600,
             chmod_flags,
@@ -923,28 +961,42 @@ fn restrict_inaccessible_request_log_with_hook(
         return Err(error.into());
     }
 
-    // SAFETY: pointers remain valid for the synchronous call and the directory fd is open.
-    let mut updated: libc::stat = unsafe { std::mem::zeroed() };
-    let result = unsafe {
-        libc::fstatat(
-            directory.as_raw_fd(),
-            file_name.as_ptr(),
-            &mut updated,
-            libc::AT_SYMLINK_NOFOLLOW,
-        )
-    };
-    if result < 0 {
-        let error = Error::last_os_error();
-        if error.kind() == ErrorKind::NotFound {
+    let updated = match request_log_entry_metadata(logs_directory, file_name) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == ErrorKind::NotFound => {
             return Ok(RestrictionOutcome::Retry);
         }
-        return Err(error.into());
-    }
+        Err(error) => return Err(error.into()),
+    };
     if metadata.st_dev != updated.st_dev || metadata.st_ino != updated.st_ino {
         return Ok(RestrictionOutcome::Retry);
     }
 
     Ok(RestrictionOutcome::Complete)
+}
+
+#[cfg(unix)]
+fn request_log_entry_metadata(
+    logs_directory: &std::fs::File,
+    file_name: &std::ffi::CStr,
+) -> std::io::Result<libc::stat> {
+    use std::os::fd::AsRawFd;
+
+    // SAFETY: libc::stat is initialized before fstatat writes it.
+    let mut metadata: libc::stat = unsafe { std::mem::zeroed() };
+    // SAFETY: pointers remain valid for the synchronous call and the retained logs fd is open.
+    if unsafe {
+        libc::fstatat(
+            logs_directory.as_raw_fd(),
+            file_name.as_ptr(),
+            &mut metadata,
+            libc::AT_SYMLINK_NOFOLLOW,
+        )
+    } < 0
+    {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(metadata)
 }
 
 #[cfg(unix)]
@@ -954,7 +1006,10 @@ fn current_effective_uid() -> libc::uid_t {
 }
 
 #[cfg(unix)]
-fn is_request_log_file_name(file_name: &str) -> bool {
+fn is_request_log_file_name(file_name: &std::ffi::CStr) -> bool {
+    let Ok(file_name) = file_name.to_str() else {
+        return false;
+    };
     let Some(identifier) = file_name
         .strip_prefix("llm_request.")
         .and_then(|name| name.strip_suffix(".jsonl"))
@@ -1233,10 +1288,10 @@ mod tests {
     #[test]
     #[cfg(unix)]
     fn request_log_file_name_matching_is_exact() {
-        assert!(is_request_log_file_name("llm_request.0.jsonl"));
-        assert!(is_request_log_file_name("llm_request.123.jsonl"));
+        assert!(is_request_log_file_name(c"llm_request.0.jsonl"));
+        assert!(is_request_log_file_name(c"llm_request.123.jsonl"));
         assert!(is_request_log_file_name(
-            "llm_request.550e8400-e29b-41d4-a716-446655440000.jsonl"
+            c"llm_request.550e8400-e29b-41d4-a716-446655440000.jsonl"
         ));
 
         for file_name in [
@@ -1247,7 +1302,8 @@ mod tests {
             "llm_request.0.jsonl.bak",
             "other.0.jsonl",
         ] {
-            assert!(!is_request_log_file_name(file_name), "{file_name}");
+            let file_name = std::ffi::CString::new(file_name).unwrap();
+            assert!(!is_request_log_file_name(&file_name));
         }
     }
 
@@ -1255,9 +1311,9 @@ mod tests {
     #[cfg(unix)]
     fn request_log_permission_upgrade_tolerates_vanished_entry() {
         let root = tempfile::tempdir().unwrap();
-        let vanished = root.path().join("llm_request.0.jsonl");
+        let directory = open_search_only_directory(root.path()).unwrap();
 
-        restrict_existing_request_log(&vanished).unwrap();
+        restrict_existing_request_log(&directory, c"llm_request.0.jsonl").unwrap();
     }
 
     #[test]
@@ -1273,15 +1329,17 @@ mod tests {
             std::fs::write(path, "legacy sensitive request").unwrap();
             std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o066)).unwrap();
         }
+        let directory = open_search_only_directory(root.path()).unwrap();
 
-        let outcome = restrict_inaccessible_request_log_with_hook(&original, || {
-            std::fs::rename(&original, &moved).unwrap();
-            std::fs::rename(&replacement, &original).unwrap();
-        })
-        .unwrap();
+        let outcome =
+            restrict_inaccessible_request_log_with_hook(&directory, c"llm_request.0.jsonl", || {
+                std::fs::rename(&original, &moved).unwrap();
+                std::fs::rename(&replacement, &original).unwrap();
+            })
+            .unwrap();
         assert!(outcome == RestrictionOutcome::Retry);
 
-        restrict_existing_request_logs(root.path()).unwrap();
+        restrict_existing_request_logs(&directory).unwrap();
         assert_owner_only(&original);
         assert_owner_only(&moved);
     }
@@ -1299,15 +1357,17 @@ mod tests {
             std::fs::write(path, "legacy sensitive request").unwrap();
             std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o644)).unwrap();
         }
+        let directory = open_search_only_directory(root.path()).unwrap();
 
-        let outcome = restrict_existing_request_log_with_hook(&original, || {
-            std::fs::rename(&original, &moved).unwrap();
-            std::fs::rename(&replacement, &original).unwrap();
-        })
-        .unwrap();
+        let outcome =
+            restrict_existing_request_log_with_hook(&directory, c"llm_request.0.jsonl", || {
+                std::fs::rename(&original, &moved).unwrap();
+                std::fs::rename(&replacement, &original).unwrap();
+            })
+            .unwrap();
         assert!(outcome == RestrictionOutcome::Retry);
 
-        restrict_existing_request_logs(root.path()).unwrap();
+        restrict_existing_request_logs(&directory).unwrap();
         assert_owner_only(&original);
         assert_owner_only(&moved);
     }
@@ -1317,13 +1377,47 @@ mod tests {
     fn request_log_permission_upgrade_reports_retry_exhaustion() {
         let root = tempfile::tempdir().unwrap();
         std::fs::write(root.path().join("llm_request.0.jsonl"), "sensitive request").unwrap();
+        let directory = open_search_only_directory(root.path()).unwrap();
 
         let error =
-            restrict_existing_request_logs_with(root.path(), |_| Ok(RestrictionOutcome::Retry))
+            restrict_existing_request_logs_with(&directory, |_, _| Ok(RestrictionOutcome::Retry))
                 .unwrap_err();
         assert!(error
             .to_string()
             .contains("request logs kept changing during permission restriction"));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn request_log_permission_upgrade_is_bound_to_opened_directory() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let parent = tempfile::tempdir().unwrap();
+        let logs_dir = parent.path().join("logs");
+        let moved_logs_dir = parent.path().join("moved-logs");
+        std::fs::create_dir(&logs_dir).unwrap();
+        let original = logs_dir.join("llm_request.0.jsonl");
+        std::fs::write(&original, "original sensitive request").unwrap();
+        std::fs::set_permissions(&original, std::fs::Permissions::from_mode(0o644)).unwrap();
+        let directory = open_search_only_directory(&logs_dir).unwrap();
+
+        std::fs::rename(&logs_dir, &moved_logs_dir).unwrap();
+        std::fs::create_dir(&logs_dir).unwrap();
+        let replacement = logs_dir.join("llm_request.1.jsonl");
+        std::fs::write(&replacement, "replacement request").unwrap();
+        std::fs::set_permissions(&replacement, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        restrict_existing_request_logs(&directory).unwrap();
+
+        assert_owner_only(&moved_logs_dir.join("llm_request.0.jsonl"));
+        assert_eq!(
+            std::fs::metadata(&replacement)
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o644
+        );
     }
 
     #[test]

--- a/crates/goose/src/providers/utils.rs
+++ b/crates/goose/src/providers/utils.rs
@@ -261,6 +261,14 @@ impl RequestLog {
 fn create_and_restrict_request_log_state_directory(
     state_dir: &std::path::Path,
 ) -> Result<std::fs::File> {
+    create_and_restrict_request_log_state_directory_with_hook(state_dir, || {})
+}
+
+#[cfg(unix)]
+fn create_and_restrict_request_log_state_directory_with_hook(
+    state_dir: &std::path::Path,
+    after_entry_metadata: impl FnOnce(),
+) -> Result<std::fs::File> {
     use std::ffi::CString;
     use std::io::{Error, ErrorKind};
     use std::os::fd::{AsRawFd, FromRawFd};
@@ -335,6 +343,8 @@ fn create_and_restrict_request_log_state_directory(
         .into());
     }
 
+    after_entry_metadata();
+
     let flags = directory_search_flags()
         | if entry_is_symlink {
             0
@@ -349,6 +359,15 @@ fn create_and_restrict_request_log_state_directory(
     // SAFETY: openat returned a new owned descriptor.
     let state_directory = unsafe { std::fs::File::from_raw_fd(state_fd) };
     let metadata = state_directory.metadata()?;
+    if !entry_is_symlink
+        && (metadata.dev() != entry.st_dev as u64 || metadata.ino() != entry.st_ino as u64)
+    {
+        return Err(Error::new(
+            ErrorKind::PermissionDenied,
+            "request log state directory changed before it was opened",
+        )
+        .into());
+    }
     let current_uid = current_effective_uid();
     let should_restrict = request_log_state_directory_needs_restriction(
         metadata.uid(),
@@ -1586,6 +1605,33 @@ mod tests {
             std::fs::metadata(state_dir).unwrap().permissions().mode() & 0o777,
             0o700
         );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn request_log_state_directory_replacement_before_open_is_rejected() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = tempfile::tempdir().unwrap();
+        let state_dir = root.path().join("state");
+        let moved_state_dir = root.path().join("moved-state");
+        let replacement = root.path().join("replacement");
+        std::fs::create_dir(&state_dir).unwrap();
+        std::fs::create_dir(&replacement).unwrap();
+        std::fs::set_permissions(&replacement, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let result = create_and_restrict_request_log_state_directory_with_hook(&state_dir, || {
+            std::fs::rename(&state_dir, &moved_state_dir).unwrap();
+            std::fs::rename(&replacement, &state_dir).unwrap();
+        });
+
+        assert!(result.is_err());
+        assert!(moved_state_dir.is_dir());
+        assert_eq!(
+            std::fs::metadata(&state_dir).unwrap().permissions().mode() & 0o777,
+            0o755
+        );
+        assert!(!state_dir.join("logs").exists());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- create provider request/response logs with owner-only access on Unix
- explicitly set each newly opened request log to `0600`, restoring owner access even under an owner-restrictive umask
- create, open, restrict, and verify the Goose state directory relative to one retained shared-parent descriptor without changing the parent
- repair the owner-owned state directory to `0700` before creating or following its `logs` entry
- repair the owner-owned logs directory to `0700` before scanning, even when owner read/list access is absent
- open restrictive directories with native traversal/search handles (`O_PATH`, `O_SEARCH`, or `O_EXEC`) across supported Unix targets
- support intentional directory symlink targets owned by the effective user or root and reject links owned by any other local account before following, chmodding, or scanning
- bind directory chmod to the retained validated descriptor by resolving `.` relative to it, without procfs
- retain the validated logs-directory descriptor and use it for legacy-log enumeration, permission repair, new log creation, deletion, and rotation so replacing the state path cannot redirect request logs
- restrict retained numbered and abandoned UUID request logs during Unix initialization
- update accessible files through nonblocking no-follow handles and tolerate concurrent rotation
- compare accessible legacy-log names with their opened descriptors after chmod and retry if concurrent rotation replaced the entry
- repair owner-owned legacy logs even when neither owner access bit is present
- verify ownership before chmod and skip matching entries owned by another account
- detect directory or file inode replacement and abort/rescan rather than trusting a changed entry
- report an error if concurrent rotation prevents the retained-log scan from stabilizing within its bounded retry budget
- skip unrelated files, directories, malformed names, symlinks, FIFOs, and Unix sockets
- preserve non-Unix behavior and rename-based rotation

Addresses https://github.com/project-loupe/audit-goose/issues/89.

## Security boundary

Provider logs may contain prompts, source/tool payloads, responses, and surfaced secrets. Their confidentiality must not depend on the ambient Unix umask, including upgrades whose state directory, logs directory, or retained files expose group/other access. The Goose state entry is created with `mkdirat`, classified without following, opened relative to the same retained shared-parent descriptor, chmodded through the bound child descriptor, and then compared with the anchored name; a shared XDG state directory is never chmodded. The validated logs-directory descriptor is retained for the lifetime of request logging, and legacy enumeration, permission repair, new log creation, deletion, and rotation are relative to that capability rather than a recomputed path. An intentional state symlink remains supported only when its parent prevents unrelated replacement, while ordinary Goose directories are safely created and opened even under writable non-sticky parents. Repair must not require owner read/list access, block on a special file, follow an untrusted or replacement symlink during chmod, mutate an unrelated or foreign-owned entry, silently exhaust a rotation retry budget, depend on procfs or a newer glibc `fchmodat` implementation, or disable tracing because a shared legacy directory contains an attacker-owned entry. Legitimate user-created and administrator-created symlinked state/log layouts remain supported because the link owner must be the effective user or root, the resolved directory must be user-owned, chmod applies to the resolved bound descriptor, and a changed entry is detected by device/inode comparison.

## Verification

- `cargo fmt` and `cargo fmt --check`
- `cargo test -p goose providers::utils::tests::request_log` (15 passed on macOS, including retained-directory enumeration and repair after pathname replacement, retained-directory operation after state-path replacement, accessible and inaccessible legacy-log replacement retries, anchored creation under writable non-sticky shared parents without parent-mode changes, retry-exhaustion reporting, trusted/foreign symlink identity, symlinked state/log targets, descriptor-bound swap, macOS socket skipping, and exact `0600` creation under umask `0600`)
- `cargo build -p goose`
- `cargo clippy -p goose --all-targets -- -D warnings`
- current-head GitHub CI provides the Linux compile/runtime gate; platform-specific constants are selected only on the owning libc targets
- `git diff --check`

_This finding was discovered by [Project Loupe](https://github.com/project-loupe/loupe)._
