### PR TITLE
Report failed scheduled runs as failed

### DIFF
--- a/crates/goose-cli/src/commands/schedule.rs
+++ b/crates/goose-cli/src/commands/schedule.rs
@@ -219,12 +219,13 @@ pub async fn handle_schedule_sessions(schedule_id: String, limit: Option<usize>)
                 println!("Sessions for schedule ID '{}':", schedule_id);
                 for (session_name, metadata) in sessions {
                     println!(
-                        "  - Session ID: {}, Messages: {}, Working Dir: {}, Description: \"{}\", Schedule ID: {:?}",
+                        "  - Session ID: {}, Messages: {}, Working Dir: {}, Description: \"{}\", Schedule ID: {:?}, Status: {}",
                         session_name,
                         metadata.message_count,
                         metadata.working_dir.display(),
                         metadata.name,
-                        metadata.schedule_id.as_deref().unwrap_or("N/A")
+                        metadata.schedule_id.as_deref().unwrap_or("N/A"),
+                        metadata.completion_status,
                     );
                 }
             }

--- a/crates/goose/src/agents/schedule_tool.rs
+++ b/crates/goose/src/agents/schedule_tool.rs
@@ -455,10 +455,11 @@ impl ScheduleTool {
                         .into_iter()
                         .map(|(session_name, session)| {
                             format!(
-                                "- Session: {} (Messages: {}, Working Dir: {})",
+                                "- Session: {} (Messages: {}, Working Dir: {}, Status: {})",
                                 session_name,
                                 session.message_count,
-                                session.working_dir.display()
+                                session.working_dir.display(),
+                                session.completion_status,
                             )
                         })
                         .collect();

--- a/crates/goose/src/scheduler.rs
+++ b/crates/goose/src/scheduler.rs
@@ -25,7 +25,7 @@ use crate::recipe::build_recipe::build_recipe_from_template;
 use crate::recipe::Recipe;
 use crate::scheduler_trait::SchedulerTrait;
 use crate::session::session_manager::SessionType;
-use crate::session::{Session, SessionManager};
+use crate::session::{Session, SessionCompletionStatus, SessionManager};
 
 type RunningTasksMap = HashMap<String, CancellationToken>;
 type JobsMap = HashMap<String, (JobId, ScheduledJob)>;
@@ -990,6 +990,33 @@ impl Scheduler {
     }
 }
 
+/// Drains an agent event stream into the running conversation, returning the
+/// conversation and the first stream error encountered (if any). Extracted so
+/// the error-vs-success decision is unit-testable without a live provider.
+async fn drain_agent_stream(
+    mut stream: impl futures::Stream<Item = Result<AgentEvent>> + Unpin,
+    mut conversation: Conversation,
+) -> (Conversation, Option<anyhow::Error>) {
+    use futures::StreamExt;
+
+    let mut stream_error: Option<anyhow::Error> = None;
+    while let Some(message_result) = stream.next().await {
+        tokio::task::yield_now().await;
+
+        match message_result {
+            Ok(AgentEvent::Message(msg)) => conversation.push(msg),
+            Ok(AgentEvent::HistoryReplaced(updated)) => conversation = updated,
+            Ok(_) => {}
+            Err(e) => {
+                stream_error = Some(e);
+                break;
+            }
+        }
+    }
+
+    (conversation, stream_error)
+}
+
 #[allow(clippy::too_many_lines)]
 async fn execute_job(
     job: ScheduledJob,
@@ -1124,7 +1151,7 @@ async fn execute_job(
         })?;
 
     let user_message = Message::user().with_text(prompt_text);
-    let mut conversation = Conversation::new_unvalidated(vec![user_message.clone()]);
+    let conversation = Conversation::new_unvalidated(vec![user_message.clone()]);
 
     agent
         .config
