### PR TITLE
RFC: re-check the compaction threshold mid-turn, not only at turn start

### DIFF
--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -3268,6 +3268,61 @@ impl Agent {
                 }
                 conversation.extend(messages_to_add);
 
+                // The turn-start check cannot see tool output, so a turn that
+                // begins under the threshold can run to the context limit
+                // without ever being re-examined. Re-check here, once the tool
+                // responses have been appended: compacting between a request
+                // and its response would orphan the request. Skipped when the
+                // turn is ending, since the next turn starts with a check, and
+                // after a recovery compaction, which already shrank the context.
+                if !exit_chat && !did_recovery_compact_this_iteration {
+                    let session_now = session_manager
+                        .get_session(&session_config.id, true)
+                        .await?;
+                    let over_threshold = check_if_compaction_needed(
+                        self.provider().await?.as_ref(),
+                        &conversation,
+                        None,
+                        &session_now,
+                    )
+                    .await?;
+
+                    if over_threshold {
+                        yield AgentEvent::Message(
+                            Message::assistant().with_system_notification(
+                                SystemNotificationType::ProgressMessage,
+                                COMPACTION_PROGRESS_TEXT,
+                            )
+                        );
+                        match compact_messages(
+                            self.provider().await?.as_ref(),
+                            &model_config,
+                            &session_config.id,
+                            &conversation,
+                            false,
+                        )
+                        .await
+                        {
+                            Ok(compaction) => {
+                                session_manager.replace_conversation(&session_config.id, &compaction.conversation).await?;
+                                self.update_session_metrics(
+                                    &session_config.id,
+                                    session_config.schedule_id.clone(),
+                                    &compaction.usage,
+                                    Some(compaction.retained_context_tokens),
+                                ).await?;
+                                conversation = compaction.conversation;
+                                yield AgentEvent::HistoryReplaced(conversation.clone());
+                            }
+                            Err(e) => {
+                                // The turn can continue: the request that follows may
+                                // still fit, and the reactive path catches it if not.
+                                error!("Mid-turn compaction failed: {}", e);
+                            }
+                        }
+                    }
+                }
+
                 if exit_chat && self.has_pending_steers(&session_config.id).await {
                     exit_chat = false;
                 }

--- a/crates/goose/src/agents/state_machine/ops_compaction.rs
+++ b/crates/goose/src/agents/state_machine/ops_compaction.rs
@@ -232,7 +232,18 @@ impl Operation for CompactionOperation {
                 return not_applicable();
             }
         } else {
-            if last_effective_role(messages)? != EffectiveRole::User {
+            // Tool output accumulates inside a turn, so a user-boundary-only
+            // check cannot see a turn that grows from under the threshold to
+            // past the context limit without ever returning to the user.
+            //
+            // `Tool` is the other safe point: it means the responses for the
+            // preceding requests have landed. `Assistant` stays excluded —
+            // compacting there would hide tool requests whose responses have
+            // not arrived yet, orphaning them.
+            if !matches!(
+                last_effective_role(messages)?,
+                EffectiveRole::User | EffectiveRole::Tool
+            ) {
                 return not_applicable();
             }
             match session.usage.total_tokens {


### PR DESCRIPTION
## RFC — draft on purpose, not ready to merge

Implements: #11072

Opened as a draft because **the new behaviour has no test yet**. Everything below about regressions is verified; the thing this PR exists to do is not. Details in "What is missing".

## The defect

Auto-compaction is evaluated once per user turn, so tool output accumulated inside a turn is never re-examined:

| path | site | gate |
|---|---|---|
| legacy | `agent.rs:2049` | `check_if_compaction_needed` runs once, before the reply stream |
| state machine | `ops_compaction.rs:235` | `not_applicable()` unless `last_effective_role == EffectiveRole::User` |

From a live session with a *correct* 49,152 limit and a 17,203 trigger:

```
16:09:29   17,513 in   is_compaction=1   -> compacted to 6,912
16:29:29   17,189 in                      past the trigger, nothing fires
16:42:15   40,783 in
16:45:14   49,120 in + 32 out = 49,152    at the ceiling
```

Six compactions fired earlier in that session, at turn boundaries, and worked. Then one tool-heavy turn ran 30+ consecutive calls with no check at all. Fixing the context limit (#11049) does not help here; the limit was already right.

## The change

Both paths re-check once tool responses have landed.

**State machine** — admit `EffectiveRole::Tool` alongside `User`:

```rust
if !matches!(
    last_effective_role(messages)?,
    EffectiveRole::User | EffectiveRole::Tool
) {
    return not_applicable();
}
```

`Assistant` stays excluded deliberately. `EffectiveRole::Tool` is a user-role message carrying tool responses, so the requests it answers are complete; compacting at `Assistant` would hide tool requests whose responses have not arrived and orphan them.

**Legacy** — check after `conversation.extend(messages_to_add)`, the point at which the same invariant holds. Skipped when the turn is ending (the next turn opens with a check) and after a recovery compaction (which already shrank the context). A mid-turn compaction failure is logged and the turn continues: the next request may still fit, and the reactive path catches it if not.

## What is verified

- [x] `cargo check -p goose`, `cargo clippy -p goose --all-targets -- -D warnings` clean, `cargo fmt`
- [x] `cargo test -p goose --test agent` — 36/36
- [x] `cargo test -p goose --lib state_machine::tests::compaction` — 7 pass, 1 fails
- [x] That failure, `a_small_model_compacts_a_large_tool_result_out_of_the_conversation`, is **pre-existing**: I stashed the change and re-ran it, and the panic is byte-identical with and without
- [x] `cargo test -p goose --lib` — three consecutive runs at the same 8 failures an untouched baseline produces

A caveat on that last line: this suite is flaky. Six baseline samples on unmodified code gave 8, 8, 8, 8, 9, 10 failures, with `scheduler::test_job_runs_on_schedule`, `prompt_manager::test_basic`, `providers::oauth::tests::test_token_cache` and others appearing and disappearing. Eight fail consistently; counts above that are noise, not signal.

## What is missing

**A test that a mid-turn compaction actually fires.** No existing test asserts compaction is skipped mid-turn, so nothing broke — which also means nothing covers the new path. The `compaction_lifecycle` harness drives turns via `pipeline.run([...])`, which appends a user message and therefore cannot express "still inside a turn"; making the mock cross the threshold *during* a tool loop needs work I have not done.

Until that exists, this PR rests on reading the code, not on evidence. Given that, it should not merge.

Two options I would take next, in order:
1. Extend the pipeline harness so a seeded tool loop can cross the threshold mid-turn, and assert exactly one `history_replacement` inside a single `run`.
2. Empirical confirmation against the session that produced the trace above — rebuild, drive a long tool loop, and check `usage_ledger` for `is_compaction=1` with no intervening user message.

## Open questions for review

- Re-fetching the session each iteration in the legacy loop (`get_session` for fresh `usage.total_tokens`) adds a read per tool round-trip. Acceptable, or should the running usage be threaded through instead?
- Should a mid-turn compaction emit the same `Exceeded auto-compact threshold` inline message as the turn-boundary one? Right now it emits only the progress message, to avoid interrupting a tool loop with chat-level notices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
