### PR TITLE
feat(ui): show recent used models in chat footer model picker

### DIFF
--- a/ui/desktop/src/components/settings/models/bottom_bar/ModelsBottomBar.test.tsx
+++ b/ui/desktop/src/components/settings/models/bottom_bar/ModelsBottomBar.test.tsx
@@ -29,6 +29,7 @@ vi.mock('../../../ConfigContext', () => ({
 
 vi.mock('../modelInterface', () => ({
   getProviderMetadata: vi.fn().mockResolvedValue({ display_name: 'Config Provider' }),
+  fetchModelReasoning: vi.fn().mockResolvedValue(null),
 }));
 
 vi.mock('../predefinedModelsUtils', () => ({

--- a/ui/desktop/src/components/settings/models/bottom_bar/ModelsBottomBar.tsx
+++ b/ui/desktop/src/components/settings/models/bottom_bar/ModelsBottomBar.tsx
@@ -228,10 +228,7 @@ export default function ModelsBottomBar({
                   onClick={() => void handleRecentModelClick(recent)}
                 >
                   <History className="mr-2 h-3.5 w-3.5 flex-shrink-0 text-text-secondary" />
-                  <div className="flex flex-col min-w-0">
-                    <span className="truncate">{getModelDisplayName(recent.model)}</span>
-                    <span className="truncate text-xs text-text-secondary">{recent.provider}</span>
-                  </div>
+                  <span className="truncate">{getModelDisplayName(recent.model)} — {recent.provider}</span>
                 </DropdownMenuItem>
               ))}
               <DropdownMenuSeparator />

--- a/ui/desktop/src/components/settings/models/bottom_bar/ModelsBottomBar.tsx
+++ b/ui/desktop/src/components/settings/models/bottom_bar/ModelsBottomBar.tsx
@@ -162,12 +162,16 @@ export default function ModelsBottomBar({
   };
 
   const handleRecentModelClick = async (recent: RecentModel) => {
+    const previousModel = currentModel;
+    const previousProvider = currentProvider;
     const success = await changeModel(sessionId, { name: recent.model, provider: recent.provider });
     if (success) {
       trackModelChanged(recent.provider, recent.model);
-      const updated = addToRecentModels(recentModels, recent.provider, recent.model);
-      await window.electron.setSetting('recentModels', updated);
-      setRecentModels(updated);
+      if (previousModel && previousProvider) {
+        const updated = addToRecentModels(recentModels, previousProvider, previousModel);
+        await window.electron.setSetting('recentModels', updated);
+        setRecentModels(updated);
+      }
       onModelChanged({ model: recent.model, provider: recent.provider });
     }
   };
@@ -224,7 +228,10 @@ export default function ModelsBottomBar({
                   onClick={() => void handleRecentModelClick(recent)}
                 >
                   <History className="mr-2 h-3.5 w-3.5 flex-shrink-0 text-text-secondary" />
-                  <span className="truncate">{getModelDisplayName(recent.model)}</span>
+                  <div className="flex flex-col min-w-0">
+                    <span className="truncate">{getModelDisplayName(recent.model)}</span>
+                    <span className="truncate text-xs text-text-secondary">{recent.provider}</span>
+                  </div>
                 </DropdownMenuItem>
               ))}
               <DropdownMenuSeparator />

--- a/ui/desktop/src/components/settings/models/bottom_bar/ModelsBottomBar.tsx
+++ b/ui/desktop/src/components/settings/models/bottom_bar/ModelsBottomBar.tsx
@@ -1,5 +1,5 @@
-import { Sliders, Bot, LoaderCircle, Settings } from 'lucide-react';
-import React, { useEffect, useMemo, useState } from 'react';
+import { Sliders, Bot, LoaderCircle, Settings, History } from 'lucide-react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useModelAndProvider } from '../../../ModelAndProviderContext';
 import { SwitchModelModal } from '../subcomponents/SwitchModelModal';
 import { View } from '../../../../utils/navigationUtils';
@@ -7,6 +7,7 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '../../../ui/dropdown-menu';
 import { getProviderMetadata } from '../modelInterface';
@@ -16,6 +17,9 @@ import { ModelSettingsPanel } from '../../localInference/ModelSettingsPanel';
 import { ScrollArea } from '../../../ui/scroll-area';
 import { defineMessages, useIntl } from '../../../../i18n';
 import type { Message } from '../../../../types/message';
+import type { RecentModel } from '../../../../utils/settings';
+import { addToRecentModels } from '../../../../utils/recentModels';
+import { trackModelChanged } from '../../../../utils/analytics';
 
 const i18n = defineMessages({
   selectModel: {
@@ -46,6 +50,10 @@ const i18n = defineMessages({
     id: 'modelsBottomBar.resolvedModel',
     defaultMessage: 'Resolved model',
   },
+  recentModels: {
+    id: 'modelsBottomBar.recentModels',
+    defaultMessage: 'Recent',
+  },
 });
 
 interface ModelsBottomBarProps {
@@ -71,7 +79,7 @@ export default function ModelsBottomBar({
 }: ModelsBottomBarProps) {
   // ChatInput owns the override state and passes effective model/provider as sessionModel/sessionProvider.
   // Fall back to config defaults when no session-specific model is available.
-  const { currentModel: configModel, currentProvider: configProvider } = useModelAndProvider();
+  const { currentModel: configModel, currentProvider: configProvider, changeModel } = useModelAndProvider();
   const currentModel = sessionModel ?? configModel;
   const currentProvider = sessionProvider ?? configProvider;
 
@@ -83,6 +91,16 @@ export default function ModelsBottomBar({
   const [isAddModelModalOpen, setIsAddModelModalOpen] = useState(false);
   const [isLocalModelSettingsOpen, setIsLocalModelSettingsOpen] = useState(false);
   const [providerDefaultModel, setProviderDefaultModel] = useState<string | null>(null);
+  const [recentModels, setRecentModels] = useState<RecentModel[]>([]);
+
+  const loadRecentModels = useCallback(async () => {
+    const stored = (await window.electron.getSetting('recentModels')) ?? [];
+    setRecentModels(stored);
+  }, []);
+
+  useEffect(() => {
+    void loadRecentModels();
+  }, [loadRecentModels]);
 
   // Show a visible loading placeholder while session metadata is still being fetched,
   // rather than flashing the config default or leaving the footer blank.
@@ -139,8 +157,25 @@ export default function ModelsBottomBar({
   );
 
   const handleModelSelected = (model: string, provider: string) => {
+    void loadRecentModels();
     onModelChanged({ model, provider });
   };
+
+  const handleRecentModelClick = async (recent: RecentModel) => {
+    const success = await changeModel(sessionId, { name: recent.model, provider: recent.provider });
+    if (success) {
+      trackModelChanged(recent.provider, recent.model);
+      const current = (await window.electron.getSetting('recentModels')) ?? [];
+      const updated = addToRecentModels(current, recent.provider, recent.model);
+      await window.electron.setSetting('recentModels', updated);
+      setRecentModels(updated);
+      onModelChanged({ model: recent.model, provider: recent.provider });
+    }
+  };
+
+  const filteredRecentModels = recentModels.filter(
+    (r) => !(r.model === currentModel && r.provider === currentProvider)
+  );
 
   return (
     <div className="relative flex items-center" ref={dropdownRef}>
@@ -178,6 +213,23 @@ export default function ModelsBottomBar({
                 {resolvedDisplayModelName}
               </p>
             </div>
+          )}
+          {filteredRecentModels.length > 0 && (
+            <>
+              <h6 className="text-xs text-text-primary mt-2 ml-2">
+                {intl.formatMessage(i18n.recentModels)}
+              </h6>
+              {filteredRecentModels.map((recent) => (
+                <DropdownMenuItem
+                  key={`${recent.provider}/${recent.model}`}
+                  onClick={() => void handleRecentModelClick(recent)}
+                >
+                  <History className="mr-2 h-3.5 w-3.5 flex-shrink-0 text-text-secondary" />
+                  <span className="truncate">{getModelDisplayName(recent.model)}</span>
+                </DropdownMenuItem>
+              ))}
+              <DropdownMenuSeparator />
+            </>
           )}
           <DropdownMenuItem onClick={() => setIsAddModelModalOpen(true)}>
             <span>{intl.formatMessage(i18n.changeModel)}</span>

--- a/ui/desktop/src/components/settings/models/bottom_bar/ModelsBottomBar.tsx
+++ b/ui/desktop/src/components/settings/models/bottom_bar/ModelsBottomBar.tsx
@@ -168,7 +168,7 @@ export default function ModelsBottomBar({
 
     const [reasoning, savedEffort] = await Promise.all([
       fetchModelReasoning(recent.provider, recent.model),
-      acpReadThinkingEffort(),
+      acpReadThinkingEffort().catch(() => null),
     ]);
     const modelArg = reasoning
       ? {

--- a/ui/desktop/src/components/settings/models/bottom_bar/ModelsBottomBar.tsx
+++ b/ui/desktop/src/components/settings/models/bottom_bar/ModelsBottomBar.tsx
@@ -165,8 +165,7 @@ export default function ModelsBottomBar({
     const success = await changeModel(sessionId, { name: recent.model, provider: recent.provider });
     if (success) {
       trackModelChanged(recent.provider, recent.model);
-      const current = (await window.electron.getSetting('recentModels')) ?? [];
-      const updated = addToRecentModels(current, recent.provider, recent.model);
+      const updated = addToRecentModels(recentModels, recent.provider, recent.model);
       await window.electron.setSetting('recentModels', updated);
       setRecentModels(updated);
       onModelChanged({ model: recent.model, provider: recent.provider });

--- a/ui/desktop/src/components/settings/models/bottom_bar/ModelsBottomBar.tsx
+++ b/ui/desktop/src/components/settings/models/bottom_bar/ModelsBottomBar.tsx
@@ -10,8 +10,9 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '../../../ui/dropdown-menu';
-import { getProviderMetadata } from '../modelInterface';
+import { getProviderMetadata, fetchModelReasoning } from '../modelInterface';
 import { getModelDisplayName } from '../predefinedModelsUtils';
+import { acpReadThinkingEffort } from '../../../../acp/providers';
 
 import { ModelSettingsPanel } from '../../localInference/ModelSettingsPanel';
 import { ScrollArea } from '../../../ui/scroll-area';
@@ -164,7 +165,19 @@ export default function ModelsBottomBar({
   const handleRecentModelClick = async (recent: RecentModel) => {
     const previousModel = currentModel;
     const previousProvider = currentProvider;
-    const success = await changeModel(sessionId, { name: recent.model, provider: recent.provider });
+
+    const [reasoning, savedEffort] = await Promise.all([
+      fetchModelReasoning(recent.provider, recent.model),
+      acpReadThinkingEffort(),
+    ]);
+    const modelArg = reasoning
+      ? {
+          name: recent.model,
+          provider: recent.provider,
+          request_params: { thinking_effort: savedEffort ?? 'off' },
+        }
+      : { name: recent.model, provider: recent.provider };
+    const success = await changeModel(sessionId, modelArg);
     if (success) {
       trackModelChanged(recent.provider, recent.model);
       if (previousModel && previousProvider) {

--- a/ui/desktop/src/components/settings/models/subcomponents/SwitchModelModal.tsx
+++ b/ui/desktop/src/components/settings/models/subcomponents/SwitchModelModal.tsx
@@ -29,6 +29,7 @@ import Model, {
 import { getPredefinedModelsFromEnv, shouldShowPredefinedModels } from '../predefinedModelsUtils';
 import type { ProviderDetails, ProviderType, ThinkingEffort } from '../../../../types/providers';
 import { trackModelChanged } from '../../../../utils/analytics';
+import { addToRecentModels } from '../../../../utils/recentModels';
 
 const i18n = defineMessages({
   thinkingEffortOff: {
@@ -427,6 +428,14 @@ export const SwitchModelModal = ({
       if (success) {
         onModelSelected?.(modelObj.name, modelObj.provider || '');
         trackModelChanged(modelObj.provider || '', modelObj.name);
+        const provider = modelObj.provider || '';
+        if (provider && modelObj.name) {
+          const current = (await window.electron.getSetting('recentModels')) ?? [];
+          await window.electron.setSetting(
+            'recentModels',
+            addToRecentModels(current, provider, modelObj.name)
+          );
+        }
       }
 
       onClose();

--- a/ui/desktop/src/components/settings/models/subcomponents/SwitchModelModal.tsx
+++ b/ui/desktop/src/components/settings/models/subcomponents/SwitchModelModal.tsx
@@ -427,11 +427,13 @@ export const SwitchModelModal = ({
       const success = await changeModel(sessionId, modelObj);
       if (success) {
         trackModelChanged(modelObj.provider || '', modelObj.name);
-        const current = (await window.electron.getSetting('recentModels')) ?? [];
-        await window.electron.setSetting(
-          'recentModels',
-          addToRecentModels(current, modelObj.provider || '', modelObj.name)
-        );
+        if (currentModel && currentProvider) {
+          const current = (await window.electron.getSetting('recentModels')) ?? [];
+          await window.electron.setSetting(
+            'recentModels',
+            addToRecentModels(current, currentProvider, currentModel)
+          );
+        }
         onModelSelected?.(modelObj.name, modelObj.provider || '');
       }
 

--- a/ui/desktop/src/components/settings/models/subcomponents/SwitchModelModal.tsx
+++ b/ui/desktop/src/components/settings/models/subcomponents/SwitchModelModal.tsx
@@ -426,16 +426,13 @@ export const SwitchModelModal = ({
 
       const success = await changeModel(sessionId, modelObj);
       if (success) {
-        onModelSelected?.(modelObj.name, modelObj.provider || '');
         trackModelChanged(modelObj.provider || '', modelObj.name);
-        const provider = modelObj.provider || '';
-        if (provider && modelObj.name) {
-          const current = (await window.electron.getSetting('recentModels')) ?? [];
-          await window.electron.setSetting(
-            'recentModels',
-            addToRecentModels(current, provider, modelObj.name)
-          );
-        }
+        const current = (await window.electron.getSetting('recentModels')) ?? [];
+        await window.electron.setSetting(
+          'recentModels',
+          addToRecentModels(current, modelObj.provider || '', modelObj.name)
+        );
+        onModelSelected?.(modelObj.name, modelObj.provider || '');
       }
 
       onClose();

--- a/ui/desktop/src/i18n/messages/de.json
+++ b/ui/desktop/src/i18n/messages/de.json
@@ -4621,5 +4621,8 @@
   },
   "userMessage.removeImageFromEdit": {
     "defaultMessage": "Bild aus Nachricht entfernen"
+  },
+  "modelsBottomBar.recentModels": {
+    "defaultMessage": "Zuletzt verwendet"
   }
 }

--- a/ui/desktop/src/i18n/messages/en.json
+++ b/ui/desktop/src/i18n/messages/en.json
@@ -2330,6 +2330,9 @@
   "modelsBottomBar.localModelSettingsTitle": {
     "defaultMessage": "Local Model Settings — {modelName}"
   },
+  "modelsBottomBar.recentModels": {
+    "defaultMessage": "Recent"
+  },
   "modelsBottomBar.resolvedModel": {
     "defaultMessage": "Resolved model"
   },

--- a/ui/desktop/src/i18n/messages/es.json
+++ b/ui/desktop/src/i18n/messages/es.json
@@ -4621,5 +4621,8 @@
   },
   "userMessage.removeImageFromEdit": {
     "defaultMessage": "Eliminar imagen del mensaje"
+  },
+  "modelsBottomBar.recentModels": {
+    "defaultMessage": "Recientes"
   }
 }

--- a/ui/desktop/src/i18n/messages/fr.json
+++ b/ui/desktop/src/i18n/messages/fr.json
@@ -4621,5 +4621,8 @@
   },
   "userMessage.removeImageFromEdit": {
     "defaultMessage": "Supprimer l'image du message"
+  },
+  "modelsBottomBar.recentModels": {
+    "defaultMessage": "Récents"
   }
 }

--- a/ui/desktop/src/i18n/messages/hi.json
+++ b/ui/desktop/src/i18n/messages/hi.json
@@ -4621,5 +4621,8 @@
   },
   "userMessage.removeImageFromEdit": {
     "defaultMessage": "संदेश से छवि हटाएँ"
+  },
+  "modelsBottomBar.recentModels": {
+    "defaultMessage": "हाल के"
   }
 }

--- a/ui/desktop/src/i18n/messages/id.json
+++ b/ui/desktop/src/i18n/messages/id.json
@@ -4621,5 +4621,8 @@
   },
   "userMessage.removeImageFromEdit": {
     "defaultMessage": "Hapus gambar dari pesan"
+  },
+  "modelsBottomBar.recentModels": {
+    "defaultMessage": "Terbaru"
   }
 }

--- a/ui/desktop/src/i18n/messages/it.json
+++ b/ui/desktop/src/i18n/messages/it.json
@@ -4621,5 +4621,8 @@
   },
   "userMessage.removeImageFromEdit": {
     "defaultMessage": "Rimuovi immagine dal messaggio"
+  },
+  "modelsBottomBar.recentModels": {
+    "defaultMessage": "Recenti"
   }
 }

--- a/ui/desktop/src/i18n/messages/ja.json
+++ b/ui/desktop/src/i18n/messages/ja.json
@@ -4621,5 +4621,8 @@
   },
   "userMessage.removeImageFromEdit": {
     "defaultMessage": "メッセージから画像を削除"
+  },
+  "modelsBottomBar.recentModels": {
+    "defaultMessage": "最近"
   }
 }

--- a/ui/desktop/src/i18n/messages/ko.json
+++ b/ui/desktop/src/i18n/messages/ko.json
@@ -4621,5 +4621,8 @@
   },
   "userMessage.removeImageFromEdit": {
     "defaultMessage": "메시지에서 이미지 제거"
+  },
+  "modelsBottomBar.recentModels": {
+    "defaultMessage": "최근"
   }
 }

--- a/ui/desktop/src/i18n/messages/ms.json
+++ b/ui/desktop/src/i18n/messages/ms.json
@@ -4621,5 +4621,8 @@
   },
   "userMessage.removeImageFromEdit": {
     "defaultMessage": "Alih keluar imej daripada mesej"
+  },
+  "modelsBottomBar.recentModels": {
+    "defaultMessage": "Terkini"
   }
 }

--- a/ui/desktop/src/i18n/messages/pt.json
+++ b/ui/desktop/src/i18n/messages/pt.json
@@ -4621,5 +4621,8 @@
   },
   "userMessage.removeImageFromEdit": {
     "defaultMessage": "Remover imagem da mensagem"
+  },
+  "modelsBottomBar.recentModels": {
+    "defaultMessage": "Recentes"
   }
 }

--- a/ui/desktop/src/i18n/messages/ru.json
+++ b/ui/desktop/src/i18n/messages/ru.json
@@ -4621,5 +4621,8 @@
   },
   "userMessage.removeImageFromEdit": {
     "defaultMessage": "Удалить изображение из сообщения"
+  },
+  "modelsBottomBar.recentModels": {
+    "defaultMessage": "Недавние"
   }
 }

--- a/ui/desktop/src/i18n/messages/tr.json
+++ b/ui/desktop/src/i18n/messages/tr.json
@@ -4621,5 +4621,8 @@
   },
   "userMessage.removeImageFromEdit": {
     "defaultMessage": "Görseli mesajdan kaldır"
+  },
+  "modelsBottomBar.recentModels": {
+    "defaultMessage": "Son kullanılan"
   }
 }

--- a/ui/desktop/src/i18n/messages/vi.json
+++ b/ui/desktop/src/i18n/messages/vi.json
@@ -4621,5 +4621,8 @@
   },
   "userMessage.removeImageFromEdit": {
     "defaultMessage": "Xóa hình ảnh khỏi tin nhắn"
+  },
+  "modelsBottomBar.recentModels": {
+    "defaultMessage": "Gần đây"
   }
 }

--- a/ui/desktop/src/i18n/messages/zh-CN.json
+++ b/ui/desktop/src/i18n/messages/zh-CN.json
@@ -4621,5 +4621,8 @@
   },
   "userMessage.removeImageFromEdit": {
     "defaultMessage": "从消息中移除图片"
+  },
+  "modelsBottomBar.recentModels": {
+    "defaultMessage": "最近"
   }
 }

--- a/ui/desktop/src/i18n/messages/zh-TW.json
+++ b/ui/desktop/src/i18n/messages/zh-TW.json
@@ -4621,5 +4621,8 @@
   },
   "userMessage.removeImageFromEdit": {
     "defaultMessage": "從訊息中移除圖片"
+  },
+  "modelsBottomBar.recentModels": {
+    "defaultMessage": "最近"
   }
 }

--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -1962,6 +1962,7 @@ const validSettingKeys: Set<string> = new Set([
   'showPricing',
   'seenAnnouncementIds',
   'disableAutoDownload',
+  'recentModels',
 ]);
 
 ipcMain.handle('set-setting', (_event, key: SettingKey, value: unknown) => {

--- a/ui/desktop/src/utils/recentModels.ts
+++ b/ui/desktop/src/utils/recentModels.ts
@@ -1,0 +1,12 @@
+import type { RecentModel } from './settings';
+
+const MAX_RECENT_MODELS = 5;
+
+export function addToRecentModels(
+  current: RecentModel[],
+  provider: string,
+  model: string
+): RecentModel[] {
+  const filtered = current.filter((m) => !(m.provider === provider && m.model === model));
+  return [{ provider, model }, ...filtered].slice(0, MAX_RECENT_MODELS);
+}

--- a/ui/desktop/src/utils/settings.ts
+++ b/ui/desktop/src/utils/settings.ts
@@ -1,3 +1,8 @@
+export type RecentModel = {
+  provider: string;
+  model: string;
+};
+
 export interface ExternalBackendConfig {
   enabled: boolean;
   url: string;
@@ -49,6 +54,7 @@ export interface Settings {
   responseStyle: string;
   showPricing: boolean;
   seenAnnouncementIds: string[];
+  recentModels: RecentModel[];
 }
 
 export type SettingKey = keyof Settings;
@@ -89,6 +95,7 @@ export const defaultSettings: Settings = {
   responseStyle: 'concise',
   showPricing: true,
   seenAnnouncementIds: [],
+  recentModels: [],
 };
 
 export function getKeyboardShortcuts(settings: Settings): KeyboardShortcuts {


### PR DESCRIPTION
fixes: #9080

## Summary

Adds a "Recent" section to the chat footer model dropdown showing the last 5 models used, so you can switch back without opening the full picker. Clicking a recent model switches the session directly. List persists across restarts, excludes the current model, and is hidden when empty

### Testing
manual

### Screenshots (UI/UX change) 

<img width="1404" height="898" alt="image" src="https://github.com/user-attachments/assets/fd87240d-8ec6-4bd7-ba63-cf34f198013b" />
