### PR TITLE
fix(security): fail closed on malformed app visibility

### DIFF
--- a/crates/goose/src/agents/reply_parts.rs
+++ b/crates/goose/src/agents/reply_parts.rs
@@ -795,7 +795,7 @@ pub fn is_tool_visible_to_app(tool: &Tool) -> bool {
         return true;
     };
     let Some(arr) = visibility.as_array() else {
-        return true;
+        return false;
     };
     arr.iter().any(|v| v.as_str() == Some("app"))
 }
@@ -1754,6 +1754,12 @@ mod tests {
     #[test]
     fn test_app_hidden_when_visibility_is_empty() {
         let tool = make_tool_with_meta(Some(serde_json::json!({"ui": {"visibility": []}})));
+        assert!(!is_tool_visible_to_app(&tool));
+    }
+
+    #[test]
+    fn test_app_hidden_when_visibility_is_not_array() {
+        let tool = make_tool_with_meta(Some(serde_json::json!({"ui": {"visibility": "model"}})));
         assert!(!is_tool_visible_to_app(&tool));
     }
 


### PR DESCRIPTION
## Summary

- treat malformed app-visibility metadata as hidden
- preserve the documented behavior for absent metadata and valid app/model visibility lists
- add regression coverage for malformed, empty, and valid visibility values

## Security invariant

Malformed authorization metadata must fail closed and must not expand direct app tool access.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p goose visibility --lib`
- `cargo build -p goose`
- `cargo clippy -p goose --all-targets -- -D warnings`
- `git diff origin/main...HEAD --check`

*This finding was discovered by [Project Loupe](https://github.com/project-loupe/loupe)*
