### PR TITLE
fix(hooks): include working directory in stop context

### DIFF
--- a/crates/goose/src/agents/state_machine/ops_stop_hook.rs
+++ b/crates/goose/src/agents/state_machine/ops_stop_hook.rs
@@ -78,7 +78,8 @@ impl Operation for StopHookOperation {
             .unwrap_or_default();
 
         let context = HookContext::new(HookEvent::Stop, &session.id)
-            .with_last_assistant_message(last_assistant_text);
+            .with_last_assistant_message(last_assistant_text)
+            .with_working_dir(session.working_dir.to_string_lossy().into_owned());
         match self
             .hook_manager
             .emit_blocking(HookEvent::Stop, context)

--- a/crates/goose/src/agents/state_machine/tests/hooks_lifecycle.rs
+++ b/crates/goose/src/agents/state_machine/tests/hooks_lifecycle.rs
@@ -44,11 +44,20 @@ impl HookTestEnv {
             .lines()
             .count()
     }
+
+    fn last_context(&self) -> serde_json::Value {
+        serde_json::from_str(
+            &std::fs::read_to_string(self.plugin_dir.join("context.json"))
+                .expect("hook context was recorded"),
+        )
+        .expect("hook context is valid JSON")
+    }
 }
 
 const LOG_AND_ALLOW_SCRIPT: &str = "#!/bin/sh\necho ran >> \"$PLUGIN_ROOT/hook.log\"\nexit 0\n";
 const LOG_AND_BLOCK_SCRIPT: &str =
     "#!/bin/sh\necho blocked >> \"$PLUGIN_ROOT/hook.log\"\necho \"not done yet\" >&2\nexit 2\n";
+const LOG_CONTEXT_AND_BLOCK_SCRIPT: &str = "#!/bin/sh\ncat > \"$PLUGIN_ROOT/context.json\"\necho blocked >> \"$PLUGIN_ROOT/hook.log\"\necho \"not done yet\" >&2\nexit 2\n";
 
 #[tokio::test]
 async fn stop_hooks_allow_block_and_skip_non_stop_exits() -> Result<()> {
@@ -62,8 +71,9 @@ async fn stop_hooks_allow_block_and_skip_non_stop_exits() -> Result<()> {
     assert_eq!(api.call_count(), 1);
     assert_eq!(allowed.invocations(), 1);
 
-    let blocked = HookTestEnv::new("Stop", LOG_AND_BLOCK_SCRIPT);
+    let blocked = HookTestEnv::new("Stop", LOG_CONTEXT_AND_BLOCK_SCRIPT);
     let (pipeline, api) = test_pipeline().await?;
+    let expected_working_dir = pipeline.working_dir().to_string_lossy().into_owned();
     let pipeline = pipeline
         .with_hook_manager(blocked.hook_manager())
         .with_stop_hook_block_cap(2);
@@ -73,6 +83,7 @@ async fn stop_hooks_allow_block_and_skip_non_stop_exits() -> Result<()> {
     let (_, result, _) = pipeline.run_reconstructing_each_step("hello").await?;
     assert_eq!(api.call_count(), 3);
     assert_eq!(blocked.invocations(), 3);
+    assert_eq!(blocked.last_context()["working_dir"], expected_working_dir);
     assert_eq!(
         result
             .conversation()


### PR DESCRIPTION
## Summary

- include the session working directory in state-machine `Stop` hook context
- keep stop-hook allow/block behavior unchanged
- add a regression that records the hook payload and verifies `working_dir`

## Security impact

Blocking Stop hooks can use `working_dir` to apply repository-specific completion policy—for example, requiring an additional check before a turn may end in selected workspaces. The state-machine path omitted that field, so a hook that treats a missing or nonmatching path as out of scope could return allow and skip its intended repository-specific gate. Supplying the active session directory restores parity with the legacy agent loop and gives the same configured hook the context required to make its allow/block decision.

This change does not alter the hook subprocess working directory or add a new policy; it only restores the missing policy input on the state-machine path.

Closes no audit issue until post-merge verification. Tracks [project-loupe/audit-goose#708](https://github.com/project-loupe/audit-goose/issues/708).

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p goose stop_hooks_allow_block_and_skip_non_stop_exits`
- `cargo test -p goose agents::state_machine::tests::hooks_lifecycle`
- `cargo build -p goose`
- `cargo clippy -p goose --all-targets -- -D warnings`

*This finding was discovered by [Project Loupe](https://github.com/project-loupe/loupe)*
