### PR TITLE
feat(desktop): add interactive git branch indicator to chat bottom bar

### DIFF
--- a/ui/desktop/src/components/ChatInput.tsx
+++ b/ui/desktop/src/components/ChatInput.tsx
@@ -10,6 +10,7 @@ import { ChatState } from '../types/chatState';
 import debounce from 'lodash/debounce';
 import { LocalMessageStorage } from '../utils/localMessageStorage';
 import { DirSwitcher } from './bottom_menu/DirSwitcher';
+import { GitBranchIndicator } from './GitBranchIndicator';
 import ModelsBottomBar from './settings/models/bottom_bar/ModelsBottomBar';
 import { BottomMenuExtensionSelection } from './bottom_menu/BottomMenuExtensionSelection';
 import { cn } from '../utils';
@@ -1681,6 +1682,10 @@ export default function ChatInput({
               setWorkingDirOverride(newDir);
             }}
           />
+        )}
+
+        {!isBottomBarNarrow && currentWorkingDir && (
+          <GitBranchIndicator dir={currentWorkingDir} className="ml-1" />
         )}
 
         {/* Spacer */}

--- a/ui/desktop/src/components/GitBranchIndicator.tsx
+++ b/ui/desktop/src/components/GitBranchIndicator.tsx
@@ -66,10 +66,12 @@ export const GitBranchIndicator: React.FC<{ dir: string; className?: string }> =
     let cancelled = false;
     setBranches([]);
     setSearch('');
-    window.electron
-      .listGitBranches(dir)
-      .then((list) => {
-        if (!cancelled) setBranches(list);
+    Promise.all([window.electron.getGitBranchInfo(dir), window.electron.listGitBranches(dir)])
+      .then(([info, list]) => {
+        if (!cancelled) {
+          setBranch(info?.branch ?? null);
+          setBranches(list);
+        }
       })
       .catch(() => {});
     setTimeout(() => searchRef.current?.focus(), 50);

--- a/ui/desktop/src/components/GitBranchIndicator.tsx
+++ b/ui/desktop/src/components/GitBranchIndicator.tsx
@@ -1,0 +1,117 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { GitBranch, Check, Search } from 'lucide-react';
+import { toastError } from '../toasts';
+import { cn } from '../utils';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from './ui/dropdown-menu';
+
+export const GitBranchIndicator: React.FC<{ dir: string; className?: string }> = ({
+  dir,
+  className,
+}) => {
+  const [branch, setBranch] = useState<string | null>(null);
+  const [open, setOpen] = useState(false);
+  const [branches, setBranches] = useState<string[]>([]);
+  const [search, setSearch] = useState('');
+  const [switching, setSwitching] = useState(false);
+  const searchRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!dir) return;
+    let cancelled = false;
+    const refresh = () => {
+      window.electron
+        .getGitBranchInfo(dir)
+        .then((info) => { if (!cancelled && info) setBranch(info.branch); })
+        .catch(() => {});
+    };
+    setBranch(null);
+    refresh();
+    window.addEventListener('focus', refresh);
+    return () => {
+      cancelled = true;
+      window.removeEventListener('focus', refresh);
+    };
+  }, [dir]);
+
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    setBranches([]);
+    setSearch('');
+    window.electron.listGitBranches(dir).then((list) => { if (!cancelled) setBranches(list); }).catch(() => {});
+    setTimeout(() => searchRef.current?.focus(), 50);
+    return () => { cancelled = true; };
+  }, [open, dir]);
+
+  if (!branch) return null;
+
+  const filtered = branches.filter((b) => b.toLowerCase().includes(search.toLowerCase()));
+
+  const handleSwitch = async (target: string) => {
+    if (target === branch || switching) return;
+    setSwitching(true);
+    setOpen(false);
+    const result = await window.electron
+      .switchGitBranch(dir, target)
+      .catch((err: Error) => ({ success: false, error: err.message }));
+    if (result.success) {
+      setBranch(target);
+    } else {
+      toastError({
+        title: `Failed to switch to ${target}`,
+        msg: result.error ?? 'You may have uncommitted changes.',
+      });
+    }
+    setSwitching(false);
+  };
+
+  return (
+    <DropdownMenu open={open} onOpenChange={setOpen}>
+      <DropdownMenuTrigger asChild>
+        <button
+          className={cn(
+            'text-text-primary/70 text-xs flex items-center transition-colors',
+            switching ? 'opacity-50' : 'hover:cursor-pointer hover:text-text-primary',
+            className
+          )}
+          disabled={switching}
+        >
+          <GitBranch className="mr-1" size={14} />
+          <span className="max-w-[100px] truncate whitespace-nowrap">{branch}</span>
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent side="top" align="start" className="w-64 p-0 overflow-hidden">
+        <div className="overflow-y-auto p-1 max-h-52 space-y-0.5">
+          {filtered.length === 0 && (
+            <div className="px-2 py-1.5 text-sm text-text-primary/50">No branches found</div>
+          )}
+          {filtered.map((b) => (
+            <DropdownMenuItem key={b} onSelect={() => void handleSwitch(b)}>
+              <span className="flex-1 truncate">{b}</span>
+              {b === branch && <Check className="ml-auto h-4 w-4 flex-shrink-0" />}
+            </DropdownMenuItem>
+          ))}
+        </div>
+        <DropdownMenuSeparator />
+        <div className="px-2 py-1.5 flex items-center gap-1.5">
+          <Search className="h-3.5 w-3.5 text-text-muted flex-shrink-0" />
+          <input
+            ref={searchRef}
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            onKeyDown={(e) => e.stopPropagation()}
+            placeholder="Search branches..."
+            aria-label="Search branches"
+            className="flex-1 bg-transparent text-sm text-text-primary placeholder:text-text-primary/50 outline-none"
+          />
+        </div>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};

--- a/ui/desktop/src/components/GitBranchIndicator.tsx
+++ b/ui/desktop/src/components/GitBranchIndicator.tsx
@@ -48,7 +48,9 @@ export const GitBranchIndicator: React.FC<{ dir: string; className?: string }> =
     const refresh = () => {
       window.electron
         .getGitBranchInfo(dir)
-        .then((info) => { if (!cancelled) setBranch(info?.branch ?? null); })
+        .then((info) => {
+          if (!cancelled) setBranch(info?.branch ?? null);
+        })
         .catch(() => {});
     };
     refresh();
@@ -64,9 +66,16 @@ export const GitBranchIndicator: React.FC<{ dir: string; className?: string }> =
     let cancelled = false;
     setBranches([]);
     setSearch('');
-    window.electron.listGitBranches(dir).then((list) => { if (!cancelled) setBranches(list); }).catch(() => {});
+    window.electron
+      .listGitBranches(dir)
+      .then((list) => {
+        if (!cancelled) setBranches(list);
+      })
+      .catch(() => {});
     setTimeout(() => searchRef.current?.focus(), 50);
