### PR TITLE
feat: add Cursor ACP provider

### DIFF
--- a/crates/goose/src/providers/cursor_acp.rs
+++ b/crates/goose/src/providers/cursor_acp.rs
@@ -1,0 +1,89 @@
+use anyhow::Result;
+use futures::future::BoxFuture;
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use crate::acp::{
+    extension_configs_to_mcp_servers, AcpProvider, AcpProviderConfig, ACP_CURRENT_MODEL,
+};
+use crate::config::search_path::SearchPaths;
+use crate::config::{Config, GooseMode};
+use crate::model::ModelConfig;
+use crate::providers::acp_tooling::{acp_adapter_installed, acp_inventory_identity};
+use crate::providers::base::{ProviderDef, ProviderMetadata};
+use crate::providers::inventory::InventoryIdentityInput;
+
+const CURSOR_ACP_PROVIDER_NAME: &str = "cursor-acp";
+const CURSOR_ACP_DOC_URL: &str = "https://cursor.com/docs/cli/acp";
+const CURSOR_ACP_BINARY: &str = "cursor-agent";
+
+pub struct CursorAcpProvider;
+
+impl ProviderDef for CursorAcpProvider {
+    type Provider = AcpProvider;
+
+    fn metadata() -> ProviderMetadata {
+        ProviderMetadata::new(
+            CURSOR_ACP_PROVIDER_NAME,
+            "Cursor (ACP)",
+            "Use goose with your Cursor subscription via the cursor-agent ACP adapter.",
+            ACP_CURRENT_MODEL,
+            vec![],
+            CURSOR_ACP_DOC_URL,
+            vec![],
+        )
+        .with_setup_steps(vec![
+            "Install the Cursor agent CLI (download from https://cursor.com)",
+            "Ensure your Cursor CLI is authenticated (run `cursor-agent login` to verify)",
+            "Set in your goose config file (`~/.config/goose/config.yaml` on macOS/Linux):\n  GOOSE_PROVIDER: cursor-acp\n  GOOSE_MODEL: current",
+            "Restart goose for changes to take effect",
+        ])
+    }
+
+    fn from_env(
+        model: ModelConfig,
+        extensions: Vec<crate::config::ExtensionConfig>,
+    ) -> BoxFuture<'static, Result<AcpProvider>> {
+        Box::pin(async move {
+            let config = Config::global();
+            let resolved_command = SearchPaths::builder()
+                .with_npm()
+                .resolve(CURSOR_ACP_BINARY)?;
+            let goose_mode = config.get_goose_mode().unwrap_or(GooseMode::Auto);
+
+            let mode_mapping = HashMap::from([
+                (GooseMode::Auto, "full-auto".to_string()),
+                (GooseMode::Approve, "default".to_string()),
+                (GooseMode::SmartApprove, "auto-accept-edits".to_string()),
+                (GooseMode::Chat, "plan".to_string()),
+            ]);
+
+            let provider_config = AcpProviderConfig {
+                command: resolved_command,
+                args: vec!["acp".to_string()],
+                env: vec![],
+                env_remove: vec![],
+                work_dir: std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
+                mcp_servers: extension_configs_to_mcp_servers(&extensions),
+                session_mode_id: Some(mode_mapping[&goose_mode].clone()),
+                mode_mapping,
+                notification_callback: None,
+            };
+
+            let metadata = Self::metadata();
+            AcpProvider::connect(metadata.name, model, goose_mode, provider_config).await
+        })
+    }
+
+    fn supports_inventory_refresh() -> bool {
+        true
+    }
+
+    fn inventory_identity() -> Result<InventoryIdentityInput> {
+        acp_inventory_identity(CURSOR_ACP_PROVIDER_NAME, CURSOR_ACP_BINARY)
+    }
+
+    fn inventory_configured() -> bool {
+        acp_adapter_installed(CURSOR_ACP_BINARY)
+    }
+}

--- a/crates/goose/src/providers/cursor_acp.rs
+++ b/crates/goose/src/providers/cursor_acp.rs
@@ -8,20 +8,17 @@ use crate::acp::{
 };
 use crate::config::search_path::SearchPaths;
 use crate::config::{Config, GooseMode};
-use crate::model::ModelConfig;
-use crate::providers::acp_tooling::{acp_adapter_installed, acp_inventory_identity};
-use crate::providers::base::{ProviderDef, ProviderMetadata};
-use crate::providers::inventory::InventoryIdentityInput;
+use crate::providers::base::{
+    current_working_dir, ProviderDef, ProviderDescriptor, ProviderMetadata,
+};
 
