### PR TITLE
feat(cli): load extensions from goose deeplinks

### DIFF
--- a/crates/goose-cli/src/cli.rs
+++ b/crates/goose-cli/src/cli.rs
@@ -35,6 +35,7 @@ use crate::session::{build_session, SessionBuilderConfig};
 use goose::agents::Container;
 use goose::session::session_manager::SessionType;
 use goose::session::SessionManager;
+use std::collections::BTreeMap;
 use std::io::Read;
 use std::path::PathBuf;
 const GOOSE_SERVER_SECRET_KEY_ENV: &str = "GOOSE_SERVER__SECRET_KEY";
@@ -169,6 +170,122 @@ fn parse_streamable_http_extension(input: &str) -> Result<StreamableHttpOptions,
     Ok(StreamableHttpOptions { url, timeout })
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub struct LinkedExtension {
+    pub name: String,
+    pub config: goose::config::ExtensionConfig,
+}
+
+fn required_deeplink_parameter(url: &url::Url, parameter: &str) -> Result<String, String> {
+    url.query_pairs()
+        .find(|(key, _)| key == parameter)
+        .map(|(_, value)| value.into_owned())
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| format!("missing required '{parameter}' parameter"))
+}
+
+fn parse_deeplink_key_values(
+    url: &url::Url,
+    parameter: &str,
+) -> Result<BTreeMap<String, String>, String> {
+    url.query_pairs()
+        .filter(|(key, _)| key == parameter)
+        .map(|(_, value)| {
+            let (key, value) = value
+                .split_once('=')
+                .ok_or_else(|| format!("'{parameter}' must use KEY=VALUE format"))?;
+            if key.trim().is_empty() {
+                return Err(format!("'{parameter}' must have a non-empty key"));
+            }
+            Ok((key.to_string(), value.to_string()))
+        })
+        .collect()
+}
+
+fn parse_deeplink_env_keys(url: &url::Url) -> Result<Vec<String>, String> {
+    let env_keys = parse_deeplink_key_values(url, "env")?;
+    let env_parameter_count = url.query_pairs().filter(|(key, _)| key == "env").count();
+    if env_keys.len() != env_parameter_count {
+        return Err("'env' parameters must not have duplicate keys".to_string());
+    }
+    Ok(env_keys.into_keys().collect())
+}
+
+fn parse_linked_extension(input: &str) -> Result<LinkedExtension, String> {
+    let url = url::Url::parse(input)
+        .map_err(|error| format!("invalid goose extension deeplink: {error}"))?;
+    if url.scheme() != "goose" || url.host_str() != Some("extension") {
+        return Err("expected a goose://extension deeplink".to_string());
+    }
+
+    let name = required_deeplink_parameter(&url, "name")?;
+    let description = url
+        .query_pairs()
+        .find(|(key, _)| key == "description")
+        .map(|(_, value)| value.into_owned())
+        .unwrap_or_default();
+    let timeout = url
+        .query_pairs()
+        .find(|(key, _)| key == "timeout")
+        .map(|(_, value)| {
+            value
+                .parse::<u64>()
+                .map_err(|_| "'timeout' must be an unsigned integer".to_string())
+        })
+        .transpose()?
+        .unwrap_or(goose::config::DEFAULT_EXTENSION_TIMEOUT);
+    let env_keys = parse_deeplink_env_keys(&url)?;
+
+    let extension_type = url
+        .query_pairs()
+        .find(|(key, _)| key == "type")
+        .map(|(_, value)| value.into_owned());
+    let config = match extension_type.as_deref() {
+        Some("streamable_http") => goose::config::ExtensionConfig::StreamableHttp {
+            name: name.clone(),
+            description,
+            uri: required_deeplink_parameter(&url, "url")?,
+            envs: goose::agents::extension::Envs::default(),
+            env_keys,
+            headers: parse_deeplink_key_values(&url, "header")?
+                .into_iter()
+                .collect(),
+            timeout: Some(timeout),
+            socket: None,
+            bundled: None,
+            available_tools: Vec::new(),
+        },
+        None | Some("stdio") => {
+            if url.query_pairs().any(|(key, _)| key == "url") {
+                return Err("'url' requires type=streamable_http".to_string());
+            }
+            let cmd = required_deeplink_parameter(&url, "cmd")?;
+            let args = url
+                .query_pairs()
+                .filter(|(key, _)| key == "arg")
+                .map(|(_, value)| value.into_owned())
+                .collect();
+            goose::config::ExtensionConfig::Stdio {
+                name: name.clone(),
+                description,
+                cmd,
+                args,
+                envs: goose::agents::extension::Envs::default(),
+                env_keys,
+                timeout: Some(timeout),
+                cwd: None,
+                bundled: None,
+                available_tools: Vec::new(),
+            }
+        }
+        Some(extension_type) => {
+            return Err(format!("unsupported extension type '{extension_type}'"));
+        }
+    };
+
+    Ok(LinkedExtension { name, config })
+}
+
 /// Extension configuration options shared between Session and Run commands
 #[derive(Args, Debug, Clone, Default)]
 pub struct ExtensionOptions {
@@ -190,6 +307,16 @@ pub struct ExtensionOptions {
         value_parser = parse_streamable_http_extension
     )]
     pub streamable_http_extensions: Vec<StreamableHttpOptions>,
