### PR TITLE
feat: auto-focus chat input when user starts typing

### DIFF
--- a/ui/desktop/eslint.config.js
+++ b/ui/desktop/eslint.config.js
@@ -69,6 +69,7 @@ module.exports = [
         setInterval: 'readonly',
         clearTimeout: 'readonly',
         CustomEvent: 'readonly',
+        Element: 'readonly',
         HTMLElement: 'readonly',
         HTMLInputElement: 'readonly',
         HTMLSelectElement: 'readonly',

--- a/ui/desktop/src/components/ChatInput.tsx
+++ b/ui/desktop/src/components/ChatInput.tsx
@@ -17,6 +17,7 @@ import { AlertType, useAlerts } from './alerts';
 import { useModelAndProvider } from './ModelAndProviderContext';
 import { acpListProviderDetails } from '../acp/providers';
 import { useAudioRecorder } from '../hooks/useAudioRecorder';
+import { useFocusOnTyping } from '../hooks/useFocusOnTyping';
 import { toastError } from '../toasts';
 import MentionPopover, { DisplayItemWithMatch } from './MentionPopover';
 import { COST_TRACKING_ENABLED } from '../updates';
@@ -573,6 +574,8 @@ export default function ChatInput({
       textAreaRef.current.focus();
     }
   }, [textAreaRef]);
