### PR TITLE
fix(compaction): retry when the summary is cut off at the output-token limit

### DIFF
--- a/crates/goose/src/context_mgmt/mod.rs
+++ b/crates/goose/src/context_mgmt/mod.rs
@@ -382,6 +382,25 @@ async fn do_compact(
         .await
         {
             Ok((mut response, mut provider_usage)) => {
+                // A summary cut off at max_tokens loses its tail, and because
+                // the JSON never brace-balances it also falls back to raw text
+                // (see `structured::json_candidates`) — so the compacted
+                // context becomes scratchpad plus a half-written object. Less
+                // input yields a shorter summary, which is what the removal
+                // ladder already produces, so retry before settling for it.
+                if response.metadata.output_token_limit_reached {
+                    if attempt < removal_percentages.len() - 1 {
+                        warn!(
+                            "Compaction summary hit the output token limit at {}% tool-response removal; retrying with more removed",
+                            remove_percent
+                        );
+                        continue;
+                    }
+                    warn!(
+                        "Compaction summary still hit the output token limit after removing all tool responses; the retained context will be incomplete"
+                    );
+                }
+
                 response.role = Role::User;
 
                 // Usage must reflect the raw model output (billable tokens),
@@ -727,6 +746,10 @@ mod tests {
         config: ModelConfig,
         max_tool_responses: Option<usize>,
         captured_system: std::sync::Mutex<Option<String>>,
+        /// Number of leading attempts that come back flagged as cut off at the
+        /// output token limit, simulating a summary the model could not finish.
+        truncated_attempts: usize,
+        attempts: std::sync::atomic::AtomicUsize,
     }
 
     impl MockProvider {
@@ -746,12 +769,23 @@ mod tests {
                 },
                 max_tool_responses: None,
                 captured_system: std::sync::Mutex::new(None),
+                truncated_attempts: 0,
+                attempts: std::sync::atomic::AtomicUsize::new(0),
             }
         }
 
         fn with_max_tool_responses(mut self, max: usize) -> Self {
             self.max_tool_responses = Some(max);
             self
+        }
+
+        fn with_truncated_attempts(mut self, truncated_attempts: usize) -> Self {
+            self.truncated_attempts = truncated_attempts;
+            self
+        }
+
+        fn attempt_count(&self) -> usize {
+            self.attempts.load(std::sync::atomic::Ordering::Relaxed)
         }
     }
 
@@ -788,7 +822,13 @@ mod tests {
                 }
             }
 
-            let message = self.message.clone();
+            let attempt = self
+                .attempts
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            let mut message = self.message.clone();
+            if attempt < self.truncated_attempts {
+                message.metadata.output_token_limit_reached = true;
+            }
             let usage = ProviderUsage::new("mock-model".to_string(), Usage::default());
             Ok(stream_from_single_message(message, usage))
         }
@@ -799,6 +839,72 @@ mod tests {
         ) -> Result<usize, ProviderError> {
             Ok(self.config.context_limit())
         }
