### PR TITLE
feat(session): goose session clear --older-than to delete old sessions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,7 +200,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -211,7 +211,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2500,7 +2500,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3740,7 +3740,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4040,7 +4040,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7210,7 +7210,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8726,7 +8726,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9369,7 +9369,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9427,7 +9427,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10429,7 +10429,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10704,7 +10704,7 @@ dependencies = [
  "cfg-if 1.0.4",
  "libc",
  "psm",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11557,7 +11557,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -13095,7 +13095,7 @@ checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -13386,7 +13386,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,7 +200,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -211,7 +211,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2500,7 +2500,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3740,7 +3740,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4040,7 +4040,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7210,7 +7210,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8726,7 +8726,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9369,7 +9369,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9427,7 +9427,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10429,7 +10429,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10704,7 +10704,7 @@ dependencies = [
  "cfg-if 1.0.4",
  "libc",
  "psm",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11557,7 +11557,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13386,7 +13386,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/goose-cli/src/cli.rs
+++ b/crates/goose-cli/src/cli.rs
@@ -546,6 +546,23 @@ enum SessionCommand {
         )]
         regex: Option<String>,
     },
+    #[command(about = "Delete sessions older than a given number of days")]
+    Clear {
+        #[arg(
+            long = "older-than",
+            value_name = "DAYS",
+            help = "Delete sessions whose last activity is older than this many days"
+        )]
+        older_than: u32,
+
+        #[arg(
+            short = 'y',
+            long = "yes",
+            help = "Skip the confirmation prompt",
+            default_value_t = false
+        )]
+        yes: bool,
+    },
     #[command(about = "Export a session")]
     Export {
         #[command(flatten)]
@@ -1541,6 +1558,9 @@ async fn handle_session_subcommand(command: SessionCommand) -> Result<()> {
                 (None, None)
             };
             handle_session_remove(session_id, name, regex).await?;
+        }
+        SessionCommand::Clear { older_than, yes } => {
+            crate::commands::session::handle_session_clear(older_than, yes).await?;
         }
         SessionCommand::Export {
             identifier,

--- a/crates/goose-cli/src/commands/session.rs
+++ b/crates/goose-cli/src/commands/session.rs
@@ -90,6 +90,42 @@ fn prompt_interactive_session_removal(sessions: &[Session]) -> Result<Vec<Sessio
     Ok(selected_sessions)
 }
 
+pub async fn handle_session_clear(older_than_days: u32, yes: bool) -> Result<()> {
+    if older_than_days == 0 {
+        return Err(anyhow::anyhow!("--older-than must be greater than 0"));
+    }
+
+    let session_manager = SessionManager::instance();
+    let cutoff = chrono::Utc::now() - chrono::Duration::days(older_than_days as i64);
+
+    if !yes {
+        let should_delete = confirm(format!(
+            "Delete all sessions older than {} day(s) (last activity before {})?",
+            older_than_days,
+            cutoff.format("%Y-%m-%d %H:%M UTC")
+        ))
+        .initial_value(false)
+        .interact()?;
+
+        if !should_delete {
+            println!("Skipping deletion of sessions.");
+            return Ok(());
+        }
+    }
+
+    let deleted = session_manager.delete_sessions_older_than(cutoff).await?;
+    if deleted == 0 {
+        println!("No sessions older than {} day(s) found.", older_than_days);
+    } else {
+        println!(
+            "Removed {} session(s) older than {} day(s).",
+            deleted, older_than_days
+        );
+    }
+
+    Ok(())
+}
+
 pub async fn handle_session_remove(
     session_id: Option<String>,
     name: Option<String>,

--- a/crates/goose-cli/src/commands/session.rs
+++ b/crates/goose-cli/src/commands/session.rs
@@ -96,11 +96,20 @@ pub async fn handle_session_clear(older_than_days: u32, yes: bool) -> Result<()>
     }
 
     let session_manager = SessionManager::instance();
