### PR TITLE
fix(ui): suppress extension loading toast when all extensions succeed

### DIFF
--- a/ui/desktop/src/utils/extensionErrorUtils.test.ts
+++ b/ui/desktop/src/utils/extensionErrorUtils.test.ts
@@ -5,6 +5,7 @@ vi.mock('../toasts', () => ({
   toastService: {
     error: vi.fn(),
     extensionLoading: vi.fn(),
+    dismiss: vi.fn(),
   },
 }));
 
@@ -21,11 +22,12 @@ describe('showExtensionLoadResults', () => {
     expect(toastService.extensionLoading).not.toHaveBeenCalled();
   });
 
-  it('shows nothing when all extensions succeed', () => {
+  it('dismisses stale toast when all extensions succeed', () => {
     showExtensionLoadResults([
       { name: 'ext-a', success: true },
       { name: 'ext-b', success: true },
     ]);
+    expect(toastService.dismiss).toHaveBeenCalledWith('extension-loading');
     expect(toastService.error).not.toHaveBeenCalled();
     expect(toastService.extensionLoading).not.toHaveBeenCalled();
   });

--- a/ui/desktop/src/utils/extensionErrorUtils.test.ts
+++ b/ui/desktop/src/utils/extensionErrorUtils.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { showExtensionLoadResults } from './extensionErrorUtils';
+
+vi.mock('../toasts', () => ({
+  toastService: {
+    error: vi.fn(),
+    extensionLoading: vi.fn(),
+  },
+}));
+
+import { toastService } from '../toasts';
+
+describe('showExtensionLoadResults', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows nothing when results are empty', () => {
+    showExtensionLoadResults([]);
+    expect(toastService.error).not.toHaveBeenCalled();
+    expect(toastService.extensionLoading).not.toHaveBeenCalled();
+  });
+
+  it('shows nothing when all extensions succeed', () => {
+    showExtensionLoadResults([
+      { name: 'ext-a', success: true },
+      { name: 'ext-b', success: true },
+    ]);
+    expect(toastService.error).not.toHaveBeenCalled();
+    expect(toastService.extensionLoading).not.toHaveBeenCalled();
+  });
+
+  it('shows individual error toast for a single failed extension', () => {
+    showExtensionLoadResults([{ name: 'ext-a', success: false, error: 'connection refused' }]);
+    expect(toastService.error).toHaveBeenCalledOnce();
+    expect(toastService.extensionLoading).not.toHaveBeenCalled();
+  });
+
+  it('shows grouped toast when multiple extensions load and at least one fails', () => {
+    showExtensionLoadResults([
+      { name: 'ext-a', success: true },
+      { name: 'ext-b', success: false, error: 'timeout' },
+    ]);
+    expect(toastService.extensionLoading).toHaveBeenCalledOnce();
+    expect(toastService.error).not.toHaveBeenCalled();
+  });
+});

--- a/ui/desktop/src/utils/extensionErrorUtils.ts
+++ b/ui/desktop/src/utils/extensionErrorUtils.ts
@@ -45,6 +45,7 @@ export function showExtensionLoadResults(results: ExtensionLoadResult[] | null |
   const failedExtensions = results.filter((r) => !r.success);
 
   if (failedExtensions.length === 0) {
+    toastService.dismiss('extension-loading');
     return;
   }
 

--- a/ui/desktop/src/utils/extensionErrorUtils.ts
+++ b/ui/desktop/src/utils/extensionErrorUtils.ts
@@ -44,6 +44,10 @@ export function showExtensionLoadResults(results: ExtensionLoadResult[] | null |
 
   const failedExtensions = results.filter((r) => !r.success);
 
+  if (failedExtensions.length === 0) {
+    return;
+  }
+
   if (results.length === 1 && failedExtensions.length === 1) {
     const failed = failedExtensions[0];
     const errorMsg = failed.error || 'Unknown error';


### PR DESCRIPTION
fixes : #10953

## Summary

Every launch the extension loading toast popped up even when every extension loaded fine, the only useful case for that notification is when something actually goes wrong.

Added an early return in showExtensionLoadResults when failedExtensions.length === 0 so the toast is skipped entirely on a clean load. Errors still show as before, individual toast for a single failure, grouped for multiple

### Testing
manual 
