### PR TITLE
fix(openrouter): escape Gemini tool response ref keys

### DIFF
--- a/crates/goose/src/providers/openrouter.rs
+++ b/crates/goose/src/providers/openrouter.rs
@@ -105,25 +105,43 @@ fn is_gemini_model(model_name: &str) -> bool {
     model_name.starts_with("google/gemini")
 }
 
-fn is_json_object_key(content: &str, start: usize, end: usize) -> bool {
-    let follows_object_delimiter = content.as_bytes()[..start]
-        .iter()
-        .rev()
-        .find(|byte| !matches!(byte, b' ' | b'\t' | b'\r' | b'\n'))
-        .is_some_and(|byte| matches!(byte, b'{' | b','));
-    let precedes_colon = content.as_bytes()[end..]
-        .iter()
-        .find(|byte| !matches!(byte, b' ' | b'\t' | b'\r' | b'\n'))
-        == Some(&b':');
-
-    follows_object_delimiter && precedes_colon
+fn contains_json_object_key(value: &Value, key: &str) -> bool {
+    match value {
+        Value::Object(object) => {
+            object.contains_key(key)
+                || object
+                    .values()
+                    .any(|value| contains_json_object_key(value, key))
+        }
+        Value::Array(array) => array
+            .iter()
+            .any(|value| contains_json_object_key(value, key)),
+        _ => false,
+    }
 }
 
-fn contains_json_object_key(content: &str, key: &str) -> bool {
-    let token = format!("\"{key}\"");
-    content
-        .match_indices(&token)
-        .any(|(start, matched)| is_json_object_key(content, start, start + matched.len()))
+fn rename_json_object_key(value: &mut Value, source_key: &str, target_key: &str) -> usize {
+    match value {
+        Value::Object(object) => {
+            let mut renamed = 0;
+            let original = std::mem::take(object);
+            for (key, mut value) in original {
+                renamed += rename_json_object_key(&mut value, source_key, target_key);
+                if key == source_key {
+                    object.insert(target_key.to_string(), value);
+                    renamed += 1;
+                } else {
+                    object.insert(key, value);
+                }
+            }
+            renamed
+        }
+        Value::Array(array) => array
+            .iter_mut()
+            .map(|value| rename_json_object_key(value, source_key, target_key))
+            .sum(),
+        _ => 0,
+    }
 }
 
 fn collision_free_gemini_schema_ref_key(messages: &[Value]) -> String {
@@ -138,7 +156,8 @@ fn collision_free_gemini_schema_ref_key(messages: &[Value]) -> String {
                 && message
                     .get("content")
                     .and_then(Value::as_str)
-                    .is_some_and(|content| contains_json_object_key(content, &candidate))
+                    .and_then(|content| serde_json::from_str::<Value>(content).ok())
+                    .is_some_and(|content| contains_json_object_key(&content, &candidate))
         });
         if !collision {
             return candidate;
@@ -164,15 +183,14 @@ fn apply_gemini_compatibility(model_name: &str, payload: &mut Value, messages: &
 /// OpenRouter translates OpenAI `role: tool` messages into Gemini
 /// `function_response` parts. Gemini rejects a response containing a literal
 /// JSON Schema `$ref` key, treating its value as a function-response part name
-/// instead of arbitrary tool text. Escape only double-quoted key occurrences,
-/// only in Gemini-bound tool results, and add a reversible note so the model
-/// can reconstruct the original text.
+/// instead of arbitrary tool text. Escape only keys in complete JSON tool
+/// results and add a reversible note so the model can reconstruct the original
+/// text. Non-JSON tool output must remain byte-for-byte unchanged.
 fn escape_gemini_schema_ref_keys_in_tool_responses(payload: &mut Value) -> usize {
     let Some(messages) = payload.get("messages").and_then(Value::as_array) else {
         return 0;
     };
     let safe_key = collision_free_gemini_schema_ref_key(messages);
-    let source_token = format!("\"{GEMINI_SCHEMA_REF_KEY}\"");
     let note = gemini_schema_ref_note(&safe_key);
 
     let Some(messages) = payload.get_mut("messages").and_then(Value::as_array_mut) else {
@@ -191,35 +209,17 @@ fn escape_gemini_schema_ref_keys_in_tool_responses(payload: &mut Value) -> usize
         let Some(content_text) = content.as_str() else {
             continue;
         };
-        let mut sanitized = String::with_capacity(content_text.len());
-        let mut copied_through = 0;
-        let mut message_escaped = 0;
-        for (start, matched) in content_text.match_indices(&source_token) {
-            let end = start + matched.len();
-            if !is_json_object_key(content_text, start, end) {
-                continue;
-            }
-
-            sanitized.push_str(
-                content_text
-                    .get(copied_through..start)
-                    .expect("match indices must be UTF-8 boundaries"),
-            );
-            sanitized.push('"');
-            sanitized.push_str(&safe_key);
-            sanitized.push('"');
-            copied_through = end;
-            message_escaped += 1;
-        }
+        let Ok(mut parsed_content) = serde_json::from_str::<Value>(content_text) else {
+            continue;
+        };
+        let message_escaped =
+            rename_json_object_key(&mut parsed_content, GEMINI_SCHEMA_REF_KEY, &safe_key);
         if message_escaped == 0 {
             continue;
         }
 
-        sanitized.push_str(
-            content_text
-                .get(copied_through..)
-                .expect("match indices must be UTF-8 boundaries"),
-        );
+        let sanitized = serde_json::to_string(&parsed_content)
+            .expect("JSON values must serialize successfully");
         *content = Value::String(format!("{note}{sanitized}"));
         escaped += message_escaped;
     }
@@ -591,14 +591,14 @@ mod tests {
                 {
                     "role": "tool",
                     "tool_call_id": "call_1",
-                    "content": "schema: {\"$ref\": \"#/components/schemas/Usage\", \"nested\": {\"$ref\" : \"#/components/schemas/Base64Image\"}, \"description\": \"use $ref here\", \"literal\": \"$ref\", \"identifier\": \"$reference\"}"
+                    "content": "{\"$ref\": \"#/components/schemas/Usage\", \"nested\": {\"$ref\" : \"#/components/schemas/Base64Image\"}, \"items\": [{\"$ref\": \"#/components/schemas/Item\"}], \"description\": \"use $ref here\", \"literal\": \"$ref\", \"identifier\": \"$reference\"}"
                 }
             ]
         });
 
         assert_eq!(
             escape_gemini_schema_ref_keys_in_tool_responses(&mut payload),
-            2
+            3
         );
         assert_eq!(
             payload["messages"][0]["content"],
@@ -607,7 +607,7 @@ mod tests {
         assert_eq!(
             payload["messages"][1]["content"],
             format!(
-                "{}schema: {{\"dollar_ref\": \"#/components/schemas/Usage\", \"nested\": {{\"dollar_ref\" : \"#/components/schemas/Base64Image\"}}, \"description\": \"use $ref here\", \"literal\": \"$ref\", \"identifier\": \"$reference\"}}",
+                "{}{{\"dollar_ref\":\"#/components/schemas/Usage\",\"nested\":{{\"dollar_ref\":\"#/components/schemas/Base64Image\"}},\"items\":[{{\"dollar_ref\":\"#/components/schemas/Item\"}}],\"description\":\"use $ref here\",\"literal\":\"$ref\",\"identifier\":\"$reference\"}}",
                 gemini_schema_ref_note("dollar_ref")
             )
         );
@@ -648,12 +648,30 @@ mod tests {
     }
 
     #[test]
-    fn gemini_schema_ref_escape_leaves_values_and_prose_unchanged() {
+    fn gemini_schema_ref_escape_leaves_values_unchanged() {
         let mut payload = json!({
             "messages": [{
                 "role": "tool",
                 "tool_call_id": "call_1",
-                "content": "{\"description\":\"use $ref here\",\"literal\":\"$ref\",\"identifier\":\"$reference\"}\nshell output: use $ref here\nprose: \"$ref\": not a JSON key"
+                "content": "{\"description\":\"use $ref here\",\"literal\":\"$ref\",\"identifier\":\"$reference\"}"
+            }]
+        });
+        let original = payload.clone();
+
+        assert_eq!(
+            escape_gemini_schema_ref_keys_in_tool_responses(&mut payload),
+            0
+        );
+        assert_eq!(payload, original);
+    }
+
+    #[test]
+    fn gemini_schema_ref_escape_leaves_non_json_prose_unchanged() {
+        let mut payload = json!({
+            "messages": [{
+                "role": "tool",
+                "tool_call_id": "call_1",
+                "content": "log entry, \"$ref\": not a JSON key"
             }]
         });
         let original = payload.clone();

--- a/crates/goose/src/providers/openrouter.rs
+++ b/crates/goose/src/providers/openrouter.rs
@@ -38,10 +38,8 @@ pub const OPENROUTER_KNOWN_MODELS: &[&str] = &[
 ];
 pub const OPENROUTER_DOC_URL: &str = "https://openrouter.ai/models";
 
-const GEMINI_SCHEMA_REF_KEY_TOKEN: &str = "\"$ref\"";
-const GEMINI_SAFE_SCHEMA_REF_KEY: &str = "dollar_ref";
-const GEMINI_SCHEMA_REF_NOTE: &str =
-    "[OpenRouter/Gemini compatibility: interpret `dollar_ref` as the JSON Schema key formed by `$` followed by `ref`.]\n";
+const GEMINI_SCHEMA_REF_KEY: &str = "$ref";
+const GEMINI_SAFE_SCHEMA_REF_KEY_BASE: &str = "dollar_ref";
 
 #[derive(serde::Serialize)]
 pub struct OpenRouterProvider {
@@ -107,6 +105,55 @@ fn is_gemini_model(model_name: &str) -> bool {
     model_name.starts_with("google/")
 }
 
+fn is_json_object_key(content: &str, start: usize, end: usize) -> bool {
+    let follows_object_delimiter = content.as_bytes()[..start]
+        .iter()
+        .rev()
+        .find(|byte| !matches!(byte, b' ' | b'\t' | b'\r' | b'\n'))
+        .is_some_and(|byte| matches!(byte, b'{' | b','));
+    let precedes_colon = content.as_bytes()[end..]
+        .iter()
+        .find(|byte| !matches!(byte, b' ' | b'\t' | b'\r' | b'\n'))
+        == Some(&b':');
+
+    follows_object_delimiter && precedes_colon
+}
+
+fn contains_json_object_key(content: &str, key: &str) -> bool {
+    let token = format!("\"{key}\"");
+    content
+        .match_indices(&token)
+        .any(|(start, matched)| is_json_object_key(content, start, start + matched.len()))
+}
+
+fn collision_free_gemini_schema_ref_key(messages: &[Value]) -> String {
+    for suffix in 1.. {
+        let candidate = if suffix == 1 {
+            GEMINI_SAFE_SCHEMA_REF_KEY_BASE.to_string()
+        } else {
+            format!("{GEMINI_SAFE_SCHEMA_REF_KEY_BASE}_{suffix}")
+        };
+        let collision = messages.iter().any(|message| {
+            message.get("role").and_then(Value::as_str) == Some("tool")
+                && message
+                    .get("content")
+                    .and_then(Value::as_str)
+                    .is_some_and(|content| contains_json_object_key(content, &candidate))
+        });
+        if !collision {
+            return candidate;
+        }
+    }
+
+    unreachable!()
+}
+
+fn gemini_schema_ref_note(safe_key: &str) -> String {
+    format!(
+        "[OpenRouter/Gemini compatibility: interpret `{safe_key}` as the JSON Schema key formed by `$` followed by `ref`.]\n"
+    )
+}
+
 /// OpenRouter translates OpenAI `role: tool` messages into Gemini
 /// `function_response` parts. Gemini rejects a response containing a literal
 /// JSON Schema `$ref` key, treating its value as a function-response part name
@@ -114,6 +161,13 @@ fn is_gemini_model(model_name: &str) -> bool {
 /// only in Gemini-bound tool results, and add a reversible note so the model
 /// can reconstruct the original text.
 fn escape_gemini_schema_ref_keys_in_tool_responses(payload: &mut Value) -> usize {
+    let Some(messages) = payload.get("messages").and_then(Value::as_array) else {
+        return 0;
+    };
+    let safe_key = collision_free_gemini_schema_ref_key(messages);
+    let source_token = format!("\"{GEMINI_SCHEMA_REF_KEY}\"");
+    let note = gemini_schema_ref_note(&safe_key);
+
     let Some(messages) = payload.get_mut("messages").and_then(Value::as_array_mut) else {
         return 0;
     };
@@ -133,18 +187,9 @@ fn escape_gemini_schema_ref_keys_in_tool_responses(payload: &mut Value) -> usize
         let mut sanitized = String::with_capacity(content_text.len());
         let mut copied_through = 0;
         let mut message_escaped = 0;
-        for (start, _) in content_text.match_indices(GEMINI_SCHEMA_REF_KEY_TOKEN) {
-            let end = start + GEMINI_SCHEMA_REF_KEY_TOKEN.len();
-            let follows_object_delimiter = content_text.as_bytes()[..start]
-                .iter()
-                .rev()
-                .find(|byte| !matches!(byte, b' ' | b'\t' | b'\r' | b'\n'))
-                .is_some_and(|byte| matches!(byte, b'{' | b','));
-            let precedes_colon = content_text.as_bytes()[end..]
-                .iter()
-                .find(|byte| !matches!(byte, b' ' | b'\t' | b'\r' | b'\n'))
-                == Some(&b':');
-            if !follows_object_delimiter || !precedes_colon {
+        for (start, matched) in content_text.match_indices(&source_token) {
+            let end = start + matched.len();
+            if !is_json_object_key(content_text, start, end) {
                 continue;
             }
 
@@ -154,7 +199,7 @@ fn escape_gemini_schema_ref_keys_in_tool_responses(payload: &mut Value) -> usize
                     .expect("match indices must be UTF-8 boundaries"),
             );
             sanitized.push('"');
-            sanitized.push_str(GEMINI_SAFE_SCHEMA_REF_KEY);
+            sanitized.push_str(&safe_key);
             sanitized.push('"');
             copied_through = end;
             message_escaped += 1;
@@ -168,7 +213,7 @@ fn escape_gemini_schema_ref_keys_in_tool_responses(payload: &mut Value) -> usize
                 .get(copied_through..)
                 .expect("match indices must be UTF-8 boundaries"),
         );
-        *content = Value::String(format!("{GEMINI_SCHEMA_REF_NOTE}{sanitized}"));
+        *content = Value::String(format!("{note}{sanitized}"));
         escaped += message_escaped;
     }
 
@@ -558,7 +603,8 @@ mod tests {
         assert_eq!(
             payload["messages"][1]["content"],
             format!(
-                "{GEMINI_SCHEMA_REF_NOTE}schema: {{\"dollar_ref\": \"#/components/schemas/Usage\", \"nested\": {{\"dollar_ref\" : \"#/components/schemas/Base64Image\"}}, \"description\": \"use $ref here\", \"literal\": \"$ref\", \"identifier\": \"$reference\"}}"
+                "{}schema: {{\"dollar_ref\": \"#/components/schemas/Usage\", \"nested\": {{\"dollar_ref\" : \"#/components/schemas/Base64Image\"}}, \"description\": \"use $ref here\", \"literal\": \"$ref\", \"identifier\": \"$reference\"}}",
+                gemini_schema_ref_note("dollar_ref")
             )
         );
         assert_eq!(
@@ -583,6 +629,52 @@ mod tests {
             0
         );
         assert_eq!(payload, original);
+    }
+
+    #[test]
+    fn gemini_schema_ref_escape_avoids_existing_safe_key() {
+        let mut payload = json!({
+            "messages": [{
+                "role": "tool",
+                "tool_call_id": "call_1",
+                "content": "{\"$ref\":\"A\",\"dollar_ref\":\"B\"}"
+            }]
+        });
+
+        assert_eq!(
+            escape_gemini_schema_ref_keys_in_tool_responses(&mut payload),
+            1
+        );
+        assert_eq!(
+            payload["messages"][0]["content"],
+            format!(
+                "{}{{\"dollar_ref_2\":\"A\",\"dollar_ref\":\"B\"}}",
+                gemini_schema_ref_note("dollar_ref_2")
+            )
+        );
+    }
+
+    #[test]
+    fn gemini_schema_ref_escape_advances_past_multiple_key_collisions() {
+        let mut payload = json!({
+            "messages": [{
+                "role": "tool",
+                "tool_call_id": "call_1",
+                "content": "{\"$ref\":\"A\",\"dollar_ref\":\"B\",\"dollar_ref_2\":\"C\"}"
+            }]
+        });
+
+        assert_eq!(
+            escape_gemini_schema_ref_keys_in_tool_responses(&mut payload),
+            1
+        );
+        assert_eq!(
+            payload["messages"][0]["content"],
+            format!(
+                "{}{{\"dollar_ref_3\":\"A\",\"dollar_ref\":\"B\",\"dollar_ref_2\":\"C\"}}",
+                gemini_schema_ref_note("dollar_ref_3")
+            )
+        );
     }
 
     #[test]

--- a/crates/goose/src/providers/openrouter.rs
+++ b/crates/goose/src/providers/openrouter.rs
@@ -38,7 +38,7 @@ pub const OPENROUTER_KNOWN_MODELS: &[&str] = &[
 ];
 pub const OPENROUTER_DOC_URL: &str = "https://openrouter.ai/models";
 
-const GEMINI_SCHEMA_REF_KEY: &str = "$ref";
+const GEMINI_SCHEMA_REF_KEY_TOKEN: &str = "\"$ref\"";
 const GEMINI_SAFE_SCHEMA_REF_KEY: &str = "dollar_ref";
 const GEMINI_SCHEMA_REF_NOTE: &str =
     "[OpenRouter/Gemini compatibility: interpret `dollar_ref` as the JSON Schema key formed by `$` followed by `ref`.]\n";
@@ -110,9 +110,9 @@ fn is_gemini_model(model_name: &str) -> bool {
 /// OpenRouter translates OpenAI `role: tool` messages into Gemini
 /// `function_response` parts. Gemini rejects a response containing a literal
 /// JSON Schema `$ref` key, treating its value as a function-response part name
-/// instead of arbitrary tool text. Escape only that token, only in
-/// Gemini-bound tool results, and add a reversible note so the model can
-/// reconstruct the original text.
+/// instead of arbitrary tool text. Escape only double-quoted key occurrences,
+/// only in Gemini-bound tool results, and add a reversible note so the model
+/// can reconstruct the original text.
 fn escape_gemini_schema_ref_keys_in_tool_responses(payload: &mut Value) -> usize {
     let Some(messages) = payload.get_mut("messages").and_then(Value::as_array_mut) else {
         return 0;
@@ -130,14 +130,46 @@ fn escape_gemini_schema_ref_keys_in_tool_responses(payload: &mut Value) -> usize
         let Some(content_text) = content.as_str() else {
             continue;
         };
-        let occurrences = content_text.matches(GEMINI_SCHEMA_REF_KEY).count();
-        if occurrences == 0 {
+        let mut sanitized = String::with_capacity(content_text.len());
+        let mut copied_through = 0;
+        let mut message_escaped = 0;
+        for (start, _) in content_text.match_indices(GEMINI_SCHEMA_REF_KEY_TOKEN) {
+            let end = start + GEMINI_SCHEMA_REF_KEY_TOKEN.len();
+            let follows_object_delimiter = content_text.as_bytes()[..start]
+                .iter()
+                .rev()
+                .find(|byte| !matches!(byte, b' ' | b'\t' | b'\r' | b'\n'))
+                .is_some_and(|byte| matches!(byte, b'{' | b','));
+            let precedes_colon = content_text.as_bytes()[end..]
+                .iter()
+                .find(|byte| !matches!(byte, b' ' | b'\t' | b'\r' | b'\n'))
+                == Some(&b':');
+            if !follows_object_delimiter || !precedes_colon {
+                continue;
+            }
+
+            sanitized.push_str(
+                content_text
+                    .get(copied_through..start)
+                    .expect("match indices must be UTF-8 boundaries"),
+            );
+            sanitized.push('"');
+            sanitized.push_str(GEMINI_SAFE_SCHEMA_REF_KEY);
+            sanitized.push('"');
+            copied_through = end;
+            message_escaped += 1;
+        }
+        if message_escaped == 0 {
             continue;
         }
 
-        let sanitized = content_text.replace(GEMINI_SCHEMA_REF_KEY, GEMINI_SAFE_SCHEMA_REF_KEY);
+        sanitized.push_str(
+            content_text
+                .get(copied_through..)
+                .expect("match indices must be UTF-8 boundaries"),
+        );
         *content = Value::String(format!("{GEMINI_SCHEMA_REF_NOTE}{sanitized}"));
-        escaped += occurrences;
+        escaped += message_escaped;
     }
 
     escaped
@@ -332,14 +364,7 @@ impl Provider for OpenRouterProvider {
         }
 
         if is_gemini_model(&model_config.model_name) {
-            let escaped_schema_ref_keys =
-                escape_gemini_schema_ref_keys_in_tool_responses(&mut payload);
-            if escaped_schema_ref_keys > 0 {
-                tracing::warn!(
-                    escaped_schema_ref_keys,
-                    "escaped JSON Schema ref keys in Gemini-bound tool results"
-                );
-            }
+            escape_gemini_schema_ref_keys_in_tool_responses(&mut payload);
             openrouter_format::add_reasoning_details_to_request(&mut payload, messages);
         }
         let sent_reasoning_disable =
@@ -517,7 +542,7 @@ mod tests {
                 {
                     "role": "tool",
                     "tool_call_id": "call_1",
-                    "content": "{'$ref': '#/components/schemas/Base64Image'} and {\"$ref\": \"#/components/schemas/Usage\"}"
+                    "content": "schema: {\"$ref\": \"#/components/schemas/Usage\", \"nested\": {\"$ref\" : \"#/components/schemas/Base64Image\"}, \"description\": \"use $ref here\", \"literal\": \"$ref\", \"identifier\": \"$reference\"}"
                 }
             ]
         });
@@ -533,17 +558,31 @@ mod tests {
         assert_eq!(
             payload["messages"][1]["content"],
             format!(
-                "{GEMINI_SCHEMA_REF_NOTE}{{'dollar_ref': '#/components/schemas/Base64Image'}} and {{\"dollar_ref\": \"#/components/schemas/Usage\"}}"
+                "{GEMINI_SCHEMA_REF_NOTE}schema: {{\"dollar_ref\": \"#/components/schemas/Usage\", \"nested\": {{\"dollar_ref\" : \"#/components/schemas/Base64Image\"}}, \"description\": \"use $ref here\", \"literal\": \"$ref\", \"identifier\": \"$reference\"}}"
             )
         );
-        assert!(!payload["messages"][1]["content"]
-            .as_str()
-            .unwrap()
-            .contains(GEMINI_SCHEMA_REF_KEY));
         assert_eq!(
             escape_gemini_schema_ref_keys_in_tool_responses(&mut payload),
             0
         );
+    }
+
+    #[test]
+    fn gemini_schema_ref_escape_leaves_values_and_prose_unchanged() {
+        let mut payload = json!({
+            "messages": [{
+                "role": "tool",
+                "tool_call_id": "call_1",
+                "content": "{\"description\":\"use $ref here\",\"literal\":\"$ref\",\"identifier\":\"$reference\"}\nshell output: use $ref here\nprose: \"$ref\": not a JSON key"
+            }]
+        });
+        let original = payload.clone();
+
+        assert_eq!(
+            escape_gemini_schema_ref_keys_in_tool_responses(&mut payload),
+            0
+        );
+        assert_eq!(payload, original);
     }
 
     #[test]

--- a/crates/goose/src/providers/openrouter.rs
+++ b/crates/goose/src/providers/openrouter.rs
@@ -3,7 +3,7 @@ use async_trait::async_trait;
 use futures::future::BoxFuture;
 use goose_providers::images::ImageFormat;
 use serde_json::{json, Value};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::ops::Range;
 
 use super::api_client::{ApiClient, AuthMethod};
@@ -138,13 +138,32 @@ fn scan_schema_ref_tokens(content: &str) -> Vec<Range<usize>> {
             .and_then(|rest| rest.chars().next())
             .is_some_and(|c| c.is_ascii_alphanumeric() || c == '_');
 
-        if !continues_identifier {
+        if !continues_identifier && !starts_with_escaped_backslash(content, start) {
             spans.push(start..end);
         }
         cursor = end;
     }
 
     spans
+}
+
+/// An odd number of backslashes before `\u0024ref` means the leading backslash
+/// is itself escaped, so the text is the literal characters `\u0024ref` rather
+/// than an encoded `$ref`. Rewriting it would emit invalid JSON.
+fn starts_with_escaped_backslash(content: &str, start: usize) -> bool {
+    if !content
+        .get(start..)
+        .is_some_and(|token| token.starts_with('\\'))
+    {
+        return false;
+    }
+
+    let preceding_backslashes = content
+        .get(..start)
+        .map(|prefix| prefix.chars().rev().take_while(|c| *c == '\\').count())
+        .unwrap_or(0);
+
+    preceding_backslashes % 2 == 1
 }
 
 /// Decodes `\uXXXX` escapes so a candidate key spelled as an escape sequence
@@ -198,8 +217,15 @@ fn replace_spans(content: &str, spans: &[Range<usize>], replacement: &str) -> St
 
 /// The replacement must not already occur anywhere in the tool text, otherwise
 /// the rewrite would be ambiguous to the model reading the compatibility note.
+///
+/// Tool output is externally controlled, so occupied candidates are collected in
+/// a single pass rather than rescanning every result for each suffix.
 fn collision_free_gemini_schema_ref_key(contents: &[&str]) -> String {
-    let decoded: Vec<String> = contents.iter().map(|c| decoded_view(c)).collect();
+    let mut occupied = HashSet::new();
+    for content in contents {
+        collect_safe_key_candidates(content, &mut occupied);
+        collect_safe_key_candidates(&decoded_view(content), &mut occupied);
+    }
 
     (1..)
         .map(|suffix| {
@@ -209,11 +235,40 @@ fn collision_free_gemini_schema_ref_key(contents: &[&str]) -> String {
                 format!("{GEMINI_SAFE_SCHEMA_REF_KEY_BASE}_{suffix}")
             }
         })
-        .find(|candidate| {
-            !contents.iter().any(|content| content.contains(candidate))
-                && !decoded.iter().any(|content| content.contains(candidate))
-        })
+        .find(|candidate| !occupied.contains(candidate))
         .expect("an unbounded suffix sequence always yields an unused candidate")
+}
+
+/// Records every `dollar_ref`/`dollar_ref_N` occurrence in one scan.
+fn collect_safe_key_candidates(content: &str, occupied: &mut HashSet<String>) {
+    let mut cursor = 0;
+
+    while let Some(offset) = content
+        .get(cursor..)
+        .and_then(|tail| tail.find(GEMINI_SAFE_SCHEMA_REF_KEY_BASE))
+    {
+        let start = cursor + offset;
+        let end = start + GEMINI_SAFE_SCHEMA_REF_KEY_BASE.len();
+        let suffix_len = content
+            .get(end..)
+            .map(|rest| {
+                let digits = rest
+                    .strip_prefix('_')
+                    .map(|after| after.chars().take_while(char::is_ascii_digit).count())
+                    .unwrap_or(0);
+                if digits == 0 {
+                    0
+                } else {
+                    1 + digits
+                }
+            })
+            .unwrap_or(0);
+
+        if let Some(token) = content.get(start..end + suffix_len) {
+            occupied.insert(token.to_string());
+        }
+        cursor = end;
+    }
 }
 
 fn gemini_schema_ref_note(safe_key: &str) -> String {
@@ -702,6 +757,45 @@ mod tests {
             0
         );
         assert_eq!(payload, original);
+    }
+
+    #[test]
+    fn gemini_schema_ref_escape_preserves_literal_escaped_unicode_text() {
+        let original = r#"{"literal":"\\u0024ref"}"#;
+        let mut payload = json!({
+            "messages": [{
+                "role": "tool",
+                "tool_call_id": "call_1",
+                "content": original
+            }]
+        });
+        let untouched = payload.clone();
+
+        assert_eq!(
+            escape_gemini_schema_ref_keys_in_tool_responses(&mut payload),
+            0
+        );
+        assert_eq!(payload, untouched);
+    }
+
+    #[test]
+    fn gemini_schema_ref_escape_rewrites_unicode_token_after_even_backslashes() {
+        let mut payload = json!({
+            "messages": [{
+                "role": "tool",
+                "tool_call_id": "call_1",
+                "content": r#"{"a":"x\\\\","\u0024ref":"A"}"#
+            }]
+        });
+
+        assert_eq!(
+            escape_gemini_schema_ref_keys_in_tool_responses(&mut payload),
+            1
+        );
+        assert!(payload["messages"][0]["content"]
+            .as_str()
+            .unwrap()
+            .contains(r#""dollar_ref":"A""#));
     }
 
     #[test]

--- a/crates/goose/src/providers/openrouter.rs
+++ b/crates/goose/src/providers/openrouter.rs
@@ -102,7 +102,7 @@ fn is_mandatory_reasoning_error(error: &ProviderError) -> bool {
 }
 
 fn is_gemini_model(model_name: &str) -> bool {
-    model_name.starts_with("google/")
+    model_name.starts_with("google/gemini")
 }
 
 fn is_json_object_key(content: &str, start: usize, end: usize) -> bool {
@@ -152,6 +152,13 @@ fn gemini_schema_ref_note(safe_key: &str) -> String {
     format!(
         "[OpenRouter/Gemini compatibility: interpret `{safe_key}` as the JSON Schema key formed by `$` followed by `ref`.]\n"
     )
+}
+
+fn apply_gemini_compatibility(model_name: &str, payload: &mut Value, messages: &[Message]) {
+    if is_gemini_model(model_name) {
+        escape_gemini_schema_ref_keys_in_tool_responses(payload);
+        openrouter_format::add_reasoning_details_to_request(payload, messages);
+    }
 }
 
 /// OpenRouter translates OpenAI `role: tool` messages into Gemini
@@ -408,10 +415,7 @@ impl Provider for OpenRouterProvider {
             apply_chat_payload_breakpoints(&mut payload);
         }
 
-        if is_gemini_model(&model_config.model_name) {
-            escape_gemini_schema_ref_keys_in_tool_responses(&mut payload);
-            openrouter_format::add_reasoning_details_to_request(&mut payload, messages);
-        }
+        apply_gemini_compatibility(&model_config.model_name, &mut payload, messages);
         let sent_reasoning_disable =
             openrouter_format::apply_reasoning_config(&mut payload, model_config);
 
@@ -611,6 +615,36 @@ mod tests {
             escape_gemini_schema_ref_keys_in_tool_responses(&mut payload),
             0
         );
+    }
+
+    #[test]
+    fn gemini_compatibility_only_applies_to_gemini_models() {
+        let tool_result = r##"{"$ref":"#/components/schemas/Usage"}"##;
+        let mut gemma_payload = json!({
+            "messages": [{
+                "role": "tool",
+                "tool_call_id": "call_1",
+                "content": tool_result
+            }]
+        });
+        let original_gemma_payload = gemma_payload.clone();
+
+        apply_gemini_compatibility("google/gemma-3-27b-it", &mut gemma_payload, &[]);
+
+        assert_eq!(gemma_payload, original_gemma_payload);
+
+        let mut gemini_payload = original_gemma_payload;
+        apply_gemini_compatibility("google/gemini-2.5-flash", &mut gemini_payload, &[]);
+
+        assert_eq!(
+            gemini_payload["messages"][0]["content"],
+            format!(
+                "{}{{\"dollar_ref\":\"#/components/schemas/Usage\"}}",
+                gemini_schema_ref_note("dollar_ref")
+            )
+        );
+        assert!(is_gemini_model("google/gemini-2.0-flash-exp:free"));
+        assert!(!is_gemini_model("google/gemma-3-27b-it"));
     }
 
     #[test]

--- a/crates/goose/src/providers/openrouter.rs
+++ b/crates/goose/src/providers/openrouter.rs
@@ -40,8 +40,6 @@ pub const OPENROUTER_KNOWN_MODELS: &[&str] = &[
 pub const OPENROUTER_DOC_URL: &str = "https://openrouter.ai/models";
 
 const GEMINI_SCHEMA_REF_KEY: &str = "$ref";
-/// JSON `\uXXXX` spelling of `$ref`, which decodes to the same key.
-const GEMINI_SCHEMA_REF_KEY_ESCAPED: &str = "\\u0024ref";
 const GEMINI_SAFE_SCHEMA_REF_KEY_BASE: &str = "dollar_ref";
 
 #[derive(serde::Serialize)]
@@ -120,31 +118,63 @@ fn scan_schema_ref_tokens(content: &str) -> Vec<Range<usize>> {
     let mut spans = Vec::new();
     let mut cursor = 0;
 
-    while let Some(tail) = content.get(cursor..) {
-        let Some((start, token_len)) = [GEMINI_SCHEMA_REF_KEY, GEMINI_SCHEMA_REF_KEY_ESCAPED]
-            .iter()
-            .filter_map(|token| {
-                tail.find(token)
-                    .map(|offset| (cursor + offset, token.len()))
-            })
-            .min()
-        else {
-            break;
-        };
-
-        let end = start + token_len;
-        let continues_identifier = content
-            .get(end..)
-            .and_then(|rest| rest.chars().next())
-            .is_some_and(|c| c.is_ascii_alphanumeric() || c == '_');
-
-        if !continues_identifier && !starts_with_escaped_backslash(content, start) {
-            spans.push(start..end);
+    while cursor < content.len() {
+        if !content.is_char_boundary(cursor) {
+            cursor += 1;
+            continue;
         }
-        cursor = end;
+
+        match match_schema_ref_at(content, cursor) {
+            Some(end)
+                if !starts_with_escaped_backslash(content, cursor)
+                    && !continues_identifier(content, end) =>
+            {
+                spans.push(cursor..end);
+                cursor = end;
+            }
+            _ => {
+                cursor += content
+                    .get(cursor..)
+                    .and_then(|rest| rest.chars().next())
+                    .map_or(1, char::len_utf8);
+            }
+        }
     }
 
     spans
+}
+
+/// Decodes one character: either a literal one or a `\uXXXX` escape. JSON lets
+/// any character of a key be escaped, so `$\u0072ef` and `\u0024\u0072\u0065\u0066`
+/// both decode to `$ref` and would otherwise reach Gemini unrewritten.
+fn decode_unit(content: &str, index: usize) -> Option<(char, usize)> {
+    let rest = content.get(index..)?;
+
+    if let Some(after_prefix) = rest.strip_prefix("\\u") {
+        let character = after_prefix
+            .get(..4)
+            .and_then(|hex| u32::from_str_radix(hex, 16).ok())
+            .and_then(char::from_u32)?;
+        return Some((character, index + "\\u".len() + 4));
+    }
+
+    let character = rest.chars().next()?;
+    Some((character, index + character.len_utf8()))
+}
+
+/// Returns the end offset when the text at `start` decodes to `$ref`.
+fn match_schema_ref_at(content: &str, start: usize) -> Option<usize> {
+    let mut cursor = start;
+
+    for expected in GEMINI_SCHEMA_REF_KEY.chars() {
+        let (character, next) = decode_unit(content, cursor)?;
+        if character != expected {
+            return None;
+        }
+        cursor = next;
+    }
+
+    Some(cursor)
 }
 
 /// An odd number of backslashes before `\u0024ref` means the leading backslash
@@ -164,6 +194,13 @@ fn starts_with_escaped_backslash(content: &str, start: usize) -> bool {
         .unwrap_or(0);
 
     preceding_backslashes % 2 == 1
+}
+
+/// A trailing identifier character means the token is part of a longer name
+/// such as `$refs` or `$refresh_token`, which must be left alone.
+fn continues_identifier(content: &str, end: usize) -> bool {
+    decode_unit(content, end)
+        .is_some_and(|(character, _)| character.is_ascii_alphanumeric() || character == '_')
 }
 
 /// Decodes `\uXXXX` escapes so a candidate key spelled as an escape sequence
@@ -796,6 +833,65 @@ mod tests {
             .as_str()
             .unwrap()
             .contains(r#""dollar_ref":"A""#));
+    }
+
+    #[test]
+    fn gemini_schema_ref_escape_matches_partially_escaped_keys() {
+        let mut payload = json!({
+            "messages": [{
+                "role": "tool",
+                "tool_call_id": "call_1",
+                "content": r#"{"$\u0072ef":"A"}"#
+            }]
+        });
+
+        assert_eq!(
+            escape_gemini_schema_ref_keys_in_tool_responses(&mut payload),
+            1
+        );
+        assert!(payload["messages"][0]["content"]
+            .as_str()
+            .unwrap()
+            .contains(r#""dollar_ref":"A""#));
+    }
+
+    #[test]
+    fn gemini_schema_ref_escape_matches_fully_escaped_keys() {
+        let mut payload = json!({
+            "messages": [{
+                "role": "tool",
+                "tool_call_id": "call_1",
+                "content": r#"{"\u0024\u0072\u0065\u0066":"A"}"#
+            }]
+        });
+
+        assert_eq!(
+            escape_gemini_schema_ref_keys_in_tool_responses(&mut payload),
+            1
+        );
+        assert!(payload["messages"][0]["content"]
+            .as_str()
+            .unwrap()
+            .contains(r#""dollar_ref":"A""#));
+    }
+
+    #[test]
+    fn gemini_schema_ref_escape_preserves_escaped_longer_identifiers() {
+        let original = r#"{"$\u0072efresh_token":"A"}"#;
+        let mut payload = json!({
+            "messages": [{
+                "role": "tool",
+                "tool_call_id": "call_1",
+                "content": original
+            }]
+        });
+        let untouched = payload.clone();
+
+        assert_eq!(
+            escape_gemini_schema_ref_keys_in_tool_responses(&mut payload),
+            0
+        );
+        assert_eq!(payload, untouched);
     }
 
     #[test]

--- a/crates/goose/src/providers/openrouter.rs
+++ b/crates/goose/src/providers/openrouter.rs
@@ -3,7 +3,7 @@ use async_trait::async_trait;
 use futures::future::BoxFuture;
 use goose_providers::images::ImageFormat;
 use serde_json::{json, Value};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use super::api_client::{ApiClient, AuthMethod};
 use super::base::{ConfigKey, MessageStream, Provider, ProviderDef, ProviderMetadata};
@@ -105,18 +105,20 @@ fn is_gemini_model(model_name: &str) -> bool {
     model_name.starts_with("google/gemini")
 }
 
-fn contains_json_object_key(value: &Value, key: &str) -> bool {
+fn collect_json_object_keys(value: &Value, keys: &mut HashSet<String>) {
     match value {
         Value::Object(object) => {
-            object.contains_key(key)
-                || object
-                    .values()
-                    .any(|value| contains_json_object_key(value, key))
+            for (key, value) in object {
+                keys.insert(key.clone());
+                collect_json_object_keys(value, keys);
+            }
         }
-        Value::Array(array) => array
-            .iter()
-            .any(|value| contains_json_object_key(value, key)),
-        _ => false,
+        Value::Array(array) => {
+            for value in array {
+                collect_json_object_keys(value, keys);
+            }
+        }
+        _ => {}
     }
 }
 
@@ -144,22 +146,14 @@ fn rename_json_object_key(value: &mut Value, source_key: &str, target_key: &str)
     }
 }
 
-fn collision_free_gemini_schema_ref_key(messages: &[Value]) -> String {
+fn collision_free_gemini_schema_ref_key(occupied_keys: &HashSet<String>) -> String {
     for suffix in 1.. {
         let candidate = if suffix == 1 {
             GEMINI_SAFE_SCHEMA_REF_KEY_BASE.to_string()
         } else {
             format!("{GEMINI_SAFE_SCHEMA_REF_KEY_BASE}_{suffix}")
         };
-        let collision = messages.iter().any(|message| {
-            message.get("role").and_then(Value::as_str) == Some("tool")
-                && message
-                    .get("content")
-                    .and_then(Value::as_str)
-                    .and_then(|content| serde_json::from_str::<Value>(content).ok())
-                    .is_some_and(|content| contains_json_object_key(&content, &candidate))
-        });
-        if !collision {
+        if !occupied_keys.contains(&candidate) {
             return candidate;
         }
     }
@@ -187,31 +181,31 @@ fn apply_gemini_compatibility(model_name: &str, payload: &mut Value, messages: &
 /// results and add a reversible note so the model can reconstruct the original
 /// text. Non-JSON tool output must remain byte-for-byte unchanged.
 fn escape_gemini_schema_ref_keys_in_tool_responses(payload: &mut Value) -> usize {
-    let Some(messages) = payload.get("messages").and_then(Value::as_array) else {
-        return 0;
-    };
-    let safe_key = collision_free_gemini_schema_ref_key(messages);
-    let note = gemini_schema_ref_note(&safe_key);
-
     let Some(messages) = payload.get_mut("messages").and_then(Value::as_array_mut) else {
         return 0;
     };
 
-    let mut escaped = 0;
-    for message in messages {
+    let mut occupied_keys = HashSet::new();
+    let mut parsed_tool_results = Vec::new();
+    for (message_index, message) in messages.iter().enumerate() {
         if message.get("role").and_then(Value::as_str) != Some("tool") {
             continue;
         }
 
-        let Some(content) = message.get_mut("content") else {
+        let Some(content_text) = message.get("content").and_then(Value::as_str) else {
             continue;
         };
-        let Some(content_text) = content.as_str() else {
+        let Ok(parsed_content) = serde_json::from_str::<Value>(content_text) else {
             continue;
         };
-        let Ok(mut parsed_content) = serde_json::from_str::<Value>(content_text) else {
-            continue;
-        };
+        collect_json_object_keys(&parsed_content, &mut occupied_keys);
+        parsed_tool_results.push((message_index, parsed_content));
+    }
+
+    let safe_key = collision_free_gemini_schema_ref_key(&occupied_keys);
+    let note = gemini_schema_ref_note(&safe_key);
+    let mut escaped = 0;
+    for (message_index, mut parsed_content) in parsed_tool_results {
         let message_escaped =
             rename_json_object_key(&mut parsed_content, GEMINI_SCHEMA_REF_KEY, &safe_key);
         if message_escaped == 0 {
@@ -220,7 +214,7 @@ fn escape_gemini_schema_ref_keys_in_tool_responses(payload: &mut Value) -> usize
 
         let sanitized = serde_json::to_string(&parsed_content)
             .expect("JSON values must serialize successfully");
-        *content = Value::String(format!("{note}{sanitized}"));
+        messages[message_index]["content"] = Value::String(format!("{note}{sanitized}"));
         escaped += message_escaped;
     }
 
@@ -726,6 +720,40 @@ mod tests {
                 "{}{{\"dollar_ref_3\":\"A\",\"dollar_ref\":\"B\",\"dollar_ref_2\":\"C\"}}",
                 gemini_schema_ref_note("dollar_ref_3")
             )
+        );
+    }
+
+    #[test]
+    fn gemini_schema_ref_escape_advances_past_deep_collision_ladder() {
+        let mut payload = json!({
+            "messages": [
+                {
+                    "role": "tool",
+                    "tool_call_id": "call_1",
+                    "content": "{\"$ref\":\"A\",\"dollar_ref\":\"B\",\"nested\":{\"dollar_ref_2\":\"C\",\"items\":[{\"dollar_ref_3\":\"D\"},{\"dollar_ref_4\":\"E\"}]}}"
+                },
+                {
+                    "role": "tool",
+                    "tool_call_id": "call_2",
+                    "content": "{\"dollar_ref_5\":\"F\"}"
+                }
+            ]
+        });
+
+        assert_eq!(
+            escape_gemini_schema_ref_keys_in_tool_responses(&mut payload),
+            1
+        );
+        assert_eq!(
+            payload["messages"][0]["content"],
+            format!(
+                "{}{{\"dollar_ref_6\":\"A\",\"dollar_ref\":\"B\",\"nested\":{{\"dollar_ref_2\":\"C\",\"items\":[{{\"dollar_ref_3\":\"D\"}},{{\"dollar_ref_4\":\"E\"}}]}}}}",
+                gemini_schema_ref_note("dollar_ref_6")
+            )
+        );
+        assert_eq!(
+            payload["messages"][1]["content"],
+            "{\"dollar_ref_5\":\"F\"}"
         );
     }
 

--- a/crates/goose/src/providers/openrouter.rs
+++ b/crates/goose/src/providers/openrouter.rs
@@ -3,7 +3,7 @@ use async_trait::async_trait;
 use futures::future::BoxFuture;
 use goose_providers::images::ImageFormat;
 use serde_json::{json, Value};
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::ops::Range;
 
 use super::api_client::{ApiClient, AuthMethod};
@@ -40,6 +40,8 @@ pub const OPENROUTER_KNOWN_MODELS: &[&str] = &[
 pub const OPENROUTER_DOC_URL: &str = "https://openrouter.ai/models";
 
 const GEMINI_SCHEMA_REF_KEY: &str = "$ref";
+/// JSON `\uXXXX` spelling of `$ref`, which decodes to the same key.
+const GEMINI_SCHEMA_REF_KEY_ESCAPED: &str = "\\u0024ref";
 const GEMINI_SAFE_SCHEMA_REF_KEY_BASE: &str = "dollar_ref";
 
 #[derive(serde::Serialize)]
@@ -106,125 +108,112 @@ fn is_gemini_model(model_name: &str) -> bool {
     model_name.starts_with("google/gemini")
 }
 
-#[derive(Default)]
-struct JsonObjectKeyScan {
-    occupied_keys: HashSet<String>,
-    schema_ref_key_spans: Vec<Range<usize>>,
-}
+/// Spans of the literal `$ref` token inside opaque tool text.
+///
+/// Tool results are not required to parse as JSON. Google rejects the token in
+/// single-quoted Python `repr` output, YAML, and unquoted text just as it does
+/// in strict JSON, so matching only well-formed JSON key positions would miss
+/// the reproduction in #11260. A trailing identifier character means the token
+/// is part of a longer name such as `$refs` or `$refresh_token`, which must be
+/// left alone.
+fn scan_schema_ref_tokens(content: &str) -> Vec<Range<usize>> {
+    let mut spans = Vec::new();
+    let mut cursor = 0;
 
-fn decode_json_string_literal(content: &str, span: &Range<usize>) -> Option<String> {
-    serde_json::from_str(content.get(span.clone())?).ok()
-}
+    while let Some(tail) = content.get(cursor..) {
+        let Some((start, token_len)) = [GEMINI_SCHEMA_REF_KEY, GEMINI_SCHEMA_REF_KEY_ESCAPED]
+            .iter()
+            .filter_map(|token| {
+                tail.find(token)
+                    .map(|offset| (cursor + offset, token.len()))
+            })
+            .min()
+        else {
+            break;
+        };
 
-/// Tolerantly scans JSON-like text without requiring the entire input to parse.
-/// A string is treated as an object key only when it is inside an object,
-/// follows `{` or `,`, and is followed by `:` outside the string.
-fn scan_json_object_keys(content: &str) -> JsonObjectKeyScan {
-    let bytes = content.as_bytes();
-    let mut scan = JsonObjectKeyScan::default();
-    let mut containers = Vec::new();
-    let mut previous_non_whitespace = None;
-    let mut pending_key_span = None;
-    let mut string_start = 0;
-    let mut string_container = None;
-    let mut string_preceding_byte = None;
-    let mut in_string = false;
-    let mut escaped = false;
+        let end = start + token_len;
+        let continues_identifier = content
+            .get(end..)
+            .and_then(|rest| rest.chars().next())
+            .is_some_and(|c| c.is_ascii_alphanumeric() || c == '_');
 
-    for (index, byte) in bytes.iter().copied().enumerate() {
-        if in_string {
-            if escaped {
-                escaped = false;
-            } else if byte == b'\\' {
-                escaped = true;
-            } else if byte == b'"' {
-                in_string = false;
-                let span = string_start..index + 1;
-                if string_container == Some(b'{')
-                    && matches!(string_preceding_byte, Some(b'{') | Some(b','))
-                {
-                    pending_key_span = Some(span);
-                }
-                previous_non_whitespace = Some(b'"');
-            }
-            continue;
+        if !continues_identifier {
+            spans.push(start..end);
         }
-
-        if byte.is_ascii_whitespace() {
-            continue;
-        }
-
-        if let Some(span) = pending_key_span.take() {
-            if byte == b':' {
-                if let Some(key) = decode_json_string_literal(content, &span) {
-                    if key == GEMINI_SCHEMA_REF_KEY {
-                        scan.schema_ref_key_spans.push(span);
-                    }
-                    scan.occupied_keys.insert(key);
-                }
-            }
-        }
-
-        match byte {
-            b'"' => {
-                in_string = true;
-                escaped = false;
-                string_start = index;
-                string_container = containers.last().copied();
-                string_preceding_byte = previous_non_whitespace;
-            }
-            b'{' | b'[' => containers.push(byte),
-            b'}' if containers.last() == Some(&b'{') => {
-                containers.pop();
-            }
-            b']' if containers.last() == Some(&b'[') => {
-                containers.pop();
-            }
-            _ => {}
-        }
-        previous_non_whitespace = Some(byte);
+        cursor = end;
     }
 
-    scan
+    spans
 }
 
-fn replace_json_key_spans(content: &str, spans: &[Range<usize>], replacement: &str) -> String {
-    let serialized_replacement =
-        serde_json::to_string(replacement).expect("JSON object keys must serialize successfully");
+/// Decodes `\uXXXX` escapes so a candidate key spelled as an escape sequence
+/// still counts as occupied.
+fn decoded_view(content: &str) -> String {
+    let mut decoded = String::with_capacity(content.len());
+    let mut rest = content;
+
+    while let Some(offset) = rest.find("\\u") {
+        let (before, from_escape) = rest.split_at(offset);
+        decoded.push_str(before);
+
+        let after_prefix = from_escape.get("\\u".len()..).unwrap_or_default();
+        match after_prefix
+            .get(..4)
+            .and_then(|hex| u32::from_str_radix(hex, 16).ok())
+            .and_then(char::from_u32)
+        {
+            Some(character) => {
+                decoded.push(character);
+                rest = after_prefix.get(4..).unwrap_or_default();
+            }
+            None => {
+                decoded.push_str("\\u");
+                rest = after_prefix;
+            }
+        }
+    }
+    decoded.push_str(rest);
+
+    decoded
+}
+
+fn replace_spans(content: &str, spans: &[Range<usize>], replacement: &str) -> String {
     let mut rewritten = String::with_capacity(content.len());
     let mut copied_through = 0;
 
     for span in spans {
-        rewritten.push_str(
-            content
-                .get(copied_through..span.start)
-                .expect("scanned JSON key spans must lie on UTF-8 boundaries"),
-        );
-        rewritten.push_str(&serialized_replacement);
+        if let Some(preceding) = content.get(copied_through..span.start) {
+            rewritten.push_str(preceding);
+        }
+        rewritten.push_str(replacement);
         copied_through = span.end;
     }
-    rewritten.push_str(
-        content
-            .get(copied_through..)
-            .expect("scanned JSON key spans must lie on UTF-8 boundaries"),
-    );
+    if let Some(trailing) = content.get(copied_through..) {
+        rewritten.push_str(trailing);
+    }
 
     rewritten
 }
 
-fn collision_free_gemini_schema_ref_key(occupied_keys: &HashSet<String>) -> String {
-    for suffix in 1.. {
-        let candidate = if suffix == 1 {
-            GEMINI_SAFE_SCHEMA_REF_KEY_BASE.to_string()
-        } else {
-            format!("{GEMINI_SAFE_SCHEMA_REF_KEY_BASE}_{suffix}")
-        };
-        if !occupied_keys.contains(&candidate) {
-            return candidate;
-        }
-    }
+/// The replacement must not already occur anywhere in the tool text, otherwise
+/// the rewrite would be ambiguous to the model reading the compatibility note.
+fn collision_free_gemini_schema_ref_key(contents: &[&str]) -> String {
+    let decoded: Vec<String> = contents.iter().map(|c| decoded_view(c)).collect();
 
-    unreachable!()
+    (1..)
+        .map(|suffix| {
+            if suffix == 1 {
+                GEMINI_SAFE_SCHEMA_REF_KEY_BASE.to_string()
+            } else {
+                format!("{GEMINI_SAFE_SCHEMA_REF_KEY_BASE}_{suffix}")
+            }
+        })
+        .find(|candidate| {
+            !contents.iter().any(|content| content.contains(candidate))
+                && !decoded.iter().any(|content| content.contains(candidate))
+        })
+        .expect("an unbounded suffix sequence always yields an unused candidate")
 }
 
 fn gemini_schema_ref_note(safe_key: &str) -> String {
@@ -243,43 +232,44 @@ fn apply_gemini_compatibility(model_name: &str, payload: &mut Value, messages: &
 /// OpenRouter translates OpenAI `role: tool` messages into Gemini
 /// `function_response` parts. Gemini rejects a response containing a literal
 /// JSON Schema `$ref` key, treating its value as a function-response part name
-/// instead of arbitrary tool text. Escape object keys in otherwise opaque tool
-/// text and add a reversible note so the model can reconstruct the original
-/// text. All bytes outside matching key spans remain unchanged.
+/// instead of arbitrary tool text, and Goose replays persisted history, so one
+/// such tool result breaks every later turn in the session.
+///
+/// Rewrite the token and prepend a note so the model can reconstruct the
+/// original text. All bytes outside matching token spans remain unchanged.
 fn escape_gemini_schema_ref_keys_in_tool_responses(payload: &mut Value) -> usize {
     let Some(messages) = payload.get_mut("messages").and_then(Value::as_array_mut) else {
         return 0;
     };
 
-    let mut occupied_keys = HashSet::new();
-    let mut scanned_tool_results = Vec::new();
+    let mut tool_contents = Vec::new();
     for (message_index, message) in messages.iter().enumerate() {
         if message.get("role").and_then(Value::as_str) != Some("tool") {
             continue;
         }
-
         let Some(content_text) = message.get("content").and_then(Value::as_str) else {
             continue;
         };
-        let scan = scan_json_object_keys(content_text);
-        occupied_keys.extend(scan.occupied_keys);
-        scanned_tool_results.push((message_index, scan.schema_ref_key_spans));
+        tool_contents.push((message_index, content_text.to_string()));
     }
 
-    let safe_key = collision_free_gemini_schema_ref_key(&occupied_keys);
+    let scanned: Vec<&str> = tool_contents
+        .iter()
+        .map(|(_, content)| content.as_str())
+        .collect();
+    let safe_key = collision_free_gemini_schema_ref_key(&scanned);
     let note = gemini_schema_ref_note(&safe_key);
+
     let mut escaped = 0;
-    for (message_index, schema_ref_key_spans) in scanned_tool_results {
-        if schema_ref_key_spans.is_empty() {
+    for (message_index, content_text) in &tool_contents {
+        let spans = scan_schema_ref_tokens(content_text);
+        if spans.is_empty() {
             continue;
         }
 
-        let content_text = messages[message_index]["content"]
-            .as_str()
-            .expect("scanned tool result content must remain a string");
-        let sanitized = replace_json_key_spans(content_text, &schema_ref_key_spans, &safe_key);
-        messages[message_index]["content"] = Value::String(format!("{note}{sanitized}"));
-        escaped += schema_ref_key_spans.len();
+        let sanitized = replace_spans(content_text, &spans, &safe_key);
+        messages[*message_index]["content"] = Value::String(format!("{note}{sanitized}"));
+        escaped += spans.len();
     }
 
     escaped
@@ -656,7 +646,7 @@ mod tests {
 
         assert_eq!(
             escape_gemini_schema_ref_keys_in_tool_responses(&mut payload),
-            3
+            5
         );
         assert_eq!(
             payload["messages"][0]["content"],
@@ -665,14 +655,53 @@ mod tests {
         assert_eq!(
             payload["messages"][1]["content"],
             format!(
-                "{}{{\"dollar_ref\": \"#/components/schemas/Usage\", \"nested\": {{\"dollar_ref\" : \"#/components/schemas/Base64Image\"}}, \"items\": [{{\"dollar_ref\": \"#/components/schemas/Item\"}}], \"description\": \"use $ref here\", \"literal\": \"$ref\", \"identifier\": \"$reference\"}}",
+                "{}{{\"dollar_ref\": \"#/components/schemas/Usage\", \"nested\": {{\"dollar_ref\" : \"#/components/schemas/Base64Image\"}}, \"items\": [{{\"dollar_ref\": \"#/components/schemas/Item\"}}], \"description\": \"use dollar_ref here\", \"literal\": \"dollar_ref\", \"identifier\": \"$reference\"}}",
                 gemini_schema_ref_note("dollar_ref")
             )
         );
+    }
+
+    #[test]
+    fn gemini_schema_ref_escape_rewrites_issue_11260_reproduction() {
+        let reproduction = "{'properties': {'image': {'$ref': '#/components/schemas/Example'}}}";
+        let mut payload = json!({
+            "messages": [{
+                "role": "tool",
+                "tool_call_id": "call_1",
+                "content": reproduction
+            }]
+        });
+
+        assert_eq!(
+            escape_gemini_schema_ref_keys_in_tool_responses(&mut payload),
+            1
+        );
+        assert_eq!(
+            payload["messages"][0]["content"],
+            format!(
+                "{}{{'properties': {{'image': {{'dollar_ref': '#/components/schemas/Example'}}}}}}",
+                gemini_schema_ref_note("dollar_ref")
+            )
+        );
+    }
+
+    #[test]
+    fn gemini_schema_ref_escape_preserves_longer_identifiers() {
+        let untouched = "$refs and $refresh_token and $reference stay intact";
+        let mut payload = json!({
+            "messages": [{
+                "role": "tool",
+                "tool_call_id": "call_1",
+                "content": untouched
+            }]
+        });
+        let original = payload.clone();
+
         assert_eq!(
             escape_gemini_schema_ref_keys_in_tool_responses(&mut payload),
             0
         );
+        assert_eq!(payload, original);
     }
 
     #[test]
@@ -711,7 +740,7 @@ mod tests {
     }
 
     #[test]
-    fn gemini_schema_ref_escape_leaves_values_unchanged() {
+    fn gemini_schema_ref_escape_rewrites_value_position_tokens() {
         let mut payload = json!({
             "messages": [{
                 "role": "tool",
@@ -719,17 +748,22 @@ mod tests {
                 "content": "{\"description\":\"use $ref here\",\"literal\":\"$ref\",\"identifier\":\"$reference\"}"
             }]
         });
-        let original = payload.clone();
 
         assert_eq!(
             escape_gemini_schema_ref_keys_in_tool_responses(&mut payload),
-            0
+            2
         );
-        assert_eq!(payload, original);
+        assert_eq!(
+            payload["messages"][0]["content"],
+            format!(
+                "{}{{\"description\":\"use dollar_ref here\",\"literal\":\"dollar_ref\",\"identifier\":\"$reference\"}}",
+                gemini_schema_ref_note("dollar_ref")
+            )
+        );
     }
 
     #[test]
-    fn gemini_schema_ref_escape_leaves_non_json_prose_unchanged() {
+    fn gemini_schema_ref_escape_rewrites_non_json_prose() {
         let mut payload = json!({
             "messages": [{
                 "role": "tool",
@@ -737,13 +771,18 @@ mod tests {
                 "content": "log entry, \"$ref\": not a JSON key"
             }]
         });
-        let original = payload.clone();
 
         assert_eq!(
             escape_gemini_schema_ref_keys_in_tool_responses(&mut payload),
-            0
+            1
         );
-        assert_eq!(payload, original);
+        assert_eq!(
+            payload["messages"][0]["content"],
+            format!(
+                "{}log entry, \"dollar_ref\": not a JSON key",
+                gemini_schema_ref_note("dollar_ref")
+            )
+        );
     }
 
     #[test]
@@ -875,12 +914,12 @@ mod tests {
 
         assert_eq!(
             escape_gemini_schema_ref_keys_in_tool_responses(&mut payload),
-            1
+            2
         );
         assert_eq!(
             payload["messages"][0]["content"],
             format!(
-                r#"{}{{"text":"escaped quote \" then \\ and \"$ref\": still text","dollar_ref":"A"}}"#,
+                r#"{}{{"text":"escaped quote \" then \\ and \"dollar_ref\": still text","dollar_ref":"A"}}"#,
                 gemini_schema_ref_note("dollar_ref")
             )
         );
@@ -1115,23 +1154,24 @@ mod tests {
     }
 
     #[test]
-    fn gemini_schema_ref_escape_leaves_embedded_json_string_values_unchanged() {
-        let original = r#"{"payload":"{\"$ref\":\"A\"}"}"#;
+    fn gemini_schema_ref_escape_rewrites_nested_encoded_json() {
         let mut payload = json!({
             "messages": [{
                 "role": "tool",
                 "tool_call_id": "call_1",
-                "content": original
+                "content": r#"{"payload":"{\"$ref\":\"A\"}"}"#
             }]
         });
 
         assert_eq!(
             escape_gemini_schema_ref_keys_in_tool_responses(&mut payload),
-            0
+            1
         );
         assert_eq!(
             payload["messages"][0]["content"],
-            Value::String(original.to_string())
+            Value::String(
+                gemini_schema_ref_note("dollar_ref") + r#"{"payload":"{\"dollar_ref\":\"A\"}"}"#
+            )
         );
     }
 

--- a/crates/goose/src/providers/openrouter.rs
+++ b/crates/goose/src/providers/openrouter.rs
@@ -38,6 +38,11 @@ pub const OPENROUTER_KNOWN_MODELS: &[&str] = &[
 ];
 pub const OPENROUTER_DOC_URL: &str = "https://openrouter.ai/models";
 
+const GEMINI_SCHEMA_REF_KEY: &str = "$ref";
+const GEMINI_SAFE_SCHEMA_REF_KEY: &str = "dollar_ref";
+const GEMINI_SCHEMA_REF_NOTE: &str =
+    "[OpenRouter/Gemini compatibility: interpret `dollar_ref` as the JSON Schema key formed by `$` followed by `ref`.]\n";
+
 #[derive(serde::Serialize)]
 pub struct OpenRouterProvider {
     #[serde(skip)]
@@ -100,6 +105,42 @@ fn is_mandatory_reasoning_error(error: &ProviderError) -> bool {
 
 fn is_gemini_model(model_name: &str) -> bool {
     model_name.starts_with("google/")
+}
+
+/// OpenRouter translates OpenAI `role: tool` messages into Gemini
+/// `function_response` parts. Gemini rejects a response containing a literal
+/// JSON Schema `$ref` key, treating its value as a function-response part name
+/// instead of arbitrary tool text. Escape only that token, only in
+/// Gemini-bound tool results, and add a reversible note so the model can
+/// reconstruct the original text.
+fn escape_gemini_schema_ref_keys_in_tool_responses(payload: &mut Value) -> usize {
+    let Some(messages) = payload.get_mut("messages").and_then(Value::as_array_mut) else {
+        return 0;
+    };
+
+    let mut escaped = 0;
+    for message in messages {
+        if message.get("role").and_then(Value::as_str) != Some("tool") {
+            continue;
+        }
+
+        let Some(content) = message.get_mut("content") else {
+            continue;
+        };
+        let Some(content_text) = content.as_str() else {
+            continue;
+        };
+        let occurrences = content_text.matches(GEMINI_SCHEMA_REF_KEY).count();
+        if occurrences == 0 {
+            continue;
+        }
+
+        let sanitized = content_text.replace(GEMINI_SCHEMA_REF_KEY, GEMINI_SAFE_SCHEMA_REF_KEY);
+        *content = Value::String(format!("{GEMINI_SCHEMA_REF_NOTE}{sanitized}"));
+        escaped += occurrences;
+    }
+
+    escaped
 }
 
 fn parse_openrouter_parameters(raw: Value) -> Result<HashMap<String, Value>> {
@@ -291,6 +332,14 @@ impl Provider for OpenRouterProvider {
         }
 
         if is_gemini_model(&model_config.model_name) {
+            let escaped_schema_ref_keys =
+                escape_gemini_schema_ref_keys_in_tool_responses(&mut payload);
+            if escaped_schema_ref_keys > 0 {
+                tracing::warn!(
+                    escaped_schema_ref_keys,
+                    "escaped JSON Schema ref keys in Gemini-bound tool results"
+                );
+            }
             openrouter_format::add_reasoning_details_to_request(&mut payload, messages);
         }
         let sent_reasoning_disable =
@@ -455,5 +504,63 @@ mod tests {
             .stream(&config, "system", &[Message::user().with_text("hi")], &[])
             .await
             .unwrap();
+    }
+
+    #[test]
+    fn gemini_tool_result_schema_ref_keys_are_escaped_reversibly() {
+        let mut payload = json!({
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": "Keep {'$ref': '#/components/schemas/AssistantText'} unchanged"
+                },
+                {
+                    "role": "tool",
+                    "tool_call_id": "call_1",
+                    "content": "{'$ref': '#/components/schemas/Base64Image'} and {\"$ref\": \"#/components/schemas/Usage\"}"
+                }
+            ]
+        });
+
+        assert_eq!(
+            escape_gemini_schema_ref_keys_in_tool_responses(&mut payload),
+            2
+        );
+        assert_eq!(
+            payload["messages"][0]["content"],
+            "Keep {'$ref': '#/components/schemas/AssistantText'} unchanged"
+        );
+        assert_eq!(
+            payload["messages"][1]["content"],
+            format!(
+                "{GEMINI_SCHEMA_REF_NOTE}{{'dollar_ref': '#/components/schemas/Base64Image'}} and {{\"dollar_ref\": \"#/components/schemas/Usage\"}}"
+            )
+        );
+        assert!(!payload["messages"][1]["content"]
+            .as_str()
+            .unwrap()
+            .contains(GEMINI_SCHEMA_REF_KEY));
+        assert_eq!(
+            escape_gemini_schema_ref_keys_in_tool_responses(&mut payload),
+            0
+        );
+    }
+
+    #[test]
+    fn gemini_schema_ref_escape_ignores_non_tool_content_and_safe_tool_results() {
+        let mut payload = json!({
+            "messages": [
+                { "role": "user", "content": "{'$ref': '#/components/schemas/UserText'}" },
+                { "role": "tool", "tool_call_id": "call_1", "content": "ordinary output" },
+                { "role": "tool", "tool_call_id": "call_2", "content": [{ "type": "text", "text": "{'$ref': '#/components/schemas/Structured'}" }] }
+            ]
+        });
+        let original = payload.clone();
+
+        assert_eq!(
+            escape_gemini_schema_ref_keys_in_tool_responses(&mut payload),
+            0
+        );
+        assert_eq!(payload, original);
     }
 }

--- a/crates/goose/src/providers/openrouter.rs
+++ b/crates/goose/src/providers/openrouter.rs
@@ -4,6 +4,7 @@ use futures::future::BoxFuture;
 use goose_providers::images::ImageFormat;
 use serde_json::{json, Value};
 use std::collections::{HashMap, HashSet};
+use std::ops::Range;
 
 use super::api_client::{ApiClient, AuthMethod};
 use super::base::{ConfigKey, MessageStream, Provider, ProviderDef, ProviderMetadata};
@@ -105,45 +106,110 @@ fn is_gemini_model(model_name: &str) -> bool {
     model_name.starts_with("google/gemini")
 }
 
-fn collect_json_object_keys(value: &Value, keys: &mut HashSet<String>) {
-    match value {
-        Value::Object(object) => {
-            for (key, value) in object {
-                keys.insert(key.clone());
-                collect_json_object_keys(value, keys);
-            }
-        }
-        Value::Array(array) => {
-            for value in array {
-                collect_json_object_keys(value, keys);
-            }
-        }
-        _ => {}
-    }
+#[derive(Default)]
+struct JsonObjectKeyScan {
+    occupied_keys: HashSet<String>,
+    schema_ref_key_spans: Vec<Range<usize>>,
 }
 
-fn rename_json_object_key(value: &mut Value, source_key: &str, target_key: &str) -> usize {
-    match value {
-        Value::Object(object) => {
-            let mut renamed = 0;
-            let original = std::mem::take(object);
-            for (key, mut value) in original {
-                renamed += rename_json_object_key(&mut value, source_key, target_key);
-                if key == source_key {
-                    object.insert(target_key.to_string(), value);
-                    renamed += 1;
-                } else {
-                    object.insert(key, value);
+fn decode_json_string_literal(content: &str, span: &Range<usize>) -> Option<String> {
+    serde_json::from_str(content.get(span.clone())?).ok()
+}
+
+/// Tolerantly scans JSON-like text without requiring the entire input to parse.
+/// A string is treated as an object key only when it is inside an object,
+/// follows `{` or `,`, and is followed by `:` outside the string.
+fn scan_json_object_keys(content: &str) -> JsonObjectKeyScan {
+    let bytes = content.as_bytes();
+    let mut scan = JsonObjectKeyScan::default();
+    let mut containers = Vec::new();
+    let mut previous_non_whitespace = None;
+    let mut pending_key_span = None;
+    let mut string_start = 0;
+    let mut string_container = None;
+    let mut string_preceding_byte = None;
+    let mut in_string = false;
+    let mut escaped = false;
+
+    for (index, byte) in bytes.iter().copied().enumerate() {
+        if in_string {
+            if escaped {
+                escaped = false;
+            } else if byte == b'\\' {
+                escaped = true;
+            } else if byte == b'"' {
+                in_string = false;
+                let span = string_start..index + 1;
+                if string_container == Some(b'{')
+                    && matches!(string_preceding_byte, Some(b'{') | Some(b','))
+                {
+                    pending_key_span = Some(span);
+                }
+                previous_non_whitespace = Some(b'"');
+            }
+            continue;
+        }
+
+        if byte.is_ascii_whitespace() {
+            continue;
+        }
+
+        if let Some(span) = pending_key_span.take() {
+            if byte == b':' {
+                if let Some(key) = decode_json_string_literal(content, &span) {
+                    if key == GEMINI_SCHEMA_REF_KEY {
+                        scan.schema_ref_key_spans.push(span);
+                    }
+                    scan.occupied_keys.insert(key);
                 }
             }
-            renamed
         }
-        Value::Array(array) => array
-            .iter_mut()
-            .map(|value| rename_json_object_key(value, source_key, target_key))
-            .sum(),
-        _ => 0,
+
+        match byte {
+            b'"' => {
+                in_string = true;
+                escaped = false;
+                string_start = index;
+                string_container = containers.last().copied();
+                string_preceding_byte = previous_non_whitespace;
+            }
+            b'{' | b'[' => containers.push(byte),
+            b'}' if containers.last() == Some(&b'{') => {
+                containers.pop();
+            }
+            b']' if containers.last() == Some(&b'[') => {
+                containers.pop();
+            }
+            _ => {}
+        }
+        previous_non_whitespace = Some(byte);
     }
+
+    scan
+}
+
+fn replace_json_key_spans(content: &str, spans: &[Range<usize>], replacement: &str) -> String {
+    let serialized_replacement =
+        serde_json::to_string(replacement).expect("JSON object keys must serialize successfully");
+    let mut rewritten = String::with_capacity(content.len());
+    let mut copied_through = 0;
+
+    for span in spans {
+        rewritten.push_str(
+            content
+                .get(copied_through..span.start)
+                .expect("scanned JSON key spans must lie on UTF-8 boundaries"),
+        );
+        rewritten.push_str(&serialized_replacement);
+        copied_through = span.end;
+    }
+    rewritten.push_str(
+        content
+            .get(copied_through..)
+            .expect("scanned JSON key spans must lie on UTF-8 boundaries"),
+    );
+
+    rewritten
 }
 
 fn collision_free_gemini_schema_ref_key(occupied_keys: &HashSet<String>) -> String {
@@ -177,16 +243,16 @@ fn apply_gemini_compatibility(model_name: &str, payload: &mut Value, messages: &
 /// OpenRouter translates OpenAI `role: tool` messages into Gemini
 /// `function_response` parts. Gemini rejects a response containing a literal
 /// JSON Schema `$ref` key, treating its value as a function-response part name
-/// instead of arbitrary tool text. Escape only keys in complete JSON tool
-/// results and add a reversible note so the model can reconstruct the original
-/// text. Non-JSON tool output must remain byte-for-byte unchanged.
+/// instead of arbitrary tool text. Escape object keys in otherwise opaque tool
+/// text and add a reversible note so the model can reconstruct the original
+/// text. All bytes outside matching key spans remain unchanged.
 fn escape_gemini_schema_ref_keys_in_tool_responses(payload: &mut Value) -> usize {
     let Some(messages) = payload.get_mut("messages").and_then(Value::as_array_mut) else {
         return 0;
     };
 
     let mut occupied_keys = HashSet::new();
-    let mut parsed_tool_results = Vec::new();
+    let mut scanned_tool_results = Vec::new();
     for (message_index, message) in messages.iter().enumerate() {
         if message.get("role").and_then(Value::as_str) != Some("tool") {
             continue;
@@ -195,27 +261,25 @@ fn escape_gemini_schema_ref_keys_in_tool_responses(payload: &mut Value) -> usize
         let Some(content_text) = message.get("content").and_then(Value::as_str) else {
             continue;
         };
-        let Ok(parsed_content) = serde_json::from_str::<Value>(content_text) else {
-            continue;
-        };
-        collect_json_object_keys(&parsed_content, &mut occupied_keys);
-        parsed_tool_results.push((message_index, parsed_content));
+        let scan = scan_json_object_keys(content_text);
+        occupied_keys.extend(scan.occupied_keys);
+        scanned_tool_results.push((message_index, scan.schema_ref_key_spans));
     }
 
     let safe_key = collision_free_gemini_schema_ref_key(&occupied_keys);
     let note = gemini_schema_ref_note(&safe_key);
     let mut escaped = 0;
-    for (message_index, mut parsed_content) in parsed_tool_results {
-        let message_escaped =
-            rename_json_object_key(&mut parsed_content, GEMINI_SCHEMA_REF_KEY, &safe_key);
-        if message_escaped == 0 {
+    for (message_index, schema_ref_key_spans) in scanned_tool_results {
+        if schema_ref_key_spans.is_empty() {
             continue;
         }
 
-        let sanitized = serde_json::to_string(&parsed_content)
-            .expect("JSON values must serialize successfully");
+        let content_text = messages[message_index]["content"]
+            .as_str()
+            .expect("scanned tool result content must remain a string");
+        let sanitized = replace_json_key_spans(content_text, &schema_ref_key_spans, &safe_key);
         messages[message_index]["content"] = Value::String(format!("{note}{sanitized}"));
-        escaped += message_escaped;
+        escaped += schema_ref_key_spans.len();
     }
 
     escaped
@@ -601,7 +665,7 @@ mod tests {
         assert_eq!(
             payload["messages"][1]["content"],
             format!(
-                "{}{{\"dollar_ref\":\"#/components/schemas/Usage\",\"nested\":{{\"dollar_ref\":\"#/components/schemas/Base64Image\"}},\"items\":[{{\"dollar_ref\":\"#/components/schemas/Item\"}}],\"description\":\"use $ref here\",\"literal\":\"$ref\",\"identifier\":\"$reference\"}}",
+                "{}{{\"dollar_ref\": \"#/components/schemas/Usage\", \"nested\": {{\"dollar_ref\" : \"#/components/schemas/Base64Image\"}}, \"items\": [{{\"dollar_ref\": \"#/components/schemas/Item\"}}], \"description\": \"use $ref here\", \"literal\": \"$ref\", \"identifier\": \"$reference\"}}",
                 gemini_schema_ref_note("dollar_ref")
             )
         );
@@ -626,6 +690,11 @@ mod tests {
         apply_gemini_compatibility("google/gemma-3-27b-it", &mut gemma_payload, &[]);
 
         assert_eq!(gemma_payload, original_gemma_payload);
+
+        let mut anthropic_payload = original_gemma_payload.clone();
+        apply_gemini_compatibility("anthropic/claude-sonnet-4.5", &mut anthropic_payload, &[]);
+
+        assert_eq!(anthropic_payload, original_gemma_payload);
 
         let mut gemini_payload = original_gemma_payload;
         apply_gemini_compatibility("google/gemini-2.5-flash", &mut gemini_payload, &[]);
@@ -675,6 +744,201 @@ mod tests {
             0
         );
         assert_eq!(payload, original);
+    }
+
+    #[test]
+    fn gemini_schema_ref_escape_preserves_duplicate_ref_members() {
+        let mut payload = json!({
+            "messages": [{
+                "role": "tool",
+                "tool_call_id": "call_1",
+                "content": "{\"$ref\":\"A\",\"$ref\":\"B\"}"
+            }]
+        });
+
+        assert_eq!(
+            escape_gemini_schema_ref_keys_in_tool_responses(&mut payload),
+            2
+        );
+        assert_eq!(
+            payload["messages"][0]["content"],
+            format!(
+                "{}{{\"dollar_ref\":\"A\",\"dollar_ref\":\"B\"}}",
+                gemini_schema_ref_note("dollar_ref")
+            )
+        );
+    }
+
+    #[test]
+    fn gemini_schema_ref_escape_preserves_unrelated_duplicate_members() {
+        let mut payload = json!({
+            "messages": [{
+                "role": "tool",
+                "tool_call_id": "call_1",
+                "content": "{\"duplicate\":\"first\",\"$ref\":\"A\",\"duplicate\":\"second\"}"
+            }]
+        });
+
+        assert_eq!(
+            escape_gemini_schema_ref_keys_in_tool_responses(&mut payload),
+            1
+        );
+        assert_eq!(
+            payload["messages"][0]["content"],
+            format!(
+                "{}{{\"duplicate\":\"first\",\"dollar_ref\":\"A\",\"duplicate\":\"second\"}}",
+                gemini_schema_ref_note("dollar_ref")
+            )
+        );
+    }
+
+    #[test]
+    fn gemini_schema_ref_escape_rewrites_json_embedded_in_prose() {
+        let mut payload = json!({
+            "messages": [{
+                "role": "tool",
+                "tool_call_id": "call_1",
+                "content": "before output { \"$ref\" : \"A\" } after output"
+            }]
+        });
+
+        assert_eq!(
+            escape_gemini_schema_ref_keys_in_tool_responses(&mut payload),
+            1
+        );
+        assert_eq!(
+            payload["messages"][0]["content"],
+            format!(
+                "{}before output {{ \"dollar_ref\" : \"A\" }} after output",
+                gemini_schema_ref_note("dollar_ref")
+            )
+        );
+    }
+
+    #[test]
+    fn gemini_schema_ref_escape_rewrites_multiple_occurrences_in_one_result() {
+        let mut payload = json!({
+            "messages": [{
+                "role": "tool",
+                "tool_call_id": "call_1",
+                "content": "{\"$ref\":\"A\",\"nested\":{\"$ref\":\"B\"}}"
+            }]
+        });
+
+        assert_eq!(
+            escape_gemini_schema_ref_keys_in_tool_responses(&mut payload),
+            2
+        );
+        assert_eq!(
+            payload["messages"][0]["content"],
+            format!(
+                "{}{{\"dollar_ref\":\"A\",\"nested\":{{\"dollar_ref\":\"B\"}}}}",
+                gemini_schema_ref_note("dollar_ref")
+            )
+        );
+    }
+
+    #[test]
+    fn gemini_schema_ref_escape_matches_decoded_keys_and_collisions() {
+        let mut payload = json!({
+            "messages": [{
+                "role": "tool",
+                "tool_call_id": "call_1",
+                "content": r#"{"\u0024ref":"A","\u0064ollar_ref":"B"}"#
+            }]
+        });
+
+        assert_eq!(
+            escape_gemini_schema_ref_keys_in_tool_responses(&mut payload),
+            1
+        );
+        assert_eq!(
+            payload["messages"][0]["content"],
+            format!(
+                r#"{}{{"dollar_ref_2":"A","\u0064ollar_ref":"B"}}"#,
+                gemini_schema_ref_note("dollar_ref_2")
+            )
+        );
+    }
+
+    #[test]
+    fn gemini_schema_ref_escape_honors_escaped_quotes_and_backslashes() {
+        let original_content =
+            r#"{"text":"escaped quote \" then \\ and \"$ref\": still text","$ref":"A"}"#;
+        let mut payload = json!({
+            "messages": [{
+                "role": "tool",
+                "tool_call_id": "call_1",
+                "content": original_content
+            }]
+        });
+
+        assert_eq!(
+            escape_gemini_schema_ref_keys_in_tool_responses(&mut payload),
+            1
+        );
+        assert_eq!(
+            payload["messages"][0]["content"],
+            format!(
+                r#"{}{{"text":"escaped quote \" then \\ and \"$ref\": still text","dollar_ref":"A"}}"#,
+                gemini_schema_ref_note("dollar_ref")
+            )
+        );
+    }
+
+    #[test]
+    fn gemini_schema_ref_escape_preserves_absent_content_bytes() {
+        let original_content = "prefix { \"ordinary\" : [ 1, 2 ] } suffix";
+        let mut payload = json!({
+            "messages": [{
+                "role": "tool",
+                "tool_call_id": "call_1",
+                "content": original_content
+            }]
+        });
+
+        assert_eq!(
+            escape_gemini_schema_ref_keys_in_tool_responses(&mut payload),
+            0
+        );
+        assert_eq!(
+            payload["messages"][0]["content"]
+                .as_str()
+                .unwrap()
+                .as_bytes(),
+            original_content.as_bytes()
+        );
+    }
+
+    #[test]
+    fn gemini_schema_ref_escape_tolerates_malformed_json() {
+        let mut payload = json!({
+            "messages": [
+                {
+                    "role": "tool",
+                    "tool_call_id": "call_1",
+                    "content": "{\"$ref\": \"A\""
+                },
+                {
+                    "role": "tool",
+                    "tool_call_id": "call_2",
+                    "content": "}"
+                }
+            ]
+        });
+
+        assert_eq!(
+            escape_gemini_schema_ref_keys_in_tool_responses(&mut payload),
+            1
+        );
+        assert_eq!(
+            payload["messages"][0]["content"],
+            format!(
+                "{}{{\"dollar_ref\": \"A\"",
+                gemini_schema_ref_note("dollar_ref")
+            )
+        );
+        assert_eq!(payload["messages"][1]["content"], "}");
     }
 
     #[test]
@@ -761,7 +1025,8 @@ mod tests {
     fn gemini_schema_ref_escape_ignores_non_tool_content_and_safe_tool_results() {
         let mut payload = json!({
             "messages": [
-                { "role": "user", "content": "{'$ref': '#/components/schemas/UserText'}" },
+                { "role": "user", "content": "{\"$ref\":\"#/components/schemas/UserText\"}" },
+                { "role": "assistant", "content": "{\"$ref\":\"#/components/schemas/AssistantText\"}" },
                 { "role": "tool", "tool_call_id": "call_1", "content": "ordinary output" },
                 { "role": "tool", "tool_call_id": "call_2", "content": [{ "type": "text", "text": "{'$ref': '#/components/schemas/Structured'}" }] }
             ]

--- a/crates/goose/src/providers/openrouter.rs
+++ b/crates/goose/src/providers/openrouter.rs
@@ -1039,4 +1039,144 @@ mod tests {
         );
         assert_eq!(payload, original);
     }
+
+    #[test]
+    fn gemini_schema_ref_escape_ignores_braces_inside_string_literals() {
+        let mut payload = json!({
+            "messages": [{
+                "role": "tool",
+                "tool_call_id": "call_1",
+                "content": r#"{"a":"}}}}","$ref":"B"}"#
+            }]
+        });
+
+        assert_eq!(
+            escape_gemini_schema_ref_keys_in_tool_responses(&mut payload),
+            1
+        );
+        assert_eq!(
+            payload["messages"][0]["content"],
+            Value::String(
+                gemini_schema_ref_note("dollar_ref") + r#"{"a":"}}}}","dollar_ref":"B"}"#
+            )
+        );
+    }
+
+    #[test]
+    fn gemini_schema_ref_escape_ignores_brackets_inside_string_literals() {
+        let mut payload = json!({
+            "messages": [{
+                "role": "tool",
+                "tool_call_id": "call_1",
+                "content": r#"{"a":"[[[","$ref":"B"}"#
+            }]
+        });
+
+        assert_eq!(
+            escape_gemini_schema_ref_keys_in_tool_responses(&mut payload),
+            1
+        );
+        assert_eq!(
+            payload["messages"][0]["content"],
+            Value::String(gemini_schema_ref_note("dollar_ref") + r#"{"a":"[[[","dollar_ref":"B"}"#)
+        );
+    }
+
+    #[test]
+    fn gemini_schema_ref_escape_avoids_safe_key_used_in_another_tool_result() {
+        let untouched = r#"{"dollar_ref":"x"}"#;
+        let mut payload = json!({
+            "messages": [
+                {
+                    "role": "tool",
+                    "tool_call_id": "call_1",
+                    "content": r#"{"$ref":"A"}"#
+                },
+                {
+                    "role": "tool",
+                    "tool_call_id": "call_2",
+                    "content": untouched
+                }
+            ]
+        });
+
+        assert_eq!(
+            escape_gemini_schema_ref_keys_in_tool_responses(&mut payload),
+            1
+        );
+        assert_eq!(
+            payload["messages"][0]["content"],
+            Value::String(gemini_schema_ref_note("dollar_ref_2") + r#"{"dollar_ref_2":"A"}"#)
+        );
+        assert_eq!(
+            payload["messages"][1]["content"],
+            Value::String(untouched.to_string())
+        );
+    }
+
+    #[test]
+    fn gemini_schema_ref_escape_leaves_embedded_json_string_values_unchanged() {
+        let original = r#"{"payload":"{\"$ref\":\"A\"}"}"#;
+        let mut payload = json!({
+            "messages": [{
+                "role": "tool",
+                "tool_call_id": "call_1",
+                "content": original
+            }]
+        });
+
+        assert_eq!(
+            escape_gemini_schema_ref_keys_in_tool_responses(&mut payload),
+            0
+        );
+        assert_eq!(
+            payload["messages"][0]["content"],
+            Value::String(original.to_string())
+        );
+    }
+
+    #[test]
+    fn gemini_schema_ref_escape_preserves_multibyte_content() {
+        let mut payload = json!({
+            "messages": [{
+                "role": "tool",
+                "tool_call_id": "call_1",
+                "content": "{\"\u{540d}\u{524d}\":\"\u{1f389} ok\",\"$ref\":\"A\"}"
+            }]
+        });
+
+        assert_eq!(
+            escape_gemini_schema_ref_keys_in_tool_responses(&mut payload),
+            1
+        );
+        assert_eq!(
+            payload["messages"][0]["content"],
+            Value::String(
+                gemini_schema_ref_note("dollar_ref")
+                    + "{\"\u{540d}\u{524d}\":\"\u{1f389} ok\",\"dollar_ref\":\"A\"}"
+            )
+        );
+    }
+
+    #[test]
+    fn gemini_schema_ref_escape_is_idempotent() {
+        let mut payload = json!({
+            "messages": [{
+                "role": "tool",
+                "tool_call_id": "call_1",
+                "content": r#"{"$ref":"A","b":[{"$ref":"B"}]}"#
+            }]
+        });
+
+        assert_eq!(
+            escape_gemini_schema_ref_keys_in_tool_responses(&mut payload),
+            2
+        );
+        let after_first_pass = payload.clone();
+        assert_eq!(
+            escape_gemini_schema_ref_keys_in_tool_responses(&mut payload),
+            0
+        );
+        assert_eq!(payload, after_first_pass);
+    }
 }


### PR DESCRIPTION
## Summary

- Escape literal `$ref` key tokens in string tool-result content only when sending Google/Gemini models through OpenRouter.
- Prepend a reversible compatibility note so the model can reconstruct the original JSON Schema key.
- Leave other providers, message roles, and structured tool content unchanged.

### Testing

- `cargo test -p goose gemini_tool_result_schema_ref_keys_are_escaped_reversibly`
- `cargo test -p goose gemini_schema_ref_escape_ignores_non_tool_content_and_safe_tool_results`
- `cargo fmt --all -- --check`

### Related Issues

Fixes #11260

### Screenshots/Demos (for UX changes)

Not applicable.
