### PR TITLE
fix: nav toggle showing hamburger menu icon to open navigation

### DIFF
--- a/ui/desktop/src/components/Layout/AppLayout.tsx
+++ b/ui/desktop/src/components/Layout/AppLayout.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { IpcRendererEvent } from 'electron';
 import { Outlet, useLocation } from 'react-router';
 import { motion } from 'framer-motion';
-import { Menu, PanelLeft } from 'lucide-react';
+import { PanelLeft } from 'lucide-react';
 import { defineMessages, useIntl } from '../../i18n';
 import { Button } from '../ui/button';
 import ChatSessionsContainer from '../ChatSessionsContainer';
@@ -117,7 +117,7 @@ const AppLayoutContent: React.FC<AppLayoutContentProps> = ({ activeSessions }) =
           title={navToggleTitle}
           aria-label={navToggleTitle}
         >
-          {isNavExpanded ? <PanelLeft className="w-5 h-5" /> : <Menu className="w-5 h-5" />}
+          <PanelLeft className="w-5 h-5" />
         </Button>
       </div>
 


### PR DESCRIPTION
## Summary
The nav toggle button incorrectly showed a hamburger (Menu) icon when collapsed, which is not how opening the navigation is indicated in apps. Always render PanelLeft instead.

### Testing
Manual Testing

### Related Issues
Fixes: #11181 

### Screenshots/Demos (for UX changes)
Before:  
<img width="340" height="302" alt="image" src="https://github.com/user-attachments/assets/bb09b7cd-41a9-4d3d-a20f-dd3eb597bd83" />


After:   
<img width="330" height="402" alt="image" src="https://github.com/user-attachments/assets/c2ace881-a8b9-4150-9282-ba7b4561c847" />

