### PR TITLE
fix (provider): deprecated gemini oauth provider

### DIFF
--- a/crates/goose/src/providers/catalog_util.rs
+++ b/crates/goose/src/providers/catalog_util.rs
@@ -201,5 +201,6 @@ mod tests {
         assert!(!provider_ids.contains("claude_code"));
         assert!(!provider_ids.contains("codex"));
         assert!(!provider_ids.contains("gemini_cli"));
+        assert!(!provider_ids.contains("gemini_oauth"));
     }
 }

--- a/crates/goose/src/providers/catalog_util.rs
+++ b/crates/goose/src/providers/catalog_util.rs
@@ -201,6 +201,5 @@ mod tests {
         assert!(!provider_ids.contains("claude_code"));
         assert!(!provider_ids.contains("codex"));
         assert!(!provider_ids.contains("gemini_cli"));
-        assert!(!provider_ids.contains("gemini_oauth"));
     }
 }

--- a/crates/goose/src/providers/gemini_cli.rs
+++ b/crates/goose/src/providers/gemini_cli.rs
@@ -167,7 +167,7 @@ impl goose_providers::base::ProviderDescriptor for GeminiCliProvider {
         ProviderMetadata::new(
             GEMINI_CLI_PROVIDER_NAME,
             "Gemini CLI",
-            "[Deprecated: use gemini_oauth instead] Execute Gemini models via gemini CLI tool. Requires gemini CLI installed.",
+            "[Deprecated: use the Google or Vertex AI provider instead] Execute Gemini models via gemini CLI tool. Requires gemini CLI installed.",
             GEMINI_CLI_DEFAULT_MODEL,
             GEMINI_CLI_KNOWN_MODELS.to_vec(),
             GEMINI_CLI_DOC_URL,

--- a/crates/goose/src/providers/gemini_oauth.rs
+++ b/crates/goose/src/providers/gemini_oauth.rs
@@ -934,7 +934,7 @@ impl goose_providers::base::ProviderDescriptor for GeminiOAuthProvider {
         ProviderMetadata::new(
             GEMINI_OAUTH_PROVIDER_NAME,
             "Gemini",
-            "Sign in with your Google account to use Gemini models — no API key needed",
+            "[Deprecated: use the Google provider with a Gemini API key or Vertex AI instead] Sign in with your Google account to use Gemini models — no API key needed",
             GEMINI_OAUTH_DEFAULT_MODEL,
             GEMINI_OAUTH_KNOWN_MODELS.to_vec(),
             GOOGLE_DOC_URL,

--- a/crates/goose/src/providers/init.rs
+++ b/crates/goose/src/providers/init.rs
@@ -114,7 +114,7 @@ async fn init_registry() -> RwLock<ProviderRegistry> {
         );
         registry.register::<GeminiCliProvider>(false);
         registry.register_with_inventory::<GeminiOAuthProvider>(
-            true,
+            false,
             Some(registrations::gemini_oauth_inventory()),
         );
         registry.register_with_inventory::<GithubCopilotProvider>(

--- a/documentation/docs/guides/cli-providers.md
+++ b/documentation/docs/guides/cli-providers.md
@@ -8,10 +8,10 @@ description: Use Claude Code, Codex, Cursor Agent, or Gemini CLI subscriptions i
 # CLI Providers
 
 :::warning Deprecated — Use ACP Providers
-The Claude Code (`claude-code`), Codex (`codex`), and Gemini CLI (`gemini-cli`) providers are deprecated. Use the [ACP providers](/docs/guides/acp-providers) (`claude-acp`, `codex-acp`) instead, which support goose extensions via MCP and use the standardized Agent Client Protocol. For Gemini, use the `Gemini` (`gemini_oauth`) provider which authenticates via OAuth. CLI providers are kept for backward compatibility only.
+The Claude Code (`claude-code`), Codex (`codex`), Gemini CLI (`gemini-cli`), and Gemini OAuth (`gemini_oauth`) providers are deprecated. Use the [ACP providers](/docs/guides/acp-providers) (`claude-acp`, `codex-acp`) instead for Claude and Codex. For Gemini, use the [Google provider](/docs/getting-started/providers#google-gemini) with a Gemini API key or [Vertex AI](https://cloud.google.com/vertex-ai). Deprecated providers remain available for backward compatibility only.
 :::
 
-goose can make use of pass-through providers that integrate with existing CLI tools from Anthropic, OpenAI, Cursor, and Google. These providers allow you to use your existing Claude Code, Codex, Cursor Agent, and Google Gemini CLI subscriptions through goose's interface, adding session management, persistence, and workflow integration capabilities to these tools.
+goose can make use of pass-through providers that integrate with existing CLI tools from Anthropic, OpenAI, Cursor, and Google. These providers allow you to use your existing Claude Code, Codex, Cursor Agent, and Google Gemini CLI subscriptions through goose's interface, adding session management, persistence, and workflow integration capabilities to these tools. The Gemini OAuth provider is deprecated because Google no longer supports the underlying Code Assist login flow for some account types. See Google's [announcement](https://developers.googleblog.com/an-important-update-transitioning-gemini-cli-to-antigravity-cli/) and [deprecation notice](https://developers.google.com/gemini-code-assist/docs/deprecations/code-assist-individuals).
 
 :::warning Limitations
 These providers don’t fully support all goose features, may have platform or capability limitations, and can sometimes require advanced debugging if issues arise. They’re included here purely as a convenience.


### PR DESCRIPTION
## Summary
The gemini oauth provider is no longer working.  More info in https://github.com/aaif-goose/goose/issues/11206.  So we should deprecate it for now.

### Testing
CI

### Related Issues
Relates to https://github.com/aaif-goose/goose/issues/11206


