### PR TITLE
fix: reopen sessions whose working directory was deleted

### DIFF
--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -594,6 +594,7 @@ pub(super) fn validate_absolute_cwd(cwd: &Path) -> Result<(), agent_client_proto
 
 pub(super) fn resolve_cwd_for_reactivation(
     cwd: PathBuf,
+    stored_cwd: &Path,
 ) -> Result<PathBuf, agent_client_protocol::Error> {
     if !cwd.is_absolute() {
         return Err(
@@ -601,8 +602,12 @@ pub(super) fn resolve_cwd_for_reactivation(
         );
     }
 
-    if cwd.exists() && cwd.is_dir() {
+    if cwd.is_dir() {
         return Ok(cwd);
+    }
+
+    if cwd != stored_cwd {
+        return Err(agent_client_protocol::Error::invalid_params().data("invalid directory path"));
     }
 
     let home = dirs::home_dir().filter(|home| home.is_dir());

--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -592,6 +592,37 @@ pub(super) fn validate_absolute_cwd(cwd: &Path) -> Result<(), agent_client_proto
     Ok(())
 }
 
+/// Resolves a session's working directory for reactivation, falling back to the
+/// user's home directory when the original directory no longer exists on disk
+/// (e.g. the project was deleted or moved), so an old session can still be
+/// reopened instead of failing outright.
+pub(super) fn resolve_cwd_for_reactivation(
+    cwd: PathBuf,
+) -> Result<PathBuf, agent_client_protocol::Error> {
+    if !cwd.is_absolute() {
+        return Err(
+            agent_client_protocol::Error::invalid_params().data("cwd must be an absolute path")
+        );
+    }
+
+    if cwd.exists() && cwd.is_dir() {
+        return Ok(cwd);
+    }
+
+    let home = dirs::home_dir().filter(|home| home.is_dir());
+    match home {
+        Some(home) => {
+            warn!(
+                original_cwd = %cwd.display(),
+                fallback_cwd = %home.display(),
+                "session working directory no longer exists, falling back to home directory"
+            );
+            Ok(home)
+        }
+        None => Err(agent_client_protocol::Error::invalid_params().data("invalid directory path")),
+    }
+}
+
 impl GooseAcpAgent {
     pub fn permission_manager(&self) -> Arc<PermissionManager> {
         Arc::clone(&self.permission_manager)

--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -592,10 +592,6 @@ pub(super) fn validate_absolute_cwd(cwd: &Path) -> Result<(), agent_client_proto
     Ok(())
 }
 
-/// Resolves a session's working directory for reactivation, falling back to the
-/// user's home directory when the original directory no longer exists on disk
-/// (e.g. the project was deleted or moved), so an old session can still be
-/// reopened instead of failing outright.
 pub(super) fn resolve_cwd_for_reactivation(
     cwd: PathBuf,
 ) -> Result<PathBuf, agent_client_protocol::Error> {

--- a/crates/goose/src/acp/server/fork_session.rs
+++ b/crates/goose/src/acp/server/fork_session.rs
@@ -7,7 +7,7 @@ impl GooseAcpAgent {
         cx: &ConnectionTo<Client>,
         args: ForkSessionRequest,
     ) -> Result<ForkSessionResponse, agent_client_protocol::Error> {
-        validate_absolute_cwd(&args.cwd)?;
+        let cwd = resolve_cwd_for_reactivation(args.cwd)?;
         let conversation_before = conversation_before_from_meta(args.meta.as_ref())?;
         let source_session_id = &*args.session_id.0;
 
@@ -43,12 +43,7 @@ impl GooseAcpAgent {
             .internal_err()?;
 
         let goose_session = self
-            .prepare_session_for_activation(
-                new_session.clone(),
-                args.cwd.clone(),
-                args.mcp_servers,
-                false,
-            )
+            .prepare_session_for_activation(new_session.clone(), cwd, args.mcp_servers, false)
             .await?;
 
         let (agent, extension_results) = self.prepare_acp_session_agent(cx, &goose_session).await?;

--- a/crates/goose/src/acp/server/fork_session.rs
+++ b/crates/goose/src/acp/server/fork_session.rs
@@ -7,7 +7,6 @@ impl GooseAcpAgent {
         cx: &ConnectionTo<Client>,
         args: ForkSessionRequest,
     ) -> Result<ForkSessionResponse, agent_client_protocol::Error> {
-        let cwd = resolve_cwd_for_reactivation(args.cwd)?;
         let conversation_before = conversation_before_from_meta(args.meta.as_ref())?;
         let source_session_id = &*args.session_id.0;
 
@@ -16,6 +15,7 @@ impl GooseAcpAgent {
             .get_session(source_session_id, false)
             .await
             .internal_err()?;
+        let cwd = resolve_cwd_for_reactivation(args.cwd, &source.working_dir)?;
         let fork_name = if source.name.trim().is_empty() {
             "(copy)".to_string()
         } else {

--- a/crates/goose/src/acp/server/load_session.rs
+++ b/crates/goose/src/acp/server/load_session.rs
@@ -272,7 +272,7 @@ impl GooseAcpAgent {
         args: LoadSessionRequest,
     ) -> Result<LoadSessionResponse, agent_client_protocol::Error> {
         debug!(?args, "load session request");
-        validate_absolute_cwd(&args.cwd)?;
+        let cwd = resolve_cwd_for_reactivation(args.cwd)?;
 
         let session_id_str = args.session_id.0.to_string();
 
@@ -286,7 +286,7 @@ impl GooseAcpAgent {
             })?;
 
         session = self
-            .prepare_session_for_activation(session, args.cwd.clone(), args.mcp_servers, true)
+            .prepare_session_for_activation(session, cwd, args.mcp_servers, true)
             .await?;
 
         replay_conversation_to_client(

--- a/crates/goose/src/acp/server/load_session.rs
+++ b/crates/goose/src/acp/server/load_session.rs
@@ -272,7 +272,6 @@ impl GooseAcpAgent {
         args: LoadSessionRequest,
     ) -> Result<LoadSessionResponse, agent_client_protocol::Error> {
         debug!(?args, "load session request");
-        let cwd = resolve_cwd_for_reactivation(args.cwd)?;
 
         let session_id_str = args.session_id.0.to_string();
 
@@ -284,6 +283,8 @@ impl GooseAcpAgent {
                 agent_client_protocol::Error::resource_not_found(Some(session_id_str.clone()))
                     .data(format!("Session not found: {}", session_id_str))
             })?;
+
+        let cwd = resolve_cwd_for_reactivation(args.cwd, &session.working_dir)?;
 
         session = self
             .prepare_session_for_activation(session, cwd, args.mcp_servers, true)


### PR DESCRIPTION
## Summary
`session/load` and `session/fork` rejected reactivation with an invalid-path
error whenever a session's stored working directory no longer existed on
disk (e.g. the project folder was deleted or moved), since both round-trip
the session's own cwd back through a strict existence check.

Adds `resolve_cwd_for_reactivation`, which falls back to the user's home
directory (the same fallback convention used elsewhere in this codebase,
e.g. `onboarding.rs`) instead of hard-failing, so an old session can still
be reopened. New-session creation and explicit working-directory switches
keep the strict check, since those are user-chosen paths rather than
history being reopened.

### Testing
- `cargo fmt`
- `cargo build -p goose`
- Manually reproduced: deleted a session's project folder, reloaded the
  session via ACP `session/load`, confirmed it reopens in the home
  directory instead of erroring.
  
### Related Issues
Relates to #11231 