### PR TITLE
Add Resemble Detect to the extension directory

### DIFF
--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -827,6 +827,24 @@
       "required": false
     }
   ]
-}
-
+},
+  {
+    "id": "resemble-detect",
+    "name": "Resemble Detect",
+    "description": "Detect AI-generated audio, image, and video, trace synthetic audio to its source platform, and apply or verify invisible watermarks",
+    "url": "https://mcp.resemble.ai/mcp",
+    "link": "https://github.com/resemble-ai/resemble-mcp",
+    "installation_notes": "This is a remote extension that requires a Resemble AI API key from https://app.resemble.ai/account/api as a Request Header e.g Authorization: Bearer <YOUR_RESEMBLE_API_KEY>.",
+    "is_builtin": false,
+    "endorsed": false,
+    "environmentVariables": [],
+    "headers": [
+      {
+        "name": "Authorization",
+        "description": "Bearer <YOUR_RESEMBLE_API_KEY>",
+        "required": true
+      }
+    ],
+    "type": "streamable-http"
+  }
 ]


### PR DESCRIPTION
Adds **Resemble Detect** to the extension directory.

It gives goose the ability to check whether a piece of media is AI-generated before acting on it — useful when an agent is handling an uploaded recording, a screenshot, or a video it did not produce itself.

**What the extension exposes**

| Tool | Purpose |
|---|---|
| `detect_deepfake` | Analyze audio, image, or video for synthetic manipulation; returns a label and confidence score |
| `get_detection` | Poll a detection to completion |
| `analyze_media` | Transcription, speaker info, emotion, and misinformation signals |
| `ask_about_detection` | Natural-language questions against a completed detection |
| `trace_audio_source` | Identify which platform generated a piece of synthetic audio |
| `detect_watermark` / `apply_watermark` | Read and embed invisible provenance watermarks |

**Details**

- Remote extension over Streamable HTTP at `https://mcp.resemble.ai/mcp`, following the same `headers` pattern as the existing `github-mcp` and `rendex-mcp` entries.
- Auth is the user's own Resemble API key as a Bearer token, from https://app.resemble.ai/account/api. Nothing is stored server-side — the key is used in-memory for the call only.
- Source: https://github.com/resemble-ai/resemble-mcp (MIT), also published to the official MCP registry as `io.github.resemble-ai/resemble-mcp`.

Single-file change to `documentation/static/servers.json`; validated as parsing JSON with the new entry appended.