+    }
+
+    fn conversation_with_tool_pairs(pairs: usize) -> Conversation {
+        let mut messages = vec![Message::user().with_text("start")];
+        for i in 0..pairs {
+            messages.extend(create_tool_pair(
+                &format!("tool_{i}"),
+                &format!("resp_{i}"),
+                "read_file",
+                &format!("contents of file {i}"),
+            ));
+        }
+        Conversation::new_unvalidated(messages)
+    }
+
+    /// A summary cut off at max_tokens loses its tail and, because the JSON
+    /// never brace-balances, also falls back to raw text — so the compacted
+    /// context becomes scratchpad plus a half-written object. Less input
+    /// produces a shorter summary, so the removal ladder should be used.
+    #[tokio::test]
+    async fn compaction_retries_when_the_summary_hits_the_output_token_limit() {
+        let provider = MockProvider::new(Message::assistant().with_text("<mock summary>"), 100_000)
+            .with_truncated_attempts(1);
+        let conversation = conversation_with_tool_pairs(4);
+
+        let (summary, _usage) = do_compact(
+            &provider,
+            &provider.config.clone(),
+            "test-session",
+            conversation.messages(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            provider.attempt_count(),
+            2,
+            "a truncated summary should be retried with more tool responses removed"
+        );
+        assert!(!summary.metadata.output_token_limit_reached);
+        assert!(summary.as_concat_text().contains("<mock summary>"));
+    }
+
+    /// Retrying forever would be worse than an incomplete summary: the ladder
+    /// is finite, and the last rung's result is accepted.
+    #[tokio::test]
+    async fn compaction_accepts_a_truncated_summary_once_the_ladder_is_exhausted() {
+        let provider = MockProvider::new(Message::assistant().with_text("<mock summary>"), 100_000)
+            .with_truncated_attempts(usize::MAX);
+        let conversation = conversation_with_tool_pairs(4);
+
+        let (summary, _usage) = do_compact(
+            &provider,
+            &provider.config.clone(),
+            "test-session",
+            conversation.messages(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            provider.attempt_count(),
+            5,
+            "every rung of the removal ladder should be tried before giving up"
+        );
+        assert!(summary.as_concat_text().contains("<mock summary>"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
No issue yet — filing one if this looks right. Found while investigating #11049; independent of it and of #11050.

## The defect

`do_compact` accepts whatever the summarizer returns. It never checks whether the response was cut off at `max_tokens`, even though `MessageMetadata::output_token_limit_reached` is already populated by the OpenAI, OpenAI-Responses and Anthropic format layers.

Two things then go wrong at once:

1. The summary loses its tail. `compaction.md` orders every list "most to least important", so what gets cut is the material the model ranked as least critical — but it is cut mid-token, not at a field boundary.
2. Because the JSON never brace-balances, `structured::json_candidates` yields no candidate, `StructuredSummary::parse` returns `None`, and `apply_structured_summary` leaves the raw text in place. The retained context becomes the `<analysis>` scratchpad — which `compaction.md:38` explicitly calls "a discarded scratchpad: only the JSON survives" — plus a half-written object.

Silently, with no warning, on every compaction.

## Observed

A custom provider declaring `max_tokens: 4096` against a local llama.cpp server. All three compactions in the session returned exactly 4096 output tokens:

```
14:20:14   25,173 in / 4,096 out   is_compaction=1
15:26:36   33,389 in / 4,096 out   is_compaction=1
16:09:29   17,513 in / 4,096 out   is_compaction=1
```

The stored summary for the last one is 12,690 characters beginning `<analysis>\nThe conversation covers...` and ending:

```
"Bug #4: OnceLock for mutable sync state — Once
```

Mid-word, mid-string, inside an unterminated JSON value. That became the entire agent-visible history.

`compaction.md:42` makes this the expected outcome rather than an edge case — it instructs the model to "spend your entire length budget on the JSON fields, and quote liberally". A model with a modest `max_tokens` will do exactly that, every time.

## What this does *not* change

`structured::json_candidates` requires a brace-balanced object and falls back to raw text otherwise. That is deliberate and documented:

> an unterminated object (output cut off mid-JSON) is not repaired - repair would drop the late, continuation-critical sections that the raw-text fallback preserves

My first instinct was to relax the extractor so `safely_parse_json`'s `repair_truncated_json` could salvage the object. That would be wrong: repairing and rendering discards the `<analysis>` prose, so it loses *more* than the raw fallback keeps. The fallback is the correct behaviour for a truncated summary. The defect is that nothing tried to obtain an untruncated one.

## The change

Reuse the escalation ladder already present for `ContextLengthExceeded` — `[0, 10, 20, 50, 100]` percent of tool responses removed. Less input yields a shorter summary. One file, no new machinery.

The final rung's result is accepted rather than retried forever, with a warning, since an incomplete summary still beats no compaction.

## Parity

`do_compact` sits below both agent loops and is called by the legacy path and the state machine alike, so both are covered by the same change.

## Verification

- [x] `cargo test -p goose --lib context_mgmt::` — 26/26, including two new tests: one asserting a truncated first attempt is retried and the second result used, one asserting all five rungs are tried and the last accepted rather than looping
- [x] `cargo test -p goose --lib` — no `context_mgmt` failures; the 8 that do fail also fail on an untouched baseline
- [x] `cargo clippy -p goose --all-targets -- -D warnings` clean, `cargo fmt`

## Worth discussing separately

`compaction.md:42` telling the model to spend its entire length budget is what makes truncation the default rather than the exception. Removing or bounding that instruction would reduce how often the ladder has to run, but it changes summary quality for every provider, so I left it alone here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
