### PR TITLE
Add HumanPen to the MCP servers list

### DIFF
--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -388,7 +388,7 @@
   {
     "id": "humanpen-mcp",
     "name": "HumanPen",
-    "description": "Lower a Word/PowerPoint/PDF document's AI-detection score so it reads as human-written",
+    "description": "Rewrite a .docx/.pptx so it reads as human-written and scores lower on AI detectors",
     "command": "npx -y humanpen-mcp",
     "link": "https://github.com/humanpen/humanpen-mcp",
     "installation_notes": "Install using npx package manager.",

--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -386,6 +386,23 @@
     "environmentVariables": []
   },
   {
+    "id": "humanpen-mcp",
+    "name": "HumanPen",
+    "description": "Lower a Word/PowerPoint/PDF document's AI-detection score so it reads as human-written",
+    "command": "npx -y humanpen-mcp",
+    "link": "https://github.com/humanpen/humanpen-mcp",
+    "installation_notes": "Install using npx package manager.",
+    "is_builtin": false,
+    "endorsed": false,
+    "environmentVariables": [
+      {
+        "name": "HUMANPEN_API_KEY",
+        "description": "HumanPen API key (create one at https://humanpen.net/settings/api-keys)",
+        "required": true
+      }
+    ]
+  },
+  {
     "id": "jetbrains",
     "name": "JetBrains",
     "description": "Integrate with any JetBrains IDE (requires local setup, dependent on your IDE version)",


### PR DESCRIPTION
Adds [HumanPen](https://github.com/humanpen/humanpen-mcp) to `documentation/static/servers.json` (alphabetical, between gotoHuman and jetbrains).

An MCP server that lowers a Word/PowerPoint/PDF document's AI-detection score so it reads as human-written, keeping every fact, number, table and all formatting intact. Runs via `npx -y humanpen-mcp` with a `HUMANPEN_API_KEY`; in the official MCP Registry as `io.github.humanpen/humanpen-mcp`. `is_builtin`/`endorsed` left false. Apache-2.0.