### PR TITLE
docs: add Orshot to the extensions directory

### DIFF
--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -545,6 +545,18 @@
     "environmentVariables": []
   },
   {
+    "id": "orshot",
+    "name": "Orshot",
+    "description": "Render on-brand images, PDFs, and video from reusable templates",
+    "type": "streamable-http",
+    "url": "https://mcp.orshot.com/mcp",
+    "link": "https://orshot.com/docs/integrations/mcp-server",
+    "installation_notes": "Hosted remote server. Sign in with your Orshot account via OAuth on first connect. No API key required.",
+    "is_builtin": false,
+    "endorsed": false,
+    "environmentVariables": []
+  },
+  {
     "id": "pdf_read",
     "name": "PDF Reader",
     "description": "Read large and complex PDF documents",

--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -550,7 +550,7 @@
     "description": "Render on-brand images, PDFs, and video from reusable templates",
     "type": "streamable-http",
     "url": "https://mcp.orshot.com/mcp",
-    "link": "https://orshot.com/docs/integrations/mcp-server",
+    "link": "https://orshot.com/agents",
     "installation_notes": "Hosted remote server. Sign in with your Orshot account via OAuth on first connect. No API key required.",
     "is_builtin": false,
     "endorsed": false,


### PR DESCRIPTION
Adds [Orshot](https://orshot.com) to the extensions directory — render on-brand images, PDFs, and video from reusable templates.

The directory has plenty of ways to read and reason about things, but few that produce a finished visual asset. The case this covers is asking goose for the OG image, social card, or certificate PDF that goes with whatever it just did, instead of hand-making it afterwards.

One entry in `documentation/static/servers.json`, inserted alphabetically between `ophis` and `pdf_read`, modelled on the `ophis` entry since it's the closest shape (streamable-http, keyless setup). `endorsed: false`, as that's yours to decide.

Setup is just the hosted URL — no API key and nothing to install locally. The server does OAuth 2.1 with dynamic client registration, so goose opens the browser on first connect and there's no credential to paste, which is why `environmentVariables` is empty.

Verified before submitting:

- The file still parses, 59 → 60 entries, diff is the 12 added lines only (the file has mixed 2- and 4-space indentation in places; I inserted textually rather than re-serialising so nothing else got reformatted).
- The endpoint speaks streamable HTTP and returns `401` with `WWW-Authenticate: Bearer resource_metadata="…/.well-known/oauth-protected-resource"`, and the authorization server advertises `registration_endpoint`, so the DCR path works.
- The `link` URL is live and its setup page already documents goose specifically.

I have not run goose against it end to end — I don't have it installed. Say the word if you'd like that confirmed before merging.

Disclosure: I work on Orshot, so this is a vendor submission. Happy to close it if you'd rather keep the directory to third-party entries.
