### PR TITLE
RFC: survive and prevent context-window overflow against custom providers (series)

### DIFF
--- a/crates/goose-provider-types/src/base.rs
+++ b/crates/goose-provider-types/src/base.rs
@@ -244,6 +244,10 @@ pub struct ModelInfo {
     pub resolved_model: Option<String>,
     /// The maximum context length this model supports
     pub context_limit: usize,
+    /// The maximum output tokens to request from this model, when the provider
+    /// declares one. `None` leaves the choice to the canonical catalog.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_tokens: Option<i32>,
     /// Cost per token for input in USD (optional)
     pub input_token_cost: Option<f64>,
     /// Cost per token for output in USD (optional)
@@ -269,6 +273,7 @@ impl ModelInfo {
             name: name.into(),
             resolved_model: None,
             context_limit,
+            max_tokens: None,
             input_token_cost: None,
             output_token_cost: None,
             currency: None,
@@ -290,6 +295,7 @@ impl ModelInfo {
             name: name.into(),
             resolved_model: None,
             context_limit,
+            max_tokens: None,
             input_token_cost: Some(input_cost),
             output_token_cost: Some(output_cost),
             currency: Some("$".to_string()),
@@ -337,6 +343,7 @@ pub fn model_info_for_provider_model(provider_name: &str, model_name: &str) -> M
         context_limit: ModelConfig::new(model_name)
             .with_canonical_limits(provider_name)
             .context_limit(),
+        max_tokens: None,
         input_token_cost: None,
         output_token_cost: None,
         currency: None,
@@ -809,6 +816,7 @@ mod tests {
             name: "test-model".to_string(),
             resolved_model: None,
             context_limit: 1000,
+            max_tokens: None,
             input_token_cost: None,
             output_token_cost: None,
             currency: None,
@@ -824,6 +832,7 @@ mod tests {
             name: "test-model".to_string(),
             resolved_model: None,
             context_limit: 1000,
+            max_tokens: None,
             input_token_cost: None,
             output_token_cost: None,
             currency: None,
@@ -839,6 +848,7 @@ mod tests {
             name: "test-model".to_string(),
             resolved_model: None,
             context_limit: 2000,
+            max_tokens: None,
             input_token_cost: None,
             output_token_cost: None,
             currency: None,

--- a/crates/goose-provider-types/src/base.rs
+++ b/crates/goose-provider-types/src/base.rs
@@ -369,6 +369,14 @@ pub async fn collect_stream(
         if let Some(msg) = msg_opt {
             final_message = Some(match final_message {
                 Some(mut prev) => {
+                    // The streaming decoders set this on the chunk carrying
+                    // `finish_reason` — the last one — so merging content alone
+                    // would discard it and downstream truncation handling
+                    // (compaction retry, UI notice) would never see it. OR it
+                    // across chunks, as conversation.rs does when merging
+                    // messages.
+                    prev.metadata.output_token_limit_reached |=
+                        msg.metadata.output_token_limit_reached;
                     for new_content in msg.content {
                         match (&mut prev.content.last_mut(), &new_content) {
                             // Coalesce consecutive text blocks
@@ -743,6 +751,31 @@ mod tests {
         let stream = create_test_stream(items);
         let (msg, _) = collect_stream(Box::pin(stream)).await.unwrap();
         assert_eq!(content_to_strings(&msg), expected);
+    }
+
+    /// The flag arrives on the final chunk (the one with `finish_reason`),
+    /// after earlier chunks have already seeded `final_message` — the exact
+    /// shape real streaming produces, where merging content alone loses it.
+    #[tokio::test]
+    async fn collect_stream_keeps_output_token_limit_flag_from_a_later_chunk() {
+        use futures::stream;
+        let first = Message::new(
+            rmcp::model::Role::Assistant,
+            chrono::Utc::now().timestamp(),
+            vec![MessageContentBlock::text("partial ")],
+        );
+        let mut last = Message::new(
+            rmcp::model::Role::Assistant,
+            chrono::Utc::now().timestamp(),
+            vec![MessageContentBlock::text("answer")],
+        );
+        last.metadata.output_token_limit_reached = true;
+
+        let stream = stream::iter(vec![Ok((Some(first), None)), Ok((Some(last), None))]);
+        let (msg, _) = collect_stream(Box::pin(stream)).await.unwrap();
+
+        assert!(msg.metadata.output_token_limit_reached);
+        assert_eq!(content_to_strings(&msg), vec!["partial answer"]);
     }
 
     #[tokio::test]

--- a/crates/goose-providers/src/azure_foundry.rs
+++ b/crates/goose-providers/src/azure_foundry.rs
@@ -356,6 +356,7 @@ fn model_info_for_deployment(deployment_name: &str, model_name: &str) -> ModelIn
             .as_ref()
             .map(|model| model.limit.context)
             .unwrap_or_else(|| ModelConfig::new(model_name).context_limit()),
+        max_tokens: None,
         input_token_cost: None,
         output_token_cost: None,
         currency: None,

--- a/crates/goose-providers/src/databricks.rs
+++ b/crates/goose-providers/src/databricks.rs
@@ -464,6 +464,7 @@ impl DatabricksProvider {
             name: info.name,
             resolved_model: info.upstream_model_name,
             context_limit,
+            max_tokens: None,
             input_token_cost: None,
             output_token_cost: None,
             currency: None,

--- a/crates/goose-providers/src/http_status.rs
+++ b/crates/goose-providers/src/http_status.rs
@@ -107,6 +107,25 @@ fn parse_http_date(value: &str) -> Option<SystemTime> {
     None
 }
 
+/// Detect context overflow from a 400 body's structured fields rather than its
+/// prose. `error.code == "context_length_exceeded"` is the value OpenAI
+/// specifies, and llama.cpp-derived servers additionally attach the
+/// `n_prompt_tokens`/`n_ctx` pair. Message matching cannot separate a context
+/// overflow from any other 400 without risking false positives across every
+/// provider that shares this mapping, so structured fields are checked first.
+fn is_context_length_exceeded_payload(payload: Option<&Value>) -> bool {
+    let Some(error) = payload.and_then(|p| p.get("error")) else {
+        return false;
+    };
+
+    let code_matches = error
+        .get("code")
+        .and_then(|code| code.as_str())
+        .is_some_and(|code| code.eq_ignore_ascii_case("context_length_exceeded"));
+
+    code_matches || (error.get("n_prompt_tokens").is_some() && error.get("n_ctx").is_some())
+}
+
 pub fn is_context_length_exceeded_message(text: &str) -> bool {
     let text_lower = text.to_lowercase();
 
@@ -214,7 +233,9 @@ pub fn map_http_error_to_provider_error(
         StatusCode::PAYLOAD_TOO_LARGE => ProviderError::ContextLengthExceeded(extract_message()),
         StatusCode::BAD_REQUEST => {
             let payload_str = extract_message();
-            if is_context_length_exceeded_message(&payload_str) {
+            if is_context_length_exceeded_payload(payload.as_ref())
+                || is_context_length_exceeded_message(&payload_str)
+            {
                 ProviderError::ContextLengthExceeded(payload_str)
             } else {
                 ProviderError::RequestFailed(format!("Bad request (400): {}", payload_str))
@@ -462,5 +483,53 @@ mod tests {
                 "expected generic bad request for: {message}"
             );
         }
+    }
+
+    fn map_bad_request(payload: Value) -> ProviderError {
+        map_http_error_to_provider_error(StatusCode::BAD_REQUEST, Some(payload), "http://localhost")
+    }
+
+    #[test]
+    fn bad_request_with_structured_context_code_maps_to_context_length_exceeded() {
+        let error = map_bad_request(json!({
+            "error": {
+                "message": "Prompt has 49202 tokens, but the configured context size is 49152 tokens",
+                "type": "invalid_request_error",
+                "param": "messages",
+                "code": "context_length_exceeded",
+                "n_prompt_tokens": 49202,
+                "n_ctx": 49152
+            }
+        }));
+
+        assert!(matches!(error, ProviderError::ContextLengthExceeded(_)));
+    }
+
+    #[test]
+    fn bad_request_with_token_counts_maps_to_context_length_exceeded() {
+        let error = map_bad_request(json!({
+            "error": {
+                "message": "request exceeds the available context size, try increasing it",
+                "type": "exceed_context_size_error",
+                "code": 400,
+                "n_prompt_tokens": 370770,
+                "n_ctx": 65536
+            }
+        }));
+
+        assert!(matches!(error, ProviderError::ContextLengthExceeded(_)));
+    }
+
+    #[test]
+    fn bad_request_without_context_signals_stays_request_failed() {
+        let error = map_bad_request(json!({
+            "error": {
+                "message": "max_tokens must be less than or equal to 4096",
+                "type": "invalid_request_error",
+                "code": "invalid_value"
+            }
+        }));
+
+        assert!(matches!(error, ProviderError::RequestFailed(_)));
     }
 }

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -3284,6 +3284,61 @@ impl Agent {
                 }
                 conversation.extend(messages_to_add);
 
+                // The turn-start check cannot see tool output, so a turn that
+                // begins under the threshold can run to the context limit
+                // without ever being re-examined. Re-check here, once the tool
+                // responses have been appended: compacting between a request
+                // and its response would orphan the request. Skipped when the
+                // turn is ending, since the next turn starts with a check, and
+                // after a recovery compaction, which already shrank the context.
+                if !exit_chat && !did_recovery_compact_this_iteration {
+                    let session_now = session_manager
+                        .get_session(&session_config.id, true)
+                        .await?;
+                    let over_threshold = check_if_compaction_needed(
+                        self.provider().await?.as_ref(),
+                        &conversation,
+                        None,
+                        &session_now,
+                    )
+                    .await?;
+
+                    if over_threshold {
+                        yield AgentEvent::Message(
+                            Message::assistant().with_system_notification(
+                                SystemNotificationType::ProgressMessage,
+                                COMPACTION_PROGRESS_TEXT,
+                            )
+                        );
+                        match compact_messages(
+                            self.provider().await?.as_ref(),
+                            &model_config,
+                            &session_config.id,
+                            &conversation,
+                            false,
+                        )
+                        .await
+                        {
+                            Ok(compaction) => {
+                                session_manager.replace_conversation(&session_config.id, &compaction.conversation).await?;
+                                self.update_session_metrics(
+                                    &session_config.id,
+                                    session_config.schedule_id.clone(),
+                                    &compaction.usage,
+                                    Some(compaction.retained_context_tokens),
+                                ).await?;
+                                conversation = compaction.conversation;
+                                yield AgentEvent::HistoryReplaced(conversation.clone());
+                            }
+                            Err(e) => {
+                                // The turn can continue: the request that follows may
+                                // still fit, and the reactive path catches it if not.
+                                error!("Mid-turn compaction failed: {}", e);
+                            }
+                        }
+                    }
+                }
+
                 if exit_chat && self.has_pending_steers(&session_config.id).await {
                     exit_chat = false;
                 }

--- a/crates/goose/src/agents/state_machine/ops_compaction.rs
+++ b/crates/goose/src/agents/state_machine/ops_compaction.rs
@@ -232,7 +232,18 @@ impl Operation for CompactionOperation {
                 return not_applicable();
             }
         } else {
-            if last_effective_role(messages)? != EffectiveRole::User {
+            // Tool output accumulates inside a turn, so a user-boundary-only
+            // check cannot see a turn that grows from under the threshold to
+            // past the context limit without ever returning to the user.
+            //
+            // `Tool` is the other safe point: it means the responses for the
+            // preceding requests have landed. `Assistant` stays excluded —
+            // compacting there would hide tool requests whose responses have
+            // not arrived yet, orphaning them.
+            if !matches!(
+                last_effective_role(messages)?,
+                EffectiveRole::User | EffectiveRole::Tool
+            ) {
                 return not_applicable();
             }
             match session.usage.total_tokens {

--- a/crates/goose/src/config/declarative_providers.rs
+++ b/crates/goose/src/config/declarative_providers.rs
@@ -544,6 +544,7 @@ mod tests {
                 name: "test/model".to_string(),
                 resolved_model: None,
                 context_limit: 128_000,
+                max_tokens: None,
                 input_token_cost: None,
                 output_token_cost: None,
                 currency: None,

--- a/crates/goose/src/context_mgmt/mod.rs
+++ b/crates/goose/src/context_mgmt/mod.rs
@@ -382,6 +382,25 @@ async fn do_compact(
         .await
         {
             Ok((mut response, mut provider_usage)) => {
+                // A summary cut off at max_tokens loses its tail, and because
+                // the JSON never brace-balances it also falls back to raw text
+                // (see `structured::json_candidates`) — so the compacted
+                // context becomes scratchpad plus a half-written object. Less
+                // input yields a shorter summary, which is what the removal
+                // ladder already produces, so retry before settling for it.
+                if response.metadata.output_token_limit_reached {
+                    if attempt < removal_percentages.len() - 1 {
+                        warn!(
+                            "Compaction summary hit the output token limit at {}% tool-response removal; retrying with more removed",
+                            remove_percent
+                        );
+                        continue;
+                    }
+                    warn!(
+                        "Compaction summary still hit the output token limit after removing all tool responses; the retained context will be incomplete"
+                    );
+                }
+
                 response.role = Role::User;
 
                 // Usage must reflect the raw model output (billable tokens),
@@ -727,6 +746,10 @@ mod tests {
         config: ModelConfig,
         max_tool_responses: Option<usize>,
         captured_system: std::sync::Mutex<Option<String>>,
+        /// Number of leading attempts that come back flagged as cut off at the
+        /// output token limit, simulating a summary the model could not finish.
+        truncated_attempts: usize,
+        attempts: std::sync::atomic::AtomicUsize,
     }
 
     impl MockProvider {
@@ -746,12 +769,23 @@ mod tests {
                 },
                 max_tool_responses: None,
                 captured_system: std::sync::Mutex::new(None),
+                truncated_attempts: 0,
+                attempts: std::sync::atomic::AtomicUsize::new(0),
             }
         }
 
         fn with_max_tool_responses(mut self, max: usize) -> Self {
             self.max_tool_responses = Some(max);
             self
+        }
+
+        fn with_truncated_attempts(mut self, truncated_attempts: usize) -> Self {
+            self.truncated_attempts = truncated_attempts;
+            self
+        }
+
+        fn attempt_count(&self) -> usize {
+            self.attempts.load(std::sync::atomic::Ordering::Relaxed)
         }
     }
 
@@ -788,7 +822,13 @@ mod tests {
                 }
             }
 
-            let message = self.message.clone();
+            let attempt = self
+                .attempts
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            let mut message = self.message.clone();
+            if attempt < self.truncated_attempts {
+                message.metadata.output_token_limit_reached = true;
+            }
             let usage = ProviderUsage::new("mock-model".to_string(), Usage::default());
             Ok(stream_from_single_message(message, usage))
         }
@@ -799,6 +839,72 @@ mod tests {
         ) -> Result<usize, ProviderError> {
             Ok(self.config.context_limit())
         }
+    }
+
+    fn conversation_with_tool_pairs(pairs: usize) -> Conversation {
+        let mut messages = vec![Message::user().with_text("start")];
+        for i in 0..pairs {
+            messages.extend(create_tool_pair(
+                &format!("tool_{i}"),
+                &format!("resp_{i}"),
+                "read_file",
+                &format!("contents of file {i}"),
+            ));
+        }
+        Conversation::new_unvalidated(messages)
+    }
+
+    /// A summary cut off at max_tokens loses its tail and, because the JSON
+    /// never brace-balances, also falls back to raw text — so the compacted
+    /// context becomes scratchpad plus a half-written object. Less input
+    /// produces a shorter summary, so the removal ladder should be used.
+    #[tokio::test]
+    async fn compaction_retries_when_the_summary_hits_the_output_token_limit() {
+        let provider = MockProvider::new(Message::assistant().with_text("<mock summary>"), 100_000)
+            .with_truncated_attempts(1);
+        let conversation = conversation_with_tool_pairs(4);
+
+        let (summary, _usage) = do_compact(
+            &provider,
+            &provider.config.clone(),
+            "test-session",
+            conversation.messages(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            provider.attempt_count(),
+            2,
+            "a truncated summary should be retried with more tool responses removed"
+        );
+        assert!(!summary.metadata.output_token_limit_reached);
+        assert!(summary.as_concat_text().contains("<mock summary>"));
+    }
+
+    /// Retrying forever would be worse than an incomplete summary: the ladder
+    /// is finite, and the last rung's result is accepted.
+    #[tokio::test]
+    async fn compaction_accepts_a_truncated_summary_once_the_ladder_is_exhausted() {
+        let provider = MockProvider::new(Message::assistant().with_text("<mock summary>"), 100_000)
+            .with_truncated_attempts(usize::MAX);
+        let conversation = conversation_with_tool_pairs(4);
+
+        let (summary, _usage) = do_compact(
+            &provider,
+            &provider.config.clone(),
+            "test-session",
+            conversation.messages(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            provider.attempt_count(),
+            5,
+            "every rung of the removal ladder should be tried before giving up"
+        );
+        assert!(summary.as_concat_text().contains("<mock summary>"));
     }
 
     #[tokio::test]

--- a/crates/goose/src/providers/inventory/mod.rs
+++ b/crates/goose/src/providers/inventory/mod.rs
@@ -1082,7 +1082,8 @@ fn configured_models_to_inventory(
     let mut result: Vec<InventoryModel> = Vec::new();
     let mut seen_names: HashSet<String> = HashSet::new();
     for model in models {
-        let enriched = enriched_model(provider_family, &model.name, Some(model.context_limit));
+        let declared = (model.context_limit > 0).then_some(model.context_limit);
+        let enriched = enriched_model(provider_family, &model.name, declared);
         if seen_names.insert(enriched.name.clone()) {
             result.push(enriched);
         }
@@ -1120,10 +1121,15 @@ fn inventory_models_from_snapshot(
     }
 }
 
+/// `declared_context_limit` is the provider's own statement about the endpoint
+/// and outranks a canonical entry matched on model *name*, matching the
+/// precedence in `ProviderEntry::normalize_model_config`. Built-in providers
+/// derive their known models from the canonical registry, so the two agree and
+/// this is a no-op for them.
 fn enriched_model(
     provider_family: &str,
     model_id: &str,
-    fallback_context_limit: Option<usize>,
+    declared_context_limit: Option<usize>,
 ) -> InventoryModel {
     let registry = CanonicalModelRegistry::bundled().ok();
     let canonical = registry.as_ref().and_then(|registry| {
@@ -1139,10 +1145,8 @@ fn enriched_model(
             .map(|model| model.name.clone())
             .unwrap_or_else(|| model_id.to_string()),
         family: canonical.as_ref().and_then(|model| model.family.clone()),
-        context_limit: canonical
-            .as_ref()
-            .map(|model| model.limit.context)
-            .or(fallback_context_limit),
+        context_limit: declared_context_limit
+            .or_else(|| canonical.as_ref().map(|model| model.limit.context)),
         reasoning: canonical.as_ref().and_then(|model| model.reasoning),
         recommended: false,
     }

--- a/crates/goose/src/providers/provider_registry.rs
+++ b/crates/goose/src/providers/provider_registry.rs
@@ -55,21 +55,55 @@ impl ProviderEntry {
     }
 
     /// Apply provider-specific normalization to a model config: materialize
-    /// global defaults and backfill `context_limit` from the provider's known
-    /// models when the canonical registry didn't already resolve one. Used by
-    /// the agent/session layer to resolve effective limits (e.g. for custom
-    /// providers that declare explicit context limits in their config).
-    pub fn normalize_model_config(&self, mut model: ModelConfig) -> Result<ModelConfig> {
-        model = crate::model_config::materialize_model_config(&self.metadata.name, model)?;
+    /// global defaults, then let the provider's own model declaration outrank
+    /// the canonical catalog.
+    ///
+    /// A declaration in the provider's config describes the endpoint that will
+    /// actually serve the request. A canonical entry is matched on model *name*,
+    /// which collides whenever a local or proxied deployment reuses a well-known
+    /// name — a `deepseek-v4-flash` behind a llama.cpp server with `--ctx 49152`
+    /// inherits the hosted model's million-token limit, and auto-compaction is
+    /// then calibrated against a ceiling the endpoint will never accept.
+    ///
+    /// Built-in providers derive `known_models` from the canonical registry
+    /// (`model_info_for_provider_model`), so their declared and canonical values
+    /// already agree and this changes nothing for them.
+    ///
+    /// Precedence: caller-supplied value, then `GOOSE_CONTEXT_LIMIT` /
+    /// `GOOSE_MAX_TOKENS`, then the provider declaration, then canonical.
+    pub fn normalize_model_config(&self, model: ModelConfig) -> Result<ModelConfig> {
+        let declared = self
+            .metadata
+            .known_models
+            .iter()
+            .find(|m| m.name.eq_ignore_ascii_case(&model.model_name));
+        let declared_context_limit = declared.map(|m| m.context_limit).filter(|limit| *limit > 0);
+        let declared_max_tokens = declared
+            .and_then(|m| m.max_tokens)
+            .filter(|tokens| *tokens > 0);
 
-        if model.context_limit.is_none() {
-            if let Some(info) = self
-                .metadata
-                .known_models
-                .iter()
-                .find(|m| m.name.eq_ignore_ascii_case(&model.model_name) && m.context_limit > 0)
-            {
-                model.context_limit = Some(info.context_limit);
+        // Callers hand in an already-materialized config, so `is_some()` cannot
+        // tell a value the caller chose from one the canonical catalog filled
+        // in. Compare against what canonical alone would produce: matching it
+        // means nobody chose the value, so the declaration may take over.
+        let canonical =
+            ModelConfig::new(&model.model_name).with_canonical_limits(&self.metadata.name);
+        let context_limit_unchosen =
+            model.context_limit.is_none() || model.context_limit == canonical.context_limit;
+        let max_tokens_unchosen =
+            model.max_tokens.is_none() || model.max_tokens == canonical.max_tokens;
+
+        let mut model = crate::model_config::materialize_model_config(&self.metadata.name, model)?;
+
+        let config = crate::config::Config::global();
+        if let Some(limit) = declared_context_limit {
+            if context_limit_unchosen && config.get_goose_context_limit()?.is_none() {
+                model.context_limit = Some(limit);
+            }
+        }
+        if let Some(max_tokens) = declared_max_tokens {
+            if max_tokens_unchosen && config.get_goose_max_tokens()?.is_none() {
+                model.max_tokens = Some(max_tokens);
             }
         }
 
@@ -408,5 +442,167 @@ mod tests {
         let entry = registry.entries.get("custom_hf").unwrap();
 
         assert!(!entry.inventory_configured());
+    }
+
+    /// `deepseek-v4-flash` name-matches a hosted catalog entry with a
+    /// million-token context. A local server declaring 32_768 must not inherit it.
+    fn entry_declaring(models: Vec<ModelInfo>) -> ProviderEntry {
+        let mut config = test_config();
+        config.models = models;
+        let mut registry = ProviderRegistry::new(None);
+        registry.register_with_name_and_inventory_configured::<OpenAiProviderDef, _, _, _>(
+            &config,
+            ProviderType::Declarative,
+            false,
+            |_| unreachable!("constructor is not used by this test"),
+            || Ok(InventoryIdentityInput::new("custom_hf", "huggingface")),
+            || false,
+        );
+        registry.entries.get("custom_hf").unwrap().clone()
+    }
+
+    fn declared_flash_model() -> ModelInfo {
+        ModelInfo {
+            max_tokens: Some(4096),
+            ..ModelInfo::new("deepseek-v4-flash", 32_768)
+        }
+    }
+
+    #[test]
+    fn declared_limits_outrank_canonical_catalog() {
+        let _guard = env_lock::lock_env([
+            ("GOOSE_CONTEXT_LIMIT", None::<&str>),
+            ("GOOSE_MAX_TOKENS", None::<&str>),
+        ]);
+
+        let normalized = entry_declaring(vec![declared_flash_model()])
+            .normalize_model_config(ModelConfig::new("deepseek-v4-flash"))
+            .unwrap();
+
+        assert_eq!(normalized.context_limit, Some(32_768));
+        assert_eq!(normalized.max_tokens, Some(4096));
+    }
+
+    #[test]
+    fn undeclared_limit_still_falls_back_to_canonical_catalog() {
+        let _guard = env_lock::lock_env([
+            ("GOOSE_CONTEXT_LIMIT", None::<&str>),
+            ("GOOSE_MAX_TOKENS", None::<&str>),
+        ]);
+
+        let normalized = entry_declaring(vec![ModelInfo::new("deepseek-v4-flash", 0)])
+            .normalize_model_config(ModelConfig::new("deepseek-v4-flash"))
+            .unwrap();
+
+        assert!(
+            normalized.context_limit.is_some_and(|limit| limit > 32_768),
+            "a model with no declared limit should still be enriched from the catalog, got {:?}",
+            normalized.context_limit
+        );
+    }
+
+    #[test]
+    fn goose_context_limit_outranks_declaration() {
+        let _guard = env_lock::lock_env([
+            ("GOOSE_CONTEXT_LIMIT", Some("20000")),
+            ("GOOSE_MAX_TOKENS", Some("2048")),
+        ]);
+
+        let normalized = entry_declaring(vec![declared_flash_model()])
+            .normalize_model_config(ModelConfig::new("deepseek-v4-flash"))
+            .unwrap();
+
+        assert_eq!(normalized.context_limit, Some(20_000));
+        assert_eq!(normalized.max_tokens, Some(2048));
+    }
+
+    /// The limits an operator writes into `custom_providers/<id>.json` must
+    /// survive deserialization and reach the resolved config.
+    #[test]
+    fn limits_declared_in_provider_json_reach_the_resolved_config() {
+        let _guard = env_lock::lock_env([
+            ("GOOSE_CONTEXT_LIMIT", None::<&str>),
+            ("GOOSE_MAX_TOKENS", None::<&str>),
+        ]);
+
+        let config: DeclarativeProviderConfig = serde_json::from_str(
+            r#"{
+                "name": "custom_hf",
+                "engine": "openai",
+                "display_name": "Local ds4",
+                "base_url": "http://localhost:8000/v1",
+                "requires_auth": false,
+                "dynamic_models": false,
+                "skip_canonical_filtering": true,
+                "models": [
+                    { "name": "deepseek-v4-flash", "context_limit": 32768, "max_tokens": 4096 }
+                ]
+            }"#,
+        )
+        .unwrap();
+
+        let mut registry = ProviderRegistry::new(None);
+        registry.register_with_name_and_inventory_configured::<OpenAiProviderDef, _, _, _>(
+            &config,
+            ProviderType::Declarative,
+            false,
+            |_| unreachable!("constructor is not used by this test"),
+            || Ok(InventoryIdentityInput::new("custom_hf", "huggingface")),
+            || false,
+        );
+
+        let normalized = registry
+            .entries
+            .get("custom_hf")
+            .unwrap()
+            .normalize_model_config(ModelConfig::new("deepseek-v4-flash"))
+            .unwrap();
+
+        assert_eq!(normalized.context_limit, Some(32_768));
+        assert_eq!(normalized.max_tokens, Some(4096));
+    }
+
+    /// Every production caller (`session/builder.rs`, `acp/server.rs`) passes a
+    /// config that already went through `model_config_from_user_config`, so the
+    /// canonical limits are populated before this runs. Treating a populated
+    /// field as "the caller chose it" would silently skip the declaration —
+    /// which is the original bug.
+    #[test]
+    fn declaration_still_applies_to_an_already_materialized_config() {
+        let _guard = env_lock::lock_env([
+            ("GOOSE_CONTEXT_LIMIT", None::<&str>),
+            ("GOOSE_MAX_TOKENS", None::<&str>),
+        ]);
+
+        let already_resolved =
+            crate::model_config::model_config_from_user_config("custom_hf", "deepseek-v4-flash")
+                .unwrap();
+        assert!(
+            already_resolved.context_limit.is_some(),
+            "precondition: the caller's config arrives with canonical limits already applied"
+        );
+
+        let normalized = entry_declaring(vec![declared_flash_model()])
+            .normalize_model_config(already_resolved)
+            .unwrap();
+
+        assert_eq!(normalized.context_limit, Some(32_768));
+        assert_eq!(normalized.max_tokens, Some(4096));
+    }
+
+    #[test]
+    fn caller_supplied_limit_outranks_declaration() {
+        let _guard = env_lock::lock_env([
+            ("GOOSE_CONTEXT_LIMIT", None::<&str>),
+            ("GOOSE_MAX_TOKENS", None::<&str>),
+        ]);
+
+        let normalized = entry_declaring(vec![declared_flash_model()])
+            .normalize_model_config(
+                ModelConfig::new("deepseek-v4-flash").with_context_limit(Some(8_000)),
+            )
+            .unwrap();
+
+        assert_eq!(normalized.context_limit, Some(8_000));
     }
 }

--- a/ui/desktop/src/components/ChatInput.tsx
+++ b/ui/desktop/src/components/ChatInput.tsx
@@ -603,15 +603,12 @@ export default function ChatInput({
         return;
       }
 
-      // Priority 2: Check canonical model info (source of truth)
-      const canonicalInfo = await fetchCanonicalModelInfo(provider, model);
-      if (canonicalInfo?.contextLimit) {
-        setTokenLimit(canonicalInfo.contextLimit);
-        setIsTokenLimitLoaded(true);
-        return;
-      }
-
-      // Priority 3: Fall back to provider metadata known_models (may be outdated)
+      // Priority 2: The provider's own declaration, which describes the endpoint
+      // that will serve the request. The canonical catalog is matched on model
+      // *name*, so a local or proxied deployment reusing a well-known name
+      // inherits limits that have nothing to do with it. This mirrors the
+      // backend precedence in ProviderEntry::normalize_model_config; built-in
+      // providers derive known_models from the catalog, so they are unaffected.
       const providers = await acpListProviderDetails();
       const currentProvider = providers.find((p) => p.name === provider);
       if (currentProvider?.metadata?.known_models) {
@@ -621,6 +618,14 @@ export default function ChatInput({
           setIsTokenLimitLoaded(true);
           return;
         }
+      }
+
+      // Priority 3: Fall back to the canonical catalog
+      const canonicalInfo = await fetchCanonicalModelInfo(provider, model);
+      if (canonicalInfo?.contextLimit) {
+        setTokenLimit(canonicalInfo.contextLimit);
+        setIsTokenLimitLoaded(true);
+        return;
       }
 
       // Priority 4: Use default if nothing else found


### PR DESCRIPTION
## RFC series — consolidates #11050, #11063, #11070, #11073

One defect story in six commits: a long conversation against a custom local provider walks into the context wall and dies. Each commit is self-contained, carries its own log evidence in the commit body, and is revertable on its own. Consolidated per discussion so the series reads as one narrative instead of four cross-referencing PRs; the superseded PRs are closed with pointers here.

Deliberately **not** included: #11071 (pnpm lockfile / CI break) — unrelated infrastructure, urgent, should merge on its own.

## The commits

| # | commit | closes | what it fixes |
|---|---|---|---|
| 1 | `fix(providers): classify structured context-overflow 400s` | #11048 | a 400 carrying `code: "context_length_exceeded"` was `RequestFailed` → retried 4x, turn died. Both agent paths' recovery was unreachable |
| 2 | `fix(providers): let a provider's declared model limits outrank the catalog` | #11049 | declared `32768/4096` lost to a name-matched catalog `1000000/384000`; auto-compaction calibrated to a ceiling the endpoint never accepts |
| 3 | `fix: apply the same limit precedence to the model picker and token bar` | — (#11049) | same inversion in the two surfaces the user sees; the meter read 1M against a 32k endpoint |
| 4 | `fix(compaction): retry when the summary is cut off at the output limit` | — | every compaction summary truncated at exactly `max_tokens`; history replaced by scratchpad + half-written JSON, silently |
| 5 | `fix(providers): propagate the output-token-limit flag through collect_stream` | — | the flag arrives on the last stream chunk; `collect_stream` kept only the first chunk's metadata, so commit 4 (and the desktop's truncation notice) never saw it. New relative to the superseded PRs |
| 6 | `fix(compaction): re-check the threshold mid-turn` | #11072 | a tool-heavy turn ran 17,189 → 49,120 tokens across 30+ calls with zero compaction checks, because the check only runs at user-turn boundaries |

Ordering is the causal chain: classification makes the crash survivable (1), correct limits make it rare (2, 3), and when compaction does run it must produce a complete summary (4, 5) and must run early enough (6).

## Evidence

Each commit body carries the verbatim logs, ledger rows, and DB state it was diagnosed from — one live session (llama.cpp-derived server, `--ctx 49152`, declared `context_limit: 32768, max_tokens: 4096`) exhibited every one of these in sequence. Highlights:

- the 4x retry storm against a deterministic rejection, and the same condition recovering in the same second after commit 1
- `usage_ledger` walking 21,135 → 49,152 with `is_compaction=0` on every row (commit 2)
- three consecutive compactions returning exactly 4,096 output tokens, and a stored summary ending mid-word: `"Bug #4: OnceLock for mutable sync state — Once` (commit 4)
- the retry warning present in the binary, absent from the log, while compactions still truncated — the flag was being set and then dropped (commit 5)
- 30+ consecutive calls with no compaction check, ending at `49,120 in + 32 out` (commit 6)

## Status: draft, because of commit 6

Commits 1–5 are unit-tested and, except 5, have been observed working in a live session (0 overflow 400s across an evening of use that previously produced dozens). Commit 5 is unit-tested at the `collect_stream` level but not yet observed live — the running build predates it.

**Commit 6 has no test.** The `compaction_lifecycle` harness drives turns via `pipeline.run([...])`, which appends a user message and cannot express "still inside a turn". Options, in preference order: extend the harness so a seeded tool loop crosses the threshold mid-run and assert one `history_replacement` inside a single `run`; or empirical confirmation (`is_compaction=1` in `usage_ledger` with no intervening user message). Until one exists, commit 6 rests on reading the code. If the first five are wanted sooner, I can drop 6 from the series and it reverts to #11072's own PR.

## Verification

- [x] per-module: `goose-provider-types` 476/476 · `context_mgmt` 26/26 · `provider_registry` 7/7 · `inventory` 12/12
- [x] `cargo clippy -p goose -p goose-providers -p goose-provider-types --all-targets -- -D warnings` clean · `cargo fmt --check` clean
- [x] full `cargo test -p goose --lib`: the same 8 pre-existing failures as an untouched baseline (which flakes between 8 and 10 on unmodified code; the 8 are constant, the rest are noise)
- [x] desktop: `pnpm run typecheck` clean
- [x] live: fresh session resolves `32768/4096`; re-opened poisoned session repaired in place; an evening of use with zero overflow 400s

## Process note

None of #11048/#11049/#11072 is on the board as Ready; this stays a draft RFC until the design is agreed, per `AGENTS.md`. The superseded PRs' review threads (including the two corrections documented on #11063) remain linked from their closing comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
