### PR TITLE
fix(bedrock): sanitize hidden Unicode in tools

### DIFF
--- a/crates/goose/src/providers/bedrock.rs
+++ b/crates/goose/src/providers/bedrock.rs
@@ -1,8 +1,8 @@
 use std::collections::HashMap;
 
 use super::base::{
-    ConfigKey, DEFAULT_CONNECT_TIMEOUT_SECS, DEFAULT_PROVIDER_TIMEOUT_SECS, MessageStream,
-    Provider, ProviderDef, ProviderMetadata,
+    ConfigKey, MessageStream, Provider, ProviderDef, ProviderMetadata,
+    DEFAULT_CONNECT_TIMEOUT_SECS, DEFAULT_PROVIDER_TIMEOUT_SECS,
 };
 use super::openai_compatible::{handle_status, stream_responses_compat};
 use super::retry::{ProviderRetry, RetryConfig};
@@ -15,7 +15,7 @@ use aws_sdk_bedrockruntime::config::ProvideCredentials;
 use aws_sdk_bedrockruntime::operation::converse::ConverseError;
 use aws_sdk_bedrockruntime::operation::converse_stream::ConverseStreamError;
 use aws_sdk_bedrockruntime::types::error::ConverseStreamOutputError;
-use aws_sdk_bedrockruntime::{Client, types as bedrock};
+use aws_sdk_bedrockruntime::{types as bedrock, Client};
 use base64::Engine;
 use futures::future::BoxFuture;
 use goose_providers::conversation::token_usage::{ProviderUsage, Usage};
@@ -23,9 +23,9 @@ use goose_providers::errors::ProviderError;
 use goose_providers::formats::openai::extract_reasoning_effort;
 use goose_providers::formats::openai_responses::create_responses_request;
 use goose_providers::model::ModelConfig;
-use goose_providers::request_log::{LoggerHandleExt, start_log};
-use reqwest::header::{AUTHORIZATION, HeaderName, HeaderValue};
-use rmcp::model::{CallToolRequestParams, ErrorCode, ErrorData, Tool, object};
+use goose_providers::request_log::{start_log, LoggerHandleExt};
+use reqwest::header::{HeaderName, HeaderValue, AUTHORIZATION};
+use rmcp::model::{object, CallToolRequestParams, ErrorCode, ErrorData, Tool};
 use serde_json::Value;
 use smithy_transport_reqwest::ReqwestHttpClient;
 