@@ -1146,32 +1173,36 @@ async fn execute_job(
         .reply(user_message, session_config, Some(cancel_token))
         .await?;
 
-    use futures::StreamExt;
-    let mut stream = std::pin::pin!(stream);
+    let stream = std::pin::pin!(stream);
 
-    let mut stream_error = false;
-    while let Some(message_result) = stream.next().await {
-        tokio::task::yield_now().await;
+    let (_, stream_error) = drain_agent_stream(stream, conversation).await;
+    let failed = stream_error.is_some();
+    if let Some(ref e) = stream_error {
+        tracing::error!("Error in agent stream: {}", e);
+    }
 
-        match message_result {
-            Ok(AgentEvent::Message(msg)) => {
-                conversation.push(msg);
-            }
-            Ok(AgentEvent::HistoryReplaced(updated)) => {
-                conversation = updated;
-            }
-            Ok(_) => {}
-            Err(e) => {
-                tracing::error!("Error in agent stream: {}", e);
-                stream_error = true;
-                break;
-            }
-        }
+    // Persist the partial session's terminal outcome so that a run which
+    // terminated on a stream error stays discoverable from the session
+    // listing rather than only from log scraping.
+    let completion_status = if failed {
+        SessionCompletionStatus::Failed
+    } else {
+        SessionCompletionStatus::Completed
+    };
+    if let Err(e) = agent
+        .config
+        .session_manager
+        .update(&session.id)
+        .completion_status(completion_status)
+        .apply()
+        .await
+    {
+        tracing::error!("Failed to persist session completion status: {}", e);
     }
 
     {
         let session_duration = start_time.elapsed();
-        let exit_type = if stream_error { "error" } else { "normal" };
+        let exit_type = if failed { "error" } else { "normal" };
         let (total_tokens, message_count) = agent
             .config
             .session_manager
@@ -1211,6 +1242,7 @@ async fn execute_job(
     #[cfg(feature = "telemetry")]
     {
         let duration_secs = start_time.elapsed().as_secs();
+        let telemetry_status = if failed { "failed" } else { "completed" };
         tokio::spawn(async move {
             let mut props = HashMap::new();
             props.insert(
@@ -1219,7 +1251,7 @@ async fn execute_job(
             );
             props.insert(
                 "status".to_string(),
-                serde_json::Value::String("completed".to_string()),
+                serde_json::Value::String(telemetry_status.to_string()),
             );
             props.insert(
                 "duration_seconds".to_string(),
@@ -1231,6 +1263,9 @@ async fn execute_job(
         });
     }
 
+    if let Some(e) = stream_error {
+        return Err(e);
+    }
     Ok(session.id)
 }
 
@@ -1732,5 +1767,53 @@ mod tests {
             jobs[0].last_run.is_some(),
             "Job should have attempted to run without panicking"
         );
+    }
+
+    #[tokio::test]
+    async fn drain_agent_stream_propagates_first_error_and_keeps_partial_work() {
+        use futures::stream;
+
+        let conversation = Conversation::new_unvalidated(vec![Message::user().with_text("hi")]);
+        let events: Vec<Result<AgentEvent>> = vec![
+            Ok(AgentEvent::Message(
+                Message::assistant().with_text("partial reply"),
+            )),
+            Err(anyhow!("provider stream failed mid-turn")),
+            Ok(AgentEvent::Message(
+                Message::assistant().with_text("never seen"),
+            )),
+        ];
+
+        let (conversation, stream_error) =
+            drain_agent_stream(stream::iter(events), conversation).await;
+
+        let error = stream_error.expect("stream error should be captured");
+        assert!(
+            error
+                .to_string()
+                .contains("provider stream failed mid-turn"),
+            "expected the original error message, got: {error}"
+        );
+        // The user seed plus the assistant message drained before the error.
+        assert_eq!(conversation.messages().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn drain_agent_stream_completes_without_error_on_clean_termination() {
+        use futures::stream;
+
+        let conversation = Conversation::new_unvalidated(vec![Message::user().with_text("hi")]);
+        let events: Vec<Result<AgentEvent>> = vec![Ok(AgentEvent::Message(
+            Message::assistant().with_text("done"),
+        ))];
+
+        let (conversation, stream_error) =
+            drain_agent_stream(stream::iter(events), conversation).await;
+
+        assert!(
+            stream_error.is_none(),
+            "a clean stream must not surface an error"
+        );
+        assert_eq!(conversation.messages().len(), 2);
     }
 }

--- a/crates/goose/src/session/mod.rs
+++ b/crates/goose/src/session/mod.rs
@@ -21,5 +21,6 @@ pub use export_markdown::{
 };
 pub use extension_data::{EnabledExtensionsState, ExtensionData, ExtensionState, TodoState};
 pub use session_manager::{
-    Session, SessionInsights, SessionManager, SessionNameUpdate, SessionType, SessionUpdateBuilder,
+    Session, SessionCompletionStatus, SessionInsights, SessionManager, SessionNameUpdate,
+    SessionType, SessionUpdateBuilder,
 };

--- a/crates/goose/src/session/session_manager.rs
+++ b/crates/goose/src/session/session_manager.rs
@@ -24,7 +24,7 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, LazyLock};
 use tracing::{info, warn};
 
-pub const CURRENT_SCHEMA_VERSION: i32 = 16;
+pub const CURRENT_SCHEMA_VERSION: i32 = 17;
 pub const SESSIONS_FOLDER: &str = "sessions";
 pub const DB_NAME: &str = "sessions.db";
 const MILLISECOND_TIMESTAMP_THRESHOLD: i64 = 10_000_000_000;
@@ -52,6 +52,29 @@ pub enum SessionType {
     Terminal,
     Gateway,
     Acp,
+}
+
+/// Terminal outcome of a session's execution, persisted so that runs which
+/// terminated abnormally (e.g. a scheduled recipe whose provider stream
+/// errored mid-turn) remain discoverable without log scraping.
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    Serialize,
+    Deserialize,
+    PartialEq,
+    Eq,
+    Default,
+    strum::Display,
+    strum::EnumString,
+)]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
+pub enum SessionCompletionStatus {
+    #[default]
+    Completed,
+    Failed,
 }
 
 static SESSION_STORAGE: LazyLock<Arc<SessionStorage>> =
@@ -94,6 +117,10 @@ pub struct Session {
     pub parent_session_id: Option<String>,
     #[serde(default)]
     pub last_message_snippet: Option<String>,
+    /// Terminal outcome of the run. Defaults to `Completed` so that sessions
+    /// created outside the scheduler (or before this field existed) stay green.
+    #[serde(default)]
+    pub completion_status: SessionCompletionStatus,
 }
 
 impl From<&Session> for TokenState {
@@ -166,6 +193,7 @@ pub struct SessionUpdateBuilder<'a> {
 
     project_id: Option<Option<String>>,
     parent_session_id: Option<Option<String>>,
+    completion_status: Option<SessionCompletionStatus>,
 }
 
 #[derive(Serialize, Debug)]
@@ -203,6 +231,7 @@ impl<'a> SessionUpdateBuilder<'a> {
             archived_at: None,
             project_id: None,
             parent_session_id: None,
+            completion_status: None,
         }
     }
 
@@ -308,6 +337,11 @@ impl<'a> SessionUpdateBuilder<'a> {
 
     pub fn parent_session_id(mut self, parent_session_id: Option<String>) -> Self {
         self.parent_session_id = Some(parent_session_id);
+        self
+    }
+
+    pub fn completion_status(mut self, completion_status: SessionCompletionStatus) -> Self {
+        self.completion_status = Some(completion_status);
         self
     }
 }
@@ -751,6 +785,7 @@ impl Default for Session {
             project_id: None,
             parent_session_id: None,
             last_message_snippet: None,
+            completion_status: SessionCompletionStatus::default(),
         }
     }
 }
