### PR TITLE
Clear orphaned ACP prompt state after reconnect

### DIFF
--- a/ui/desktop/src/acp/__tests__/chatSessionStore.test.ts
+++ b/ui/desktop/src/acp/__tests__/chatSessionStore.test.ts
@@ -504,6 +504,24 @@ describe('acpChatSessionStore', () => {
     expect(snapshot.activeRunId).toBeNull();
   });
 
+  it('clears orphaned prompt attempts before replaying a session load', () => {
+    const currentSessionId = sessionId('session-1');
+
+    acpChatSessionActions.startPromptAttempt(currentSessionId, 'attempt-1');
+    const snapshot = acpChatSessionActions.startSessionLoad(currentSessionId);
+
+    expect(snapshot.activePromptAttemptId).toBeNull();
+    expect(snapshot.chatState).toBe(ChatState.LoadingConversation);
+
+    const finished = acpChatSessionActions.finishSessionLoad(
+      currentSessionId,
+      session(currentSessionId)
+    );
+
+    expect(finished.activePromptAttemptId).toBeNull();
+    expect(finished.chatState).toBe(ChatState.Idle);
+  });
+
   it('stores ACP tool notifications and clears them for a new prompt attempt', () => {
     const currentSessionId = sessionId('session-1');
 

--- a/ui/desktop/src/acp/__tests__/chatSessionStore.test.ts
+++ b/ui/desktop/src/acp/__tests__/chatSessionStore.test.ts
@@ -522,6 +522,16 @@ describe('acpChatSessionStore', () => {
     expect(finished.chatState).toBe(ChatState.Idle);
   });
 
+  it('preserves LoadingConversation when clearing orphaned prompt attempts', () => {
+    const currentSessionId = sessionId('session-1');
+
+    acpChatSessionActions.startSessionLoad(currentSessionId);
+    const snapshot = acpChatSessionActions.clearActivePromptAttempt(currentSessionId);
+
+    expect(snapshot?.activePromptAttemptId).toBeNull();
+    expect(snapshot?.chatState).toBe(ChatState.LoadingConversation);
+  });
+
   it('stores ACP tool notifications and clears them for a new prompt attempt', () => {
     const currentSessionId = sessionId('session-1');
 

--- a/ui/desktop/src/acp/chatSessionStore.ts
+++ b/ui/desktop/src/acp/chatSessionStore.ts
@@ -442,7 +442,11 @@ function createAcpChatSessionStoreInternal(): AcpChatSessionStoreInternal {
     entry.activeRunId = null;
     entry.pendingUserInputRequestIds.clear();
     discardPendingLocalSteerMessages(entry);
-    entry.chatState = ChatState.Idle;
+    // Preserve an in-flight session restore so a nested disconnect cannot mark the
+    // chat Idle while loadSessionFromServer is still replaying history.
+    if (entry.chatState !== ChatState.LoadingConversation) {
+      entry.chatState = ChatState.Idle;
+    }
     return notify(sessionId, entry);
   };
 

--- a/ui/desktop/src/acp/chatSessionStore.ts
+++ b/ui/desktop/src/acp/chatSessionStore.ts
@@ -233,6 +233,12 @@ function createAcpChatSessionStoreInternal(): AcpChatSessionStoreInternal {
     const entry = getOrCreateEntry(sessionId);
     entry.sessionLoadError = sessionLoadError;
     entry.progressMessage = undefined;
+    entry.activePromptAttemptId = null;
+    entry.activeRunId = null;
+    entry.pendingCancelPromptAttemptId = null;
+    entry.promptCancellationRestoreState = null;
+    entry.pendingUserInputRequestIds.clear();
+    discardPendingLocalSteerMessages(entry);
     entry.chatState = ChatState.Idle;
     return notify(sessionId, entry);
   };
@@ -674,6 +680,7 @@ function resetReplayState(entry: StoreEntry): void {
   entry.tokenState = { ...initialTokenState };
   entry.notifications = [];
   entry.progressMessage = undefined;
+  entry.activePromptAttemptId = null;
   entry.activeRunId = null;
   entry.pendingCancelPromptAttemptId = null;
   entry.promptCancellationRestoreState = null;

--- a/ui/desktop/src/components/ChatSessionsContainer.test.tsx
+++ b/ui/desktop/src/components/ChatSessionsContainer.test.tsx
@@ -3,6 +3,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import ChatSessionsContainer from './ChatSessionsContainer';
 import { subscribeToAcpRecovery } from '../acp/acpConnection';
 import { acpChatSessionController } from '../acp/chatSessionController';
+import { acpChatSessionActions } from '../acp/chatSessionStore';
+import { cancelAcpElicitationRequestsForSession } from '../acp/elicitationRequests';
+import { cancelAcpPermissionRequestsForSession } from '../acp/permissionRequests';
 
 vi.mock('react-router', () => ({
   useSearchParams: () => [new URLSearchParams('resumeSessionId=session-1')],
@@ -22,9 +25,49 @@ vi.mock('../acp/chatSessionController', () => ({
   },
 }));
 
+vi.mock('../acp/chatSessionStore', () => ({
+  acpChatSessionActions: {
+    clearActivePromptAttempt: vi.fn(),
+  },
+}));
+
+vi.mock('../acp/elicitationRequests', () => ({
+  cancelAcpElicitationRequestsForSession: vi.fn(),
+}));
+
+vi.mock('../acp/permissionRequests', () => ({
+  cancelAcpPermissionRequestsForSession: vi.fn(),
+}));
+
 describe('ChatSessionsContainer', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  it('clears in-flight prompt state while ACP is reconnecting', () => {
+    let onRecoveryChanged: ((recovering: boolean) => void) | undefined;
+    vi.mocked(subscribeToAcpRecovery).mockImplementation((listener) => {
+      onRecoveryChanged = listener;
+      return () => undefined;
+    });
+
+    render(
+      <ChatSessionsContainer
+        setChat={vi.fn()}
+        activeSessions={[{ sessionId: 'session-1' }, { sessionId: 'session-2' }]}
+      />
+    );
+
+    onRecoveryChanged?.(true);
+
+    expect(cancelAcpPermissionRequestsForSession).toHaveBeenCalledTimes(2);
+    expect(cancelAcpPermissionRequestsForSession).toHaveBeenCalledWith('session-1');
+    expect(cancelAcpPermissionRequestsForSession).toHaveBeenCalledWith('session-2');
+    expect(cancelAcpElicitationRequestsForSession).toHaveBeenCalledTimes(2);
+    expect(acpChatSessionActions.clearActivePromptAttempt).toHaveBeenCalledTimes(2);
+    expect(acpChatSessionActions.clearActivePromptAttempt).toHaveBeenCalledWith('session-1');
+    expect(acpChatSessionActions.clearActivePromptAttempt).toHaveBeenCalledWith('session-2');
+    expect(acpChatSessionController.restoreSession).not.toHaveBeenCalled();
   });
 
   it('restores active chat sessions after ACP reconnects', () => {

--- a/ui/desktop/src/components/ChatSessionsContainer.tsx
+++ b/ui/desktop/src/components/ChatSessionsContainer.tsx
@@ -5,6 +5,9 @@ import { ChatType } from '../types/chat';
 import { UserInput } from '../types/message';
 import { subscribeToAcpRecovery } from '../acp/acpConnection';
 import { acpChatSessionController } from '../acp/chatSessionController';
+import { acpChatSessionActions } from '../acp/chatSessionStore';
+import { cancelAcpElicitationRequestsForSession } from '../acp/elicitationRequests';
+import { cancelAcpPermissionRequestsForSession } from '../acp/permissionRequests';
 
 interface ChatSessionsContainerProps {
   setChat: (chat: ChatType) => void;
@@ -41,6 +44,11 @@ export default function ChatSessionsContainer({
   useEffect(() => {
     return subscribeToAcpRecovery((recovering) => {
       if (recovering) {
+        for (const sessionId of sessionIdsRef.current) {
+          cancelAcpPermissionRequestsForSession(sessionId);
+          cancelAcpElicitationRequestsForSession(sessionId);
+          acpChatSessionActions.clearActivePromptAttempt(sessionId);
+        }
         return;
       }
       for (const sessionId of sessionIdsRef.current) {


### PR DESCRIPTION
Issue: #11053 — filed for this PR per the contribution workflow in `AGENTS.md`; not yet triaged to **Ready**, so this PR is a proposal attached to it rather than agreed work.

Rebased onto `main`.

**Verification after rebase**
- Clean rebase, no conflicts.
- `pnpm run typecheck` (ui/desktop): the only errors are the 3 `SessionExportFormat` / `ExportSessionRequest_unstable` errors that clean `main` also produces — no new ones from this branch.
- Not re-run after rebase: the vitest suites listed in the test plan below.

---

## Summary
- After an ACP WebSocket drop, desktop reconnect restored sessions but left `activePromptAttemptId` set
- That forced chats back into permanent `Streaming` and blocked all input until Goose Desktop was restarted
- Clear in-flight prompt/permission/elicitation state when recovery starts, and reset orphaned prompt attempts before session replay

## Root cause
`resetReplayState()` cleared messages/run IDs but not `activePromptAttemptId`.
`finishSessionLoad()` then restored `chatState` to `Streaming` whenever that orphaned attempt id was still present.

## Local Goose logs
From `~/Library/Application Support/Goose/logs/main.old.log`:

```text
[2026-07-27 02:15:31.660] [error] Goose ACP server exited unexpectedly { code: null, signal: 'SIGTERM', windowIds: [ 1 ] }
[2026-08-01 11:03:41.375] [error] Goose ACP server exited unexpectedly { code: null, signal: 'SIGTERM', windowIds: [ 1 ] }
[2026-08-02 14:03:49.025] [error] Goose ACP server exited unexpectedly { code: null, signal: 'SIGTERM', windowIds: [ 3 ] }
```

From `~/.local/state/goose/logs/cli/2026-08-07/20260807_130940.log`:

```text
{"timestamp":"2026-08-07T11:09:40.283104Z","level":"INFO","fields":{"message":"Starting ACP server on https://127.0.0.1:57413"},"target":"goose_cli::cli"}
{"timestamp":"2026-08-07T11:09:40.907006Z","level":"INFO","fields":{"message":"Created new ACP agent"},"target":"goose::acp::server_factory"}
```

These confirm ACP backend lifecycle churn on this machine. Desktop already had reconnect, but orphaned `activePromptAttemptId` still left chats blocked after recovery.

## Test plan
- [x] `pnpm exec vitest run src/acp/__tests__/chatSessionStore.test.ts src/components/ChatSessionsContainer.test.tsx`
- [ ] Reproduce by dropping ACP mid-prompt and confirming chats become idle and accept input after reconnect
- [ ] Confirm multi-session restore still reloads after recovery completes

