### PR TITLE
feat(providers): optional per-request nonce header for declarative providers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5296,6 +5296,7 @@ dependencies = [
  "tracing",
  "url",
  "urlencoding",
+ "uuid",
  "wiremock",
 ]
 

--- a/crates/goose-providers/Cargo.toml
+++ b/crates/goose-providers/Cargo.toml
@@ -54,6 +54,7 @@ pkcs1 = { version = "0.7.5", default-features = false, features = ["pkcs8", "std
 pkcs8 = { version = "0.10", default-features = false, features = ["alloc", "std"], optional = true }
 sec1 = { version = "0.7", default-features = false, features = ["der", "pkcs8", "std"], optional = true }
 include_dir = { workspace = true }
+uuid = { workspace = true }
 
 [dev-dependencies]
 test-case = { workspace = true }

--- a/crates/goose-providers/src/api_client.rs
+++ b/crates/goose-providers/src/api_client.rs
@@ -30,7 +30,7 @@ pub struct ApiClient {
     default_query: Vec<(String, String)>,
     timeout: Duration,
     tls_config: Option<TlsConfig>,
-    request_builder: Option<RequestBuilderDecorator>,
+    request_builder: Vec<RequestBuilderDecorator>,
     transport_policy: TransportPolicy,
 }
 
@@ -283,7 +283,7 @@ impl ApiClient {
             default_query: Vec::new(),
             timeout,
             tls_config,
-            request_builder: None,
+            request_builder: Vec::new(),
             transport_policy: TransportPolicy::Default,
         })
     }
@@ -402,8 +402,10 @@ impl ApiClient {
         Ok(self)
     }
 
+    /// Append a request decorator. Decorators compose and run in installation
+    /// order; this does not replace previously installed ones.
     pub fn with_request_builder(mut self, request_builder: RequestBuilderDecorator) -> Self {
-        self.request_builder = Some(request_builder);
+        self.request_builder.push(request_builder);
         self
     }
 
@@ -549,7 +551,7 @@ impl<'a> ApiRequestBuilder<'a> {
             request = request.timeout(self.client.timeout);
         }
 
