### PR TITLE
fix(recipes): confine temporary extraction cleanup

### DIFF
--- a/crates/goose-cli/src/recipes/github_recipe.rs
+++ b/crates/goose-cli/src/recipes/github_recipe.rs
@@ -129,6 +129,12 @@ pub fn ensure_gh_authenticated() -> Result<()> {
 }
 
 fn temp_child_name(name: &str) -> Result<String> {
+    if !name.is_empty() && name.trim_end_matches([' ', '.']).is_empty() {
+        return Err(anyhow!(
+            "Recipe name does not map to a safe temporary directory"
+        ));
+    }
+
     let mut child = String::with_capacity(name.len());
     for ch in name.chars() {
         match ch {
@@ -142,12 +148,6 @@ fn temp_child_name(name: &str) -> Result<String> {
 
     if child.is_empty() {
         child.push('_');
-    }
-
-    if child.chars().all(|ch| ch == '.') {
-        return Err(anyhow!(
-            "Recipe name does not map to a safe temporary directory"
-        ));
     }
 
     let mut components = Path::new(&child).components();
@@ -423,7 +423,7 @@ mod tests {
     fn temp_child_path_rejects_reserved_components() {
         let parent = Path::new("goose-recipes");
 
-        for name in [".", "..", "...", "...."] {
+        for name in [".", "..", "...", "....", ". ", ".. ", ". .", ".. ."] {
             assert!(temp_child_path(parent, name).is_err(), "accepted {name}");
         }
     }
@@ -436,6 +436,7 @@ mod tests {
             ("daily-report", "daily-report"),
             ("team/weekly", "team__weekly"),
             ("../outside", "..__outside"),
+            ("daily report ", "daily_report_"),
             ("", "_"),
         ] {
             assert_eq!(temp_child_path(parent, name).unwrap(), parent.join(child));
@@ -452,7 +453,7 @@ mod tests {
         fs::write(&parent_sentinel, "keep").unwrap();
         fs::write(&child_sentinel, "keep").unwrap();
 
-        for name in [".", "..", "...", "...."] {
+        for name in [".", "..", "...", "....", ". ", ".. ", ". .", ".. ."] {
             assert!(clean_temp_child_path(&parent, name).is_err());
             assert!(parent_sentinel.exists());
             assert!(child_sentinel.exists());

--- a/crates/goose-cli/src/recipes/github_recipe.rs
+++ b/crates/goose-cli/src/recipes/github_recipe.rs
@@ -9,8 +9,7 @@ use goose::subprocess::{git_command, SubprocessExt};
 use std::env;
 use std::fs;
 
-use std::path::Path;
-use std::path::PathBuf;
+use std::path::{Component, Path, PathBuf};
 use std::process::Command;
 use std::process::Stdio;
 use tar::Archive;
@@ -129,7 +128,7 @@ pub fn ensure_gh_authenticated() -> Result<()> {
     }
 }
 
-fn temp_child_name(name: &str) -> String {
+fn temp_child_name(name: &str) -> Result<String> {
     let mut child = String::with_capacity(name.len());
     for ch in name.chars() {
         match ch {
@@ -142,10 +141,34 @@ fn temp_child_name(name: &str) -> String {
     }
 
     if child.is_empty() {
-        "_".to_string()
-    } else {
-        child
+        child.push('_');
     }
+
+    if child.chars().all(|ch| ch == '.') {
+        return Err(anyhow!(
+            "Recipe name does not map to a safe temporary directory"
+        ));
+    }
+
+    let mut components = Path::new(&child).components();
+    match (components.next(), components.next()) {
+        (Some(Component::Normal(_)), None) => Ok(child),
+        _ => Err(anyhow!(
+            "Recipe name does not map to a safe temporary directory"
+        )),
+    }
+}
+
+fn temp_child_path(parent: &Path, name: &str) -> Result<PathBuf> {
+    Ok(parent.join(temp_child_name(name)?))
+}
+
+fn clean_temp_child_path(parent: &Path, name: &str) -> Result<PathBuf> {
+    let output_dir = temp_child_path(parent, name)?;
+    if output_dir.exists() {
+        fs::remove_dir_all(&output_dir)?;
+    }
+    Ok(output_dir)
 }
 
 fn get_local_repo_path(
@@ -155,9 +178,7 @@ fn get_local_repo_path(
     let (owner, repo_name) = recipe_repo_full_name
         .split_once('/')
         .ok_or_else(|| anyhow::anyhow!("Invalid repository name format"))?;
-    let local_repo_path = local_repo_parent_path
-        .to_path_buf()
-        .join(temp_child_name(&format!("{owner}/{repo_name}")));
+    let local_repo_path = temp_child_path(local_repo_parent_path, &format!("{owner}/{repo_name}"))?;
     Ok(local_repo_path)
 }
 
@@ -206,11 +227,7 @@ fn fetch_origin(local_repo_path: &Path) -> Result<()> {
 
 fn get_folder_from_github(local_repo_path: &Path, recipe_name: &str) -> Result<PathBuf> {
     let ref_and_path = format!("origin/main:{}", recipe_name);
-    let output_dir = env::temp_dir().join(temp_child_name(recipe_name));
-
-    if output_dir.exists() {
-        fs::remove_dir_all(&output_dir)?;
-    }
+    let output_dir = clean_temp_child_path(&env::temp_dir(), recipe_name)?;
     fs::create_dir_all(&output_dir)?;
 
     let archive_output = git_command()
@@ -395,10 +412,68 @@ mod tests {
     #[test]
     fn temp_child_name_keeps_recipe_downloads_under_temp_dir() {
         let parent = Path::new("goose-recipes");
-        let child = temp_child_name("../outside");
+        let child = temp_child_name("../outside").unwrap();
         let output_dir = parent.join(&child);
 
         assert_eq!(child, "..__outside");
         assert!(output_dir.starts_with(parent));
+    }
+
+    #[test]
+    fn temp_child_path_rejects_reserved_components() {
+        let parent = Path::new("goose-recipes");
+
+        for name in [".", "..", "...", "...."] {
+            assert!(temp_child_path(parent, name).is_err(), "accepted {name}");
+        }
+    }
+
+    #[test]
+    fn temp_child_path_preserves_safe_recipe_names() {
+        let parent = Path::new("goose-recipes");
+
+        for (name, child) in [
+            ("daily-report", "daily-report"),
+            ("team/weekly", "team__weekly"),
+            ("../outside", "..__outside"),
+            ("", "_"),
+        ] {
+            assert_eq!(temp_child_path(parent, name).unwrap(), parent.join(child));
+        }
+    }
+
+    #[test]
+    fn cleanup_rejects_reserved_components_before_removing_files() {
+        let root = tempfile::tempdir().unwrap();
+        let parent = root.path().join("recipe-temp");
+        fs::create_dir(&parent).unwrap();
+        let parent_sentinel = root.path().join("parent-sentinel");
+        let child_sentinel = parent.join("child-sentinel");
+        fs::write(&parent_sentinel, "keep").unwrap();
+        fs::write(&child_sentinel, "keep").unwrap();
+
+        for name in [".", "..", "...", "...."] {
+            assert!(clean_temp_child_path(&parent, name).is_err());
+            assert!(parent_sentinel.exists());
+            assert!(child_sentinel.exists());
+        }
+    }
+
+    #[test]
+    fn cleanup_removes_only_the_existing_recipe_child() {
+        let root = tempfile::tempdir().unwrap();
+        let parent = root.path().join("recipe-temp");
+        let child = parent.join("daily-report");
+        fs::create_dir_all(&child).unwrap();
+        let parent_sentinel = parent.join("keep");
+        fs::write(&parent_sentinel, "keep").unwrap();
+        fs::write(child.join("old-recipe.yaml"), "old").unwrap();
+
+        assert_eq!(
+            clean_temp_child_path(&parent, "daily-report").unwrap(),
+            child
+        );
+        assert!(!child.exists());
+        assert!(parent_sentinel.exists());
     }
 }

--- a/crates/goose-cli/src/recipes/github_recipe.rs
+++ b/crates/goose-cli/src/recipes/github_recipe.rs
@@ -150,6 +150,12 @@ fn temp_child_name(name: &str) -> Result<String> {
         child.push('_');
     }
 
+    if child.trim_end_matches([' ', '.']) != child {
+        return Err(anyhow!(
+            "Recipe name does not map to a safe temporary directory"
+        ));
+    }
+
     let mut components = Path::new(&child).components();
     match (components.next(), components.next()) {
         (Some(Component::Normal(_)), None) => Ok(child),
@@ -423,7 +429,18 @@ mod tests {
     fn temp_child_path_rejects_reserved_components() {
         let parent = Path::new("goose-recipes");
 
-        for name in [".", "..", "...", "....", ". ", ".. ", ". .", ".. ."] {
+        for name in [
+            ".",
+            "..",
+            "...",
+            "....",
+            ". ",
+            ".. ",
+            ". .",
+            ".. .",
+            "report.",
+            "report...",
+        ] {
             assert!(temp_child_path(parent, name).is_err(), "accepted {name}");
         }
     }
@@ -453,7 +470,18 @@ mod tests {
         fs::write(&parent_sentinel, "keep").unwrap();
         fs::write(&child_sentinel, "keep").unwrap();
 
-        for name in [".", "..", "...", "....", ". ", ".. ", ". .", ".. ."] {
+        for name in [
+            ".",
+            "..",
+            "...",
+            "....",
+            ". ",
+            ".. ",
+            ". .",
+            ".. .",
+            "report.",
+            "report...",
+        ] {
             assert!(clean_temp_child_path(&parent, name).is_err());
             assert!(parent_sentinel.exists());
             assert!(child_sentinel.exists());


### PR DESCRIPTION
## Summary

- derive recipe extraction paths through one fallible child-path validator before any filesystem cleanup
- reject reserved and dot-only basenames that can resolve to the temporary directory or its parent
- reject Windows trailing-space/period aliases before sanitization
- preserve ordinary sanitized recipe names and remove only the intended existing recipe child

## Security

Audit: project-loupe/audit-goose#119

A selected shared recipe can otherwise supply a nested `.` or `..` path that reaches GitHub fallback and is joined to the system temporary directory before `remove_dir_all`. The validator now requires exactly one normal child component and rejects dot-only and Windows-equivalent aliases before the existence check or recursive deletion.

## Validation

- `cargo fmt --all`
- `cargo test -p goose-cli github_recipe` (6 passed)
- `cargo build -p goose-cli`
- `cargo clippy -p goose-cli --all-targets -- -D warnings`
- `git diff --check`

*This finding was discovered by [Project Loupe](https://github.com/project-loupe/loupe)*
