### PR TITLE
fix(security): bound call graph traversal

### DIFF
--- a/crates/goose/src/agents/platform_extensions/analyze/graph.rs
+++ b/crates/goose/src/agents/platform_extensions/analyze/graph.rs
@@ -7,6 +7,9 @@ use super::parser::{Call, FileAnalysis, Symbol};
 /// functions in the same file (e.g. two `process()` in different impl blocks).
 type NodeKey = (PathBuf, String, usize);
 
+const MAX_CALL_GRAPH_DEPTH: u32 = 32;
+const MAX_CALL_GRAPH_PATHS: usize = 2_000;
+
 #[derive(Clone)]
 pub struct ChainLink {
     pub file: PathBuf,
@@ -150,13 +153,17 @@ impl CallGraph {
         if depth == 0 {
             return vec![];
         }
+        let depth = depth.min(MAX_CALL_GRAPH_DEPTH);
 
         let mut chains = Vec::new();
         let mut queue: VecDeque<(Vec<NodeKey>, u32)> = VecDeque::new();
 
-        for start in starts {
+        'starts: for start in starts {
             if let Some(neighbors) = edges.get(start) {
                 for neighbor in neighbors {
+                    if queue.len() >= MAX_CALL_GRAPH_PATHS {
+                        break 'starts;
+                    }
                     queue.push_back((vec![start.clone(), neighbor.clone()], 1));
                 }
             }
@@ -178,6 +185,9 @@ impl CallGraph {
                     let mut extended = false;
                     for neighbor in neighbors {
                         if !visited.contains(neighbor) {
+                            if chains.len() + queue.len() >= MAX_CALL_GRAPH_PATHS {
+                                break;
+                            }
                             let mut new_path = path.clone();
                             new_path.push(neighbor.clone());
                             queue.push_back((new_path, d + 1));
@@ -270,5 +280,94 @@ fn resolve_callee(
             .collect()
     } else {
         vec![]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn symbol(name: impl Into<String>, line: usize) -> Symbol {
+        Symbol {
+            name: name.into(),
+            line,
+            parent: None,
+            detail: None,
+        }
+    }
+
+    #[test]
+    fn outgoing_paths_are_bounded_for_dense_graphs() {
+        let width = 50;
+        let mut functions = vec![symbol("root", 1)];
+        let mut calls = Vec::new();
+
+        for i in 0..width {
+            let name = format!("branch_{i}");
+            let line = 100 + i;
+            functions.push(symbol(&name, line));
+            calls.push(Call {
+                caller: "root".to_string(),
+                callee: name,
+                line: 2 + i,
+            });
+        }
+
+        for j in 0..width {
+            functions.push(symbol(format!("leaf_{j}"), 1_000 + j));
+        }
+
+        for i in 0..width {
+            for j in 0..width {
+                calls.push(Call {
+                    caller: format!("branch_{i}"),
+                    callee: format!("leaf_{j}"),
+                    line: 100 + i,
+                });
+            }
+        }
+
+        let graph = CallGraph::build(&[FileAnalysis {
+            path: PathBuf::from("dense.rs"),
+            language: "rust",
+            loc: 2_000,
+            functions,
+            classes: Vec::new(),
+            imports: Vec::new(),
+            calls,
+        }]);
+
+        let chains = graph.outgoing("root", 2);
+
+        assert_eq!(chains.len(), MAX_CALL_GRAPH_PATHS);
+    }
+
+    #[test]
+    fn outgoing_depth_is_bounded() {
+        let node_count = MAX_CALL_GRAPH_DEPTH as usize + 20;
+        let functions = (0..node_count)
+            .map(|i| symbol(format!("node_{i}"), i + 1))
+            .collect();
+        let calls = (0..node_count - 1)
+            .map(|i| Call {
+                caller: format!("node_{i}"),
+                callee: format!("node_{}", i + 1),
+                line: i + 1,
+            })
+            .collect();
+        let graph = CallGraph::build(&[FileAnalysis {
+            path: PathBuf::from("deep.rs"),
+            language: "rust",
+            loc: node_count,
+            functions,
+            classes: Vec::new(),
+            imports: Vec::new(),
+            calls,
+        }]);
+
+        let chains = graph.outgoing("node_0", u32::MAX);
+
+        assert_eq!(chains.len(), 1);
+        assert_eq!(chains[0].len(), MAX_CALL_GRAPH_DEPTH as usize + 1);
     }
 }


### PR DESCRIPTION
## Summary

- cap focused call-graph traversal at 32 edges even when `follow_depth` is larger
- cap queued and materialized breadth-first paths at 2,000 before combinatorial expansion
- preserve the existing breadth-first and cycle-avoidance behavior below both budgets
- add dense-fanout and excessive-depth regressions

## Security impact

This gives the Analyze extension explicit work budgets before it clones and buffers caller-influenced call-graph paths, preventing combinatorial CPU and memory exhaustion. The Analyze platform extension is shared by the legacy and state-machine agent paths, so no duplicate loop implementation is required.

This fixes https://github.com/project-loupe/audit-goose/issues/26.

## Verification

- `cargo fmt --all`
- `cargo test -p goose agents::platform_extensions::analyze::graph::tests` (2 passed)
- `cargo test -p goose agents::platform_extensions::analyze` (6 passed)
- `cargo build -p goose`
- `cargo clippy --all-targets -- -D warnings`
- `git diff --check`

*This finding was discovered by [Project Loupe](https://github.com/project-loupe/loupe)*
