### PR TITLE
fix(cli): avoid reading file params in recipe explain

### DIFF
--- a/crates/goose-cli/src/recipes/recipe.rs
+++ b/crates/goose-cli/src/recipes/recipe.rs
@@ -7,7 +7,7 @@ use crate::recipes::secret_discovery::{discover_recipe_secrets, SecretRequiremen
 use anyhow::Result;
 use goose::config::Config;
 use goose::recipe::build_recipe::{
-    apply_values_to_parameters, build_recipe_from_template, RecipeError,
+    apply_values_to_parameters_without_file_expansion, build_recipe_from_template, RecipeError,
 };
 use goose::recipe::validate_recipe::parse_and_validate_parameters;
 use goose::recipe::Recipe;
@@ -140,7 +140,7 @@ pub fn explain_recipe(recipe_name: &str, params: Vec<(String, String)>) -> Resul
         parse_and_validate_parameters(recipe_file_content, Some(recipe_dir_str.clone()))?;
     let recipe_parameters = recipe_template.parameters.clone();
 
-    let (params_for_template, missing_params) = apply_values_to_parameters(
+    let (params_for_template, missing_params) = apply_values_to_parameters_without_file_expansion(
         &params,
         recipe_parameters,
         &recipe_dir_str,
@@ -154,6 +154,7 @@ pub fn explain_recipe(recipe_name: &str, params: Vec<(String, String)>) -> Resul
 
 #[cfg(test)]
 mod tests {
+    use goose::recipe::build_recipe::apply_values_to_parameters_without_file_expansion;
     use goose::recipe::{RecipeParameterInputType, RecipeParameterRequirement};
 
     use crate::recipes::recipe::load_recipe;
@@ -197,5 +198,33 @@ mod tests {
             ));
             assert_eq!(param.description, "A test parameter");
         }
+    }
+
+    #[test]
+    fn explanation_preserves_file_parameter_path_without_reading_contents() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let file_path = temp_dir.path().join("does-not-exist.txt");
+        let parameters = vec![goose::recipe::RecipeParameter {
+            key: "input_file".to_string(),
+            input_type: RecipeParameterInputType::File,
+            requirement: RecipeParameterRequirement::Required,
+            description: "Input file".to_string(),
+            default: None,
+            options: None,
+        }];
+
+        let (values, missing) = apply_values_to_parameters_without_file_expansion(
+            &[("input_file".to_string(), file_path.display().to_string())],
+            Some(parameters),
+            temp_dir.path().to_str().unwrap(),
+            None::<fn(&str, &str) -> anyhow::Result<String>>,
+        )
+        .unwrap();
+
+        assert!(missing.is_empty());
+        assert_eq!(
+            values.get("input_file"),
+            Some(&file_path.display().to_string())
+        );
     }
 }

--- a/crates/goose/src/recipe/build_recipe/mod.rs
+++ b/crates/goose/src/recipe/build_recipe/mod.rs
@@ -84,6 +84,44 @@ pub fn apply_values_to_parameters<F>(
 where
     F: Fn(&str, &str) -> Result<String, anyhow::Error>,
 {
+    apply_values_to_parameters_with_file_handler(
+        user_params,
+        recipe_parameters,
+        recipe_dir,
+        user_prompt_fn,
+        |path| read_parameter_file_content(path),
+    )
+}
+
+pub fn apply_values_to_parameters_without_file_expansion<F>(
+    user_params: &[(String, String)],
+    recipe_parameters: Option<Vec<RecipeParameter>>,
+    recipe_dir: &str,
+    user_prompt_fn: Option<F>,
+) -> Result<(HashMap<String, String>, Vec<String>)>
+where
+    F: Fn(&str, &str) -> Result<String, anyhow::Error>,
+{
+    apply_values_to_parameters_with_file_handler(
+        user_params,
+        recipe_parameters,
+        recipe_dir,
+        user_prompt_fn,
+        |path| Ok(path.to_string()),
+    )
+}
+
+fn apply_values_to_parameters_with_file_handler<F, H>(
+    user_params: &[(String, String)],
+    recipe_parameters: Option<Vec<RecipeParameter>>,
+    recipe_dir: &str,
+    user_prompt_fn: Option<F>,
+    file_handler: H,
+) -> Result<(HashMap<String, String>, Vec<String>)>
+where
+    F: Fn(&str, &str) -> Result<String, anyhow::Error>,
+    H: Fn(&str) -> Result<String, anyhow::Error>,
+{
     let mut param_map: HashMap<String, String> = user_params.iter().cloned().collect();
     param_map.insert(
         BUILT_IN_RECIPE_DIR_PARAM.to_string(),
@@ -106,7 +144,7 @@ where
         match raw_value {
             Some(value) => {
                 let final_value = if matches!(param.input_type, RecipeParameterInputType::File) {
-                    read_parameter_file_content(&value)?
+                    file_handler(&value)?
                 } else {
                     value
                 };


### PR DESCRIPTION
## Summary

- preserve submitted file paths when displaying recipe parameters with `--explain`
- keep normal recipe execution's file-content expansion unchanged
- cover both the no-read explanation behavior and legitimate file loading

## Security impact

`goose --recipe ... --explain` is a metadata-only operation, but it previously opened each supplied `file` parameter and printed the file contents to stdout. The explanation path now collects parameter values without expanding file paths, so a sensitive local file cannot be disclosed to terminal or CI logs through this command.

Addresses [project-loupe/audit-goose#666](https://github.com/project-loupe/audit-goose/issues/666).

## Verification

- `cargo fmt`
- `cargo test -p goose-cli recipes::recipe::tests`
- `cargo test -p goose recipe::build_recipe::tests::file_parameter_tests`
- `cargo build -p goose-cli`
- `cargo clippy -p goose-cli --all-targets -- -D warnings`
- `git diff --check`

_This finding was discovered by [Project Loupe](https://github.com/project-loupe/loupe)._
