### PR TITLE
fix(security): render visualizer data as text

### DIFF
--- a/crates/goose-mcp/src/autovisualiser/mod.rs
+++ b/crates/goose-mcp/src/autovisualiser/mod.rs
@@ -1720,6 +1720,64 @@ mod tests {
         assert!(result.is_ok());
         assert_mcp_apps_result(&result.unwrap(), "ui://autovisualiser/mermaid", "mermaid");
     }
+
+    #[test]
+    fn donut_legend_renders_dynamic_values_as_text() {
+        let html = AutoVisualiserRouter::new()
+            .get_template_html("ui://autovisualiser/donut")
+            .unwrap();
+
+        assert!(!html.contains("legendEl.innerHTML"));
+        assert!(html.contains("labelEl.textContent = label"));
+        assert!(html.contains("valueEl.textContent = pct"));
+    }
+
+    #[test]
+    fn chord_tooltips_render_dynamic_values_as_text() {
+        let html = AutoVisualiserRouter::new()
+            .get_template_html("ui://autovisualiser/chord")
+            .unwrap();
+
+        assert!(!html.contains(".html("));
+        assert!(html.contains(".text(line)"));
+        assert!(html.contains("data.labels[d.source.index]"));
+        assert!(html.contains("data.labels[d.target.index]"));
+    }
+
+    #[test]
+    fn mermaid_errors_render_as_text_without_changing_svg_rendering() {
+        let html = AutoVisualiserRouter::new()
+            .get_template_html("ui://autovisualiser/mermaid")
+            .unwrap();
+
+        assert!(html.contains("errorEl.textContent = String(err.message || err)"));
+        assert!(html.contains("output.replaceChildren(errorEl)"));
+        assert!(html.contains("output.innerHTML = result.svg"));
+        assert!(!html.contains("'<div class=\"mermaid-error\">' +"));
+    }
+
+    #[test]
+    fn sankey_tooltips_render_dynamic_values_as_text() {
+        let html = AutoVisualiserRouter::new()
+            .get_template_html("ui://autovisualiser/sankey")
+            .unwrap();
+
+        assert!(!html.contains(".html("));
+        assert!(html.contains("tooltip.append(index === 0 ? \"strong\" : \"span\").text(line)"));
+        assert!(html.contains("d.source.name + \" → \" + d.target.name"));
+        assert!(html.contains("var lines = [d.name]"));
+    }
+
+    #[test]
+    fn treemap_tooltips_render_dynamic_values_as_text() {
+        let html = AutoVisualiserRouter::new()
+            .get_template_html("ui://autovisualiser/treemap")
+            .unwrap();
+
+        assert!(!html.contains("tt.innerHTML"));
+        assert!(html.contains("name.textContent = d.data.name"));
+        assert!(html.contains("document.createTextNode(d.data.category)"));
+    }
 }
 
 #[cfg(test)]

--- a/crates/goose-mcp/src/autovisualiser/templates/chord_template.html
+++ b/crates/goose-mcp/src/autovisualiser/templates/chord_template.html
@@ -87,8 +87,11 @@
                 .attr("d", arcGen)
                 .on("mouseover", function (event, d) {
                     fadeChords(g, d.index, 0.08);
-                    tooltipEl.style("opacity", 1)
-                        .html("<strong>" + data.labels[d.index] + "</strong><br/>Total: " + d.value.toLocaleString());
+                    setTooltip([
+                        data.labels[d.index],
+                        "Total: " + d.value.toLocaleString(),
+                    ], true);
+                    tooltipEl.style("opacity", 1);
                     McpAppBridge.positionTooltip(tooltipEl, event);
                 })
                 .on("mouseout", function () {
@@ -114,15 +117,25 @@
                     d3.select(this).style("fill-opacity", 0.8);
                     var s2t = data.matrix[d.source.index][d.target.index];
                     var t2s = data.matrix[d.target.index][d.source.index];
-                    tooltipEl.style("opacity", 1)
-                        .html(data.labels[d.source.index] + " → " + data.labels[d.target.index] + ": " + s2t.toLocaleString() +
-                            "<br/>" + data.labels[d.target.index] + " → " + data.labels[d.source.index] + ": " + t2s.toLocaleString());
+                    setTooltip([
+                        data.labels[d.source.index] + " → " + data.labels[d.target.index] + ": " + s2t.toLocaleString(),
+                        data.labels[d.target.index] + " → " + data.labels[d.source.index] + ": " + t2s.toLocaleString(),
+                    ], false);
+                    tooltipEl.style("opacity", 1);
                     McpAppBridge.positionTooltip(tooltipEl, event);
                 })
                 .on("mouseout", function () {
                     d3.select(this).style("fill-opacity", 0.55);
                     tooltipEl.style("opacity", 0);
                 });
