### PR TITLE
Add PCRZERO community extension (stdio npx)

### DIFF
--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -545,6 +545,23 @@
     "environmentVariables": []
   },
   {
+    "id": "pcrzero-mcp",
+    "name": "PCRZERO",
+    "description": "Issue and independently verify signed receipts for agent actions. verify_receipt and get_keyset work with no account; issue_receipt is metered.",
+    "command": "npx -y @scytalex-llc/pcrzero-mcp",
+    "link": "https://github.com/Scytalex-LLC/pcrzero-mcp",
+    "installation_notes": "Install using npx. Requires Node 22+. PCRZERO_API_KEY is optional: omit it to use only the free verify_receipt and get_keyset tools. Spec: https://pcrzero.com/spec",
+    "is_builtin": false,
+    "endorsed": false,
+    "environmentVariables": [
+      {
+        "name": "PCRZERO_API_KEY",
+        "description": "Optional. Required only for the metered issue_receipt tool. Leave unset to verify receipts and fetch the public keyset.",
+        "required": false
+      }
+    ]
+  },
+  {
     "id": "pdf_read",
     "name": "PDF Reader",
     "description": "Read large and complex PDF documents",
@@ -807,26 +824,25 @@
     "environmentVariables": []
   },
   {
-  "id": "scholar-sidekick",
-  "name": "Scholar Sidekick",
-  "description": "Resolve, format, export, and verify academic citations (DOI, PMID, ISBN, arXiv) plus retraction and open-access checks",
-  "command": "npx -y scholar-sidekick-mcp@latest",
-  "link": "https://github.com/mlava/scholar-sidekick-mcp",
-  "installation_notes": "No API key required — works anonymously on a free, rate-limited tier. Optionally set SCHOLAR_API_KEY (a free first-party ssk_ key from https://scholar-sidekick.com/account) for higher limits, or RAPIDAPI_KEY for paid tiers via RapidAPI.",
-  "is_builtin": false,
-  "endorsed": false,
-  "environmentVariables": [
-    {
-      "name": "SCHOLAR_API_KEY",
-      "description": "Optional first-party API key (ssk_) from https://scholar-sidekick.com/account; raises rate limits. Sent as Authorization: Bearer.",
-      "required": false
-    },
-    {
-      "name": "RAPIDAPI_KEY",
-      "description": "Optional RapidAPI key for paid/managed tiers; routes calls through the RapidAPI gateway.",
-      "required": false
-    }
-  ]
-}
-
+    "id": "scholar-sidekick",
+    "name": "Scholar Sidekick",
+    "description": "Resolve, format, export, and verify academic citations (DOI, PMID, ISBN, arXiv) plus retraction and open-access checks",
+    "command": "npx -y scholar-sidekick-mcp@latest",
+    "link": "https://github.com/mlava/scholar-sidekick-mcp",
+    "installation_notes": "No API key required \u2014 works anonymously on a free, rate-limited tier. Optionally set SCHOLAR_API_KEY (a free first-party ssk_ key from https://scholar-sidekick.com/account) for higher limits, or RAPIDAPI_KEY for paid tiers via RapidAPI.",
+    "is_builtin": false,
+    "endorsed": false,
+    "environmentVariables": [
+      {
+        "name": "SCHOLAR_API_KEY",
+        "description": "Optional first-party API key (ssk_) from https://scholar-sidekick.com/account; raises rate limits. Sent as Authorization: Bearer.",
+        "required": false
+      },
+      {
+        "name": "RAPIDAPI_KEY",
+        "description": "Optional RapidAPI key for paid/managed tiers; routes calls through the RapidAPI gateway.",
+        "required": false
+      }
+    ]
+  }
 ]


### PR DESCRIPTION
Adds PCRZERO to `documentation/static/servers.json` as a community stdio extension.

- Command: `npx -y @scytalex-llc/pcrzero-mcp`
- `PCRZERO_API_KEY` is **optional** (`required: false`) — `verify_receipt` and `get_keyset` work with no account; only metered `issue_receipt` needs a key
- No hosted/remote MCP URL (that surface is still being stood up separately)
- Spec: https://pcrzero.com/spec · repo: https://github.com/Scytalex-LLC/pcrzero-mcp · official registry: `com.pcrzero/mcp`