### PR TITLE
fix: adjust rmcp::model::Meta ref

### DIFF
--- a/crates/goose-provider-types/src/conversation/message.rs
+++ b/crates/goose-provider-types/src/conversation/message.rs
@@ -1580,7 +1580,7 @@ mod tests {
         );
         let mut result = CallToolResult::success(vec![text, image]);
         result.structured_content = Some(serde_json::json!({"safe": "世界"}));
-        result.meta = Some(rmcp::model::Meta(object!({"source": "test"})));
+        result.meta = Some(rmcp::model::MetaObject(object!({"source": "test"})));
         let expected = result.clone();
 
         let content = MessageContentBlock::tool_response("tool-1", Ok(result));


### PR DESCRIPTION
## Summary

- update the legitimate tool-response sanitization fixture for the locked `rmcp` 3.0.0 API
- restore compilation and execution of the regression coverage added by #10609
- preserve coverage for text/image annotations, structured content, and result metadata

## Security context

Supersedes duplicate PR #11101 and completes post-merge verification for:

- [project-loupe/audit-goose#408](https://github.com/project-loupe/audit-goose/issues/408)
- [project-loupe/audit-goose#412](https://github.com/project-loupe/audit-goose/issues/412)
- [project-loupe/audit-goose#527](https://github.com/project-loupe/audit-goose/issues/527)

The production sanitizer is already on `main`; this corrects the metadata constructor in its legitimate-content regression fixture so the covered issues can be verified on current main after merge.

## Verification

- all required GitHub CI checks passed, including Build/Test, MSRV, both TLS backends, format, clippy, schemas, Desktop, and Live Provider Tests
- the duplicate #11101 branch independently passed `cargo fmt --check`, 29 focused tool-response tests, the changed-crate build, and all-target clippy

_This finding was discovered by [Project Loupe](https://github.com/project-loupe/loupe)._
