### PR TITLE
Add Kin to the extensions registry

### DIFF
--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -398,6 +398,17 @@
     "environmentVariables": []
   },
   {
+    "id": "kin",
+    "name": "Kin",
+    "description": "Semantic code retrieval over a graph of entities, relationships, changes, and provenance",
+    "command": "npx -y @kinlab/kin-mcp",
+    "link": "https://github.com/firelock-ai/kin",
+    "installation_notes": "Install using npx package manager. Requires a Kin repo in your project. Run kin init . first, or set KIN_MCP_AUTO_INIT=1 to let the wrapper create one.",
+    "is_builtin": false,
+    "endorsed": false,
+    "environmentVariables": []
+  },
+  {
     "id": "knowledge_graph_memory",
     "name": "Knowledge Graph Memory",
     "description": "Graph-based memory system for persistent knowledge storage",


### PR DESCRIPTION
## Summary

Kin keeps a persistent graph of a codebase's entities, relationships, changes, and provenance, so an agent can ask what a change touches instead of searching for it by name.

This adds one entry to `documentation/static/servers.json` so Kin appears in the extension directory and the Extension Manager. It's a stdio server run through npx with no required environment variables, inserted alphabetically between `jetbrains` and `knowledge_graph_memory`. No other entries change.

Install:

```sh
goose session --with-extension "npx -y @kinlab/kin-mcp"
```

Kin reads a repo's graph, so run `kin init .` in your project first, or set `KIN_MCP_AUTO_INIT=1` and the npx wrapper will create one. The entry's installation notes say the same thing.

- Package: https://www.npmjs.com/package/@kinlab/kin-mcp
- Source: https://github.com/firelock-ai/kin
- Install guide: https://kinlab.ai/install

### Testing

Confirmed the file still parses as JSON, that the new entry is between `jetbrains` and `knowledge_graph_memory`, and that the diff is 11 added lines with no other entry touched. Ran `npx -y @kinlab/kin-mcp` from a clean directory to check the published package resolves and starts, and that without a Kin repo it exits with the message the installation notes describe.