-        if let Some(decorator) = &self.client.request_builder {
+        for decorator in &self.client.request_builder {
             request = decorator(request)?;
         }
 

--- a/crates/goose-providers/src/declarative.rs
+++ b/crates/goose-providers/src/declarative.rs
@@ -149,6 +149,21 @@ pub struct DeclarativeProviderConfig {
     pub preserves_thinking: bool,
     #[serde(default)]
     pub setup: Option<goose_provider_types::canonical::catalog::ProviderSetupMetadata>,
+    /// Optional header name carrying a fresh per-request value (UUIDv4).
+    /// Absent means no decorator is installed and no code path is taken.
+    ///
+    /// Currently honoured only by the OpenAI declarative builder
+    /// ([`crate::openai::from_declarative_config`]). Other engines, and
+    /// specialised constructors that build their own `ApiClient` (for example
+    /// `HuggingFaceProvider::from_custom_config`), do not install the decorator
+    /// and will ignore this field.
+    ///
+    /// Names overwritten by a later request stage are rejected at config load:
+    /// `agent-session-id`, `authorization`, `proxy-authorization`. A name matching
+    /// a provider's own configured `ApiKey` auth header is also overwritten, since
+    /// authentication is applied after all decorators.
+    #[serde(default)]
+    pub nonce_header: Option<String>,
 }
 
 fn default_requires_auth() -> bool {

--- a/crates/goose-providers/src/ollama.rs
+++ b/crates/goose-providers/src/ollama.rs
@@ -574,6 +574,7 @@ mod tests {
             fast_model: None,
             preserves_thinking: false,
             setup: None,
+            nonce_header: None,
         }
     }
 

--- a/crates/goose-providers/src/openai.rs
+++ b/crates/goose-providers/src/openai.rs
@@ -27,6 +27,7 @@ use reqwest::StatusCode;
 use serde_json::json;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
+use uuid::Uuid;
 
 use crate::base::{MessageStream, ProviderDescriptor};
 use crate::model::ModelConfig;
@@ -929,6 +930,33 @@ pub fn from_declarative_config(
         api_client = api_client.with_headers(header_map)?;
     }
 
+    if let Some(ref header_name) = config.nonce_header {
+        // Parse the configured header name once, here, rather than on every request: a typo in
+        // `nonce_header` should fail at config load with a name you can act on, not turn every
+        // subsequent request into an opaque header-parse error.
+        let name = reqwest::header::HeaderName::from_bytes(header_name.as_bytes())
+            .map_err(|e| anyhow::anyhow!("invalid nonce_header {header_name:?}: {e}"))?;
+        // Reject names that a later stage overwrites, so a configured nonce cannot silently
+        // carry nothing: `session_id_request_builder` removes and rewrites the session header,
+        // and `ApiClient::send_request` applies authentication after every decorator.
+        const RESERVED: [&str; 3] = ["agent-session-id", "authorization", "proxy-authorization"];
+        if RESERVED.contains(&name.as_str()) {
+            return Err(anyhow::anyhow!(
+                "nonce_header {header_name:?} is reserved: it is overwritten by a later request \
+                 stage, so the nonce would not be sent. Choose a different header name."
+            ));
+        }
+        api_client = api_client.with_request_builder(Arc::new(move |request| {
+            let (client, req) = request.build_split();
+            let mut req = req?;
+            req.headers_mut().insert(
+                name.clone(),
+                reqwest::header::HeaderValue::from_str(&Uuid::new_v4().to_string())?,
+            );
+            Ok(reqwest::RequestBuilder::from_parts(client, req))
+        }));
+    }
+
     Ok(OpenAiProviderBuilder::new(api_client)
         .base_path(base_path)
         .custom_headers(config.headers)
@@ -1353,6 +1381,7 @@ mod tests {
             fast_model: None,
             preserves_thinking: false,
             setup: None,
+            nonce_header: None,
         }
     }
 
@@ -1702,5 +1731,64 @@ mod tests {
         assert_eq!(payload["stream"], json!(true));
         assert_eq!(payload["stream_options"], json!({"include_usage": true}));
         assert_eq!(payload["messages"].as_array().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn nonce_header_absent_does_not_send_header() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::any())
+            .respond_with(wiremock::ResponseTemplate::new(200))
+            .mount(&server)
+            .await;
+        let config: DeclarativeProviderConfig = serde_json::from_value(json!({
+            "name": "t", "engine": "openai", "display_name": "T",
+            "base_url": server.uri(), "models": [{"name": "m", "context_limit": 4096}]
+        }))
+        .unwrap();
+        let provider =
+            from_declarative_config(config, None, crate::declarative::EnvKeyResolver::new())
+                .unwrap()
+                .build();
+        let _ = provider
+            .api_client
+            .request("v1/models")
+            .response_get()
+            .await;
+        let reqs = server.received_requests().await.unwrap();
+        assert!(reqs[0].headers.get("x-test-nonce").is_none());
+    }
+
+    #[tokio::test]
+    async fn nonce_header_present_generates_unique_values_per_request() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::any())
+            .respond_with(wiremock::ResponseTemplate::new(200))
+            .mount(&server)
+            .await;
+        let config: DeclarativeProviderConfig = serde_json::from_value(json!({
+            "name": "t", "engine": "openai", "display_name": "T",
+            "base_url": server.uri(),
+            "models": [{"name": "m", "context_limit": 4096}],
+            "nonce_header": "x-test-nonce"
+        }))
+        .unwrap();
+        let provider =
+            from_declarative_config(config, None, crate::declarative::EnvKeyResolver::new())
+                .unwrap()
+                .build();
+        let _ = provider
+            .api_client
+            .request("v1/models")
+            .response_get()
+            .await;
+        let _ = provider
+            .api_client
+            .request("v1/models")
+            .response_get()
+            .await;
+        let reqs = server.received_requests().await.unwrap();
+        let v1 = reqs[0].headers["x-test-nonce"].to_str().unwrap();
+        let v2 = reqs[1].headers["x-test-nonce"].to_str().unwrap();
+        assert_ne!(v1, v2);
     }
 }