+
+  useFocusOnTyping(textAreaRef, !isRecording);
 
   // Load providers and get current model's token limit
   const loadProviderDetails = async () => {

--- a/ui/desktop/src/hooks/useFocusOnTyping.ts
+++ b/ui/desktop/src/hooks/useFocusOnTyping.ts
@@ -40,6 +40,13 @@ function isSpaceActivatableControl(element: Element | null): boolean {
   return role !== null && SPACE_ACTIVATABLE_ROLES.has(role);
 }
 
+const COMPOSITE_WIDGET_SELECTOR =
+  '[role="menu"], [role="listbox"], [role="tree"], [role="grid"], [role="combobox"], [data-radix-collection-item]';
+
+function isInsideCompositeWidget(element: Element | null): boolean {
+  return element instanceof HTMLElement && element.closest(COMPOSITE_WIDGET_SELECTOR) !== null;
+}
+
 export function useFocusOnTyping(
   targetRef: RefObject<HTMLTextAreaElement | null>,
   enabled: boolean
@@ -48,9 +55,11 @@ export function useFocusOnTyping(
     if (!enabled) return;
 
     const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.defaultPrevented) return;
       if (e.metaKey || e.ctrlKey || e.altKey) return;
       if (e.key.length !== 1) return;
       if (isEditableElement(document.activeElement)) return;
+      if (isInsideCompositeWidget(document.activeElement)) return;
       if (e.key === ' ' && isSpaceActivatableControl(document.activeElement)) return;
 
       const selection = window.getSelection();

--- a/ui/desktop/src/hooks/useFocusOnTyping.ts
+++ b/ui/desktop/src/hooks/useFocusOnTyping.ts
@@ -62,8 +62,7 @@ export function useFocusOnTyping(
 
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.defaultPrevented) return;
-      const isAltGraph = e.getModifierState?.('AltGraph') ?? false;
-      if (e.metaKey || e.ctrlKey || (e.altKey && !isAltGraph)) return;
+      if (e.metaKey || e.ctrlKey) return;
       if (e.key.length !== 1) return;
       if (isEditableElement(document.activeElement)) return;
       if (isInsideCompositeWidget(document.activeElement)) return;

--- a/ui/desktop/src/hooks/useFocusOnTyping.ts
+++ b/ui/desktop/src/hooks/useFocusOnTyping.ts
@@ -1,0 +1,67 @@
+import { RefObject, useEffect } from 'react';
+
+function isEditableElement(element: Element | null): boolean {
+  if (!element) return false;
+  if (element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement) return true;
+  return element instanceof HTMLElement && element.isContentEditable;
+}
+
+const SPACE_ACTIVATABLE_INPUT_TYPES = new Set([
+  'checkbox',
+  'radio',
+  'submit',
+  'button',
+  'reset',
+  'file',
+  'range',
+  'color',
+]);
+
+const SPACE_ACTIVATABLE_ROLES = new Set([
+  'button',
+  'checkbox',
+  'radio',
+  'switch',
+  'menuitem',
+  'menuitemcheckbox',
+  'menuitemradio',
+  'tab',
+  'link',
+]);
+
+function isSpaceActivatableControl(element: Element | null): boolean {
+  if (!(element instanceof HTMLElement)) return false;
+  const tag = element.tagName;
+  if (tag === 'BUTTON' || tag === 'A' || tag === 'SUMMARY' || tag === 'SELECT') return true;
+  if (tag === 'INPUT') {
+    return SPACE_ACTIVATABLE_INPUT_TYPES.has((element as HTMLInputElement).type);
+  }
+  const role = element.getAttribute('role');
+  return role !== null && SPACE_ACTIVATABLE_ROLES.has(role);
+}
+
+export function useFocusOnTyping(
+  targetRef: RefObject<HTMLTextAreaElement | null>,
+  enabled: boolean
+) {
+  useEffect(() => {
+    if (!enabled) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+      if (e.key.length !== 1) return;
+      if (isEditableElement(document.activeElement)) return;
+      if (e.key === ' ' && isSpaceActivatableControl(document.activeElement)) return;
+
+      const selection = window.getSelection();
+      if (selection && !selection.isCollapsed) return;
+
+      targetRef.current?.focus();
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [targetRef, enabled]);
+}

--- a/ui/desktop/src/hooks/useFocusOnTyping.ts
+++ b/ui/desktop/src/hooks/useFocusOnTyping.ts
@@ -2,7 +2,13 @@ import { RefObject, useEffect } from 'react';
 
 function isEditableElement(element: Element | null): boolean {
   if (!element) return false;
-  if (element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement) return true;
+  if (
+    element instanceof HTMLInputElement ||
+    element instanceof HTMLTextAreaElement ||
+    element instanceof HTMLSelectElement
+  ) {
+    return true;
+  }
   return element instanceof HTMLElement && element.isContentEditable;
 }
 
@@ -32,7 +38,7 @@ const SPACE_ACTIVATABLE_ROLES = new Set([
 function isSpaceActivatableControl(element: Element | null): boolean {
   if (!(element instanceof HTMLElement)) return false;
   const tag = element.tagName;
-  if (tag === 'BUTTON' || tag === 'A' || tag === 'SUMMARY' || tag === 'SELECT') return true;
+  if (tag === 'BUTTON' || tag === 'A' || tag === 'SUMMARY') return true;
   if (tag === 'INPUT') {
     return SPACE_ACTIVATABLE_INPUT_TYPES.has((element as HTMLInputElement).type);
   }
@@ -56,7 +62,8 @@ export function useFocusOnTyping(
 
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.defaultPrevented) return;
-      if (e.metaKey || e.ctrlKey || e.altKey) return;
+      const isAltGraph = e.getModifierState?.('AltGraph') ?? false;
+      if (e.metaKey || e.ctrlKey || (e.altKey && !isAltGraph)) return;
       if (e.key.length !== 1) return;
       if (isEditableElement(document.activeElement)) return;
       if (isInsideCompositeWidget(document.activeElement)) return;


### PR DESCRIPTION
## Summary
Add a global keydown listener that focuses the chat textarea when the user starts typing anywhere on the page, matching the behavior of Claude.ai and ChatGPT. Guards against modifier keys, already-focused editable elements, Space activating a focused button/link/checkbox, and active text selections.

<!-- Describe your change -->
Right now, if focus is anywhere other than the chat box, typing does nothing until you click back into the input.
This PR adds that behavior here. A small hook (`useFocusOnTyping`) listens for keydown on the page and focuses the chat textarea the moment you start typing a real character,

### Testing
Manually tested

### Related Issues
Relates to #11180 