### PR TITLE
GOOSE-11201: added support for arm on Linux

### DIFF
--- a/.github/workflows/bundle-desktop-linux.yml
+++ b/.github/workflows/bundle-desktop-linux.yml
@@ -24,22 +24,51 @@ permissions:
 
 jobs:
   build-desktop-linux:
-    name: Build Desktop (Linux, ${{ matrix.variant }})
+    name: Build Desktop (Linux, ${{ matrix.variant }}, ${{ matrix.architecture }})
     runs-on: ${{ matrix.build-on }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - variant: standard
+            architecture: x64
             build-on: ubuntu-22.04
+          - variant: standard
+            architecture: arm64
+            build-on: ubuntu-22.04-arm
           - variant: vulkan
+            architecture: x64
             build-on: ubuntu-24.04
+          # arm64 Vulkan is intentionally excluded for now due to concerns about unused
+          # builds eating up release time. When vulkan compat is desired, we can add it.
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           ref: ${{ inputs.ref }}
+
+      # This block resolves path and package naming outside the matrix
+      # to keep it clean. At time of writing, the outlier is flatpak.
+      - name: Resolve architecture-derived build variables
+        run: |
+          case "${{ matrix.architecture }}" in
+            x64)
+              echo "TARGET=x86_64-unknown-linux-gnu" >> "$GITHUB_ENV"
+              echo "FLATPAK_ARCH=x86_64" >> "$GITHUB_ENV"
+              ;;
+            arm64)
+              echo "TARGET=aarch64-unknown-linux-gnu" >> "$GITHUB_ENV"
+              # electron-forge's flatpak maker translates arm64 -> aarch64 for its
+              # own output directory and Flatpak ref naming; the deb/rpm makers
+              # use the raw electron arch name instead.
+              echo "FLATPAK_ARCH=aarch64" >> "$GITHUB_ENV"
+              ;;
+            *)
+              echo "::error::Unknown matrix.architecture '${{ matrix.architecture }}'"
+              exit 1
+              ;;
+          esac
 
       - name: Update versions
         if: ${{ inputs.version != '' }}
@@ -126,7 +155,6 @@ jobs:
           RUST_BACKTRACE: 1
         run: |
           source ./bin/activate-hermit
-          export TARGET="x86_64-unknown-linux-gnu"
           rustup target add "${TARGET}"
           FEATURE_ARGS=()
           if [ "${{ matrix.variant }}" = "vulkan" ]; then
@@ -138,7 +166,6 @@ jobs:
       - name: Copy backend binary into Electron folder
         run: |
           echo "Copying backend binary to ui/desktop/src/bin/"
-          export TARGET="x86_64-unknown-linux-gnu"
           mkdir -p ui/desktop/src/bin
           rm -f ui/desktop/src/bin/goose
           cp target/$TARGET/release/goose ui/desktop/src/bin/
@@ -156,9 +183,9 @@ jobs:
           path: |
             ui/desktop/node_modules
             .hermit/node/cache
-          key: linux-pnpm-cache-v1-${{ runner.os }}-${{ hashFiles('ui/pnpm-lock.yaml') }}
+          key: linux-pnpm-cache-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('ui/pnpm-lock.yaml') }}
           restore-keys: |
-            linux-pnpm-cache-v1-${{ runner.os }}-
+            linux-pnpm-cache-v1-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Install pnpm dependencies
         run: |
@@ -177,10 +204,10 @@ jobs:
           echo "Building Linux packages (.deb, .rpm, and .flatpak) for ${{ matrix.variant }}..."
 
           # Build all configured packages
-          pnpm run make --platform=linux --arch=x64
+          pnpm run make --platform=linux --arch=${{ matrix.architecture }}
 
           if [ "${{ matrix.variant }}" = "vulkan" ]; then
