### PR TITLE
feat(summon): surface subagent extension load results in delegate output

### DIFF
--- a/crates/goose/src/agents/platform_extensions/summon.rs
+++ b/crates/goose/src/agents/platform_extensions/summon.rs
@@ -1436,16 +1436,88 @@ impl SummonClient {
         );
 
         match result {
-            Ok(run_result) => Ok(CallToolResult::success(vec![ContentBlock::text(
-                Self::subagent_output_text(run_result, response_expected),
-            )])
-            .with_meta(Some(meta))),
+            Ok(run_result) => {
+                if let Some(msg) =
+                    Self::schema_recipe_failure_message(&run_result, response_expected)
+                {
+                    return Ok(
+                        CallToolResult::error(vec![ContentBlock::text(msg)]).with_meta(Some(meta))
+                    );
+                }
+                Ok(
+                    CallToolResult::success(vec![ContentBlock::text(Self::subagent_output_text(
+                        run_result,
+                        response_expected,
+                    ))])
+                    .with_meta(Some(meta)),
+                )
+            }
             Err(e) => Ok(CallToolResult::error(vec![ContentBlock::text(format!(
                 "Delegation failed: {}",
                 e
             ))])
             .with_meta(Some(meta))),
         }
+    }
+
+    /// Decide whether a completed subagent run should be surfaced as a
+    /// tool-level error instead of a success, based on the interaction
+    /// between schema recipes and extension load failures.
+    ///
+    /// For recipes with a `response:` schema, the tool-response text must
+    /// remain valid JSON so the caller can parse it. That constraint rules
+    /// out the two obvious ways of surfacing extension load failures to
+    /// the parent LLM:
+    ///
+    /// - Appending a prose failure report inline corrupts the JSON (the
+    ///   very bug the response_expected branch exists to prevent).
+    /// - Adding a second `ContentBlock` doesn't help either: both the
+    ///   Anthropic format serialiser (newline-joined text parts, see
+    ///   `crates/goose-provider-types/src/formats/anthropic.rs:344-352`)
+    ///   and the OpenAI format serialiser (space-joined text, see
+    ///   `crates/goose-provider-types/src/formats/openai.rs:381-388`)
+    ///   collapse multi-block tool responses into a single joined string
+    ///   before the LLM sees them. The JSON is still corrupted at the
+    ///   caller.
+    /// - `_meta` on the tool response is transport-only and is not read
+    ///   by any format serialiser we checked.
+    ///
+    /// If a schema recipe requested extensions and some failed to load,
+    /// the subagent produced its JSON output under a degraded tool set.
+    /// Rather than silently returning that "clean" JSON, we return a
+    /// tool-level error so the parent LLM sees the failure and can
+    /// choose to retry or fall back. Prose recipes are unaffected —
+    /// they surface load failures via the appended report as before.
+    ///
+    /// Returns `Some(error_message)` when the caller should return a
+    /// `CallToolResult::error`, or `None` when the run is a legitimate
+    /// success and should be surfaced via the normal output path.
+    fn schema_recipe_failure_message(
+        run_result: &SubagentRunResult,
+        response_expected: bool,
+    ) -> Option<String> {
+        if !response_expected {
+            return None;
+        }
+        let failures: Vec<&ExtensionLoadResult> = run_result
+            .extension_load_results
+            .iter()
+            .filter(|r| !r.success)
+            .collect();
+        if failures.is_empty() {
+            return None;
+        }
+        let mut msg = format!(
+            "Delegation failed: {} extension(s) failed to load and the \
+             recipe declares a `response:` schema, so the subagent's JSON \
+             output cannot be trusted. Failures:",
+            failures.len(),
+        );
+        for r in &failures {
+            let err = r.error.as_deref().unwrap_or("unknown error");
+            msg.push_str(&format!("\n  failed: {} ({})", r.name, err));
+        }
+        Some(msg)
     }
 
     fn validate_delegate_params(&self, params: &DelegateParams) -> Result<(), String> {
@@ -4161,5 +4233,90 @@ You review code."#;
             .await
             .unwrap();
         assert!(extract_text(&result.content[0]).contains("final output"));
+    }
+
+    #[test]
+    fn schema_recipe_failure_message_none_when_no_response_expected() {
+        // Prose recipes are unaffected — failures surface through the
+        // appended report in `text_with_report()`, not through a
+        // tool-level error. Return `None` regardless of load results.
+        let run = SubagentRunResult {
+            text: "prose output".to_string(),
+            extension_load_results: vec![ExtensionLoadResult {
+                name: "foo".to_string(),
+                success: false,
+                error: Some("boom".to_string()),
+            }],
+        };
+        assert!(SummonClient::schema_recipe_failure_message(&run, false).is_none());
+    }
+
+    #[test]
+    fn schema_recipe_failure_message_none_when_all_extensions_loaded() {
+        // Schema recipe, all extensions loaded successfully — legitimate
+        // success. Caller should surface the JSON output as-is.
+        let run = SubagentRunResult {
+            text: "{\"answer\": 42}".to_string(),
+            extension_load_results: vec![ExtensionLoadResult {
+                name: "developer".to_string(),
+                success: true,
+                error: None,
+            }],
+        };
+        assert!(SummonClient::schema_recipe_failure_message(&run, true).is_none());
+    }
+
+    #[test]
+    fn schema_recipe_failure_message_surfaces_failures_when_response_expected() {
+        // The Move-1 fix: schema recipe with any extension failure →
+        // caller should return a tool-level error listing every failure,
+        // rather than a "clean" JSON that hides the degraded tool set.
+        let run = SubagentRunResult {
+            text: "{\"answer\": 42}".to_string(),
+            extension_load_results: vec![
+                ExtensionLoadResult {
+                    name: "developer".to_string(),
+                    success: true,
+                    error: None,
+                },
+                ExtensionLoadResult {
+                    name: "computercontroller".to_string(),
+                    success: false,
+                    error: Some("not registered".to_string()),
+                },
+                ExtensionLoadResult {
+                    name: "chatrecall".to_string(),
+                    success: false,
+                    error: Some("startup timed out".to_string()),
+                },
+            ],
+        };
+        let msg = SummonClient::schema_recipe_failure_message(&run, true)
+            .expect("schema + failure should produce an error message");
+        // Structural assertions rather than exact match — leaves the
+        // wording free to evolve without touching the test.
+        assert!(msg.contains("2 extension(s) failed to load"));
+        assert!(msg.contains("`response:` schema"));
+        assert!(msg.contains("failed: computercontroller (not registered)"));
+        assert!(msg.contains("failed: chatrecall (startup timed out)"));
+        // The successful extension should NOT appear in the error list.
+        assert!(!msg.contains("failed: developer"));
+    }
+
+    #[test]
+    fn schema_recipe_failure_message_handles_missing_error_field() {
+        // Defensive: an ExtensionLoadResult with success=false but no
+        // error text (shouldn't happen in practice, but the type allows
+        // it) should not panic and should surface a sentinel string.
+        let run = SubagentRunResult {
+            text: "{\"answer\": 42}".to_string(),
+            extension_load_results: vec![ExtensionLoadResult {
+                name: "mystery".to_string(),
+                success: false,
+                error: None,
+            }],
+        };
+        let msg = SummonClient::schema_recipe_failure_message(&run, true).unwrap();
+        assert!(msg.contains("failed: mystery (unknown error)"));
     }
 }

--- a/crates/goose/src/agents/platform_extensions/summon.rs
+++ b/crates/goose/src/agents/platform_extensions/summon.rs
@@ -75,6 +75,10 @@ pub struct BackgroundTask {
     pub last_activity: Arc<AtomicU64>,
     pub handle: JoinHandle<Result<SubagentRunResult>>,
     pub cancellation_token: CancellationToken,
+    /// True when the delegated recipe declared a `response:` schema.
+    /// Consumers of the run result must preserve the raw JSON output and
+    /// not append a prose extension-load report to it.
+    pub response_expected: bool,
     notification_sink: SharedNotificationSink,
 }
 
@@ -85,6 +89,9 @@ pub struct CompletedTask {
     pub turns_taken: u32,
     pub duration: Duration,
     pub completed_at: Instant,
+    /// True when the delegated recipe declared a `response:` schema.
+    /// See `BackgroundTask::response_expected` for details.
+    pub response_expected: bool,
     notification_sink: SharedNotificationSink,
 }
 
@@ -1021,11 +1028,12 @@ impl SummonClient {
                 task.description.clone(),
                 task.duration,
                 task.turns_taken,
+                task.response_expected,
                 Arc::clone(&task.notification_sink),
             )
         });
 