+        }
+
+        function setTooltip(lines, boldFirst) {
+            tooltipEl.selectAll("*").remove();
+            lines.forEach(function (line, index) {
+                if (index > 0) tooltipEl.append("br");
+                tooltipEl.append(index === 0 && boldFirst ? "strong" : "span").text(line);
+            });
         }
 
         function fadeChords(g, focusIndex, opacity) {

--- a/crates/goose-mcp/src/autovisualiser/templates/donut_template.html
+++ b/crates/goose-mcp/src/autovisualiser/templates/donut_template.html
@@ -134,9 +134,25 @@
                 var total = cd.values.reduce(function (a, b) { return a + b; }, 0);
                 cd.labels.forEach(function (label, i) {
                     var pct = total > 0 ? ((cd.values[i] / total) * 100).toFixed(1) : "0";
-                    legendEl.innerHTML += '<div class="legend-item"><div class="legend-dot" style="background:' + cd.colors[i] + '"></div>' +
-                        '<span class="legend-label">' + label + '</span>' +
-                        '<span class="legend-value">' + pct + '%</span></div>';
+                    var item = document.createElement("div");
+                    item.className = "legend-item";
+
+                    var dot = document.createElement("div");
+                    dot.className = "legend-dot";
+                    dot.style.background = cd.colors[i];
+                    item.appendChild(dot);
+
+                    var labelEl = document.createElement("span");
+                    labelEl.className = "legend-label";
+                    labelEl.textContent = label;
+                    item.appendChild(labelEl);
+
+                    var valueEl = document.createElement("span");
+                    valueEl.className = "legend-value";
+                    valueEl.textContent = pct + "%";
+                    item.appendChild(valueEl);
+
+                    legendEl.appendChild(item);
                 });
                 card.appendChild(legendEl);
                 grid.appendChild(card);

--- a/crates/goose-mcp/src/autovisualiser/templates/mermaid_template.html
+++ b/crates/goose-mcp/src/autovisualiser/templates/mermaid_template.html
@@ -135,7 +135,10 @@
             }).catch(function (err) {
                 // Remove any error artefacts mermaid injected (bomb-icon SVGs, etc.)
                 document.querySelectorAll('[id^="d' + uid + '"]').forEach(function (el) { el.remove(); });
-                output.innerHTML = '<div class="mermaid-error">' + (err.message || err) + "</div>";
+                var errorEl = document.createElement("div");
+                errorEl.className = "mermaid-error";
+                errorEl.textContent = String(err.message || err);
+                output.replaceChildren(errorEl);
                 setTimeout(McpAppBridge.reportSize, 80);
             });
         }

--- a/crates/goose-mcp/src/autovisualiser/templates/sankey_template.html
+++ b/crates/goose-mcp/src/autovisualiser/templates/sankey_template.html
@@ -172,8 +172,11 @@
                 .attr("stroke", function (d) { return nodeColor(d.source); })
                 .attr("stroke-width", function (d) { return Math.max(1, d.width); })
                 .on("mouseover", function (event, d) {
-                    tooltip.style("opacity", 1)
-                        .html("<strong>" + d.source.name + " → " + d.target.name + "</strong><br/>" + d.value.toLocaleString());
+                    setTooltip([
+                        d.source.name + " → " + d.target.name,
+                        d.value.toLocaleString(),
+                    ]);
+                    tooltip.style("opacity", 1);
                     McpAppBridge.positionTooltip(tooltip, event);
                 })
                 .on("mouseout", function () { tooltip.style("opacity", 0); });
