### PR TITLE
fix(security): confine cache file operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,6 +158,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "ambient-authority"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9d4ee0d472d1cd2e28c97dfa124b3d8d992e10eb0a035f33f5d12e3a177ba3b"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2098,6 +2104,48 @@ dependencies = [
  "ug",
  "ug-cuda",
  "ug-metal",
+]
+
+[[package]]
+name = "cap-fs-ext"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d78e5a3368ae89b7cb68186411452b4b9fac8b41be9c19bf3f47c2d2c8e36e6b"
+dependencies = [
+ "cap-primitives",
+ "cap-std",
+ "io-lifetimes 3.0.1",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "cap-primitives"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdadbd7c002d3a484b35243669abdae85a0ebaded5a61117169dc3400f9a7ff0"
+dependencies = [
+ "ambient-authority",
+ "fs-set-times",
+ "io-extras",
+ "io-lifetimes 3.0.1",
+ "ipnet",
+ "maybe-owned",
+ "rustix 1.1.4",
+ "rustix-linux-procfs",
+ "windows-sys 0.61.2",
+ "winx",
+]
+
+[[package]]
+name = "cap-std"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7281235d6e96d3544ca18bba9049be92f4190f8d923e3caef1b5f66cfa752608"
+dependencies = [
+ "cap-primitives",
+ "io-extras",
+ "io-lifetimes 3.0.1",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -4393,6 +4441,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs-set-times"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
+dependencies = [
+ "io-lifetimes 2.0.4",
+ "rustix 1.1.4",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "fs2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5218,6 +5277,8 @@ version = "1.46.0"
 dependencies = [
  "anyhow",
  "base64 0.23.0",
+ "cap-fs-ext",
+ "cap-std",
  "chrono",
  "docx-rs",
  "etcetera 0.11.0",
@@ -6190,6 +6251,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-extras"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20fd6de4ccfcc187e38bc21cfa543cb5a302cb86a8b114eb7f0bf0dc9f8ac00f"
+dependencies = [
+ "io-lifetimes 3.0.1",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
+
+[[package]]
+name = "io-lifetimes"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0fb0570afe1fed943c5c3d4102d5358592d8625fda6a0007fdbe65a92fba96"
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6796,6 +6879,12 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "maybe-owned"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "md-5"
@@ -9354,6 +9443,16 @@ dependencies = [
  "libc",
  "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustix-linux-procfs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fc84bf7e9aa16c4f2c758f27412dc9841341e16aa682d9c7ac308fe3ee12056"
+dependencies = [
+ "once_cell",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -13785,6 +13884,16 @@ name = "winsafe"
 version = "0.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
+
+[[package]]
+name = "winx"
+version = "0.36.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
+dependencies = [
+ "bitflags 2.13.0",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "wiremock"

--- a/crates/goose-mcp/Cargo.toml
+++ b/crates/goose-mcp/Cargo.toml
@@ -41,3 +41,5 @@ image = { version = "0.24.4", default-features = false, features = ["bmp", "dds"
 umya-spreadsheet = { version = "3", default-features = false }
 shell-words = { workspace = true }
 process-wrap = { version = "9", default-features = false, features = ["std", "process-session"] }
+cap-std = "4.0.2"
+cap-fs-ext = "4.0.2"

--- a/crates/goose-mcp/src/computercontroller/mod.rs
+++ b/crates/goose-mcp/src/computercontroller/mod.rs
@@ -3,6 +3,11 @@ use crate::subprocess::merged_path;
 use crate::subprocess::SubprocessExt;
 #[cfg(target_os = "macos")]
 use base64::Engine;
+use cap_fs_ext::{FollowSymlinks, OpenOptionsFollowExt};
+use cap_std::{
+    ambient_authority,
+    fs::{Dir, OpenOptions},
+};
 use etcetera::{choose_app_strategy, AppStrategy};
 use indoc::{formatdoc, indoc};
 use reqwest::{Client, Url};
@@ -22,6 +27,7 @@ use serde::{Deserialize, Serialize};
 use std::{
     collections::HashMap,
     fs,
+    io::Read,
     path::{Path, PathBuf},
     sync::Arc,
     sync::Mutex,
@@ -562,41 +568,60 @@ impl ComputerControllerServer {
             .join(format!("{}_{}.{}", prefix, timestamp, extension))
     }
 
-    fn cache_file_candidate(&self, path: &str) -> PathBuf {
+    fn cache_file_location(&self, path: &str) -> Result<(PathBuf, PathBuf), ErrorData> {
         let requested_path = Path::new(path);
-        if requested_path.is_absolute() {
-            requested_path.to_path_buf()
+        let relative_path = if requested_path.is_absolute() {
+            if let Ok(relative_path) = requested_path.strip_prefix(&self.cache_dir) {
+                relative_path.to_path_buf()
+            } else {
+                let canonical_cache_dir = fs::canonicalize(&self.cache_dir).map_err(|e| {
+                    ErrorData::new(
+                        ErrorCode::INTERNAL_ERROR,
+                        format!("Failed to resolve cache directory: {e}"),
+                        None,
+                    )
+                })?;
+                requested_path
+                    .strip_prefix(canonical_cache_dir)
+                    .map(Path::to_path_buf)
+                    .map_err(|_| {
+                        ErrorData::new(
+                            ErrorCode::INVALID_PARAMS,
+                            "Cache path must stay inside the cache directory".to_string(),
+                            None,
+                        )
+                    })?
+            }
         } else {
-            self.cache_dir.join(requested_path)
-        }
-    }
+            requested_path.to_path_buf()
+        };
 
-    fn resolve_cache_file(&self, path: &str) -> Result<PathBuf, ErrorData> {
-        let candidate = self.cache_file_candidate(path);
-
-        let metadata = fs::symlink_metadata(&candidate).map_err(|_| {
-            ErrorData::new(
-                ErrorCode::INVALID_PARAMS,
-                "Path must identify an existing cached file".to_string(),
-                None,
-            )
-        })?;
-        if metadata.file_type().is_symlink() {
+        if relative_path.as_os_str().is_empty()
+            || !relative_path
+                .components()
+                .all(|component| matches!(component, std::path::Component::Normal(_)))
+        {
             return Err(ErrorData::new(
                 ErrorCode::INVALID_PARAMS,
-                "Cache path must not be a symbolic link".to_string(),
+                "Cache path must identify a file inside the cache directory".to_string(),
                 None,
             ));
         }
 
-        let cache_dir = fs::canonicalize(&self.cache_dir).map_err(|e| {
-            ErrorData::new(
-                ErrorCode::INTERNAL_ERROR,
-                format!("Failed to resolve cache directory: {e}"),
-                None,
-            )
-        })?;
-        let resolved_path = fs::canonicalize(&candidate).map_err(|_| {
+        Ok((relative_path.clone(), self.cache_dir.join(&relative_path)))
+    }
+
+    fn cache_file_capability(&self, path: &str) -> Result<(Dir, PathBuf, PathBuf), ErrorData> {
+        let (relative_path, candidate_path) = self.cache_file_location(path)?;
+        let cache_dir =
+            Dir::open_ambient_dir(&self.cache_dir, ambient_authority()).map_err(|e| {
+                ErrorData::new(
+                    ErrorCode::INTERNAL_ERROR,
+                    format!("Failed to open cache directory: {e}"),
+                    None,
+                )
+            })?;
+        let metadata = cache_dir.symlink_metadata(&relative_path).map_err(|_| {
             ErrorData::new(
                 ErrorCode::INVALID_PARAMS,
                 "Path must identify an existing cached file".to_string(),
@@ -604,7 +629,7 @@ impl ComputerControllerServer {
             )
         })?;
 
-        if !resolved_path.starts_with(&cache_dir) || !resolved_path.is_file() {
+        if metadata.file_type().is_symlink() || !metadata.is_file() {
             return Err(ErrorData::new(
                 ErrorCode::INVALID_PARAMS,
                 "Path must identify a regular file inside the cache directory".to_string(),
@@ -612,7 +637,7 @@ impl ComputerControllerServer {
             ));
         }
 
-        Ok(resolved_path)
+        Ok((cache_dir, relative_path, candidate_path))
     }
 
     // Helper function to save content to cache
@@ -1603,9 +1628,30 @@ impl ComputerControllerServer {
                         None,
                     )
                 })?;
-                let resolved_path = self.resolve_cache_file(path)?;
+                let (cache_dir, relative_path, _) = self.cache_file_capability(path)?;
+                let mut options = OpenOptions::new();
+                options.read(true).follow(FollowSymlinks::No);
+                let mut file = cache_dir.open_with(&relative_path, &options).map_err(|e| {
+                    ErrorData::new(
+                        ErrorCode::INVALID_PARAMS,
+                        format!("Failed to open cached file: {e}"),
+                        None,
+                    )
+                })?;
+                if !file
+                    .metadata()
+                    .map(|metadata| metadata.is_file())
+                    .unwrap_or(false)
+                {
+                    return Err(ErrorData::new(
+                        ErrorCode::INVALID_PARAMS,
+                        "Path must identify a regular file inside the cache directory".to_string(),
+                        None,
+                    ));
+                }
 
-                let content = fs::read_to_string(resolved_path).map_err(|e| {
+                let mut content = String::new();
+                file.read_to_string(&mut content).map_err(|e| {
                     ErrorData::new(
                         ErrorCode::INTERNAL_ERROR,
                         format!("Failed to read file: {}", e),
@@ -1626,10 +1672,11 @@ impl ComputerControllerServer {
                         None,
                     )
                 })?;
-                let candidate_path = self.cache_file_candidate(path);
-                let resolved_path = self.resolve_cache_file(path)?;
+                let (cache_dir, relative_path, candidate_path) =
+                    self.cache_file_capability(path)?;
+                let canonical_path = fs::canonicalize(&candidate_path).ok();
 
-                fs::remove_file(&resolved_path).map_err(|e| {
+                cache_dir.remove_file(&relative_path).map_err(|e| {
                     ErrorData::new(
                         ErrorCode::INTERNAL_ERROR,
                         format!("Failed to delete file: {}", e),
@@ -1639,7 +1686,8 @@ impl ComputerControllerServer {
 
                 // Remove from active resources if present
                 let mut active_resources = self.active_resources.lock().unwrap();
-                for resource_path in [&candidate_path, &resolved_path] {
+                for resource_path in std::iter::once(&candidate_path).chain(canonical_path.as_ref())
+                {
                     if let Ok(url) = Url::from_file_path(resource_path) {
                         active_resources.remove(&url.to_string());
                     }

--- a/crates/goose-mcp/src/computercontroller/mod.rs
+++ b/crates/goose-mcp/src/computercontroller/mod.rs
@@ -19,7 +19,13 @@ use rmcp::{
     tool, tool_handler, tool_router, RoleServer, ServerHandler,
 };
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, fs, path::PathBuf, sync::Arc, sync::Mutex};
+use std::{
+    collections::HashMap,
+    fs,
+    path::{Path, PathBuf},
+    sync::Arc,
+    sync::Mutex,
+};
 use tokio::process::Command;
 
 #[cfg(target_os = "macos")]
@@ -554,6 +560,59 @@ impl ComputerControllerServer {
         let timestamp = chrono::Local::now().format("%Y%m%d_%H%M%S");
         self.cache_dir
             .join(format!("{}_{}.{}", prefix, timestamp, extension))
+    }
+
+    fn cache_file_candidate(&self, path: &str) -> PathBuf {
+        let requested_path = Path::new(path);
+        if requested_path.is_absolute() {
+            requested_path.to_path_buf()
+        } else {
+            self.cache_dir.join(requested_path)
+        }
+    }
+
+    fn resolve_cache_file(&self, path: &str) -> Result<PathBuf, ErrorData> {
+        let candidate = self.cache_file_candidate(path);
+
+        let metadata = fs::symlink_metadata(&candidate).map_err(|_| {
+            ErrorData::new(
+                ErrorCode::INVALID_PARAMS,
+                "Path must identify an existing cached file".to_string(),
+                None,
+            )
+        })?;
+        if metadata.file_type().is_symlink() {
+            return Err(ErrorData::new(
+                ErrorCode::INVALID_PARAMS,
+                "Cache path must not be a symbolic link".to_string(),
+                None,
+            ));
+        }
+
+        let cache_dir = fs::canonicalize(&self.cache_dir).map_err(|e| {
+            ErrorData::new(
+                ErrorCode::INTERNAL_ERROR,
+                format!("Failed to resolve cache directory: {e}"),
+                None,
+            )
+        })?;
+        let resolved_path = fs::canonicalize(&candidate).map_err(|_| {
+            ErrorData::new(
+                ErrorCode::INVALID_PARAMS,
+                "Path must identify an existing cached file".to_string(),
+                None,
+            )
+        })?;
+
+        if !resolved_path.starts_with(&cache_dir) || !resolved_path.is_file() {
+            return Err(ErrorData::new(
+                ErrorCode::INVALID_PARAMS,
+                "Path must identify a regular file inside the cache directory".to_string(),
+                None,
+            ));
+        }
+
+        Ok(resolved_path)
     }
 
     // Helper function to save content to cache
@@ -1544,8 +1603,9 @@ impl ComputerControllerServer {
                         None,
                     )
                 })?;
+                let resolved_path = self.resolve_cache_file(path)?;
 
-                let content = fs::read_to_string(path).map_err(|e| {
+                let content = fs::read_to_string(resolved_path).map_err(|e| {
                     ErrorData::new(
                         ErrorCode::INTERNAL_ERROR,
                         format!("Failed to read file: {}", e),
@@ -1566,8 +1626,10 @@ impl ComputerControllerServer {
                         None,
                     )
                 })?;
+                let candidate_path = self.cache_file_candidate(path);
+                let resolved_path = self.resolve_cache_file(path)?;
 
-                fs::remove_file(path).map_err(|e| {
+                fs::remove_file(&resolved_path).map_err(|e| {
                     ErrorData::new(
                         ErrorCode::INTERNAL_ERROR,
                         format!("Failed to delete file: {}", e),
@@ -1576,11 +1638,11 @@ impl ComputerControllerServer {
                 })?;
 
                 // Remove from active resources if present
-                if let Ok(url) = Url::from_file_path(path) {
-                    self.active_resources
-                        .lock()
-                        .unwrap()
-                        .remove(&url.to_string());
+                let mut active_resources = self.active_resources.lock().unwrap();
+                for resource_path in [&candidate_path, &resolved_path] {
+                    if let Ok(url) = Url::from_file_path(resource_path) {
+                        active_resources.remove(&url.to_string());
+                    }
                 }
 
                 Ok(CallToolResult::success(vec![ContentBlock::text(format!(
@@ -1670,5 +1732,132 @@ impl ServerHandler for ComputerControllerServer {
 
         // Clone the resource to return
         Ok(ReadResourceResult::new(vec![resource.clone()]).into())
+    }
+}
+
+#[cfg(test)]
+mod cache_tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn server_with_cache_dir(cache_dir: &Path) -> ComputerControllerServer {
+        let mut server = ComputerControllerServer::new();
+        server.cache_dir = cache_dir.to_path_buf();
+        server
+    }
+
+    async fn call_cache(
+        server: &ComputerControllerServer,
+        command: CacheCommand,
+        path: impl Into<String>,
+    ) -> Result<CallToolResult, ErrorData> {
+        server
+            .cache(Parameters(CacheParams {
+                command,
+                path: Some(path.into()),
+            }))
+            .await
+    }
+
+    #[tokio::test]
+    async fn cache_accepts_relative_and_listed_absolute_file_paths() {
+        let temp_dir = TempDir::new().unwrap();
+        let cache_dir = temp_dir.path().join("cache");
+        let nested_dir = cache_dir.join("nested");
+        fs::create_dir_all(&nested_dir).unwrap();
+        let cached_file = nested_dir.join("result.txt");
+        fs::write(&cached_file, "cached content").unwrap();
+
+        let server = server_with_cache_dir(&cache_dir);
+        let relative_result = call_cache(&server, CacheCommand::View, "nested/result.txt").await;
+        assert!(relative_result.is_ok());
+
+        server
+            .register_as_resource(&cached_file, "text/plain")
+            .unwrap();
+        let resource_url = Url::from_file_path(&cached_file).unwrap().to_string();
+        assert!(server
+            .active_resources
+            .lock()
+            .unwrap()
+            .contains_key(&resource_url));
+
+        let delete_result =
+            call_cache(&server, CacheCommand::Delete, cached_file.to_string_lossy()).await;
+        assert!(delete_result.is_ok());
+        assert!(!cached_file.exists());
+        assert!(!server
+            .active_resources
+            .lock()
+            .unwrap()
+            .contains_key(&resource_url));
+    }
+
+    #[tokio::test]
+    async fn cache_rejects_absolute_and_traversal_paths_outside_cache() {
+        let temp_dir = TempDir::new().unwrap();
+        let cache_dir = temp_dir.path().join("cache");
+        fs::create_dir(&cache_dir).unwrap();
+        let outside_file = temp_dir.path().join("outside.txt");
+        fs::write(&outside_file, "outside content").unwrap();
+
+        let server = server_with_cache_dir(&cache_dir);
+        for path in [
+            outside_file.to_string_lossy().into_owned(),
+            "../outside.txt".to_string(),
+        ] {
+            assert!(call_cache(&server, CacheCommand::View, path.clone())
+                .await
+                .is_err());
+            assert!(call_cache(&server, CacheCommand::Delete, path)
+                .await
+                .is_err());
+            assert_eq!(
+                fs::read_to_string(&outside_file).unwrap(),
+                "outside content"
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn cache_rejects_intermediate_symlink_escape() {
+        let temp_dir = TempDir::new().unwrap();
+        let cache_dir = temp_dir.path().join("cache");
+        let outside_dir = temp_dir.path().join("outside");
+        fs::create_dir(&cache_dir).unwrap();
+        fs::create_dir(&outside_dir).unwrap();
+        let outside_file = outside_dir.join("secret.txt");
+        fs::write(&outside_file, "secret").unwrap();
+        std::os::unix::fs::symlink(&outside_dir, cache_dir.join("escape")).unwrap();
+
+        let server = server_with_cache_dir(&cache_dir);
+        for command in [CacheCommand::View, CacheCommand::Delete] {
+            assert!(call_cache(&server, command, "escape/secret.txt")
+                .await
+                .is_err());
+        }
+        assert_eq!(fs::read_to_string(outside_file).unwrap(), "secret");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn cache_rejects_final_symlinks_without_removing_them() {
+        let temp_dir = TempDir::new().unwrap();
+        let cache_dir = temp_dir.path().join("cache");
+        fs::create_dir(&cache_dir).unwrap();
+        let outside_file = temp_dir.path().join("secret.txt");
+        fs::write(&outside_file, "secret").unwrap();
+        let link = cache_dir.join("secret-link.txt");
+        std::os::unix::fs::symlink(&outside_file, &link).unwrap();
+
+        let server = server_with_cache_dir(&cache_dir);
+        for command in [CacheCommand::View, CacheCommand::Delete] {
+            assert!(call_cache(&server, command, link.to_string_lossy())
+                .await
+                .is_err());
+        }
+        assert!(link.symlink_metadata().unwrap().file_type().is_symlink());
+        assert_eq!(fs::read_to_string(outside_file).unwrap(), "secret");
     }
 }

--- a/crates/goose-mcp/src/computercontroller/mod.rs
+++ b/crates/goose-mcp/src/computercontroller/mod.rs
@@ -3,7 +3,7 @@ use crate::subprocess::merged_path;
 use crate::subprocess::SubprocessExt;
 #[cfg(target_os = "macos")]
 use base64::Engine;
-use cap_fs_ext::{FollowSymlinks, OpenOptionsFollowExt};
+use cap_fs_ext::{DirExt, FollowSymlinks, OpenOptionsFollowExt};
 use cap_std::{
     ambient_authority,
     fs::{Dir, OpenOptions},
@@ -27,7 +27,7 @@ use serde::{Deserialize, Serialize};
 use std::{
     collections::HashMap,
     fs,
-    io::Read,
+    io::{self, Read},
     path::{Path, PathBuf},
     sync::Arc,
     sync::Mutex,
@@ -340,6 +340,24 @@ impl Default for ComputerControllerServer {
 
 #[tool_router(router = tool_router)]
 impl ComputerControllerServer {
+    fn open_cache_dir(cache_dir: &Path) -> io::Result<Dir> {
+        let parent_path = cache_dir.parent().ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidInput, "Cache directory has no parent")
+        })?;
+        let cache_name = cache_dir.file_name().ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidInput, "Cache directory has no name")
+        })?;
+
+        fs::create_dir_all(parent_path)?;
+        let parent = Dir::open_ambient_dir(parent_path, ambient_authority())?;
+        match parent.create_dir(cache_name) {
+            Ok(()) => {}
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {}
+            Err(error) => return Err(error),
+        }
+        parent.open_dir_nofollow(cache_name)
+    }
+
     pub fn new() -> Self {
         // choose_app_strategy().cache_dir()
         // - macOS/Linux: ~/.cache/goose/computer_controller/
@@ -349,15 +367,16 @@ impl ComputerControllerServer {
             .map(|strategy| strategy.in_cache_dir("computer_controller"))
             .unwrap_or_else(|_| create_system_automation().get_temp_path());
 
-        fs::create_dir_all(&cache_dir).unwrap_or_else(|_| {
-            println!(
-                "Warning: Failed to create cache directory at {:?}",
-                cache_dir
-            )
-        });
-        let cache_dir_handle = Dir::open_ambient_dir(&cache_dir, ambient_authority())
-            .ok()
-            .map(Arc::new);
+        let cache_dir_handle = match Self::open_cache_dir(&cache_dir) {
+            Ok(directory) => Some(Arc::new(directory)),
+            Err(error) => {
+                println!(
+                    "Warning: Failed to securely open cache directory at {:?}: {}",
+                    cache_dir, error
+                );
+                None
+            }
+        };
 
         let system_automation: Arc<Box<dyn SystemAutomation + Send + Sync>> =
             Arc::new(create_system_automation());
@@ -573,30 +592,29 @@ impl ComputerControllerServer {
             .join(format!("{}_{}.{}", prefix, timestamp, extension))
     }
 
+    fn cache_dir_capability(&self) -> Result<Arc<Dir>, ErrorData> {
+        self.cache_dir_handle.clone().ok_or_else(|| {
+            ErrorData::new(
+                ErrorCode::INTERNAL_ERROR,
+                "Failed to securely open cache directory".to_string(),
+                None,
+            )
+        })
+    }
+
     fn cache_file_location(&self, path: &str) -> Result<(PathBuf, PathBuf), ErrorData> {
         let requested_path = Path::new(path);
         let relative_path = if requested_path.is_absolute() {
-            if let Ok(relative_path) = requested_path.strip_prefix(&self.cache_dir) {
-                relative_path.to_path_buf()
-            } else {
-                let canonical_cache_dir = fs::canonicalize(&self.cache_dir).map_err(|e| {
+            requested_path
+                .strip_prefix(&self.cache_dir)
+                .map(Path::to_path_buf)
+                .map_err(|_| {
                     ErrorData::new(
-                        ErrorCode::INTERNAL_ERROR,
-                        format!("Failed to resolve cache directory: {e}"),
+                        ErrorCode::INVALID_PARAMS,
+                        "Cache path must stay inside the cache directory".to_string(),
                         None,
                     )
-                })?;
-                requested_path
-                    .strip_prefix(canonical_cache_dir)
-                    .map(Path::to_path_buf)
-                    .map_err(|_| {
-                        ErrorData::new(
-                            ErrorCode::INVALID_PARAMS,
-                            "Cache path must stay inside the cache directory".to_string(),
-                            None,
-                        )
-                    })?
-            }
+                })?
         } else {
             requested_path.to_path_buf()
         };
@@ -618,13 +636,7 @@ impl ComputerControllerServer {
 
     fn cache_file_capability(&self, path: &str) -> Result<(Arc<Dir>, PathBuf, PathBuf), ErrorData> {
         let (relative_path, candidate_path) = self.cache_file_location(path)?;
-        let cache_dir = self.cache_dir_handle.clone().ok_or_else(|| {
-            ErrorData::new(
-                ErrorCode::INTERNAL_ERROR,
-                "Failed to open cache directory".to_string(),
-                None,
-            )
-        })?;
+        let cache_dir = self.cache_dir_capability()?;
         let metadata = cache_dir.symlink_metadata(&relative_path).map_err(|_| {
             ErrorData::new(
                 ErrorCode::INVALID_PARAMS,
@@ -652,13 +664,22 @@ impl ComputerControllerServer {
         extension: &str,
     ) -> Result<PathBuf, ErrorData> {
         let cache_path = self.get_cache_path(prefix, extension);
-        fs::write(&cache_path, content).map_err(|e| {
+        let relative_path = cache_path.file_name().ok_or_else(|| {
             ErrorData::new(
                 ErrorCode::INTERNAL_ERROR,
-                format!("Failed to write to cache: {}", e),
+                "Invalid cache file name".to_string(),
                 None,
             )
         })?;
+        self.cache_dir_capability()?
+            .write(relative_path, content)
+            .map_err(|e| {
+                ErrorData::new(
+                    ErrorCode::INTERNAL_ERROR,
+                    format!("Failed to write to cache: {}", e),
+                    None,
+                )
+            })?;
         Ok(cache_path)
     }
 
@@ -1211,19 +1232,27 @@ impl ComputerControllerServer {
 
         let is_see = args[0] == "see";
         let is_image = args[0] == "image";
-        let screenshot_path = if is_see || is_image {
-            Some(self.get_cache_path(&args[0], "png"))
+        let manages_screenshot = (is_see || is_image) && !args.iter().any(|arg| arg == "--path");
+        let screenshot_dir = if manages_screenshot {
+            Some(tempfile::tempdir().map_err(|e| {
+                ErrorData::new(
+                    ErrorCode::INTERNAL_ERROR,
+                    format!("Failed to create screenshot directory: {e}"),
+                    None,
+                )
+            })?)
         } else {
             None
         };
+        let screenshot_path = screenshot_dir
+            .as_ref()
+            .map(|directory| directory.path().join(format!("{}.png", args[0])));
 
         let mut full_args: Vec<String> = args.clone();
 
         if let Some(ref path) = screenshot_path {
-            if !full_args.iter().any(|a| a == "--path") {
-                full_args.push("--path".to_string());
-                full_args.push(path.to_string_lossy().to_string());
-            }
+            full_args.push("--path".to_string());
+            full_args.push(path.to_string_lossy().to_string());
         }
         if is_see && !full_args.iter().any(|a| a == "--json-output") {
             full_args.push("--json-output".to_string());
@@ -1254,6 +1283,12 @@ impl ComputerControllerServer {
             };
             if image_path.exists() {
                 if let Ok(bytes) = fs::read(&image_path) {
+                    let prefix = if image_path == *path {
+                        args[0].as_str()
+                    } else {
+                        "see_annotated"
+                    };
+                    self.save_to_cache(&bytes, prefix, "png").await?;
                     let data = base64::prelude::BASE64_STANDARD.encode(&bytes);
                     contents.push(ContentBlock::image(data, "image/png"));
                 }
@@ -1261,7 +1296,14 @@ impl ComputerControllerServer {
         }
 
         if params.capture_screenshot && screenshot_path.is_none() {
-            let cap_path = self.get_cache_path("peekaboo_capture", "png");
+            let capture_dir = tempfile::tempdir().map_err(|e| {
+                ErrorData::new(
+                    ErrorCode::INTERNAL_ERROR,
+                    format!("Failed to create screenshot directory: {e}"),
+                    None,
+                )
+            })?;
+            let cap_path = capture_dir.path().join("capture.png");
             let cap_path_str = cap_path.to_string_lossy().to_string();
             if self
                 .run_peekaboo_cmd(&["image", "--mode", "frontmost", "--path", &cap_path_str])
@@ -1269,6 +1311,8 @@ impl ComputerControllerServer {
                 && cap_path.exists()
             {
                 if let Ok(bytes) = fs::read(&cap_path) {
+                    self.save_to_cache(&bytes, "peekaboo_capture", "png")
+                        .await?;
                     let data = base64::prelude::BASE64_STANDARD.encode(&bytes);
                     contents.push(ContentBlock::image(data, "image/png"));
                 }
@@ -1573,10 +1617,15 @@ impl ComputerControllerServer {
             PdfOperation::ExtractImages => "extract_images",
         };
 
-        let result =
-            crate::computercontroller::pdf_tool::pdf_tool(path, operation_str, &self.cache_dir)
-                .await
-                .map_err(|e| ErrorData::new(e.code, e.message, e.data))?;
+        let cache_dir = self.cache_dir_capability()?;
+        let result = crate::computercontroller::pdf_tool::pdf_tool(
+            path,
+            operation_str,
+            &cache_dir,
+            &self.cache_dir,
+        )
+        .await
+        .map_err(|e| ErrorData::new(e.code, e.message, e.data))?;
 
         Ok(CallToolResult::success(result))
     }
@@ -1602,7 +1651,7 @@ impl ComputerControllerServer {
         match command {
             CacheCommand::List => {
                 let mut files = Vec::new();
-                for entry in fs::read_dir(&self.cache_dir).map_err(|e| {
+                for entry in self.cache_dir_capability()?.entries().map_err(|e| {
                     ErrorData::new(
                         ErrorCode::INTERNAL_ERROR,
                         format!("Failed to read cache directory: {}", e),
@@ -1616,7 +1665,7 @@ impl ComputerControllerServer {
                             None,
                         )
                     })?;
-                    files.push(format!("{}", entry.path().display()));
+                    files.push(self.cache_dir.join(entry.file_name()).display().to_string());
                 }
                 files.sort();
                 Ok(CallToolResult::success(vec![ContentBlock::text(format!(
@@ -1703,13 +1752,7 @@ impl ComputerControllerServer {
                 ))]))
             }
             CacheCommand::Clear => {
-                let cache_dir = self.cache_dir_handle.as_ref().ok_or_else(|| {
-                    ErrorData::new(
-                        ErrorCode::INTERNAL_ERROR,
-                        "Failed to open cache directory".to_string(),
-                        None,
-                    )
-                })?;
+                let cache_dir = self.cache_dir_capability()?;
                 for entry in cache_dir.entries().map_err(|e| {
                     ErrorData::new(
                         ErrorCode::INTERNAL_ERROR,
@@ -1966,6 +2009,23 @@ mod cache_tests {
         assert!(view.text.contains("cached"));
         assert!(!view.text.contains("outside"));
 
+        let saved_path = server
+            .save_to_cache(b"new cached content", "new", "txt")
+            .await
+            .unwrap();
+        let saved_name = saved_path.file_name().unwrap();
+        assert_eq!(
+            fs::read_to_string(moved_cache_dir.join(saved_name)).unwrap(),
+            "new cached content"
+        );
+        assert!(!outside_dir.join(saved_name).exists());
+
+        let list = call_cache(&server, CacheCommand::List, "").await.unwrap();
+        let ContentBlock::Text(list) = &list.content[0] else {
+            panic!("expected text content");
+        };
+        assert!(list.text.contains(&saved_path.display().to_string()));
+
         call_cache(&server, CacheCommand::Delete, "victim.txt")
             .await
             .unwrap();
@@ -1974,6 +2034,18 @@ mod cache_tests {
             fs::read_to_string(outside_dir.join("victim.txt")).unwrap(),
             "outside"
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn cache_rejects_a_symlinked_root() {
+        let temp_dir = TempDir::new().unwrap();
+        let outside_dir = temp_dir.path().join("outside");
+        let cache_dir = temp_dir.path().join("cache");
+        fs::create_dir(&outside_dir).unwrap();
+        std::os::unix::fs::symlink(&outside_dir, &cache_dir).unwrap();
+
+        assert!(ComputerControllerServer::open_cache_dir(&cache_dir).is_err());
     }
 
     #[tokio::test]
@@ -1989,8 +2061,8 @@ mod cache_tests {
         call_cache(&server, CacheCommand::Clear, "").await.unwrap();
         assert!(fs::read_dir(&cache_dir).unwrap().next().is_none());
 
-        fs::write(cache_dir.join("new.txt"), "new").unwrap();
-        let view = call_cache(&server, CacheCommand::View, "new.txt")
+        let new_path = server.save_to_cache(b"new", "new", "txt").await.unwrap();
+        let view = call_cache(&server, CacheCommand::View, new_path.to_string_lossy())
             .await
             .unwrap();
         let ContentBlock::Text(view) = &view.content[0] else {

--- a/crates/goose-mcp/src/computercontroller/mod.rs
+++ b/crates/goose-mcp/src/computercontroller/mod.rs
@@ -1617,12 +1617,16 @@ impl ComputerControllerServer {
             PdfOperation::ExtractImages => "extract_images",
         };
 
-        let cache_dir = self.cache_dir_capability()?;
+        let cache_dir = match operation {
+            PdfOperation::ExtractText => None,
+            PdfOperation::ExtractImages => Some(self.cache_dir_capability()?),
+        };
         let result = crate::computercontroller::pdf_tool::pdf_tool(
             path,
             operation_str,
-            &cache_dir,
-            &self.cache_dir,
+            cache_dir
+                .as_deref()
+                .map(|directory| (directory, self.cache_dir.as_path())),
         )
         .await
         .map_err(|e| ErrorData::new(e.code, e.message, e.data))?;
@@ -1880,6 +1884,23 @@ mod cache_tests {
                 path: Some(path.into()),
             }))
             .await
+    }
+
+    #[tokio::test]
+    async fn pdf_text_extraction_does_not_require_cache() {
+        let mut server = ComputerControllerServer::new();
+        server.cache_dir_handle = None;
+        let test_pdf_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("src/computercontroller/tests/data/test.pdf");
+
+        let result = server
+            .pdf_tool(Parameters(PdfToolParams {
+                path: test_pdf_path.to_string_lossy().into_owned(),
+                operation: PdfOperation::ExtractText,
+            }))
+            .await;
+
+        assert!(result.is_ok());
     }
 
     #[tokio::test]

--- a/crates/goose-mcp/src/computercontroller/mod.rs
+++ b/crates/goose-mcp/src/computercontroller/mod.rs
@@ -1703,20 +1703,45 @@ impl ComputerControllerServer {
                 ))]))
             }
             CacheCommand::Clear => {
-                fs::remove_dir_all(&self.cache_dir).map_err(|e| {
+                let cache_dir = self.cache_dir_handle.as_ref().ok_or_else(|| {
                     ErrorData::new(
                         ErrorCode::INTERNAL_ERROR,
-                        format!("Failed to clear cache directory: {}", e),
+                        "Failed to open cache directory".to_string(),
                         None,
                     )
                 })?;
-                fs::create_dir_all(&self.cache_dir).map_err(|e| {
+                for entry in cache_dir.entries().map_err(|e| {
                     ErrorData::new(
                         ErrorCode::INTERNAL_ERROR,
-                        format!("Failed to recreate cache directory: {}", e),
+                        format!("Failed to read cache directory: {e}"),
                         None,
                     )
-                })?;
+                })? {
+                    let entry = entry.map_err(|e| {
+                        ErrorData::new(
+                            ErrorCode::INTERNAL_ERROR,
+                            format!("Failed to read cache entry: {e}"),
+                            None,
+                        )
+                    })?;
+                    let file_name = entry.file_name();
+                    let result = if entry
+                        .file_type()
+                        .map(|file_type| file_type.is_dir())
+                        .unwrap_or(false)
+                    {
+                        cache_dir.remove_dir_all(&file_name)
+                    } else {
+                        cache_dir.remove_file(&file_name)
+                    };
+                    result.map_err(|e| {
+                        ErrorData::new(
+                            ErrorCode::INTERNAL_ERROR,
+                            format!("Failed to clear cache entry: {e}"),
+                            None,
+                        )
+                    })?;
+                }
 
                 // Clear active resources
                 self.active_resources.lock().unwrap().clear();
@@ -1949,5 +1974,28 @@ mod cache_tests {
             fs::read_to_string(outside_dir.join("victim.txt")).unwrap(),
             "outside"
         );
+    }
+
+    #[tokio::test]
+    async fn cache_remains_usable_after_clear() {
+        let temp_dir = TempDir::new().unwrap();
+        let cache_dir = temp_dir.path().join("cache");
+        fs::create_dir(&cache_dir).unwrap();
+        fs::write(cache_dir.join("old.txt"), "old").unwrap();
+        fs::create_dir(cache_dir.join("nested")).unwrap();
+        fs::write(cache_dir.join("nested/old.txt"), "old").unwrap();
+
+        let server = server_with_cache_dir(&cache_dir);
+        call_cache(&server, CacheCommand::Clear, "").await.unwrap();
+        assert!(fs::read_dir(&cache_dir).unwrap().next().is_none());
+
+        fs::write(cache_dir.join("new.txt"), "new").unwrap();
+        let view = call_cache(&server, CacheCommand::View, "new.txt")
+            .await
+            .unwrap();
+        let ContentBlock::Text(view) = &view.content[0] else {
+            panic!("expected text content");
+        };
+        assert!(view.text.contains("new"));
     }
 }

--- a/crates/goose-mcp/src/computercontroller/mod.rs
+++ b/crates/goose-mcp/src/computercontroller/mod.rs
@@ -323,6 +323,7 @@ pub struct XlsxToolParams {
 pub struct ComputerControllerServer {
     tool_router: ToolRouter<Self>,
     cache_dir: PathBuf,
+    cache_dir_handle: Option<Arc<Dir>>,
     active_resources: Arc<Mutex<HashMap<String, ResourceContents>>>,
     http_client: Client,
     instructions: String,
@@ -354,6 +355,9 @@ impl ComputerControllerServer {
                 cache_dir
             )
         });
+        let cache_dir_handle = Dir::open_ambient_dir(&cache_dir, ambient_authority())
+            .ok()
+            .map(Arc::new);
 
         let system_automation: Arc<Box<dyn SystemAutomation + Send + Sync>> =
             Arc::new(create_system_automation());
@@ -552,6 +556,7 @@ impl ComputerControllerServer {
         Self {
             tool_router,
             cache_dir,
+            cache_dir_handle,
             active_resources: Arc::new(Mutex::new(HashMap::new())),
             http_client: Client::builder().user_agent("goose/1.0").build().unwrap(),
             instructions,
@@ -611,16 +616,15 @@ impl ComputerControllerServer {
         Ok((relative_path.clone(), self.cache_dir.join(&relative_path)))
     }
 
-    fn cache_file_capability(&self, path: &str) -> Result<(Dir, PathBuf, PathBuf), ErrorData> {
+    fn cache_file_capability(&self, path: &str) -> Result<(Arc<Dir>, PathBuf, PathBuf), ErrorData> {
         let (relative_path, candidate_path) = self.cache_file_location(path)?;
-        let cache_dir =
-            Dir::open_ambient_dir(&self.cache_dir, ambient_authority()).map_err(|e| {
-                ErrorData::new(
-                    ErrorCode::INTERNAL_ERROR,
-                    format!("Failed to open cache directory: {e}"),
-                    None,
-                )
-            })?;
+        let cache_dir = self.cache_dir_handle.clone().ok_or_else(|| {
+            ErrorData::new(
+                ErrorCode::INTERNAL_ERROR,
+                "Failed to open cache directory".to_string(),
+                None,
+            )
+        })?;
         let metadata = cache_dir.symlink_metadata(&relative_path).map_err(|_| {
             ErrorData::new(
                 ErrorCode::INVALID_PARAMS,
@@ -1791,6 +1795,9 @@ mod cache_tests {
     fn server_with_cache_dir(cache_dir: &Path) -> ComputerControllerServer {
         let mut server = ComputerControllerServer::new();
         server.cache_dir = cache_dir.to_path_buf();
+        server.cache_dir_handle = Some(Arc::new(
+            Dir::open_ambient_dir(cache_dir, ambient_authority()).unwrap(),
+        ));
         server
     }
 
@@ -1907,5 +1914,40 @@ mod cache_tests {
         }
         assert!(link.symlink_metadata().unwrap().file_type().is_symlink());
         assert_eq!(fs::read_to_string(outside_file).unwrap(), "secret");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn cache_operations_remain_anchored_after_root_replacement() {
+        let temp_dir = TempDir::new().unwrap();
+        let cache_dir = temp_dir.path().join("cache");
+        let moved_cache_dir = temp_dir.path().join("moved-cache");
+        let outside_dir = temp_dir.path().join("outside");
+        fs::create_dir(&cache_dir).unwrap();
+        fs::create_dir(&outside_dir).unwrap();
+        fs::write(cache_dir.join("victim.txt"), "cached").unwrap();
+        fs::write(outside_dir.join("victim.txt"), "outside").unwrap();
+
+        let server = server_with_cache_dir(&cache_dir);
+        fs::rename(&cache_dir, &moved_cache_dir).unwrap();
+        std::os::unix::fs::symlink(&outside_dir, &cache_dir).unwrap();
+
+        let view = call_cache(&server, CacheCommand::View, "victim.txt")
+            .await
+            .unwrap();
+        let ContentBlock::Text(view) = &view.content[0] else {
+            panic!("expected text content");
+        };
+        assert!(view.text.contains("cached"));
+        assert!(!view.text.contains("outside"));
+
+        call_cache(&server, CacheCommand::Delete, "victim.txt")
+            .await
+            .unwrap();
+        assert!(!moved_cache_dir.join("victim.txt").exists());
+        assert_eq!(
+            fs::read_to_string(outside_dir.join("victim.txt")).unwrap(),
+            "outside"
+        );
     }
 }

--- a/crates/goose-mcp/src/computercontroller/mod.rs
+++ b/crates/goose-mcp/src/computercontroller/mod.rs
@@ -8,7 +8,7 @@ use cap_std::{
     ambient_authority,
     fs::{Dir, OpenOptions},
 };
-use etcetera::{choose_app_strategy, AppStrategy};
+use etcetera::{choose_app_strategy, choose_base_strategy, AppStrategy, BaseStrategy};
 use indoc::{formatdoc, indoc};
 use reqwest::{Client, Url};
 use rmcp::{
@@ -340,22 +340,36 @@ impl Default for ComputerControllerServer {
 
 #[tool_router(router = tool_router)]
 impl ComputerControllerServer {
-    fn open_cache_dir(cache_dir: &Path) -> io::Result<Dir> {
-        let parent_path = cache_dir.parent().ok_or_else(|| {
-            io::Error::new(io::ErrorKind::InvalidInput, "Cache directory has no parent")
+    fn open_cache_dir(base_dir: &Path, cache_dir: &Path) -> io::Result<Dir> {
+        let relative_path = cache_dir.strip_prefix(base_dir).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "Cache directory is outside the platform cache directory",
+            )
         })?;
-        let cache_name = cache_dir.file_name().ok_or_else(|| {
-            io::Error::new(io::ErrorKind::InvalidInput, "Cache directory has no name")
-        })?;
-
-        fs::create_dir_all(parent_path)?;
-        let parent = Dir::open_ambient_dir(parent_path, ambient_authority())?;
-        match parent.create_dir(cache_name) {
-            Ok(()) => {}
-            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {}
-            Err(error) => return Err(error),
+        if relative_path.as_os_str().is_empty()
+            || !relative_path
+                .components()
+                .all(|component| matches!(component, std::path::Component::Normal(_)))
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "Cache directory has invalid platform-relative components",
+            ));
         }
-        parent.open_dir_nofollow(cache_name)
+
+        fs::create_dir_all(base_dir)?;
+        let mut directory = Dir::open_ambient_dir(base_dir, ambient_authority())?;
+        for component in relative_path.components() {
+            let name = component.as_os_str();
+            match directory.create_dir(name) {
+                Ok(()) => {}
+                Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {}
+                Err(error) => return Err(error),
+            }
+            directory = directory.open_dir_nofollow(name)?;
+        }
+        Ok(directory)
     }
 
     pub fn new() -> Self {
@@ -363,11 +377,25 @@ impl ComputerControllerServer {
         // - macOS/Linux: ~/.cache/goose/computer_controller/
         // - Windows:     ~\AppData\Local\Block\goose\cache\computer_controller\
         // keep previous behavior of defaulting to /tmp/
-        let cache_dir = choose_app_strategy(crate::APP_STRATEGY.clone())
-            .map(|strategy| strategy.in_cache_dir("computer_controller"))
-            .unwrap_or_else(|_| create_system_automation().get_temp_path());
+        let (base_cache_dir, cache_dir) = choose_base_strategy()
+            .and_then(|base_strategy| {
+                choose_app_strategy(crate::APP_STRATEGY.clone()).map(|app_strategy| {
+                    (
+                        base_strategy.cache_dir(),
+                        app_strategy.in_cache_dir("computer_controller"),
+                    )
+                })
+            })
+            .unwrap_or_else(|_| {
+                let temp_path = create_system_automation().get_temp_path();
+                let parent = temp_path
+                    .parent()
+                    .map(Path::to_path_buf)
+                    .unwrap_or_else(|| temp_path.clone());
+                (parent, temp_path)
+            });
 
-        let cache_dir_handle = match Self::open_cache_dir(&cache_dir) {
+        let cache_dir_handle = match Self::open_cache_dir(&base_cache_dir, &cache_dir) {
             Ok(directory) => Some(Arc::new(directory)),
             Err(error) => {
                 println!(
@@ -2066,7 +2094,20 @@ mod cache_tests {
         fs::create_dir(&outside_dir).unwrap();
         std::os::unix::fs::symlink(&outside_dir, &cache_dir).unwrap();
 
-        assert!(ComputerControllerServer::open_cache_dir(&cache_dir).is_err());
+        assert!(ComputerControllerServer::open_cache_dir(temp_dir.path(), &cache_dir).is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn cache_rejects_a_symlinked_app_ancestor() {
+        let temp_dir = TempDir::new().unwrap();
+        let outside_dir = temp_dir.path().join("outside");
+        let app_dir = temp_dir.path().join("goose");
+        let cache_dir = app_dir.join("computer_controller");
+        fs::create_dir(&outside_dir).unwrap();
+        std::os::unix::fs::symlink(&outside_dir, &app_dir).unwrap();
+
+        assert!(ComputerControllerServer::open_cache_dir(temp_dir.path(), &cache_dir).is_err());
     }
 
     #[tokio::test]

--- a/crates/goose-mcp/src/computercontroller/mod.rs
+++ b/crates/goose-mcp/src/computercontroller/mod.rs
@@ -585,14 +585,12 @@ impl ComputerControllerServer {
               - This is not optimised for complex websites, so don't use this as the first tool.
             cache
               - Manage your cached files
-              - List, view, delete files
+              - List, view, delete files using the relative identifiers returned by this extension
               - Clear all cached data
             The extension automatically manages:
-            - Cache directory: {cache_dir}
             - File organization and cleanup
             "#,
-            os_instructions = os_specific_instructions,
-            cache_dir = cache_dir.display()
+            os_instructions = os_specific_instructions
         };
 
         let mut tool_router = Self::tool_router();
@@ -692,15 +690,15 @@ impl ComputerControllerServer {
         extension: &str,
     ) -> Result<PathBuf, ErrorData> {
         let cache_path = self.get_cache_path(prefix, extension);
-        let relative_path = cache_path.file_name().ok_or_else(|| {
+        let relative_path = PathBuf::from(cache_path.file_name().ok_or_else(|| {
             ErrorData::new(
                 ErrorCode::INTERNAL_ERROR,
                 "Invalid cache file name".to_string(),
                 None,
             )
-        })?;
+        })?);
         self.cache_dir_capability()?
-            .write(relative_path, content)
+            .write(&relative_path, content)
             .map_err(|e| {
                 ErrorData::new(
                     ErrorCode::INTERNAL_ERROR,
@@ -708,20 +706,41 @@ impl ComputerControllerServer {
                     None,
                 )
             })?;
-        Ok(cache_path)
+        Ok(relative_path)
+    }
+
+    fn cache_resource_uri(cache_path: &Path) -> Result<String, ErrorData> {
+        let mut uri = Url::parse("cache:///").map_err(|_| {
+            ErrorData::new(
+                ErrorCode::INTERNAL_ERROR,
+                "Failed to create cache resource URI".to_string(),
+                None,
+            )
+        })?;
+        let mut segments = uri.path_segments_mut().map_err(|_| {
+            ErrorData::new(
+                ErrorCode::INTERNAL_ERROR,
+                "Failed to create cache resource URI".to_string(),
+                None,
+            )
+        })?;
+        for component in cache_path.components() {
+            let std::path::Component::Normal(segment) = component else {
+                return Err(ErrorData::new(
+                    ErrorCode::INTERNAL_ERROR,
+                    "Invalid cache resource path".to_string(),
+                    None,
+                ));
+            };
+            segments.push(&segment.to_string_lossy());
+        }
+        drop(segments);
+        Ok(uri.to_string())
     }
 
     // Helper function to register a file as a resource
-    fn register_as_resource(&self, cache_path: &PathBuf, mime_type: &str) -> Result<(), ErrorData> {
-        let uri = Url::from_file_path(cache_path)
-            .map_err(|_| {
-                ErrorData::new(
-                    ErrorCode::INTERNAL_ERROR,
-                    "Invalid cache path".to_string(),
-                    None,
-                )
-            })?
-            .to_string();
+    fn register_as_resource(&self, cache_path: &Path, mime_type: &str) -> Result<(), ErrorData> {
+        let uri = Self::cache_resource_uri(cache_path)?;
 
         let resource = ResourceContents::TextResourceContents {
             uri: uri.clone(),
@@ -1652,9 +1671,7 @@ impl ComputerControllerServer {
         let result = crate::computercontroller::pdf_tool::pdf_tool(
             path,
             operation_str,
-            cache_dir
-                .as_deref()
-                .map(|directory| (directory, self.cache_dir.as_path())),
+            cache_dir.as_deref(),
         )
         .await
         .map_err(|e| ErrorData::new(e.code, e.message, e.data))?;
@@ -1697,7 +1714,7 @@ impl ComputerControllerServer {
                             None,
                         )
                     })?;
-                    files.push(self.cache_dir.join(entry.file_name()).display().to_string());
+                    files.push(entry.file_name().to_string_lossy().into_owned());
                 }
                 files.sort();
                 Ok(CallToolResult::success(vec![ContentBlock::text(format!(
@@ -1757,9 +1774,7 @@ impl ComputerControllerServer {
                         None,
                     )
                 })?;
-                let (cache_dir, relative_path, candidate_path) =
-                    self.cache_file_capability(path)?;
-                let canonical_path = fs::canonicalize(&candidate_path).ok();
+                let (cache_dir, relative_path, _) = self.cache_file_capability(path)?;
 
                 cache_dir.remove_file(&relative_path).map_err(|e| {
                     ErrorData::new(
@@ -1770,12 +1785,8 @@ impl ComputerControllerServer {
                 })?;
 
                 // Remove from active resources if present
-                let mut active_resources = self.active_resources.lock().unwrap();
-                for resource_path in std::iter::once(&candidate_path).chain(canonical_path.as_ref())
-                {
-                    if let Ok(url) = Url::from_file_path(resource_path) {
-                        active_resources.remove(&url.to_string());
-                    }
+                if let Ok(uri) = Self::cache_resource_uri(&relative_path) {
+                    self.active_resources.lock().unwrap().remove(&uri);
                 }
 
                 Ok(CallToolResult::success(vec![ContentBlock::text(format!(
@@ -1945,9 +1956,10 @@ mod cache_tests {
         assert!(relative_result.is_ok());
 
         server
-            .register_as_resource(&cached_file, "text/plain")
+            .register_as_resource(Path::new("nested/result.txt"), "text/plain")
             .unwrap();
-        let resource_url = Url::from_file_path(&cached_file).unwrap().to_string();
+        let resource_url =
+            ComputerControllerServer::cache_resource_uri(Path::new("nested/result.txt")).unwrap();
         assert!(server
             .active_resources
             .lock()
@@ -2062,6 +2074,7 @@ mod cache_tests {
             .save_to_cache(b"new cached content", "new", "txt")
             .await
             .unwrap();
+        assert!(saved_path.is_relative());
         let saved_name = saved_path.file_name().unwrap();
         assert_eq!(
             fs::read_to_string(moved_cache_dir.join(saved_name)).unwrap(),
@@ -2069,11 +2082,24 @@ mod cache_tests {
         );
         assert!(!outside_dir.join(saved_name).exists());
 
+        server
+            .register_as_resource(&saved_path, "text/plain")
+            .unwrap();
+        let resource_uri = ComputerControllerServer::cache_resource_uri(&saved_path).unwrap();
+        assert!(resource_uri.starts_with("cache:///"));
+        assert!(!resource_uri.contains(&cache_dir.display().to_string()));
+        assert!(server
+            .active_resources
+            .lock()
+            .unwrap()
+            .contains_key(&resource_uri));
+
         let list = call_cache(&server, CacheCommand::List, "").await.unwrap();
         let ContentBlock::Text(list) = &list.content[0] else {
             panic!("expected text content");
         };
         assert!(list.text.contains(&saved_path.display().to_string()));
+        assert!(!list.text.contains(&cache_dir.display().to_string()));
 
         call_cache(&server, CacheCommand::Delete, "victim.txt")
             .await

--- a/crates/goose-mcp/src/computercontroller/pdf_tool.rs
+++ b/crates/goose-mcp/src/computercontroller/pdf_tool.rs
@@ -1,11 +1,13 @@
+use cap_std::fs::Dir;
 use lopdf::{content::Content as PdfContent, Document, Object};
 use rmcp::model::{ContentBlock, ErrorCode, ErrorData};
-use std::{fs, path::Path};
+use std::path::Path;
 
 pub async fn pdf_tool(
     path: &str,
     operation: &str,
-    cache_dir: &Path,
+    cache_dir: &Dir,
+    cache_dir_path: &Path,
 ) -> Result<Vec<ContentBlock>, ErrorData> {
     // Open and parse the PDF file
     let doc = Document::load(path).map_err(|e| {
@@ -117,8 +119,8 @@ pub async fn pdf_tool(
         }
 
         "extract_images" => {
-            let cache_dir = cache_dir.join("pdf_images");
-            fs::create_dir_all(&cache_dir).map_err(|e| {
+            let image_dir = Path::new("pdf_images");
+            cache_dir.create_dir_all(image_dir).map_err(|e| {
                 ErrorData::new(
                     ErrorCode::INTERNAL_ERROR,
                     format!("Failed to create image cache directory: {}", e),
@@ -305,7 +307,7 @@ pub async fn pdf_tool(
 
                                     // Get the image data
                                     if let Ok(data) = stream.get_plain_content() {
-                                        let image_path = cache_dir.join(format!(
+                                        let relative_path = image_dir.join(format!(
                                             "page{}_obj{}_{}{}",
                                             page_num,
                                             xobject_id.0,
@@ -313,7 +315,7 @@ pub async fn pdf_tool(
                                             extension
                                         ));
 
-                                        fs::write(&image_path, &data).map_err(|e| {
+                                        cache_dir.write(&relative_path, &data).map_err(|e| {
                                             ErrorData::new(
                                                 ErrorCode::INTERNAL_ERROR,
                                                 format!("Failed to write image: {}", e),
@@ -323,7 +325,7 @@ pub async fn pdf_tool(
 
                                         images.push(format!(
                                             "Saved image to: {} ({}x{}, {} bits per component)",
-                                            image_path.display(),
+                                            cache_dir_path.join(&relative_path).display(),
                                             width,
                                             height,
                                             bpc
@@ -364,15 +366,27 @@ mod tests {
     use super::*;
     use std::path::PathBuf;
 
+    fn cache_dir() -> (tempfile::TempDir, Dir) {
+        let directory = tempfile::tempdir().unwrap();
+        let handle = Dir::open_ambient_dir(directory.path(), cap_std::ambient_authority()).unwrap();
+        (directory, handle)
+    }
+
     #[tokio::test]
     async fn test_pdf_text_extraction() {
         let test_pdf_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join("src/computercontroller/tests/data/test.pdf");
-        let cache_dir = tempfile::tempdir().unwrap().keep();
+        let (cache_dir_path, cache_dir) = cache_dir();
 
         println!("Testing text extraction from: {}", test_pdf_path.display());
 
-        let result = pdf_tool(test_pdf_path.to_str().unwrap(), "extract_text", &cache_dir).await;
+        let result = pdf_tool(
+            test_pdf_path.to_str().unwrap(),
+            "extract_text",
+            &cache_dir,
+            cache_dir_path.path(),
+        )
+        .await;
 
         assert!(result.is_ok(), "PDF text extraction should succeed");
         let content = result.unwrap();
@@ -390,7 +404,7 @@ mod tests {
     async fn test_pdf_image_extraction() {
         let test_pdf_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join("src/computercontroller/tests/data/test_image.pdf");
-        let cache_dir = tempfile::tempdir().unwrap().keep();
+        let (cache_dir_path, cache_dir) = cache_dir();
 
         println!("Testing image extraction from: {}", test_pdf_path.display());
 
@@ -399,6 +413,7 @@ mod tests {
             test_pdf_path.to_str().unwrap(),
             "extract_images",
             &cache_dir,
+            cache_dir_path.path(),
         )
         .await;
 
@@ -436,8 +451,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_pdf_invalid_path() {
-        let cache_dir = tempfile::tempdir().unwrap().keep();
-        let result = pdf_tool("nonexistent.pdf", "extract_text", &cache_dir).await;
+        let (cache_dir_path, cache_dir) = cache_dir();
+        let result = pdf_tool(
+            "nonexistent.pdf",
+            "extract_text",
+            &cache_dir,
+            cache_dir_path.path(),
+        )
+        .await;
 
         assert!(result.is_err(), "Should fail with invalid path");
     }
@@ -446,12 +467,13 @@ mod tests {
     async fn test_pdf_invalid_operation() {
         let test_pdf_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join("src/computercontroller/tests/data/test.pdf");
-        let cache_dir = tempfile::tempdir().unwrap().keep();
+        let (cache_dir_path, cache_dir) = cache_dir();
 
         let result = pdf_tool(
             test_pdf_path.to_str().unwrap(),
             "invalid_operation",
             &cache_dir,
+            cache_dir_path.path(),
         )
         .await;
 

--- a/crates/goose-mcp/src/computercontroller/pdf_tool.rs
+++ b/crates/goose-mcp/src/computercontroller/pdf_tool.rs
@@ -6,8 +6,7 @@ use std::path::Path;
 pub async fn pdf_tool(
     path: &str,
     operation: &str,
-    cache_dir: &Dir,
-    cache_dir_path: &Path,
+    cache: Option<(&Dir, &Path)>,
 ) -> Result<Vec<ContentBlock>, ErrorData> {
     // Open and parse the PDF file
     let doc = Document::load(path).map_err(|e| {
@@ -119,6 +118,13 @@ pub async fn pdf_tool(
         }
 
         "extract_images" => {
+            let (cache_dir, cache_dir_path) = cache.ok_or_else(|| {
+                ErrorData::new(
+                    ErrorCode::INTERNAL_ERROR,
+                    "Cache directory is unavailable".to_string(),
+                    None,
+                )
+            })?;
             let image_dir = Path::new("pdf_images");
             cache_dir.create_dir_all(image_dir).map_err(|e| {
                 ErrorData::new(
@@ -376,17 +382,9 @@ mod tests {
     async fn test_pdf_text_extraction() {
         let test_pdf_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join("src/computercontroller/tests/data/test.pdf");
-        let (cache_dir_path, cache_dir) = cache_dir();
-
         println!("Testing text extraction from: {}", test_pdf_path.display());
 
-        let result = pdf_tool(
-            test_pdf_path.to_str().unwrap(),
-            "extract_text",
-            &cache_dir,
-            cache_dir_path.path(),
-        )
-        .await;
+        let result = pdf_tool(test_pdf_path.to_str().unwrap(), "extract_text", None).await;
 
         assert!(result.is_ok(), "PDF text extraction should succeed");
         let content = result.unwrap();
@@ -412,8 +410,7 @@ mod tests {
         let result = pdf_tool(
             test_pdf_path.to_str().unwrap(),
             "extract_images",
-            &cache_dir,
-            cache_dir_path.path(),
+            Some((&cache_dir, cache_dir_path.path())),
         )
         .await;
 
@@ -451,14 +448,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_pdf_invalid_path() {
-        let (cache_dir_path, cache_dir) = cache_dir();
-        let result = pdf_tool(
-            "nonexistent.pdf",
-            "extract_text",
-            &cache_dir,
-            cache_dir_path.path(),
-        )
-        .await;
+        let result = pdf_tool("nonexistent.pdf", "extract_text", None).await;
 
         assert!(result.is_err(), "Should fail with invalid path");
     }
@@ -467,15 +457,7 @@ mod tests {
     async fn test_pdf_invalid_operation() {
         let test_pdf_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join("src/computercontroller/tests/data/test.pdf");
-        let (cache_dir_path, cache_dir) = cache_dir();
-
-        let result = pdf_tool(
-            test_pdf_path.to_str().unwrap(),
-            "invalid_operation",
-            &cache_dir,
-            cache_dir_path.path(),
-        )
-        .await;
+        let result = pdf_tool(test_pdf_path.to_str().unwrap(), "invalid_operation", None).await;
 
         assert!(result.is_err(), "Should fail with invalid operation");
     }

--- a/crates/goose-mcp/src/computercontroller/pdf_tool.rs
+++ b/crates/goose-mcp/src/computercontroller/pdf_tool.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 pub async fn pdf_tool(
     path: &str,
     operation: &str,
-    cache: Option<(&Dir, &Path)>,
+    cache: Option<&Dir>,
 ) -> Result<Vec<ContentBlock>, ErrorData> {
     // Open and parse the PDF file
     let doc = Document::load(path).map_err(|e| {
@@ -118,7 +118,7 @@ pub async fn pdf_tool(
         }
 
         "extract_images" => {
-            let (cache_dir, cache_dir_path) = cache.ok_or_else(|| {
+            let cache_dir = cache.ok_or_else(|| {
                 ErrorData::new(
                     ErrorCode::INTERNAL_ERROR,
                     "Cache directory is unavailable".to_string(),
@@ -331,7 +331,7 @@ pub async fn pdf_tool(
 
                                         images.push(format!(
                                             "Saved image to: {} ({}x{}, {} bits per component)",
-                                            cache_dir_path.join(&relative_path).display(),
+                                            relative_path.display(),
                                             width,
                                             height,
                                             bpc
@@ -410,7 +410,7 @@ mod tests {
         let result = pdf_tool(
             test_pdf_path.to_str().unwrap(),
             "extract_images",
-            Some((&cache_dir, cache_dir_path.path())),
+            Some(&cache_dir),
         )
         .await;
 
@@ -441,8 +441,12 @@ mod tests {
                 .and_then(|path| path.split(" (").next())
                 .expect("Should have a valid file path");
 
+            assert!(Path::new(file_path).is_relative());
             println!("Verifying image file exists: {}", file_path);
-            assert!(PathBuf::from(file_path).exists(), "Image file should exist");
+            assert!(
+                cache_dir_path.path().join(file_path).exists(),
+                "Image file should exist"
+            );
         }
     }
 


### PR DESCRIPTION
## Summary

- operate cache reads, writes, listing, deletion, and clearing through an open directory capability
- anchor beneath the platform-designated cache directory and reject symlinked or junction-backed Goose-specific path components
- retain that cache-root capability for the server lifetime so root replacement cannot redirect later requests
- clear entries through the retained capability without unlinking or replacing its root
- stage external screenshot output in a private temporary directory before importing it through the cache capability
- route PDF image extraction through the same retained capability
- keep PDF text extraction independent of cache availability
- preserve relative cache names and absolute paths returned by cache listing
- read through a no-follow file handle and delete relative to the cache handle
- reject outside paths, traversal, non-files, final symlinks, and intermediate symlink escapes without pathname-reopen races
- preserve active-resource cleanup when a cached file is deleted
- add `cap-std` and `cap-fs-ext` through `cargo add` for cross-platform beneath/no-follow semantics
- add focused valid-path, symlink-escape, linked-root/ancestor, root-replacement, and post-clear reuse regressions

## Security impact

This restores the cache tool's advertised filesystem boundary by ensuring all managed cache I/O remains beneath the retained Computer Controller cache directory, including when the cache pathname changes concurrently.

This fixes https://github.com/project-loupe/audit-goose/issues/134.

## Verification

- `cargo fmt --all`
- `cargo test -p goose-mcp computercontroller::cache_tests` (9 passed)
- `cargo test -p goose-mcp computercontroller::pdf_tool::tests` (4 passed)
- `cargo test -p goose-mcp computercontroller` (29 passed)
- `cargo build -p goose-mcp`
- `cargo clippy --all-targets -- -D warnings`
- `git diff --check`

*This finding was discovered by [Project Loupe](https://github.com/project-loupe/loupe)*
