### PR TITLE
fix(provider-types): use rmcp 3.0 MetaObject in tool-response test

### DIFF
--- a/crates/goose-provider-types/src/conversation/message.rs
+++ b/crates/goose-provider-types/src/conversation/message.rs
@@ -1580,7 +1580,7 @@ mod tests {
         );
         let mut result = CallToolResult::success(vec![text, image]);
         result.structured_content = Some(serde_json::json!({"safe": "世界"}));
-        result.meta = Some(rmcp::model::Meta(object!({"source": "test"})));
+        result.meta = Some(rmcp::model::MetaObject(object!({"source": "test"})));
         let expected = result.clone();
 
         let content = MessageContentBlock::tool_response("tool-1", Ok(result));


### PR DESCRIPTION
`crates/goose-provider-types/src/conversation/message.rs` constructs a `CallToolResult.meta` value in a test via `rmcp::model::Meta(object!(...))` — the rmcp 1.8 API. The workspace pins rmcp `3.0.0`, where that type is `MetaObject(pub JsonObject)` (`rmcp-3.0.0/src/model/meta.rs:244`), and `CallToolResult.meta` is `Option<MetaObject>` (`rmcp-3.0.0/src/model.rs:3791`). The old name no longer resolves, so the crate fails to compile under `#[cfg(test)]`:

```
error[E0425]: cannot find `Meta` in module `rmcp::model`
 --> crates/goose-provider-types/src/conversation/message.rs:1583:41
```

This is a semantic merge collision: #10609 added the test against the rmcp 1.8 API while the rmcp 3.0 bump landed separately, leaving `main` red on `Build and Test Rust Project`, `Lint Rust Code`, and `Check MSRV` for the last 3 commits (last green was 433f621).

Construct the field with `MetaObject`; the `object!` macro already yields the `JsonObject` it wraps, so no other change is needed.

Verified with `cargo test -p goose-provider-types` (510 + 8 pass) and `cargo fmt -p goose-provider-types --check`.
