### PR TITLE
fix(hints): keep subdirectory hints resume-safe

### DIFF
--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -872,6 +872,14 @@ impl Agent {
                 )
             );
         }
+        // Rebuild subdirectory-hint state from the conversation before the
+        // first system prompt is rendered, so a resumed session keeps the
+        // hints its earlier tool calls pulled in (#10330).
+        self.prompt_manager
+            .lock()
+            .await
+            .record_tool_arguments_from_history(conversation.messages(), working_dir);
+
         let (tools, toolshim_tools, system_prompt, model_config) = self
             .prepare_tools_and_prompt(session_id, working_dir)
             .await?;

--- a/crates/goose/src/agents/prompt_manager.rs
+++ b/crates/goose/src/agents/prompt_manager.rs
@@ -473,6 +473,50 @@ mod tests {
         assert!(result.contains("hidden instructions"));
     }
 
+    /// The case @michaelneale flagged as untested on the exemplar: does replay
+    /// still work after the conversation has been compacted?
+    ///
+    /// It does, and the reason is structural. `compact_messages` does not
+    /// delete the pre-compaction messages -- it flips them to
+    /// `agent_invisible` and appends an agent-only summary. The tool requests
+    /// therefore remain in the stored conversation, and
+    /// `record_tool_arguments_from_history` walks `conversation.messages()`,
+    /// which is every message regardless of visibility. Replay is blind to
+    /// the agent/user projection, so compaction cannot starve it.
+    #[test]
+    fn replay_survives_compaction() {
+        use rmcp::{model::CallToolRequestParams, object};
+
+        let working_dir = tempfile::tempdir().unwrap();
+        let subdir = working_dir.path().join("sub");
+        std::fs::create_dir(&subdir).unwrap();
+        std::fs::write(subdir.join(".goosehints"), "hint from the subdirectory").unwrap();
+
+        let mut params = CallToolRequestParams::new("text_editor");
+        params.arguments = Some(object!({"path": subdir.join("file.rs").to_string_lossy()}));
+        let tool_request = Message::assistant().with_tool_request("call-1", Ok(params));
+
+        // Exactly the shape compact_messages leaves behind: the originals
+        // demoted to agent-invisible, plus an agent-only summary that never
+        // mentions the path.
+        let compacted = vec![
+            tool_request.with_metadata(
+                crate::conversation::message::MessageMetadata::default().with_agent_invisible(),
+            ),
+            Message::assistant()
+                .with_text("Summary: the user asked about some code.")
+                .with_visibility(false, true),
+        ];
+
+        let mut resumed = PromptManager::new();
+        resumed.record_tool_arguments_from_history(&compacted, working_dir.path());
+
+        assert!(
+            resumed.load_subdirectory_hints(working_dir.path()),
+            "a compacted conversation must still yield its subdirectory hints"
+        );
+    }
+
     /// The #10330 regression: a resumed session has an in-memory tracker that
     /// never saw the earlier tool calls, so replaying the conversation's tool
     /// requests has to bring the subdirectory hints back.

--- a/crates/goose/src/agents/prompt_manager.rs
+++ b/crates/goose/src/agents/prompt_manager.rs
@@ -7,6 +7,7 @@ use serde_json::Value;
 use std::collections::HashMap;
 
 use crate::agents::{extension::ExtensionInfo, moim};