@@ -870,6 +905,11 @@ impl sqlx::FromRow<'_, sqlx::sqlite::SqliteRow> for Session {
             project_id: row.try_get("project_id").ok().flatten(),
             parent_session_id: row.try_get("parent_session_id").ok().flatten(),
             last_message_snippet: None,
+            completion_status: row
+                .try_get::<String, _>("completion_status")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or_default(),
         })
     }
 }
@@ -1024,7 +1064,8 @@ impl SessionStorage {
                 goose_mode TEXT NOT NULL DEFAULT 'auto',
                 archived_at TIMESTAMP,
                 project_id TEXT,
-                parent_session_id TEXT
+                parent_session_id TEXT,
+                completion_status TEXT NOT NULL DEFAULT 'completed'
             )
         "#,
         )
@@ -1570,6 +1611,27 @@ impl SessionStorage {
                 .execute(&mut **tx)
                 .await?;
             }
+            17 => {
+                // Records whether a session's run reached a normal terminal state
+                // or terminated on an error (e.g. a scheduled recipe whose provider
+                // stream errored mid-turn). Defaults to 'completed' so existing rows
+                // are not retroactively flagged as failed. The existence check keeps
+                // the migration idempotent for databases whose `create_schema` path
+                // already added the column.
+                let has_completion_status = sqlx::query_scalar::<_, i32>(
+                    "SELECT COUNT(*) FROM pragma_table_info('sessions') WHERE name = 'completion_status'",
+                )
+                .fetch_one(&mut **tx)
+                .await?
+                    > 0;
+                if !has_completion_status {
+                    sqlx::query(
+                        "ALTER TABLE sessions ADD COLUMN completion_status TEXT NOT NULL DEFAULT 'completed'",
+                    )
+                    .execute(&mut **tx)
+                    .await?;
+                }
+            }
             _ => {
                 anyhow::bail!("Unknown migration version: {}", version);
             }