@@ -113,7 +113,11 @@ impl BedrockProvider {
         let bearer_token = match config.get_secret::<String>("AWS_BEARER_TOKEN_BEDROCK") {
             Ok(token) => {
                 let token = token.trim().to_string();
-                if token.is_empty() { None } else { Some(token) }
+                if token.is_empty() {
+                    None
+                } else {
+                    Some(token)
+                }
             }
             Err(_) => None,
         };

--- a/crates/goose/src/providers/bedrock.rs
+++ b/crates/goose/src/providers/bedrock.rs
@@ -1,8 +1,8 @@
 use std::collections::HashMap;
 
 use super::base::{
-    ConfigKey, MessageStream, Provider, ProviderDef, ProviderMetadata,
-    DEFAULT_CONNECT_TIMEOUT_SECS, DEFAULT_PROVIDER_TIMEOUT_SECS,
+    ConfigKey, DEFAULT_CONNECT_TIMEOUT_SECS, DEFAULT_PROVIDER_TIMEOUT_SECS, MessageStream,
+    Provider, ProviderDef, ProviderMetadata,
 };
 use super::openai_compatible::{handle_status, stream_responses_compat};
 use super::retry::{ProviderRetry, RetryConfig};
@@ -15,7 +15,7 @@ use aws_sdk_bedrockruntime::config::ProvideCredentials;
 use aws_sdk_bedrockruntime::operation::converse::ConverseError;
 use aws_sdk_bedrockruntime::operation::converse_stream::ConverseStreamError;
 use aws_sdk_bedrockruntime::types::error::ConverseStreamOutputError;
-use aws_sdk_bedrockruntime::{types as bedrock, Client};
+use aws_sdk_bedrockruntime::{Client, types as bedrock};
 use base64::Engine;
 use futures::future::BoxFuture;
 use goose_providers::conversation::token_usage::{ProviderUsage, Usage};
@@ -23,15 +23,16 @@ use goose_providers::errors::ProviderError;
 use goose_providers::formats::openai::extract_reasoning_effort;
 use goose_providers::formats::openai_responses::create_responses_request;
 use goose_providers::model::ModelConfig;
-use goose_providers::request_log::{start_log, LoggerHandleExt};
-use reqwest::header::{HeaderName, HeaderValue, AUTHORIZATION};
-use rmcp::model::{object, CallToolRequestParams, ErrorCode, ErrorData, Tool};
+use goose_providers::request_log::{LoggerHandleExt, start_log};
+use reqwest::header::{AUTHORIZATION, HeaderName, HeaderValue};
+use rmcp::model::{CallToolRequestParams, ErrorCode, ErrorData, Tool, object};
 use serde_json::Value;
 use smithy_transport_reqwest::ReqwestHttpClient;
 
 use super::formats::bedrock::{
     bedrock_anthropic_thinking_fields, bedrock_inference_config, from_bedrock_message,
-    from_bedrock_usage, to_bedrock_message_with_caching, to_bedrock_tool_config,
+    from_bedrock_usage, sanitize_json_unicode_tags, to_bedrock_message_with_caching,
+    to_bedrock_tool_config,
 };
 
 pub(crate) const BEDROCK_PROVIDER_NAME: &str = "aws_bedrock";
@@ -112,11 +113,7 @@ impl BedrockProvider {
         let bearer_token = match config.get_secret::<String>("AWS_BEARER_TOKEN_BEDROCK") {
             Ok(token) => {
                 let token = token.trim().to_string();
-                if token.is_empty() {
-                    None
-                } else {
-                    Some(token)
-                }
+                if token.is_empty() { None } else { Some(token) }
             }
             Err(_) => None,
         };
@@ -683,9 +680,13 @@ fn process_stream_event(
                         .with_arguments(object(serde_json::json!({}))))
                 } else {
                     match serde_json::from_str::<Value>(&input_json) {
-                        Ok(parsed) => {
-                            Ok(CallToolRequestParams::new(name).with_arguments(object(parsed)))
-                        }
+                        Ok(parsed) => sanitize_json_unicode_tags(parsed)
+                            .map(|arguments| {
+                                CallToolRequestParams::new(name).with_arguments(object(arguments))
+                            })
+                            .map_err(|error| {
+                                ErrorData::new(ErrorCode::INVALID_PARAMS, error.to_string(), None)
+                            }),
                         Err(_) => Err(ErrorData::new(
                             ErrorCode::INVALID_PARAMS,
                             format!("Could not parse tool arguments: {}", input_json),
@@ -1310,6 +1311,41 @@ mod tests {
             }
             other => panic!("expected ToolRequest, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn test_stream_tool_use_sanitizes_nested_arguments() {
+        let mut state = StreamBlockState::default();
+
+        process_stream_event(
+            tool_start_event(1, "tool-1", "lookup"),
+            &mut state,
+            TEST_MESSAGE_ID,
+        );
+        process_stream_event(
+            tool_delta_event(
+                1,
+                "{\"query\":\"visible\u{E0041}text\",\"nested\":[{\"cit\u{E0042}y\":\"東京🌍\u{E0043}\"}]}",
+            ),
+            &mut state,
+            TEST_MESSAGE_ID,
+        );
+
+        let (messages, _) = process_stream_event(stop_event(1), &mut state, TEST_MESSAGE_ID);
+        let MessageContent::ToolRequest(request) = &messages[0].content[0] else {
+            panic!("expected tool request");
+        };
+        let call = request
+            .tool_call
+            .as_ref()
+            .expect("expected valid tool call");
+        assert_eq!(
+            call.arguments,
+            Some(object(serde_json::json!({
+                "query": "visibletext",
+                "nested": [{"city": "東京🌍"}]
+            })))
+        );
     }
 
     #[test]

--- a/crates/goose/src/providers/formats/bedrock.rs
+++ b/crates/goose/src/providers/formats/bedrock.rs
@@ -3,13 +3,13 @@ use std::collections::HashMap;
 use std::path::Path;
 
 use crate::mcp_utils::ToolResult;
-use anyhow::{anyhow, bail, Result};
+use anyhow::{Result, anyhow, bail};
 use aws_sdk_bedrockruntime::types as bedrock;
 use aws_smithy_types::{Document, Number};
 use base64::Engine;
 use chrono::Utc;
 use rmcp::model::{
-    object, CallToolRequestParams, ContentBlock, ErrorCode, ErrorData, ResourceContents, Role, Tool,
+    CallToolRequestParams, ContentBlock, ErrorCode, ErrorData, ResourceContents, Role, Tool, object,
 };
 use serde_json::Value;
 
@@ -17,9 +17,9 @@ use crate::conversation::message::{Message, MessageContent};
 use crate::providers::bedrock::BEDROCK_PROVIDER_NAME;
 use crate::providers::canonical::maybe_get_canonical_model;
 use crate::providers::formats::anthropic::{
-    adaptive_output_effort, model_supports_temperature, thinking_block_is_stale,
-    thinking_budget_tokens, thinking_type_for_provider, ThinkingType, ANTHROPIC_PROVIDER_NAME,
-    MIN_ANSWER_TOKENS,
+    ANTHROPIC_PROVIDER_NAME, MIN_ANSWER_TOKENS, ThinkingType, adaptive_output_effort,
+    model_supports_temperature, thinking_block_is_stale, thinking_budget_tokens,
+    thinking_type_for_provider,
 };
 use crate::utils::sanitize_unicode_tags;
 use goose_providers::conversation::token_usage::Usage;
@@ -384,6 +384,7 @@ pub fn to_bedrock_tool(tool: &Tool) -> Result<bedrock::Tool> {
     if !input_schema.contains_key("type") {
         input_schema.insert("type".to_string(), Value::String("object".to_string()));
     }
+    let input_schema = sanitize_json_unicode_tags(Value::Object(input_schema))?;
 
     Ok(bedrock::Tool::ToolSpec(
         bedrock::ToolSpecification::builder()
@@ -391,14 +392,38 @@ pub fn to_bedrock_tool(tool: &Tool) -> Result<bedrock::Tool> {
             .description(
                 tool.description
                     .as_ref()
-                    .map(|d| d.to_string())
+                    .map(|d| sanitize_unicode_tags(d))
                     .unwrap_or_default(),
             )
             .input_schema(bedrock::ToolInputSchema::Json(to_bedrock_json(
-                &Value::Object(input_schema),
+                &input_schema,
             )))
             .build()?,
     ))
+}
+
+pub(crate) fn sanitize_json_unicode_tags(value: Value) -> Result<Value> {
+    Ok(match value {
+        Value::String(text) => Value::String(sanitize_unicode_tags(&text)),
+        Value::Array(values) => Value::Array(
+            values
+                .into_iter()
+                .map(sanitize_json_unicode_tags)
+                .collect::<Result<_>>()?,
+        ),
+        Value::Object(values) => {
+            let mut sanitized = serde_json::Map::new();
+            for (key, value) in values {
+                let key = sanitize_unicode_tags(&key);
+                if sanitized.contains_key(&key) {
+                    bail!("JSON contains a duplicate key after Unicode tag sanitization");
+                }
+                sanitized.insert(key, sanitize_json_unicode_tags(value)?);
+            }
+            Value::Object(sanitized)
+        }
+        value => value,
+    })
 }
 
 fn args_to_value(args: Option<serde_json::Map<String, Value>>) -> Value {
@@ -490,11 +515,15 @@ pub fn from_bedrock_message(message: &bedrock::Message) -> Result<Message> {
 pub fn from_bedrock_content_block(block: &bedrock::ContentBlock) -> Result<MessageContent> {
     Ok(match block {
         bedrock::ContentBlock::Text(text) => MessageContent::text(text),
-        bedrock::ContentBlock::ToolUse(tool_use) => MessageContent::tool_request(
-            tool_use.tool_use_id.to_string(),
-            Ok(CallToolRequestParams::new(tool_use.name.clone())
-                .with_arguments(object(from_bedrock_json(&tool_use.input.clone())?))),
-        ),
+        bedrock::ContentBlock::ToolUse(tool_use) => {
+            let arguments =
+                sanitize_json_unicode_tags(from_bedrock_json(&tool_use.input.clone())?)?;
+            MessageContent::tool_request(
+                tool_use.tool_use_id.to_string(),
+                Ok(CallToolRequestParams::new(tool_use.name.clone())
+                    .with_arguments(object(arguments))),
+            )
+        }
         bedrock::ContentBlock::ToolResult(tool_res) => MessageContent::tool_response(
             tool_res.tool_use_id.to_string(),
             if tool_res.content.is_empty() {
@@ -818,6 +847,70 @@ mod tests {
     }
 
     #[test]
+    fn test_to_bedrock_tool_sanitizes_description_and_schema_metadata() -> Result<()> {
+        let tool = Tool::new(
+            "lookup",
+            "検索\u{E0041} ツール",
+            serde_json::Map::from_iter([
+                ("type".to_string(), json!("object")),
+                (
+                    "properties".to_string(),
+                    json!({
+                        "pro\u{E0042}mpt": {
+                            "type": "string",
+                            "description": "都市🌍\u{E0043}"
+                        }
+                    }),
+                ),
+            ]),
+        );
+
+        let bedrock_tool = to_bedrock_tool(&tool)?;
+        let spec = bedrock_tool
+            .as_tool_spec()
+            .expect("expected Bedrock tool specification");
+        assert_eq!(spec.description(), Some("検索 ツール"));
+
+        let schema = spec
+            .input_schema()
+            .expect("expected input schema")
+            .as_json()
+            .expect("expected JSON input schema");
+        assert_eq!(
+            from_bedrock_json(schema)?,
+            json!({
+                "type": "object",
+                "properties": {
+                    "prompt": {
+                        "type": "string",
+                        "description": "都市🌍"
+                    }
+                }
+            })
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_to_bedrock_tool_rejects_schema_key_collision_after_sanitization() {
+        let mut properties = serde_json::Map::new();
+        properties.insert("prompt".to_string(), json!({"type": "string"}));
+        properties.insert("pro\u{E0041}mpt".to_string(), json!({"type": "string"}));
+        let tool = Tool::new(
+            "lookup",
+            "Lookup",
+            serde_json::Map::from_iter([
+                ("type".to_string(), json!("object")),
+                ("properties".to_string(), Value::Object(properties)),
+            ]),
+        );
+
+        let error = to_bedrock_tool(&tool).expect_err("sanitized keys must remain unique");
+        assert!(error.to_string().contains("duplicate key"));
+    }
+
+    #[test]
     fn test_to_bedrock_message_content_image() -> Result<()> {
         let image = ImageContent::new(TEST_IMAGE_B64.to_string(), "image/png".to_string());
 
@@ -826,6 +919,34 @@ mod tests {
 
         // Verify we get an Image content block
         assert!(matches!(result, bedrock::ContentBlock::Image(_)));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_from_bedrock_tool_use_sanitizes_nested_arguments() -> Result<()> {
+        let original = bedrock::ContentBlock::ToolUse(
+            bedrock::ToolUseBlock::builder()
+                .tool_use_id("tool-1")
+                .name("lookup")
+                .input(to_bedrock_json(&json!({
+                    "query": "visible\u{E0041}text",
+                    "nested": [{"cit\u{E0042}y": "東京🌍\u{E0043}"}]
+                })))
+                .build()?,
+        );
+
+        let MessageContent::ToolRequest(request) = from_bedrock_content_block(&original)? else {
+            panic!("expected tool request");
+        };
+        let call = request.tool_call.expect("expected valid tool call");
+        assert_eq!(
+            call.arguments,
+            Some(object(json!({
+                "query": "visibletext",
+                "nested": [{"city": "東京🌍"}]
+            })))
+        );
 
         Ok(())
     }
@@ -992,10 +1113,12 @@ mod tests {
         // Verify that converting a cache point results in an error
         let result = from_bedrock_content_block(&content_block);
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("CachePoint blocks should have been filtered out"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("CachePoint blocks should have been filtered out")
+        );
     }
 
     #[test]

--- a/crates/goose/src/providers/formats/bedrock.rs
+++ b/crates/goose/src/providers/formats/bedrock.rs
@@ -3,13 +3,13 @@ use std::collections::HashMap;
 use std::path::Path;
 
 use crate::mcp_utils::ToolResult;
-use anyhow::{Result, anyhow, bail};
+use anyhow::{anyhow, bail, Result};
 use aws_sdk_bedrockruntime::types as bedrock;
 use aws_smithy_types::{Document, Number};
 use base64::Engine;
 use chrono::Utc;
 use rmcp::model::{
-    CallToolRequestParams, ContentBlock, ErrorCode, ErrorData, ResourceContents, Role, Tool, object,
+    object, CallToolRequestParams, ContentBlock, ErrorCode, ErrorData, ResourceContents, Role, Tool,
 };
 use serde_json::Value;
 
@@ -17,11 +17,11 @@ use crate::conversation::message::{Message, MessageContent};
 use crate::providers::bedrock::BEDROCK_PROVIDER_NAME;
 use crate::providers::canonical::maybe_get_canonical_model;
 use crate::providers::formats::anthropic::{
-    ANTHROPIC_PROVIDER_NAME, MIN_ANSWER_TOKENS, ThinkingType, adaptive_output_effort,
-    model_supports_temperature, thinking_block_is_stale, thinking_budget_tokens,
-    thinking_type_for_provider,
+    adaptive_output_effort, model_supports_temperature, thinking_block_is_stale,
+    thinking_budget_tokens, thinking_type_for_provider, ThinkingType, ANTHROPIC_PROVIDER_NAME,
+    MIN_ANSWER_TOKENS,
 };
-use crate::utils::sanitize_unicode_tags;
+use crate::utils::{sanitize_unicode_tags, strip_unicode_tags};
 use goose_providers::conversation::token_usage::Usage;
 use goose_providers::model::ModelConfig;
 use once_cell::sync::Lazy;
@@ -392,7 +392,7 @@ pub fn to_bedrock_tool(tool: &Tool) -> Result<bedrock::Tool> {
             .description(
                 tool.description
                     .as_ref()
-                    .map(|d| sanitize_unicode_tags(d))
+                    .map(|d| strip_unicode_tags(d))
                     .unwrap_or_default(),
             )
             .input_schema(bedrock::ToolInputSchema::Json(to_bedrock_json(
@@ -404,7 +404,7 @@ pub fn to_bedrock_tool(tool: &Tool) -> Result<bedrock::Tool> {
 
 pub(crate) fn sanitize_json_unicode_tags(value: Value) -> Result<Value> {
     Ok(match value {
-        Value::String(text) => Value::String(sanitize_unicode_tags(&text)),
+        Value::String(text) => Value::String(strip_unicode_tags(&text)),
         Value::Array(values) => Value::Array(
             values
                 .into_iter()
@@ -414,7 +414,7 @@ pub(crate) fn sanitize_json_unicode_tags(value: Value) -> Result<Value> {
         Value::Object(values) => {
             let mut sanitized = serde_json::Map::new();
             for (key, value) in values {
-                let key = sanitize_unicode_tags(&key);
+                let key = strip_unicode_tags(&key);
                 if sanitized.contains_key(&key) {
                     bail!("JSON contains a duplicate key after Unicode tag sanitization");
                 }
@@ -516,13 +516,16 @@ pub fn from_bedrock_content_block(block: &bedrock::ContentBlock) -> Result<Messa
     Ok(match block {
         bedrock::ContentBlock::Text(text) => MessageContent::text(text),
         bedrock::ContentBlock::ToolUse(tool_use) => {
-            let arguments =
-                sanitize_json_unicode_tags(from_bedrock_json(&tool_use.input.clone())?)?;
-            MessageContent::tool_request(
-                tool_use.tool_use_id.to_string(),
-                Ok(CallToolRequestParams::new(tool_use.name.clone())
-                    .with_arguments(object(arguments))),
-            )
+            let arguments = from_bedrock_json(&tool_use.input.clone())
+                .and_then(sanitize_json_unicode_tags)
+                .map(|arguments| {
+                    CallToolRequestParams::new(tool_use.name.clone())
+                        .with_arguments(object(arguments))
+                })
+                .map_err(|error| {
+                    ErrorData::new(ErrorCode::INVALID_PARAMS, error.to_string(), None)
+                });
+            MessageContent::tool_request(tool_use.tool_use_id.to_string(), arguments)
         }
         bedrock::ContentBlock::ToolResult(tool_res) => MessageContent::tool_response(
             tool_res.tool_use_id.to_string(),
@@ -850,7 +853,7 @@ mod tests {
     fn test_to_bedrock_tool_sanitizes_description_and_schema_metadata() -> Result<()> {
         let tool = Tool::new(
             "lookup",
-            "検索\u{E0041} ツール",
+            "検索\u{E0041} ツール cafe\u{301}",
             serde_json::Map::from_iter([
                 ("type".to_string(), json!("object")),
                 (
@@ -869,7 +872,7 @@ mod tests {
         let spec = bedrock_tool
             .as_tool_spec()
             .expect("expected Bedrock tool specification");
-        assert_eq!(spec.description(), Some("検索 ツール"));
+        assert_eq!(spec.description(), Some("検索 ツール cafe\u{301}"));
 
         let schema = spec
             .input_schema()
@@ -931,7 +934,8 @@ mod tests {
                 .name("lookup")
                 .input(to_bedrock_json(&json!({
                     "query": "visible\u{E0041}text",
-                    "nested": [{"cit\u{E0042}y": "東京🌍\u{E0043}"}]
+                    "nested": [{"cit\u{E0042}y": "東京🌍\u{E0043}"}],
+                    "path": "cafe\u{301}.txt"
                 })))
                 .build()?,
         );
@@ -944,9 +948,35 @@ mod tests {
             call.arguments,
             Some(object(json!({
                 "query": "visibletext",
-                "nested": [{"city": "東京🌍"}]
+                "nested": [{"city": "東京🌍"}],
+                "path": "cafe\u{301}.txt"
             })))
         );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_from_bedrock_tool_use_collision_yields_error_request() -> Result<()> {
+        let original = bedrock::ContentBlock::ToolUse(
+            bedrock::ToolUseBlock::builder()
+                .tool_use_id("tool-1")
+                .name("lookup")
+                .input(to_bedrock_json(&json!({
+                    "prompt": "visible",
+                    "pro\u{E0041}mpt": "hidden"
+                })))
+                .build()?,
+        );
+
+        let MessageContent::ToolRequest(request) = from_bedrock_content_block(&original)? else {
+            panic!("expected tool request");
+        };
+        let error = request
+            .tool_call
+            .expect_err("sanitized key collision must produce an invalid tool call");
+        assert_eq!(error.code, ErrorCode::INVALID_PARAMS);
+        assert!(error.message.contains("duplicate key"));
 
         Ok(())
     }
@@ -1113,12 +1143,10 @@ mod tests {
         // Verify that converting a cache point results in an error
         let result = from_bedrock_content_block(&content_block);
         assert!(result.is_err());
-        assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("CachePoint blocks should have been filtered out")
-        );
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("CachePoint blocks should have been filtered out"));
     }
 
     #[test]

--- a/crates/goose/src/utils.rs
+++ b/crates/goose/src/utils.rs
@@ -28,14 +28,16 @@ pub fn contains_unicode_tags(text: &str) -> bool {
     text.chars().any(is_in_unicode_tag_range)
 }
 
+pub fn strip_unicode_tags(text: &str) -> String {
+    text.chars()
+        .filter(|&c| !is_in_unicode_tag_range(c))
+        .collect()
+}
+
 /// Sanitize Unicode Tags Block characters from text
 pub fn sanitize_unicode_tags(text: &str) -> String {
     let normalized: String = text.nfc().collect();
-
-    normalized
-        .chars()
-        .filter(|&c| !is_in_unicode_tag_range(c))
-        .collect()
+    strip_unicode_tags(&normalized)
 }
 
 /// Safely truncate a string at character boundaries, not byte boundaries
@@ -132,6 +134,12 @@ mod tests {
         let clean_text = "Hello world 世界 🌍";
         let cleaned = sanitize_unicode_tags(clean_text);
         assert_eq!(cleaned, clean_text);
+    }
+
+    #[test]
+    fn test_strip_unicode_tags_preserves_canonical_form() {
+        let decomposed = "cafe\u{301}\u{E0041}";
+        assert_eq!(strip_unicode_tags(decomposed), "cafe\u{301}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- sanitize Unicode Tags recursively from Bedrock tool-call arguments before Goose dispatches them
- sanitize outbound Bedrock tool descriptions and JSON schemas, including nested keys and string values
- reject JSON objects whose keys collide after sanitization instead of executing ambiguous arguments
- preserve ordinary Unicode while covering both blocking and streaming Bedrock paths

## Security context

This hardens Bedrock tool boundaries against hidden Unicode Tags while preserving ordinary Unicode input.

## Verification

- `cargo fmt -- crates/goose/src/providers/formats/bedrock.rs crates/goose/src/providers/bedrock.rs`
- `cargo test -p goose --features aws-providers bedrock`
- `cargo build -p goose --features aws-providers`
- `cargo clippy -p goose --features aws-providers --all-targets -- -D warnings`
- `git diff --check`

*This finding was discovered by [Project Loupe](https://github.com/project-loupe/loupe)*