-const CURSOR_ACP_PROVIDER_NAME: &str = "cursor-acp";
+pub(crate) const CURSOR_ACP_PROVIDER_NAME: &str = "cursor-acp";
 const CURSOR_ACP_DOC_URL: &str = "https://cursor.com/docs/cli/acp";
-const CURSOR_ACP_BINARY: &str = "cursor-agent";
+pub(crate) const CURSOR_ACP_BINARY: &str = "cursor-agent";
 
 pub struct CursorAcpProvider;
 
-impl ProviderDef for CursorAcpProvider {
-    type Provider = AcpProvider;
-
+impl goose_providers::base::ProviderDescriptor for CursorAcpProvider {
     fn metadata() -> ProviderMetadata {
         ProviderMetadata::new(
             CURSOR_ACP_PROVIDER_NAME,
@@ -35,14 +32,27 @@ impl ProviderDef for CursorAcpProvider {
         .with_setup_steps(vec![
             "Install the Cursor agent CLI (download from https://cursor.com)",
             "Ensure your Cursor CLI is authenticated (run `cursor-agent login` to verify)",
-            "Set in your goose config file (`~/.config/goose/config.yaml` on macOS/Linux):\n  GOOSE_PROVIDER: cursor-acp\n  GOOSE_MODEL: current",
+            "Add to your goose config file (`~/.config/goose/config.yaml` on macOS/Linux):\n  GOOSE_PROVIDER: cursor-acp\n  GOOSE_MODEL: current\n  cursor-acp_configured: true",
             "Restart goose for changes to take effect",
         ])
+        .with_model_selection_hint("Use the Cursor model picker or set GOOSE_MODEL explicitly")
     }
+}
+
+impl ProviderDef for CursorAcpProvider {
+    type Provider = AcpProvider;
 
     fn from_env(
-        model: ModelConfig,
         extensions: Vec<crate::config::ExtensionConfig>,
+        tls_config: Option<crate::providers::api_client::TlsConfig>,
+    ) -> BoxFuture<'static, Result<AcpProvider>> {
+        Self::from_env_with_working_dir(extensions, current_working_dir(), tls_config)
+    }
+
+    fn from_env_with_working_dir(
+        extensions: Vec<crate::config::ExtensionConfig>,
+        working_dir: PathBuf,
+        _tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> BoxFuture<'static, Result<AcpProvider>> {
         Box::pin(async move {
             let config = Config::global();
@@ -50,12 +60,21 @@ impl ProviderDef for CursorAcpProvider {
                 .with_npm()
                 .resolve(CURSOR_ACP_BINARY)?;
             let goose_mode = config.get_goose_mode().unwrap_or(GooseMode::Auto);
+            let model = config
+                .get_goose_model()
+                .unwrap_or_else(|_| ACP_CURRENT_MODEL.to_string());
+
+            let session_config_options = if model == ACP_CURRENT_MODEL {
+                vec![]
+            } else {
+                vec![("model".to_string(), model)]
+            };
 
             let mode_mapping = HashMap::from([
-                (GooseMode::Auto, "full-auto".to_string()),
-                (GooseMode::Approve, "default".to_string()),
-                (GooseMode::SmartApprove, "auto-accept-edits".to_string()),
-                (GooseMode::Chat, "plan".to_string()),
+                (GooseMode::Auto, vec!["agent".to_string()]),
+                (GooseMode::Approve, vec!["ask".to_string()]),
+                (GooseMode::SmartApprove, vec!["agent".to_string()]),
+                (GooseMode::Chat, vec!["plan".to_string()]),
             ]);
 
             let provider_config = AcpProviderConfig {
@@ -63,27 +82,17 @@ impl ProviderDef for CursorAcpProvider {
                 args: vec!["acp".to_string()],
                 env: vec![],
                 env_remove: vec![],
-                work_dir: std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
+                work_dir: working_dir,
                 mcp_servers: extension_configs_to_mcp_servers(&extensions),
-                session_mode_id: Some(mode_mapping[&goose_mode].clone()),
+                session_mode_id: mode_mapping[&goose_mode].first().cloned(),
+                session_config_options,
+                model_config_option_id: Some("model".to_string()),
                 mode_mapping,
                 notification_callback: None,
             };
 
             let metadata = Self::metadata();
-            AcpProvider::connect(metadata.name, model, goose_mode, provider_config).await
+            AcpProvider::connect(metadata.name, goose_mode, provider_config).await
         })
-    }
-
-    fn supports_inventory_refresh() -> bool {
-        true
-    }
-
-    fn inventory_identity() -> Result<InventoryIdentityInput> {
-        acp_inventory_identity(CURSOR_ACP_PROVIDER_NAME, CURSOR_ACP_BINARY)
-    }
-
-    fn inventory_configured() -> bool {
-        acp_adapter_installed(CURSOR_ACP_BINARY)
     }
 }

--- a/crates/goose/src/providers/init.rs
+++ b/crates/goose/src/providers/init.rs
@@ -18,6 +18,7 @@ use super::{
     codex::CodexProvider,
     codex_acp::CodexAcpProvider,
     copilot_acp::CopilotAcpProvider,
+    cursor_acp::CursorAcpProvider,
     cursor_agent::CursorAgentProvider,
     gcpvertexai::GcpVertexAIProvider,
     gemini_cli::GeminiCliProvider,
@@ -96,6 +97,10 @@ async fn init_registry() -> RwLock<ProviderRegistry> {
             Some(registrations::copilot_acp_inventory()),
         );
         registry.register::<CodexProvider>(true);
+        registry.register_with_inventory::<CursorAcpProvider>(
+            false,
+            Some(registrations::cursor_acp_inventory()),
+        );
         registry.register_with_inventory::<CursorAgentProvider>(
             false,
             Some(registrations::refresh_only()),

--- a/crates/goose/src/providers/inventory/registrations.rs
+++ b/crates/goose/src/providers/inventory/registrations.rs
@@ -259,6 +259,14 @@ pub fn pi_acp_inventory() -> InventoryRegistration {
     acp_inventory(PI_ACP_PROVIDER_NAME, PI_ACP_BINARY, false)
 }
 
+pub fn cursor_acp_inventory() -> InventoryRegistration {
+    acp_inventory(
+        crate::providers::cursor_acp::CURSOR_ACP_PROVIDER_NAME,
+        crate::providers::cursor_acp::CURSOR_ACP_BINARY,
+        true,
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/goose/src/providers/mod.rs
+++ b/crates/goose/src/providers/mod.rs
@@ -28,6 +28,7 @@ pub(crate) mod cli_common;
 pub mod codex;
 pub mod codex_acp;
 pub mod copilot_acp;
+pub mod cursor_acp;
 pub mod cursor_agent;
 pub mod custom_provider_config;
 pub mod databricks_def;

--- a/crates/goose/tests/providers.rs
+++ b/crates/goose/tests/providers.rs
@@ -908,6 +908,14 @@ async fn test_codex_acp_provider() -> Result<()> {
         .await
 }
 
+// Requires: cursor-agent CLI installed and authenticated
+#[tokio::test]
+async fn test_cursor_acp_provider() -> Result<()> {
+    ProviderTestConfig::with_agentic_provider("cursor-acp", ACP_CURRENT_MODEL, "cursor-agent")
+        .run()
+        .await
+}
+
 // Requires: npm install -g @github/copilot
 #[tokio::test]
 async fn test_copilot_acp_provider() -> Result<()> {


### PR DESCRIPTION
## Summary

- Adds a `cursor-acp` provider that wraps `cursor-agent acp`, following the same pattern as `claude-acp`, `copilot-acp`, and other ACP providers.
- Registers inventory-based auto-detection via `cursor_acp_inventory()` so Goose can discover `cursor-agent` on `GOOSE_SEARCH_PATHS`.
- Adapts the original implementation for the current Goose v1.45+ provider API (ProviderDef, mode IDs `agent`/`plan`/`ask`, inventory registration).

## Attribution

This PR revives work from the closed PR #9250 and issue #8391. The core provider implementation is based on commit `3bbe8e0` by **Douwe Osinga** (Signed-off-by preserved in the first commit). The v1.45 API adaptation is in the second commit.

## Test plan

- [x] `cargo build -p goose --lib`
- [x] `cargo clippy -p goose --lib -- -D warnings`
- [x] `cargo test -p goose --lib providers::init` (7/8 pass; one pre-existing env-sensitive custom-provider test fails locally due to unrelated `custom_inf` config on disk)
- [ ] CI

Fixes #8391

Made with [Cursor](https://cursor.com)