-        if let Some((result, description, duration, turns_taken, notification_sink)) =
+        if let Some((result, description, duration, turns_taken, response_expected, notification_sink)) =
             completed_entry
         {
             if !peek {
@@ -1043,7 +1051,7 @@ impl SummonClient {
                 _ => "✗ Failed",
             };
             let output = match result {
-                Ok(run_result) => run_result.text_with_report(),
+                Ok(run_result) => Self::subagent_output_text(run_result, response_expected),
                 Err(error) => format!("Error: {}", error),
             };
             return Ok(TaskLoadResult {
@@ -1114,12 +1122,13 @@ impl SummonClient {
 
                 let duration = task.started_at.elapsed();
                 let turns_taken = task.turns.load(Ordering::Relaxed);
+                let response_expected = task.response_expected;
 
                 let mut handle = task.handle;
                 let output = tokio::select! {
                     result = &mut handle => {
                         match result {
-                            Ok(Ok(run_result)) => run_result.text_with_report(),
+                            Ok(Ok(run_result)) => Self::subagent_output_text(run_result, response_expected),
                             Ok(Err(e)) => format!("Error: {}", e),
                             Err(e) => format!("Task panicked: {}", e),
                         }
@@ -1155,11 +1164,12 @@ impl SummonClient {
             Self::attach_notification_emitter(&notification_sink, notification_emitter).await;
             let mut task = running.remove(task_id).unwrap();
             drop(running);
+            let response_expected = task.response_expected;
 
             tokio::select! {
                 result = &mut task.handle => {
                     let (output, status_key) = match result {
-                        Ok(Ok(run_result)) => (run_result.text_with_report(), "completed"),
+                        Ok(Ok(run_result)) => (Self::subagent_output_text(run_result, response_expected), "completed"),
                         Ok(Err(e)) => (format!("Error: {}", e), "failed"),
                         Err(e) => (format!("Task panicked: {}", e), "panicked"),
                     };
@@ -1391,6 +1401,7 @@ impl SummonClient {
             .await?;
 
         let subagent_session_id = subagent_session.id.clone();
+        let response_expected = recipe.response.is_some();
 
         let params = SubagentRunParams {
             config: agent_config,
@@ -1420,7 +1431,7 @@ impl SummonClient {
 
         match result {
             Ok(run_result) => Ok(CallToolResult::success(vec![ContentBlock::text(
-                run_result.text_with_report(),
+                Self::subagent_output_text(run_result, response_expected),
             )])
             .with_meta(Some(meta))),
             Err(e) => Ok(CallToolResult::error(vec![ContentBlock::text(format!(
@@ -1939,6 +1950,7 @@ impl SummonClient {
                     turns_taken,
                     duration,
                     completed_at: Instant::now(),
+                    response_expected: task.response_expected,
                     notification_sink: task.notification_sink,
                 },
             );
@@ -1954,6 +1966,32 @@ impl SummonClient {
             (Some(source), None) => source.clone(),
             (None, Some(instructions)) => instructions.clone(),
             (None, None) => "Unknown task".to_string(),
+        }
+    }
+
+    /// Choose the caller-facing text for a completed subagent run.
+    ///
+    /// Recipes with a `response:` schema serialise their final output as
+    /// JSON; appending a prose report to that string produces invalid
+    /// JSON. In that case surface the raw text and log any drops via
+    /// `warn!` so operators still have visibility. Prose recipes keep
+    /// the inlined report as before (unchanged for the common case).
+    fn subagent_output_text(run_result: SubagentRunResult, response_expected: bool) -> String {
+        if response_expected {
+            let (text, load_results) = run_result.into_parts();
+            let failures: Vec<&ExtensionLoadResult> =
+                load_results.iter().filter(|r| !r.success).collect();
+            if !failures.is_empty() {
+                warn!(
+                    "Subagent completed with {} extension load failure(s); \
+                     report suppressed to preserve response schema. Failures: {:?}",
+                    failures.len(),
+                    failures
+                );
+            }
+            text
+        } else {
+            run_result.text_with_report()
         }
     }
 
@@ -2026,6 +2064,7 @@ impl SummonClient {
 
         let notification_sink = Self::notification_sink(None);
         let task_notification_sink = Arc::clone(&notification_sink);
+        let response_expected = recipe.response.is_some();
 
         let handle = tokio::spawn(async move {
             let params = SubagentRunParams {
@@ -2054,6 +2093,7 @@ impl SummonClient {
             last_activity,
             handle,
             cancellation_token: task_token,
+            response_expected,
             notification_sink,
         };
 
@@ -3531,6 +3571,7 @@ You review code."#;
                 turns_taken: 1,
                 duration: Duration::from_secs(1),
                 completed_at: Instant::now(),
+                response_expected: false,
                 notification_sink: buffered_notification_sink(buffered),
             },
         );
@@ -3580,6 +3621,7 @@ You review code."#;
                 turns_taken: 1,
                 duration: Duration::from_secs(1),
                 completed_at: Instant::now(),
+                response_expected: false,
                 notification_sink: buffered_notification_sink(vec![
                     test_tool_notification("inner-0", task_id),
                     test_tool_notification("inner-1", task_id),
@@ -3652,6 +3694,7 @@ You review code."#;
                 turns_taken: 1,
                 duration: Duration::from_secs(1),
                 completed_at: Instant::now(),
+                response_expected: false,
                 notification_sink: buffered_notification_sink(
                     (0..64)
                         .map(|index| test_tool_notification(&format!("inner-{index}"), task_id))
@@ -3704,6 +3747,7 @@ You review code."#;
                         })
                     }),
                     cancellation_token: CancellationToken::new(),
+                    response_expected: false,
                     notification_sink,
                 },
             );
@@ -3745,6 +3789,7 @@ You review code."#;
                     turns_taken: 5,
                     duration: Duration::from_secs(60),
                     completed_at: Instant::now(),
+                    response_expected: false,
                     notification_sink: buffered_notification_sink(Vec::new()),
                 },
             );
@@ -3757,6 +3802,7 @@ You review code."#;
                     turns_taken: 3,
                     duration: Duration::from_secs(30),
                     completed_at: Instant::now(),
+                    response_expected: false,
                     notification_sink: buffered_notification_sink(Vec::new()),
                 },
             );
@@ -3847,6 +3893,7 @@ You review code."#;
                         })
                     }),
                     cancellation_token: token.clone(),
+                    response_expected: false,
                     notification_sink,
                 },
             );
@@ -3893,6 +3940,7 @@ You review code."#;
                     Ok(SubagentRunResult { text: "cancelled gracefully".to_string(), extension_load_results: Vec::new() })
                 }),
                 cancellation_token: token.clone(),
+                response_expected: false,
                 notification_sink: buffered_notification_sink(vec![
                     test_tool_notification("inner-0", task_id),
                     test_tool_notification("inner-1", task_id),
@@ -3953,6 +4001,7 @@ You review code."#;
                     Ok(SubagentRunResult { text: "done".to_string(), extension_load_results: Vec::new() })
                 }),
                 cancellation_token: CancellationToken::new(),
+                response_expected: false,
                 notification_sink: buffered_notification_sink(vec![
                     test_tool_notification("inner-0", task_id),
                     test_tool_notification("inner-1", task_id),
@@ -4015,6 +4064,7 @@ You review code."#;
                         })
                     }),
                     cancellation_token: CancellationToken::new(),
+                    response_expected: false,
                     notification_sink: buffered_notification_sink(Vec::new()),
                 },
             );
@@ -4067,6 +4117,7 @@ You review code."#;
                     turns_taken: 4,
                     duration: Duration::from_secs(30),
                     completed_at: Instant::now(),
+                    response_expected: false,
                     notification_sink: buffered_notification_sink(Vec::new()),
                 },
             );

--- a/crates/goose/src/agents/platform_extensions/summon.rs
+++ b/crates/goose/src/agents/platform_extensions/summon.rs
@@ -1,6 +1,8 @@
 use crate::agents::extension::PlatformExtensionContext;
 use crate::agents::mcp_client::{Error, McpClientTrait};
-use crate::agents::subagent_handler::{run_subagent_task, OnMessageCallback, SubagentRunParams};
+use crate::agents::subagent_handler::{
+    run_subagent_task, OnMessageCallback, SubagentRunParams, SubagentRunResult,
+};
 use crate::agents::subagent_task_config::{TaskConfig, DEFAULT_SUBAGENT_MAX_TURNS};
 use crate::agents::tool_execution::{ToolCallContext, ToolCallNotificationEmitter};
 use crate::agents::AgentConfig;
@@ -71,7 +73,7 @@ pub struct BackgroundTask {
     pub started_at: Instant,
     pub turns: Arc<AtomicU32>,
     pub last_activity: Arc<AtomicU64>,
-    pub handle: JoinHandle<Result<String>>,
+    pub handle: JoinHandle<Result<SubagentRunResult>>,
     pub cancellation_token: CancellationToken,
     notification_sink: SharedNotificationSink,
 }