+
+    #[arg(
+        long = "with-linked-extension",
+        value_name = "DEEPLINK",
+        help = "Add an extension from a goose deeplink (can be specified multiple times)",
+        long_help = "Add an extension for this session from a goose://extension deeplink. The deeplink name, description, command or URL, arguments, timeout, headers, and environment-variable names are preserved without installing it to your profile.",
+        action = clap::ArgAction::Append,
+        value_parser = parse_linked_extension
+    )]
+    pub linked_extensions: Vec<LinkedExtension>,
 
     #[arg(
         long = "with-builtin",
@@ -1685,6 +1812,7 @@ async fn handle_interactive_session(
         no_session: false,
         extensions: extension_opts.extensions,
         streamable_http_extensions: extension_opts.streamable_http_extensions,
+        linked_extensions: extension_opts.linked_extensions,
         builtins: extension_opts.builtins,
         no_profile: extension_opts.no_profile,
         recipe: None,
@@ -1900,6 +2028,7 @@ async fn handle_run_command(
         no_session: run_behavior.no_session,
         extensions: extension_opts.extensions,
         streamable_http_extensions: extension_opts.streamable_http_extensions,
+        linked_extensions: extension_opts.linked_extensions,
         builtins: extension_opts.builtins,
         no_profile: extension_opts.no_profile,
         recipe: recipe.clone(),
@@ -2190,6 +2319,7 @@ async fn handle_default_session() -> Result<()> {
         no_session: false,
         extensions: Vec::new(),
         streamable_http_extensions: Vec::new(),
+        linked_extensions: Vec::new(),
         builtins: Vec::new(),
         no_profile: false,
         recipe: None,
@@ -2383,6 +2513,106 @@ pub async fn cli() -> anyhow::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parses_stdio_linked_extension_with_display_name() {
+        let extension = parse_linked_extension(
+            "goose://extension?cmd=uvx&arg=mcp-server-fetch&id=fetch&name=Fetch%20Files&description=Fetch%20web%20content&timeout=42",
+        )
+        .unwrap();
+
+        assert_eq!(extension.name, "Fetch Files");
+        assert_eq!(
+            extension.config,
+            goose::config::ExtensionConfig::Stdio {
+                name: "Fetch Files".to_string(),
+                description: "Fetch web content".to_string(),
+                cmd: "uvx".to_string(),
+                args: vec!["mcp-server-fetch".to_string()],
+                envs: goose::agents::extension::Envs::default(),
+                env_keys: Vec::new(),
+                timeout: Some(42),
+                cwd: None,
+                bundled: None,
+                available_tools: Vec::new(),
+            }
+        );
+    }
+
+    #[test]
+    fn parses_streamable_http_linked_extension_with_headers_and_env_keys() {
+        let extension = parse_linked_extension(
+            "goose://extension?type=streamable_http&url=https%3A%2F%2Fmcp.example.com%2Fmcp&id=example&name=Example&description=Example%20server&timeout=120&header=Authorization%3DBearer%20token&env=API_TOKEN%3DAPI%20token",
+        )
+        .unwrap();
+
+        assert_eq!(extension.name, "Example");
+        assert_eq!(
+            extension.config,
+            goose::config::ExtensionConfig::StreamableHttp {
+                name: "Example".to_string(),
+                description: "Example server".to_string(),
+                uri: "https://mcp.example.com/mcp".to_string(),
+                envs: goose::agents::extension::Envs::default(),
+                env_keys: vec!["API_TOKEN".to_string()],
+                headers: [("Authorization".to_string(), "Bearer token".to_string())].into(),
+                timeout: Some(120),
+                socket: None,
+                bundled: None,
+                available_tools: Vec::new(),
+            }
+        );
+    }
+
+    #[test]
+    fn linked_extension_flag_is_repeatable_for_session_and_run() {
+        for args in [
+            vec![
+                "goose",
+                "session",
+                "--with-linked-extension",
+                "goose://extension?cmd=uvx&name=First",
+                "--with-linked-extension",
+                "goose://extension?type=streamable_http&url=https%3A%2F%2Fexample.com&name=Second",
+            ],
+            vec![
+                "goose",
+                "run",
+                "--with-linked-extension",
+                "goose://extension?cmd=uvx&name=First",
+                "--with-linked-extension",
+                "goose://extension?type=streamable_http&url=https%3A%2F%2Fexample.com&name=Second",
+                "--text",
+                "hello",
+            ],
+        ] {
+            let cli = Cli::try_parse_from(args).expect("parse failed");
+            let extension_opts = match cli.command.unwrap() {
+                Command::Session { extension_opts, .. } | Command::Run { extension_opts, .. } => {
+                    extension_opts
+                }
+                _ => unreachable!(),
+            };
+            assert_eq!(extension_opts.linked_extensions.len(), 2);
+        }
+    }
+
+    #[test]
+    fn rejects_invalid_linked_extension_deeplinks() {
+        for link in [
+            "https://extension?cmd=uvx&name=Fetch",
+            "goose://recipe?cmd=uvx&name=Fetch",
+            "goose://extension?cmd=uvx",
+            "goose://extension?type=sse&url=https%3A%2F%2Fexample.com&name=Example",
+            "goose://extension?url=https%3A%2F%2Fexample.com&name=Example",
+            "goose://extension?type=streamable_http&url=https%3A%2F%2Fexample.com&name=Example&timeout=fast",
+            "goose://extension?cmd=uvx&name=Fetch&env==missing-key",
+            "goose://extension?cmd=uvx&name=Fetch&env=TOKEN%3Done&env=TOKEN%3Dtwo",
+            "goose://extension?type=streamable_http&url=https%3A%2F%2Fexample.com&name=Example&header==missing-key",
+        ] {
+            assert!(parse_linked_extension(link).is_err(), "expected {link} to fail");
+        }
+    }
 
     #[test]
     fn completion_command_accepts_nushell_alias() {

--- a/crates/goose-cli/src/session/builder.rs
+++ b/crates/goose-cli/src/session/builder.rs
@@ -1,4 +1,4 @@
-use crate::cli::StreamableHttpOptions;
+use crate::cli::{LinkedExtension, StreamableHttpOptions};
 
 use super::output;
 use super::CliSession;
@@ -31,6 +31,7 @@ fn truncate_with_ellipsis(s: &str, max_len: usize) -> String {
 fn parse_cli_flag_extensions(
     extensions: &[String],
     streamable_http_extensions: &[StreamableHttpOptions],
+    linked_extensions: &[LinkedExtension],
     builtins: &[String],
 ) -> Vec<(String, ExtensionConfig)> {
     let mut extensions_to_load = Vec::new();
@@ -62,6 +63,10 @@ fn parse_cli_flag_extensions(
         extensions_to_load.push((label, config));
     }
 
+    for extension in linked_extensions {
+        extensions_to_load.push((extension.name.clone(), extension.config.clone()));
+    }
+
     for builtin_str in builtins {
         let configs = CliSession::parse_builtin_extensions(builtin_str);
         for config in configs {
@@ -90,6 +95,8 @@ pub struct SessionBuilderConfig {
     pub extensions: Vec<String>,
     /// List of streamable HTTP extension commands to add
     pub streamable_http_extensions: Vec<StreamableHttpOptions>,
+    /// List of extension configs parsed from goose deeplinks to add
+    pub linked_extensions: Vec<LinkedExtension>,
     /// List of builtin extension commands to add
     pub builtins: Vec<String>,
     pub no_profile: bool,
@@ -132,6 +139,7 @@ impl Default for SessionBuilderConfig {
             no_session: false,
             extensions: Vec::new(),
             streamable_http_extensions: Vec::new(),
+            linked_extensions: Vec::new(),
             builtins: Vec::new(),
             no_profile: false,
             recipe: None,
@@ -434,6 +442,7 @@ async fn collect_extension_configs(
     let cli_flag_extensions = parse_cli_flag_extensions(
         &session_config.extensions,
         &session_config.streamable_http_extensions,
+        &session_config.linked_extensions,
         &session_config.builtins,
     );
 
@@ -713,6 +722,7 @@ mod tests {
                 url: "http://localhost:8080/mcp".to_string(),
                 timeout: goose::config::DEFAULT_EXTENSION_TIMEOUT,
             }],
+            linked_extensions: Vec::new(),
             builtins: vec!["developer".to_string()],
             no_profile: false,
             recipe: None,
@@ -732,6 +742,7 @@ mod tests {
 
         assert_eq!(config.extensions.len(), 1);
         assert_eq!(config.streamable_http_extensions.len(), 1);
+        assert!(config.linked_extensions.is_empty());
         assert_eq!(config.builtins.len(), 1);
         assert!(config.debug);
         assert_eq!(config.max_tool_repetitions, Some(5));
@@ -750,6 +761,7 @@ mod tests {
         assert!(!config.no_session);
         assert!(config.extensions.is_empty());
         assert!(config.streamable_http_extensions.is_empty());
+        assert!(config.linked_extensions.is_empty());
         assert!(config.builtins.is_empty());
         assert!(!config.no_profile);
         assert!(config.recipe.is_none());

--- a/documentation/docs/getting-started/using-extensions.md
+++ b/documentation/docs/getting-started/using-extensions.md
@@ -281,6 +281,8 @@ Required parameters:
 - `name`: Display name for the extension
 - `description`: Brief description of the extension's functionality
 
+Pass a deeplink to the CLI with [`--with-linked-extension`](#extensions-from-deeplinks) to use it for one session without installing it to your profile.
+
 A command like `npx -y @modelcontextprotocol/server-github` would be represented as:
 
 ```
@@ -301,6 +303,8 @@ Parameters:
 - `id`: Unique identifier for the extension
 - `name`: Display name for the extension
 - `description`: Brief description of the extension's functionality
+
+Pass a deeplink to the CLI with [`--with-linked-extension`](#extensions-from-deeplinks) to use it for one session without installing it to your profile.
 
 For example, a deeplink for a URL like `https://example.com/streamable` would look like this when URL-encoded:
 
@@ -669,6 +673,24 @@ For example, to start a session with a Streamable HTTP extension, you'd run:
 ```bash
 goose session --with-streamable-http-extension "https://example.com/streamable"
 ```
+
+### Extensions from Deeplinks
+
+Use `--with-linked-extension` to run an extension described by a `goose://extension` deeplink for the current session. This preserves the deeplink's display name, description, transport settings, and command or URL, so the model receives a meaningful extension name. It does not install or modify the extension in your goose profile.
+
+```bash
+goose session --with-linked-extension "goose://extension?cmd=uvx&arg=mcp-server-fetch&id=fetch&name=Fetch&description=Fetch%20web%20content"
+```
+
+The flag accepts both StandardIO and Streamable HTTP deeplinks and can be repeated:
+
+```bash
+goose session \
+  --with-linked-extension "goose://extension?cmd=uvx&arg=mcp-server-fetch&id=fetch&name=Fetch&description=Fetch%20web%20content" \
+  --with-linked-extension "goose://extension?type=streamable_http&url=https%3A%2F%2Fexample.com%2Fmcp&id=example&name=Example&description=Example%20remote%20tools"
+```
+
+Use shell quoting around the entire deeplink so `&` is not interpreted by your shell. Deeplinks that declare `env` parameters use the corresponding goose configuration keys; configure those values before starting the session.
 
 ### Extensions in Containers
 

--- a/documentation/docs/guides/goose-cli-commands.md
+++ b/documentation/docs/guides/goose-cli-commands.md
@@ -217,6 +217,7 @@ Start or resume interactive chat sessions.
 **Extension Options:**
 - **`--with-extension <command>`**: Add stdio extensions
 - **`--with-streamable-http-extension <url>`**: Add remote extensions over Streamable HTTP
+- **`--with-linked-extension <deeplink>`**: Add an extension from a `goose://extension` deeplink, preserving its name and configuration for the current session
 - **`--with-builtin <id>`**: Enable built-in extensions (e.g., 'developer', 'computercontroller')
 
 **Usage:**
@@ -246,6 +247,7 @@ goose session --resume --session-id 20251108_2 --fork --edit --history
 goose session --with-extension "npx -y @modelcontextprotocol/server-memory"
 goose session --with-builtin developer
 goose session --with-streamable-http-extension "http://localhost:8080/mcp"
+goose session --with-linked-extension "goose://extension?cmd=uvx&arg=mcp-server-fetch&id=fetch&name=Fetch&description=Fetch%20web%20content"
 
 # Advanced: Mix multiple extension types
 goose session \
@@ -421,6 +423,7 @@ Execute commands from an instruction file or stdin. Check out the [full guide](/
 **Extension Options:**
 - **`--with-extension <COMMAND>`**: Add stdio extensions (can be used multiple times)
 - **`--with-streamable-http-extension <URL>`**: Add remote extensions over Streamable HTTP (can be used multiple times)
+- **`--with-linked-extension <DEEPLINK>`**: Add an extension from a `goose://extension` deeplink without installing it to your profile (can be used multiple times)
 - **`--with-builtin <name>`**: Add builtin extensions by name (e.g., 'developer' or multiple: 'developer,github')
 
 **Control Options:**

--- a/documentation/docs/guides/running-tasks.md
+++ b/documentation/docs/guides/running-tasks.md
@@ -106,7 +106,7 @@ goose run --provider anthropic --model claude-4-sonnet -t "initial prompt"
 
 ### Working with Extensions
 
-If you want to ensure specific extensions are available when running your task, you can indicate this with arguments. This can be done using the `--with-extension`, `--with-remote-extension`, `--with-streamable-http-extension`, or `--with-builtin` flags:
+If you want to ensure specific extensions are available when running your task, you can indicate this with the `--with-extension`, `--with-streamable-http-extension`, `--with-linked-extension`, or `--with-builtin` flags:
 
 - Using built-in extensions e.g developer and computercontroller extensions
 
@@ -124,6 +124,14 @@ goose run --with-extension "ENV1=value1 custom-extension-args" -t "your instruct
 
 ```bash
 goose run --with-streamable-http-extension "https://example.com/streamable" -t "your instructions"
+```
+
+- Using an extension deeplink without installing it to your profile
+
+```bash
+goose run \
+  --with-linked-extension "goose://extension?cmd=uvx&arg=mcp-server-fetch&id=fetch&name=Fetch&description=Fetch%20web%20content" \
+  -t "your instructions"
 ```
 
 ### Debug Mode


### PR DESCRIPTION
## Summary

Adds `--with-linked-extension <DEEPLINK>` to `goose session` and `goose run`.

- Parses `goose://extension` deeplinks into ephemeral extension configuration.
- Preserves the provided extension name and description, command arguments or Streamable HTTP URL, timeout, headers, and environment-variable keys.
- Supports repeatable stdio and Streamable HTTP entries without writing them to the user's profile.
- Documents the new option in the extensions, CLI command, and task-running guides.

## Verification

- `cargo test -p goose-cli --lib --no-default-features --features rustls-tls`
- `cargo fmt --check`
- `cargo clippy -p goose-cli --all-targets --no-default-features --features rustls-tls -- -D warnings`
- Verified `goose session --help` and `goose run --help` expose the new option.

Documentation typecheck was not run because this environment has neither `pnpm` nor the documentation project's installed TypeScript dependencies.

## Notes

The project contribution workflow requires a Ready issue for external PRs. This was maintainer-directed work; local-only Beads issue `goose-xbd` tracks the implementation and was intentionally not pushed.
