### PR TITLE
RFC: classify structured context-overflow 400s as ContextLengthExceeded

### DIFF
--- a/crates/goose-providers/src/http_status.rs
+++ b/crates/goose-providers/src/http_status.rs
@@ -107,6 +107,25 @@ fn parse_http_date(value: &str) -> Option<SystemTime> {
     None
 }
 
+/// Detect context overflow from a 400 body's structured fields rather than its
+/// prose. `error.code == "context_length_exceeded"` is the value OpenAI
+/// specifies, and llama.cpp-derived servers additionally attach the
+/// `n_prompt_tokens`/`n_ctx` pair. Message matching cannot separate a context
+/// overflow from any other 400 without risking false positives across every
+/// provider that shares this mapping, so structured fields are checked first.
+fn is_context_length_exceeded_payload(payload: Option<&Value>) -> bool {
+    let Some(error) = payload.and_then(|p| p.get("error")) else {
+        return false;
+    };
+
+    let code_matches = error
+        .get("code")
+        .and_then(|code| code.as_str())
+        .is_some_and(|code| code.eq_ignore_ascii_case("context_length_exceeded"));
+
+    code_matches || (error.get("n_prompt_tokens").is_some() && error.get("n_ctx").is_some())
+}
+
 pub fn is_context_length_exceeded_message(text: &str) -> bool {
     let text_lower = text.to_lowercase();
 
@@ -214,7 +233,9 @@ pub fn map_http_error_to_provider_error(
         StatusCode::PAYLOAD_TOO_LARGE => ProviderError::ContextLengthExceeded(extract_message()),
         StatusCode::BAD_REQUEST => {
             let payload_str = extract_message();
-            if is_context_length_exceeded_message(&payload_str) {
+            if is_context_length_exceeded_payload(payload.as_ref())
+                || is_context_length_exceeded_message(&payload_str)
+            {
                 ProviderError::ContextLengthExceeded(payload_str)
             } else {
                 ProviderError::RequestFailed(format!("Bad request (400): {}", payload_str))
@@ -462,5 +483,53 @@ mod tests {
                 "expected generic bad request for: {message}"
             );
         }
+    }
+
+    fn map_bad_request(payload: Value) -> ProviderError {
+        map_http_error_to_provider_error(StatusCode::BAD_REQUEST, Some(payload), "http://localhost")
+    }
+
+    #[test]
+    fn bad_request_with_structured_context_code_maps_to_context_length_exceeded() {
+        let error = map_bad_request(json!({
+            "error": {
+                "message": "Prompt has 49202 tokens, but the configured context size is 49152 tokens",
+                "type": "invalid_request_error",
+                "param": "messages",
+                "code": "context_length_exceeded",
+                "n_prompt_tokens": 49202,
+                "n_ctx": 49152
+            }
+        }));
+
+        assert!(matches!(error, ProviderError::ContextLengthExceeded(_)));
+    }
+
+    #[test]
+    fn bad_request_with_token_counts_maps_to_context_length_exceeded() {
+        let error = map_bad_request(json!({
+            "error": {
+                "message": "request exceeds the available context size, try increasing it",
+                "type": "exceed_context_size_error",
+                "code": 400,
+                "n_prompt_tokens": 370770,
+                "n_ctx": 65536
+            }
+        }));
+
+        assert!(matches!(error, ProviderError::ContextLengthExceeded(_)));
+    }
+
+    #[test]
+    fn bad_request_without_context_signals_stays_request_failed() {
+        let error = map_bad_request(json!({
+            "error": {
+                "message": "max_tokens must be less than or equal to 4096",
+                "type": "invalid_request_error",
+                "code": "invalid_value"
+            }
+        }));
+
+        assert!(matches!(error, ProviderError::RequestFailed(_)));
     }
 }


### PR DESCRIPTION
## RFC — not for merge until the issue is Ready

Per `AGENTS.md`, implementation work needs a Ready issue first. This PR is a **proposal attached to #11048**, opened so the design and the diff can be discussed against something concrete rather than in the abstract. Please treat it as an RFC: if the design in #11048 lands differently, I'll rewrite or close this. Happy to convert it to a draft or close it on request.

Implements: #11048
Related (deliberately **not** included here): #11049

## The defect

`map_http_error_to_provider_error` builds its verdict from `error.message` alone. `error.code` is never read anywhere in `http_status.rs`. So a 400 that says, in machine-readable form, "your prompt was N tokens and my limit is M" becomes `ProviderError::RequestFailed`.

Two consequences, both already-built machinery going unused:

| path | trigger | site |
|---|---|---|
| legacy | `Err(ProviderError::ContextLengthExceeded)` → compact + retry | `crates/goose/src/agents/agent.rs:2906` |
| state machine | `reactive_context_error` on `MessageErrorKind::ContextLengthExceeded` → compact | `crates/goose/src/agents/state_machine/ops_compaction.rs:218` |

And `RequestFailed` is retryable (`retry.rs:106`), so the byte-identical payload is resent 4x against a deterministic rejection before the turn ends with "Please retry if you think this is a transient or recoverable error."

Worth noting: `"context_length_exceeded"` is *already* in `direct_context_phrases` at `http_status.rs:115`. The right string is in the payload, in a field nothing reads.

## The change

One file. In the `BAD_REQUEST` arm, check structured fields before prose:

- `error.code == "context_length_exceeded"` (case-insensitive) — the value OpenAI specifies
- or both `n_prompt_tokens` and `n_ctx` present — the numeric pair llama.cpp-derived servers attach

`is_context_length_exceeded_message` is **unchanged**. No new word-combination heuristics were added, deliberately: this mapping is shared by every provider, so broadening prose matching risks classifying unrelated 400s as context overflow and silently compacting instead of surfacing the real error. That objection was raised on #11046 and I think it was correct.

Retry amplification needs no separate fix — `should_retry` already returns `false` for `ContextLengthExceeded`.

## Parity

The fix sits in `goose-providers`, below both agent loops, so the legacy and state-machine paths are corrected by the same change. `AGENTS.md` asks for both paths to be handled; here there is no second site to touch. If you'd rather see an explicit recovery test per path on top of the unit tests, say so and I'll add them.

## Evidence

Three payload shapes observed across 116 events from 3 different local servers:

| count | `error.type` | `error.code` |
|---|---|---|
| 64 | `invalid_request_error` | `"context_length_exceeded"` (string) |
| 28 | `exceed_context_size_error` | `400` (number) |
| 24 | `BadRequestError` | `400` (number) |

Only the first carries the standard string code, which is why the numeric pair is also checked. This is the concrete argument for keying on structured fields rather than wording.

## Verification

- [x] `cargo test -p goose-providers --lib http_status::` — 15/15 pass
- [x] `cargo clippy -p goose-providers --all-targets -- -D warnings` — clean
- [x] `cargo fmt`
- [x] Three new tests: structured string `code`; numeric-pair-only; and a negative case asserting `max_tokens must be less than or equal to 4096` still maps to `RequestFailed`
- [x] Existing message-classifier accept/reject tests unchanged and passing

Recovery is known to work once reached: in the affected session a manual compaction took the context from 49,121 to 25,930 tokens and the 400s stopped immediately.

## What this does not fix

The overflow itself. Separately (#11049), a custom provider's declared `context_limit: 32768` was discarded in favour of a name-matched canonical catalog value of `1000000`, so auto-compaction was calibrated to fire at ~350,000 tokens against a server that rejects at 49,152 — it could never fire in time. That needs a precedence decision affecting all providers, so it is intentionally out of scope here. This PR only ensures that when a provider does reject an oversized request, goose recovers instead of giving up.

## Relationship to #11046

That PR was closed for good reasons: no Ready issue, unrelated desktop/ACP changes bundled in, narrating comments, and fuzzy message matching as the mechanism. This replaces it: issue-first, one file, structured signals only, no desktop changes. The investigation notes there are superseded by #11048 and #11049.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
