### PR TITLE
fix(security): validate memory categories

### DIFF
--- a/crates/goose-mcp/src/memory/mod.rs
+++ b/crates/goose-mcp/src/memory/mod.rs
@@ -204,10 +204,22 @@ impl MemoryServer {
             for entry in fs::read_dir(&base_dir)? {
                 let entry = entry?;
                 if entry.file_type()?.is_file() {
-                    let category = entry.file_name().to_string_lossy().replace(".txt", "");
-                    let category_memories = self.retrieve(&category, is_global, working_dir)?;
+                    let file_name = entry.file_name();
+                    let Some(category) = file_name
+                        .to_str()
+                        .and_then(|name| name.strip_suffix(".txt"))
+                    else {
+                        continue;
+                    };
+                    if self
+                        .get_memory_file(category, is_global, working_dir)
+                        .is_err()
+                    {
+                        continue;
+                    }
+                    let category_memories = self.retrieve(category, is_global, working_dir)?;
                     memories.insert(
-                        category,
+                        category.to_string(),
                         category_memories.into_values().flatten().collect(),
                     );
                 }
@@ -769,5 +781,28 @@ mod tests {
         assert!(working_dir
             .join(".goose/memory/project notes_2026.txt")
             .is_file());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_retrieve_all_skips_invalid_legacy_categories() {
+        let temp_dir = tempdir().unwrap();
+        let working_dir = temp_dir.path().join("working");
+        let memory_dir = working_dir.join(".goose/memory");
+        fs::create_dir_all(&memory_dir).unwrap();
+        fs::write(memory_dir.join("valid.txt"), "kept").unwrap();
+        fs::write(memory_dir.join("work:api.txt"), "legacy").unwrap();
+        fs::write(memory_dir.join(r"work\api.txt"), "legacy").unwrap();
+
+        let router = MemoryServer {
+            tool_router: ToolRouter::new(),
+            instructions: String::new(),
+            global_memory_dir: temp_dir.path().join("global"),
+        };
+
+        let memories = router.retrieve_all(false, Some(&working_dir)).unwrap();
+
+        assert_eq!(memories.len(), 1);
+        assert!(memories["valid"].iter().any(|entry| entry == "kept"));
     }
 }

--- a/crates/goose-mcp/src/memory/mod.rs
+++ b/crates/goose-mcp/src/memory/mod.rs
@@ -158,7 +158,21 @@ impl MemoryServer {
         category: &str,
         is_global: bool,
         working_dir: Option<&PathBuf>,
-    ) -> PathBuf {
+    ) -> io::Result<PathBuf> {
+        if category.is_empty()
+            || category == "*"
+            || category == "."
+            || category == ".."
+            || category.contains('/')
+            || category.contains('\\')
+            || category.contains(':')
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "memory category must be a single filename component",
+            ));
+        }
+
         let base_dir = if is_global {
             self.global_memory_dir.clone()
         } else {
@@ -168,7 +182,7 @@ impl MemoryServer {
                 .unwrap_or_else(|| PathBuf::from("."));
             local_base.join(".goose").join("memory")
         };
-        base_dir.join(format!("{}.txt", category))
+        Ok(base_dir.join(format!("{}.txt", category)))
     }
 
     pub fn retrieve_all(
@@ -211,7 +225,7 @@ impl MemoryServer {
         is_global: bool,
         working_dir: Option<&PathBuf>,
     ) -> io::Result<()> {
-        let memory_file_path = self.get_memory_file(category, is_global, working_dir);
+        let memory_file_path = self.get_memory_file(category, is_global, working_dir)?;
 
         if let Some(parent) = memory_file_path.parent() {
             fs::create_dir_all(parent)?;
@@ -235,7 +249,7 @@ impl MemoryServer {
         is_global: bool,
         working_dir: Option<&PathBuf>,
     ) -> io::Result<HashMap<String, Vec<String>>> {
-        let memory_file_path = self.get_memory_file(category, is_global, working_dir);
+        let memory_file_path = self.get_memory_file(category, is_global, working_dir)?;
         if !memory_file_path.exists() {
             return Ok(HashMap::new());
         }
@@ -276,7 +290,7 @@ impl MemoryServer {
         is_global: bool,
         working_dir: Option<&PathBuf>,
     ) -> io::Result<()> {
-        let memory_file_path = self.get_memory_file(category, is_global, working_dir);
+        let memory_file_path = self.get_memory_file(category, is_global, working_dir)?;
         if !memory_file_path.exists() {
             return Ok(());
         }
@@ -303,7 +317,7 @@ impl MemoryServer {
         is_global: bool,
         working_dir: Option<&PathBuf>,
     ) -> io::Result<()> {
-        let memory_file_path = self.get_memory_file(category, is_global, working_dir);
+        let memory_file_path = self.get_memory_file(category, is_global, working_dir)?;
         if memory_file_path.exists() {
             fs::remove_file(memory_file_path)?;
         }
@@ -664,5 +678,96 @@ mod tests {
             .values()
             .any(|v| v.iter().any(|content| content.contains("keep_this")));
         assert!(has_kept);
+    }
+
+    #[test]
+    fn test_memory_operations_reject_escape_capable_categories() {
+        let temp_dir = tempdir().unwrap();
+        let working_dir = temp_dir.path().join("working");
+        let outside_file = temp_dir.path().join("outside.txt");
+        fs::write(&outside_file, "secret").unwrap();
+
+        let router = MemoryServer {
+            tool_router: ToolRouter::new(),
+            instructions: String::new(),
+            global_memory_dir: temp_dir.path().join("global"),
+        };
+
+        for category in [
+            "",
+            "*",
+            ".",
+            "..",
+            "../../../outside",
+            "/tmp/outside",
+            r"..\..\outside",
+            "C:outside",
+            r"C:\outside",
+        ] {
+            assert_eq!(
+                router
+                    .remember(
+                        "context",
+                        category,
+                        "malicious",
+                        &[],
+                        false,
+                        Some(&working_dir)
+                    )
+                    .unwrap_err()
+                    .kind(),
+                io::ErrorKind::InvalidInput
+            );
+            assert_eq!(
+                router
+                    .retrieve(category, false, Some(&working_dir))
+                    .unwrap_err()
+                    .kind(),
+                io::ErrorKind::InvalidInput
+            );
+            assert_eq!(
+                router
+                    .remove_specific_memory_internal(category, "secret", false, Some(&working_dir),)
+                    .unwrap_err()
+                    .kind(),
+                io::ErrorKind::InvalidInput
+            );
+            assert_eq!(
+                router
+                    .clear_memory(category, false, Some(&working_dir))
+                    .unwrap_err()
+                    .kind(),
+                io::ErrorKind::InvalidInput
+            );
+        }
+
+        assert_eq!(fs::read_to_string(outside_file).unwrap(), "secret");
+        assert!(!working_dir.join(".goose").exists());
+    }
+
+    #[test]
+    fn test_memory_category_allows_safe_filename_characters() {
+        let temp_dir = tempdir().unwrap();
+        let working_dir = temp_dir.path().join("working");
+        let router = MemoryServer {
+            tool_router: ToolRouter::new(),
+            instructions: String::new(),
+            global_memory_dir: temp_dir.path().join("global"),
+        };
+
+        router
+            .remember(
+                "context",
+                "project notes_2026",
+                "safe",
+                &[],
+                false,
+                Some(&working_dir),
+            )
+            .unwrap();
+
+        assert!(working_dir
+            .join(".goose/memory/project notes_2026.txt")
+            .is_file());
     }
 }

--- a/crates/goose-mcp/src/memory/mod.rs
+++ b/crates/goose-mcp/src/memory/mod.rs
@@ -20,6 +20,25 @@ use std::{
 
 const WORKING_DIR_HEADER: &str = "agent-working-dir";
 
+fn is_reserved_windows_category(category: &str) -> bool {
+    let basename = category
+        .split('.')
+        .next()
+        .unwrap_or(category)
+        .trim_end_matches([' ', '.']);
+    let uppercase = basename.to_ascii_uppercase();
+
+    matches!(uppercase.as_str(), "CON" | "PRN" | "AUX" | "NUL" | "CLOCK$")
+        || ["COM", "LPT"].iter().any(|prefix| {
+            uppercase.strip_prefix(prefix).is_some_and(|suffix| {
+                matches!(
+                    suffix,
+                    "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" | "¹" | "²" | "³"
+                )
+            })
+        })
+}
+
 fn extract_working_dir_from_meta(meta: &MetaObject) -> Option<PathBuf> {
     meta.0
         .get(WORKING_DIR_HEADER)
@@ -166,6 +185,7 @@ impl MemoryServer {
             || category.contains('/')
             || category.contains('\\')
             || category.contains(':')
+            || is_reserved_windows_category(category)
         {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
@@ -715,6 +735,11 @@ mod tests {
             r"..\..\outside",
             "C:outside",
             r"C:\outside",
+            "NUL",
+            "con",
+            "AUX.log",
+            "COM1",
+            "lpt9",
         ] {
             assert_eq!(
                 router

--- a/crates/goose-mcp/src/memory/mod.rs
+++ b/crates/goose-mcp/src/memory/mod.rs
@@ -47,6 +47,15 @@ fn extract_working_dir_from_meta(meta: &MetaObject) -> Option<PathBuf> {
         .map(PathBuf::from)
 }
 
+fn memory_error(error: io::Error) -> ErrorData {
+    let code = if error.kind() == io::ErrorKind::InvalidInput {
+        ErrorCode::INVALID_PARAMS
+    } else {
+        ErrorCode::INTERNAL_ERROR
+    };
+    ErrorData::new(code, error.to_string(), None)
+}
+
 /// Parameters for the remember_memory tool
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
 pub struct RememberMemoryParams {
@@ -407,7 +416,7 @@ impl MemoryServer {
             params.is_global,
             working_dir.as_ref(),
         )
-        .map_err(|e| ErrorData::new(ErrorCode::INTERNAL_ERROR, e.to_string(), None))?;
+        .map_err(memory_error)?;
 
         Ok(CallToolResult::success(vec![ContentBlock::text(format!(
             "Stored memory in category: {}",
@@ -433,7 +442,7 @@ impl MemoryServer {
         } else {
             self.retrieve(&params.category, params.is_global, working_dir.as_ref())
         }
-        .map_err(|e| ErrorData::new(ErrorCode::INTERNAL_ERROR, e.to_string(), None))?;
+        .map_err(memory_error)?;
 
         Ok(CallToolResult::success(vec![ContentBlock::text(format!(
             "Retrieved memories: {:?}",
@@ -456,14 +465,14 @@ impl MemoryServer {
 
         let message = if params.category == "*" {
             self.clear_all_global_or_local_memories(params.is_global, working_dir.as_ref())
-                .map_err(|e| ErrorData::new(ErrorCode::INTERNAL_ERROR, e.to_string(), None))?;
+                .map_err(memory_error)?;
             format!(
                 "Cleared all memory {} categories",
                 if params.is_global { "global" } else { "local" }
             )
         } else {
             self.clear_memory(&params.category, params.is_global, working_dir.as_ref())
-                .map_err(|e| ErrorData::new(ErrorCode::INTERNAL_ERROR, e.to_string(), None))?;
+                .map_err(memory_error)?;
             format!("Cleared memories in category: {}", params.category)
         };
 
@@ -489,7 +498,7 @@ impl MemoryServer {
             params.is_global,
             working_dir.as_ref(),
         )
-        .map_err(|e| ErrorData::new(ErrorCode::INTERNAL_ERROR, e.to_string(), None))?;
+        .map_err(memory_error)?;
 
         Ok(CallToolResult::success(vec![ContentBlock::text(format!(
             "Removed specific memory from category: {}",
@@ -829,5 +838,14 @@ mod tests {
 
         assert_eq!(memories.len(), 1);
         assert!(memories["valid"].iter().any(|entry| entry == "kept"));
+    }
+
+    #[test]
+    fn test_memory_error_preserves_invalid_parameter_distinction() {
+        let invalid = memory_error(io::Error::new(io::ErrorKind::InvalidInput, "bad category"));
+        assert_eq!(invalid.code, ErrorCode::INVALID_PARAMS);
+
+        let filesystem = memory_error(io::Error::new(io::ErrorKind::PermissionDenied, "denied"));
+        assert_eq!(filesystem.code, ErrorCode::INTERNAL_ERROR);
     }
 }


### PR DESCRIPTION
## Summary

- validate memory categories at the shared path constructor used by read, append, rewrite, and delete operations
- reject empty, wildcard, dot, traversal, absolute, separator-bearing, and Windows drive-prefixed category values before filesystem access
- reject Windows reserved DOS device basenames case-insensitively, including extension-bearing and COM/LPT variants
- preserve ordinary single-component category names, including spaces
- add regression coverage across all four filesystem operations and both Unix- and Windows-style escape inputs
- skip invalid legacy filenames during bulk retrieval so they cannot suppress valid memories
- return rejected categories as MCP invalid parameters while preserving genuine filesystem failures as internal errors

## Security impact

This confines model-controlled memory categories to one file beneath the selected local or global memory directory, preventing lexical path traversal to process-accessible `.txt` files. The separate pre-existing-symlink condition tracked by audit #438 is outside this fix.

This fixes https://github.com/project-loupe/audit-goose/issues/140.

## Verification

- `cargo fmt --all`
- `cargo test -p goose-mcp memory::tests` (9 passed)
- `cargo build -p goose-mcp`
- `cargo clippy --all-targets -- -D warnings`
- `git diff --check`

*This finding was discovered by [Project Loupe](https://github.com/project-loupe/loupe)*
