### PR TITLE
fix(scheduler): prevent deleting active jobs

### DIFF
--- a/crates/goose/src/acp/server/schedule.rs
+++ b/crates/goose/src/acp/server/schedule.rs
@@ -46,6 +46,8 @@ fn schedule_not_found_or_internal(error: SchedulerError) -> agent_client_protoco
         SchedulerError::JobNotFound(id) => {
             agent_client_protocol::Error::resource_not_found(Some(id))
         }
+        SchedulerError::JobRunning(id) => agent_client_protocol::Error::invalid_params()
+            .data(format!("Schedule is currently running: {id}")),
         error => agent_client_protocol::Error::internal_error().data(error.to_string()),
     }
 }

--- a/crates/goose/src/scheduler.rs
+++ b/crates/goose/src/scheduler.rs
@@ -157,6 +157,7 @@ pub fn get_default_scheduled_recipes_dir() -> Result<PathBuf, SchedulerError> {
 pub enum SchedulerError {
     JobIdExists(String),
     JobNotFound(String),
+    JobRunning(String),
     StorageError(io::Error),
     RecipeLoadError(String),
     AgentSetupError(String),
@@ -171,6 +172,9 @@ impl std::fmt::Display for SchedulerError {
         match self {
             SchedulerError::JobIdExists(id) => write!(f, "Job ID '{}' already exists.", id),
             SchedulerError::JobNotFound(id) => write!(f, "Job ID '{}' not found.", id),
+            SchedulerError::JobRunning(id) => {
+                write!(f, "Job ID '{}' cannot be removed while it is running.", id)
+            }
             SchedulerError::StorageError(e) => write!(f, "Storage error: {}", e),
             SchedulerError::RecipeLoadError(e) => write!(f, "Recipe load error: {}", e),
             SchedulerError::AgentSetupError(e) => write!(f, "Agent setup error: {}", e),
@@ -744,10 +748,15 @@ impl Scheduler {
     ) -> Result<(), SchedulerError> {
         let (job_uuid, recipe_path) = {
             let mut jobs_guard = self.jobs.lock().await;
-            match jobs_guard.remove(id) {
-                Some((uuid, job)) => (uuid, job.source.clone()),
+            match jobs_guard.get(id) {
+                Some((_, job)) if job.currently_running => {
+                    return Err(SchedulerError::JobRunning(id.to_string()));
+                }
                 None => return Err(SchedulerError::JobNotFound(id.to_string())),
+                _ => {}
             }
+            let (uuid, job) = jobs_guard.remove(id).expect("job was checked above");
+            (uuid, job.source)
         };
 
         self.tokio_scheduler
@@ -1581,6 +1590,62 @@ mod tests {
             !recipe_path.exists(),
             "Recipe should be deleted when remove_recipe is true"
         );
+    }
+
+    #[tokio::test]
+    async fn test_remove_scheduled_job_rejects_running_job() {
+        let temp_dir = tempdir().unwrap();
+        let storage_path = temp_dir.path().join("schedule.json");
+        let recipe_path = create_test_recipe(temp_dir.path(), "running_removal_job");
+        let session_manager = Arc::new(SessionManager::new(temp_dir.path().to_path_buf()));
+        let scheduler = Scheduler::new(storage_path.clone(), session_manager)
+            .await
+            .unwrap();
+
+        let job = ScheduledJob {
+            id: "running_removal_job".to_string(),
+            source: recipe_path.to_string_lossy().to_string(),
+            cron: "0 0 0 1 1 *".to_string(),
+            last_run: None,
+            currently_running: true,
+            paused: false,
+            current_session_id: Some("session-id".to_string()),
+            process_start_time: Some(Utc::now()),
+            parameters: vec![],
+            recipe_base_dir: None,
+        };
+
+        scheduler.add_scheduled_job(job, false).await.unwrap();
+        let token = CancellationToken::new();
+        scheduler
+            .running_tasks
+            .lock()
+            .await
+            .insert("running_removal_job".to_string(), token.clone());
+
+        let error = scheduler
+            .remove_scheduled_job("running_removal_job", false)
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, SchedulerError::JobRunning(id) if id == "running_removal_job"));
+        assert!(scheduler
+            .jobs
+            .lock()
+            .await
+            .contains_key("running_removal_job"));
+        assert!(scheduler
+            .running_tasks
+            .lock()
+            .await
+            .contains_key("running_removal_job"));
+        assert!(!token.is_cancelled());
+
+        let persisted_jobs: Vec<ScheduledJob> =
+            serde_json::from_str(&fs::read_to_string(storage_path).unwrap()).unwrap();
+        assert!(persisted_jobs
+            .iter()
+            .any(|job| job.id == "running_removal_job" && job.currently_running));
     }
 
     #[tokio::test]

--- a/crates/goose/src/scheduler.rs
+++ b/crates/goose/src/scheduler.rs
@@ -286,6 +286,31 @@ async fn claim_cron_execution(
     true
 }
 
+async fn claim_manual_execution(
+    jobs: &Arc<Mutex<JobsMap>>,
+    running_tasks: &Arc<Mutex<RunningTasksMap>>,
+    job_id: &str,
+    current_time: DateTime<Utc>,
+    cancel_token: CancellationToken,
+) -> Result<ScheduledJob, SchedulerError> {
+    let mut jobs_guard = jobs.lock().await;
+    let Some((_, job)) = jobs_guard.get_mut(job_id) else {
+        return Err(SchedulerError::JobNotFound(job_id.to_string()));
+    };
+    if job.currently_running {
+        return Err(SchedulerError::AnyhowError(anyhow!(
+            "Job '{}' is already running",
+            job_id
+        )));
+    }
+
+    let mut tasks_guard = running_tasks.lock().await;
+    job.currently_running = true;
+    job.process_start_time = Some(current_time);
+    tasks_guard.insert(job_id.to_string(), cancel_token);
+    Ok(job.clone())
+}
+
 pub struct Scheduler {
     tokio_scheduler: TokioJobScheduler,
     jobs: Arc<Mutex<JobsMap>>,
@@ -808,31 +833,17 @@ impl Scheduler {
     }
 
     pub async fn run_now(&self, sched_id: &str) -> Result<String, SchedulerError> {
-        let job_to_run = {
-            let mut jobs_guard = self.jobs.lock().await;
-            match jobs_guard.get_mut(sched_id) {
-                Some((_, job)) => {
-                    if job.currently_running {
-                        return Err(SchedulerError::AnyhowError(anyhow!(
-                            "Job '{}' is already running",
-                            sched_id
-                        )));
-                    }
-                    job.currently_running = true;
-                    job.process_start_time = Some(Utc::now());
-                    job.clone()
-                }
-                None => return Err(SchedulerError::JobNotFound(sched_id.to_string())),
-            }
-        };
+        let cancel_token = CancellationToken::new();
+        let job_to_run = claim_manual_execution(
+            &self.jobs,
+            &self.running_tasks,
+            sched_id,
+            Utc::now(),
+            cancel_token.clone(),
+        )
+        .await?;
 
         persist_jobs(&self.storage_path, &self.jobs).await?;
-
-        let cancel_token = CancellationToken::new();
-        {
-            let mut tasks = self.running_tasks.lock().await;
-            tasks.insert(sched_id.to_string(), cancel_token.clone());
-        }
 
         let result = execute_job(
             job_to_run,
@@ -1777,6 +1788,73 @@ mod tests {
         let tasks_guard = scheduler.running_tasks.lock().await;
         assert!(tasks_guard.get("active_cron_job").unwrap().is_cancelled());
         assert!(!second_token.is_cancelled());
+    }
+
+    #[tokio::test]
+    async fn manual_claim_serializes_with_kill() {
+        let temp_dir = tempdir().unwrap();
+        let storage_path = temp_dir.path().join("schedule.json");
+        let recipe_path = create_test_recipe(temp_dir.path(), "manual_claim_job");
+        let session_manager = Arc::new(SessionManager::new(temp_dir.path().to_path_buf()));
+        let scheduler = Scheduler::new(storage_path, session_manager).await.unwrap();
+
+        let job = ScheduledJob {
+            id: "manual_claim_job".to_string(),
+            source: recipe_path.to_string_lossy().to_string(),
+            cron: "0 0 0 1 1 *".to_string(),
+            last_run: None,
+            currently_running: false,
+            paused: false,
+            current_session_id: None,
+            process_start_time: None,
+            parameters: vec![],
+            recipe_base_dir: None,
+        };
+        scheduler.add_scheduled_job(job, false).await.unwrap();
+
+        let running_tasks_guard = scheduler.running_tasks.lock().await;
+        let claim_scheduler = scheduler.clone();
+        let cancel_token = CancellationToken::new();
+        let claim_token = cancel_token.clone();
+        let claim = tokio::spawn(async move {
+            claim_manual_execution(
+                &claim_scheduler.jobs,
+                &claim_scheduler.running_tasks,
+                "manual_claim_job",
+                Utc::now(),
+                claim_token,
+            )
+            .await
+        });
+
+        timeout(Duration::from_secs(1), async {
+            while scheduler.jobs.try_lock().is_ok() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("manual claim should lock jobs while registering its cancellation token");
+
+        let kill_scheduler = scheduler.clone();
+        let kill =
+            tokio::spawn(async move { kill_scheduler.kill_running_job("manual_claim_job").await });
+        drop(running_tasks_guard);
+
+        claim.await.unwrap().unwrap();
+        kill.await.unwrap().unwrap();
+
+        let jobs_guard = scheduler.jobs.lock().await;
+        let (_, claimed_job) = jobs_guard.get("manual_claim_job").unwrap();
+        assert!(!claimed_job.currently_running);
+        assert!(claimed_job.process_start_time.is_none());
+        drop(jobs_guard);
+
+        assert!(cancel_token.is_cancelled());
+        assert!(!scheduler
+            .running_tasks
+            .lock()
+            .await
+            .contains_key("manual_claim_job"));
     }
 
     #[tokio::test]

--- a/crates/goose/src/scheduler.rs
+++ b/crates/goose/src/scheduler.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
 use tokio_cron_scheduler::{job::JobId, Job, JobScheduler as TokioJobScheduler};
 use tokio_util::sync::CancellationToken;
+use uuid::Uuid;
 
 use crate::agents::{Agent, AgentConfig, AgentEvent, GoosePlatform, SessionConfig};
 use crate::config::paths::Paths;
@@ -27,7 +28,12 @@ use crate::scheduler_trait::SchedulerTrait;
 use crate::session::session_manager::SessionType;
 use crate::session::{Session, SessionManager};
 
-type RunningTasksMap = HashMap<String, CancellationToken>;
+struct RunningTask {
+    execution_id: Uuid,
+    cancel_token: CancellationToken,
+}
+
+type RunningTasksMap = HashMap<String, RunningTask>;
 type JobsMap = HashMap<String, (JobId, ScheduledJob)>;
 
 pub(crate) const MAX_SCHEDULE_RECIPE_BYTES: u64 = 1024 * 1024;
@@ -269,21 +275,26 @@ async fn claim_cron_execution(
     job_id: &str,
     current_time: DateTime<Utc>,
     cancel_token: CancellationToken,
-) -> bool {
+) -> Option<Uuid> {
     let mut jobs_guard = jobs.lock().await;
-    let Some((_, job)) = jobs_guard.get_mut(job_id) else {
-        return false;
-    };
+    let (_, job) = jobs_guard.get_mut(job_id)?;
     if job.paused || job.currently_running {
-        return false;
+        return None;
     }
 
     let mut tasks_guard = running_tasks.lock().await;
+    let execution_id = Uuid::new_v4();
     job.last_run = Some(current_time);
     job.currently_running = true;
     job.process_start_time = Some(current_time);
-    tasks_guard.insert(job_id.to_string(), cancel_token);
-    true
+    tasks_guard.insert(
+        job_id.to_string(),
+        RunningTask {
+            execution_id,
+            cancel_token,
+        },
+    );
+    Some(execution_id)
 }
 
 async fn claim_manual_execution(
@@ -292,7 +303,7 @@ async fn claim_manual_execution(
     job_id: &str,
     current_time: DateTime<Utc>,
     cancel_token: CancellationToken,
-) -> Result<ScheduledJob, SchedulerError> {
+) -> Result<(ScheduledJob, Uuid), SchedulerError> {
     let mut jobs_guard = jobs.lock().await;
     let Some((_, job)) = jobs_guard.get_mut(job_id) else {
         return Err(SchedulerError::JobNotFound(job_id.to_string()));
@@ -305,10 +316,66 @@ async fn claim_manual_execution(
     }
 
     let mut tasks_guard = running_tasks.lock().await;
+    let execution_id = Uuid::new_v4();
     job.currently_running = true;
     job.process_start_time = Some(current_time);
-    tasks_guard.insert(job_id.to_string(), cancel_token);
-    Ok(job.clone())
+    tasks_guard.insert(
+        job_id.to_string(),
+        RunningTask {
+            execution_id,
+            cancel_token,
+        },
+    );
+    Ok((job.clone(), execution_id))
+}
+
+async fn set_execution_session(
+    jobs: &Arc<Mutex<JobsMap>>,
+    running_tasks: &Arc<Mutex<RunningTasksMap>>,
+    job_id: &str,
+    execution_id: Uuid,
+    session_id: String,
+) -> bool {
+    let mut jobs_guard = jobs.lock().await;
+    let tasks_guard = running_tasks.lock().await;
+    if !matches!(
+        tasks_guard.get(job_id),
+        Some(task) if task.execution_id == execution_id
+    ) {
+        return false;
+    }
+
+    let Some((_, job)) = jobs_guard.get_mut(job_id) else {
+        return false;
+    };
+    job.current_session_id = Some(session_id);
+    true
+}
+
+async fn finish_execution(
+    jobs: &Arc<Mutex<JobsMap>>,
+    running_tasks: &Arc<Mutex<RunningTasksMap>>,
+    job_id: &str,
+    execution_id: Uuid,
+    completed_at: Option<DateTime<Utc>>,
+) -> bool {
+    let mut jobs_guard = jobs.lock().await;
+    let mut tasks_guard = running_tasks.lock().await;
+    if !matches!(
+        tasks_guard.get(job_id),
+        Some(task) if task.execution_id == execution_id
+    ) {
+        return false;
+    }
+
+    tasks_guard.remove(job_id);
+    if let Some((_, job)) = jobs_guard.get_mut(job_id) {
+        clear_running_state(job);
+        if let Some(completed_at) = completed_at {
+            job.last_run = Some(completed_at);
+        }
+    }
+    true
 }
 
 pub struct Scheduler {
@@ -390,7 +457,7 @@ impl Scheduler {
             Box::pin(async move {
                 let current_time = Utc::now();
                 let cancel_token = CancellationToken::new();
-                if !claim_cron_execution(
+                let Some(execution_id) = claim_cron_execution(
                     &current_jobs_arc,
                     &running_tasks,
                     &task_job_id,
@@ -398,9 +465,9 @@ impl Scheduler {
                     cancel_token.clone(),
                 )
                 .await
-                {
+                else {
                     return;
-                }
+                };
 
                 if let Err(e) = persist_jobs(&local_storage_path, &current_jobs_arc).await {
                     tracing::error!("Failed to persist job status: {}", e);
@@ -409,25 +476,22 @@ impl Scheduler {
                 let result = execute_job(
                     job_to_execute,
                     current_jobs_arc.clone(),
+                    running_tasks.clone(),
                     task_job_id.clone(),
+                    execution_id,
                     cancel_token.clone(),
                     session_manager,
                 )
                 .await;
 
-                {
-                    let mut tasks = running_tasks.lock().await;
-                    tasks.remove(&task_job_id);
-                }
-
-                {
-                    let mut jobs_guard = current_jobs_arc.lock().await;
-                    if let Some((_, job)) = jobs_guard.get_mut(&task_job_id) {
-                        job.currently_running = false;
-                        job.current_session_id = None;
-                        job.process_start_time = None;
-                    }
-                }
+                finish_execution(
+                    &current_jobs_arc,
+                    &running_tasks,
+                    &task_job_id,
+                    execution_id,
+                    None,
+                )
+                .await;
 
                 if let Err(e) = persist_jobs(&local_storage_path, &current_jobs_arc).await {
                     tracing::error!("Failed to persist job completion: {}", e);
@@ -834,7 +898,7 @@ impl Scheduler {
 
     pub async fn run_now(&self, sched_id: &str) -> Result<String, SchedulerError> {
         let cancel_token = CancellationToken::new();
-        let job_to_run = claim_manual_execution(
+        let (job_to_run, execution_id) = claim_manual_execution(
             &self.jobs,
             &self.running_tasks,
             sched_id,
@@ -848,27 +912,23 @@ impl Scheduler {
         let result = execute_job(
             job_to_run,
             self.jobs.clone(),
+            self.running_tasks.clone(),
             sched_id.to_string(),
+            execution_id,
             cancel_token.clone(),
             self.session_manager.clone(),
         )
         .await;
         let was_cancelled = cancel_token.is_cancelled();
 
-        {
-            let mut tasks = self.running_tasks.lock().await;
-            tasks.remove(sched_id);
-        }
-
-        {
-            let mut jobs_guard = self.jobs.lock().await;
-            if let Some((_, job)) = jobs_guard.get_mut(sched_id) {
-                job.currently_running = false;
-                job.current_session_id = None;
-                job.process_start_time = None;
-                job.last_run = Some(Utc::now());
-            }
-        }
+        finish_execution(
+            &self.jobs,
+            &self.running_tasks,
+            sched_id,
+            execution_id,
+            Some(Utc::now()),
+        )
+        .await;
 
         persist_jobs(&self.storage_path, &self.jobs).await?;
 
@@ -967,35 +1027,22 @@ impl Scheduler {
 
     pub async fn kill_running_job(&self, sched_id: &str) -> Result<(), SchedulerError> {
         {
-            let jobs_guard = self.jobs.lock().await;
-            match jobs_guard.get(sched_id) {
-                Some((_, job)) if !job.currently_running => {
-                    return Err(SchedulerError::AnyhowError(anyhow!(
-                        "Schedule '{}' is not running",
-                        sched_id
-                    )));
-                }
-                None => return Err(SchedulerError::JobNotFound(sched_id.to_string())),
-                _ => {}
-            }
-        }
-
-        let token = {
-            let mut tasks = self.running_tasks.lock().await;
-            tasks.remove(sched_id)
-        };
-        if let Some(token) = token {
-            token.cancel();
-        }
-
-        {
             let mut jobs_guard = self.jobs.lock().await;
-            match jobs_guard.get_mut(sched_id) {
-                Some((_, job)) => {
-                    clear_running_state(job);
-                }
-                None => return Err(SchedulerError::JobNotFound(sched_id.to_string())),
+            let Some((_, job)) = jobs_guard.get_mut(sched_id) else {
+                return Err(SchedulerError::JobNotFound(sched_id.to_string()));
+            };
+            if !job.currently_running {
+                return Err(SchedulerError::AnyhowError(anyhow!(
+                    "Schedule '{}' is not running",
+                    sched_id
+                )));
             }
+
+            let mut tasks_guard = self.running_tasks.lock().await;
+            if let Some(task) = tasks_guard.remove(sched_id) {
+                task.cancel_token.cancel();
+            }
+            clear_running_state(job);
         }
 
         persist_jobs(&self.storage_path, &self.jobs).await
@@ -1023,7 +1070,9 @@ impl Scheduler {
 async fn execute_job(
     job: ScheduledJob,
     jobs: Arc<Mutex<JobsMap>>,
+    running_tasks: Arc<Mutex<RunningTasksMap>>,
     job_id: String,
+    execution_id: Uuid,
     cancel_token: CancellationToken,
     session_manager: Arc<SessionManager>,
 ) -> Result<String> {
@@ -1095,11 +1144,17 @@ async fn execute_job(
         .update_goose_mode(GooseMode::Auto, &session.id)
         .await?;
 
-    let mut jobs_guard = jobs.lock().await;
-    if let Some((_, job_def)) = jobs_guard.get_mut(job_id.as_str()) {
-        job_def.current_session_id = Some(session.id.clone());
+    if !set_execution_session(
+        &jobs,
+        &running_tasks,
+        &job_id,
+        execution_id,
+        session.id.clone(),
+    )
+    .await
+    {
+        return Err(anyhow!("Scheduled execution was cancelled"));
     }
-    drop(jobs_guard);
 
     let start_time = std::time::Instant::now();
 
@@ -1637,11 +1692,13 @@ mod tests {
 
         scheduler.add_scheduled_job(job, false).await.unwrap();
         let token = CancellationToken::new();
-        scheduler
-            .running_tasks
-            .lock()
-            .await
-            .insert("running_removal_job".to_string(), token.clone());
+        scheduler.running_tasks.lock().await.insert(
+            "running_removal_job".to_string(),
+            RunningTask {
+                execution_id: Uuid::new_v4(),
+                cancel_token: token.clone(),
+            },
+        );
 
         let error = scheduler
             .remove_scheduled_job("running_removal_job", false)
@@ -1721,7 +1778,7 @@ mod tests {
         });
         drop(running_tasks_guard);
 
-        assert!(claim.await.unwrap());
+        assert!(claim.await.unwrap().is_some());
         assert!(matches!(
             removal.await.unwrap(),
             Err(SchedulerError::JobRunning(id)) if id == "cron_claim_job"
@@ -1760,11 +1817,13 @@ mod tests {
         };
         scheduler.add_scheduled_job(job, false).await.unwrap();
         let original_token = CancellationToken::new();
-        scheduler
-            .running_tasks
-            .lock()
-            .await
-            .insert("active_cron_job".to_string(), original_token.clone());
+        scheduler.running_tasks.lock().await.insert(
+            "active_cron_job".to_string(),
+            RunningTask {
+                execution_id: Uuid::new_v4(),
+                cancel_token: original_token.clone(),
+            },
+        );
         let second_token = CancellationToken::new();
 
         let claimed = claim_cron_execution(
@@ -1776,7 +1835,7 @@ mod tests {
         )
         .await;
 
-        assert!(!claimed);
+        assert!(claimed.is_none());
         let jobs_guard = scheduler.jobs.lock().await;
         let (_, active_job) = jobs_guard.get("active_cron_job").unwrap();
         assert_eq!(active_job.last_run, Some(original_start));
@@ -1786,7 +1845,11 @@ mod tests {
 
         original_token.cancel();
         let tasks_guard = scheduler.running_tasks.lock().await;
-        assert!(tasks_guard.get("active_cron_job").unwrap().is_cancelled());
+        assert!(tasks_guard
+            .get("active_cron_job")
+            .unwrap()
+            .cancel_token
+            .is_cancelled());
         assert!(!second_token.is_cancelled());
     }
 
@@ -1858,6 +1921,115 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn stale_execution_cannot_clear_or_relabel_its_successor() {
+        let temp_dir = tempdir().unwrap();
+        let storage_path = temp_dir.path().join("schedule.json");
+        let recipe_path = create_test_recipe(temp_dir.path(), "successor_job");
+        let session_manager = Arc::new(SessionManager::new(temp_dir.path().to_path_buf()));
+        let scheduler = Scheduler::new(storage_path, session_manager).await.unwrap();
+
+        let job = ScheduledJob {
+            id: "successor_job".to_string(),
+            source: recipe_path.to_string_lossy().to_string(),
+            cron: "0 0 0 1 1 *".to_string(),
+            last_run: None,
+            currently_running: false,
+            paused: false,
+            current_session_id: None,
+            process_start_time: None,
+            parameters: vec![],
+            recipe_base_dir: None,
+        };
+        scheduler.add_scheduled_job(job, false).await.unwrap();
+
+        let first_token = CancellationToken::new();
+        let (_, first_execution_id) = claim_manual_execution(
+            &scheduler.jobs,
+            &scheduler.running_tasks,
+            "successor_job",
+            Utc::now(),
+            first_token.clone(),
+        )
+        .await
+        .unwrap();
+        scheduler.kill_running_job("successor_job").await.unwrap();
+        assert!(first_token.is_cancelled());
+
+        let successor_token = CancellationToken::new();
+        let (_, successor_execution_id) = claim_manual_execution(
+            &scheduler.jobs,
+            &scheduler.running_tasks,
+            "successor_job",
+            Utc::now(),
+            successor_token.clone(),
+        )
+        .await
+        .unwrap();
+        assert!(
+            set_execution_session(
+                &scheduler.jobs,
+                &scheduler.running_tasks,
+                "successor_job",
+                successor_execution_id,
+                "successor-session".to_string(),
+            )
+            .await
+        );
+
+        assert!(
+            !set_execution_session(
+                &scheduler.jobs,
+                &scheduler.running_tasks,
+                "successor_job",
+                first_execution_id,
+                "stale-session".to_string(),
+            )
+            .await
+        );
+        assert!(
+            !finish_execution(
+                &scheduler.jobs,
+                &scheduler.running_tasks,
+                "successor_job",
+                first_execution_id,
+                Some(Utc::now()),
+            )
+            .await
+        );
+
+        let jobs_guard = scheduler.jobs.lock().await;
+        let (_, successor_job) = jobs_guard.get("successor_job").unwrap();
+        assert!(successor_job.currently_running);
+        assert_eq!(
+            successor_job.current_session_id.as_deref(),
+            Some("successor-session")
+        );
+        drop(jobs_guard);
+
+        let tasks_guard = scheduler.running_tasks.lock().await;
+        let successor_task = tasks_guard.get("successor_job").unwrap();
+        assert_eq!(successor_task.execution_id, successor_execution_id);
+        assert!(!successor_task.cancel_token.is_cancelled());
+        drop(tasks_guard);
+
+        assert!(matches!(
+            scheduler
+                .remove_scheduled_job("successor_job", false)
+                .await,
+            Err(SchedulerError::JobRunning(id)) if id == "successor_job"
+        ));
+
+        finish_execution(
+            &scheduler.jobs,
+            &scheduler.running_tasks,
+            "successor_job",
+            successor_execution_id,
+            Some(Utc::now()),
+        )
+        .await;
+    }
+
+    #[tokio::test]
     async fn test_kill_running_job_clears_state_and_persists() {
         let temp_dir = tempdir().unwrap();
         let storage_path = temp_dir.path().join("schedule.json");
@@ -1890,7 +2062,13 @@ mod tests {
         }
         {
             let mut tasks = scheduler.running_tasks.lock().await;
-            tasks.insert("running_job".to_string(), CancellationToken::new());
+            tasks.insert(
+                "running_job".to_string(),
+                RunningTask {
+                    execution_id: Uuid::new_v4(),
+                    cancel_token: CancellationToken::new(),
+                },
+            );
         }
         persist_jobs(&storage_path, &scheduler.jobs).await.unwrap();
 

--- a/crates/goose/src/scheduler.rs
+++ b/crates/goose/src/scheduler.rs
@@ -263,6 +263,29 @@ fn clear_running_state(job: &mut ScheduledJob) -> bool {
     changed
 }
 
+async fn claim_cron_execution(
+    jobs: &Arc<Mutex<JobsMap>>,
+    running_tasks: &Arc<Mutex<RunningTasksMap>>,
+    job_id: &str,
+    current_time: DateTime<Utc>,
+    cancel_token: CancellationToken,
+) -> bool {
+    let mut jobs_guard = jobs.lock().await;
+    let Some((_, job)) = jobs_guard.get_mut(job_id) else {
+        return false;
+    };
+    if job.paused || job.currently_running {
+        return false;
+    }
+
+    let mut tasks_guard = running_tasks.lock().await;
+    job.last_run = Some(current_time);
+    job.currently_running = true;
+    job.process_start_time = Some(current_time);
+    tasks_guard.insert(job_id.to_string(), cancel_token);
+    true
+}
+
 pub struct Scheduler {
     tokio_scheduler: TokioJobScheduler,
     jobs: Arc<Mutex<JobsMap>>,
@@ -340,36 +363,22 @@ impl Scheduler {
             let session_manager = session_manager.clone();
 
             Box::pin(async move {
-                let should_execute = {
-                    let jobs_guard = current_jobs_arc.lock().await;
-                    jobs_guard
-                        .get(&task_job_id)
-                        .map(|(_, j)| !j.paused)
-                        .unwrap_or(false)
-                };
-
-                if !should_execute {
-                    return;
-                }
-
                 let current_time = Utc::now();
+                let cancel_token = CancellationToken::new();
+                if !claim_cron_execution(
+                    &current_jobs_arc,
+                    &running_tasks,
+                    &task_job_id,
+                    current_time,
+                    cancel_token.clone(),
+                )
+                .await
                 {
-                    let mut jobs_guard = current_jobs_arc.lock().await;
-                    if let Some((_, job)) = jobs_guard.get_mut(&task_job_id) {
-                        job.last_run = Some(current_time);
-                        job.currently_running = true;
-                        job.process_start_time = Some(current_time);
-                    }
+                    return;
                 }
 
                 if let Err(e) = persist_jobs(&local_storage_path, &current_jobs_arc).await {
                     tracing::error!("Failed to persist job status: {}", e);
-                }
-
-                let cancel_token = CancellationToken::new();
-                {
-                    let mut tasks = running_tasks.lock().await;
-                    tasks.insert(task_job_id.clone(), cancel_token.clone());
                 }
 
                 let result = execute_job(
@@ -1326,7 +1335,7 @@ impl SchedulerTrait for Scheduler {
 mod tests {
     use super::*;
     use tempfile::tempdir;
-    use tokio::time::{sleep, Duration};
+    use tokio::time::{sleep, timeout, Duration};
 
     fn create_test_recipe(dir: &Path, name: &str) -> PathBuf {
         let recipe_path = dir.join(format!("{}.yaml", name));
@@ -1646,6 +1655,128 @@ mod tests {
         assert!(persisted_jobs
             .iter()
             .any(|job| job.id == "running_removal_job" && job.currently_running));
+    }
+
+    #[tokio::test]
+    async fn cron_claim_serializes_with_job_removal() {
+        let temp_dir = tempdir().unwrap();
+        let storage_path = temp_dir.path().join("schedule.json");
+        let recipe_path = create_test_recipe(temp_dir.path(), "cron_claim_job");
+        let session_manager = Arc::new(SessionManager::new(temp_dir.path().to_path_buf()));
+        let scheduler = Scheduler::new(storage_path, session_manager).await.unwrap();
+
+        let job = ScheduledJob {
+            id: "cron_claim_job".to_string(),
+            source: recipe_path.to_string_lossy().to_string(),
+            cron: "0 0 0 1 1 *".to_string(),
+            last_run: None,
+            currently_running: false,
+            paused: false,
+            current_session_id: None,
+            process_start_time: None,
+            parameters: vec![],
+            recipe_base_dir: None,
+        };
+        scheduler.add_scheduled_job(job, false).await.unwrap();
+
+        let running_tasks_guard = scheduler.running_tasks.lock().await;
+        let claim_scheduler = scheduler.clone();
+        let cancel_token = CancellationToken::new();
+        let claim_token = cancel_token.clone();
+        let claim = tokio::spawn(async move {
+            claim_cron_execution(
+                &claim_scheduler.jobs,
+                &claim_scheduler.running_tasks,
+                "cron_claim_job",
+                Utc::now(),
+                claim_token,
+            )
+            .await
+        });
+
+        timeout(Duration::from_secs(1), async {
+            while scheduler.jobs.try_lock().is_ok() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("cron claim should lock jobs while registering its cancellation token");
+
+        let remove_scheduler = scheduler.clone();
+        let removal = tokio::spawn(async move {
+            remove_scheduler
+                .remove_scheduled_job("cron_claim_job", false)
+                .await
+        });
+        drop(running_tasks_guard);
+
+        assert!(claim.await.unwrap());
+        assert!(matches!(
+            removal.await.unwrap(),
+            Err(SchedulerError::JobRunning(id)) if id == "cron_claim_job"
+        ));
+
+        let jobs_guard = scheduler.jobs.lock().await;
+        let (_, claimed_job) = jobs_guard.get("cron_claim_job").unwrap();
+        assert!(claimed_job.currently_running);
+        drop(jobs_guard);
+
+        let tasks_guard = scheduler.running_tasks.lock().await;
+        assert!(tasks_guard.contains_key("cron_claim_job"));
+        assert!(!cancel_token.is_cancelled());
+    }
+
+    #[tokio::test]
+    async fn cron_claim_does_not_replace_an_active_execution() {
+        let temp_dir = tempdir().unwrap();
+        let storage_path = temp_dir.path().join("schedule.json");
+        let recipe_path = create_test_recipe(temp_dir.path(), "active_cron_job");
+        let session_manager = Arc::new(SessionManager::new(temp_dir.path().to_path_buf()));
+        let scheduler = Scheduler::new(storage_path, session_manager).await.unwrap();
+        let original_start = Utc::now();
+
+        let job = ScheduledJob {
+            id: "active_cron_job".to_string(),
+            source: recipe_path.to_string_lossy().to_string(),
+            cron: "0 0 0 1 1 *".to_string(),
+            last_run: Some(original_start),
+            currently_running: true,
+            paused: false,
+            current_session_id: None,
+            process_start_time: Some(original_start),
+            parameters: vec![],
+            recipe_base_dir: None,
+        };
+        scheduler.add_scheduled_job(job, false).await.unwrap();
+        let original_token = CancellationToken::new();
+        scheduler
+            .running_tasks
+            .lock()
+            .await
+            .insert("active_cron_job".to_string(), original_token.clone());
+        let second_token = CancellationToken::new();
+
+        let claimed = claim_cron_execution(
+            &scheduler.jobs,
+            &scheduler.running_tasks,
+            "active_cron_job",
+            Utc::now(),
+            second_token.clone(),
+        )
+        .await;
+
+        assert!(!claimed);
+        let jobs_guard = scheduler.jobs.lock().await;
+        let (_, active_job) = jobs_guard.get("active_cron_job").unwrap();
+        assert_eq!(active_job.last_run, Some(original_start));
+        assert_eq!(active_job.process_start_time, Some(original_start));
+        assert!(active_job.currently_running);
+        drop(jobs_guard);
+
+        original_token.cancel();
+        let tasks_guard = scheduler.running_tasks.lock().await;
+        assert!(tasks_guard.get("active_cron_job").unwrap().is_cancelled());
+        assert!(!second_token.is_cancelled());
     }
 
     #[tokio::test]

--- a/ui/desktop/src/components/schedule/SchedulesView.tsx
+++ b/ui/desktop/src/components/schedule/SchedulesView.tsx
@@ -203,18 +203,20 @@ const ScheduleCard: React.FC<{
               </Button>
             </>
           )}
-          <Button
-            onClick={(e) => {
-              e.stopPropagation();
-              onDelete(job.id);
-            }}
-            disabled={actionInProgress}
-            variant="ghost"
-            size="sm"
-            className="h-8 text-red-500 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-900/20"
-          >
-            <TrashIcon className="w-4 h-4" />
-          </Button>
+          {!job.currentlyRunning && (
+            <Button
+              onClick={(e) => {
+                e.stopPropagation();
+                onDelete(job.id);
+              }}
+              disabled={actionInProgress}
+              variant="ghost"
+              size="sm"
+              className="h-8 text-red-500 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-900/20"
+            >
+              <TrashIcon className="w-4 h-4" />
+            </Button>
+          )}
         </div>
       </div>
     </Card>

--- a/ui/desktop/src/components/schedule/__tests__/SchedulesView.security.test.tsx
+++ b/ui/desktop/src/components/schedule/__tests__/SchedulesView.security.test.tsx
@@ -1,0 +1,79 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import type { ScheduledJobDto } from '@aaif/goose-sdk';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { acpDeleteSchedule, acpListSchedules } from '../../../acp/schedules';
+import { IntlTestWrapper } from '../../../i18n/test-utils';
+import SchedulesView from '../SchedulesView';
+
+vi.mock('../../../acp/schedules', () => ({
+  acpListSchedules: vi.fn(),
+  acpCreateSchedule: vi.fn(),
+  acpDeleteSchedule: vi.fn(),
+  acpPauseSchedule: vi.fn(),
+  acpUnpauseSchedule: vi.fn(),
+  acpUpdateSchedule: vi.fn(),
+  acpKillRunningJob: vi.fn(),
+  acpInspectRunningJob: vi.fn(),
+}));
+
+vi.mock('../../Layout/MainPanelLayout', () => ({
+  MainPanelLayout: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('../ScheduleModal', () => ({
+  ScheduleModal: () => null,
+}));
+
+vi.mock('../ScheduleDetailView', () => ({
+  default: () => null,
+}));
+
+const schedule = (currentlyRunning: boolean): ScheduledJobDto => ({
+  id: currentlyRunning ? 'running-job' : 'idle-job',
+  source: 'recipe.yaml',
+  cron: '0 0 * * * *',
+  lastRun: null,
+  currentlyRunning,
+  paused: false,
+});
+
+function renderSchedules() {
+  render(
+    <MemoryRouter>
+      <IntlTestWrapper>
+        <SchedulesView />
+      </IntlTestWrapper>
+    </MemoryRouter>
+  );
+}
+
+describe('SchedulesView running schedule controls', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+    vi.mocked(acpDeleteSchedule).mockResolvedValue(undefined);
+  });
+
+  it('does not offer deletion while the schedule is running', async () => {
+    vi.mocked(acpListSchedules).mockResolvedValue([schedule(true)]);
+
+    renderSchedules();
+
+    await screen.findByText('running-job');
+    expect(screen.getByRole('button', { name: 'Inspect' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Kill' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: '' })).not.toBeInTheDocument();
+  });
+
+  it('keeps deletion available for an idle schedule', async () => {
+    vi.mocked(acpListSchedules).mockResolvedValue([schedule(false)]);
+
+    renderSchedules();
+
+    await screen.findByText('idle-job');
+    fireEvent.click(screen.getByRole('button', { name: '' }));
+
+    await waitFor(() => expect(acpDeleteSchedule).toHaveBeenCalledWith('idle-job'));
+  });
+});


### PR DESCRIPTION
## Summary

- reject schedule deletion in the backend while the job is running
- atomically claim cron execution and register its cancellation token before deletion can proceed
- atomically claim manual runs before Kill or Delete can observe partially registered state
- bind tokens, session attachment, and cleanup to a unique execution ID so an old cancelled run cannot corrupt a successor with the same schedule ID
- reject overlapping cron claims so the single running state and token cannot be replaced prematurely
- keep the running job and cancellation token reachable so Inspect and Kill remain effective
- hide the Desktop Delete action until the job has stopped
- preserve ordinary deletion and optional recipe-file removal for idle schedules

## Security context

Fixes [project-loupe/audit-goose#775](https://github.com/project-loupe/audit-goose/issues/775).

Previously, deleting a running schedule removed its job-map entry without cancelling the active task. Later Kill and Inspect requests could no longer find the job, while its recipe execution continued invisibly. Cron and manual startup also had check/use gaps where Delete or Kill could win before `currently_running` and the cancellation token were both recorded. Each claim is now one serialized state transition, Kill uses the same lock order, and later session/cleanup writes must match that execution's unique identity.

## Verification

- `bin/cargo fmt`
- `bin/cargo test -p goose test_remove_scheduled_job` (2 passed)
- `bin/cargo test -p goose cron_claim` (2 passed)
- `bin/cargo test -p goose manual_claim_serializes_with_kill` (1 passed)
- `bin/cargo test -p goose scheduler::tests::` (15 passed, including successor-generation isolation)
- `../../bin/pnpm exec vitest run src/components/schedule/__tests__/SchedulesView.security.test.tsx` (2 passed)
- `bin/cargo build -p goose`
- `bin/cargo clippy -p goose --all-targets -- -D warnings`
- `../../bin/pnpm lint:check`
- `../../bin/pnpm package`

_This finding was discovered by [Project Loupe](https://github.com/project-loupe/loupe)._
