### PR TITLE
feat(providers): replace Z.ai GLM-5.2 with GLM-5.3

### DIFF
--- a/crates/goose-providers/src/declarative/definitions/zai.json
+++ b/crates/goose-providers/src/declarative/definitions/zai.json
@@ -19,6 +19,7 @@
   "fast_model": "glm-4.5-air",
   "preserves_thinking": true,
   "models": [
+    {"name": "glm-5.3", "context_limit": 1000000},
     {"name": "glm-5.2", "context_limit": 1000000},
     {"name": "glm-5.1", "context_limit": 200000},
     {"name": "glm-5", "context_limit": 204800},

--- a/crates/goose-providers/src/declarative/definitions/zai.json
+++ b/crates/goose-providers/src/declarative/definitions/zai.json
@@ -21,7 +21,6 @@
   "models": [
     {"name": "glm-5.3[1m]", "context_limit": 1000000},
     {"name": "glm-5.3", "context_limit": 200000},
-    {"name": "glm-5.2", "context_limit": 1000000},
     {"name": "glm-5.1", "context_limit": 200000},
     {"name": "glm-5", "context_limit": 204800},
     {"name": "glm-5-turbo", "context_limit": 200000},

--- a/crates/goose-providers/src/declarative/definitions/zai.json
+++ b/crates/goose-providers/src/declarative/definitions/zai.json
@@ -19,7 +19,8 @@
   "fast_model": "glm-4.5-air",
   "preserves_thinking": true,
   "models": [
-    {"name": "glm-5.3", "context_limit": 1000000},
+    {"name": "glm-5.3[1m]", "context_limit": 1000000},
+    {"name": "glm-5.3", "context_limit": 200000},
     {"name": "glm-5.2", "context_limit": 1000000},
     {"name": "glm-5.1", "context_limit": 200000},
     {"name": "glm-5", "context_limit": 204800},

--- a/crates/goose-providers/src/declarative/definitions/zai.json
+++ b/crates/goose-providers/src/declarative/definitions/zai.json
@@ -19,8 +19,7 @@
   "fast_model": "glm-4.5-air",
   "preserves_thinking": true,
   "models": [
-    {"name": "glm-5.3[1m]", "context_limit": 1000000},
-    {"name": "glm-5.3", "context_limit": 200000},
+    {"name": "glm-5.3[1m]", "context_limit": 1000000, "reasoning": true},
     {"name": "glm-5.1", "context_limit": 200000},
     {"name": "glm-5", "context_limit": 204800},
     {"name": "glm-5-turbo", "context_limit": 200000},

--- a/crates/goose-providers/src/declarative/definitions/zhipu.json
+++ b/crates/goose-providers/src/declarative/definitions/zhipu.json
@@ -11,7 +11,7 @@
       "required": false,
       "secret": false,
       "default": "https://open.bigmodel.cn/api/paas/v4",
-      "description": "Zhipu API base URL. Change to https://open.bigmodel.cn/api/coding/paas/v4 for Coding Plan models like GLM-5.2."
+      "description": "Zhipu API base URL. Change to https://open.bigmodel.cn/api/coding/paas/v4 for Coding Plan models like GLM-5.3."
     }
   ],
   "catalog_provider_id": "zhipuai",
@@ -23,7 +23,8 @@
     {"name": "glm-4.7", "context_limit": 204800},
     {"name": "glm-4.7-flash", "context_limit": 200000},
     {"name": "glm-5", "context_limit": 204800},
-    {"name": "glm-5.2", "context_limit": 1000000, "reasoning": true}
+    {"name": "glm-5.2", "context_limit": 1000000, "reasoning": true},
+    {"name": "glm-5.3", "context_limit": 1000000, "reasoning": true}
   ],
   "preserves_thinking": true,
   "supports_streaming": true

--- a/crates/goose-providers/src/declarative/definitions/zhipu.json
+++ b/crates/goose-providers/src/declarative/definitions/zhipu.json
@@ -23,7 +23,6 @@
     {"name": "glm-4.7", "context_limit": 204800},
     {"name": "glm-4.7-flash", "context_limit": 200000},
     {"name": "glm-5", "context_limit": 204800},
-    {"name": "glm-5.2", "context_limit": 1000000, "reasoning": true},
     {"name": "glm-5.3", "context_limit": 1000000, "reasoning": true}
   ],
   "preserves_thinking": true,


### PR DESCRIPTION
## Summary

Replace `glm-5.2` with GLM-5.3 in the Z.AI/Zhipu provider definitions — the flagship lineup goes `glm-5.1` → `glm-5.3`.

Z.AI consolidated the GLM-5 line onto GLM-5.3: on the Coding Plan endpoints, requesting `glm-5`, `glm-5.1` or `glm-5.2` all serve `glm-5.3` weights (verified with live API calls returning `"model": "glm-5.3"`), and no pinned 5.2 snapshot exists.

- `zai.json` (Anthropic-compatible, `api.z.ai/api/anthropic`): add `glm-5.3[1m]` (1M context, reasoning) — the documented 1M route for Anthropic-compatible clients — and remove `glm-5.2`. The bare 200K `glm-5.3` id listed by an earlier revision of this PR was dropped during review, leaving `glm-5.3[1m]` as the single 5.3 entry.
- `zhipu.json` (OpenAI-compatible, `open.bigmodel.cn`): add `glm-5.3` (1M, reasoning — bare id; the OpenAI-compatible endpoints list no `[1m]` id); remove `glm-5.2`.

### Testing

- Manually tested API (live requests to the Z.AI/Zhipu endpoints; `GET /api/coding/paas/v4/models` listings checked on both hosts).
- `cargo fmt --check`, `cargo clippy -p goose-providers --all-targets -- -D warnings`, and `cargo test -p goose-providers` pass (two network-dependent tests fail identically on an unmodified tree — pre-existing, unrelated).