-            for package in out/make/deb/x64/*.deb out/make/rpm/x64/*.rpm out/make/flatpak/x86_64/*.flatpak; do
+            for package in out/make/deb/${{ matrix.architecture }}/*.deb out/make/rpm/${{ matrix.architecture }}/*.rpm out/make/flatpak/$FLATPAK_ARCH/*.flatpak; do
               [ -e "$package" ] || continue
               extension="${package##*.}"
               base="${package%.*}"
@@ -188,7 +215,7 @@ jobs:
             done
           fi
 
-          for package in out/make/rpm/x64/*.rpm; do
+          for package in out/make/rpm/${{ matrix.architecture }}/*.rpm; do
             package_contents="$(rpm -qlp "$package")"
             if grep -qE '^/usr/lib/\.build-id(/|$)' <<< "$package_contents"; then
               echo "::error file=$package::RPM contains build-id links"
@@ -215,46 +242,46 @@ jobs:
         if: matrix.variant == 'standard'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: Goose-linux-x64-deb
-          path: ui/desktop/out/make/deb/x64/*.deb
+          name: Goose-linux-${{ matrix.architecture }}-deb
+          path: ui/desktop/out/make/deb/${{ matrix.architecture }}/*.deb
           if-no-files-found: error
 
       - name: Upload .deb package (Vulkan)
         if: matrix.variant == 'vulkan'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: Goose-linux-x64-vulkan-deb
-          path: ui/desktop/out/make/deb/x64/*-vulkan.deb
+          name: Goose-linux-${{ matrix.architecture }}-vulkan-deb
+          path: ui/desktop/out/make/deb/${{ matrix.architecture }}/*-vulkan.deb
           if-no-files-found: error
 
       - name: Upload .rpm package
         if: matrix.variant == 'standard'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: Goose-linux-x64-rpm
-          path: ui/desktop/out/make/rpm/x64/*.rpm
+          name: Goose-linux-${{ matrix.architecture }}-rpm
+          path: ui/desktop/out/make/rpm/${{ matrix.architecture }}/*.rpm
           if-no-files-found: error
 
       - name: Upload .rpm package (Vulkan)
         if: matrix.variant == 'vulkan'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: Goose-linux-x64-vulkan-rpm
-          path: ui/desktop/out/make/rpm/x64/*-vulkan.rpm
+          name: Goose-linux-${{ matrix.architecture }}-vulkan-rpm
+          path: ui/desktop/out/make/rpm/${{ matrix.architecture }}/*-vulkan.rpm
           if-no-files-found: error
 
       - name: Upload .flatpak package
         if: matrix.variant == 'standard'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: Goose-linux-x64-flatpak
-          path: ui/desktop/out/make/flatpak/x86_64/*.flatpak
+          name: Goose-linux-${{ matrix.architecture }}-flatpak
+          path: ui/desktop/out/make/flatpak/${{ env.FLATPAK_ARCH }}/*.flatpak
           if-no-files-found: error
 
       - name: Upload .flatpak package (Vulkan)
         if: matrix.variant == 'vulkan'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: Goose-linux-x64-vulkan-flatpak
-          path: ui/desktop/out/make/flatpak/x86_64/*-vulkan.flatpak
+          name: Goose-linux-${{ matrix.architecture }}-vulkan-flatpak
+          path: ui/desktop/out/make/flatpak/${{ env.FLATPAK_ARCH }}/*-vulkan.flatpak
           if-no-files-found: error

--- a/documentation/src/components/LinuxDesktopInstallButtons.js
+++ b/documentation/src/components/LinuxDesktopInstallButtons.js
@@ -6,6 +6,28 @@ const FALLBACK_URL = "https://github.com/aaif-goose/goose/releases/latest";
 
 const isStandardLinuxAsset = (asset) => !asset.name.includes('-vulkan');
 
+// Package-type naming is inconsistent between architectures: rpm/flatpak use the
+// translated arch name for x64 (x86_64) but rpm keeps the raw "arm64" token while
+// flatpak translates to "aarch64"; deb uses "amd64"/"arm64". Verified against real
+// release assets and a local arm64 build rather than assumed.
+const ARCH_ASSET_TOKENS = {
+  x64: { deb: 'amd64', rpm: 'x86_64', flatpak: 'x86_64' },
+  arm64: { deb: 'arm64', rpm: 'arm64', flatpak: 'aarch64' },
+};
+
+const detectLinuxArch = async () => {
+  if (typeof navigator === 'undefined') return 'x64';
+  try {
+    if (navigator.userAgentData?.getHighEntropyValues) {
+      const { architecture } = await navigator.userAgentData.getHighEntropyValues(['architecture']);
+      if (architecture) return /arm/i.test(architecture) ? 'arm64' : 'x64';
+    }
+  } catch {
+    // Fall through to User-Agent sniffing below.
+  }
+  return /aarch64|arm64/i.test(navigator.userAgent || '') ? 'arm64' : 'x64';
+};
+
 const LinuxDesktopInstallButtons = () => {
   const [downloadUrls, setDownloadUrls] = useState({
     deb: FALLBACK_URL,
@@ -16,9 +38,14 @@ const LinuxDesktopInstallButtons = () => {
   useEffect(() => {
     const fetchLatestRelease = async () => {
       try {
+        const arch = await detectLinuxArch();
+        const tokens = ARCH_ASSET_TOKENS[arch];
+        const cacheKey = `goose-release-cache-${arch}`;
+        const cacheTimeKey = `goose-release-cache-time-${arch}`;
+
         // Check cache first (1 hour expiry)
-        const cached = localStorage.getItem('goose-release-cache');
-        const cacheTime = localStorage.getItem('goose-release-cache-time');
+        const cached = localStorage.getItem(cacheKey);
+        const cacheTime = localStorage.getItem(cacheTimeKey);
         const now = Date.now();
 
         if (cached && cacheTime && (now - parseInt(cacheTime)) < 3600000) {
@@ -34,15 +61,15 @@ const LinuxDesktopInstallButtons = () => {
         const release = await response.json();
         const assets = release.assets || [];
 
-        // Find DEB, RPM, and Flatpak files
+        // Find DEB, RPM, and Flatpak files matching the visitor's architecture
         const debAsset = assets.find(asset =>
-          isStandardLinuxAsset(asset) && asset.name.includes('.deb') && asset.name.includes('amd64')
+          isStandardLinuxAsset(asset) && asset.name.includes('.deb') && asset.name.includes(tokens.deb)
         );
         const rpmAsset = assets.find(asset =>
-          isStandardLinuxAsset(asset) && asset.name.includes('.rpm') && asset.name.includes('x86_64')
+          isStandardLinuxAsset(asset) && asset.name.includes('.rpm') && asset.name.includes(tokens.rpm)
         );
         const flatpakAsset = assets.find(asset =>
-          isStandardLinuxAsset(asset) && asset.name.endsWith('.flatpak')
+          isStandardLinuxAsset(asset) && asset.name.endsWith('.flatpak') && asset.name.includes(tokens.flatpak)
         );
 
         const newUrls = {
@@ -53,8 +80,8 @@ const LinuxDesktopInstallButtons = () => {
 
         // Update state and cache
         setDownloadUrls(newUrls);
-        localStorage.setItem('goose-release-cache', JSON.stringify(newUrls));
-        localStorage.setItem('goose-release-cache-time', now.toString());
+        localStorage.setItem(cacheKey, JSON.stringify(newUrls));
+        localStorage.setItem(cacheTimeKey, now.toString());
       } catch (error) {
         console.warn('Failed to fetch latest release, using fallback URLs:', error);
         // Fallback URLs are already set in initial state


### PR DESCRIPTION
## Summary
The Goose desktop client app generates builds based on a yaml file per OS, each of which has a small matrix of build options (i.e. Intel vs Apple Silicon for MacOS). In the Linux build file, we add one dimension to that matrix based on common package distribution methods across the Linux community (i.e. .flatpak vs .deb). Each build spec follows a similar pattern but their development appears to be based on demand rather than completion (i.e. MacOS but not Windows support for ARM because everyone and their mom is developing on Apple Silicon these days). This change expands the Linux build file's matrix to include a processor architecture dimension, enabling support for both x86 and ARM systems. 

Admittedly, most Linux users in the short term will be on x86 - market trends show enthusiasts bailing on Windows desktop for Linux - rather than on ARM. However, I'm writing this from a DGX Spark which is a new class of local-AI machines that ships with Linux on ARM for consumers. It's practically perfect for the Goose + roam design: plug in a power-efficient machine and let it work while you control it from your phone or laptop.

### Testing
I've tested the build locally. See screenshot for a functioning goose desktop experience on ARM Linux after building it locally based on the release pattern.
<img width="2494" height="1408" alt="Screenshot from 2026-08-15 13-59-43" src="https://github.com/user-attachments/assets/4b809f0a-3907-4100-b1b0-465504c2d144" />
What I don't have permission to test is the actual release job in Github. That would tell us if my change is not safe for existing release artifacts.

### Related Issues
Relates to #11201
