### PR TITLE
fix(ui): remove duplicated brace-expansion keys that break every pnpm install

### DIFF
--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -3191,9 +3191,6 @@ packages:
   brace-expansion@2.1.4:
     resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
 
-  brace-expansion@2.1.4:
-    resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
-
   brace-expansion@5.0.4:
     resolution: {integrity: sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==}
     engines: {node: 18 || 20 || >=22}
@@ -9995,10 +9992,6 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
-
-  brace-expansion@2.1.4:
-    dependencies:
-      balanced-match: 1.0.2
 
   brace-expansion@2.1.4:
     dependencies:


### PR DESCRIPTION
CI has been red on every PR since 2026-08-08. This is a repo-wide break rather than a feature, so I've opened it directly per the maintainer-directed/urgent carve-out in `AGENTS.md` — happy to file an issue first if you'd prefer.

## The break

```
ERR_PNPM_BROKEN_LOCKFILE  The lockfile at ui/pnpm-lock.yaml is broken:
                          duplicated mapping key (3194:3)
##[error]Process completed with exit code 1
```

YAML forbids duplicate mapping keys and pnpm enforces it. `Test and Lint Electron Desktop App` dies on its first step — `pnpm install --frozen-lockfile` — so lint and tests have not run on any PR for days. It fails for authors who touched no JavaScript: #11050 changes one `.rs` file and is red for this reason.

`brace-expansion@2.1.4` appears twice under `packages:` (3191, 3194) and twice under `snapshots:` (9999, 10003). The line number pnpm reports, 3194, is the second `packages:` entry.

## Where it came from

Counting `^  brace-expansion@2\.1\.4:$` across the lockfile's history — a healthy lockfile has exactly 2, one per section:

| commit | count | |
|---|---|---|
| `681e99251` migrate desktop routing to React Router 8.3.0 | 0 | package not yet present |
| `d2192c0f3` bump postcss (#10946) | 2 | healthy |
| `c81a637b0` bump electron (#10969) | 2 | healthy |
| **`f0d840674` bump @types/yauzl (#10975)** | **4** | **broken** |
| `064244e6b` current main | 4 | |

That commit rewrote `brace-expansion@2.0.2` → `2.1.4` in both sections while a `2.1.4` entry already existed in each, so the key ends up twice per section. A two-line dependency bump that produced `20 ++++++/------` in the lockfile.

## Why it went unnoticed

- Plain `pnpm install` *regenerates* the lockfile instead of erroring; only `--frozen-lockfile` refuses, and that is what CI uses.
- Anyone with an existing `node_modules` never reinstalls, so it is invisible locally.
- The failing job is the Electron one, which Rust-only contributors have little reason to open.

## The change

Delete the second copy of each duplicated block — 7 lines. Both are byte-identical to the entries they shadow (asserted before removing; the script I used refuses to delete a block that differs), so this is a no-op for resolution.

Hand-edited rather than regenerated on purpose: `pnpm install` without `--frozen-lockfile` would rewrite the whole file and risk unrelated version churn in a change meant only to unbreak CI. `AGENTS.md` asks that manual lockfile edits keep things consistent, which a byte-identical-duplicate removal does by construction.

## Verification

Clean `node_modules`, running exactly the three steps the job runs:

- [x] `pnpm install --frozen-lockfile` — succeeds, 8.2s (previously aborted immediately)
- [x] `pnpm run lint:check` — typecheck, eslint and i18n all pass; locale validation across 15 languages, 1538 messages
- [x] `pnpm run test:run` — 65 files, **604 tests, all passing**

## Note on the other red check

`Check Generated Schemas are Up-to-Date` also fails on all three open PRs I have out, including the Rust-only one. I have not diagnosed it and it is not addressed here — it may or may not share this cause. Flagging it so this PR is not mistaken for turning the board fully green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
