### PR TITLE
fix(providers): reserve max_tokens budget for reasoning content on OpenAI-compatible providers

### DIFF
--- a/crates/goose-provider-types/src/formats.rs
+++ b/crates/goose-provider-types/src/formats.rs
@@ -5,4 +5,7 @@ pub mod ollama;
 pub mod openai;
 pub mod openai_responses;
 
+#[cfg(test)]
+mod openai_max_tokens;
+
 pub mod snowflake;

--- a/crates/goose-provider-types/src/formats/openai.rs
+++ b/crates/goose-provider-types/src/formats/openai.rs
@@ -1590,6 +1590,53 @@ where
     }
 }
 
+/// Minimum content tokens to reserve when a reasoning model shares one
+/// `max_tokens` budget between `reasoning_content` and `content`.
+///
+/// OpenAI-compatible servers (llama.cpp, vLLM, Ollama) count both streams
+/// against the same `max_tokens`, so a verbose thinking pass can consume the
+/// whole budget and leave an empty answer (`finish_reason: "length"`, 0
+/// content tokens). Bumping the budget by a per-effort thinking budget keeps
+/// the answer from being starved. See issue #11142.
+const MIN_ANSWER_TOKENS: i32 = 1_024;
+
+/// Thinking budget added on top of the base `max_tokens` for a given thinking
+/// effort, so reasoning + content both fit within a single request budget.
+fn thinking_budget_for_effort(effort: ThinkingEffort) -> i32 {
+    match effort {
+        ThinkingEffort::Off => 0,
+        ThinkingEffort::Low => 2_048,
+        ThinkingEffort::Medium => 8_192,
+        ThinkingEffort::High | ThinkingEffort::Max => 16_384,
+    }
+}
+
+/// Compute the effective `max_tokens` for a request, accounting for reasoning
+/// tokens sharing the budget with content on OpenAI-compatible endpoints.
+///
+/// When a model has reasoning enabled and a thinking effort other than `Off`,
+/// the base budget is topped up with a thinking budget and content is floored
+/// at [`MIN_ANSWER_TOKENS`]. Requests to the OpenAI Responses API
+/// (`max_completion_tokens`) are left untouched: that API already counts
+/// reasoning inside the completion cap, and inflating it risks exceeding the
+/// model's hard output cap.
+fn effective_max_tokens_for_reasoning(
+    model_config: &ModelConfig,
+    base_max_tokens: i32,
+    uses_max_completion_tokens: bool,
+) -> i32 {
+    if uses_max_completion_tokens || !model_config.is_reasoning_model() {
+        return base_max_tokens;
+    }
+    let Some(effort) = model_config.thinking_effort() else {
+        return base_max_tokens;
+    };
+    if effort == ThinkingEffort::Off {
+        return base_max_tokens;
+    }
+    base_max_tokens.max(MIN_ANSWER_TOKENS) + thinking_budget_for_effort(effort)
+}
+
 pub fn create_request(
     model_config: &ModelConfig,
     system: &str,
@@ -1713,10 +1760,12 @@ pub fn create_request_for_model_with_options(
         } else {
             "max_tokens"
         };
+        let tokens =
+            effective_max_tokens_for_reasoning(model_config, max_tokens, is_reasoning_model);
         payload
             .as_object_mut()
             .unwrap()
-            .insert(key.to_string(), json!(max_tokens));
+            .insert(key.to_string(), json!(tokens));
     }
 
     if for_streaming {

--- a/crates/goose-provider-types/src/formats/openai.rs
+++ b/crates/goose-provider-types/src/formats/openai.rs
@@ -1621,8 +1621,9 @@ fn thinking_budget_for_effort(effort: ThinkingEffort) -> i32 {
 /// reasoning inside the completion cap, and inflating it risks exceeding the
 /// model's hard output cap. The chat `max_tokens` path applies the same
 /// caution: when the base budget is already at (or beyond) the provider's
-/// advertised output cap, the top-up is skipped so the request never exceeds
-/// the model's hard cap.
+/// advertised output cap the top-up is skipped, and when a top-up would push
+/// the total past the cap it is clamped so the request never exceeds the
+/// model's hard cap.
 fn effective_max_tokens_for_reasoning(
     model_config: &ModelConfig,
     base_max_tokens: i32,
@@ -1637,15 +1638,23 @@ fn effective_max_tokens_for_reasoning(
     if effort == ThinkingEffort::Off {
         return base_max_tokens;
     }
+    let Some(cap) = provider_output_cap(&model_config.model_name) else {
+        // Unknown model (e.g. local llama.cpp / vLLM / Ollama): keep the
+        // existing thinking top-up.
+        return base_max_tokens.max(MIN_ANSWER_TOKENS) + thinking_budget_for_effort(effort);
+    };
     // When the base max_tokens is already at (or beyond) the provider's
     // advertised output cap (e.g. x-ai/grok-4.3, limit.output 30000), there is
     // no headroom to reserve a thinking budget — topping up would push the
     // request past the model's hard cap. Skip the top-up, mirroring the
     // Responses-API exemption above.
-    if provider_output_cap(&model_config.model_name).is_some_and(|cap| base_max_tokens >= cap) {
+    if base_max_tokens >= cap {
         return base_max_tokens;
     }
-    base_max_tokens.max(MIN_ANSWER_TOKENS) + thinking_budget_for_effort(effort)
+    // Below the cap: reserve a thinking budget, but clamp the total so the
+    // request never exceeds the model's hard cap (e.g. GOOSE_MAX_TOKENS=20000
+    // + High effort on grok-4.3 must yield 30000, not 36384).
+    (base_max_tokens.max(MIN_ANSWER_TOKENS) + thinking_budget_for_effort(effort)).min(cap)
 }
 
 /// Best-effort resolution of a model's advertised max output tokens
@@ -3073,6 +3082,33 @@ mod tests {
         assert!(obj.get("thinking_effort").is_none());
 
         Ok(())
+    }
+
+    #[test]
+    fn test_thinking_budget_topup_is_clamped_to_provider_cap() {
+        // Regression for the review on #11145: when the base budget is below the
+        // provider's advertised output cap but the thinking top-up would push it
+        // over (e.g. GOOSE_MAX_TOKENS=20000 + High effort on x-ai/grok-4.3,
+        // whose cap is 30000), the total must be clamped to the cap instead of
+        // sending an out-of-cap max_tokens.
+        let cap = provider_output_cap("grok-4.3").expect("grok-4.3 resolves to a canonical cap");
+        assert_eq!(cap, 30_000, "x-ai/grok-4.3 advertised output cap");
+
+        // Base below the cap: the top-up is attempted but clamped so the request
+        // never exceeds the model's hard cap.
+        let model_config =
+            test_model_config("grok-4.3").with_thinking_effort(ThinkingEffort::High);
+        assert_eq!(effective_max_tokens_for_reasoning(&model_config, 20_000, false), cap);
+
+        // Base already at the cap: no headroom, the top-up is skipped.
+        assert_eq!(effective_max_tokens_for_reasoning(&model_config, cap, false), cap);
+
+        // Plenty of headroom: the normal top-up is preserved.
+        let low = test_model_config("grok-4.3").with_thinking_effort(ThinkingEffort::Low);
+        assert_eq!(
+            effective_max_tokens_for_reasoning(&low, 1_000, false),
+            MIN_ANSWER_TOKENS + thinking_budget_for_effort(ThinkingEffort::Low)
+        );
     }
 
     struct StreamingUsageTestResult {

--- a/crates/goose-provider-types/src/formats/openai.rs
+++ b/crates/goose-provider-types/src/formats/openai.rs
@@ -1619,7 +1619,10 @@ fn thinking_budget_for_effort(effort: ThinkingEffort) -> i32 {
 /// at [`MIN_ANSWER_TOKENS`]. Requests to the OpenAI Responses API
 /// (`max_completion_tokens`) are left untouched: that API already counts
 /// reasoning inside the completion cap, and inflating it risks exceeding the
-/// model's hard output cap.
+/// model's hard output cap. The chat `max_tokens` path applies the same
+/// caution: when the base budget is already at (or beyond) the provider's
+/// advertised output cap, the top-up is skipped so the request never exceeds
+/// the model's hard cap.
 fn effective_max_tokens_for_reasoning(
     model_config: &ModelConfig,
     base_max_tokens: i32,
@@ -1634,7 +1637,30 @@ fn effective_max_tokens_for_reasoning(
     if effort == ThinkingEffort::Off {
         return base_max_tokens;
     }
+    // When the base max_tokens is already at (or beyond) the provider's
+    // advertised output cap (e.g. x-ai/grok-4.3, limit.output 30000), there is
+    // no headroom to reserve a thinking budget — topping up would push the
+    // request past the model's hard cap. Skip the top-up, mirroring the
+    // Responses-API exemption above.
+    if provider_output_cap(&model_config.model_name)
+        .is_some_and(|cap| base_max_tokens >= cap)
+    {
+        return base_max_tokens;
+    }
     base_max_tokens.max(MIN_ANSWER_TOKENS) + thinking_budget_for_effort(effort)
+}
+
+/// Best-effort resolution of a model's advertised max output tokens
+/// (`limit.output`) from the bundled canonical registry. The generic chat path
+/// carries no provider name, so the lookup leans on the registry's model-name
+/// inference (e.g. "grok-4.3" -> x-ai). Returns `None` for models that are not
+/// in the registry (e.g. local llama.cpp / vLLM / Ollama), in which case the
+/// caller keeps the existing thinking top-up.
+fn provider_output_cap(model_name: &str) -> Option<i32> {
+    let (base_model, _) = extract_reasoning_effort(model_name);
+    crate::canonical::maybe_get_canonical_model("", &base_model)
+        .and_then(|canonical| canonical.limit.output)
+        .map(|output| output as i32)
 }
 
 pub fn create_request(

--- a/crates/goose-provider-types/src/formats/openai.rs
+++ b/crates/goose-provider-types/src/formats/openai.rs
@@ -3096,12 +3096,17 @@ mod tests {
 
         // Base below the cap: the top-up is attempted but clamped so the request
         // never exceeds the model's hard cap.
-        let model_config =
-            test_model_config("grok-4.3").with_thinking_effort(ThinkingEffort::High);
-        assert_eq!(effective_max_tokens_for_reasoning(&model_config, 20_000, false), cap);
+        let model_config = test_model_config("grok-4.3").with_thinking_effort(ThinkingEffort::High);
+        assert_eq!(
+            effective_max_tokens_for_reasoning(&model_config, 20_000, false),
+            cap
+        );
 
         // Base already at the cap: no headroom, the top-up is skipped.
-        assert_eq!(effective_max_tokens_for_reasoning(&model_config, cap, false), cap);
+        assert_eq!(
+            effective_max_tokens_for_reasoning(&model_config, cap, false),
+            cap
+        );
 
         // Plenty of headroom: the normal top-up is preserved.
         let low = test_model_config("grok-4.3").with_thinking_effort(ThinkingEffort::Low);

--- a/crates/goose-provider-types/src/formats/openai.rs
+++ b/crates/goose-provider-types/src/formats/openai.rs
@@ -1642,9 +1642,7 @@ fn effective_max_tokens_for_reasoning(
     // no headroom to reserve a thinking budget — topping up would push the
     // request past the model's hard cap. Skip the top-up, mirroring the
     // Responses-API exemption above.
-    if provider_output_cap(&model_config.model_name)
-        .is_some_and(|cap| base_max_tokens >= cap)
-    {
+    if provider_output_cap(&model_config.model_name).is_some_and(|cap| base_max_tokens >= cap) {
         return base_max_tokens;
     }
     base_max_tokens.max(MIN_ANSWER_TOKENS) + thinking_budget_for_effort(effort)

--- a/crates/goose-provider-types/src/formats/openai_max_tokens.rs
+++ b/crates/goose-provider-types/src/formats/openai_max_tokens.rs
@@ -1,0 +1,107 @@
+//! Regression tests for the reasoning-model `max_tokens` budget (issue #11142).
+//!
+//! OpenAI-compatible servers (llama.cpp, vLLM, Ollama) count `reasoning_content`
+//! and `content` against a single `max_tokens`, so a verbose thinking pass can
+//! consume the whole budget and leave an empty answer. The request builder in
+//! [`super::openai`] must reserve budget for both.
+
+use crate::images::ImageFormat;
+use crate::model::ModelConfig;
+use crate::thinking::ThinkingEffort;
+use serde_json::json;
+
+use super::openai::create_request;
+
+fn reasoning_model_config(max_tokens: i32, effort: Option<ThinkingEffort>) -> ModelConfig {
+    let mut config = ModelConfig::new("nemotron-35-lightning").with_max_tokens(Some(max_tokens));
+    if let Some(effort) = effort {
+        config = config.with_thinking_effort(effort);
+    }
+    config.reasoning = Some(true);
+    config
+}
+
+#[test]
+fn reasoning_model_max_tokens_include_thinking_budget() -> anyhow::Result<()> {
+    // A custom OpenAI-compatible provider serving a local reasoning model
+    // (llama.cpp / vLLM / Ollama). These servers count reasoning_content and
+    // content against a single max_tokens, so a verbose thinking pass can
+    // consume the whole budget and leave an empty answer (#11142). The request
+    // must reserve budget for both.
+    let model_config = reasoning_model_config(4096, Some(ThinkingEffort::High));
+
+    let request = create_request(
+        &model_config,
+        "system",
+        &[],
+        &[],
+        &ImageFormat::OpenAi,
+        true,
+    )?;
+
+    // 4096 content budget + 16384 thinking budget = 20480.
+    assert_eq!(request["max_tokens"], json!(20480));
+
+    Ok(())
+}
+
+#[test]
+fn reasoning_model_max_tokens_unchanged_without_thinking() -> anyhow::Result<()> {
+    // Same reasoning model, but no thinking effort configured: the budget must
+    // be left untouched.
+    let model_config = reasoning_model_config(4096, None);
+
+    let request = create_request(
+        &model_config,
+        "system",
+        &[],
+        &[],
+        &ImageFormat::OpenAi,
+        true,
+    )?;
+
+    assert_eq!(request["max_tokens"], json!(4096));
+
+    Ok(())
+}
+
+#[test]
+fn reasoning_model_max_tokens_unchanged_when_thinking_off() -> anyhow::Result<()> {
+    // When thinking is explicitly disabled, no extra budget is needed.
+    let model_config = reasoning_model_config(4096, Some(ThinkingEffort::Off));
+
+    let request = create_request(
+        &model_config,
+        "system",
+        &[],
+        &[],
+        &ImageFormat::OpenAi,
+        true,
+    )?;
+
+    assert_eq!(request["max_tokens"], json!(4096));
+
+    Ok(())
+}
+
+#[test]
+fn responses_model_max_completion_tokens_unchanged() -> anyhow::Result<()> {
+    // The OpenAI Responses API already counts reasoning tokens inside
+    // max_completion_tokens; inflating it risks exceeding the hard cap.
+    let model_config = ModelConfig::new("gpt-5.4")
+        .with_thinking_effort(ThinkingEffort::High)
+        .with_max_tokens(Some(16384));
+
+    let request = create_request(
+        &model_config,
+        "system",
+        &[],
+        &[],
+        &ImageFormat::OpenAi,
+        true,
+    )?;
+
+    assert_eq!(request["max_completion_tokens"], json!(16384));
+
+    Ok(())
+}

--- a/crates/goose-provider-types/src/formats/openai_max_tokens.rs
+++ b/crates/goose-provider-types/src/formats/openai_max_tokens.rs
@@ -105,3 +105,57 @@ fn responses_model_max_completion_tokens_unchanged() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn chat_reasoning_model_max_tokens_clamped_at_provider_output_cap() -> anyhow::Result<()> {
+    // A hosted OpenAI-compatible reasoning model whose canonical max_tokens is
+    // ALREADY the provider's advertised output limit (x-ai/grok-4.3,
+    // limit.output 30000). Reserving a thinking budget on top would push the
+    // request past the model's hard cap (30000 + 16384 = 46384), so the chat
+    // `max_tokens` must stay at the cap.
+    let model_config = ModelConfig::new("grok-4.3")
+        .with_canonical_limits("xai")
+        .with_thinking_effort(ThinkingEffort::High);
+
+    // Sanity check: the canonical output limit is what landed in max_tokens.
+    assert_eq!(model_config.max_tokens, Some(30000));
+
+    let request = create_request(
+        &model_config,
+        "system",
+        &[],
+        &[],
+        &ImageFormat::OpenAi,
+        true,
+    )?;
+
+    // Effective max_tokens stays at the provider cap, not 30000 + 16384.
+    assert_eq!(request["max_tokens"], json!(30000));
+
+    Ok(())
+}
+
+#[test]
+fn chat_reasoning_model_max_tokens_still_tops_up_with_headroom() -> anyhow::Result<()> {
+    // Same hosted reasoning model, but the user set max_tokens below the cap
+    // (GOOSE_MAX_TOKENS=10000 < limit.output 30000). The thinking top-up must
+    // still be applied because there is headroom left under the hard cap.
+    let model_config = ModelConfig::new("grok-4.3")
+        .with_max_tokens(Some(10000))
+        .with_canonical_limits("xai")
+        .with_thinking_effort(ThinkingEffort::High);
+
+    let request = create_request(
+        &model_config,
+        "system",
+        &[],
+        &[],
+        &ImageFormat::OpenAi,
+        true,
+    )?;
+
+    // 10000 content budget + 16384 thinking budget = 26384 (<= 30000 cap).
+    assert_eq!(request["max_tokens"], json!(26384));
+
+    Ok(())
+}


### PR DESCRIPTION
Fixes #11142

## What

When a custom OpenAI-compatible provider serves a reasoning model with `reasoning: true` (e.g. DeepSeek, Nemotron, Qwen3-thinking via llama.cpp / vLLM / Ollama), the request built by `formats::openai` carried the configured `max_tokens` verbatim. Those servers count `reasoning_content` and `content` against a single `max_tokens` budget, so a verbose thinking pass could consume the whole budget and the assistant reply came back empty (`finish_reason: "length"`, 0 content tokens).

## Fix

In `crates/goose-provider-types/src/formats/openai.rs` the request builder now computes the effective budget via `effective_max_tokens_for_reasoning`:

- When the model is a reasoning model (`reasoning: true` or canonical record) and a thinking effort other than `Off` is configured, `max_tokens` is topped up with a per-effort thinking budget (low: 2048, medium: 8192, high/max: 16384, mirroring the pi reference the issue cites), and the content share is floored at a minimum of 1024 tokens so the answer is never starved.
- Requests to the OpenAI Responses API (`max_completion_tokens`, o-series/gpt-5) are left untouched: that API already counts reasoning inside the completion cap, and inflating it risks exceeding the model's hard output cap.
- When thinking is disabled, no effort is set, or the model is not a reasoning model, behaviour is unchanged.

## Verification

Added unit tests in `formats::openai_max_tokens` (no live API needed):

- `reasoning_model_max_tokens_include_thinking_budget` reproduces the issue: on `main` the request carries `max_tokens: 4096` instead of the reserved `20480`, i.e. reasoning would starve content; with the fix it passes.
- `reasoning_model_max_tokens_unchanged_without_thinking`, `reasoning_model_max_tokens_unchanged_when_thinking_off`, and `responses_model_max_completion_tokens_unchanged` pin the no-effort / effort-off / Responses-API cases so the bump stays limited to exactly the reasoning + thinking path.

Verified with `cargo test -p goose-provider-types --lib openai_max_tokens`.

## Notes

Related prior work: #9814 handled the same class of problem on the Anthropic format (keeping extended thinking within the output cap); this PR covers the OpenAI-compatible (chat-completions) path for local reasoning models. The issue author's open RFC #11075 covers the neighbouring context-window-overflow area and is out of scope here.