-    let cutoff = chrono::Utc::now() - chrono::Duration::days(older_than_days as i64);
+    let cutoff = chrono::Utc::now()
+        .checked_sub_signed(chrono::Duration::days(older_than_days as i64))
+        .ok_or_else(|| anyhow::anyhow!("--older-than {} is too large", older_than_days))?;
 
     if !yes {
+        let matching = session_manager.count_sessions_older_than(cutoff).await?;
+        if matching == 0 {
+            println!("No sessions older than {} day(s) found.", older_than_days);
+            return Ok(());
+        }
+
         let should_delete = confirm(format!(
-            "Delete all sessions older than {} day(s) (last activity before {})?",
+            "Delete {} session(s) older than {} day(s) (last activity before {})?",
+            matching,
             older_than_days,
             cutoff.format("%Y-%m-%d %H:%M UTC")
         ))

--- a/crates/goose/src/config/base.rs
+++ b/crates/goose/src/config/base.rs
@@ -1151,17 +1151,6 @@ impl Config {
         }
     }
 
-    pub fn get_goose_session_retention_days(&self) -> Result<Option<u32>, ConfigError> {
-        match self.get_param::<u32>("GOOSE_SESSION_RETENTION_DAYS") {
-            Ok(0) => Err(ConfigError::DeserializeError(
-                "GOOSE_SESSION_RETENTION_DAYS must be greater than 0".to_string(),
-            )),
-            Ok(days) => Ok(Some(days)),
-            Err(ConfigError::NotFound(_)) => Ok(None),
-            Err(e) => Err(e),
-        }
-    }
-
     pub fn get_goose_max_tokens(&self) -> Result<Option<i32>, ConfigError> {
         match self.get_param::<i32>("GOOSE_MAX_TOKENS") {
             Ok(tokens) if tokens <= 0 => Err(ConfigError::DeserializeError(

--- a/crates/goose/src/config/base.rs
+++ b/crates/goose/src/config/base.rs
@@ -1151,6 +1151,17 @@ impl Config {
         }
     }
 
+    pub fn get_goose_session_retention_days(&self) -> Result<Option<u32>, ConfigError> {
+        match self.get_param::<u32>("GOOSE_SESSION_RETENTION_DAYS") {
+            Ok(0) => Err(ConfigError::DeserializeError(
+                "GOOSE_SESSION_RETENTION_DAYS must be greater than 0".to_string(),
+            )),
+            Ok(days) => Ok(Some(days)),
+            Err(ConfigError::NotFound(_)) => Ok(None),
+            Err(e) => Err(e),
+        }
+    }
+
     pub fn get_goose_max_tokens(&self) -> Result<Option<i32>, ConfigError> {
         match self.get_param::<i32>("GOOSE_MAX_TOKENS") {
             Ok(tokens) if tokens <= 0 => Err(ConfigError::DeserializeError(

--- a/crates/goose/src/session/session_manager.rs
+++ b/crates/goose/src/session/session_manager.rs
@@ -423,9 +423,24 @@ impl SessionManager {
         session_type: SessionType,
         goose_mode: GooseMode,
     ) -> Result<Session> {
+        self.maybe_spawn_retention_cleanup();
         self.storage
             .create_session(working_dir, name, session_type, goose_mode)
             .await
+    }
+
+    fn maybe_spawn_retention_cleanup(&self) {
+        static CLEANUP_STARTED: std::sync::atomic::AtomicBool =
+            std::sync::atomic::AtomicBool::new(false);
+        if CLEANUP_STARTED.swap(true, std::sync::atomic::Ordering::SeqCst) {
+            return;
+        }
+        let manager = Self {
+            storage: Arc::clone(&self.storage),
+        };
+        tokio::spawn(async move {
+            manager.run_retention_cleanup().await;
+        });
     }
 
     pub async fn get_session(&self, id: &str, include_messages: bool) -> Result<Session> {
@@ -469,6 +484,39 @@ impl SessionManager {
 
     pub async fn delete_session(&self, id: &str) -> Result<()> {
         self.storage.delete_session(id).await
+    }
+
+    /// Deletes all sessions whose last update is older than the cutoff.
+    /// Returns the number of sessions deleted.
+    pub async fn delete_sessions_older_than(&self, cutoff: DateTime<Utc>) -> Result<u64> {
+        self.storage.delete_sessions_older_than(cutoff).await
+    }
+
+    /// Runs retention cleanup if GOOSE_SESSION_RETENTION_DAYS is configured.
+    /// Best-effort: errors are logged, never propagated.
+    pub async fn run_retention_cleanup(&self) {
+        let retention_days =
+            match crate::config::Config::global().get_goose_session_retention_days() {
+                Ok(Some(days)) => days,
+                Ok(None) => return,
+                Err(e) => {
+                    tracing::warn!("Invalid GOOSE_SESSION_RETENTION_DAYS setting: {e}");
+                    return;
+                }
+            };
+
+        let cutoff = Utc::now() - chrono::Duration::days(retention_days as i64);
+        match self.delete_sessions_older_than(cutoff).await {
+            Ok(0) => {}
+            Ok(deleted) => {
+                tracing::info!(
+                    "Session retention cleanup removed {deleted} session(s) older than {retention_days} day(s)"
+                );
+            }
+            Err(e) => {
+                tracing::warn!("Session retention cleanup failed: {e}");
+            }
+        }
     }
 
     pub async fn get_insights(&self) -> Result<SessionInsights> {
@@ -2125,6 +2173,36 @@ impl SessionStorage {
 
         tx.commit().await?;
         Ok(())
+    }
+
+    async fn delete_sessions_older_than(&self, cutoff: DateTime<Utc>) -> Result<u64> {
+        let pool = self.pool().await?;
+        let mut tx = pool.begin_with("BEGIN IMMEDIATE").await?;
+
+        let cutoff_str = cutoff.format("%Y-%m-%d %H:%M:%S").to_string();
+
+        sqlx::query(
+            "DELETE FROM messages WHERE session_id IN (SELECT id FROM sessions WHERE updated_at < ?)",
+        )
+        .bind(&cutoff_str)
+        .execute(&mut *tx)
+        .await?;
+
+        sqlx::query(
+            "DELETE FROM usage_ledger WHERE session_id IN (SELECT id FROM sessions WHERE updated_at < ?)",
+        )
+        .bind(&cutoff_str)
+        .execute(&mut *tx)
+        .await?;
+
+        let deleted = sqlx::query("DELETE FROM sessions WHERE updated_at < ?")
+            .bind(&cutoff_str)
+            .execute(&mut *tx)
+            .await?
+            .rows_affected();
+
+        tx.commit().await?;
+        Ok(deleted)
     }
 
     async fn get_insights(&self, types: &[SessionType]) -> Result<SessionInsights> {
@@ -4567,6 +4645,68 @@ mod tests {
 
         sm.delete_session(&id).await.unwrap();
         assert!(sm.get_session(&id, false).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_delete_sessions_older_than_removes_old_sessions() {
+        let temp_dir = TempDir::new().unwrap();
+        let sm = SessionManager::new(temp_dir.path().to_path_buf());
+
+        let old_session = new_session(&sm).await;
+        let new_session_id = new_session(&sm).await;
+
+        seed_ledger(&sm, &old_session, &message_usage(100, 20, 0.10, false))
+            .await
+            .unwrap();
+        sm.add_message(&new_session_id, &Message::user().with_text("keep me"))
+            .await
+            .unwrap();
+
+        set_sessions_updated_at(
+            &sm,
+            std::slice::from_ref(&old_session),
+            "2020-01-01T00:00:00Z",
+        )
+        .await;
+
+        let cutoff = Utc::now() - chrono::Duration::days(30);
+        let deleted = sm.delete_sessions_older_than(cutoff).await.unwrap();
+        assert_eq!(deleted, 1);
+
+        assert!(sm.get_session(&old_session, false).await.is_err());
+        assert!(sm.get_session(&new_session_id, false).await.is_ok());
+
+        let pool = sm.storage().pool().await.unwrap();
+        let remaining_messages: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM messages WHERE session_id = ?")
+                .bind(&old_session)
+                .fetch_one(pool)
+                .await
+                .unwrap();
+        assert_eq!(remaining_messages, 0);
+        let remaining_ledger: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM usage_ledger WHERE session_id = ?")
+                .bind(&old_session)
+                .fetch_one(pool)
+                .await
+                .unwrap();
+        assert_eq!(remaining_ledger, 0);
+    }
+
+    #[tokio::test]
+    async fn test_delete_sessions_older_than_retains_recent_sessions() {
+        let temp_dir = TempDir::new().unwrap();
+        let sm = SessionManager::new(temp_dir.path().to_path_buf());
+
+        let a = new_session(&sm).await;
+        let b = new_session(&sm).await;
+
+        let cutoff = Utc::now() - chrono::Duration::days(7);
+        let deleted = sm.delete_sessions_older_than(cutoff).await.unwrap();
+        assert_eq!(deleted, 0);
+
+        assert!(sm.get_session(&a, false).await.is_ok());
+        assert!(sm.get_session(&b, false).await.is_ok());
     }
 
     #[tokio::test]

--- a/crates/goose/src/session/session_manager.rs
+++ b/crates/goose/src/session/session_manager.rs
@@ -471,7 +471,12 @@ impl SessionManager {
         self.storage.delete_session(id).await
     }
 
-    /// Deletes all sessions whose last update is older than the cutoff.
+    /// Counts sessions whose last activity is older than the cutoff.
+    pub async fn count_sessions_older_than(&self, cutoff: DateTime<Utc>) -> Result<u64> {
+        self.storage.count_sessions_older_than(cutoff).await
+    }
+
+    /// Deletes all sessions whose last activity is older than the cutoff.
     /// Returns the number of sessions deleted.
     pub async fn delete_sessions_older_than(&self, cutoff: DateTime<Utc>) -> Result<u64> {
         self.storage.delete_sessions_older_than(cutoff).await
@@ -706,6 +711,28 @@ fn normalized_message_timestamp_sql(column: &str) -> String {
 
 fn user_visible_message_sql(column: &str) -> String {
     format!("COALESCE(json_extract({column}, '$.userVisible'), 1) != 0")
+}
+
+/// Session ids whose last activity predates a bound cutoff (unix seconds).
+///
+/// Activity is the later of the newest message timestamp and `updated_at`.
+/// Listing uses `COALESCE(MAX(message), updated_at)`, which lets a stale message
+/// timestamp win; that is harmless for sort order but would delete a session the
+/// user just touched, so deletion takes the newer of the two signals instead.
+/// `unixepoch` normalizes both stored `updated_at` formats (space-separated and
+/// RFC 3339).
+fn sessions_older_than_ids_sql() -> String {
+    let normalized = normalized_message_timestamp_sql("m.created_timestamp");
+    format!(
+        "SELECT s.id FROM sessions s \
+         WHERE MAX( \
+             COALESCE( \
+                 (SELECT MAX({normalized}) FROM messages m WHERE m.session_id = s.id), \
+                 0 \
+             ), \
+             COALESCE(unixepoch(s.updated_at), 0) \
+         ) < ?"
+    )
 }
 
 fn session_sort_at(session: &Session) -> DateTime<Utc> {
@@ -2133,34 +2160,48 @@ impl SessionStorage {
         Ok(())
     }
 
+    async fn count_sessions_older_than(&self, cutoff: DateTime<Utc>) -> Result<u64> {
+        let pool = self.pool().await?;
+        let sql = format!("SELECT COUNT(*) FROM ({})", sessions_older_than_ids_sql());
+        let count: i64 = sqlx::query_scalar(AssertSqlSafe(sql))
+            .bind(cutoff.timestamp())
+            .fetch_one(pool)
+            .await?;
+        Ok(count as u64)
+    }
+
     async fn delete_sessions_older_than(&self, cutoff: DateTime<Utc>) -> Result<u64> {
         let pool = self.pool().await?;
         let mut tx = pool.begin_with("BEGIN IMMEDIATE").await?;
 
-        let cutoff_str = cutoff.format("%Y-%m-%d %H:%M:%S").to_string();
+        // Resolve the id set before deleting: the activity expression reads
+        // `messages`, so re-evaluating it after those rows are gone would narrow
+        // the set and leave emptied-out sessions behind.
+        let stale_ids: Vec<String> =
+            sqlx::query_scalar(AssertSqlSafe(sessions_older_than_ids_sql()))
+                .bind(cutoff.timestamp())
+                .fetch_all(&mut *tx)
+                .await?;
 
-        sqlx::query(
-            "DELETE FROM messages WHERE session_id IN (SELECT id FROM sessions WHERE updated_at < ?)",
-        )
-        .bind(&cutoff_str)
-        .execute(&mut *tx)
-        .await?;
+        for id in &stale_ids {
+            sqlx::query("DELETE FROM messages WHERE session_id = ?")
+                .bind(id)
+                .execute(&mut *tx)
+                .await?;
 
-        sqlx::query(
-            "DELETE FROM usage_ledger WHERE session_id IN (SELECT id FROM sessions WHERE updated_at < ?)",
-        )
-        .bind(&cutoff_str)
-        .execute(&mut *tx)
-        .await?;
+            sqlx::query("DELETE FROM usage_ledger WHERE session_id = ?")
+                .bind(id)
+                .execute(&mut *tx)
+                .await?;
 
-        let deleted = sqlx::query("DELETE FROM sessions WHERE updated_at < ?")
-            .bind(&cutoff_str)
-            .execute(&mut *tx)
-            .await?
-            .rows_affected();
+            sqlx::query("DELETE FROM sessions WHERE id = ?")
+                .bind(id)
+                .execute(&mut *tx)
+                .await?;
+        }
 
         tx.commit().await?;
-        Ok(deleted)
+        Ok(stale_ids.len() as u64)
     }
 
     async fn get_insights(&self, types: &[SessionType]) -> Result<SessionInsights> {
@@ -4665,6 +4706,131 @@ mod tests {
 
         assert!(sm.get_session(&a, false).await.is_ok());
         assert!(sm.get_session(&b, false).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_delete_sessions_older_than_retains_sessions_with_recent_messages() {
+        let temp_dir = TempDir::new().unwrap();
+        let sm = SessionManager::new(temp_dir.path().to_path_buf());
+
+        let stale_updated_at = new_session(&sm).await;
+        add_message_at(
+            &sm,
+            &stale_updated_at,
+            "recent activity",
+            &(Utc::now() - chrono::Duration::days(1)).to_rfc3339(),
+        )
+        .await;
+        set_sessions_updated_at(
+            &sm,
+            std::slice::from_ref(&stale_updated_at),
+            "2020-01-01T00:00:00Z",
+        )
+        .await;
+
+        let cutoff = Utc::now() - chrono::Duration::days(30);
+        assert_eq!(sm.count_sessions_older_than(cutoff).await.unwrap(), 0);
+        assert_eq!(sm.delete_sessions_older_than(cutoff).await.unwrap(), 0);
+        assert!(sm.get_session(&stale_updated_at, false).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_delete_sessions_older_than_retains_recently_touched_with_old_messages() {
+        let temp_dir = TempDir::new().unwrap();
+        let sm = SessionManager::new(temp_dir.path().to_path_buf());
+
+        let recently_touched = new_session(&sm).await;
+        add_message_at(
+            &sm,
+            &recently_touched,
+            "ancient message",
+            "2020-01-01T00:00:00Z",
+        )
+        .await;
+
+        let cutoff = Utc::now() - chrono::Duration::days(30);
+        assert_eq!(sm.count_sessions_older_than(cutoff).await.unwrap(), 0);
+        assert_eq!(sm.delete_sessions_older_than(cutoff).await.unwrap(), 0);
+        assert!(sm.get_session(&recently_touched, false).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_delete_sessions_older_than_leaves_no_orphaned_rows() {
+        let temp_dir = TempDir::new().unwrap();
+        let sm = SessionManager::new(temp_dir.path().to_path_buf());
+
+        let stale = new_session(&sm).await;
+        add_message_at(&sm, &stale, "ancient message", "2020-01-01T00:00:00Z").await;
+        seed_ledger(&sm, &stale, &message_usage(100, 20, 0.10, false))
+            .await
+            .unwrap();
+        set_sessions_updated_at(&sm, std::slice::from_ref(&stale), "2020-01-01T00:00:00Z").await;
+
+        let cutoff = Utc::now() - chrono::Duration::days(30);
+        assert_eq!(sm.delete_sessions_older_than(cutoff).await.unwrap(), 1);
+        assert!(sm.get_session(&stale, false).await.is_err());
+
+        let pool = sm.storage().pool().await.unwrap();
+        for table in ["messages", "usage_ledger"] {
+            let orphaned: i64 = sqlx::query_scalar(AssertSqlSafe(format!(
+                "SELECT COUNT(*) FROM {table} WHERE session_id NOT IN (SELECT id FROM sessions)"
+            )))
+            .fetch_one(pool)
+            .await
+            .unwrap();
+            assert_eq!(orphaned, 0, "{table} left orphaned rows");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_delete_sessions_older_than_normalizes_millisecond_message_timestamps() {
+        let temp_dir = TempDir::new().unwrap();
+        let sm = SessionManager::new(temp_dir.path().to_path_buf());
+
+        let stale = new_session(&sm).await;
+        add_message_at_millis(&sm, &stale, "ancient", "2020-01-01T00:00:00Z").await;
+        set_sessions_updated_at(&sm, std::slice::from_ref(&stale), "2020-01-01T00:00:00Z").await;
+
+        let recent = new_session(&sm).await;
+        add_message_at_millis(
+            &sm,
+            &recent,
+            "fresh",
+            &(Utc::now() - chrono::Duration::days(1)).to_rfc3339(),
+        )
+        .await;
+        set_sessions_updated_at(&sm, std::slice::from_ref(&recent), "2020-01-01T00:00:00Z").await;
+
+        let cutoff = Utc::now() - chrono::Duration::days(30);
+        assert_eq!(sm.count_sessions_older_than(cutoff).await.unwrap(), 1);
+        assert_eq!(sm.delete_sessions_older_than(cutoff).await.unwrap(), 1);
+        assert!(sm.get_session(&stale, false).await.is_err());
+        assert!(sm.get_session(&recent, false).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_delete_sessions_older_than_handles_rfc3339_updated_at() {
+        let temp_dir = TempDir::new().unwrap();
+        let sm = SessionManager::new(temp_dir.path().to_path_buf());
+
+        // Same calendar date as the cutoff, so a lexicographic string compare is
+        // decided by 'T' (0x54) vs the space (0x20) in the cutoff's format and
+        // wrongly retains this session.
+        let legacy = new_session(&sm).await;
+        let pool = sm.storage().pool().await.unwrap();
+        sqlx::query("UPDATE sessions SET updated_at = ? WHERE id = ?")
+            .bind("2026-07-21T01:00:00Z")
+            .bind(&legacy)
+            .execute(pool)
+            .await
+            .unwrap();
+
+        let cutoff = chrono::DateTime::parse_from_rfc3339("2026-07-21T12:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        assert_eq!(sm.count_sessions_older_than(cutoff).await.unwrap(), 1);
+        assert_eq!(sm.delete_sessions_older_than(cutoff).await.unwrap(), 1);
+        assert!(sm.get_session(&legacy, false).await.is_err());
     }
 
     #[tokio::test]

--- a/crates/goose/src/session/session_manager.rs
+++ b/crates/goose/src/session/session_manager.rs
@@ -423,24 +423,9 @@ impl SessionManager {
         session_type: SessionType,
         goose_mode: GooseMode,
     ) -> Result<Session> {
-        self.maybe_spawn_retention_cleanup();
         self.storage
             .create_session(working_dir, name, session_type, goose_mode)
             .await
-    }
-
-    fn maybe_spawn_retention_cleanup(&self) {
-        static CLEANUP_STARTED: std::sync::atomic::AtomicBool =
-            std::sync::atomic::AtomicBool::new(false);
-        if CLEANUP_STARTED.swap(true, std::sync::atomic::Ordering::SeqCst) {
-            return;
-        }
-        let manager = Self {
-            storage: Arc::clone(&self.storage),
-        };
-        tokio::spawn(async move {
-            manager.run_retention_cleanup().await;
-        });
     }
 
     pub async fn get_session(&self, id: &str, include_messages: bool) -> Result<Session> {
@@ -490,33 +475,6 @@ impl SessionManager {
     /// Returns the number of sessions deleted.
     pub async fn delete_sessions_older_than(&self, cutoff: DateTime<Utc>) -> Result<u64> {
         self.storage.delete_sessions_older_than(cutoff).await
-    }
-
-    /// Runs retention cleanup if GOOSE_SESSION_RETENTION_DAYS is configured.
-    /// Best-effort: errors are logged, never propagated.
-    pub async fn run_retention_cleanup(&self) {
-        let retention_days =
-            match crate::config::Config::global().get_goose_session_retention_days() {
-                Ok(Some(days)) => days,
-                Ok(None) => return,
-                Err(e) => {
-                    tracing::warn!("Invalid GOOSE_SESSION_RETENTION_DAYS setting: {e}");
-                    return;
-                }
-            };
-
-        let cutoff = Utc::now() - chrono::Duration::days(retention_days as i64);
-        match self.delete_sessions_older_than(cutoff).await {
-            Ok(0) => {}
-            Ok(deleted) => {
-                tracing::info!(
-                    "Session retention cleanup removed {deleted} session(s) older than {retention_days} day(s)"
-                );
-            }
-            Err(e) => {
-                tracing::warn!("Session retention cleanup failed: {e}");
-            }
-        }
     }
 
     pub async fn get_insights(&self) -> Result<SessionInsights> {


### PR DESCRIPTION
## Summary

Adds a **single CLI command** to manually delete old sessions:

```
goose session clear --older-than <DAYS> [--yes|-y]
```

Deletes sessions whose last activity predates the cutoff. Confirmation prompt shows how many sessions match before asking (skipped with `-y`), prints the deleted count, and rejects `--older-than 0`.

### What this does NOT add

- **No automatic / time-based / background deletion** — deletion happens only when a user runs the command
- **No Desktop UI** — deferred intentionally, no `ui/desktop/` or `goose-server` code touched
- **No HTTP endpoint and no new config keys** — `GOOSE_SESSION_RETENTION_DAYS` from an earlier revision of this PR is gone entirely

### Implementation

- `crates/goose-cli/src/cli.rs` — `SessionCommand::Clear { older_than, yes }`
- `crates/goose-cli/src/commands/session.rs` — `handle_session_clear`, the only production caller
- `crates/goose/src/session/session_manager.rs` — `count_sessions_older_than` and `delete_sessions_older_than`; deletes `messages` → `usage_ledger` → `sessions` in one `BEGIN IMMEDIATE` transaction, mirroring the existing single-session delete

### How "last activity" is defined

This was the substantive review finding, so it is worth stating precisely. An earlier revision keyed the cutoff on `sessions.updated_at` alone and claimed recently-active sessions were "protected by definition." That was wrong: `list_sessions` computes activity as `COALESCE(MAX(m.created_timestamp), unixepoch(s.updated_at))`, and `replace_conversation_inner` writes message rows without touching `updated_at` — so a session the UI showed as recent could be irreversibly deleted.

The predicate now takes the **later of** the newest message timestamp and `updated_at`. Note this is deliberately *not* identical to the listing expression: listing's `COALESCE` lets a stale message timestamp override a fresh `updated_at`, which is harmless for sort order but would delete a session the user just touched. Deletion takes the newer of the two signals so both paths protect a session.

Also fixed in the same pass:

- Timestamps are compared as normalized epochs rather than raw strings. `import_legacy_session` can store `updated_at` as RFC 3339 with a `T`, and SQLite compares lexicographically, so `'T'` (0x54) vs the cutoff's space (0x20) previously retained legacy sessions a day too long.
- The stale id set is resolved *before* any deletes, since the activity expression reads `messages` and would otherwise narrow mid-transaction and leave emptied-out sessions behind.
- `Utc::now() - Duration::days(u32)` → `checked_sub_signed`, so a large `--older-than` returns an error instead of panicking before the prompt.

### Testing

Unit tests in `session_manager.rs`:

- `test_delete_sessions_older_than_removes_old_sessions`
- `test_delete_sessions_older_than_retains_recent_sessions`
- `test_delete_sessions_older_than_retains_sessions_with_recent_messages` — stale `updated_at`, recent message → retained
- `test_delete_sessions_older_than_retains_recently_touched_with_old_messages` — old message, fresh `updated_at` → retained
- `test_delete_sessions_older_than_normalizes_millisecond_message_timestamps` — ms-format `created_timestamp` on both sides of the cutoff
- `test_delete_sessions_older_than_handles_rfc3339_updated_at` — same-date cutoff, so the `T`-vs-space byte is what decides
- `test_delete_sessions_older_than_leaves_no_orphaned_rows` — no dangling `messages` / `usage_ledger` rows

Each regression test was verified to **fail** against the previous `updated_at`-string predicate, not just to pass against the new one.

Also run: `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo check --workspace --locked --all-targets`, and the full `cargo test -p goose` / `-p goose-cli` suites. All 136 `session::` tests pass. The remaining `cargo test -p goose` failures (gcpauth/jsonwebtoken CryptoProvider, config env tests) reproduce identically on a clean `origin/main` worktree and are unrelated to this change.

### Cargo.lock

Regenerated to fix a dangling `syn 2.0.118` reference on `main` that made `cargo check --locked` fail, plus `h2` 0.4.15 → 0.4.17 to clear RUSTSEC-2026-0258 for `cargo deny`. A previous push also contained 13 `windows-sys` downgrades; those were an artifact of `cargo update -p` on a non-Windows host and have been reverted — the lock diff is now 4 lines.

### Out of scope (follow-ups)

Automatic retention, Desktop UI, onboarding retention prompt with a 30-day default, scheduled-session sidebar filtering, incognito/unlogged mode, DB-size-based limits, clear-by-range UX.

Note that `clear` sweeps all session types, including scheduled/recipe sessions — sidebar/type filtering is part of the deferred work above.

### Related Issues

Part of #10961

Deliberately **not** `Fixes` — @davidnugent2425 asked that the initial PR not close the issue, and @Mic agreed follow-on PRs are the approach. #10697 and #10530 were closed as duplicates *into* #10961, so auto-closing it would leave the scheduled-session work with no tracking issue.

### Screenshots/Demos (for UX changes)

N/A — CLI command; covered by unit tests.
