### PR TITLE
docs: add Mnemoverse Memory to the extensions directory

### DIFF
--- a/documentation/docs/mcp/mnemoverse-memory-mcp.md
+++ b/documentation/docs/mcp/mnemoverse-memory-mcp.md
@@ -1,0 +1,109 @@
+---
+title: Mnemoverse Memory Extension
+description: Add Mnemoverse Memory MCP Server as a goose Extension
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import GooseDesktopInstaller from '@site/src/components/GooseDesktopInstaller';
+import CLIExtensionInstructions from '@site/src/components/CLIExtensionInstructions';
+
+This tutorial covers how to add the [Mnemoverse Memory MCP Server](https://github.com/mnemoverse/mcp-memory-server) as a goose extension to give goose persistent memory that is shared across your AI tools: write a memory in goose, recall it in Claude Code, Cursor, or any other MCP client, and the other way around.
+
+:::tip Quick Install
+
+<Tabs groupId="interface">
+  <TabItem value="ui" label="goose Desktop" default>
+  [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=%40mnemoverse%2Fmcp-memory-server&id=mnemoverse-memory&name=Mnemoverse%20Memory&description=Persistent%20memory%20shared%20across%20AI%20tools&env=MNEMOVERSE_API_KEY%3DMnemoverse%20API%20Key)
+  </TabItem>
+  <TabItem value="cli" label="goose CLI">
+  **Command**
+  ```sh
+  npx -y @mnemoverse/mcp-memory-server
+  ```
+  </TabItem>
+</Tabs>
+  **Environment Variable**
+  ```
+  MNEMOVERSE_API_KEY: <YOUR_API_KEY>
+  ```
+:::
+
+## Configuration
+
+:::info
+Note that you'll need [Node.js](https://nodejs.org/) installed on your system to run this command, as it uses `npx`. A free API key is available at [console.mnemoverse.com](https://console.mnemoverse.com), no credit card required.
+:::
+
+<Tabs groupId="interface">
+  <TabItem value="ui" label="goose Desktop" default>
+  <GooseDesktopInstaller
+    extensionId="mnemoverse-memory"
+    extensionName="Mnemoverse Memory"
+    description="Persistent memory shared across AI tools"
+    command="npx"
+    args={["-y", "@mnemoverse/mcp-memory-server"]}
+    envVars={[
+      { name: "MNEMOVERSE_API_KEY", label: "Mnemoverse API Key" }
+    ]}
+    apiKeyLink="https://console.mnemoverse.com"
+    apiKeyLinkText="MNEMOVERSE_API_KEY"
+  />
+  </TabItem>
+  <TabItem value="cli" label="goose CLI">
+    <CLIExtensionInstructions
+      name="mnemoverse"
+      description="Persistent memory shared across AI tools"
+      command="npx -y @mnemoverse/mcp-memory-server"
+      envVars={[
+        { key: "MNEMOVERSE_API_KEY", value: "▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪" }
+      ]}
+      infoNote={
+        <>
+          Get a free <a href="https://console.mnemoverse.com" target="_blank" rel="noopener noreferrer">Mnemoverse API Key</a> and paste it in. The same key gives every MCP client the same memory.
+        </>
+      }
+    />
+
+  </TabItem>
+</Tabs>
+
+## Example Usage
+
+Let's use the Mnemoverse Memory extension to save a project decision in goose and rely on it in a later session.
+
+### goose Prompt
+
+```
+Remember that this project uses pnpm, not npm. We decided this after a
+lockfile conflict, and it applies to every package in this repo.
+```
+
+### goose Output
+
+```
+I'll save that decision to long-term memory.
+
+─── memory_write | mnemoverse ──────────────────────────
+content: Project uses pnpm, not npm. Decided after a lockfile conflict;
+applies to all packages in this repo.
+
+Saved. Future sessions, in goose or in any other tool connected to the
+same Mnemoverse account, will recall this before running package commands.
+```
+
+In a later session, ask:
+
+```
+Before you install anything, check what package manager we use here.
+```
+
+```
+─── memory_read | mnemoverse ──────────────────────────
+query: package manager for this repo
+
+Found it: this project uses pnpm, not npm (decided after a lockfile
+conflict). I'll use pnpm for the install.
+```
+
+The server exposes tools for writing, recalling, listing recent memories, usage stats, and rating which recalled memories helped, which tunes future recall. Memories carry importance scores and associations that strengthen with use. See the [documentation](https://mnemoverse.com/docs/api/mcp-server) for the full tool list.

--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -36,7 +36,7 @@
   {
     "id": "apify",
     "name": "Apify",
-    "description": "Extract data from any website with thousands of scrapers, crawlers, and automations on Apify Store \u26a1",
+    "description": "Extract data from any website with thousands of scrapers, crawlers, and automations on Apify Store ⚡",
     "command": "npx -y @apify/actors-mcp-server",
     "link": "https://github.com/apify/apify-mcp-server",
     "installation_notes": "Install using npx. Requires an Apify API token.",
@@ -448,6 +448,23 @@
     "environmentVariables": []
   },
   {
+    "id": "mnemoverse-memory",
+    "name": "Mnemoverse Memory",
+    "description": "Persistent memory shared across AI tools: write a memory in one MCP client, recall it in another",
+    "command": "npx -y @mnemoverse/mcp-memory-server",
+    "link": "https://github.com/mnemoverse/mcp-memory-server",
+    "installation_notes": "Install using npx package manager. Get a free API key at https://console.mnemoverse.com (no credit card).",
+    "is_builtin": false,
+    "endorsed": false,
+    "environmentVariables": [
+      {
+        "name": "MNEMOVERSE_API_KEY",
+        "description": "Required environment variable",
+        "required": true
+      }
+    ]
+  },
+  {
     "id": "mongodb",
     "name": "MongoDB",
     "description": "MongoDB database integration",
@@ -797,7 +814,7 @@
   {
     "id": "cash-app",
     "name": "Cash App",
-    "description": "Cash App brings local food ordering into the AI era. Discover nearby sellers, browse menus with calories and allergen info, customize orders, and complete checkout\u2014all conversationally.",
+    "description": "Cash App brings local food ordering into the AI era. Discover nearby sellers, browse menus with calories and allergen info, customize orders, and complete checkout—all conversationally.",
     "type": "streamable-http",
     "url": "https://connect.squareup.com/v2/mcp/cash-app",
     "link": "",
@@ -807,26 +824,25 @@
     "environmentVariables": []
   },
   {
-  "id": "scholar-sidekick",
-  "name": "Scholar Sidekick",
-  "description": "Resolve, format, export, and verify academic citations (DOI, PMID, ISBN, arXiv) plus retraction and open-access checks",
-  "command": "npx -y scholar-sidekick-mcp@latest",
-  "link": "https://github.com/mlava/scholar-sidekick-mcp",
-  "installation_notes": "No API key required — works anonymously on a free, rate-limited tier. Optionally set SCHOLAR_API_KEY (a free first-party ssk_ key from https://scholar-sidekick.com/account) for higher limits, or RAPIDAPI_KEY for paid tiers via RapidAPI.",
-  "is_builtin": false,
-  "endorsed": false,
-  "environmentVariables": [
-    {
-      "name": "SCHOLAR_API_KEY",
-      "description": "Optional first-party API key (ssk_) from https://scholar-sidekick.com/account; raises rate limits. Sent as Authorization: Bearer.",
-      "required": false
-    },
-    {
-      "name": "RAPIDAPI_KEY",
-      "description": "Optional RapidAPI key for paid/managed tiers; routes calls through the RapidAPI gateway.",
-      "required": false
-    }
-  ]
-}
-
+    "id": "scholar-sidekick",
+    "name": "Scholar Sidekick",
+    "description": "Resolve, format, export, and verify academic citations (DOI, PMID, ISBN, arXiv) plus retraction and open-access checks",
+    "command": "npx -y scholar-sidekick-mcp@latest",
+    "link": "https://github.com/mlava/scholar-sidekick-mcp",
+    "installation_notes": "No API key required — works anonymously on a free, rate-limited tier. Optionally set SCHOLAR_API_KEY (a free first-party ssk_ key from https://scholar-sidekick.com/account) for higher limits, or RAPIDAPI_KEY for paid tiers via RapidAPI.",
+    "is_builtin": false,
+    "endorsed": false,
+    "environmentVariables": [
+      {
+        "name": "SCHOLAR_API_KEY",
+        "description": "Optional first-party API key (ssk_) from https://scholar-sidekick.com/account; raises rate limits. Sent as Authorization: Bearer.",
+        "required": false
+      },
+      {
+        "name": "RAPIDAPI_KEY",
+        "description": "Optional RapidAPI key for paid/managed tiers; routes calls through the RapidAPI gateway.",
+        "required": false
+      }
+    ]
+  }
 ]


### PR DESCRIPTION
Adds Mnemoverse Memory to `documentation/static/servers.json`.

- **What it is:** persistent memory shared across AI tools: write a memory in one MCP client, recall it in another. Importance-scored writes, associative recall, feedback-tuned ranking.
- **Entry shape:** same as the AgentQL entry: `npx -y @mnemoverse/mcp-memory-server` with one required env var `MNEMOVERSE_API_KEY` (free key at console.mnemoverse.com, no credit card).
- **Provenance:** MIT, [repo](https://github.com/mnemoverse/mcp-memory-server), ~1,250 npm downloads/month, listed in the official MCP registry as `io.github.mnemoverse/mcp-memory-server` (v0.8.1, isLatest).
- JSON validated after the edit; inserted in alphabetical order; `endorsed` left `false`.

Happy to adjust the entry to any house rule I missed.