### PR TITLE
fix(providers): map kimi_code provider name and pass correct provider to create_request

### DIFF
--- a/crates/goose-provider-types/src/canonical.rs
+++ b/crates/goose-provider-types/src/canonical.rs
@@ -132,4 +132,13 @@ mod tests {
         assert!(canonical.cost.input.is_some());
         assert!(canonical.cost.output.is_some());
     }
+
+    #[test]
+    fn kimi_code_k3_resolves_with_reasoning_and_context_limit() {
+        let canonical = maybe_get_canonical_model("kimi_code", "k3")
+            .expect("kimi_code/k3 should resolve via kimi-for-coding provider mapping");
+        assert_eq!(canonical.limit.context, 1_048_576);
+        assert_eq!(canonical.reasoning, Some(true));
+        assert_eq!(canonical.temperature, Some(false));
+    }
 }

--- a/crates/goose-provider-types/src/canonical/name_builder.rs
+++ b/crates/goose-provider-types/src/canonical/name_builder.rs
@@ -54,6 +54,7 @@ pub fn map_provider_name(provider: &str) -> &str {
         "novita" => "novita-ai",
         "opencode_go" => "opencode-go",
         "ollama_cloud" => "ollama-cloud",
+        "kimi_code" => "kimi-for-coding",
         _ => provider,
     }
 }
@@ -530,6 +531,16 @@ mod tests {
         assert_eq!(
             map_to_canonical_model("zhipu", "glm-5", r),
             Some("zhipuai/glm-5".to_string())
+        );
+
+        // === Kimi Code ===
+        assert_eq!(
+            map_to_canonical_model("kimi_code", "kimi-for-coding", r),
+            Some("kimi-for-coding/kimi-for-coding".to_string())
+        );
+        assert_eq!(
+            map_to_canonical_model("kimi_code", "kimi-for-coding-highspeed", r),
+            Some("kimi-for-coding/kimi-for-coding-highspeed".to_string())
         );
 
         // === GCP Vertex AI ===

--- a/crates/goose/src/providers/kimicode.rs
+++ b/crates/goose/src/providers/kimicode.rs
@@ -4,7 +4,7 @@ use async_stream::try_stream;
 use async_trait::async_trait;
 use chrono::{DateTime, Duration, Utc};
 use futures::TryStreamExt;
-use goose_providers::formats::anthropic::{AnthropicFormatOptions, ANTHROPIC_PROVIDER_NAME};
+use goose_providers::formats::anthropic::AnthropicFormatOptions;
 use reqwest::header::{HeaderMap, HeaderValue};
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
@@ -420,7 +420,7 @@ impl Provider for KimiCodeProvider {
         tools: &[Tool],
     ) -> Result<MessageStream, ProviderError> {
         let mut payload = create_request(
-            ANTHROPIC_PROVIDER_NAME,
+            KIMI_CODE_PROVIDER_NAME,
             model_config,
             system,
             messages,


### PR DESCRIPTION
Fixes: #11116

## Summary

`kimi_code` inventory rows had NULL context_limit and reasoning, so Desktop showed 128k and hid the Thinking Effort control.

Two root causes: map_provider_name had no kimi_code → kimi-for-coding arm so every registry lookup missed, and kimicode.rs was passing `ANTHROPIC_PROVIDER_NAME` to `create_request` which broke formatter-side canonical lookups and kept thinking disabled server-side.

Fix adds the missing mapping arm and passes KIMI_CODE_PROVIDER_NAME to create_request instead.

### Testing
`cargo test -p goose-provider-types -- canonical::name_builder::tests::test_map_to_canonical_model` `canonical::tests::kimi_code_k3_resolves_with_reasoning_and_context_limit` — all passing.