--- a/crates/goose/src/config/declarative_providers.rs
+++ b/crates/goose/src/config/declarative_providers.rs
@@ -216,6 +216,7 @@ pub fn create_custom_provider(
         fast_model: None,
         preserves_thinking,
         setup: None,
+        nonce_header: None,
     };
 
     let custom_providers_dir = custom_providers_dir();
@@ -297,6 +298,7 @@ pub fn update_custom_provider(params: UpdateCustomProviderParams) -> Result<()> 
             fast_model: existing_config.fast_model.clone(),
             preserves_thinking,
             setup: existing_config.setup,
+            nonce_header: existing_config.nonce_header,
         };
 
         let file_path = custom_provider_file_path(&updated_config.name)?;
@@ -568,6 +570,7 @@ mod tests {
             fast_model: None,
             preserves_thinking: true,
             setup: None,
+            nonce_header: None,
         }
     }
 

--- a/crates/goose/src/providers/anthropic_def.rs
+++ b/crates/goose/src/providers/anthropic_def.rs
@@ -134,6 +134,7 @@ mod tests {
             fast_model: None,
             preserves_thinking: false,
             setup: None,
+            nonce_header: None,
         }
     }
 

--- a/crates/goose/src/providers/huggingface.rs
+++ b/crates/goose/src/providers/huggingface.rs
@@ -546,6 +546,7 @@ mod tests {
             fast_model: None,
             preserves_thinking: true,
             setup: None,
+            nonce_header: None,
         }
     }
 }

--- a/crates/goose/src/providers/ollama_cloud.rs
+++ b/crates/goose/src/providers/ollama_cloud.rs
@@ -473,6 +473,7 @@ mod tests {
             fast_model: None,
             preserves_thinking: true,
             setup: None,
+            nonce_header: None,
         }
     }
 

--- a/crates/goose/src/providers/openai_def.rs
+++ b/crates/goose/src/providers/openai_def.rs
@@ -399,4 +399,57 @@ mod tests {
     fn parse_base_url_rejects_whitespace_only() {
         assert!(parse_base_url("  ").is_err());
     }
+
+    /// Regression pin for the decorator-composition bug.
+    ///
+    /// `from_custom_config` installs the session-id decorator *after*
+    /// `from_declarative_config` has installed the nonce decorator. While
+    /// `ApiClient::with_request_builder` replaced a single `Option` slot, the second
+    /// install silently discarded the first, so the CLI and Desktop paths sent no nonce
+    /// even though the `goose-providers` tests passed — those call
+    /// `from_declarative_config` directly and never exercise this wrapper.
+    ///
+    /// Both headers must arrive on the same request.
+    #[tokio::test]
+    async fn from_custom_config_composes_nonce_and_session_decorators() {
+        use crate::providers::base::Provider;
+        use crate::session_context::{with_session_id, SESSION_ID_HEADER};
+
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::any())
+            .respond_with(wiremock::ResponseTemplate::new(200))
+            .mount(&server)
+            .await;
+
+        let config: DeclarativeProviderConfig = serde_json::from_value(serde_json::json!({
+            "name": "t", "engine": "openai", "display_name": "T",
+            "base_url": server.uri(),
+            "models": [{"name": "m", "context_limit": 4096}],
+            "requires_auth": false,
+            "nonce_header": "x-test-nonce"
+        }))
+        .unwrap();
+
+        let provider = from_custom_config(config, None).unwrap();
+
+        // Any public call that reaches the wire; the response is irrelevant.
+        with_session_id(Some("session-abc".to_string()), async {
+            let _ = provider.fetch_supported_models().await;
+        })
+        .await;
+
+        let reqs = server.received_requests().await.unwrap();
+        assert_eq!(reqs.len(), 1, "expected exactly one request");
+        let headers = &reqs[0].headers;
+
+        assert!(
+            headers.get("x-test-nonce").is_some(),
+            "nonce header missing — the session decorator replaced it instead of composing"
+        );
+        assert_eq!(
+            headers.get(SESSION_ID_HEADER).map(|v| v.to_str().unwrap()),
+            Some("session-abc"),
+            "session header missing — the nonce decorator replaced it instead of composing"
+        );
+    }
 }

