### PR TITLE
fix(openrouter): send session_id in request body for provider sticky routing

### DIFF
--- a/crates/goose/src/providers/openrouter.rs
+++ b/crates/goose/src/providers/openrouter.rs
@@ -276,10 +276,13 @@ impl Provider for OpenRouterProvider {
             true,
         )?;
 
-        // Add user field for OpenRouter attribution/rate-limiting
+        // `user` is for OpenRouter attribution/rate-limiting; `session_id` activates
+        // provider sticky routing so every turn in a session lands on the endpoint
+        // holding the warm prompt cache.
         if !session_id.is_empty() {
             if let Some(obj) = payload.as_object_mut() {
-                obj.insert("user".to_string(), Value::String(session_id.to_string()));
+                obj.insert("user".to_string(), Value::String(session_id.clone()));
+                obj.insert("session_id".to_string(), Value::String(session_id.clone()));
             }
         }
 
@@ -399,6 +402,88 @@ mod tests {
         let request_params = model.request_params.as_ref().unwrap();
         assert_eq!(request_params["plugins"], json!([{ "id": "web" }]));
         assert_eq!(request_params["verbosity"], json!("xhigh"));
+    }
+
+    #[tokio::test]
+    async fn stream_sends_session_id_body_field_for_sticky_routing() {
+        use wiremock::matchers::{body_partial_json, method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/v1/chat/completions"))
+            .and(body_partial_json(json!({
+                "user": "20260809_29",
+                "session_id": "20260809_29",
+            })))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string("data: [DONE]\n\n"),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let provider = OpenRouterProvider {
+            api_client: ApiClient::new_with_tls(
+                server.uri(),
+                AuthMethod::BearerToken("test-key".to_string()),
+                None,
+            )
+            .unwrap(),
+            supports_streaming: true,
+            name: OPENROUTER_PROVIDER_NAME.to_string(),
+            configured_parameters: None,
+        };
+
+        let config = model_config("z-ai/glm-5.2");
+        let _stream = crate::session_context::with_session_id(
+            Some("20260809_29".to_string()),
+            provider.stream(&config, "system", &[Message::user().with_text("hi")], &[]),
+        )
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn stream_omits_session_id_body_field_without_session() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, Request, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/v1/chat/completions"))
+            .and(|req: &Request| {
+                let body: Value = serde_json::from_slice(&req.body).unwrap();
+                body.get("session_id").is_none() && body.get("user").is_none()
+            })
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string("data: [DONE]\n\n"),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let provider = OpenRouterProvider {
+            api_client: ApiClient::new_with_tls(
+                server.uri(),
+                AuthMethod::BearerToken("test-key".to_string()),
+                None,
+            )
+            .unwrap(),
+            supports_streaming: true,
+            name: OPENROUTER_PROVIDER_NAME.to_string(),
+            configured_parameters: None,
+        };
+
+        let config = model_config("z-ai/glm-5.2");
+        let _stream = provider
+            .stream(&config, "system", &[Message::user().with_text("hi")], &[])
+            .await
+            .unwrap();
     }
 
     #[tokio::test]

--- a/crates/goose/src/providers/openrouter.rs
+++ b/crates/goose/src/providers/openrouter.rs
@@ -276,12 +276,10 @@ impl Provider for OpenRouterProvider {
             true,
         )?;
 
-        // `user` is for OpenRouter attribution/rate-limiting; `session_id` activates
-        // provider sticky routing so every turn in a session lands on the endpoint
-        // holding the warm prompt cache.
+        // `session_id` activates provider sticky routing so every turn in a session
+        // lands on the endpoint holding the warm prompt cache.
         if !session_id.is_empty() {
             if let Some(obj) = payload.as_object_mut() {
-                obj.insert("user".to_string(), Value::String(session_id.clone()));
                 obj.insert("session_id".to_string(), Value::String(session_id.clone()));
             }
         }
@@ -413,7 +411,6 @@ mod tests {
         Mock::given(method("POST"))
             .and(path("/api/v1/chat/completions"))
             .and(body_partial_json(json!({
-                "user": "20260809_29",
                 "session_id": "20260809_29",
             })))
             .respond_with(
@@ -444,46 +441,6 @@ mod tests {
         )
         .await
         .unwrap();
-    }
-
-    #[tokio::test]
-    async fn stream_omits_session_id_body_field_without_session() {
-        use wiremock::matchers::{method, path};
-        use wiremock::{Mock, MockServer, Request, ResponseTemplate};
-
-        let server = MockServer::start().await;
-        Mock::given(method("POST"))
-            .and(path("/api/v1/chat/completions"))
-            .and(|req: &Request| {
-                let body: Value = serde_json::from_slice(&req.body).unwrap();
-                body.get("session_id").is_none() && body.get("user").is_none()
-            })
-            .respond_with(
-                ResponseTemplate::new(200)
-                    .insert_header("content-type", "text/event-stream")
-                    .set_body_string("data: [DONE]\n\n"),
-            )
-            .expect(1)
-            .mount(&server)
-            .await;
-
-        let provider = OpenRouterProvider {
-            api_client: ApiClient::new_with_tls(
-                server.uri(),
-                AuthMethod::BearerToken("test-key".to_string()),
-                None,
-            )
-            .unwrap(),
-            supports_streaming: true,
-            name: OPENROUTER_PROVIDER_NAME.to_string(),
-            configured_parameters: None,
-        };
-
-        let config = model_config("z-ai/glm-5.2");
-        let _stream = provider
-            .stream(&config, "system", &[Message::user().with_text("hi")], &[])
-            .await
-            .unwrap();
     }
 
     #[tokio::test]


### PR DESCRIPTION
Fixes #11066

## Problem

OpenRouter's provider sticky routing keys off a `session_id` field in the **request body**. goose never sends it, so every turn in a session can be load-balanced to a different upstream provider endpoint — losing the warm prompt cache and producing inconsistent behavior across turns of one session.

The `agent-session-id` header goose already sends (`crates/goose/src/session_context.rs`, `SESSION_ID_HEADER`) is goose-side infra and is not OpenRouter's sticky-routing header (`x-session-id`), so it does nothing for routing.

## Change

Two lines in the existing session-id guard in `OpenRouterProvider::stream()` (`crates/goose/src/providers/openrouter.rs`): set `session_id`, and stop setting `user`.

```rust
// `session_id` activates provider sticky routing so every turn in a session
// lands on the endpoint holding the warm prompt cache.
if !session_id.is_empty() {
    if let Some(obj) = payload.as_object_mut() {
        obj.insert("session_id".to_string(), Value::String(session_id.clone()));
    }
}
```

`user` previously carried the session ID. That field is meant for a stable, persistent identifier for the end user, so populating it per-session mislabels every new session as a new user and skews OpenRouter attribution and rate-limiting. Sticky routing does not need it, so it is removed rather than left alongside `session_id`.

## Scope decisions

- **OpenRouter only.** `session_id` is not a standard OpenAI request field, so setting it from the shared request builder risks unknown-parameter rejections on strict OpenAI-compatible endpoints.
- **No header rename.** `agent-session-id` is consumed by goose-side infra; renaming it to `x-session-id` is a separate, riskier change and the body field is sufficient and documented.

## Verification

- New unit test `stream_sends_session_id_body_field_for_sticky_routing` asserts the body field is present under a session, via a wiremock `body_partial_json` matcher.
- **Mutation-checked**: deleting the `session_id` insert makes that test fail (404, no mock match), so the assertion is not vacuous.
- `cargo clippy --all-targets -p goose -- -D warnings` clean; `cargo fmt --check` clean.
- `cargo test -p goose`: 1746 passed, 6 failed. The same 6 fail on clean `origin/main` at this base — jsonwebtoken `CryptoProvider` in `gcpauth`/`chatgpt_codex`, an insta snapshot in `prompt_manager`, and a state-machine compaction test. All pre-existing and unrelated.
