### PR TITLE
test(recipe): add a regression guard for minijinja's builtins feature

### DIFF
--- a/crates/goose/src/recipe/template_recipe.rs
+++ b/crates/goose/src/recipe/template_recipe.rs
@@ -355,6 +355,28 @@ mod tests {
         }
 
         #[test]
+        fn test_builtin_filters_are_registered() {
+            // Regression test for #11301: minijinja's `builtins` feature (where
+            // indent/upper/trim/etc. live) was dropped from Cargo.toml, so every
+            // documented recipe filter except safe/escape/e failed as "unknown filter".
+            let content = "{{ raw_data | indent(2) }}";
+            let params = HashMap::from([
+                ("recipe_dir".to_string(), "some_dir".to_string()),
+                ("raw_data".to_string(), "line one\nline two".to_string()),
+            ]);
+            let result = render_recipe_content_with_params(content, &params).unwrap();
+            assert_eq!(result, "line one\n  line two");
+
+            let content = "{{ raw_data | upper }} / {{ raw_data | trim }}";
+            let params = HashMap::from([
+                ("recipe_dir".to_string(), "some_dir".to_string()),
+                ("raw_data".to_string(), "  hi  ".to_string()),
+            ]);
+            let result = render_recipe_content_with_params(content, &params).unwrap();
+            assert_eq!(result, "  HI   / hi");
+        }
+
+        #[test]
         fn test_render_content_with_spaced_variables() {
             let content = "Hello {{hf model org}}_{{hf model name}}!";
             let params = HashMap::from([("recipe_dir".to_string(), "some_dir".to_string())]);


### PR DESCRIPTION
Follow-up to #11310, at ilovewalking7's suggestion in [this comment](https://github.com/aaif-goose/goose/pull/11310#issuecomment-5327494926).

## Summary

`#11310` fixed the missing `builtins` feature on minijinja (`indent`/`upper`/`trim`/etc. failing as `unknown filter`), but shipped no test — so nothing in the repo currently catches that `Cargo.toml` line drifting again. It has already drifted once, when the feature was dropped in a version bump.

Adds the regression test we'd already built and proven while independently verifying #11301 — verified failing on the pre-#11310 dependency line (reproduces the exact reported error) and passing on current `main`.

### Testing

- `cargo test -p goose --lib test_builtin_filters_are_registered` — passes on current `main`
- `cargo clippy -p goose --all-targets` — clean, 0 warnings
- `cargo fmt --check` — clean