--- a/crates/goose/src/providers/provider_registry.rs
+++ b/crates/goose/src/providers/provider_registry.rs
@@ -401,6 +401,7 @@ mod tests {
             fast_model: None,
             preserves_thinking: false,
             setup: None,
+            nonce_header: None,
         }
     }
 


### PR DESCRIPTION
## Motivation

Proxies and sidecars sitting in front of an OpenAI-compatible endpoint often need a per-request unique value — idempotency keys, replay-window dedup, request correlation. Declarative (custom) providers currently have no way to supply one.

Every built-in provider can reach `ApiClient::with_request_builder`; `from_declarative_config` is the only path that cannot. This closes that gap rather than adding a feature: static `headers` are resolved once at provider init, so they can carry a constant but never a fresh per-request value.

Pure config, no new concept: **no header name is hardcoded, and absent means no-op.**

Concrete consumer: Mesh-LLM's local sidecar, so the *client* rather than the intermediary contributes the per-request nonce (Mesh-LLM/mesh-llm#1233). Disclosure: the companion Mesh-LLM PR is also mine and will follow this one.

## Change

- `DeclarativeProviderConfig` gains `nonce_header: Option<String>` (`#[serde(default)]`).
- When set, `from_declarative_config` installs a request-builder decorator that inserts a fresh UUIDv4 under that header name on every request.
- When unset, no decorator is installed and no code path is taken.
- The configured header name is parsed **once, at config load**, so a typo fails immediately with a message naming the key rather than turning every subsequent request into an opaque header-parse error.
- `uuid` was already a workspace dependency; this adds `uuid = { workspace = true }` to `goose-providers`.

## Tests

- `nonce_header_present_generates_unique_values_per_request` — two real requests captured via wiremock; asserts both carry the header and that the values differ.
- `nonce_header_absent_does_not_send_header` — no decorator installed, header absent.

`cargo test -p goose-providers --lib -- --test-threads=1` → 137 passed, 0 failed.

## Notes for reviewers

Decorators now compose. ApiClient::request_builder was a single Option that with_request_builder replaced, and the registry path installs a second decorator: openai_def::from_custom_config adds the session-id builder immediately after from_declarative_config returns. That silently discarded the nonce, so the CLI and Desktop paths would never have sent it — caught in review, and my original description of this seam was wrong. The slot is now a Vec and the setter appends; decorators run in installation order. Existing callers are unaffected, since each installs one.

Worth naming why the tests didn't catch it: they call from_declarative_config directly and assert on the wire, so they exercised the builder but not the registry path that wraps it. A test through openai_def::from_custom_config asserting both headers arrive is the right regression pin — happy to add it here if you'd want it in this PR.

**Adding a field to `DeclarativeProviderConfig` breaks struct-literal construction** for out-of-tree callers (deserialization is unaffected, thanks to `#[serde(default)]`). Two in-repo fixtures needed updating, which is the same signal. If you'd prefer `#[non_exhaustive]` on that struct, or a builder, I'll follow your lead.

Scope. nonce_header is honoured by the OpenAI declarative builder only. The registry has several construction paths that bypass from_json — load_custom_providers into engine-specific from_custom_config, and HuggingFaceProvider::from_custom_config building its own ApiClient — so the field is documented as builder-scoped rather than validated in a place that wouldn't run. Open question in the review thread about where you'd want validation to live.

**Unrelated, but you'll hit it if you run the suite locally:** `cargo test -p goose-providers --lib` has a pre-existing parallel-execution flake — 9 tests fail (8 × `anthropic::tests::fetch_supported_models*` / `fetch_models_*`, plus `api_client::tests::loopback_transport_does_not_use_environment_proxy`). It reproduces on `main` **without** this patch, and all 137 pass with `--test-threads=1`. The proxy test mutates process-global proxy env vars, so concurrently scheduled tests making HTTP calls get routed at its listener. Happy to file it separately if useful.
