### PR TITLE
fix(provider-types): update tool response metadata fixture

### DIFF
--- a/crates/goose-provider-types/src/conversation/message.rs
+++ b/crates/goose-provider-types/src/conversation/message.rs
@@ -1580,7 +1580,7 @@ mod tests {
         );
         let mut result = CallToolResult::success(vec![text, image]);
         result.structured_content = Some(serde_json::json!({"safe": "世界"}));
-        result.meta = Some(rmcp::model::Meta(object!({"source": "test"})));
+        result.meta = Some(rmcp::model::MetaObject(object!({"source": "test"})));
         let expected = result.clone();
 
         let content = MessageContentBlock::tool_response("tool-1", Ok(result));


### PR DESCRIPTION
## Summary

- update the legitimate tool-response sanitization fixture for the locked `rmcp` 3.0.0 API
- restore compilation and execution of the regression coverage added by #10609
- preserve coverage for text/image annotations, structured content, and result metadata

## Security context

This is a follow-up to the merged remediation for:

- [project-loupe/audit-goose#408](https://github.com/project-loupe/audit-goose/issues/408)
- [project-loupe/audit-goose#412](https://github.com/project-loupe/audit-goose/issues/412)
- [project-loupe/audit-goose#527](https://github.com/project-loupe/audit-goose/issues/527)

The production sanitizer is already on `main`; this corrects the metadata constructor in its legitimate-content regression fixture so the covered issues can be verified on current main after merge.

## Verification

- `bin/cargo fmt --check`
- `bin/cargo test -p goose-provider-types tool_response` (29 passed)
- `bin/cargo build -p goose-provider-types`
- `bin/cargo clippy -p goose-provider-types --all-targets -- -D warnings`

_This finding was discovered by [Project Loupe](https://github.com/project-loupe/loupe)._
