### PR TITLE
fix(core): compact with the main session model, not the fast model

### DIFF
--- a/crates/goose/src/context_mgmt/mod.rs
+++ b/crates/goose/src/context_mgmt/mod.rs
@@ -276,20 +276,20 @@ pub async fn check_if_compaction_needed(
     Ok(needs_compaction)
 }
 
-struct FastCompactionModel<'a> {
+struct GooseCompactionModel<'a> {
     provider: &'a dyn Provider,
     model_config: &'a ModelConfig,
     session_id: &'a str,
 }
 
 #[async_trait::async_trait]
-impl goose_context_management::CompactionModel for FastCompactionModel<'_> {
+impl goose_context_management::CompactionModel for GooseCompactionModel<'_> {
     async fn complete(
         &self,
         system: &str,
         messages: &[Message],
     ) -> Result<(Message, ProviderUsage), ProviderError> {
-        crate::model_config::complete_fast(
+        crate::model_config::complete_compaction(
             self.provider,
             self.model_config,
             self.session_id,
@@ -348,7 +348,7 @@ async fn do_compact(
     )
     .agent_visible_messages();
 
-    let model = FastCompactionModel {
+    let model = GooseCompactionModel {
         provider,
         model_config,
         session_id,
@@ -475,7 +475,7 @@ pub async fn summarize_tool_call(
                 if that is what it was.
             "#};
 
-    let (mut response, _) = crate::model_config::complete_fast(
+    let (mut response, _) = crate::model_config::complete_compaction(
         provider,
         model_config,
         session_id,

--- a/crates/goose/src/model_config.rs
+++ b/crates/goose/src/model_config.rs
@@ -78,16 +78,38 @@ fn materialize_model_config_inner(
     Ok(model)
 }
 
-fn configured_fast_model_name() -> Option<String> {
+fn configured_model_name(key: &str) -> Option<String> {
     Config::global()
-        .get_param::<String>("GOOSE_FAST_MODEL")
+        .get_param::<String>(key)
         .ok()
         .map(|v| v.trim().to_string())
         .filter(|v| !v.is_empty())
 }
 
+fn configured_fast_model_name() -> Option<String> {
+    configured_model_name("GOOSE_FAST_MODEL")
+}
+
+fn configured_compaction_model_name() -> Option<String> {
+    configured_model_name("GOOSE_COMPACTION_MODEL")
+}
+
+fn resolve_override_model(
+    override_name: Option<String>,
+    provider_name: &str,
+    model_config: &ModelConfig,
+) -> Result<ModelConfig> {
+    match override_name {
+        Some(name) if name != model_config.model_name => {
+            model_config_from_user_config(provider_name, name)
+                .map(|config| config.with_request_headers(model_config.request_headers.clone()))
+        }
+        _ => Ok(model_config.clone()),
+    }
+}
+
 /// Resolve the model config to use for lightweight "fast" tasks (session
-/// naming, compaction, summarization). Resolution order:
+/// naming, tool-call labels, orchestrator routing). Resolution order:
 ///   1. `GOOSE_FAST_MODEL` (user override)
 ///   2. the provider's declared default fast model
 ///   3. the supplied `model_config` (i.e. the main model)
@@ -103,17 +125,11 @@ pub async fn get_fast_model(
         None => provider_default_fast_model(provider_name).await,
     };
 
-    match fast_model_name {
-        Some(name) if name != model_config.model_name => {
-            model_config_from_user_config(provider_name, name)
-                .map(|config| config.with_request_headers(model_config.request_headers.clone()))
-        }
-        _ => Ok(model_config.clone()),
-    }
+    resolve_override_model(fast_model_name, provider_name, model_config)
 }
 
-/// Fast tasks summarize a transcript or tool result that never recurs, so a prompt
-/// cache entry written for one can never be read back and only costs the
+/// A one-shot task summarizes a transcript or tool result that never recurs, so
+/// a prompt cache entry written for it can never be read back and only costs the
 /// cache-write premium.
 fn one_shot_model_config(model_config: ModelConfig) -> ModelConfig {
     model_config
@@ -121,9 +137,24 @@ fn one_shot_model_config(model_config: ModelConfig) -> ModelConfig {
         .with_prompt_cache_disabled()
 }
 
-/// Run a completion for a lightweight "fast" task (session naming, compaction,
-/// summarization) using the provider's fast model, falling back to the supplied
-/// main `model_config` if the fast model errors.
+/// Resolve the model config to use for compaction and tool-result
+/// summarization. Resolution order:
+///   1. `GOOSE_COMPACTION_MODEL` (user override)
+///   2. the supplied `model_config` (i.e. the main model)
+pub fn get_compaction_model(
+    provider_name: &str,
+    model_config: &ModelConfig,
+) -> Result<ModelConfig> {
+    resolve_override_model(
+        configured_compaction_model_name(),
+        provider_name,
+        model_config,
+    )
+}
+
+/// Run a completion for a lightweight "fast" task (session naming, tool-call
+/// labels, orchestrator routing) using the provider's fast model, falling back
+/// to the supplied main `model_config` if the fast model errors.
 pub async fn complete_fast(
     provider: &dyn Provider,
     model_config: &ModelConfig,
@@ -132,23 +163,71 @@ pub async fn complete_fast(
     messages: &[Message],
     tools: &[Tool],
 ) -> Result<(Message, ProviderUsage), ProviderError> {
-    let fast_model_config = one_shot_model_config(
-        get_fast_model(provider.get_name(), model_config)
-            .await
-            .map_err(|e| ProviderError::ExecutionError(e.to_string()))?,
-    );
+    let fast_model_config = get_fast_model(provider.get_name(), model_config)
+        .await
+        .map_err(|e| ProviderError::ExecutionError(e.to_string()))?;
+
+    complete_with_main_fallback(
+        provider,
+        fast_model_config,
+        model_config,
+        session_id,
+        system,
+        messages,
+        tools,
+    )
+    .await
+}
+
+/// Run a completion for compaction or tool-result summarization on the model
+/// resolved by [`get_compaction_model`], with one-shot semantics (thinking off,
+/// no prompt-cache writes). An explicitly overridden compaction model falls
+/// back to the main `model_config` if it errors.
+pub async fn complete_compaction(
+    provider: &dyn Provider,
+    model_config: &ModelConfig,
+    session_id: &str,
+    system: &str,
+    messages: &[Message],
+    tools: &[Tool],
+) -> Result<(Message, ProviderUsage), ProviderError> {
+    let compaction_model_config = get_compaction_model(provider.get_name(), model_config)
+        .map_err(|e| ProviderError::ExecutionError(e.to_string()))?;
+
+    complete_with_main_fallback(
+        provider,
+        compaction_model_config,
+        model_config,
+        session_id,
+        system,
+        messages,
+        tools,
+    )
+    .await
+}
+
+async fn complete_with_main_fallback(
+    provider: &dyn Provider,
+    task_model_config: ModelConfig,
+    model_config: &ModelConfig,
+    session_id: &str,
+    system: &str,
+    messages: &[Message],
+    tools: &[Tool],
+) -> Result<(Message, ProviderUsage), ProviderError> {
+    let task_model_config = one_shot_model_config(task_model_config);
 
     match crate::session_context::with_session_id(
         Some(session_id.to_string()),
-        provider.complete(&fast_model_config, system, messages, tools),
+        provider.complete(&task_model_config, system, messages, tools),
     )
     .await
     {
         Ok(response) => Ok(response),
-        Err(e) if fast_model_config.model_name != model_config.model_name => {
+        Err(e) if task_model_config.model_name != model_config.model_name => {
             tracing::warn!(
-                "Fast model {} failed with error: {}. Falling back to main model {}",
-                fast_model_config.model_name,
+                "Model {} failed with error: {}. Falling back to main model {}",
+                task_model_config.model_name,
                 e,
                 model_config.model_name
             );
@@ -276,6 +355,74 @@ mod one_shot_tests {
     #[test]
     fn prompt_cache_is_disabled() {
         assert!(one_shot_model_config(ModelConfig::new("claude-haiku-4-5")).prompt_cache_disabled());
+    }
+}
+
+#[cfg(test)]
+mod compaction_model_tests {
+    use super::*;
+    use serial_test::serial;
+
+    struct EnvGuard {
+        keys: Vec<&'static str>,
+    }
+
+    impl EnvGuard {
+        fn set(vars: &[(&'static str, &str)]) -> Self {
+            for (key, value) in vars {
+                std::env::set_var(key, value);
+            }
+            Self {
+                keys: vars.iter().map(|(key, _)| *key).collect(),
+            }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            for key in &self.keys {
+                std::env::remove_var(key);
+            }
+        }
+    }
+
+    fn main_model() -> ModelConfig {
+        ModelConfig::new("gpt-5.1")
+    }
+
+    #[test]
+    fn override_matching_main_model_keeps_main_config() {
+        let main = main_model().with_context_limit(Some(9999));
+        let resolved =
+            resolve_override_model(Some("gpt-5.1".to_string()), "openai", &main).unwrap();
+        assert_eq!(resolved.model_name, "gpt-5.1");
+        assert_eq!(resolved.context_limit, Some(9999));
+    }
+
+    // Env vars shadow the config file in `Config::get_param`, so setting them
+    // (blank included) makes these tests independent of the local config file.
+    #[test]
+    #[serial(compaction_model_env)]
+    fn compaction_model_env_var_wins_over_fast_model() {
+        let _guard = EnvGuard::set(&[
+            ("GOOSE_COMPACTION_MODEL", "gpt-5.1-mini"),
+            ("GOOSE_FAST_MODEL", "gpt-4o-mini"),
+        ]);
+
+        let resolved = get_compaction_model("openai", &main_model()).unwrap();
+        assert_eq!(resolved.model_name, "gpt-5.1-mini");
+    }
+
+    #[test]
+    #[serial(compaction_model_env)]
+    fn fast_model_does_not_affect_compaction() {
+        let _guard = EnvGuard::set(&[
+            ("GOOSE_COMPACTION_MODEL", "   "),
+            ("GOOSE_FAST_MODEL", "gpt-4o-mini"),
+        ]);
+
+        let resolved = get_compaction_model("openai", &main_model()).unwrap();
+        assert_eq!(resolved.model_name, "gpt-5.1");
     }
 }
 

--- a/crates/goose/src/model_config.rs
+++ b/crates/goose/src/model_config.rs
@@ -78,34 +78,12 @@ fn materialize_model_config_inner(
     Ok(model)
 }
 
-fn configured_model_name(key: &str) -> Option<String> {
+fn configured_fast_model_name() -> Option<String> {
     Config::global()
-        .get_param::<String>(key)
+        .get_param::<String>("GOOSE_FAST_MODEL")
         .ok()
         .map(|v| v.trim().to_string())
         .filter(|v| !v.is_empty())
-}
-
-fn configured_fast_model_name() -> Option<String> {
-    configured_model_name("GOOSE_FAST_MODEL")
-}
-
-fn configured_compaction_model_name() -> Option<String> {
-    configured_model_name("GOOSE_COMPACTION_MODEL")
-}
-
-fn resolve_override_model(
-    override_name: Option<String>,
-    provider_name: &str,
-    model_config: &ModelConfig,
-) -> Result<ModelConfig> {
-    match override_name {
-        Some(name) if name != model_config.model_name => {
-            model_config_from_user_config(provider_name, name)
-                .map(|config| config.with_request_headers(model_config.request_headers.clone()))
-        }
-        _ => Ok(model_config.clone()),
-    }
 }
 
 /// Resolve the model config to use for lightweight "fast" tasks (session
@@ -125,7 +103,13 @@ pub async fn get_fast_model(
         None => provider_default_fast_model(provider_name).await,
     };
 
-    resolve_override_model(fast_model_name, provider_name, model_config)
+    match fast_model_name {
+        Some(name) if name != model_config.model_name => {
+            model_config_from_user_config(provider_name, name)
+                .map(|config| config.with_request_headers(model_config.request_headers.clone()))
+        }
+        _ => Ok(model_config.clone()),
+    }
 }
 
 /// A one-shot task summarizes a transcript or tool result that never recurs, so
@@ -135,19 +119,6 @@ fn one_shot_model_config(model_config: ModelConfig) -> ModelConfig {
     model_config
         .with_thinking_effort(ThinkingEffort::Off)
         .with_prompt_cache_disabled()
-}
-
-/// Resolve the model config for compaction and tool-result summarization:
-/// `GOOSE_COMPACTION_MODEL` if set, otherwise the supplied main `model_config`.
-pub fn get_compaction_model(
-    provider_name: &str,
-    model_config: &ModelConfig,
-) -> Result<ModelConfig> {
-    resolve_override_model(
-        configured_compaction_model_name(),
-        provider_name,
-        model_config,
-    )
 }
 
 /// Run a completion for a lightweight "fast" task (session naming, tool-call
@@ -161,70 +132,23 @@ pub async fn complete_fast(
     messages: &[Message],
     tools: &[Tool],
 ) -> Result<(Message, ProviderUsage), ProviderError> {
-    let fast_model_config = get_fast_model(provider.get_name(), model_config)
-        .await
-        .map_err(|e| ProviderError::ExecutionError(e.to_string()))?;
-
-    complete_with_main_fallback(
-        provider,
-        fast_model_config,
-        model_config,
-        session_id,
-        system,
-        messages,
-        tools,
-    )
-    .await
-}
-
-/// Run a completion for compaction or tool-result summarization on the model
-/// resolved by [`get_compaction_model`], falling back to the supplied main
-/// `model_config` if an overridden compaction model errors.
-pub async fn complete_compaction(
-    provider: &dyn Provider,
-    model_config: &ModelConfig,
-    session_id: &str,
-    system: &str,
-    messages: &[Message],
-    tools: &[Tool],
-) -> Result<(Message, ProviderUsage), ProviderError> {
-    let compaction_model_config = get_compaction_model(provider.get_name(), model_config)
-        .map_err(|e| ProviderError::ExecutionError(e.to_string()))?;
-
-    complete_with_main_fallback(
-        provider,
-        compaction_model_config,
-        model_config,
-        session_id,
-        system,
-        messages,
-        tools,
-    )
-    .await
-}
-
-async fn complete_with_main_fallback(
-    provider: &dyn Provider,
-    task_model_config: ModelConfig,
-    model_config: &ModelConfig,
-    session_id: &str,
-    system: &str,
-    messages: &[Message],
-    tools: &[Tool],
-) -> Result<(Message, ProviderUsage), ProviderError> {
-    let task_model_config = one_shot_model_config(task_model_config);
+    let fast_model_config = one_shot_model_config(
+        get_fast_model(provider.get_name(), model_config)
+            .await
+            .map_err(|e| ProviderError::ExecutionError(e.to_string()))?,
+    );
 
     match crate::session_context::with_session_id(
         Some(session_id.to_string()),
-        provider.complete(&task_model_config, system, messages, tools),
+        provider.complete(&fast_model_config, system, messages, tools),
     )
     .await
     {
         Ok(response) => Ok(response),
-        Err(e) if task_model_config.model_name != model_config.model_name => {
+        Err(e) if fast_model_config.model_name != model_config.model_name => {
             tracing::warn!(
-                "Model {} failed with error: {}. Falling back to main model {}",
-                task_model_config.model_name,
+                "Fast model {} failed with error: {}. Falling back to main model {}",
+                fast_model_config.model_name,
                 e,
                 model_config.model_name
             );
@@ -237,6 +161,25 @@ async fn complete_with_main_fallback(
         }
         Err(e) => Err(e),
     }
+}
+
+/// Run a completion for compaction or tool-result summarization on the main
+/// session model with one-shot semantics (thinking off, no prompt-cache writes).
+pub async fn complete_compaction(
+    provider: &dyn Provider,
+    model_config: &ModelConfig,
+    session_id: &str,
+    system: &str,
+    messages: &[Message],
+    tools: &[Tool],
+) -> Result<(Message, ProviderUsage), ProviderError> {
+    let compaction_model_config = one_shot_model_config(model_config.clone());
+
+    crate::session_context::with_session_id(
+        Some(session_id.to_string()),
+        provider.complete(&compaction_model_config, system, messages, tools),
+    )
+    .await
 }
 
 async fn provider_default_fast_model(provider_name: &str) -> Option<String> {
@@ -352,63 +295,6 @@ mod one_shot_tests {
     #[test]
     fn prompt_cache_is_disabled() {
         assert!(one_shot_model_config(ModelConfig::new("claude-haiku-4-5")).prompt_cache_disabled());
-    }
-}
-
-#[cfg(test)]
-mod compaction_model_tests {
-    use super::*;
-    use serial_test::serial;
-
-    struct EnvGuard {
-        keys: Vec<&'static str>,
-    }
-
-    impl EnvGuard {
-        fn set(vars: &[(&'static str, &str)]) -> Self {
-            for (key, value) in vars {
-                std::env::set_var(key, value);
-            }
-            Self {
-                keys: vars.iter().map(|(key, _)| *key).collect(),
-            }
-        }
-    }
-
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            for key in &self.keys {
-                std::env::remove_var(key);
-            }
-        }
-    }
-
-    fn main_model() -> ModelConfig {
-        ModelConfig::new("gpt-5.1")
-    }
-
-    #[test]
-    #[serial(compaction_model_env)]
-    fn compaction_model_env_var_wins_over_fast_model() {
-        let _guard = EnvGuard::set(&[
-            ("GOOSE_COMPACTION_MODEL", "gpt-5.1-mini"),
-            ("GOOSE_FAST_MODEL", "gpt-4o-mini"),
-        ]);
-
-        let resolved = get_compaction_model("openai", &main_model()).unwrap();
-        assert_eq!(resolved.model_name, "gpt-5.1-mini");
-    }
-
-    #[test]
-    #[serial(compaction_model_env)]
-    fn fast_model_does_not_affect_compaction() {
-        let _guard = EnvGuard::set(&[
-            ("GOOSE_COMPACTION_MODEL", "   "),
-            ("GOOSE_FAST_MODEL", "gpt-4o-mini"),
-        ]);
-
-        let resolved = get_compaction_model("openai", &main_model()).unwrap();
-        assert_eq!(resolved.model_name, "gpt-5.1");
     }
 }
 

--- a/crates/goose/src/model_config.rs
+++ b/crates/goose/src/model_config.rs
@@ -137,10 +137,8 @@ fn one_shot_model_config(model_config: ModelConfig) -> ModelConfig {
         .with_prompt_cache_disabled()
 }
 
-/// Resolve the model config to use for compaction and tool-result
-/// summarization. Resolution order:
-///   1. `GOOSE_COMPACTION_MODEL` (user override)
-///   2. the supplied `model_config` (i.e. the main model)
+/// Resolve the model config for compaction and tool-result summarization:
+/// `GOOSE_COMPACTION_MODEL` if set, otherwise the supplied main `model_config`.
 pub fn get_compaction_model(
     provider_name: &str,
     model_config: &ModelConfig,
@@ -180,9 +178,8 @@ pub async fn complete_fast(
 }
 
 /// Run a completion for compaction or tool-result summarization on the model
-/// resolved by [`get_compaction_model`], with one-shot semantics (thinking off,
-/// no prompt-cache writes). An explicitly overridden compaction model falls
-/// back to the main `model_config` if it errors.
+/// resolved by [`get_compaction_model`], falling back to the supplied main
+/// `model_config` if an overridden compaction model errors.
 pub async fn complete_compaction(
     provider: &dyn Provider,
     model_config: &ModelConfig,
@@ -390,17 +387,6 @@ mod compaction_model_tests {
         ModelConfig::new("gpt-5.1")
     }
 
-    #[test]
-    fn override_matching_main_model_keeps_main_config() {
-        let main = main_model().with_context_limit(Some(9999));
-        let resolved =
-            resolve_override_model(Some("gpt-5.1".to_string()), "openai", &main).unwrap();
-        assert_eq!(resolved.model_name, "gpt-5.1");
-        assert_eq!(resolved.context_limit, Some(9999));
-    }
-
-    // Env vars shadow the config file in `Config::get_param`, so setting them
-    // (blank included) makes these tests independent of the local config file.
     #[test]
     #[serial(compaction_model_env)]
     fn compaction_model_env_var_wins_over_fast_model() {

--- a/documentation/docs/guides/environment-variables.md
+++ b/documentation/docs/guides/environment-variables.md
@@ -19,7 +19,6 @@ These are the minimum required variables to get started with goose.
 | `GOOSE_PROVIDER` | Specifies the LLM provider to use | [See available providers](/docs/getting-started/providers#available-providers) | None (must be [configured](/docs/getting-started/providers#configure-provider-and-model)) |
 | `GOOSE_MODEL` | Specifies which model to use from the provider | Model name (e.g., "gpt-4", "claude-sonnet-4-20250514") | None (must be [configured](/docs/getting-started/providers#configure-provider-and-model)) |
 | `GOOSE_FAST_MODEL` | Overrides the provider's default fast model used for auxiliary calls (tool-selection, classification, session titles) | Model name (e.g., "gpt-4o-mini", "google/gemini-2.5-flash") | Provider-specific default |
-| `GOOSE_COMPACTION_MODEL` | Overrides the model used for context compaction and summarization | Model name (e.g., "gpt-5.1-mini") | The main model (`GOOSE_MODEL`) |
 | `GOOSE_TEMPERATURE` | Sets the [temperature](https://medium.com/@kelseyywang/a-comprehensive-guide-to-llm-temperature-%EF%B8%8F-363a40bbc91f) for model responses | Float between 0.0 and 1.0 | Model-specific default |
 | `GOOSE_MAX_TOKENS` | Sets the maximum number of tokens for each model response (truncates longer responses) | Positive integer (e.g., 4096, 8192) | Model-specific default |
 

--- a/documentation/docs/guides/environment-variables.md
+++ b/documentation/docs/guides/environment-variables.md
@@ -19,6 +19,7 @@ These are the minimum required variables to get started with goose.
 | `GOOSE_PROVIDER` | Specifies the LLM provider to use | [See available providers](/docs/getting-started/providers#available-providers) | None (must be [configured](/docs/getting-started/providers#configure-provider-and-model)) |
 | `GOOSE_MODEL` | Specifies which model to use from the provider | Model name (e.g., "gpt-4", "claude-sonnet-4-20250514") | None (must be [configured](/docs/getting-started/providers#configure-provider-and-model)) |
 | `GOOSE_FAST_MODEL` | Overrides the provider's default fast model used for auxiliary calls (tool-selection, classification, session titles) | Model name (e.g., "gpt-4o-mini", "google/gemini-2.5-flash") | Provider-specific default |
+| `GOOSE_COMPACTION_MODEL` | Overrides the model used for context compaction and summarization | Model name (e.g., "gpt-5.1-mini") | The main model (`GOOSE_MODEL`) |
 | `GOOSE_TEMPERATURE` | Sets the [temperature](https://medium.com/@kelseyywang/a-comprehensive-guide-to-llm-temperature-%EF%B8%8F-363a40bbc91f) for model responses | Float between 0.0 and 1.0 | Model-specific default |
 | `GOOSE_MAX_TOKENS` | Sets the maximum number of tokens for each model response (truncates longer responses) | Positive integer (e.g., 4096, 8192) | Model-specific default |
 


### PR DESCRIPTION
## Summary
Compaction and tool-result summarization now run on the main session model instead of the fast model (with thinking off and prompt-cache writes disabled, as before). `GOOSE_FAST_MODEL` still covers the genuinely lightweight tasks: session naming, tool-call labels, orchestrator routing.

The compaction summary is the foundation for every token generated after it, so it deserves the strongest model available - and since compaction runs rarely, fires when the context is at its largest, and was already falling back to the main model on Anthropic, the fast-model discount bought inconsistency and summary-quality risk for almost no saving.

### Related Issues
Fixes #11187
