### PR TITLE
refactor(goose-local-inference): move mlx deps under macos

### DIFF
--- a/crates/goose-local-inference/Cargo.toml
+++ b/crates/goose-local-inference/Cargo.toml
@@ -45,12 +45,11 @@ tracing = { workspace = true }
 uuid = { workspace = true, features = ["v4", "std"] }
 tempfile = { workspace = true }
 
+[target.'cfg(target_os = "macos")'.dependencies]
+llama-cpp-2 = { workspace = true, features = ["sampler", "metal", "mtmd"] }
 safemlx = { default-features = false, features = ["accelerate", "metal", "safetensors"], optional = true, version = "0.1.2" }
 safemlx-lm = { optional = true, version = "0.1.5" }
 safemlx-lm-utils = { optional = true, version = "0.1.2" }
-
-[target.'cfg(target_os = "macos")'.dependencies]
-llama-cpp-2 = { workspace = true, features = ["sampler", "metal", "mtmd"] }
 
 [dev-dependencies]
 env-lock.workspace = true

--- a/crates/goose-local-inference/src/hf_models.rs
+++ b/crates/goose-local-inference/src/hf_models.rs
@@ -1842,14 +1842,14 @@ fn mlx_config_support(config: &Option<serde_json::Value>) -> Option<String> {
     mlx_config_support_for_value(config)
 }
 
-#[cfg(feature = "mlx")]
+#[cfg(all(feature = "mlx", target_os = "macos"))]
 fn mlx_config_support_for_value(config: &serde_json::Value) -> Option<String> {
     safemlx_lm::check_model_config(config)
         .unsupported_reason()
         .map(str::to_string)
 }
 
-#[cfg(not(feature = "mlx"))]
+#[cfg(not(all(feature = "mlx", target_os = "macos")))]
 fn mlx_config_support_for_value(_config: &serde_json::Value) -> Option<String> {
     None
 }

--- a/crates/goose-local-inference/src/mlx.rs
+++ b/crates/goose-local-inference/src/mlx.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "mlx")]
+#[cfg(all(feature = "mlx", target_os = "macos"))]
 mod imp {
     use std::any::Any;
     use std::path::{Path, PathBuf};
@@ -990,7 +990,7 @@ mod imp {
     }
 }
 
-#[cfg(not(feature = "mlx"))]
+#[cfg(not(all(feature = "mlx", target_os = "macos")))]
 mod imp {
     use crate::backend::{BackendLoadedModel, LocalGenerationRequest, LocalInferenceBackend};
     use crate::local_model_registry::ModelSettings;


### PR DESCRIPTION
## Summary

The 3 MLX deps (mentioned in #11327)  are declared as if they work on any OS, but the actual feature only ever gets used on macOS.

The PR moves them to be defined as "macOS-only" . I don't see any impact on other parts of the code, is just a safety that mlx deps are kept away from linux & windows

### Testing
Just built it locally, as far as I understand if the CI is passing that should be sufficient. Happy to test it further if the reviewers think otherwise <3

### Related Issues
Relates to https://github.com/aaif-goose/goose/issues/11327
Discussion: LINK (if any)


### Screenshots/Demos (for UX changes)
Before:  

After:   

Assisted-by: Claude Sonnet 4.6