### PR TITLE
Add freehire to the extensions directory

### DIFF
--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -827,6 +827,24 @@
       "required": false
     }
   ]
+},
+
+{
+  "id": "freehire",
+  "name": "freehire",
+  "description": "Search 3.3M+ IT jobs on freehire.me, crawled straight from 294K company career boards, with market-fit scoring, application tracking and CV tailoring",
+  "command": "npx -y freehire-mcp",
+  "link": "https://github.com/strelov1/freehire-mcp",
+  "installation_notes": "Install using npx package manager. A freehire.me API key is optional: without one the server starts and lists its tools, and only tool calls report that authentication is missing.",
+  "is_builtin": false,
+  "endorsed": false,
+  "environmentVariables": [
+    {
+      "name": "FREEHIRE_TOKEN",
+      "description": "A freehire.me personal API key (account menu -> API keys). Optional; the server also reads the key stored by the freehire CLI.",
+      "required": false
+    }
+  ]
 }
 
 ]


### PR DESCRIPTION
Adds [freehire-mcp](https://github.com/strelov1/freehire-mcp) to `servers.json`.

An MCP server over [freehire.me](https://freehire.me), an open-source IT job aggregator that crawls postings straight from company career boards rather than reposts — 3.3M+ open roles across 294K companies, normalized into one schema and tagged with stack, seniority, region and work mode.

23 tools: faceted search over the live market, market-fit scoring of a skill set against real demand, full posting and company reads, apply, save, application stages and notes, CV context/edit/render, and vacancy submission. `search` returns each posting's full description as markdown, so a session can screen a result set without a follow-up call per hit.

- `npx -y freehire-mcp`, stdio, MIT, TypeScript
- Listed in the official MCP registry as `me.freehire/freehire`
- `FREEHIRE_TOKEN` is marked **not required**, and that is accurate: without it the server starts and lists its tools, and only tool calls report missing auth. So adding the extension never fails on a missing credential.

Appended in place — the file is not sorted by id, so the entry goes last rather than reordering the rest.