### PR TITLE
refactor: share `axum-server` via `workspace.dependencies`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ anyhow = { version = "1.0.102", default-features = false, features = ["std"] }
 async-stream = { version = "0.3.6", default-features = false }
 async-trait = { version = "0.1.89", default-features = false }
 axum = { version = "0.8", default-features = false, features = ["http1", "http2", "json", "tokio", "query"] }
+axum-server = { version = "0.8", default-features = false }
 base64 = { version = "0.23.0", default-features = false, features = ["std"] }
 bytes = { version = "1.10.1", default-features = false, features = ["std"] }
 candle-core = { version = "0.11", default-features = false }

--- a/crates/goose-cli/Cargo.toml
+++ b/crates/goose-cli/Cargo.toml
@@ -65,7 +65,7 @@ comfy-table = { version = "7", default-features = false }
 sha2 = { workspace = true }
 sigstore-verify = { version = "0.11", default-features = false, optional = true }
 axum.workspace = true
-axum-server = { version = "0.8", default-features = false, optional = true }
+axum-server = { workspace = true, optional = true }
 clap_complete_nushell = { version = "4", default-features = false }
 
 [target.'cfg(target_os = "windows")'.dependencies]

--- a/crates/goose/Cargo.toml
+++ b/crates/goose/Cargo.toml
@@ -217,7 +217,7 @@ nostr = { version = "0.44.7", default-features = false, features = ["nip44", "st
 nostr-sdk = { version = "0.44", default-features = false, features = ["nip44"], optional = true }
 rustls = { workspace = true, optional = true }
 rcgen = { version = "0.14", default-features = false, features = ["crypto", "pem"], optional = true }
-axum-server = { version = "0.8", default-features = false, optional = true }
+axum-server = { workspace = true, optional = true }
 aws-lc-rs = { version = "1.17", default-features = false, optional = true }
 openssl = { version = "0.10.66", default-features = false, optional = true }
 pem = { version = "4.0.0", default-features = false, features = ["std"], optional = true }


### PR DESCRIPTION
## Summary
`axum-server` was pinned independently in `crates/goose/Cargo.toml` and `crates/goose-cli/Cargo.toml` (both where on "0.8", default-features = false), and fortunately so far they were matching. I would say better to have a single source of truth.

Thus, I'm moving it to [workspace.dependencies] and reference it with `workspace = true` from both crates, consistent with the pattern used for axum and other shared deps.

### Testing
Is a pretty straightforward change, as long as the CI is passing, my understanding is that's sufficient.

### Related Issues
Relates to https://github.com/aaif-goose/goose/issues/11325
Discussion: LINK (if any)


### Screenshots/Demos (for UX changes)
N/A

Assisted-by: Claude Sonnet 4.6
