### PR TITLE
fix(ui): raise chat input z-index so slash menu appears above loading indicator

### DIFF
--- a/ui/desktop/src/components/BaseChat.tsx
+++ b/ui/desktop/src/components/BaseChat.tsx
@@ -493,7 +493,7 @@ export default function BaseChat({
 
         <ChatInputCard
           className={cn(
-            'relative z-10 mx-4 mb-4',
+            'relative z-30 mx-4 mb-4',
             !disableAnimation && 'animate-[fadein_400ms_ease-in_forwards]'
           )}
         >


### PR DESCRIPTION
fixes : #11001

## Summary

When the agent is busy, the "goose is working on it" indicator (z-20) was painting over the / command flyout menu. The flyout sits inside ChatInputCard, which establishes a CSS stacking context at z-10, so the popover's z-50 was trapped inside that context and couldn't compete with the z-20 indicator in the parent.

Fix raises ChatInputCard from z-10 to z-30, putting its entire subtree (including the flyout) above the loading indicator.

### Testing
manual 

### Screenshots/Demos (for UX changes)

<img width="1387" height="674" alt="image" src="https://github.com/user-attachments/assets/4c4eeb4f-58ee-4858-8a0c-34afd6717204" />