+use crate::conversation::message::{Message, MessageContent};
 use crate::hints::load_hints::build_gitignore;
 use crate::hints::{get_context_filenames, load_hint_files, SubdirectoryHintTracker};
 use crate::{
@@ -234,6 +235,30 @@ impl PromptManager {
             .record_tool_arguments(arguments, working_dir);
     }
 
+    /// Re-derive subdirectory hints from a conversation's tool-call history.
+    ///
+    /// The tracker lives in memory, so a resumed session starts with no record
+    /// of the directories the conversation already touched and silently drops
+    /// the hints that applied before the resume (#10330). Replaying the
+    /// history's tool requests rebuilds that state from the conversation
+    /// itself, which is already the source of truth and is already how the
+    /// state-machine loop derives hints (`ops_toolcalling::prompt_parts`).
+    ///
+    /// Idempotent: the tracker skips directories it has already loaded, so
+    /// calling this on every reply does not re-inject hints mid-session.
+    pub fn record_tool_arguments_from_history(&mut self, messages: &[Message], working_dir: &Path) {
+        for message in messages {
+            for content in &message.content {
+                if let MessageContent::ToolRequest(request) = content {
+                    if let Ok(tool_call) = &request.tool_call {
+                        self.subdirectory_hint_tracker
+                            .record_tool_arguments(&tool_call.arguments, working_dir);
+                    }
+                }
+            }
+        }
+    }
+
     pub fn load_subdirectory_hints(&mut self, working_dir: &Path) -> bool {
         let new_hints = self.subdirectory_hint_tracker.load_new_hints(working_dir);
         let has_new = !new_hints.is_empty();
@@ -446,6 +471,76 @@ mod tests {
         assert!(!result.contains('\u{E0043}'));
         assert!(result.contains("Extension help"));
         assert!(result.contains("hidden instructions"));
+    }
+
+    /// The #10330 regression: a resumed session has an in-memory tracker that
+    /// never saw the earlier tool calls, so replaying the conversation's tool
+    /// requests has to bring the subdirectory hints back.
+    #[test]
+    fn hints_from_a_resumed_conversation_survive_a_fresh_prompt_manager() {
+        use rmcp::{model::CallToolRequestParams, object};
+
+        let working_dir = tempfile::tempdir().unwrap();
+        let subdir = working_dir.path().join("sub");
+        std::fs::create_dir(&subdir).unwrap();
+        std::fs::write(subdir.join(".goosehints"), "hint from the subdirectory").unwrap();
+
+        // A conversation that already read a file under `sub/`, as it would
+        // look when loaded back off disk.
+        let history = vec![Message::assistant().with_tool_request(
+            "1",
+            Ok(CallToolRequestParams::new("developer__text_editor")
+                .with_arguments(object!({ "path": subdir.join("file.txt").to_str().unwrap() }))),
+        )];
+
+        // Before: a fresh manager (i.e. a resumed session) knows nothing.
+        let mut resumed = PromptManager::new();
+        let without_replay =
+            resumed.build_system_prompt(working_dir.path(), vec![], GooseMode::Auto);
+        assert!(
+            !without_replay.contains("hint from the subdirectory"),
+            "precondition: a fresh manager should not have the hint yet"
+        );
+
+        // After: replaying the history restores it.
+        let mut resumed = PromptManager::new();
+        resumed.record_tool_arguments_from_history(&history, working_dir.path());
+        let with_replay = resumed.build_system_prompt(working_dir.path(), vec![], GooseMode::Auto);
+        assert!(
+            with_replay.contains("hint from the subdirectory"),
+            "resumed session should recover the subdirectory hint from tool history"
+        );
+    }
+
+    /// Replay runs on every reply, so it must not re-inject hints that the
+    /// live session already loaded.
+    #[test]
+    fn replaying_history_twice_does_not_duplicate_hints() {
+        use rmcp::{model::CallToolRequestParams, object};
+
+        let working_dir = tempfile::tempdir().unwrap();
+        let subdir = working_dir.path().join("sub");
+        std::fs::create_dir(&subdir).unwrap();
+        std::fs::write(subdir.join(".goosehints"), "hint from the subdirectory").unwrap();
+
+        let history = vec![Message::assistant().with_tool_request(
+            "1",
+            Ok(CallToolRequestParams::new("developer__text_editor")
+                .with_arguments(object!({ "path": subdir.join("file.txt").to_str().unwrap() }))),
+        )];
+
+        let mut manager = PromptManager::new();
+        manager.record_tool_arguments_from_history(&history, working_dir.path());
+        let first = manager.build_system_prompt(working_dir.path(), vec![], GooseMode::Auto);
+        assert_eq!(first.matches("hint from the subdirectory").count(), 1);
+
+        manager.record_tool_arguments_from_history(&history, working_dir.path());
+        let second = manager.build_system_prompt(working_dir.path(), vec![], GooseMode::Auto);
+        assert_eq!(
+            second.matches("hint from the subdirectory").count(),
+            1,
+            "replaying the same history must not add the hint twice"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Subdirectory `.goosehints` discovered mid-session were injected by mutating the system prompt through an in-memory tracker. That tracker does not survive a resume, so a resumed session silently lost the hints its earlier tool calls had pulled in.

**Hint state does not need to be persisted, because it is already derivable.** The conversation records which paths were touched, and `SubdirectoryHintTracker` skips directories it has already loaded — so resume-safety is a *replay* problem, not a *storage* problem.

The whole change:

- `record_tool_arguments_from_history()` on `PromptManager` replays a conversation's tool requests into the existing tracker.
- One call in `prepare_reply_context`, before the first system prompt is rendered.

Hints keep travelling through `system_prompt_extras`, the same channel as root-level hints. Nothing is written into the conversation or any stored artifact. This also converges the two agent loops on one mechanism — `ops_toolcalling::prompt_parts` in the state machine has always derived hints this way — satisfying the `AGENTS.md` parity rule by construction rather than by duplicated logic.

**Authorship:** the implementation commit is @michaelneale's, from the `exemplar/simple-subdir-hints` branch. This PR previously carried a much larger design of mine (+275 lines across 12 files, with carve-outs in export, compaction, chat search, and the session editor) built to contain hint contents that were being persisted into the conversation. That design was answering a threat model that does not hold: the session DB is a single SQLite file under one OS user, and the agent only knows a directory has hints because a tool call already read a path under it. The only real boundary is egress via `SessionStorage::export_session`, and storing nothing closes it by construction. See the thread for the full history — it is worth reading before re-litigating any of this.

Fixes #10330

## Tests

- `hints_from_a_resumed_conversation_survive_a_fresh_prompt_manager` — a fresh `PromptManager` (i.e. a resumed session) does not have the hint; replaying history restores it.
- replay-twice test — the hint appears exactly once, since replay runs on every reply.
- `replay_survives_compaction` — the case flagged as untested. `compact_messages` does not delete pre-compaction messages; it flips them `agent_invisible` and appends an agent-only summary, and `record_tool_arguments_from_history` walks `conversation.messages()` regardless of visibility. Both compaction entry points (threshold and `ContextLengthExceeded` recovery) go through `compact_messages`, so neither can starve replay.

`cargo test -p goose --lib -- hints:: prompt_manager context_mgmt`: 71 passed, 1 failed — `test_all_platform_extensions`, an insta snapshot that fails identically on pristine `main` in this environment.