-    return () => { cancelled = true; };
+    return () => {
+      cancelled = true;
+    };
   }, [open, dir]);
 
   if (!branch) return null;
@@ -109,7 +118,9 @@ export const GitBranchIndicator: React.FC<{ dir: string; className?: string }> =
       <DropdownMenuContent side="top" align="start" className="w-64 p-0 overflow-hidden">
         <div className="overflow-y-auto p-1 max-h-52 space-y-0.5">
           {filtered.length === 0 && (
-            <div className="px-2 py-1.5 text-sm text-text-primary/50">{intl.formatMessage(i18n.noBranchesFound)}</div>
+            <div className="px-2 py-1.5 text-sm text-text-primary/50">
+              {intl.formatMessage(i18n.noBranchesFound)}
+            </div>
           )}
           {filtered.map((b) => (
             <DropdownMenuItem key={b} onSelect={() => void handleSwitch(b)}>
@@ -125,7 +136,9 @@ export const GitBranchIndicator: React.FC<{ dir: string; className?: string }> =
             ref={searchRef}
             value={search}
             onChange={(e) => setSearch(e.target.value)}
-            onKeyDown={(e) => e.stopPropagation()}
+            onKeyDown={(e) => {
+              if (e.key.length === 1) e.stopPropagation();
+            }}
             placeholder={intl.formatMessage(i18n.searchBranches)}
             aria-label={intl.formatMessage(i18n.searchBranches)}
             className="flex-1 bg-transparent text-sm text-text-primary placeholder:text-text-primary/50 outline-none"

--- a/ui/desktop/src/components/GitBranchIndicator.tsx
+++ b/ui/desktop/src/components/GitBranchIndicator.tsx
@@ -27,10 +27,9 @@ export const GitBranchIndicator: React.FC<{ dir: string; className?: string }> =
     const refresh = () => {
       window.electron
         .getGitBranchInfo(dir)
-        .then((info) => { if (!cancelled && info) setBranch(info.branch); })
+        .then((info) => { if (!cancelled) setBranch(info?.branch ?? null); })
         .catch(() => {});
     };
-    setBranch(null);
     refresh();
     window.addEventListener('focus', refresh);
     return () => {

--- a/ui/desktop/src/components/GitBranchIndicator.tsx
+++ b/ui/desktop/src/components/GitBranchIndicator.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { GitBranch, Check, Search } from 'lucide-react';
 import { toastError } from '../toasts';
 import { cn } from '../utils';
+import { defineMessages, useIntl } from '../i18n';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -9,6 +10,25 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from './ui/dropdown-menu';
+
+const i18n = defineMessages({
+  noBranchesFound: {
+    id: 'gitBranchIndicator.noBranchesFound',
+    defaultMessage: 'No branches found',
+  },
+  searchBranches: {
+    id: 'gitBranchIndicator.searchBranches',
+    defaultMessage: 'Search branches…',
+  },
+  failedToSwitch: {
+    id: 'gitBranchIndicator.failedToSwitch',
+    defaultMessage: 'Failed to switch to {branch}',
+  },
+  uncommittedChanges: {
+    id: 'gitBranchIndicator.uncommittedChanges',
+    defaultMessage: 'You may have uncommitted changes.',
+  },
+});
 
 export const GitBranchIndicator: React.FC<{ dir: string; className?: string }> = ({
   dir,
@@ -19,6 +39,7 @@ export const GitBranchIndicator: React.FC<{ dir: string; className?: string }> =
   const [branches, setBranches] = useState<string[]>([]);
   const [search, setSearch] = useState('');
   const [switching, setSwitching] = useState(false);
+  const intl = useIntl();
   const searchRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -63,8 +84,8 @@ export const GitBranchIndicator: React.FC<{ dir: string; className?: string }> =
       setBranch(target);
     } else {
       toastError({
-        title: `Failed to switch to ${target}`,
-        msg: result.error ?? 'You may have uncommitted changes.',
+        title: intl.formatMessage(i18n.failedToSwitch, { branch: target }),
+        msg: result.error ?? intl.formatMessage(i18n.uncommittedChanges),
       });
     }
     setSwitching(false);
@@ -88,7 +109,7 @@ export const GitBranchIndicator: React.FC<{ dir: string; className?: string }> =
       <DropdownMenuContent side="top" align="start" className="w-64 p-0 overflow-hidden">
         <div className="overflow-y-auto p-1 max-h-52 space-y-0.5">
           {filtered.length === 0 && (
-            <div className="px-2 py-1.5 text-sm text-text-primary/50">No branches found</div>
+            <div className="px-2 py-1.5 text-sm text-text-primary/50">{intl.formatMessage(i18n.noBranchesFound)}</div>
           )}
           {filtered.map((b) => (
             <DropdownMenuItem key={b} onSelect={() => void handleSwitch(b)}>
@@ -105,8 +126,8 @@ export const GitBranchIndicator: React.FC<{ dir: string; className?: string }> =
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             onKeyDown={(e) => e.stopPropagation()}
-            placeholder="Search branches..."
-            aria-label="Search branches"
+            placeholder={intl.formatMessage(i18n.searchBranches)}
+            aria-label={intl.formatMessage(i18n.searchBranches)}
             className="flex-1 bg-transparent text-sm text-text-primary placeholder:text-text-primary/50 outline-none"
           />
         </div>

--- a/ui/desktop/src/components/Layout/AppLayout.tsx
+++ b/ui/desktop/src/components/Layout/AppLayout.tsx
@@ -120,6 +120,7 @@ const AppLayoutContent: React.FC<AppLayoutContentProps> = ({ activeSessions }) =
           <PanelLeft className="w-5 h-5" />
         </Button>
       </div>
+
       {/* Main content with navigation. Shared white canvas; the sidebar is a
           rounded outlined card floating on it with breathing room. */}
       <div className="flex flex-1 w-full h-full min-h-0 flex-row">

--- a/ui/desktop/src/components/Layout/AppLayout.tsx
+++ b/ui/desktop/src/components/Layout/AppLayout.tsx
@@ -120,7 +120,6 @@ const AppLayoutContent: React.FC<AppLayoutContentProps> = ({ activeSessions }) =
           <PanelLeft className="w-5 h-5" />
         </Button>
       </div>
-
       {/* Main content with navigation. Shared white canvas; the sidebar is a
           rounded outlined card floating on it with breathing room. */}
       <div className="flex flex-1 w-full h-full min-h-0 flex-row">

--- a/ui/desktop/src/i18n/messages/de.json
+++ b/ui/desktop/src/i18n/messages/de.json
@@ -933,16 +933,16 @@
     "defaultMessage": "Zuletzt verwendete Verzeichnisse"
   },
   "gitBranchIndicator.failedToSwitch": {
-    "defaultMessage": "Failed to switch to {branch}"
+    "defaultMessage": "Wechsel zu {branch} fehlgeschlagen"
   },
   "gitBranchIndicator.noBranchesFound": {
-    "defaultMessage": "No branches found"
+    "defaultMessage": "Keine Branches gefunden"
   },
   "gitBranchIndicator.searchBranches": {
-    "defaultMessage": "Search branches…"
+    "defaultMessage": "Branches durchsuchen…"
   },
   "gitBranchIndicator.uncommittedChanges": {
-    "defaultMessage": "You may have uncommitted changes."
+    "defaultMessage": "Möglicherweise gibt es noch nicht committete Änderungen."
   },
   "elicitationRequest.accept": {
     "defaultMessage": "Akzeptieren"

--- a/ui/desktop/src/i18n/messages/de.json
+++ b/ui/desktop/src/i18n/messages/de.json
@@ -932,6 +932,18 @@
   "dirSwitcher.recentDirectories": {
     "defaultMessage": "Zuletzt verwendete Verzeichnisse"
   },
+  "gitBranchIndicator.failedToSwitch": {
+    "defaultMessage": "Failed to switch to {branch}"
+  },
+  "gitBranchIndicator.noBranchesFound": {
+    "defaultMessage": "No branches found"
+  },
+  "gitBranchIndicator.searchBranches": {
+    "defaultMessage": "Search branches…"
+  },
+  "gitBranchIndicator.uncommittedChanges": {
+    "defaultMessage": "You may have uncommitted changes."
+  },
   "elicitationRequest.accept": {
     "defaultMessage": "Akzeptieren"
   },

--- a/ui/desktop/src/i18n/messages/en.json
+++ b/ui/desktop/src/i18n/messages/en.json
@@ -1259,6 +1259,18 @@
   "externalBackendSection.workingDirPlaceholder": {
     "defaultMessage": "/home/goose/workspace"
   },
+  "gitBranchIndicator.failedToSwitch": {
+    "defaultMessage": "Failed to switch to {branch}"
+  },
+  "gitBranchIndicator.noBranchesFound": {
+    "defaultMessage": "No branches found"
+  },
+  "gitBranchIndicator.searchBranches": {
+    "defaultMessage": "Search branches…"
+  },
+  "gitBranchIndicator.uncommittedChanges": {
+    "defaultMessage": "You may have uncommitted changes."
+  },
   "goosehintsModal.close": {
     "defaultMessage": "Close"
   },

--- a/ui/desktop/src/i18n/messages/es.json
+++ b/ui/desktop/src/i18n/messages/es.json
@@ -932,6 +932,18 @@
   "dirSwitcher.recentDirectories": {
     "defaultMessage": "Directorios recientes"
   },
+  "gitBranchIndicator.failedToSwitch": {
+    "defaultMessage": "Failed to switch to {branch}"
+  },
+  "gitBranchIndicator.noBranchesFound": {
+    "defaultMessage": "No branches found"
+  },
+  "gitBranchIndicator.searchBranches": {
+    "defaultMessage": "Search branches…"
+  },
+  "gitBranchIndicator.uncommittedChanges": {
+    "defaultMessage": "You may have uncommitted changes."
+  },
   "elicitationRequest.accept": {
     "defaultMessage": "Aceptar"
   },

--- a/ui/desktop/src/i18n/messages/es.json
+++ b/ui/desktop/src/i18n/messages/es.json
@@ -933,16 +933,16 @@
     "defaultMessage": "Directorios recientes"
   },
   "gitBranchIndicator.failedToSwitch": {
-    "defaultMessage": "Failed to switch to {branch}"
+    "defaultMessage": "No se pudo cambiar a {branch}"
   },
   "gitBranchIndicator.noBranchesFound": {
-    "defaultMessage": "No branches found"
+    "defaultMessage": "No se encontraron ramas"
   },
   "gitBranchIndicator.searchBranches": {
-    "defaultMessage": "Search branches…"
+    "defaultMessage": "Buscar ramas…"
   },
   "gitBranchIndicator.uncommittedChanges": {
-    "defaultMessage": "You may have uncommitted changes."
+    "defaultMessage": "Puede que tengas cambios sin confirmar."
   },
   "elicitationRequest.accept": {
     "defaultMessage": "Aceptar"

--- a/ui/desktop/src/i18n/messages/fr.json
+++ b/ui/desktop/src/i18n/messages/fr.json
@@ -932,6 +932,18 @@
   "dirSwitcher.recentDirectories": {
     "defaultMessage": "Répertoires récents"
   },
+  "gitBranchIndicator.failedToSwitch": {
+    "defaultMessage": "Failed to switch to {branch}"
+  },
+  "gitBranchIndicator.noBranchesFound": {
+    "defaultMessage": "No branches found"
+  },
+  "gitBranchIndicator.searchBranches": {
+    "defaultMessage": "Search branches…"
+  },
+  "gitBranchIndicator.uncommittedChanges": {
+    "defaultMessage": "You may have uncommitted changes."
+  },
   "elicitationRequest.accept": {
     "defaultMessage": "Accepter"
   },

--- a/ui/desktop/src/i18n/messages/fr.json
+++ b/ui/desktop/src/i18n/messages/fr.json
@@ -933,16 +933,16 @@
     "defaultMessage": "Répertoires récents"
   },
   "gitBranchIndicator.failedToSwitch": {
-    "defaultMessage": "Failed to switch to {branch}"
+    "defaultMessage": "Impossible de basculer vers {branch}"
   },
   "gitBranchIndicator.noBranchesFound": {
-    "defaultMessage": "No branches found"
+    "defaultMessage": "Aucune branche trouvée"
   },
   "gitBranchIndicator.searchBranches": {
-    "defaultMessage": "Search branches…"
+    "defaultMessage": "Rechercher des branches…"
   },
   "gitBranchIndicator.uncommittedChanges": {
-    "defaultMessage": "You may have uncommitted changes."
+    "defaultMessage": "Vous avez peut-être des modifications non validées."
   },
   "elicitationRequest.accept": {
     "defaultMessage": "Accepter"

--- a/ui/desktop/src/i18n/messages/hi.json
+++ b/ui/desktop/src/i18n/messages/hi.json
@@ -932,6 +932,18 @@
   "dirSwitcher.recentDirectories": {
     "defaultMessage": "हाल की निर्देशिकाएँ"
   },
+  "gitBranchIndicator.failedToSwitch": {
+    "defaultMessage": "Failed to switch to {branch}"
+  },
+  "gitBranchIndicator.noBranchesFound": {
+    "defaultMessage": "No branches found"
+  },
+  "gitBranchIndicator.searchBranches": {
+    "defaultMessage": "Search branches…"
+  },
+  "gitBranchIndicator.uncommittedChanges": {
+    "defaultMessage": "You may have uncommitted changes."
+  },
   "elicitationRequest.accept": {
     "defaultMessage": "स्वीकार करो"
   },

--- a/ui/desktop/src/i18n/messages/hi.json
+++ b/ui/desktop/src/i18n/messages/hi.json
@@ -933,16 +933,16 @@
     "defaultMessage": "हाल की निर्देशिकाएँ"
   },
   "gitBranchIndicator.failedToSwitch": {
-    "defaultMessage": "Failed to switch to {branch}"
+    "defaultMessage": "{branch} पर स्विच नहीं किया जा सका"
   },
   "gitBranchIndicator.noBranchesFound": {
-    "defaultMessage": "No branches found"
+    "defaultMessage": "कोई ब्रांच नहीं मिली"
   },
   "gitBranchIndicator.searchBranches": {
-    "defaultMessage": "Search branches…"
+    "defaultMessage": "ब्रांच खोजें…"
   },
   "gitBranchIndicator.uncommittedChanges": {
-    "defaultMessage": "You may have uncommitted changes."
+    "defaultMessage": "आपके कुछ बदलाव कमिट नहीं हुए हो सकते हैं।"
   },
   "elicitationRequest.accept": {
     "defaultMessage": "स्वीकार करो"

--- a/ui/desktop/src/i18n/messages/id.json
+++ b/ui/desktop/src/i18n/messages/id.json
@@ -932,6 +932,18 @@
   "dirSwitcher.recentDirectories": {
     "defaultMessage": "Direktori terbaru"
   },
+  "gitBranchIndicator.failedToSwitch": {
+    "defaultMessage": "Failed to switch to {branch}"
+  },
+  "gitBranchIndicator.noBranchesFound": {
+    "defaultMessage": "No branches found"
+  },
+  "gitBranchIndicator.searchBranches": {
+    "defaultMessage": "Search branches…"
+  },
+  "gitBranchIndicator.uncommittedChanges": {
+    "defaultMessage": "You may have uncommitted changes."
+  },
   "elicitationRequest.accept": {
     "defaultMessage": "Terima"
   },

--- a/ui/desktop/src/i18n/messages/id.json
+++ b/ui/desktop/src/i18n/messages/id.json
@@ -933,16 +933,16 @@
     "defaultMessage": "Direktori terbaru"
   },
   "gitBranchIndicator.failedToSwitch": {
-    "defaultMessage": "Failed to switch to {branch}"
+    "defaultMessage": "Gagal beralih ke {branch}"
   },
   "gitBranchIndicator.noBranchesFound": {
-    "defaultMessage": "No branches found"
+    "defaultMessage": "Tidak ada branch yang ditemukan"
   },
   "gitBranchIndicator.searchBranches": {
-    "defaultMessage": "Search branches…"
+    "defaultMessage": "Cari branch…"
   },
   "gitBranchIndicator.uncommittedChanges": {
-    "defaultMessage": "You may have uncommitted changes."
+    "defaultMessage": "Anda mungkin memiliki perubahan yang belum di-commit."
   },
   "elicitationRequest.accept": {
     "defaultMessage": "Terima"

--- a/ui/desktop/src/i18n/messages/it.json
+++ b/ui/desktop/src/i18n/messages/it.json
@@ -932,6 +932,18 @@
   "dirSwitcher.recentDirectories": {
     "defaultMessage": "Cartelle recenti"
   },
+  "gitBranchIndicator.failedToSwitch": {
+    "defaultMessage": "Failed to switch to {branch}"
+  },
+  "gitBranchIndicator.noBranchesFound": {
+    "defaultMessage": "No branches found"
+  },
+  "gitBranchIndicator.searchBranches": {
+    "defaultMessage": "Search branches…"
+  },
+  "gitBranchIndicator.uncommittedChanges": {
+    "defaultMessage": "You may have uncommitted changes."
+  },
   "elicitationRequest.accept": {
     "defaultMessage": "Accetta"
   },

--- a/ui/desktop/src/i18n/messages/it.json
+++ b/ui/desktop/src/i18n/messages/it.json
@@ -933,16 +933,16 @@
     "defaultMessage": "Cartelle recenti"
   },
   "gitBranchIndicator.failedToSwitch": {
-    "defaultMessage": "Failed to switch to {branch}"
+    "defaultMessage": "Impossibile passare a {branch}"
   },
   "gitBranchIndicator.noBranchesFound": {
-    "defaultMessage": "No branches found"
+    "defaultMessage": "Nessun branch trovato"
   },
   "gitBranchIndicator.searchBranches": {
-    "defaultMessage": "Search branches…"
+    "defaultMessage": "Cerca branch…"
   },
   "gitBranchIndicator.uncommittedChanges": {
-    "defaultMessage": "You may have uncommitted changes."
+    "defaultMessage": "Potresti avere modifiche non incluse in un commit."
   },
   "elicitationRequest.accept": {
     "defaultMessage": "Accetta"

--- a/ui/desktop/src/i18n/messages/ja.json
+++ b/ui/desktop/src/i18n/messages/ja.json
@@ -933,16 +933,16 @@
     "defaultMessage": "最近のディレクトリ"
   },
   "gitBranchIndicator.failedToSwitch": {
-    "defaultMessage": "Failed to switch to {branch}"
+    "defaultMessage": "{branch} への切り替えに失敗しました"
   },
   "gitBranchIndicator.noBranchesFound": {
-    "defaultMessage": "No branches found"
+    "defaultMessage": "ブランチが見つかりません"
   },
   "gitBranchIndicator.searchBranches": {
-    "defaultMessage": "Search branches…"
+    "defaultMessage": "ブランチを検索…"
   },
   "gitBranchIndicator.uncommittedChanges": {
-    "defaultMessage": "You may have uncommitted changes."
+    "defaultMessage": "コミットされていない変更がある可能性があります。"
   },
   "elicitationRequest.accept": {
     "defaultMessage": "承諾"

--- a/ui/desktop/src/i18n/messages/ja.json
+++ b/ui/desktop/src/i18n/messages/ja.json
@@ -932,6 +932,18 @@
   "dirSwitcher.recentDirectories": {
     "defaultMessage": "最近のディレクトリ"
   },
+  "gitBranchIndicator.failedToSwitch": {
+    "defaultMessage": "Failed to switch to {branch}"
+  },
+  "gitBranchIndicator.noBranchesFound": {
+    "defaultMessage": "No branches found"
+  },
+  "gitBranchIndicator.searchBranches": {
+    "defaultMessage": "Search branches…"
+  },
+  "gitBranchIndicator.uncommittedChanges": {
+    "defaultMessage": "You may have uncommitted changes."
+  },
   "elicitationRequest.accept": {
     "defaultMessage": "承諾"
   },

--- a/ui/desktop/src/i18n/messages/ko.json
+++ b/ui/desktop/src/i18n/messages/ko.json
@@ -932,6 +932,18 @@
   "dirSwitcher.recentDirectories": {
     "defaultMessage": "최근 디렉터리"
   },
+  "gitBranchIndicator.failedToSwitch": {
+    "defaultMessage": "Failed to switch to {branch}"
+  },
+  "gitBranchIndicator.noBranchesFound": {
+    "defaultMessage": "No branches found"
+  },
+  "gitBranchIndicator.searchBranches": {
+    "defaultMessage": "Search branches…"
+  },
+  "gitBranchIndicator.uncommittedChanges": {
+    "defaultMessage": "You may have uncommitted changes."
+  },
   "elicitationRequest.accept": {
     "defaultMessage": "수락"
   },

--- a/ui/desktop/src/i18n/messages/ko.json
+++ b/ui/desktop/src/i18n/messages/ko.json
@@ -933,16 +933,16 @@
     "defaultMessage": "최근 디렉터리"
   },
   "gitBranchIndicator.failedToSwitch": {
-    "defaultMessage": "Failed to switch to {branch}"
+    "defaultMessage": "{branch} 브랜치로 전환하지 못했습니다"
   },
   "gitBranchIndicator.noBranchesFound": {
-    "defaultMessage": "No branches found"
+    "defaultMessage": "브랜치를 찾을 수 없습니다"
   },
   "gitBranchIndicator.searchBranches": {
-    "defaultMessage": "Search branches…"
+    "defaultMessage": "브랜치 검색…"
   },
   "gitBranchIndicator.uncommittedChanges": {
-    "defaultMessage": "You may have uncommitted changes."
+    "defaultMessage": "커밋되지 않은 변경 사항이 있을 수 있습니다."
   },
   "elicitationRequest.accept": {
     "defaultMessage": "수락"

--- a/ui/desktop/src/i18n/messages/ms.json
+++ b/ui/desktop/src/i18n/messages/ms.json
@@ -932,6 +932,18 @@
   "dirSwitcher.recentDirectories": {
     "defaultMessage": "Direktori terkini"
   },
+  "gitBranchIndicator.failedToSwitch": {
+    "defaultMessage": "Failed to switch to {branch}"
+  },
+  "gitBranchIndicator.noBranchesFound": {
+    "defaultMessage": "No branches found"
+  },
+  "gitBranchIndicator.searchBranches": {
+    "defaultMessage": "Search branches…"
+  },
+  "gitBranchIndicator.uncommittedChanges": {
+    "defaultMessage": "You may have uncommitted changes."
+  },
   "elicitationRequest.accept": {
     "defaultMessage": "Terima"
   },

--- a/ui/desktop/src/i18n/messages/ms.json
+++ b/ui/desktop/src/i18n/messages/ms.json
@@ -933,16 +933,16 @@
     "defaultMessage": "Direktori terkini"
   },
   "gitBranchIndicator.failedToSwitch": {
-    "defaultMessage": "Failed to switch to {branch}"
+    "defaultMessage": "Gagal beralih ke {branch}"
   },
   "gitBranchIndicator.noBranchesFound": {
-    "defaultMessage": "No branches found"
+    "defaultMessage": "Tiada cabang ditemui"
   },
   "gitBranchIndicator.searchBranches": {
-    "defaultMessage": "Search branches…"
+    "defaultMessage": "Cari cabang…"
   },
   "gitBranchIndicator.uncommittedChanges": {
-    "defaultMessage": "You may have uncommitted changes."
+    "defaultMessage": "Anda mungkin mempunyai perubahan yang belum dikomit."
   },
   "elicitationRequest.accept": {
     "defaultMessage": "Terima"

--- a/ui/desktop/src/i18n/messages/pt.json
+++ b/ui/desktop/src/i18n/messages/pt.json
@@ -932,6 +932,18 @@
   "dirSwitcher.recentDirectories": {
     "defaultMessage": "Diretórios recentes"
   },
+  "gitBranchIndicator.failedToSwitch": {
+    "defaultMessage": "Failed to switch to {branch}"
+  },
+  "gitBranchIndicator.noBranchesFound": {
+    "defaultMessage": "No branches found"
+  },
+  "gitBranchIndicator.searchBranches": {
+    "defaultMessage": "Search branches…"
+  },
+  "gitBranchIndicator.uncommittedChanges": {
+    "defaultMessage": "You may have uncommitted changes."
+  },
   "elicitationRequest.accept": {
     "defaultMessage": "Aceitar"
   },

--- a/ui/desktop/src/i18n/messages/pt.json
+++ b/ui/desktop/src/i18n/messages/pt.json
@@ -933,16 +933,16 @@
     "defaultMessage": "Diretórios recentes"
   },
   "gitBranchIndicator.failedToSwitch": {
-    "defaultMessage": "Failed to switch to {branch}"
+    "defaultMessage": "Falha ao mudar para {branch}"
   },
   "gitBranchIndicator.noBranchesFound": {
-    "defaultMessage": "No branches found"
+    "defaultMessage": "Nenhum ramo encontrado"
   },
   "gitBranchIndicator.searchBranches": {
-    "defaultMessage": "Search branches…"
+    "defaultMessage": "Pesquisar ramos…"
   },
   "gitBranchIndicator.uncommittedChanges": {
-    "defaultMessage": "You may have uncommitted changes."
+    "defaultMessage": "Pode haver alterações sem commit."
   },
   "elicitationRequest.accept": {
     "defaultMessage": "Aceitar"

--- a/ui/desktop/src/i18n/messages/ru.json
+++ b/ui/desktop/src/i18n/messages/ru.json
@@ -932,6 +932,18 @@
   "dirSwitcher.recentDirectories": {
     "defaultMessage": "Недавние каталоги"
   },
+  "gitBranchIndicator.failedToSwitch": {
+    "defaultMessage": "Failed to switch to {branch}"
+  },
+  "gitBranchIndicator.noBranchesFound": {
+    "defaultMessage": "No branches found"
+  },
+  "gitBranchIndicator.searchBranches": {
+    "defaultMessage": "Search branches…"
+  },
+  "gitBranchIndicator.uncommittedChanges": {
+    "defaultMessage": "You may have uncommitted changes."
+  },
   "elicitationRequest.accept": {
     "defaultMessage": "Принять"
   },

--- a/ui/desktop/src/i18n/messages/ru.json
+++ b/ui/desktop/src/i18n/messages/ru.json
@@ -933,16 +933,16 @@
     "defaultMessage": "Недавние каталоги"
   },
   "gitBranchIndicator.failedToSwitch": {
-    "defaultMessage": "Failed to switch to {branch}"
+    "defaultMessage": "Не удалось переключиться на {branch}"
   },
   "gitBranchIndicator.noBranchesFound": {
-    "defaultMessage": "No branches found"
+    "defaultMessage": "Ветки не найдены"
   },
   "gitBranchIndicator.searchBranches": {
-    "defaultMessage": "Search branches…"
+    "defaultMessage": "Поиск веток…"
   },
   "gitBranchIndicator.uncommittedChanges": {
-    "defaultMessage": "You may have uncommitted changes."
+    "defaultMessage": "Возможно, у вас есть незакоммиченные изменения."
   },
   "elicitationRequest.accept": {
     "defaultMessage": "Принять"

--- a/ui/desktop/src/i18n/messages/tr.json
+++ b/ui/desktop/src/i18n/messages/tr.json
@@ -933,16 +933,16 @@
     "defaultMessage": "Son dizinler"
   },
   "gitBranchIndicator.failedToSwitch": {
-    "defaultMessage": "Failed to switch to {branch}"
+    "defaultMessage": "{branch} dalına geçilemedi"
   },
   "gitBranchIndicator.noBranchesFound": {
-    "defaultMessage": "No branches found"
+    "defaultMessage": "Dal bulunamadı"
   },
   "gitBranchIndicator.searchBranches": {
-    "defaultMessage": "Search branches…"
+    "defaultMessage": "Dal ara…"
   },
   "gitBranchIndicator.uncommittedChanges": {
-    "defaultMessage": "You may have uncommitted changes."
+    "defaultMessage": "Commit edilmemiş değişiklikleriniz olabilir."
   },
   "elicitationRequest.accept": {
     "defaultMessage": "Kabul et"

--- a/ui/desktop/src/i18n/messages/tr.json
+++ b/ui/desktop/src/i18n/messages/tr.json
@@ -932,6 +932,18 @@
   "dirSwitcher.recentDirectories": {
     "defaultMessage": "Son dizinler"
   },
+  "gitBranchIndicator.failedToSwitch": {
+    "defaultMessage": "Failed to switch to {branch}"
+  },
+  "gitBranchIndicator.noBranchesFound": {
+    "defaultMessage": "No branches found"
+  },
+  "gitBranchIndicator.searchBranches": {
+    "defaultMessage": "Search branches…"
+  },
+  "gitBranchIndicator.uncommittedChanges": {
+    "defaultMessage": "You may have uncommitted changes."
+  },
   "elicitationRequest.accept": {
     "defaultMessage": "Kabul et"
   },

--- a/ui/desktop/src/i18n/messages/vi.json
+++ b/ui/desktop/src/i18n/messages/vi.json
@@ -932,6 +932,18 @@
   "dirSwitcher.recentDirectories": {
     "defaultMessage": "Thư mục gần đây"
   },
+  "gitBranchIndicator.failedToSwitch": {
+    "defaultMessage": "Failed to switch to {branch}"
+  },
+  "gitBranchIndicator.noBranchesFound": {
+    "defaultMessage": "No branches found"
+  },
+  "gitBranchIndicator.searchBranches": {
+    "defaultMessage": "Search branches…"
+  },
+  "gitBranchIndicator.uncommittedChanges": {
+    "defaultMessage": "You may have uncommitted changes."
+  },
   "elicitationRequest.accept": {
     "defaultMessage": "Chấp nhận"
   },

--- a/ui/desktop/src/i18n/messages/vi.json
+++ b/ui/desktop/src/i18n/messages/vi.json
@@ -933,16 +933,16 @@
     "defaultMessage": "Thư mục gần đây"
   },
   "gitBranchIndicator.failedToSwitch": {
-    "defaultMessage": "Failed to switch to {branch}"
+    "defaultMessage": "Không thể chuyển sang {branch}"
   },
   "gitBranchIndicator.noBranchesFound": {
-    "defaultMessage": "No branches found"
+    "defaultMessage": "Không tìm thấy nhánh"
   },
   "gitBranchIndicator.searchBranches": {
-    "defaultMessage": "Search branches…"
+    "defaultMessage": "Tìm kiếm nhánh…"
   },
   "gitBranchIndicator.uncommittedChanges": {
-    "defaultMessage": "You may have uncommitted changes."
+    "defaultMessage": "Bạn có thể có các thay đổi chưa commit."
   },
   "elicitationRequest.accept": {
     "defaultMessage": "Chấp nhận"

--- a/ui/desktop/src/i18n/messages/zh-CN.json
+++ b/ui/desktop/src/i18n/messages/zh-CN.json
@@ -933,16 +933,16 @@
     "defaultMessage": "最近的目录"
   },
   "gitBranchIndicator.failedToSwitch": {
-    "defaultMessage": "Failed to switch to {branch}"
+    "defaultMessage": "无法切换到 {branch}"
   },
   "gitBranchIndicator.noBranchesFound": {
-    "defaultMessage": "No branches found"
+    "defaultMessage": "未找到分支"
   },
   "gitBranchIndicator.searchBranches": {
-    "defaultMessage": "Search branches…"
+    "defaultMessage": "搜索分支…"
   },
   "gitBranchIndicator.uncommittedChanges": {
-    "defaultMessage": "You may have uncommitted changes."
+    "defaultMessage": "你可能有尚未提交的更改。"
   },
   "elicitationRequest.accept": {
     "defaultMessage": "接受"

--- a/ui/desktop/src/i18n/messages/zh-CN.json
+++ b/ui/desktop/src/i18n/messages/zh-CN.json
@@ -932,6 +932,18 @@
   "dirSwitcher.recentDirectories": {
     "defaultMessage": "最近的目录"
   },
+  "gitBranchIndicator.failedToSwitch": {
+    "defaultMessage": "Failed to switch to {branch}"
+  },
+  "gitBranchIndicator.noBranchesFound": {
+    "defaultMessage": "No branches found"
+  },
+  "gitBranchIndicator.searchBranches": {
+    "defaultMessage": "Search branches…"
+  },
+  "gitBranchIndicator.uncommittedChanges": {
+    "defaultMessage": "You may have uncommitted changes."
+  },
   "elicitationRequest.accept": {
     "defaultMessage": "接受"
   },

--- a/ui/desktop/src/i18n/messages/zh-TW.json
+++ b/ui/desktop/src/i18n/messages/zh-TW.json
@@ -933,16 +933,16 @@
     "defaultMessage": "最近的目錄"
   },
   "gitBranchIndicator.failedToSwitch": {
-    "defaultMessage": "Failed to switch to {branch}"
+    "defaultMessage": "無法切換至 {branch}"
   },
   "gitBranchIndicator.noBranchesFound": {
-    "defaultMessage": "No branches found"
+    "defaultMessage": "找不到分支"
   },
   "gitBranchIndicator.searchBranches": {
-    "defaultMessage": "Search branches…"
+    "defaultMessage": "搜尋分支…"
   },
   "gitBranchIndicator.uncommittedChanges": {
-    "defaultMessage": "You may have uncommitted changes."
+    "defaultMessage": "你可能有尚未提交的變更。"
   },
   "elicitationRequest.accept": {
     "defaultMessage": "接受"

--- a/ui/desktop/src/i18n/messages/zh-TW.json
+++ b/ui/desktop/src/i18n/messages/zh-TW.json
@@ -932,6 +932,18 @@
   "dirSwitcher.recentDirectories": {
     "defaultMessage": "最近的目錄"
   },
+  "gitBranchIndicator.failedToSwitch": {
+    "defaultMessage": "Failed to switch to {branch}"
+  },
+  "gitBranchIndicator.noBranchesFound": {
+    "defaultMessage": "No branches found"
+  },
+  "gitBranchIndicator.searchBranches": {
+    "defaultMessage": "Search branches…"
+  },
+  "gitBranchIndicator.uncommittedChanges": {
+    "defaultMessage": "You may have uncommitted changes."
+  },
   "elicitationRequest.accept": {
     "defaultMessage": "接受"
   },

--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -2003,6 +2003,21 @@ ipcMain.handle(
   }
 );
 
+ipcMain.handle('list-git-branches', (_event, dir: string): Promise<string[]> => {
+  if (!dir?.trim()) return Promise.resolve([]);
+  return new Promise<string[]>((resolve) => {
+    execFile(
+      'git',
+      ['-c', 'safe.bareRepository=explicit', '-c', 'core.fsmonitor=false', '-C', dir, 'for-each-ref', 'refs/heads/', '--format=%(refname:short)'],
+      { timeout: 3000 },
+      (error, stdout) => {
+        if (error) resolve([]);
+        else resolve(stdout.trim().split('\n').filter(Boolean));
+      }
+    );
+  });
+});
+
 ipcMain.handle('get-setting', (_event, key: SettingKey) => {
   const settings = getSettings();
   return settings[key];

--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -1974,6 +1974,35 @@ ipcMain.handle('list-git-worktree-dirs', async (_event, dir: string) => {
   return await listGitWorktreeDirs(dir);
 });
 
+ipcMain.handle(
+  'get-git-branch-info',
+  async (_event, dir: string): Promise<{ branch: string } | null> => {
+    if (!dir?.trim()) return null;
+
+    const git = (args: string[]) =>
+      new Promise<string>((resolve, reject) => {
+        execFile(
+          'git',
+          ['-c', 'safe.bareRepository=explicit', '-c', 'core.fsmonitor=false', '-C', dir, ...args],
+          { timeout: 3000 },
+          (error, stdout) => {
+            if (error) reject(error);
+            else resolve(stdout.trim());
+          }
+        );
+      });
+
+    try {
+      const branch = await git(['rev-parse', '--abbrev-ref', 'HEAD']);
+      const displayBranch =
+        branch === 'HEAD' ? await git(['rev-parse', '--short', 'HEAD']) : branch;
+      return { branch: displayBranch };
+    } catch {
+      return null;
+    }
+  }
+);
+
 ipcMain.handle('get-setting', (_event, key: SettingKey) => {
   const settings = getSettings();
   return settings[key];

--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -2018,6 +2018,33 @@ ipcMain.handle('list-git-branches', (_event, dir: string): Promise<string[]> => 
   });
 });
 
+ipcMain.handle(
+  'switch-git-branch',
+  (_event, dir: string, branch: string): Promise<{ success: boolean; error?: string }> => {
+    if (!dir?.trim() || !branch?.trim()) return Promise.resolve({ success: false });
+    return new Promise<{ success: boolean; error?: string }>((resolve) => {
+      execFile(
+        'git',
+        [
+          '-c',
+          'safe.bareRepository=explicit',
+          '-c',
+          'core.fsmonitor=false',
+          '-C',
+          dir,
+          'checkout',
+          branch,
+        ],
+        { timeout: 30000 },
+        (error) => {
+          if (error) resolve({ success: false, error: error.stderr?.toString() || error.message });
+          else resolve({ success: true });
+        }
+      );
+    });
+  }
+);
+
 ipcMain.handle('get-setting', (_event, key: SettingKey) => {
   const settings = getSettings();
   return settings[key];

--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -51,6 +51,7 @@ import {
   updateTrayMenu,
 } from './utils/autoUpdater';
 import { UPDATES_ENABLED } from './updates';
+import './utils/gitBranchIpc';
 import './utils/recipeHash';
 import type { GooseApp } from './types/apps';
 import installExtension, { REACT_DEVELOPER_TOOLS } from 'electron-devtools-installer';
@@ -1973,77 +1974,6 @@ ipcMain.handle('list-recent-dirs', () => {
 ipcMain.handle('list-git-worktree-dirs', async (_event, dir: string) => {
   return await listGitWorktreeDirs(dir);
 });
-
-ipcMain.handle(
-  'get-git-branch-info',
-  async (_event, dir: string): Promise<{ branch: string } | null> => {
-    if (!dir?.trim()) return null;
-
-    const git = (args: string[]) =>
-      new Promise<string>((resolve, reject) => {
-        execFile(
-          'git',
-          ['-c', 'safe.bareRepository=explicit', '-c', 'core.fsmonitor=false', '-C', dir, ...args],
-          { timeout: 3000 },
-          (error, stdout) => {
-            if (error) reject(error);
-            else resolve(stdout.trim());
-          }
-        );
-      });
-
-    try {
-      const branch = await git(['rev-parse', '--abbrev-ref', 'HEAD']);
-      const displayBranch =
-        branch === 'HEAD' ? await git(['rev-parse', '--short', 'HEAD']) : branch;
-      return { branch: displayBranch };
-    } catch {
-      return null;
-    }
-  }
-);
-
-ipcMain.handle('list-git-branches', (_event, dir: string): Promise<string[]> => {
-  if (!dir?.trim()) return Promise.resolve([]);
-  return new Promise<string[]>((resolve) => {
-    execFile(
-      'git',
-      ['-c', 'safe.bareRepository=explicit', '-c', 'core.fsmonitor=false', '-C', dir, 'for-each-ref', 'refs/heads/', '--format=%(refname:lstrip=2)'],
-      { timeout: 3000 },
-      (error, stdout) => {
-        if (error) resolve([]);
-        else resolve(stdout.trim().split('\n').filter(Boolean));
-      }
-    );
-  });
-});
-
-ipcMain.handle(
-  'switch-git-branch',
-  (_event, dir: string, branch: string): Promise<{ success: boolean; error?: string }> => {
-    if (!dir?.trim() || !branch?.trim()) return Promise.resolve({ success: false });
-    return new Promise<{ success: boolean; error?: string }>((resolve) => {
-      execFile(
-        'git',
-        [
-          '-c',
-          'safe.bareRepository=explicit',
-          '-c',
-          'core.fsmonitor=false',
-          '-C',
-          dir,
-          'checkout',
-          branch,
-        ],
-        { timeout: 30000 },
-        (error) => {
-          if (error) resolve({ success: false, error: error.stderr?.toString() || error.message });
-          else resolve({ success: true });
-        }
-      );
-    });
-  }
-);
 
 ipcMain.handle('get-setting', (_event, key: SettingKey) => {
   const settings = getSettings();

--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -2008,7 +2008,7 @@ ipcMain.handle('list-git-branches', (_event, dir: string): Promise<string[]> => 
   return new Promise<string[]>((resolve) => {
     execFile(
       'git',
-      ['-c', 'safe.bareRepository=explicit', '-c', 'core.fsmonitor=false', '-C', dir, 'for-each-ref', 'refs/heads/', '--format=%(refname:short)'],
+      ['-c', 'safe.bareRepository=explicit', '-c', 'core.fsmonitor=false', '-C', dir, 'for-each-ref', 'refs/heads/', '--format=%(refname:lstrip=2)'],
       { timeout: 3000 },
       (error, stdout) => {
         if (error) resolve([]);

--- a/ui/desktop/src/preload.ts
+++ b/ui/desktop/src/preload.ts
@@ -180,6 +180,9 @@ type ElectronAPI = {
   addRecentDir: (dir: string) => Promise<boolean>;
   listRecentDirs: () => Promise<string[]>;
   listGitWorktreeDirs: (dir: string) => Promise<string[]>;
+  getGitBranchInfo: (dir: string) => Promise<{ branch: string } | null>;
+  listGitBranches: (dir: string) => Promise<string[]>;
+  switchGitBranch: (dir: string, branch: string) => Promise<{ success: boolean; error?: string }>;
 };
 
 type AppConfigAPI = {
@@ -339,6 +342,10 @@ const electronAPI: ElectronAPI = {
   addRecentDir: (dir: string) => ipcRenderer.invoke('add-recent-dir', dir),
   listRecentDirs: () => ipcRenderer.invoke('list-recent-dirs'),
   listGitWorktreeDirs: (dir: string) => ipcRenderer.invoke('list-git-worktree-dirs', dir),
+  getGitBranchInfo: (dir: string) => ipcRenderer.invoke('get-git-branch-info', dir),
+  listGitBranches: (dir: string) => ipcRenderer.invoke('list-git-branches', dir),
+  switchGitBranch: (dir: string, branch: string) =>
+    ipcRenderer.invoke('switch-git-branch', dir, branch),
 };
 
 function getAppLocale(): unknown {

--- a/ui/desktop/src/utils/gitBranchIpc.ts
+++ b/ui/desktop/src/utils/gitBranchIpc.ts
@@ -1,0 +1,69 @@
+import { execFile } from 'child_process';
+import { ipcMain } from 'electron';
+
+const gitArgs = (dir: string, args: string[]) => [
+  '-c',
+  'safe.bareRepository=explicit',
+  '-c',
+  'core.fsmonitor=false',
+  '-C',
+  dir,
+  ...args,
+];
+
+const git = (dir: string, args: string[], timeout = 3000) =>
+  new Promise<string>((resolve, reject) => {
+    execFile('git', gitArgs(dir, args), { timeout }, (error, stdout) => {
+      if (error) reject(error);
+      else resolve(stdout.trim());
+    });
+  });
+
+ipcMain.handle(
+  'get-git-branch-info',
+  async (_event, dir: string): Promise<{ branch: string } | null> => {
+    if (!dir?.trim()) return null;
+
+    try {
+      const branch = await git(dir, ['rev-parse', '--abbrev-ref', 'HEAD']);
+      const displayBranch =
+        branch === 'HEAD' ? await git(dir, ['rev-parse', '--short', 'HEAD']) : branch;
+      return { branch: displayBranch };
+    } catch {
+      return null;
+    }
+  }
+);
+
+ipcMain.handle('list-git-branches', async (_event, dir: string): Promise<string[]> => {
+  if (!dir?.trim()) return [];
+
+  try {
+    const branches = await git(dir, [
+      'for-each-ref',
+      'refs/heads/',
+      '--format=%(refname:lstrip=2)',
+    ]);
+    return branches.split('\n').filter(Boolean);
+  } catch {
+    return [];
+  }
+});
+
+ipcMain.handle(
+  'switch-git-branch',
+  async (_event, dir: string, branch: string): Promise<{ success: boolean; error?: string }> => {
+    if (!dir?.trim() || !branch?.trim()) return { success: false };
+
+    try {
+      await git(dir, ['checkout', branch], 30000);
+      return { success: true };
+    } catch (error) {
+      const currentBranch = await git(dir, ['rev-parse', '--abbrev-ref', 'HEAD']).catch(() => null);
+      if (currentBranch === branch) return { success: true };
+
+      const gitError = error as Error & { stderr?: string };
+      return { success: false, error: gitError.stderr?.toString() || gitError.message };
+    }
+  }
+);

--- a/ui/desktop/src/utils/gitBranchIpc.ts
+++ b/ui/desktop/src/utils/gitBranchIpc.ts
@@ -19,19 +19,22 @@ const git = (dir: string, args: string[], timeout = 3000) =>
     });
   });
 
+const getCurrentBranch = async (dir: string) => {
+  try {
+    const ref = await git(dir, ['symbolic-ref', 'HEAD']);
+    return ref.startsWith('refs/heads/') ? ref.slice('refs/heads/'.length) : ref;
+  } catch {
+    return git(dir, ['rev-parse', '--short', 'HEAD']).catch(() => null);
+  }
+};
+
 ipcMain.handle(
   'get-git-branch-info',
   async (_event, dir: string): Promise<{ branch: string } | null> => {
     if (!dir?.trim()) return null;
 
-    try {
-      const branch = await git(dir, ['rev-parse', '--abbrev-ref', 'HEAD']);
-      const displayBranch =
-        branch === 'HEAD' ? await git(dir, ['rev-parse', '--short', 'HEAD']) : branch;
-      return { branch: displayBranch };
-    } catch {
-      return null;
-    }
+    const branch = await getCurrentBranch(dir);
+    return branch ? { branch } : null;
   }
 );
 
@@ -59,7 +62,7 @@ ipcMain.handle(
       await git(dir, ['checkout', branch], 30000);
       return { success: true };
     } catch (error) {
-      const currentBranch = await git(dir, ['rev-parse', '--abbrev-ref', 'HEAD']).catch(() => null);
+      const currentBranch = await getCurrentBranch(dir);
       if (currentBranch === branch) return { success: true };
 
       const gitError = error as Error & { stderr?: string };


### PR DESCRIPTION
Fixes #10709

## Summary

Adds an interactive git branch chip to the chat input bottom bar next to the directory switcher. Clicking it opens a searchable dropdown for local branches; failures show a toast with Git stderr. Non-git directories, narrow bars, detached HEADs, linked worktrees, external branch changes, post-checkout hook failures, and ambiguous branch/tag names are handled. The branch-switcher UI is translated across all supported locales.

## Verification

- Built the generated `@aaif/goose-sdk` package.
- Ran `pnpm --filter goose-app run typecheck`.
- Ran ESLint on `src/main.ts`, `src/utils/gitBranchIpc.ts`, and `src/components/GitBranchIndicator.tsx`.
- Ran `pnpm --filter goose-app run i18n:check` across all 15 non-English catalogs.
- Ran Prettier on the changed desktop files.
- Ran `cargo fmt --all`.
- Reproduced a branch/tag name collision and verified the full symbolic ref normalizes to the local branch name.
- The contributor supplied a Goose Desktop screenshot and reported manual testing.