@@ -188,10 +191,11 @@
                 .on("mouseover", function (event, d) {
                     var totalIn = d.targetLinks.reduce(function (s, l) { return s + l.value; }, 0);
                     var totalOut = d.sourceLinks.reduce(function (s, l) { return s + l.value; }, 0);
-                    tooltip.style("opacity", 1)
-                        .html("<strong>" + d.name + "</strong>" +
-                            (totalIn ? "<br/>In: " + totalIn.toLocaleString() : "") +
-                            (totalOut ? "<br/>Out: " + totalOut.toLocaleString() : ""));
+                    var lines = [d.name];
+                    if (totalIn) lines.push("In: " + totalIn.toLocaleString());
+                    if (totalOut) lines.push("Out: " + totalOut.toLocaleString());
+                    setTooltip(lines);
+                    tooltip.style("opacity", 1);
                     McpAppBridge.positionTooltip(tooltip, event);
                 })
                 .on("mouseout", function () { tooltip.style("opacity", 0); });
@@ -203,6 +207,14 @@
                 .attr("dy", "0.35em")
                 .attr("text-anchor", function (d) { return d.x0 < w / 2 ? "start" : "end"; })
                 .text(function (d) { return d.name; });
+        }
+
+        function setTooltip(lines) {
+            tooltip.selectAll("*").remove();
+            lines.forEach(function (line, index) {
+                if (index > 0) tooltip.append("br");
+                tooltip.append(index === 0 ? "strong" : "span").text(line);
+            });
         }
 
         function renderData(data) {

--- a/crates/goose-mcp/src/autovisualiser/templates/treemap_template.html
+++ b/crates/goose-mcp/src/autovisualiser/templates/treemap_template.html
@@ -105,8 +105,15 @@
                 .on("mouseover", function (event, d) {
                     var pct = ((d.data.value / root.value) * 100).toFixed(1);
                     var tt = document.getElementById("tooltip");
-                    tt.innerHTML = "<strong>" + d.data.name + "</strong><br/>" + formatValue(d.data.value) + " (" + pct + "%)" +
-                        (d.data.category ? "<br/>" + d.data.category : "");
+                    var name = document.createElement("strong");
+                    name.textContent = d.data.name;
+                    tt.replaceChildren(name);
+                    tt.appendChild(document.createElement("br"));
+                    tt.appendChild(document.createTextNode(formatValue(d.data.value) + " (" + pct + "%)"));
+                    if (d.data.category) {
+                        tt.appendChild(document.createElement("br"));
+                        tt.appendChild(document.createTextNode(d.data.category));
+                    }
                     tt.style.opacity = 1;
                     McpAppBridge.positionTooltip(tt, event);
                 })


### PR DESCRIPTION
## Summary

- render AutoVisualiser donut legends with DOM nodes and `textContent`
- render chord, Sankey, and treemap tooltip values with text nodes instead of HTML interpolation
- render Mermaid parser errors as text while preserving the successful SVG path
- add template regression coverage for each protected sink

## Security impact

This prevents model- or data-controlled labels, names, categories, and parser error text from becoming executable markup inside the AutoVisualiser MCP App guest.

This fixes:

- https://github.com/project-loupe/audit-goose/issues/131
- https://github.com/project-loupe/audit-goose/issues/133
- https://github.com/project-loupe/audit-goose/issues/136
- https://github.com/project-loupe/audit-goose/issues/138

The adjacent treemap tooltip used the same unsafe raw-name `innerHTML` pattern and is hardened in the same focused change.

## Verification

- `cargo fmt --all`
- `cargo test -p goose-mcp autovisualiser` (54 passed)
- `cargo build -p goose-mcp`
- `cargo clippy --all-targets -- -D warnings`
- `git diff --check`

The package-only `cargo clippy -p goose-mcp --all-targets` configuration cannot compile the unchanged `examples/mcp.rs` because its standalone feature set lacks Tokio `rt-multi-thread`; the repository-prescribed workspace-wide all-targets clippy gate passed.

_This finding was discovered by [Project Loupe](https://github.com/project-loupe/loupe)._