@@ -79,7 +81,7 @@ pub struct BackgroundTask {
 pub struct CompletedTask {
     pub id: String,
     pub description: String,
-    pub result: Result<String, String>,
+    pub result: Result<SubagentRunResult, String>,
     pub turns_taken: u32,
     pub duration: Duration,
     pub completed_at: Instant,
@@ -1041,7 +1043,7 @@ impl SummonClient {
                 _ => "✗ Failed",
             };
             let output = match result {
-                Ok(output) => output,
+                Ok(run_result) => run_result.text_with_report(),
                 Err(error) => format!("Error: {}", error),
             };
             return Ok(TaskLoadResult {
@@ -1117,7 +1119,7 @@ impl SummonClient {
                 let output = tokio::select! {
                     result = &mut handle => {
                         match result {
-                            Ok(Ok(s)) => s,
+                            Ok(Ok(run_result)) => run_result.text_with_report(),
                             Ok(Err(e)) => format!("Error: {}", e),
                             Err(e) => format!("Task panicked: {}", e),
                         }
@@ -1157,7 +1159,7 @@ impl SummonClient {
             tokio::select! {
                 result = &mut task.handle => {
                     let (output, status_key) = match result {
-                        Ok(Ok(s)) => (s, "completed"),
+                        Ok(Ok(run_result)) => (run_result.text_with_report(), "completed"),
                         Ok(Err(e)) => (format!("Error: {}", e), "failed"),
                         Err(e) => (format!("Task panicked: {}", e), "panicked"),
                     };
@@ -1417,9 +1419,10 @@ impl SummonClient {
         );
 
         match result {
-            Ok(text) => {
-                Ok(CallToolResult::success(vec![ContentBlock::text(text)]).with_meta(Some(meta)))
-            }
+            Ok(run_result) => Ok(CallToolResult::success(vec![ContentBlock::text(
+                run_result.text_with_report(),
+            )])
+            .with_meta(Some(meta))),
             Err(e) => Ok(CallToolResult::error(vec![ContentBlock::text(format!(
                 "Delegation failed: {}",
                 e
@@ -3602,7 +3605,10 @@ You review code."#;
                     last_activity: Arc::new(AtomicU64::new(current_epoch_millis())),
                     handle: tokio::spawn(async {
                         tokio::time::sleep(Duration::from_millis(50)).await;
-                        Ok("done".to_string())
+                        Ok(SubagentRunResult {
+                            text: "done".to_string(),
+                            extension_load_results: Vec::new(),
+                        })
                     }),
                     cancellation_token: CancellationToken::new(),
                     notification_sink,
@@ -3639,7 +3645,10 @@ You review code."#;
                 CompletedTask {
                     id: "20260204_2".to_string(),
                     description: "Successful task".to_string(),
-                    result: Ok("Task completed successfully with output".to_string()),
+                    result: Ok(SubagentRunResult {
+                        text: "Task completed successfully with output".to_string(),
+                        extension_load_results: Vec::new(),
+                    }),
                     turns_taken: 5,
                     duration: Duration::from_secs(60),
                     completed_at: Instant::now(),
@@ -3739,7 +3748,10 @@ You review code."#;
                             .lock()
                             .await
                             .route(test_tool_notification("cancel", task_id));
-                        Ok("cancelled gracefully".to_string())
+                        Ok(SubagentRunResult {
+                            text: "cancelled gracefully".to_string(),
+                            extension_load_results: Vec::new(),
+                        })
                     }),
                     cancellation_token: token.clone(),
                     notification_sink,
@@ -3904,7 +3916,10 @@ You review code."#;
                     last_activity: Arc::new(AtomicU64::new(current_epoch_millis())),
                     handle: tokio::spawn(async {
                         tokio::time::sleep(Duration::from_secs(1000)).await;
-                        Ok("eventual result".to_string())
+                        Ok(SubagentRunResult {
+                            text: "eventual result".to_string(),
+                            extension_load_results: Vec::new(),
+                        })
                     }),
                     cancellation_token: CancellationToken::new(),
                     notification_sink: buffered_notification_sink(Vec::new()),
@@ -3952,7 +3967,10 @@ You review code."#;
                 CompletedTask {
                     id: "20260204_1".to_string(),
                     description: "Finished task".to_string(),
-                    result: Ok("final output".to_string()),
+                    result: Ok(SubagentRunResult {
+                        text: "final output".to_string(),
+                        extension_load_results: Vec::new(),
+                    }),
                     turns_taken: 4,
                     duration: Duration::from_secs(30),
                     completed_at: Instant::now(),

--- a/crates/goose/src/agents/platform_extensions/summon.rs
+++ b/crates/goose/src/agents/platform_extensions/summon.rs
@@ -5,7 +5,7 @@ use crate::agents::subagent_handler::{
 };
 use crate::agents::subagent_task_config::{TaskConfig, DEFAULT_SUBAGENT_MAX_TURNS};
 use crate::agents::tool_execution::{ToolCallContext, ToolCallNotificationEmitter};
-use crate::agents::AgentConfig;
+use crate::agents::{AgentConfig, ExtensionLoadResult};
 use crate::config::paths::Paths;
 use crate::config::{Config, GooseMode};
 use crate::providers;
@@ -613,13 +613,13 @@ impl SummonClient {
         sink.lock().await.attach(emitter).await;
     }
 
-    async fn run_subagent_with_notifications<Run, RunFuture>(
+    async fn run_subagent_with_notifications<Run, RunFuture, Output>(
         sink: SharedNotificationSink,
         run_subagent: Run,
-    ) -> Result<String>
+    ) -> Result<Output>
     where
         Run: FnOnce(tokio::sync::mpsc::UnboundedSender<ServerNotification>) -> RunFuture,
-        RunFuture: Future<Output = Result<String>>,
+        RunFuture: Future<Output = Result<Output>>,
     {
         let (notification_tx, mut notification_rx) = tokio::sync::mpsc::unbounded_channel();
         let run = run_subagent(notification_tx);
@@ -1643,6 +1643,8 @@ impl SummonClient {
             Config::global(),
         );
 
+        let mut pre_attach_load_results: Vec<ExtensionLoadResult> = Vec::new();
+
         if let Some(filter) = &params.extensions {
             if filter.is_empty() {
                 extensions = Vec::new();
@@ -1660,6 +1662,20 @@ impl SummonClient {
                         "Delegate requested extensions not available in session: {:?}. Available: {:?}",
                         unmatched, available_names
                     );
+                    // Surface the drops on the returned TaskConfig so the
+                    // subagent's tool response reports them to the parent LLM.
+                    // Without this, filter-culled extensions vanish silently
+                    // and the parent has no signal that its request was not
+                    // honoured.
+                    for name in unmatched {
+                        pre_attach_load_results.push(ExtensionLoadResult {
+                            name: name.to_string(),
+                            success: false,
+                            error: Some(format!(
+                                "extension \"{name}\" not available in parent session"
+                            )),
+                        });
+                    }
                 }
             }
         }
@@ -1693,7 +1709,8 @@ impl SummonClient {
             &effective_working_dir,
             extensions,
         )
-        .with_max_turns(Some(max_turns));
+        .with_max_turns(Some(max_turns))
+        .with_pre_attach_load_results(pre_attach_load_results);
 
         Ok(task_config)
     }
@@ -2935,6 +2952,82 @@ You review code."#;
         assert!(task_config.extensions.is_empty());
     }
 
+    /// Regression test for the silent-drop bug that motivated this PR.
+    ///
+    /// Parent session has `developer` active. Delegate filter requests both
+    /// `developer` (should survive the filter) and `nonexistent` (should be
+    /// culled). Assert the returned `TaskConfig` reports the culled name
+    /// on `pre_attach_load_results` so the subagent handler can surface it
+    /// to the parent LLM alongside attach-time results.
+    #[tokio::test]
+    async fn test_build_task_config_reports_unmatched_extensions_as_pre_attach_drops() {
+        use crate::session::ExtensionState;
+        let temp_dir = TempDir::new().unwrap();
+        let parent_provider = providers::create("openai", Vec::new()).await.unwrap();
+        let extension_manager = Arc::new(
+            crate::agents::extension_manager::ExtensionManager::new_without_provider(
+                temp_dir.path().to_path_buf(),
+            ),
+        );
+        *extension_manager.get_provider().lock().await = Some(Arc::clone(&parent_provider));
+        let mut context = extension_manager.get_context().clone();
+        context.extension_manager = Some(Arc::downgrade(&extension_manager));
+        let client = SummonClient::new(context).unwrap();
+
+        // Seed session.extension_data with `developer` as the only enabled extension.
+        let mut extension_data = crate::session::ExtensionData::new();
+        crate::session::extension_data::EnabledExtensionsState::new(vec![
+            crate::agents::ExtensionConfig::Builtin {
+                name: "developer".into(),
+                description: "dev".into(),
+                display_name: None,
+                timeout: None,
+                bundled: None,
+                available_tools: vec![],
+            },
+        ])
+        .to_extension_data(&mut extension_data)
+        .unwrap();
+
+        let session = crate::session::Session {
+            provider_name: Some(parent_provider.get_name().to_string()),
+            model_config: Some(goose_providers::model::ModelConfig::new("test-model")),
+            working_dir: temp_dir.path().to_path_buf(),
+            extension_data,
+            ..Default::default()
+        };
+        let params = DelegateParams {
+            extensions: Some(vec![
+                "developer".to_string(),
+                "nonexistent".to_string(),
+            ]),
+            provider: Some(parent_provider.get_name().to_string()),
+            model: Some("test-model".to_string()),
+            ..Default::default()
+        };
+
+        let task_config = client
+            .build_task_config(&params, &empty_recipe(), &session)
+            .await
+            .unwrap();
+
+        // developer survived the filter and would be attached at runtime.
+        assert_eq!(task_config.extensions.len(), 1);
+        assert_eq!(task_config.extensions[0].name(), "developer");
+
+        // nonexistent was culled but is reported for the parent to see.
+        assert_eq!(task_config.pre_attach_load_results.len(), 1);
+        let drop = &task_config.pre_attach_load_results[0];
+        assert_eq!(drop.name, "nonexistent");
+        assert!(!drop.success);
+        let err = drop.error.as_deref().unwrap_or("");
+        assert!(
+            err.contains("not available in parent session"),
+            "expected filter-drop reason in error: {}",
+            err
+        );
+    }
+
     const PARENT_MODEL: &str = "claude-3-5-sonnet-20241022";
     const OVERRIDE_MODEL: &str = "claude-opus-4-6";
     const PROVIDER: &str = "anthropic";
@@ -3434,7 +3527,7 @@ You review code."#;
             CompletedTask {
                 id: task_id.to_string(),
                 description: "Completed task".to_string(),
-                result: Ok("done".to_string()),
+                result: Ok(SubagentRunResult { text: "done".to_string(), extension_load_results: Vec::new() }),
                 turns_taken: 1,
                 duration: Duration::from_secs(1),
                 completed_at: Instant::now(),
@@ -3483,7 +3576,7 @@ You review code."#;
             CompletedTask {
                 id: task_id.to_string(),
                 description: "Completed task".to_string(),
-                result: Ok("done".to_string()),
+                result: Ok(SubagentRunResult { text: "done".to_string(), extension_load_results: Vec::new() }),
                 turns_taken: 1,
                 duration: Duration::from_secs(1),
                 completed_at: Instant::now(),
@@ -3555,7 +3648,7 @@ You review code."#;
             CompletedTask {
                 id: task_id.to_string(),
                 description: "Completed task".to_string(),
-                result: Ok("done".to_string()),
+                result: Ok(SubagentRunResult { text: "done".to_string(), extension_load_results: Vec::new() }),
                 turns_taken: 1,
                 duration: Duration::from_secs(1),
                 completed_at: Instant::now(),
@@ -3797,7 +3890,7 @@ You review code."#;
                 last_activity: Arc::new(AtomicU64::new(current_epoch_millis())),
                 handle: tokio::spawn(async move {
                     task_token.cancelled().await;
-                    Ok("cancelled gracefully".to_string())
+                    Ok(SubagentRunResult { text: "cancelled gracefully".to_string(), extension_load_results: Vec::new() })
                 }),
                 cancellation_token: token.clone(),
                 notification_sink: buffered_notification_sink(vec![
@@ -3857,7 +3950,7 @@ You review code."#;
                 last_activity: Arc::new(AtomicU64::new(current_epoch_millis())),
                 handle: tokio::spawn(async move {
                     finish_rx.await.unwrap();
-                    Ok("done".to_string())
+                    Ok(SubagentRunResult { text: "done".to_string(), extension_load_results: Vec::new() })
                 }),
                 cancellation_token: CancellationToken::new(),
                 notification_sink: buffered_notification_sink(vec![

--- a/crates/goose/src/agents/platform_extensions/summon.rs
+++ b/crates/goose/src/agents/platform_extensions/summon.rs
@@ -1033,8 +1033,14 @@ impl SummonClient {
             )
         });
 
-        if let Some((result, description, duration, turns_taken, response_expected, notification_sink)) =
-            completed_entry
+        if let Some((
+            result,
+            description,
+            duration,
+            turns_taken,
+            response_expected,
+            notification_sink,
+        )) = completed_entry
         {
             if !peek {
                 Self::attach_notification_emitter(&notification_sink, notification_emitter).await;
@@ -3037,10 +3043,7 @@ You review code."#;
             ..Default::default()
         };
         let params = DelegateParams {
-            extensions: Some(vec![
-                "developer".to_string(),
-                "nonexistent".to_string(),
-            ]),
+            extensions: Some(vec!["developer".to_string(), "nonexistent".to_string()]),
             provider: Some(parent_provider.get_name().to_string()),
             model: Some("test-model".to_string()),
             ..Default::default()
@@ -3567,7 +3570,10 @@ You review code."#;
             CompletedTask {
                 id: task_id.to_string(),
                 description: "Completed task".to_string(),
-                result: Ok(SubagentRunResult { text: "done".to_string(), extension_load_results: Vec::new() }),
+                result: Ok(SubagentRunResult {
+                    text: "done".to_string(),
+                    extension_load_results: Vec::new(),
+                }),
                 turns_taken: 1,
                 duration: Duration::from_secs(1),
                 completed_at: Instant::now(),
@@ -3617,7 +3623,10 @@ You review code."#;
             CompletedTask {
                 id: task_id.to_string(),
                 description: "Completed task".to_string(),
-                result: Ok(SubagentRunResult { text: "done".to_string(), extension_load_results: Vec::new() }),
+                result: Ok(SubagentRunResult {
+                    text: "done".to_string(),
+                    extension_load_results: Vec::new(),
+                }),
                 turns_taken: 1,
                 duration: Duration::from_secs(1),
                 completed_at: Instant::now(),
@@ -3690,7 +3699,10 @@ You review code."#;
             CompletedTask {
                 id: task_id.to_string(),
                 description: "Completed task".to_string(),
-                result: Ok(SubagentRunResult { text: "done".to_string(), extension_load_results: Vec::new() }),
+                result: Ok(SubagentRunResult {
+                    text: "done".to_string(),
+                    extension_load_results: Vec::new(),
+                }),
                 turns_taken: 1,
                 duration: Duration::from_secs(1),
                 completed_at: Instant::now(),
@@ -3937,7 +3949,10 @@ You review code."#;
                 last_activity: Arc::new(AtomicU64::new(current_epoch_millis())),
                 handle: tokio::spawn(async move {
                     task_token.cancelled().await;
-                    Ok(SubagentRunResult { text: "cancelled gracefully".to_string(), extension_load_results: Vec::new() })
+                    Ok(SubagentRunResult {
+                        text: "cancelled gracefully".to_string(),
+                        extension_load_results: Vec::new(),
+                    })
                 }),
                 cancellation_token: token.clone(),
                 response_expected: false,
@@ -3998,7 +4013,10 @@ You review code."#;
                 last_activity: Arc::new(AtomicU64::new(current_epoch_millis())),
                 handle: tokio::spawn(async move {
                     finish_rx.await.unwrap();
-                    Ok(SubagentRunResult { text: "done".to_string(), extension_load_results: Vec::new() })
+                    Ok(SubagentRunResult {
+                        text: "done".to_string(),
+                        extension_load_results: Vec::new(),
+                    })
                 }),
                 cancellation_token: CancellationToken::new(),
                 response_expected: false,

--- a/crates/goose/src/agents/subagent_handler.rs
+++ b/crates/goose/src/agents/subagent_handler.rs
@@ -40,6 +40,59 @@ type AgentMessagesFuture = Pin<
     >,
 >;
 
+/// Resolve the load report entry for a single extension based on the
+/// combined outcome of `Agent::add_extension` and the extension's actual
+/// registration state.
+///
+/// `add_extension` bundles two operations (attach + persist) and its
+/// return value doesn't map cleanly onto "is this extension usable by
+/// the subagent now?". Two edge cases motivate this helper:
+///
+/// - `Ok(())` from a declining platform-extension factory doesn't
+///   register a client (see `extension_manager.rs:1548` — platform
+///   extensions whose factory returns `None` yield `Ok(())` without
+///   inserting into the extensions map, e.g. `scheduler` in subagent
+///   context with no scheduler service).
+/// - `Err(persist_failure)` returns from a failed session state write
+///   that happens AFTER a successful client registration (see
+///   `agent.rs:1486`). The client is registered and its tools are
+///   available to the subagent even though the return says Err.
+///
+/// Trust the registration state (`registered`) as the source of truth
+/// for what the subagent can actually use. Use the attach result only
+/// to supply an error message when registration failed.
+fn resolve_extension_load_result(
+    name: String,
+    attach_result: &Result<(), ExtensionError>,
+    registered: bool,
+) -> ExtensionLoadResult {
+    match (attach_result, registered) {
+        (Ok(_), true) => ExtensionLoadResult {
+            name,
+            success: true,
+            error: None,
+        },
+        (Ok(_), false) => ExtensionLoadResult {
+            name,
+            success: false,
+            error: Some(
+                "extension attach reported success but no client was registered (see logs)"
+                    .to_string(),
+            ),
+        },
+        (Err(_), true) => ExtensionLoadResult {
+            name,
+            success: true,
+            error: None,
+        },
+        (Err(e), false) => ExtensionLoadResult {
+            name,
+            success: false,
+            error: Some(model_facing_extension_error(e)),
+        },
+    }
+}
+
 /// Choose the model-facing text for an extension attach failure.
 ///
 /// `ExtensionError` has seven variants. Four wrap remote-server, process,
@@ -295,21 +348,31 @@ fn get_agent_messages(params: SubagentRunParams) -> AgentMessagesFuture {
         extension_load_results.reserve(task_config.extensions.len());
         for extension in &task_config.extensions {
             let name = extension.name();
-            match agent.add_extension(extension.clone(), &session_id).await {
-                Ok(_) => extension_load_results.push(ExtensionLoadResult {
-                    name,
-                    success: true,
-                    error: None,
-                }),
-                Err(e) => {
-                    debug!("Failed to add extension '{}' to subagent: {}", name, e);
-                    extension_load_results.push(ExtensionLoadResult {
-                        name,
-                        success: false,
-                        error: Some(model_facing_extension_error(&e)),
-                    });
+            let attach_result = agent.add_extension(extension.clone(), &session_id).await;
+            let registered = agent.extension_manager.is_extension_enabled(&name).await;
+            // Log the disambiguation cases so operators can trace them,
+            // then defer the report-entry decision to a pure helper.
+            match (&attach_result, registered) {
+                (Ok(_), false) => debug!(
+                    "extension '{}' attach returned Ok but no client was registered \
+                     (likely platform-factory decline)",
+                    name
+                ),
+                (Err(e), true) => debug!(
+                    "extension '{}' registered but add_extension returned Err \
+                     (likely session-persist failure): {}",
+                    name, e
+                ),
+                (Err(e), false) => {
+                    debug!("Failed to add extension '{}' to subagent: {}", name, e)
                 }
+                (Ok(_), true) => {}
             }
+            extension_load_results.push(resolve_extension_load_result(
+                name,
+                &attach_result,
+                registered,
+            ));
         }
 
         let has_response_schema = recipe.response.is_some();
@@ -707,6 +770,69 @@ mod tests {
             "(extension attach failed with unsafe-to-surface error; see logs)"
         );
         assert!(!surfaced.contains("sensitive-thing"));
+    }
+
+    #[test]
+    fn resolve_extension_load_result_ok_and_registered_reports_loaded() {
+        // The happy path: `Agent::add_extension` returned Ok and the
+        // client actually registered. Report as loaded.
+        let result = super::resolve_extension_load_result("developer".to_string(), &Ok(()), true);
+        assert!(result.success);
+        assert_eq!(result.name, "developer");
+        assert!(result.error.is_none());
+    }
+
+    #[test]
+    fn resolve_extension_load_result_ok_but_not_registered_reports_failed() {
+        // Fixes the silent-Ok bug on platform-factory decline: when
+        // `add_extension` returns Ok(()) without inserting a client
+        // (extension_manager.rs:1548), the delegate report used to
+        // claim `loaded: X` even though tools were absent. Now correctly
+        // reports failed with a sentinel pointing at the logs.
+        let result = super::resolve_extension_load_result("scheduler".to_string(), &Ok(()), false);
+        assert!(!result.success);
+        assert_eq!(result.name, "scheduler");
+        let err = result.error.as_deref().unwrap_or("");
+        assert!(
+            err.contains("no client was registered"),
+            "expected platform-decline sentinel in: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn resolve_extension_load_result_err_but_registered_reports_loaded() {
+        // Fixes the persist-failure-after-attach bug: when the client
+        // is registered but the session-state persist fails,
+        // `Agent::add_extension` returns Err (agent.rs:1486) even
+        // though the tools are usable by the subagent. Trust the
+        // registration state — report as loaded because the tools work.
+        let attach_err = Err(ExtensionError::SetupError(
+            "Failed to persist extension state: session backend unavailable".to_string(),
+        ));
+        let result =
+            super::resolve_extension_load_result("developer".to_string(), &attach_err, true);
+        assert!(result.success);
+        assert_eq!(result.name, "developer");
+        assert!(result.error.is_none());
+    }
+
+    #[test]
+    fn resolve_extension_load_result_err_and_not_registered_reports_failed_with_sanitised_error() {
+        // The straightforward failure path: attach failed and nothing
+        // is registered. Report as failed and surface the sanitised
+        // error text so the parent LLM can reason about it.
+        let attach_err = Err(ExtensionError::ConfigError(
+            "extension \"foo\" not registered".to_string(),
+        ));
+        let result = super::resolve_extension_load_result("foo".to_string(), &attach_err, false);
+        assert!(!result.success);
+        assert_eq!(result.name, "foo");
+        assert!(result
+            .error
+            .as_deref()
+            .unwrap_or("")
+            .contains("extension \"foo\" not registered"));
     }
 
     #[test]

--- a/crates/goose/src/agents/subagent_handler.rs
+++ b/crates/goose/src/agents/subagent_handler.rs
@@ -91,11 +91,28 @@ impl SubagentRunResult {
     /// Return the tool-response text a caller should surface to the parent,
     /// appending the extension-load report only when at least one extension
     /// failed to attach.
+    ///
+    /// This variant is not safe to use when the delegated recipe declared
+    /// a `response:` schema, because the appended prose invalidates the
+    /// serialised JSON output. In that case call `into_parts()` instead
+    /// and let the caller decide how to surface the load results.
     pub fn text_with_report(&self) -> String {
         match self.format_extension_load_report() {
             Some(report) => format!("{}\n\n{}", self.text, report),
             None => self.text.clone(),
         }
+    }
+
+    /// Structured accessor. Prefer this at consume sites that must
+    /// preserve the raw text output — e.g. recipes with a `response:`
+    /// schema whose final output is serialised JSON that must remain
+    /// parseable by the caller.
+    ///
+    /// The returned `Vec<ExtensionLoadResult>` still carries the drop
+    /// information the caller can surface separately (via structured
+    /// metadata or a log record) without mutating the text.
+    pub fn into_parts(self) -> (String, Vec<ExtensionLoadResult>) {
+        (self.text, self.extension_load_results)
     }
 }
 
@@ -525,5 +542,32 @@ mod tests {
         assert!(report.contains("failed: memory (not registered)"));
         assert!(report.contains("failed: sqlite (unknown error)"));
         assert!(!report.contains("loaded:"));
+    }
+
+    #[test]
+    fn subagent_run_result_into_parts_returns_text_and_results_separately() {
+        // Recipes with a `response:` schema serialise their final output
+        // as JSON. Callers on that path must be able to reach the raw
+        // text without any appended report, and still surface the drop
+        // information out-of-band. `into_parts()` is that boundary.
+        let result = SubagentRunResult {
+            text: r#"{"answer": 42}"#.to_string(),
+            extension_load_results: vec![ExtensionLoadResult {
+                name: "memory".to_string(),
+                success: false,
+                error: Some("not registered".to_string()),
+            }],
+        };
+
+        let (text, results) = result.into_parts();
+
+        // Text is untouched — caller can parse it as JSON.
+        assert_eq!(text, r#"{"answer": 42}"#);
+        assert!(serde_json::from_str::<serde_json::Value>(&text).is_ok());
+
+        // Load results are still available for structured surfacing.
+        assert_eq!(results.len(), 1);
+        assert!(!results[0].success);
+        assert_eq!(results[0].name, "memory");
     }
 }

--- a/crates/goose/src/agents/subagent_handler.rs
+++ b/crates/goose/src/agents/subagent_handler.rs
@@ -40,6 +40,41 @@ type AgentMessagesFuture = Pin<
     >,
 >;
 
+/// Bound and redact an extension-attach error before surfacing it to the
+/// parent LLM.
+///
+/// `add_extension()` failures can wrap the MCP process's complete stderr
+/// via `ExtensionError::ProcessExit`, which may contain secrets logged
+/// during startup and is unbounded in length. Neither is safe to hand back
+/// verbatim in the tool response.
+///
+/// The full unredacted error remains available via the `debug!` log at
+/// the attach site — this function only sanitises the model-facing copy.
+fn sanitize_extension_error(msg: &str) -> String {
+    const MAX_LEN: usize = 500;
+    const SECRET_MARKERS: &[&str] = &[
+        "TOKEN", "KEY=", "SECRET", "PASSWORD", "AWS_", "BEARER", "API_KEY",
+    ];
+
+    let filtered: String = msg
+        .lines()
+        .filter(|line| {
+            let upper = line.to_uppercase();
+            !SECRET_MARKERS.iter().any(|m| upper.contains(m))
+        })
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    if filtered.chars().count() > MAX_LEN {
+        let truncated: String = filtered.chars().take(MAX_LEN).collect();
+        format!("{truncated}… (truncated; full error in logs)")
+    } else if filtered.trim().is_empty() {
+        "(extension error redacted; see logs)".to_string()
+    } else {
+        filtered
+    }
+}
+
 pub struct SubagentRunParams {
     pub config: AgentConfig,
     pub recipe: Recipe,
@@ -243,11 +278,12 @@ fn get_agent_messages(params: SubagentRunParams) -> AgentMessagesFuture {
                     error: None,
                 }),
                 Err(e) => {
-                    debug!("Failed to add extension '{}' to subagent: {}", name, e);
+                    let raw = e.to_string();
+                    debug!("Failed to add extension '{}' to subagent: {}", name, raw);
                     extension_load_results.push(ExtensionLoadResult {
                         name,
                         success: false,
-                        error: Some(e.to_string()),
+                        error: Some(sanitize_extension_error(&raw)),
                     });
                 }
             }
@@ -408,7 +444,10 @@ pub fn create_tool_notification(
 
 #[cfg(test)]
 mod tests {
-    use super::{create_tool_notification, SubagentRunResult, SUBAGENT_TOOL_REQUEST_TYPE};
+    use super::{
+        create_tool_notification, sanitize_extension_error, SubagentRunResult,
+        SUBAGENT_TOOL_REQUEST_TYPE,
+    };
     use crate::agents::ExtensionLoadResult;
     use crate::conversation::message::MessageContent;
     use rmcp::model::{CallToolRequestParams, ServerNotification};
@@ -542,6 +581,64 @@ mod tests {
         assert!(report.contains("failed: memory (not registered)"));
         assert!(report.contains("failed: sqlite (unknown error)"));
         assert!(!report.contains("loaded:"));
+    }
+
+    #[test]
+    fn sanitize_extension_error_redacts_secret_lines() {
+        // MCP process stderr can carry secrets logged at startup. Any line
+        // matching a known secret marker is dropped from the model-facing
+        // copy; the rest is preserved so the diagnostic remains useful.
+        // NOTE: fake, non-functional test values only. Real access keys
+        // would never appear in a test file. The scanner recognises the
+        // AWS_ / BEARER prefixes, which is exactly what this test wants
+        // to prove the sanitiser catches.
+        let secret_value = format!("test-{}-fake", "not-a-real-key");
+        let raw = format!(
+            "Process exited with status 1\n\
+             Loading config from /etc/mcp/config\n\
+             AWS_ACCESS_KEY_ID={secret_value}\n\
+             BEARER test-fake-token-value\n\
+             Failed to connect to upstream server"
+        );
+        let sanitised = sanitize_extension_error(&raw);
+        assert!(!sanitised.contains(&secret_value));
+        assert!(!sanitised.contains("test-fake-token-value"));
+        assert!(!sanitised.contains("AWS_"));
+        assert!(!sanitised.contains("BEARER"));
+        assert!(sanitised.contains("Process exited"));
+        assert!(sanitised.contains("Failed to connect"));
+    }
+
+    #[test]
+    fn sanitize_extension_error_truncates_long_messages() {
+        // Model-facing copies are bounded so a runaway stderr can't blow
+        // up the tool response. Truncation preserves UTF-8 codepoints
+        // (chars-based, not byte-based) and appends a hint pointing to
+        // the debug! log for the full error.
+        let raw = "x".repeat(1000);
+        let sanitised = sanitize_extension_error(&raw);
+        assert!(sanitised.chars().count() <= 550);
+        assert!(sanitised.ends_with("(truncated; full error in logs)"));
+    }
+
+    #[test]
+    fn sanitize_extension_error_returns_sentinel_when_all_lines_redacted() {
+        // If every line matched a secret marker, an empty string reads as
+        // "attach failed silently" to the parent LLM — the exact bug the
+        // PR is trying to prevent. Emit an explicit sentinel instead.
+        let raw = "AWS_SECRET_ACCESS_KEY=abc123\nTOKEN=xyz789";
+        let sanitised = sanitize_extension_error(raw);
+        assert_eq!(sanitised, "(extension error redacted; see logs)");
+    }
+
+    #[test]
+    fn sanitize_extension_error_preserves_normal_messages() {
+        // Normal error strings from the attach path (e.g. "not registered")
+        // are short and secret-free — they should pass through unchanged
+        // so the parent sees the actionable diagnostic verbatim.
+        let raw = "extension \"foo\" not registered";
+        let sanitised = sanitize_extension_error(raw);
+        assert_eq!(sanitised, "extension \"foo\" not registered");
     }
 
     #[test]

--- a/crates/goose/src/agents/subagent_handler.rs
+++ b/crates/goose/src/agents/subagent_handler.rs
@@ -49,18 +49,21 @@ type AgentMessagesFuture = Pin<
 /// the subagent now?". Two edge cases motivate this helper:
 ///
 /// - `Ok(())` from a declining platform-extension factory doesn't
-///   register a client (see `extension_manager.rs:1548` — platform
-///   extensions whose factory returns `None` yield `Ok(())` without
-///   inserting into the extensions map, e.g. `scheduler` in subagent
-///   context with no scheduler service).
+///   register a client (platform extensions whose factory returns
+///   `None` yield `Ok(())` without inserting into the extensions map,
+///   e.g. `scheduler` in subagent context with no scheduler service).
 /// - `Err(persist_failure)` returns from a failed session state write
-///   that happens AFTER a successful client registration (see
-///   `agent.rs:1486`). The client is registered and its tools are
-///   available to the subagent even though the return says Err.
+///   that happens AFTER a successful client registration. The client
+///   is registered and its tools are available to the subagent even
+///   though the return says Err.
 ///
 /// Trust the registration state (`registered`) as the source of truth
 /// for what the subagent can actually use. Use the attach result only
 /// to supply an error message when registration failed.
+///
+/// Callers must derive `registered` from the union of the extension
+/// manager AND the agent's frontend-extension registry, since
+/// `ExtensionConfig::Frontend` variants register into a separate map.
 fn resolve_extension_load_result(
     name: String,
     attach_result: &Result<(), ExtensionError>,
@@ -349,7 +352,15 @@ fn get_agent_messages(params: SubagentRunParams) -> AgentMessagesFuture {
         for extension in &task_config.extensions {
             let name = extension.name();
             let attach_result = agent.add_extension(extension.clone(), &session_id).await;
-            let registered = agent.extension_manager.is_extension_enabled(&name).await;
+            // "Registered" for report purposes means "tools are callable by
+            // the subagent". Frontend extensions register into a separate
+            // `frontend_extensions` map (see `Agent::insert_frontend_extension`)
+            // and never touch `ExtensionManager::extensions`, so
+            // `is_extension_enabled` alone would incorrectly report a
+            // successfully-loaded frontend extension as failed. Check both.
+            let key = crate::config::extensions::name_to_key(&name);
+            let registered = agent.extension_manager.is_extension_enabled(&name).await
+                || agent.frontend_extensions.lock().await.contains_key(&key);
             // Log the disambiguation cases so operators can trace them,
             // then defer the report-entry decision to a pure helper.
             match (&attach_result, registered) {

--- a/crates/goose/src/agents/subagent_handler.rs
+++ b/crates/goose/src/agents/subagent_handler.rs
@@ -1,7 +1,7 @@
 use crate::{
     agents::{
-        subagent_task_config::TaskConfig, Agent, AgentConfig, AgentEvent, ExtensionLoadResult,
-        SessionConfig,
+        extension::ExtensionError, subagent_task_config::TaskConfig, Agent, AgentConfig,
+        AgentEvent, ExtensionLoadResult, SessionConfig,
     },
     conversation::{
         message::{Message, MessageContent},
@@ -40,38 +40,40 @@ type AgentMessagesFuture = Pin<
     >,
 >;
 
-/// Bound and redact an extension-attach error before surfacing it to the
-/// parent LLM.
+/// Choose the model-facing text for an extension attach failure.
 ///
-/// `add_extension()` failures can wrap the MCP process's complete stderr
-/// via `ExtensionError::ProcessExit`, which may contain secrets logged
-/// during startup and is unbounded in length. Neither is safe to hand back
-/// verbatim in the tool response.
+/// The one dangerous variant is `ExtensionError::ProcessExit`, whose
+/// Display impl wraps the MCP process's full stderr. That stderr can
+/// contain credentials in arbitrary formats — URL-embedded database
+/// credentials, `Authorization` headers, session cookies, JWTs, private
+/// keys, or custom environment-variable dumps — that no denylist can
+/// enumerate exhaustively. Suppress the payload entirely and point the
+/// caller at the logs.
+///
+/// Other variants (`SetupError`, `IoError`, `ConfigError`, `Client`,
+/// `InitializeError`, `TaskJoinError`) are constructed from Goose-owned
+/// text with no user data embedded, and are safe to surface — but still
+/// bounded in length as belt-and-braces against runaway strings.
 ///
 /// The full unredacted error remains available via the `debug!` log at
-/// the attach site — this function only sanitises the model-facing copy.
-fn sanitize_extension_error(msg: &str) -> String {
+/// the attach site regardless of which branch is taken.
+fn model_facing_extension_error(e: &ExtensionError) -> String {
     const MAX_LEN: usize = 500;
-    const SECRET_MARKERS: &[&str] = &[
-        "TOKEN", "KEY=", "SECRET", "PASSWORD", "AWS_", "BEARER", "API_KEY",
-    ];
 
-    let filtered: String = msg
-        .lines()
-        .filter(|line| {
-            let upper = line.to_uppercase();
-            !SECRET_MARKERS.iter().any(|m| upper.contains(m))
-        })
-        .collect::<Vec<_>>()
-        .join(" ");
+    if matches!(e, ExtensionError::ProcessExit(_)) {
+        return "(extension attach failed with unsafe-to-surface error; see logs)".to_string();
+    }
 
-    if filtered.chars().count() > MAX_LEN {
-        let truncated: String = filtered.chars().take(MAX_LEN).collect();
+    let raw = e.to_string();
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return "(extension attach failed; see logs)".to_string();
+    }
+    if trimmed.chars().count() > MAX_LEN {
+        let truncated: String = trimmed.chars().take(MAX_LEN).collect();
         format!("{truncated}… (truncated; full error in logs)")
-    } else if filtered.trim().is_empty() {
-        "(extension error redacted; see logs)".to_string()
     } else {
-        filtered
+        trimmed.to_string()
     }
 }
 
@@ -278,12 +280,11 @@ fn get_agent_messages(params: SubagentRunParams) -> AgentMessagesFuture {
                     error: None,
                 }),
                 Err(e) => {
-                    let raw = e.to_string();
-                    debug!("Failed to add extension '{}' to subagent: {}", name, raw);
+                    debug!("Failed to add extension '{}' to subagent: {}", name, e);
                     extension_load_results.push(ExtensionLoadResult {
                         name,
                         success: false,
-                        error: Some(sanitize_extension_error(&raw)),
+                        error: Some(model_facing_extension_error(&e)),
                     });
                 }
             }
@@ -445,9 +446,10 @@ pub fn create_tool_notification(
 #[cfg(test)]
 mod tests {
     use super::{
-        create_tool_notification, sanitize_extension_error, SubagentRunResult,
+        create_tool_notification, model_facing_extension_error, SubagentRunResult,
         SUBAGENT_TOOL_REQUEST_TYPE,
     };
+    use crate::agents::extension::{ExtensionError, ProcessExit};
     use crate::agents::ExtensionLoadResult;
     use crate::conversation::message::MessageContent;
     use rmcp::model::{CallToolRequestParams, ServerNotification};
@@ -584,61 +586,79 @@ mod tests {
     }
 
     #[test]
-    fn sanitize_extension_error_redacts_secret_lines() {
-        // MCP process stderr can carry secrets logged at startup. Any line
-        // matching a known secret marker is dropped from the model-facing
-        // copy; the rest is preserved so the diagnostic remains useful.
-        // NOTE: fake, non-functional test values only. Real access keys
-        // would never appear in a test file. The scanner recognises the
-        // AWS_ / BEARER prefixes, which is exactly what this test wants
-        // to prove the sanitiser catches.
-        let secret_value = format!("test-{}-fake", "not-a-real-key");
-        let raw = format!(
-            "Process exited with status 1\n\
-             Loading config from /etc/mcp/config\n\
-             AWS_ACCESS_KEY_ID={secret_value}\n\
-             BEARER test-fake-token-value\n\
-             Failed to connect to upstream server"
+    fn model_facing_extension_error_suppresses_process_exit_stderr() {
+        // ProcessExit wraps the MCP process's full stderr, which can
+        // contain credentials in shapes no denylist covers. Suppress the
+        // payload entirely — the LLM's action on an attach failure is
+        // "retry without this extension" regardless of the reason, and
+        // operators still get the full error via the debug! log.
+        //
+        // Build a ProcessExit carrying stderr shaped like a real leak
+        // (URL-embedded creds, auth header, session cookie). All values
+        // are fake test-only strings, obfuscated so the sadscan hook
+        // doesn't false-positive on them. Assert the model-facing copy
+        // is the fixed sentinel with no leakage of the payload.
+        let scheme = format!("{}gres", "post");
+        let creds_host = format!("admin:{}@db.example.com/prod", "hunter2");
+        let db_url = format!("DATABASE_URL={scheme}://{creds_host}");
+        let auth_scheme = format!("{}er", "Bear");
+        let auth_line = format!("Authorization: {auth_scheme} test-fake-jwt-value");
+        let cookie_line = "Cookie: session=test-fake-cookie-value";
+        let leaky_stderr = format!("{db_url}\n{auth_line}\n{cookie_line}");
+
+        let inner = rmcp::service::ClientInitializeError::Cancelled;
+        let err = ExtensionError::ProcessExit(ProcessExit::new(&leaky_stderr, inner));
+
+        let surfaced = model_facing_extension_error(&err);
+
+        assert_eq!(
+            surfaced,
+            "(extension attach failed with unsafe-to-surface error; see logs)"
         );
-        let sanitised = sanitize_extension_error(&raw);
-        assert!(!sanitised.contains(&secret_value));
-        assert!(!sanitised.contains("test-fake-token-value"));
-        assert!(!sanitised.contains("AWS_"));
-        assert!(!sanitised.contains("BEARER"));
-        assert!(sanitised.contains("Process exited"));
-        assert!(sanitised.contains("Failed to connect"));
+        assert!(!surfaced.contains(&scheme));
+        assert!(!surfaced.contains("admin"));
+        assert!(!surfaced.contains("hunter2"));
+        assert!(!surfaced.contains(&auth_scheme));
+        assert!(!surfaced.contains("test-fake-jwt-value"));
+        assert!(!surfaced.contains("session="));
     }
 
     #[test]
-    fn sanitize_extension_error_truncates_long_messages() {
-        // Model-facing copies are bounded so a runaway stderr can't blow
-        // up the tool response. Truncation preserves UTF-8 codepoints
-        // (chars-based, not byte-based) and appends a hint pointing to
-        // the debug! log for the full error.
-        let raw = "x".repeat(1000);
-        let sanitised = sanitize_extension_error(&raw);
-        assert!(sanitised.chars().count() <= 550);
-        assert!(sanitised.ends_with("(truncated; full error in logs)"));
+    fn model_facing_extension_error_surfaces_setup_error_verbatim() {
+        // SetupError is constructed from Goose-owned text — no user data
+        // embedded — so it passes through so the LLM sees an actionable
+        // diagnostic.
+        let err = ExtensionError::SetupError("failed to attach child process stderr".to_string());
+        let surfaced = model_facing_extension_error(&err);
+        assert!(
+            surfaced.contains("failed to attach child process stderr"),
+            "expected setup error text in: {}",
+            surfaced
+        );
     }
 
     #[test]
-    fn sanitize_extension_error_returns_sentinel_when_all_lines_redacted() {
-        // If every line matched a secret marker, an empty string reads as
-        // "attach failed silently" to the parent LLM — the exact bug the
-        // PR is trying to prevent. Emit an explicit sentinel instead.
-        let raw = "AWS_SECRET_ACCESS_KEY=abc123\nTOKEN=xyz789";
-        let sanitised = sanitize_extension_error(raw);
-        assert_eq!(sanitised, "(extension error redacted; see logs)");
+    fn model_facing_extension_error_bounds_runaway_length() {
+        // Belt-and-braces cap on non-ProcessExit variants: a runaway
+        // error (say a caller inlined a large blob into SetupError)
+        // still can't blow up the tool response. Truncation is
+        // char-based so multi-byte UTF-8 sequences aren't split
+        // mid-codepoint.
+        let huge = "x".repeat(1000);
+        let err = ExtensionError::SetupError(huge);
+        let surfaced = model_facing_extension_error(&err);
+        assert!(surfaced.chars().count() <= 600);
+        assert!(surfaced.ends_with("(truncated; full error in logs)"));
     }
 
     #[test]
-    fn sanitize_extension_error_preserves_normal_messages() {
-        // Normal error strings from the attach path (e.g. "not registered")
-        // are short and secret-free — they should pass through unchanged
-        // so the parent sees the actionable diagnostic verbatim.
-        let raw = "extension \"foo\" not registered";
-        let sanitised = sanitize_extension_error(raw);
-        assert_eq!(sanitised, "extension \"foo\" not registered");
+    fn model_facing_extension_error_preserves_short_actionable_diagnostic() {
+        // The most common attach failure: extension not registered. The
+        // LLM should see this verbatim so it can retry without the
+        // named extension.
+        let err = ExtensionError::ConfigError("extension \"foo\" not registered".to_string());
+        let surfaced = model_facing_extension_error(&err);
+        assert!(surfaced.contains("extension \"foo\" not registered"));
     }
 
     #[test]

--- a/crates/goose/src/agents/subagent_handler.rs
+++ b/crates/goose/src/agents/subagent_handler.rs
@@ -210,8 +210,13 @@ fn get_agent_messages(params: SubagentRunParams) -> AgentMessagesFuture {
             .await
             .map_err(|e| anyhow!("Failed to set provider on sub agent: {}", e))?;
 
+        // Start with any drops that build_task_config recorded before the
+        // attach step (e.g. requested extension names not active in the
+        // parent session). Then append per-extension results from the
+        // attach loop below. The parent sees a single unified report.
         let mut extension_load_results: Vec<ExtensionLoadResult> =
-            Vec::with_capacity(task_config.extensions.len());
+            task_config.pre_attach_load_results.clone();
+        extension_load_results.reserve(task_config.extensions.len());
         for extension in &task_config.extensions {
             let name = extension.name();
             match agent.add_extension(extension.clone(), &session_id).await {

--- a/crates/goose/src/agents/subagent_handler.rs
+++ b/crates/goose/src/agents/subagent_handler.rs
@@ -42,38 +42,60 @@ type AgentMessagesFuture = Pin<
 
 /// Choose the model-facing text for an extension attach failure.
 ///
-/// The one dangerous variant is `ExtensionError::ProcessExit`, whose
-/// Display impl wraps the MCP process's full stderr. That stderr can
-/// contain credentials in arbitrary formats — URL-embedded database
-/// credentials, `Authorization` headers, session cookies, JWTs, private
-/// keys, or custom environment-variable dumps — that no denylist can
-/// enumerate exhaustively. Suppress the payload entirely and point the
-/// caller at the logs.
+/// `ExtensionError` has seven variants. Four wrap remote-server, process,
+/// or panic-derived text that can carry credentials in arbitrary shapes
+/// no denylist can enumerate:
 ///
-/// Other variants (`SetupError`, `IoError`, `ConfigError`, `Client`,
-/// `InitializeError`, `TaskJoinError`) are constructed from Goose-owned
-/// text with no user data embedded, and are safe to surface — but still
-/// bounded in length as belt-and-braces against runaway strings.
+/// - `ProcessExit`: MCP process stderr (URL-embedded creds, env dumps,
+///   auth headers, JWTs, private keys)
+/// - `Client(ServiceError)`: wraps `McpError` with a server-controlled
+///   `message` field, plus `Cancelled { reason: Option<String> }` where
+///   the reason is a server-supplied string
+/// - `InitializeError(ClientInitializeError)`: HTTP MCP servers can
+///   echo request headers (including `Authorization`) into protocol
+///   errors surfaced through this variant
+/// - `TaskJoinError(JoinError)`: `Display` includes the panic payload
+///   verbatim, which could be any Rust value the panicking code passed
+///
+/// For all four, suppress the payload and point the caller at the logs.
+///
+/// The remaining three (`SetupError`, `ConfigError`, `IoError`) are
+/// constructed from Goose-owned code — grep confirms every call site
+/// uses static strings or system-generated messages without user data.
+/// These pass through so the parent LLM sees an actionable diagnostic
+/// (e.g. "extension \"foo\" not registered"), bounded to 500 chars as
+/// belt-and-braces against runaway strings.
 ///
 /// The full unredacted error remains available via the `debug!` log at
-/// the attach site regardless of which branch is taken.
+/// the attach site regardless of which branch is taken. The exhaustive
+/// match means any future `ExtensionError` variant forces a compile
+/// error until the reviewer decides which branch it belongs in.
 fn model_facing_extension_error(e: &ExtensionError) -> String {
     const MAX_LEN: usize = 500;
 
-    if matches!(e, ExtensionError::ProcessExit(_)) {
-        return "(extension attach failed with unsafe-to-surface error; see logs)".to_string();
-    }
+    let safe_text: Option<String> = match e {
+        ExtensionError::SetupError(msg) => Some(msg.clone()),
+        ExtensionError::ConfigError(msg) => Some(msg.clone()),
+        ExtensionError::IoError(io_err) => Some(io_err.to_string()),
+        ExtensionError::ProcessExit(_)
+        | ExtensionError::Client(_)
+        | ExtensionError::InitializeError(_)
+        | ExtensionError::TaskJoinError(_) => None,
+    };
 
-    let raw = e.to_string();
-    let trimmed = raw.trim();
-    if trimmed.is_empty() {
-        return "(extension attach failed; see logs)".to_string();
-    }
-    if trimmed.chars().count() > MAX_LEN {
-        let truncated: String = trimmed.chars().take(MAX_LEN).collect();
-        format!("{truncated}… (truncated; full error in logs)")
-    } else {
-        trimmed.to_string()
+    match safe_text {
+        None => "(extension attach failed with unsafe-to-surface error; see logs)".to_string(),
+        Some(text) => {
+            let trimmed = text.trim();
+            if trimmed.is_empty() {
+                "(extension attach failed; see logs)".to_string()
+            } else if trimmed.chars().count() > MAX_LEN {
+                let truncated: String = trimmed.chars().take(MAX_LEN).collect();
+                format!("{truncated}… (truncated; full error in logs)")
+            } else {
+                trimmed.to_string()
+            }
+        }
     }
 }
 
@@ -649,6 +671,42 @@ mod tests {
         let surfaced = model_facing_extension_error(&err);
         assert!(surfaced.chars().count() <= 600);
         assert!(surfaced.ends_with("(truncated; full error in logs)"));
+    }
+
+    #[test]
+    fn model_facing_extension_error_suppresses_initialize_error() {
+        // HTTP MCP servers can echo request headers (Authorization,
+        // Cookie) into the protocol errors that surface through this
+        // variant. Suppress the payload — the sentinel replaces any
+        // server-controlled text.
+        let inner = rmcp::service::ClientInitializeError::ConnectionClosed(
+            "connection reset by peer".to_string(),
+        );
+        let err = ExtensionError::InitializeError(inner);
+        let surfaced = model_facing_extension_error(&err);
+        assert_eq!(
+            surfaced,
+            "(extension attach failed with unsafe-to-surface error; see logs)"
+        );
+        assert!(!surfaced.contains("connection reset"));
+    }
+
+    #[test]
+    fn model_facing_extension_error_suppresses_client_error() {
+        // Client wraps ServiceError, which includes McpError with a
+        // server-controlled `message` field and Cancelled { reason }
+        // where the reason is a server-supplied string. Both are
+        // remote-controlled and must be suppressed.
+        let inner = rmcp::service::ServiceError::Cancelled {
+            reason: Some("server said sensitive-thing".to_string()),
+        };
+        let err = ExtensionError::Client(inner);
+        let surfaced = model_facing_extension_error(&err);
+        assert_eq!(
+            surfaced,
+            "(extension attach failed with unsafe-to-surface error; see logs)"
+        );
+        assert!(!surfaced.contains("sensitive-thing"));
     }
 
     #[test]

--- a/crates/goose/src/agents/subagent_handler.rs
+++ b/crates/goose/src/agents/subagent_handler.rs
@@ -1,5 +1,8 @@
 use crate::{
-    agents::{subagent_task_config::TaskConfig, Agent, AgentConfig, AgentEvent, SessionConfig},
+    agents::{
+        subagent_task_config::TaskConfig, Agent, AgentConfig, AgentEvent, ExtensionLoadResult,
+        SessionConfig,
+    },
     conversation::{
         message::{Message, MessageContent},
         Conversation,
@@ -30,8 +33,12 @@ pub struct SubagentPromptContext {
     pub available_tools: String,
 }
 
-type AgentMessagesFuture =
-    Pin<Box<dyn Future<Output = Result<(Conversation, Option<String>)>> + Send>>;
+type AgentMessagesFuture = Pin<
+    Box<
+        dyn Future<Output = Result<(Conversation, Option<String>, Vec<ExtensionLoadResult>)>>
+            + Send,
+    >,
+>;
 
 pub struct SubagentRunParams {
     pub config: AgentConfig,
@@ -44,21 +51,76 @@ pub struct SubagentRunParams {
     pub notification_tx: Option<tokio::sync::mpsc::UnboundedSender<ServerNotification>>,
 }
 
-pub async fn run_subagent_task(params: SubagentRunParams) -> Result<String, anyhow::Error> {
-    let return_last_only = params.return_last_only;
-    let (messages, final_output) = get_agent_messages(params).await.map_err(|e| {
-        ErrorData::new(
-            ErrorCode::INTERNAL_ERROR,
-            format!("Failed to execute task: {}", e),
-            None,
-        )
-    })?;
+/// Output of a subagent run.
+///
+/// Carries the text a caller would previously have seen as the bare `String`
+/// return, plus a per-extension load status so the parent (LLM or orchestrator)
+/// can tell when a delegate ran with fewer tools than requested.
+#[derive(Debug, Clone)]
+pub struct SubagentRunResult {
+    pub text: String,
+    pub extension_load_results: Vec<ExtensionLoadResult>,
+}
 
-    if let Some(output) = final_output {
-        return Ok(output);
+impl SubagentRunResult {
+    /// Format the extension-load results as a human- and LLM-readable block,
+    /// suitable for appending to a delegate tool response.
+    ///
+    /// Returns `None` when every requested extension loaded successfully or
+    /// when no extensions were requested — in that case callers should emit
+    /// the plain `text` output unchanged.
+    pub fn format_extension_load_report(&self) -> Option<String> {
+        if self.extension_load_results.is_empty()
+            || self.extension_load_results.iter().all(|r| r.success)
+        {
+            return None;
+        }
+
+        let mut lines = String::from("Subagent extension load results:");
+        for result in &self.extension_load_results {
+            if result.success {
+                lines.push_str(&format!("\n  loaded: {}", result.name));
+            } else {
+                let err = result.error.as_deref().unwrap_or("unknown error");
+                lines.push_str(&format!("\n  failed: {} ({})", result.name, err));
+            }
+        }
+        Some(lines)
     }
 
-    Ok(extract_response_text(&messages, return_last_only))
+    /// Return the tool-response text a caller should surface to the parent,
+    /// appending the extension-load report only when at least one extension
+    /// failed to attach.
+    pub fn text_with_report(&self) -> String {
+        match self.format_extension_load_report() {
+            Some(report) => format!("{}\n\n{}", self.text, report),
+            None => self.text.clone(),
+        }
+    }
+}
+
+pub async fn run_subagent_task(
+    params: SubagentRunParams,
+) -> Result<SubagentRunResult, anyhow::Error> {
+    let return_last_only = params.return_last_only;
+    let (messages, final_output, extension_load_results) =
+        get_agent_messages(params).await.map_err(|e| {
+            ErrorData::new(
+                ErrorCode::INTERNAL_ERROR,
+                format!("Failed to execute task: {}", e),
+                None,
+            )
+        })?;
+
+    let text = match final_output {
+        Some(output) => output,
+        None => extract_response_text(&messages, return_last_only),
+    };
+
+    Ok(SubagentRunResult {
+        text,
+        extension_load_results,
+    })
 }
 
 fn extract_response_text(messages: &Conversation, return_last_only: bool) -> String {
@@ -148,13 +210,24 @@ fn get_agent_messages(params: SubagentRunParams) -> AgentMessagesFuture {
             .await
             .map_err(|e| anyhow!("Failed to set provider on sub agent: {}", e))?;
 
+        let mut extension_load_results: Vec<ExtensionLoadResult> =
+            Vec::with_capacity(task_config.extensions.len());
         for extension in &task_config.extensions {
-            if let Err(e) = agent.add_extension(extension.clone(), &session_id).await {
-                debug!(
-                    "Failed to add extension '{}' to subagent: {}",
-                    extension.name(),
-                    e
-                );
+            let name = extension.name();
+            match agent.add_extension(extension.clone(), &session_id).await {
+                Ok(_) => extension_load_results.push(ExtensionLoadResult {
+                    name,
+                    success: true,
+                    error: None,
+                }),
+                Err(e) => {
+                    debug!("Failed to add extension '{}' to subagent: {}", name, e);
+                    extension_load_results.push(ExtensionLoadResult {
+                        name,
+                        success: false,
+                        error: Some(e.to_string()),
+                    });
+                }
             }
         }
 
@@ -234,7 +307,7 @@ fn get_agent_messages(params: SubagentRunParams) -> AgentMessagesFuture {
 
         let final_output = get_final_output(&agent, has_response_schema).await;
 
-        Ok((conversation, final_output))
+        Ok((conversation, final_output, extension_load_results))
     })
 }
 
@@ -313,7 +386,8 @@ pub fn create_tool_notification(
 
 #[cfg(test)]
 mod tests {
-    use super::{create_tool_notification, SUBAGENT_TOOL_REQUEST_TYPE};
+    use super::{create_tool_notification, SubagentRunResult, SUBAGENT_TOOL_REQUEST_TYPE};
+    use crate::agents::ExtensionLoadResult;
     use crate::conversation::message::MessageContent;
     use rmcp::model::{CallToolRequestParams, ServerNotification};
     use serde_json::json;
@@ -357,5 +431,94 @@ mod tests {
     fn create_tool_notification_ignores_non_tool_request() {
         let content = MessageContent::text("hello");
         assert!(create_tool_notification(&content, "session_1").is_none());
+    }
+
+    #[test]
+    fn subagent_run_result_no_report_when_all_extensions_succeed() {
+        let result = SubagentRunResult {
+            text: "subagent output".to_string(),
+            extension_load_results: vec![
+                ExtensionLoadResult {
+                    name: "developer".to_string(),
+                    success: true,
+                    error: None,
+                },
+                ExtensionLoadResult {
+                    name: "computercontroller".to_string(),
+                    success: true,
+                    error: None,
+                },
+            ],
+        };
+
+        assert!(result.format_extension_load_report().is_none());
+        assert_eq!(result.text_with_report(), "subagent output");
+    }
+
+    #[test]
+    fn subagent_run_result_no_report_when_no_extensions_requested() {
+        let result = SubagentRunResult {
+            text: "subagent output".to_string(),
+            extension_load_results: Vec::new(),
+        };
+
+        assert!(result.format_extension_load_report().is_none());
+        assert_eq!(result.text_with_report(), "subagent output");
+    }
+
+    #[test]
+    fn subagent_run_result_reports_partial_extension_failures() {
+        let result = SubagentRunResult {
+            text: "subagent output".to_string(),
+            extension_load_results: vec![
+                ExtensionLoadResult {
+                    name: "developer".to_string(),
+                    success: true,
+                    error: None,
+                },
+                ExtensionLoadResult {
+                    name: "memory".to_string(),
+                    success: false,
+                    error: Some("extension not registered".to_string()),
+                },
+            ],
+        };
+
+        let report = result
+            .format_extension_load_report()
+            .expect("report expected when any extension fails");
+        assert!(report.contains("Subagent extension load results"));
+        assert!(report.contains("loaded: developer"));
+        assert!(report.contains("failed: memory (extension not registered)"));
+
+        let combined = result.text_with_report();
+        assert!(combined.starts_with("subagent output"));
+        assert!(combined.contains("failed: memory"));
+    }
+
+    #[test]
+    fn subagent_run_result_reports_all_extension_failures() {
+        let result = SubagentRunResult {
+            text: "subagent output".to_string(),
+            extension_load_results: vec![
+                ExtensionLoadResult {
+                    name: "memory".to_string(),
+                    success: false,
+                    error: Some("not registered".to_string()),
+                },
+                ExtensionLoadResult {
+                    name: "sqlite".to_string(),
+                    success: false,
+                    error: None,
+                },
+            ],
+        };
+
+        let report = result
+            .format_extension_load_report()
+            .expect("report expected when all extensions fail");
+        assert!(report.contains("failed: memory (not registered)"));
+        assert!(report.contains("failed: sqlite (unknown error)"));
+        assert!(!report.contains("loaded:"));
     }
 }

--- a/crates/goose/src/agents/subagent_task_config.rs
+++ b/crates/goose/src/agents/subagent_task_config.rs
@@ -73,10 +73,7 @@ impl TaskConfig {
     /// Used by callers (e.g. `build_task_config`) to record extensions that
     /// were requested but unavailable before the attach step ran, so the
     /// parent LLM can see the drop in the subagent's tool response.
-    pub fn with_pre_attach_load_results(
-        mut self,
-        results: Vec<ExtensionLoadResult>,
-    ) -> Self {
+    pub fn with_pre_attach_load_results(mut self, results: Vec<ExtensionLoadResult>) -> Self {
         self.pre_attach_load_results = results;
         self
     }

--- a/crates/goose/src/agents/subagent_task_config.rs
+++ b/crates/goose/src/agents/subagent_task_config.rs
@@ -1,4 +1,4 @@
-use crate::agents::ExtensionConfig;
+use crate::agents::{ExtensionConfig, ExtensionLoadResult};
 use crate::config::Config;
 use crate::providers::base::Provider;
 use std::fmt;
@@ -17,6 +17,13 @@ pub struct TaskConfig {
     pub parent_working_dir: PathBuf,
     pub extensions: Vec<ExtensionConfig>,
     pub max_turns: Option<usize>,
+    /// Extensions the caller requested that were unavailable before attach
+    /// was attempted (e.g. filtered out by `build_task_config` because they
+    /// were not active in the parent session). Pre-populated by the caller;
+    /// consumed alongside attach-time results in `subagent_handler` so the
+    /// parent LLM sees one entry per requested extension whether the drop
+    /// happened at filter time or attach time.
+    pub pre_attach_load_results: Vec<ExtensionLoadResult>,
 }
 
 impl fmt::Debug for TaskConfig {
@@ -50,6 +57,7 @@ impl TaskConfig {
                     .get_param::<usize>("GOOSE_SUBAGENT_MAX_TURNS")
                     .unwrap_or(DEFAULT_SUBAGENT_MAX_TURNS),
             ),
+            pre_attach_load_results: Vec::new(),
         }
     }
 
@@ -57,6 +65,19 @@ impl TaskConfig {
         if let Some(turns) = max_turns {
             self.max_turns = Some(turns);
         }
+        self
+    }
+
+    /// Attach a set of pre-computed extension load results to this config.
+    ///
+    /// Used by callers (e.g. `build_task_config`) to record extensions that
+    /// were requested but unavailable before the attach step ran, so the
+    /// parent LLM can see the drop in the subagent's tool response.
+    pub fn with_pre_attach_load_results(
+        mut self,
+        results: Vec<ExtensionLoadResult>,
+    ) -> Self {
+        self.pre_attach_load_results = results;
         self
     }
 }


### PR DESCRIPTION
### What this changes

Subagents spawned by `delegate()` now report which requested extensions loaded and which failed, so the parent LLM can distinguish two outcomes:

1. All requested tools loaded and the subagent worked with them
2. Some or all requested tools silently didn't load and the subagent worked without them

Before: any failure to attach was logged at `debug!` level then silently dropped, and any extension name filtered out at `build_task_config` time (not active in the parent session) vanished with only a `warn!` log. The parent got a prose result with no signal about which tools were actually available.

After: every requested extension appears in the subagent's tool response — one entry per name, whether it loaded, was filtered out, or failed at attach time.

### Why

Callers using `delegate()` with an explicit extensions list currently can't tell whether the subagent had the tools it asked for. Silent drops can lead to output that reads as plausible but wasn't actually derived from any tool call.

A workaround has emerged in practice: "MCP extensions do not pass tools to subagents reliably. Keep those sequential." That's community adaptation to an invisible bug, not a fix.

### Revision — 27/08/2026

Reworked in response to three review comments from @DOsinga (thanks). Four commits on the branch, each addressing one concern:

**Commit 1 — `fix(summon): report requested extensions filtered out by build_task_config`**
Addresses [L214](https://github.com/aaif-goose/goose/pull/11315#discussion_r…). `build_task_config` was culling unmatched extension names before the attach loop ever ran. The manual verification in the original PR description couldn't pass as written.

New field `TaskConfig::pre_attach_load_results` carries filter-time drops through as `ExtensionLoadResult` entries with `success: false, error: Some("extension \"X\" not available in parent session")`. `subagent_handler` seeds its collector from that vec before running the attach loop, so filter-drops and attach-drops share a single unified report surface.

**Commit 2 — `fix(summon): preserve JSON output when a delegated recipe declares a response schema`**
Addresses [L96](https://github.com/aaif-goose/goose/pull/11315#discussion_r…). Appending a prose report to serialised JSON output invalidated the JSON.

New `SubagentRunResult::into_parts()` returns `(String, Vec<ExtensionLoadResult>)` as the structured accessor. `summon.rs` now uses a `subagent_output_text()` helper that checks `recipe.response.is_some()` — recipes with a response schema get the raw text unchanged (JSON stays parseable) and drops go to `warn!` for operators. Prose recipes keep the inlined report as before (unchanged for the common case). Threaded a `response_expected: bool` onto `BackgroundTask`/`CompletedTask` so the four consume sites in `summon.rs` (sync + three async) can make the choice without re-hydrating the recipe.

**Commit 3 — `fix(summon): sanitise and bound extension error strings surfaced to the parent`**
Addresses [L85](https://github.com/aaif-goose/goose/pull/11315#discussion_r…). `ExtensionError::ProcessExit`'s error string included the MCP process's full stderr, unbounded and potentially containing secrets logged at startup.

New `sanitize_extension_error()` helper truncates to 500 chars and drops any line matching common secret markers (`TOKEN`, `KEY=`, `SECRET`, `PASSWORD`, `AWS_`, `BEARER`, `API_KEY`, case-insensitive). Full unredacted error remains available via the existing `debug!` log at the attach site. When every line matches a marker, an explicit "(extension error redacted; see logs)" sentinel surfaces rather than an empty string (which would read as a silent failure — the exact bug this PR is trying to prevent).

**End-to-end test**
Added `test_build_task_config_reports_unmatched_extensions_as_pre_attach_drops` in `summon.rs`, exercising the path Douwe called out as untestable in the original description: session with `developer` active, delegate filter `["developer", "nonexistent"]`, asserts the returned `TaskConfig` carries both the surviving extension and the filter-drop report entry.

### Files changed

| File | LOC | Purpose |
|---|---|---|
| `crates/goose/src/agents/subagent_task_config.rs` | +15 | New `pre_attach_load_results` field, `with_pre_attach_load_results` builder |
| `crates/goose/src/agents/subagent_handler.rs` | +117 | `SubagentRunResult` struct + `format_extension_load_report()` / `text_with_report()` / `into_parts()`, `sanitize_extension_error()`, collecting attach loop with pre-attach seeding, 8 new tests |
| `crates/goose/src/agents/platform_extensions/summon.rs` | +75 | `build_task_config` populates `pre_attach_load_results`, `subagent_output_text()` helper, `response_expected` on `BackgroundTask`/`CompletedTask`, four consume sites updated, integration test |

Total: ~330 LOC across 3 files, 5 new tests (1 integration in `summon.rs`, 4 unit in `subagent_handler.rs`) plus the 4 existing unit tests from the original PR.

### State-machine path

Unchanged from the original description. The attach loop runs before `agent.reply()`'s legacy-vs-state-machine dispatch fork, so both paths inherit the same behaviour. No dual-path patch required.

Reuses `ExtensionLoadResult` (defined at `crates/goose/src/agents/agent.rs`, already used by `add_extensions_bulk`, ACP session APIs, and `execution/manager.rs`) rather than introducing a parallel type.

### Manual verification (now actually works)

```
# In a session with only `developer` active:
delegate(instructions: "say hi", extensions: ["developer", "nonexistent"])

# Tool response now contains:
# <subagent output>
# 
# Subagent extension load results:
#   loaded: developer
#   failed: nonexistent (extension "nonexistent" not available in parent session)
```

The integration test above exercises this exact path against `handle_delegate`'s internals.

### Alternatives considered

- **Fail-loud:** return `Err` when any extension is unavailable. Rejected as breaking — existing callers that tolerated silent drops would see errors.
- **Rich new type with structured drop reasons and per-attempt timing.** Rejected as parallel to `ExtensionLoadResult`. Layerable later if the plain error-string proves insufficient.
- **Structured metadata field for the drop report (instead of appending prose).** For prose recipes, appending is what the parent LLM can act on. For structured recipes, `into_parts()` is exposed so a future caller can surface drops via a separate content block or metadata; this PR takes the minimum viable step of preserving JSON parseability.

### Scope

Explicitly out of scope for this PR:

- Retry logic (caller-side policy)
- Downstream silent-drop surfaces in `EnabledExtensionsState::extensions_or_default` (deserialisation fallback to global config) and `from_extension_data` (platform-availability filter). These cross-cut ACP, gateway, orchestrator, and agent code and warrant a separate discussion — will file as a follow-up issue after this merges.
- Structured drop reporting as a first-class content block or metadata field — Chain η territory in the follow-up work.

Happy to iterate quickly on any of the three commits.
