### PR TITLE
Fix RMCP metadata test fixture

### DIFF
--- a/crates/goose-provider-types/src/conversation/message.rs
+++ b/crates/goose-provider-types/src/conversation/message.rs
@@ -1580,7 +1580,7 @@ mod tests {
         );
         let mut result = CallToolResult::success(vec![text, image]);
         result.structured_content = Some(serde_json::json!({"safe": "世界"}));
-        result.meta = Some(rmcp::model::Meta(object!({"source": "test"})));
+        result.meta = Some(rmcp::model::MetaObject(object!({"source": "test"})));
         let expected = result.clone();
 
         let content = MessageContentBlock::tool_response("tool-1", Ok(result));


### PR DESCRIPTION
## What changed

Update the tool response sanitization test fixture to construct RMCP metadata with `MetaObject`, the type exported by RMCP 3.0.

## Why

The RMCP 3.0 upgrade removed the old `Meta` tuple struct. The stale test-only constructor prevented all-target builds from compiling, which broke the MSRV, clippy, and Rust test jobs on [main CI run 31414053165](https://github.com/aaif-goose/goose/actions/runs/31414053165).

There is no runtime behavior change.

## Validation

- `cargo fmt --check`
- `cargo test -p goose-provider-types test_tool_response_sanitization_preserves_legitimate_content`
- `cargo clippy -p goose-provider-types --all-targets -- -D warnings`
- `git diff --check`