@@ -1635,7 +1697,7 @@ impl SessionStorage {
                accumulated_cost,
                schedule_id, recipe_json, user_recipe_values_json,
                provider_name, model_config_json, goose_mode,
-               archived_at, project_id, parent_session_id
+               archived_at, project_id, parent_session_id, completion_status
         FROM sessions
         WHERE id = ?
     "#,
@@ -1720,6 +1782,7 @@ impl SessionStorage {
 
         add_update!(builder.project_id, "project_id");
         add_update!(builder.parent_session_id, "parent_session_id");
+        add_update!(builder.completion_status, "completion_status");
 
         if updates.is_empty() {
             return Ok(());
@@ -1798,6 +1861,9 @@ impl SessionStorage {
         }
         if let Some(ref parent_session_id) = builder.parent_session_id {
             q = q.bind(parent_session_id.as_ref());
+        }
+        if let Some(completion_status) = builder.completion_status {
+            q = q.bind(completion_status.to_string());
         }
 
         let pool = self.pool().await?;
@@ -2001,7 +2067,7 @@ impl SessionStorage {
                    s.accumulated_cost,
                    s.schedule_id, s.recipe_json, s.user_recipe_values_json,
                    s.provider_name, s.model_config_json, s.goose_mode,
-                   s.archived_at, s.project_id, s.parent_session_id,
+                   s.archived_at, s.project_id, s.parent_session_id, s.completion_status,
                    COUNT(m.id) FILTER (WHERE {}) as message_count,
                    MAX({}) as last_message_timestamp,
                    {} as sort_timestamp
@@ -4398,6 +4464,77 @@ mod tests {
         let loaded = sm.get_session("cache_id", false).await.unwrap();
         assert_eq!(loaded.usage, usage);
         assert_eq!(loaded.accumulated_usage, accumulated_usage);
+    }
+
+    #[tokio::test]
+    async fn test_completion_status_migration_and_round_trip() {
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join(SESSIONS_FOLDER).join(DB_NAME);
+
+        if let Some(parent) = db_path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+
+        let pool = SqlitePoolOptions::new()
+            .connect_with(
+                SqliteConnectOptions::new()
+                    .filename(&db_path)
+                    .create_if_missing(true),
+            )
+            .await
+            .unwrap();
+
+        SessionStorage::create_schema(&pool).await.unwrap();
+
+        // Simulate a database that predates the completion_status column.
+        sqlx::query("ALTER TABLE sessions DROP COLUMN completion_status")
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query("UPDATE schema_version SET version = 16")
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        sqlx::query(
+            "INSERT INTO sessions (id, name, user_set_name, session_type, working_dir, extension_data, goose_mode)
+             VALUES (?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind("failed_run")
+        .bind("Failed Run")
+        .bind(false)
+        .bind("scheduled")
+        .bind("/tmp")
+        .bind("{}")
+        .bind("auto")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        pool.close().await;
+
+        let sm = SessionManager::new(temp_dir.path().to_path_buf());
+        sm.storage().pool().await.unwrap(); // Triggers migration 17
+
+        // Pre-existing rows default to `completed` rather than being flagged failed.
+        let pre_migration = sm.get_session("failed_run", false).await.unwrap();
+        assert_eq!(
+            pre_migration.completion_status,
+            SessionCompletionStatus::Completed
+        );
+
+        // A run that terminated on an error records its true outcome.
+        sm.update("failed_run")
+            .completion_status(SessionCompletionStatus::Failed)
+            .apply()
+            .await
+            .unwrap();
+
+        let after_failure = sm.get_session("failed_run", false).await.unwrap();
+        assert_eq!(
+            after_failure.completion_status,
+            SessionCompletionStatus::Failed
+        );
     }
 
     fn message_usage(input: i32, output: i32, cost: f64, is_compaction: bool) -> MessageUsage {


### PR DESCRIPTION
## Summary
- `execute_job` captured mid-stream errors in a local flag used only to pick a metrics label, then returned `Ok(session.id)` on both paths — so a run that errored mid-stream (provider failure, rate limit, network drop) was logged, telemetered, and surfaced as successful everywhere: the cron handler's `Err` arm never ran, `schedule_job_completed` reported `completed`, `run_now` returned `Ok` so the CLI printed success, and nothing marked the run as failed.
- Propagate the stream error out of `execute_job` (via a unit-tested `drain_agent_stream` helper) so the cron handler's existing `Err` arm (`scheduler_job_failed` telemetry) and the `run_now`/CLI error paths actually fire.
- `schedule_job_completed` telemetry now reports `status: "failed"` for errored runs instead of `"completed"`.
- Add a persisted `completion_status` on sessions (schema migration v17, idempotent) so failed runs stay discoverable from the session listing — surfaced in both the CLI and the schedule MCP tool.
- The partial session is still persisted; only the reported outcome changes.

Refs aaif-goose/goose#11051

## Review Notes
- Production-safety review passed (1 round).
- Local CI green: `cargo fmt --check`, `cargo clippy -p goose -p goose-cli --all-targets -- -D warnings`, plus `session::session_manager` (45), `scheduler` (12), `schedule_tool` integration (5), `schedule_tool_security` (6).
- Based on `aaif-goose/main`; touches scheduler + session only, no dependency on any provider-streaming work.

## Decision Log
**Hardest decision:** how to satisfy the issue's "discoverable after the fact from the session listing" requirement. I added a `completion_status` column via migration v17 defaulting to `'completed'`, rather than overloading an existing field or skipping it. Skipping would leave failed nightly jobs invisible; the migration route keeps the outcome queryable and matches how the schema already tracks per-session attributes.

**Alternatives rejected:**
- *Only fix error propagation, leave the session-listing status out:* rejected — the issue explicitly lists session-listing discoverability as expected behavior; a half-fix leaves failed background jobs invisible in every surface goose exposes.
- *Default `completion_status` to a distinct `unknown`/`incomplete` variant:* rejected — migrating every existing row to `incomplete` would retroactively flag all prior sessions, including genuinely-completed ones.
- *Return the error without persisting a status:* rejected — defeats discoverability; the value of a failed run is being able to inspect how far it got and that it failed.

**Least confident about:** sessions created but abandoned before the stream starts (e.g. provider/extension setup failure). Those return `Err` via `?` before the drain, so reporting (`scheduler_job_failed` + CLI error) still fires, but their `completion_status` keeps the default `completed` since they never reach the drain where the status is set. They're empty (0 messages) so low-impact, but a follow-up could set `Failed` earlier. Cancellation semantics for the status field are intentionally out of scope — #11051 defers the separate cron-overlap/cancellation bug.

## Test plan
- [ ] CI passes
- [ ] `cargo test -p goose --lib scheduler::` — `drain_agent_stream` propagates the first stream error and keeps partial work; clean termination surfaces no error
- [ ] `cargo test -p goose --lib session::session_manager::test_completion_status_migration_and_round_trip` — v17 migration is idempotent, legacy rows default to `completed`, and `Failed` round-trips
- [ ] Manual: a scheduled recipe pointed at an unreachable provider records a `failed` completion status, `schedule_job_completed` reports `failed`, and `goose schedule sessions --id` shows `Status: failed`
