### PR TITLE
Use rmcp ContentBlock in goose-sdk UniFFI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,30 @@ jobs:
         env:
           RUST_MIN_STACK: 8388608
 
+  goose-sdk-uniffi:
+    name: Check goose-sdk UniFFI
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.code == 'true' || github.event_name != 'pull_request'
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+
+      - name: Install Dependencies
+        run: |
+          sudo apt update -y
+          sudo apt install -y libdbus-1-dev libxcb1-dev
+
+      - name: Check UniFFI feature
+        run: |
+          export CARGO_INCREMENTAL=0
+          cargo check -p goose-sdk --features uniffi --locked
+          cargo test -p goose-sdk --features uniffi --locked
+        env:
+          RUST_MIN_STACK: 8388608
+
   rust-build-and-test-tls:
     name: Build and Test TLS Backend (${{ matrix.tls-feature }})
     runs-on: ubuntu-latest

--- a/crates/goose-sdk/src/bindings.rs
+++ b/crates/goose-sdk/src/bindings.rs
@@ -25,8 +25,7 @@ use goose_providers::{
     utils::sanitize_unicode_tags,
 };
 use rmcp::model::{
-    CallToolRequestParams, CallToolResult, ContentBlock as Content, ErrorCode, ErrorData, Role,
-    Tool,
+    CallToolRequestParams, CallToolResult, ContentBlock, ErrorCode, ErrorData, Role, Tool,
 };
 use serde_json::Value;
 
@@ -306,15 +305,15 @@ fn call_tool_result(value: Value, is_error: bool) -> CallToolResult {
     }
 }
 
-fn value_to_content(value: Value) -> Content {
+fn value_to_content(value: Value) -> ContentBlock {
     match value {
-        Value::String(text) => Content::text(text),
+        Value::String(text) => ContentBlock::text(text),
         Value::Object(object) => match object.get("type").and_then(|value| value.as_str()) {
             Some("text") => object
                 .get("text")
                 .and_then(|value| value.as_str().map(str::to_owned))
-                .map(Content::text)
-                .unwrap_or_else(|| Content::text(Value::Object(object).to_string())),
+                .map(ContentBlock::text)
+                .unwrap_or_else(|| ContentBlock::text(Value::Object(object).to_string())),
             Some("image") => {
                 let mime_type = object
                     .get("mimeType")
@@ -325,11 +324,11 @@ fn value_to_content(value: Value) -> Content {
                     .get("data")
                     .and_then(|value| value.as_str().map(str::to_owned))
                     .unwrap_or_default();
-                Content::image(data, mime_type)
+                ContentBlock::image(data, mime_type)
             }
-            _ => Content::text(Value::Object(object).to_string()),
+            _ => ContentBlock::text(Value::Object(object).to_string()),
         },
-        other => Content::text(other.to_string()),
+        other => ContentBlock::text(other.to_string()),
     }
 }
 


### PR DESCRIPTION
## Summary
- `cargo build -p goose-sdk --features uniffi` broke after rmcp 3.0 renamed `Content` to `ContentBlock` (`E0432` in `bindings.rs`).
- Main already compiles via `ContentBlock as Content` from #11042; that alias is easy to miss on branches, and default PR CI never enables `--features uniffi`.
- This drops the alias and adds a `goose-sdk-uniffi` CI job so the next rmcp rename fails on the PR, not at Maven publish time.

Fixes #11209

## Test plan
- [x] `cargo check -p goose-sdk --features uniffi --locked`
- [x] `cargo test -p goose-sdk --features uniffi --locked --lib` (`tool_result_content_converts` and 3 other UniFFI unit tests)
- [x] `cargo clippy -p goose-sdk --features uniffi -- -D warnings`
- [ ] GitHub `Check goose-sdk UniFFI` job is green


Made with [Cursor](https://cursor.com)