### PR TITLE
fix(desktop): open large sessions at the latest messages

### DIFF
--- a/crates/goose-sdk-types/src/custom_requests.rs
+++ b/crates/goose-sdk-types/src/custom_requests.rs
@@ -729,6 +729,8 @@ pub struct GetSessionConversationRequest {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub before: Option<i64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub after: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub limit: Option<u32>,
 }
 
@@ -737,8 +739,35 @@ pub struct GetSessionConversationRequest {
 pub struct GetSessionConversationResponse {
     pub messages: Vec<serde_json::Value>,
     pub has_earlier: bool,
+    #[serde(default)]
+    pub has_later: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub next_before: Option<i64>,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema, JsonRpcRequest)]
+#[request(
+    method = "_goose/unstable/session/conversation/search",
+    response = SearchSessionConversationResponse
+)]
+#[serde(rename_all = "camelCase")]
+pub struct SearchSessionConversationRequest {
+    pub session_id: String,
+    pub query: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub limit: Option<u32>,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema, JsonRpcResponse)]
+#[serde(rename_all = "camelCase")]
+pub struct SearchSessionConversationResponse {
+    pub messages: Vec<serde_json::Value>,
+    pub has_earlier: bool,
+    pub has_later: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub match_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub match_created: Option<i64>,
 }
 
 /// Truncate a session conversation from the given message timestamp onward.

--- a/crates/goose-sdk-types/src/custom_requests.rs
+++ b/crates/goose-sdk-types/src/custom_requests.rs
@@ -717,6 +717,30 @@ pub struct GetSessionInfoResponse {
     pub session: SessionInfo,
 }
 
+/// Return a page of user-visible session messages, newest-bounded by `before`.
+#[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema, JsonRpcRequest)]
+#[request(
+    method = "_goose/unstable/session/conversation/get",
+    response = GetSessionConversationResponse
+)]
+#[serde(rename_all = "camelCase")]
+pub struct GetSessionConversationRequest {
+    pub session_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub before: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub limit: Option<u32>,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema, JsonRpcResponse)]
+#[serde(rename_all = "camelCase")]
+pub struct GetSessionConversationResponse {
+    pub messages: Vec<serde_json::Value>,
+    pub has_earlier: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub next_before: Option<i64>,
+}
+
 /// Truncate a session conversation from the given message timestamp onward.
 #[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema, JsonRpcRequest)]
 #[request(

--- a/crates/goose/src/acp/response_builder.rs
+++ b/crates/goose/src/acp/response_builder.rs
@@ -96,6 +96,10 @@ pub(super) fn session_response_meta(
         "workingDir".to_string(),
         serde_json::Value::String(session.working_dir.to_string_lossy().to_string()),
     );
+    meta.insert(
+        "hasEarlier".to_string(),
+        serde_json::Value::Bool(session.message_count > 80),
+    );
     meta
 }
 

--- a/crates/goose/src/acp/server/custom_dispatch.rs
+++ b/crates/goose/src/acp/server/custom_dispatch.rs
@@ -667,6 +667,14 @@ impl GooseAcpAgent {
         self.on_get_session_conversation(req).await
     }
 
+    #[custom_method(SearchSessionConversationRequest)]
+    async fn dispatch_search_session_conversation(
+        &self,
+        req: SearchSessionConversationRequest,
+    ) -> Result<SearchSessionConversationResponse, agent_client_protocol::Error> {
+        self.on_search_session_conversation(req).await
+    }
+
     #[custom_method(TruncateSessionConversationRequest)]
     async fn dispatch_truncate_session_conversation(
         &self,

--- a/crates/goose/src/acp/server/custom_dispatch.rs
+++ b/crates/goose/src/acp/server/custom_dispatch.rs
@@ -659,6 +659,14 @@ impl GooseAcpAgent {
         self.on_get_session_info(req).await
     }
 
+    #[custom_method(GetSessionConversationRequest)]
+    async fn dispatch_get_session_conversation(
+        &self,
+        req: GetSessionConversationRequest,
+    ) -> Result<GetSessionConversationResponse, agent_client_protocol::Error> {
+        self.on_get_session_conversation(req).await
+    }
+
     #[custom_method(TruncateSessionConversationRequest)]
     async fn dispatch_truncate_session_conversation(
         &self,

--- a/crates/goose/src/acp/server/load_session.rs
+++ b/crates/goose/src/acp/server/load_session.rs
@@ -22,8 +22,10 @@ fn replay_audience_annotations(audience: &[Role]) -> Annotations {
     )
 }
 
+const ACP_SESSION_REPLAY_LIMIT: usize = 80;
+
 fn messages_for_acp_replay(conversation: &Conversation) -> Vec<Message> {
-    conversation
+    let messages: Vec<Message> = conversation
         .messages()
         .iter()
         .filter(|message| message.is_user_visible())
@@ -33,7 +35,11 @@ fn messages_for_acp_replay(conversation: &Conversation) -> Vec<Message> {
             message
         })
         .filter(|message| !message.content.is_empty())
-        .collect()
+        .collect();
+    if messages.len() <= ACP_SESSION_REPLAY_LIMIT {
+        return messages;
+    }
+    messages[messages.len() - ACP_SESSION_REPLAY_LIMIT..].to_vec()
 }
 
 fn active_turn_messages(conversation: &Conversation) -> &[Message] {
@@ -278,7 +284,7 @@ impl GooseAcpAgent {
 
         let mut session = self
             .session_manager
-            .get_session(&session_id_str, true)
+            .get_session(&session_id_str, false)
             .await
             .map_err(|_| {
                 agent_client_protocol::Error::resource_not_found(Some(session_id_str.clone()))
@@ -286,8 +292,15 @@ impl GooseAcpAgent {
             })?;
 
         session = self
-            .prepare_session_for_activation(session, args.cwd.clone(), args.mcp_servers, true)
+            .prepare_session_for_activation(session, args.cwd.clone(), args.mcp_servers, false)
             .await?;
+
+        let (replay_messages, _) = self
+            .session_manager
+            .get_user_visible_messages_before(&session_id_str, None, ACP_SESSION_REPLAY_LIMIT)
+            .await
+            .internal_err_ctx("Failed to load session messages")?;
+        session.conversation = Some(Conversation::new_unvalidated(replay_messages));
 
         replay_conversation_to_client(
             cx,
@@ -447,6 +460,23 @@ mod tests {
                 },
             }),
         );
+    }
+
+    #[test]
+    fn replay_window_keeps_the_latest_visible_messages() {
+        let mut messages = Vec::new();
+        for index in 0..90 {
+            if index % 2 == 0 {
+                messages.push(Message::user().with_text(format!("user-{index}")));
+            } else {
+                messages.push(Message::assistant().with_text(format!("assistant-{index}")));
+            }
+        }
+        let conversation = Conversation::new_unvalidated(messages);
+        let replayed = messages_for_acp_replay(&conversation);
+        assert_eq!(replayed.len(), 80);
+        assert_eq!(replayed[0].as_concat_text(), "user-10");
+        assert_eq!(replayed.last().unwrap().as_concat_text(), "assistant-89");
     }
 
     #[test]

--- a/crates/goose/src/acp/server/manage_sessions.rs
+++ b/crates/goose/src/acp/server/manage_sessions.rs
@@ -219,11 +219,17 @@ impl GooseAcpAgent {
         }
 
         let limit = req.limit.unwrap_or(80).clamp(1, 160) as usize;
-        let (messages, has_earlier) = self
-            .session_manager
-            .get_user_visible_messages_before(session_id, req.before, limit)
-            .await
-            .internal_err()?;
+        let (messages, has_more) = if req.after.is_some() {
+            self.session_manager
+                .get_user_visible_messages_after(session_id, req.after, limit)
+                .await
+                .internal_err()?
+        } else {
+            self.session_manager
+                .get_user_visible_messages_before(session_id, req.before, limit)
+                .await
+                .internal_err()?
+        };
         let next_before = messages.first().map(|message| message.created);
         let messages = messages
             .into_iter()
@@ -232,8 +238,44 @@ impl GooseAcpAgent {
 
         Ok(GetSessionConversationResponse {
             messages,
-            has_earlier,
+            has_earlier: req.after.is_none() && has_more,
+            has_later: req.after.is_some() && has_more,
             next_before,
+        })
+    }
+
+    pub(super) async fn on_search_session_conversation(
+        &self,
+        req: SearchSessionConversationRequest,
+    ) -> Result<SearchSessionConversationResponse, agent_client_protocol::Error> {
+        let session_id = req.session_id.trim();
+        if session_id.is_empty() {
+            return Err(
+                agent_client_protocol::Error::invalid_params().data("sessionId cannot be empty")
+            );
+        }
+        let query = req.query.trim();
+        if query.is_empty() {
+            return Ok(SearchSessionConversationResponse::default());
+        }
+
+        let limit = req.limit.unwrap_or(80).clamp(1, 160) as usize;
+        let page = self
+            .session_manager
+            .search_user_visible_messages(session_id, query, limit)
+            .await
+            .internal_err()?;
+
+        Ok(SearchSessionConversationResponse {
+            messages: page
+                .messages
+                .into_iter()
+                .map(|message| serde_json::to_value(message).unwrap_or(serde_json::Value::Null))
+                .collect(),
+            has_earlier: page.has_earlier,
+            has_later: page.has_later,
+            match_id: page.match_id,
+            match_created: page.match_created,
         })
     }
 

--- a/crates/goose/src/acp/server/manage_sessions.rs
+++ b/crates/goose/src/acp/server/manage_sessions.rs
@@ -207,6 +207,36 @@ impl GooseAcpAgent {
         })
     }
 
+    pub(super) async fn on_get_session_conversation(
+        &self,
+        req: GetSessionConversationRequest,
+    ) -> Result<GetSessionConversationResponse, agent_client_protocol::Error> {
+        let session_id = req.session_id.trim();
+        if session_id.is_empty() {
+            return Err(
+                agent_client_protocol::Error::invalid_params().data("sessionId cannot be empty")
+            );
+        }
+
+        let limit = req.limit.unwrap_or(80).clamp(1, 160) as usize;
+        let (messages, has_earlier) = self
+            .session_manager
+            .get_user_visible_messages_before(session_id, req.before, limit)
+            .await
+            .internal_err()?;
+        let next_before = messages.first().map(|message| message.created);
+        let messages = messages
+            .into_iter()
+            .map(|message| serde_json::to_value(message).unwrap_or(serde_json::Value::Null))
+            .collect();
+
+        Ok(GetSessionConversationResponse {
+            messages,
+            has_earlier,
+            next_before,
+        })
+    }
+
     pub(super) async fn on_truncate_session_conversation(
         &self,
         req: TruncateSessionConversationRequest,

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -1913,19 +1913,9 @@ impl Agent {
 
         let message_text = message_text_for_trace;
 
-        let session = session_manager
-            .get_session(&session_config.id, true)
+        let is_first_agent_turn = !session_manager
+            .session_has_agent_visible_messages(&session_config.id)
             .await?;
-        let is_first_agent_turn = session
-            .conversation
-            .as_ref()
-            .map(|conversation| {
-                conversation.messages().iter().all(|message| {
-                    !message.is_agent_visible()
-                        || message.agent_visible_content().content.is_empty()
-                })
-            })
-            .unwrap_or(true);
 
         if !user_message.is_agent_visible()
             || user_message.agent_visible_content().content.is_empty()

--- a/crates/goose/src/session/session_manager.rs
+++ b/crates/goose/src/session/session_manager.rs
@@ -1,14 +1,14 @@
-use crate::config::GooseMode;
 use crate::config::paths::Paths;
-use crate::conversation::Conversation;
+use crate::config::GooseMode;
 use crate::conversation::message::{Message, MessageUsage, TokenState};
+use crate::conversation::Conversation;
 use crate::providers::base::CostSource;
 use crate::providers::base::Provider;
 use crate::recipe::Recipe;
 use crate::session::export_markdown::export_session_to_markdown;
 use crate::session::extension_data::ExtensionData;
 use crate::session::session_naming::{
-    MSG_COUNT_FOR_SESSION_NAME_GENERATION, generate_session_name,
+    generate_session_name, MSG_COUNT_FOR_SESSION_NAME_GENERATION,
 };
 use anyhow::Result;
 use chrono::{DateTime, TimeZone, Utc};
@@ -443,6 +443,32 @@ impl SessionManager {
             .await
     }
 
+    pub async fn search_user_visible_messages(
+        &self,
+        id: &str,
+        query: &str,
+        limit: usize,
+    ) -> Result<SessionConversationSearchPage> {
+        self.storage
+            .search_user_visible_messages(id, query, limit)
+            .await
+    }
+
+    pub async fn get_user_visible_messages_after(
+        &self,
+        id: &str,
+        after: Option<i64>,
+        limit: usize,
+    ) -> Result<(Vec<Message>, bool)> {
+        self.storage
+            .get_user_visible_messages_after(id, after, limit)
+            .await
+    }
+
+    pub async fn session_has_agent_visible_messages(&self, id: &str) -> Result<bool> {
+        self.storage.session_has_agent_visible_messages(id).await
+    }
+
     pub fn update(&self, id: &str) -> SessionUpdateBuilder<'_> {
         SessionUpdateBuilder::new(self, id.to_string())
     }
@@ -711,6 +737,45 @@ fn normalized_message_timestamp_sql(column: &str) -> String {
 
 fn user_visible_message_sql(column: &str) -> String {
     format!("COALESCE(json_extract({column}, '$.userVisible'), 1) != 0")
+}
+
+fn agent_visible_message_sql(column: &str) -> String {
+    format!("COALESCE(json_extract({column}, '$.agentVisible'), 1) != 0")
+}
+
+#[derive(Debug, Default)]
+pub struct SessionConversationSearchPage {
+    pub messages: Vec<Message>,
+    pub has_earlier: bool,
+    pub has_later: bool,
+    pub match_id: Option<String>,
+    pub match_created: Option<i64>,
+}
+
+type MessageRow = (String, String, i64, Option<String>, Option<String>);
+
+fn rows_to_messages(rows: Vec<MessageRow>) -> Vec<Message> {
+    let mut messages = Vec::with_capacity(rows.len());
+    for (role_str, content_json, created_timestamp, metadata_json, message_id) in rows {
+        let role = match role_str.as_str() {
+            "user" => Role::User,
+            "assistant" => Role::Assistant,
+            _ => continue,
+        };
+        let Ok(content) = serde_json::from_str(&content_json) else {
+            continue;
+        };
+        let metadata = metadata_json
+            .and_then(|json| serde_json::from_str(&json).ok())
+            .unwrap_or_default();
+        let mut message = Message::new(role, created_timestamp, content);
+        message.metadata = metadata;
+        if let Some(id) = message_id {
+            message = message.with_id(id);
+        }
+        messages.push(message);
+    }
+    messages
 }
 
 fn session_sort_at(session: &Session) -> DateTime<Utc> {
@@ -1822,30 +1887,26 @@ impl SessionStorage {
         let pool = self.pool().await?;
         let visible = user_visible_message_sql("metadata_json");
         let rows = if let Some(before) = before {
-            sqlx::query_as::<_, (String, String, i64, Option<String>, Option<String>)>(
-                AssertSqlSafe(format!(
-                    "SELECT role, content_json, created_timestamp, metadata_json, message_id
+            sqlx::query_as::<_, MessageRow>(AssertSqlSafe(format!(
+                "SELECT role, content_json, created_timestamp, metadata_json, message_id
                      FROM messages
                      WHERE session_id = ? AND {visible} AND created_timestamp < ?
                      ORDER BY created_timestamp DESC, id DESC
                      LIMIT ?"
-                )),
-            )
+            )))
             .bind(session_id)
             .bind(before)
             .bind((limit + 1) as i64)
             .fetch_all(pool)
             .await?
         } else {
-            sqlx::query_as::<_, (String, String, i64, Option<String>, Option<String>)>(
-                AssertSqlSafe(format!(
-                    "SELECT role, content_json, created_timestamp, metadata_json, message_id
+            sqlx::query_as::<_, MessageRow>(AssertSqlSafe(format!(
+                "SELECT role, content_json, created_timestamp, metadata_json, message_id
                      FROM messages
                      WHERE session_id = ? AND {visible}
                      ORDER BY created_timestamp DESC, id DESC
                      LIMIT ?"
-                )),
-            )
+            )))
             .bind(session_id)
             .bind((limit + 1) as i64)
             .fetch_all(pool)
@@ -1853,33 +1914,166 @@ impl SessionStorage {
         };
 
         let has_earlier = rows.len() > limit;
-        let mut messages = Vec::new();
-        for (role_str, content_json, created_timestamp, metadata_json, message_id) in
-            rows.into_iter().take(limit)
-        {
-            let role = match role_str.as_str() {
-                "user" => Role::User,
-                "assistant" => Role::Assistant,
-                _ => continue,
-            };
-            let content = serde_json::from_str(&content_json)?;
-            let metadata = metadata_json
-                .and_then(|json| serde_json::from_str(&json).ok())
-                .unwrap_or_default();
-            let mut message = Message::new(role, created_timestamp, content);
-            message.metadata = metadata;
-            if let Some(id) = message_id {
-                message = message.with_id(id);
-            }
-            messages.push(message);
-        }
+        let mut messages = rows_to_messages(rows.into_iter().take(limit).collect());
         messages.reverse();
         Ok((messages, has_earlier))
     }
 
+    async fn get_user_visible_messages_after(
+        &self,
+        session_id: &str,
+        after: Option<i64>,
+        limit: usize,
+    ) -> Result<(Vec<Message>, bool)> {
+        if limit == 0 {
+            return Ok((Vec::new(), false));
+        }
+
+        let pool = self.pool().await?;
+        let visible = user_visible_message_sql("metadata_json");
+        let rows = if let Some(after) = after {
+            sqlx::query_as::<_, MessageRow>(AssertSqlSafe(format!(
+                "SELECT role, content_json, created_timestamp, metadata_json, message_id
+                     FROM messages
+                     WHERE session_id = ? AND {visible} AND created_timestamp > ?
+                     ORDER BY created_timestamp ASC, id ASC
+                     LIMIT ?"
+            )))
+            .bind(session_id)
+            .bind(after)
+            .bind((limit + 1) as i64)
+            .fetch_all(pool)
+            .await?
+        } else {
+            return self
+                .get_user_visible_messages_before(session_id, None, limit)
+                .await;
+        };
+
+        let has_later = rows.len() > limit;
+        Ok((
+            rows_to_messages(rows.into_iter().take(limit).collect()),
+            has_later,
+        ))
+    }
+
+    async fn search_user_visible_messages(
+        &self,
+        session_id: &str,
+        query: &str,
+        limit: usize,
+    ) -> Result<SessionConversationSearchPage> {
+        let query = query.trim();
+        if query.is_empty() || limit == 0 {
+            return Ok(SessionConversationSearchPage::default());
+        }
+
+        let pool = self.pool().await?;
+        let visible = user_visible_message_sql("metadata_json");
+        let needle = query.to_lowercase();
+        let row: Option<(Option<String>, i64)> = sqlx::query_as(AssertSqlSafe(format!(
+            "SELECT message_id, created_timestamp
+             FROM messages
+             WHERE session_id = ? AND {visible} AND instr(LOWER(content_json), ?) > 0
+             ORDER BY created_timestamp DESC, id DESC
+             LIMIT 1"
+        )))
+        .bind(session_id)
+        .bind(&needle)
+        .fetch_optional(pool)
+        .await?;
+
+        let Some((match_id, match_created)) = row else {
+            return Ok(SessionConversationSearchPage::default());
+        };
+
+        let half = limit / 2;
+        let before_limit = half;
+        let after_limit = limit.saturating_sub(before_limit).saturating_sub(1);
+
+        let older_rows = if before_limit == 0 {
+            Vec::new()
+        } else {
+            sqlx::query_as::<_, MessageRow>(AssertSqlSafe(format!(
+                "SELECT role, content_json, created_timestamp, metadata_json, message_id
+                     FROM messages
+                     WHERE session_id = ? AND {visible} AND created_timestamp < ?
+                     ORDER BY created_timestamp DESC, id DESC
+                     LIMIT ?"
+            )))
+            .bind(session_id)
+            .bind(match_created)
+            .bind((before_limit + 1) as i64)
+            .fetch_all(pool)
+            .await?
+        };
+        let has_earlier = older_rows.len() > before_limit;
+        let mut older = rows_to_messages(older_rows.into_iter().take(before_limit).collect());
+        older.reverse();
+
+        let newer_rows = if after_limit == 0 {
+            Vec::new()
+        } else {
+            sqlx::query_as::<_, MessageRow>(AssertSqlSafe(format!(
+                "SELECT role, content_json, created_timestamp, metadata_json, message_id
+                     FROM messages
+                     WHERE session_id = ? AND {visible} AND created_timestamp > ?
+                     ORDER BY created_timestamp ASC, id ASC
+                     LIMIT ?"
+            )))
+            .bind(session_id)
+            .bind(match_created)
+            .bind((after_limit + 1) as i64)
+            .fetch_all(pool)
+            .await?
+        };
+        let has_later = newer_rows.len() > after_limit;
+        let newer = rows_to_messages(newer_rows.into_iter().take(after_limit).collect());
+
+        let match_rows = sqlx::query_as::<_, MessageRow>(AssertSqlSafe(format!(
+            "SELECT role, content_json, created_timestamp, metadata_json, message_id
+                 FROM messages
+                 WHERE session_id = ? AND {visible} AND created_timestamp = ?
+                 ORDER BY id ASC"
+        )))
+        .bind(session_id)
+        .bind(match_created)
+        .fetch_all(pool)
+        .await?;
+        let matched = rows_to_messages(match_rows);
+
+        let mut messages = older;
+        messages.extend(matched);
+        messages.extend(newer);
+
+        Ok(SessionConversationSearchPage {
+            messages,
+            has_earlier,
+            has_later,
+            match_id,
+            match_created: Some(match_created),
+        })
+    }
+
+    async fn session_has_agent_visible_messages(&self, session_id: &str) -> Result<bool> {
+        let pool = self.pool().await?;
+        let exists: bool = sqlx::query_scalar(AssertSqlSafe(format!(
+            "SELECT EXISTS(
+                SELECT 1 FROM messages
+                WHERE session_id = ? AND {}
+                LIMIT 1
+            )",
+            agent_visible_message_sql("metadata_json")
+        )))
+        .bind(session_id)
+        .fetch_one(pool)
+        .await?;
+        Ok(exists)
+    }
+
     async fn get_conversation(&self, session_id: &str) -> Result<Conversation> {
         let pool = self.pool().await?;
-        let rows = sqlx::query_as::<_, (String, String, i64, Option<String>, Option<String>)>(
+        let rows = sqlx::query_as::<_, MessageRow>(
             // Order by created_timestamp, then by id to break ties. created_timestamp is in seconds,
             // so messages created in the same second (e.g., tool request and response) need to
             // maintain their insertion order via the auto-increment id.
@@ -4464,6 +4658,44 @@ mod tests {
             first_page[0].created - 1
         );
         assert!(older_page.iter().all(|message| message.is_user_visible()));
+    }
+
+    #[tokio::test]
+    async fn test_search_user_visible_messages_returns_window_around_match() {
+        let temp_dir = TempDir::new().unwrap();
+        let sm = SessionManager::new(temp_dir.path().to_path_buf());
+        let id = new_session(&sm).await;
+
+        for index in 0..241 {
+            let role = if index % 2 == 0 {
+                Role::User
+            } else {
+                Role::Assistant
+            };
+            let text = if index == 10 {
+                "unique-search-hit".to_string()
+            } else {
+                format!("m{index}")
+            };
+            let mut message = Message::new(role, 1_700_000_000 + index, vec![]).with_text(text);
+            if index == 3 {
+                message.metadata.user_visible = false;
+            }
+            sm.add_message(&id, &message).await.unwrap();
+        }
+
+        let page = sm
+            .search_user_visible_messages(&id, "unique-search-hit", 80)
+            .await
+            .unwrap();
+        assert!(page
+            .messages
+            .iter()
+            .any(|message| message.as_concat_text() == "unique-search-hit"));
+        assert!(page.messages.len() <= 80);
+        assert!(page.has_later);
+        assert!(!page.has_earlier);
+        assert_eq!(page.messages.first().unwrap().as_concat_text(), "m0");
     }
 
     async fn new_session(sm: &SessionManager) -> String {

--- a/crates/goose/src/session/session_manager.rs
+++ b/crates/goose/src/session/session_manager.rs
@@ -1,14 +1,14 @@
-use crate::config::paths::Paths;
 use crate::config::GooseMode;
-use crate::conversation::message::{Message, MessageUsage, TokenState};
+use crate::config::paths::Paths;
 use crate::conversation::Conversation;
+use crate::conversation::message::{Message, MessageUsage, TokenState};
 use crate::providers::base::CostSource;
 use crate::providers::base::Provider;
 use crate::recipe::Recipe;
 use crate::session::export_markdown::export_session_to_markdown;
 use crate::session::extension_data::ExtensionData;
 use crate::session::session_naming::{
-    generate_session_name, MSG_COUNT_FOR_SESSION_NAME_GENERATION,
+    MSG_COUNT_FOR_SESSION_NAME_GENERATION, generate_session_name,
 };
 use anyhow::Result;
 use chrono::{DateTime, TimeZone, Utc};
@@ -430,6 +430,17 @@ impl SessionManager {
 
     pub async fn get_session(&self, id: &str, include_messages: bool) -> Result<Session> {
         self.storage.get_session(id, include_messages).await
+    }
+
+    pub async fn get_user_visible_messages_before(
+        &self,
+        id: &str,
+        before: Option<i64>,
+        limit: usize,
+    ) -> Result<(Vec<Message>, bool)> {
+        self.storage
+            .get_user_visible_messages_before(id, before, limit)
+            .await
     }
 
     pub fn update(&self, id: &str) -> SessionUpdateBuilder<'_> {
@@ -1796,6 +1807,74 @@ impl SessionStorage {
 
         tx.commit().await?;
         Ok(())
+    }
+
+    async fn get_user_visible_messages_before(
+        &self,
+        session_id: &str,
+        before: Option<i64>,
+        limit: usize,
+    ) -> Result<(Vec<Message>, bool)> {
+        if limit == 0 {
+            return Ok((Vec::new(), false));
+        }
+
+        let pool = self.pool().await?;
+        let visible = user_visible_message_sql("metadata_json");
+        let rows = if let Some(before) = before {
+            sqlx::query_as::<_, (String, String, i64, Option<String>, Option<String>)>(
+                AssertSqlSafe(format!(
+                    "SELECT role, content_json, created_timestamp, metadata_json, message_id
+                     FROM messages
+                     WHERE session_id = ? AND {visible} AND created_timestamp < ?
+                     ORDER BY created_timestamp DESC, id DESC
+                     LIMIT ?"
+                )),
+            )
+            .bind(session_id)
+            .bind(before)
+            .bind((limit + 1) as i64)
+            .fetch_all(pool)
+            .await?
+        } else {
+            sqlx::query_as::<_, (String, String, i64, Option<String>, Option<String>)>(
+                AssertSqlSafe(format!(
+                    "SELECT role, content_json, created_timestamp, metadata_json, message_id
+                     FROM messages
+                     WHERE session_id = ? AND {visible}
+                     ORDER BY created_timestamp DESC, id DESC
+                     LIMIT ?"
+                )),
+            )
+            .bind(session_id)
+            .bind((limit + 1) as i64)
+            .fetch_all(pool)
+            .await?
+        };
+
+        let has_earlier = rows.len() > limit;
+        let mut messages = Vec::new();
+        for (role_str, content_json, created_timestamp, metadata_json, message_id) in
+            rows.into_iter().take(limit)
+        {
+            let role = match role_str.as_str() {
+                "user" => Role::User,
+                "assistant" => Role::Assistant,
+                _ => continue,
+            };
+            let content = serde_json::from_str(&content_json)?;
+            let metadata = metadata_json
+                .and_then(|json| serde_json::from_str(&json).ok())
+                .unwrap_or_default();
+            let mut message = Message::new(role, created_timestamp, content);
+            message.metadata = metadata;
+            if let Some(id) = message_id {
+                message = message.with_id(id);
+            }
+            messages.push(message);
+        }
+        messages.reverse();
+        Ok((messages, has_earlier))
     }
 
     async fn get_conversation(&self, session_id: &str) -> Result<Conversation> {
@@ -4343,6 +4422,48 @@ mod tests {
             is_compaction,
             ..Default::default()
         }
+    }
+
+    #[tokio::test]
+    async fn test_user_visible_messages_before_returns_latest_page() {
+        let temp_dir = TempDir::new().unwrap();
+        let sm = SessionManager::new(temp_dir.path().to_path_buf());
+        let id = new_session(&sm).await;
+
+        for index in 0..241 {
+            let role = if index % 2 == 0 {
+                Role::User
+            } else {
+                Role::Assistant
+            };
+            let mut message =
+                Message::new(role, 1_700_000_000 + index, vec![]).with_text(format!("m{index}"));
+            if index == 3 {
+                message.metadata.user_visible = false;
+            }
+            sm.add_message(&id, &message).await.unwrap();
+        }
+
+        let (first_page, has_earlier) = sm
+            .get_user_visible_messages_before(&id, None, 80)
+            .await
+            .unwrap();
+        assert!(has_earlier);
+        assert_eq!(first_page.len(), 80);
+        assert_eq!(first_page[0].as_concat_text(), "m161");
+        assert_eq!(first_page.last().unwrap().as_concat_text(), "m240");
+
+        let (older_page, has_more) = sm
+            .get_user_visible_messages_before(&id, Some(first_page[0].created), 80)
+            .await
+            .unwrap();
+        assert!(has_more);
+        assert_eq!(older_page.len(), 80);
+        assert_eq!(
+            older_page.last().unwrap().created,
+            first_page[0].created - 1
+        );
+        assert!(older_page.iter().all(|message| message.is_user_visible()));
     }
 
     async fn new_session(sm: &SessionManager) -> String {

--- a/ui/desktop/src/acp/__tests__/chatNotifications.test.ts
+++ b/ui/desktop/src/acp/__tests__/chatNotifications.test.ts
@@ -73,6 +73,7 @@ function snapshotWithName(name: string): AcpChatSessionSnapshot {
     session: sessionWithName(name),
     messages: [],
     hasEarlierMessages: false,
+    hasLaterMessages: false,
     tokenState: {
       inputTokens: 0,
       outputTokens: 0,
@@ -96,6 +97,7 @@ function snapshotWithoutSession(): AcpChatSessionSnapshot {
     session: undefined,
     messages: [],
     hasEarlierMessages: false,
+    hasLaterMessages: false,
     tokenState: {
       inputTokens: 0,
       outputTokens: 0,

--- a/ui/desktop/src/acp/__tests__/chatNotifications.test.ts
+++ b/ui/desktop/src/acp/__tests__/chatNotifications.test.ts
@@ -72,6 +72,7 @@ function snapshotWithName(name: string): AcpChatSessionSnapshot {
   return {
     session: sessionWithName(name),
     messages: [],
+    hasEarlierMessages: false,
     tokenState: {
       inputTokens: 0,
       outputTokens: 0,
@@ -94,6 +95,7 @@ function snapshotWithoutSession(): AcpChatSessionSnapshot {
   return {
     session: undefined,
     messages: [],
+    hasEarlierMessages: false,
     tokenState: {
       inputTokens: 0,
       outputTokens: 0,

--- a/ui/desktop/src/acp/__tests__/chatSessionController.test.ts
+++ b/ui/desktop/src/acp/__tests__/chatSessionController.test.ts
@@ -99,6 +99,7 @@ function snapshotWithActivePrompt(activePromptAttemptId: string | null): AcpChat
   return {
     session: undefined,
     messages: [],
+    hasEarlierMessages: false,
     tokenState: {
       inputTokens: 0,
       outputTokens: 0,

--- a/ui/desktop/src/acp/__tests__/chatSessionController.test.ts
+++ b/ui/desktop/src/acp/__tests__/chatSessionController.test.ts
@@ -100,6 +100,7 @@ function snapshotWithActivePrompt(activePromptAttemptId: string | null): AcpChat
     session: undefined,
     messages: [],
     hasEarlierMessages: false,
+    hasLaterMessages: false,
     tokenState: {
       inputTokens: 0,
       outputTokens: 0,

--- a/ui/desktop/src/acp/__tests__/chatSessionStore.test.ts
+++ b/ui/desktop/src/acp/__tests__/chatSessionStore.test.ts
@@ -540,6 +540,40 @@ describe('acpChatSessionStore', () => {
     expect(finishedSnapshot.messages[0].content).toEqual([{ type: 'text', text: 'Hello' }]);
   });
 
+  it('defers replayed messages until session load finishes', () => {
+    const currentSessionId = sessionId('session-load-defer');
+    const replayedChunk = agentMessageChunkNotification(currentSessionId, 'message-1', 'Hello');
+
+    acpChatSessionActions.startSessionLoad(currentSessionId);
+    const loadingSnapshot = acpChatSessionActions.applyAcpSessionNotification(replayedChunk);
+    expect(loadingSnapshot.messages).toEqual([]);
+
+    const finished = acpChatSessionActions.finishSessionLoad(
+      currentSessionId,
+      session(currentSessionId)
+    );
+    expect(finished.messages).toHaveLength(1);
+    expect(finished.messages[0].content).toEqual([{ type: 'text', text: 'Hello' }]);
+  });
+
+  it('reuses unchanged message objects across streamed snapshots', () => {
+    const currentSessionId = sessionId('session-shared-identity');
+    acpChatSessionActions.setMessages(currentSessionId, [message('user-1', 'Hello')]);
+
+    const firstSnapshot = acpChatSessionActions.applyAcpSessionNotification(
+      agentMessageChunkNotification(currentSessionId, 'assistant-1', 'Hel')
+    );
+    const secondSnapshot = acpChatSessionActions.applyAcpSessionNotification(
+      agentMessageChunkNotification(currentSessionId, 'assistant-1', 'lo')
+    );
+
+    expect(secondSnapshot.messages).toHaveLength(2);
+    expect(secondSnapshot.messages[0]).toBe(firstSnapshot.messages[0]);
+    expect(secondSnapshot.messages[1]).not.toBe(firstSnapshot.messages[1]);
+    expect(secondSnapshot.messages[1].content).toEqual([{ type: 'text', text: 'Hello' }]);
+    expect(firstSnapshot.messages[1].content).toEqual([{ type: 'text', text: 'Hel' }]);
+  });
+
   it('applies permission requests as waiting action-required messages', () => {
     const currentSessionId = sessionId('session-1');
 
@@ -676,6 +710,10 @@ describe('useAcpChatSessionSnapshot', () => {
       acpChatSessionActions.setMessages(sessionId, [nextMessage]);
     });
 
-    expect(result.current?.messages).toEqual([nextMessage]);
+    expect(result.current?.messages).toHaveLength(1);
+    expect(result.current?.messages[0]).toMatchObject({
+      id: nextMessage.id,
+      content: nextMessage.content,
+    });
   });
 });

--- a/ui/desktop/src/acp/__tests__/chatSessionStore.test.ts
+++ b/ui/desktop/src/acp/__tests__/chatSessionStore.test.ts
@@ -9,6 +9,7 @@ import {
   acpChatSessionActions,
   acpPermissionUserInputRequestId,
   acpChatSessionStore,
+  flushAcpChatSessionNotifications,
   useAcpChatSessionSnapshot,
 } from '../chatSessionStore';
 import type { AcpElicitationRequest } from '../elicitationRequests';
@@ -182,6 +183,7 @@ describe('acpChatSessionStore', () => {
   };
 
   afterEach(() => {
+    flushAcpChatSessionNotifications();
     for (const id of sessionIds) {
       acpChatSessionActions.deleteSnapshot(id);
     }
@@ -574,6 +576,28 @@ describe('acpChatSessionStore', () => {
     expect(firstSnapshot.messages[1].content).toEqual([{ type: 'text', text: 'Hel' }]);
   });
 
+  it('coalesces subscriber notifications until the flush', () => {
+    const currentSessionId = sessionId('session-flush');
+    const { result } = renderHook(() => useAcpChatSessionSnapshot(currentSessionId));
+    expect(result.current).toBeUndefined();
+
+    act(() => {
+      acpChatSessionActions.setMessages(currentSessionId, [message('user-1', 'Hello')]);
+      acpChatSessionActions.applyAcpSessionNotification(
+        agentMessageChunkNotification(currentSessionId, 'assistant-1', 'Hel')
+      );
+      acpChatSessionActions.applyAcpSessionNotification(
+        agentMessageChunkNotification(currentSessionId, 'assistant-1', 'lo')
+      );
+    });
+
+    expect(result.current).toBeUndefined();
+    act(() => {
+      flushAcpChatSessionNotifications(currentSessionId);
+    });
+    expect(result.current?.messages).toHaveLength(2);
+  });
+
   it('applies permission requests as waiting action-required messages', () => {
     const currentSessionId = sessionId('session-1');
 
@@ -697,6 +721,7 @@ describe('useAcpChatSessionSnapshot', () => {
   const sessionId = 'hook-session-1';
 
   afterEach(() => {
+    flushAcpChatSessionNotifications();
     acpChatSessionActions.deleteSnapshot(sessionId);
   });
 
@@ -712,6 +737,7 @@ describe('useAcpChatSessionSnapshot', () => {
     expect(snapshot?.messages.map((entry) => entry.id)).toEqual(['older', 'newer']);
     expect(snapshot?.messages[1]).toBe(afterSet?.messages[0]);
     expect(snapshot?.hasEarlierMessages).toBe(true);
+    expect(snapshot?.hasLaterMessages).toBe(false);
   });
 
   it('subscribes to session store snapshots', () => {
@@ -722,6 +748,7 @@ describe('useAcpChatSessionSnapshot', () => {
     const nextMessage = message('message-1', 'Hello from hook');
     act(() => {
       acpChatSessionActions.setMessages(sessionId, [nextMessage]);
+      flushAcpChatSessionNotifications(sessionId);
     });
 
     expect(result.current?.messages).toHaveLength(1);

--- a/ui/desktop/src/acp/__tests__/chatSessionStore.test.ts
+++ b/ui/desktop/src/acp/__tests__/chatSessionStore.test.ts
@@ -700,6 +700,20 @@ describe('useAcpChatSessionSnapshot', () => {
     acpChatSessionActions.deleteSnapshot(sessionId);
   });
 
+  it('prepends older messages without rewriting the live tail', () => {
+    const older = message('older', 'Earlier');
+    const newer = message('newer', 'Later');
+    acpChatSessionActions.setMessages(sessionId, [newer]);
+    const afterSet = acpChatSessionStore.getSnapshot(sessionId);
+    acpChatSessionActions.prependMessages(sessionId, [older]);
+    acpChatSessionActions.setHasEarlierMessages(sessionId, true);
+    const snapshot = acpChatSessionStore.getSnapshot(sessionId);
+
+    expect(snapshot?.messages.map((entry) => entry.id)).toEqual(['older', 'newer']);
+    expect(snapshot?.messages[1]).toBe(afterSet?.messages[0]);
+    expect(snapshot?.hasEarlierMessages).toBe(true);
+  });
+
   it('subscribes to session store snapshots', () => {
     const { result } = renderHook(() => useAcpChatSessionSnapshot(sessionId));
 

--- a/ui/desktop/src/acp/__tests__/cloneMessagesSharingUnchanged.test.ts
+++ b/ui/desktop/src/acp/__tests__/cloneMessagesSharingUnchanged.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import type { Message } from '../../types/message';
+import { cloneMessagesSharingUnchanged } from '../adapter/shared';
+
+function message(id: string, text: string): Message {
+  return {
+    id,
+    role: 'assistant',
+    created: 1,
+    content: [{ type: 'text', text }],
+    metadata: { userVisible: true, agentVisible: true },
+  };
+}
+
+describe('cloneMessagesSharingUnchanged', () => {
+  it('keeps the published object when the live message was not rewritten', () => {
+    const first = message('one', 'hello');
+    const second = message('two', 'wor');
+    const publishedFirst = { ...first, content: [{ ...first.content[0] }] };
+    const nextSecond = message('two', 'world');
+    const publishedByLive = new Map<Message, Message>([[first, publishedFirst]]);
+
+    const previousPublished = [publishedFirst, second];
+    const cloned = cloneMessagesSharingUnchanged(
+      [first, nextSecond],
+      publishedByLive,
+      previousPublished
+    );
+
+    expect(cloned[0]).toBe(publishedFirst);
+    expect(cloned[1]).not.toBe(nextSecond);
+    expect(cloned[1].content).toEqual([{ type: 'text', text: 'world' }]);
+  });
+
+  it('reuses the previous published array when nothing changed', () => {
+    const first = message('one', 'hello');
+    const publishedFirst = { ...first, content: [{ ...first.content[0] }] };
+    const previousPublished = [publishedFirst];
+    const publishedByLive = new Map<Message, Message>([[first, publishedFirst]]);
+
+    const cloned = cloneMessagesSharingUnchanged([first], publishedByLive, previousPublished);
+
+    expect(cloned).toBe(previousPublished);
+  });
+
+  it('clones every message when there is no previous snapshot', () => {
+    const original = message('one', 'hello');
+    const cloned = cloneMessagesSharingUnchanged([original], undefined, undefined);
+
+    expect(cloned).toHaveLength(1);
+    expect(cloned[0]).not.toBe(original);
+    expect(cloned[0]).toEqual(original);
+  });
+});

--- a/ui/desktop/src/acp/adapter/gooseSessionNotifications.ts
+++ b/ui/desktop/src/acp/adapter/gooseSessionNotifications.ts
@@ -1,6 +1,7 @@
 import type { GooseSessionNotification_unstable } from '@aaif/goose-sdk';
 import type { MessageUsage } from '../../types/message';
 import { type AcpChatStateChange, type AdapterState, messagesChange } from './shared';
+import { replaceMessage } from './messages';
 
 export function applyGooseSessionNotification(
   state: AdapterState,
@@ -101,6 +102,9 @@ function applyMessageUsage(
     isCompaction: update.usage.isCompaction,
   };
 
-  target.metadata = { ...target.metadata, usage };
+  replaceMessage(state, target, {
+    ...target,
+    metadata: { ...target.metadata, usage },
+  });
   return messagesChange(state);
 }

--- a/ui/desktop/src/acp/adapter/messages.ts
+++ b/ui/desktop/src/acp/adapter/messages.ts
@@ -51,11 +51,20 @@ export function applyContentChunk(
     }
 
     if (lastContent?.type === 'text' && content.type === 'text') {
-      lastContent.text += content.text;
+      replaceMessage(state, existing, {
+        ...existing,
+        content: [
+          ...existing.content.slice(0, -1),
+          { ...lastContent, text: lastContent.text + content.text },
+        ],
+      });
     } else if (content.type === 'image' && hasImageContent(existing, content)) {
       return messagesChangeWithLocalSteerConfirmation(state, existing, gooseMeta.steer);
     } else {
-      existing.content.push(content);
+      replaceMessage(state, existing, {
+        ...existing,
+        content: [...existing.content, content],
+      });
     }
 
     return messagesChangeWithLocalSteerConfirmation(state, existing, gooseMeta.steer);
@@ -87,26 +96,39 @@ export function applyThoughtChunk(
 
   const gooseMeta = getGooseMessageMeta(update);
   const messageId = update.messageId ?? gooseMeta.messageId;
-  let message = findMessageForChunk(state, 'assistant', messageId, gooseMeta.created);
+  const existing = findMessageForChunk(state, 'assistant', messageId, gooseMeta.created);
 
-  if (!message) {
-    message = {
+  if (existing) {
+    const lastContent = existing.content[existing.content.length - 1];
+    const nextContent =
+      lastContent?.type === 'thinking'
+        ? [
+            ...existing.content.slice(0, -1),
+            { ...lastContent, thinking: lastContent.thinking + update.content.text },
+          ]
+        : [
+            ...existing.content,
+            { type: 'thinking' as const, thinking: update.content.text, signature: '' },
+          ];
+    replaceMessage(state, existing, {
+      ...existing,
+      metadata: {
+        ...existing.metadata,
+        outputTokenLimitReached: gooseMeta.outputTokenLimitReached,
+      },
+      content: nextContent,
+    });
+  } else {
+    state.messages.push({
       ...(messageId ? { id: messageId } : {}),
       role: 'assistant',
       created: gooseMeta.created ?? Math.floor(Date.now() / 1000),
-      content: [],
-      metadata: { ...DEFAULT_VISIBLE_MESSAGE_METADATA },
-    };
-    state.messages.push(message);
-  }
-
-  message.metadata.outputTokenLimitReached = gooseMeta.outputTokenLimitReached;
-
-  const lastContent = message.content[message.content.length - 1];
-  if (lastContent?.type === 'thinking') {
-    lastContent.thinking += update.content.text;
-  } else {
-    message.content.push({ type: 'thinking', thinking: update.content.text, signature: '' });
+      content: [{ type: 'thinking', thinking: update.content.text, signature: '' }],
+      metadata: {
+        ...DEFAULT_VISIBLE_MESSAGE_METADATA,
+        outputTokenLimitReached: gooseMeta.outputTokenLimitReached,
+      },
+    });
   }
 
   return messagesChange(state);
@@ -155,9 +177,11 @@ export function findMessageForChunk(
 
   const pending = lastMergeableMessageWithRole(state, role);
   if (pending && !pending.id) {
-    pending.id = messageId;
-    pending.created = created ?? pending.created;
-    return pending;
+    return replaceMessage(state, pending, {
+      ...pending,
+      id: messageId,
+      created: created ?? pending.created,
+    });
   }
 
   return undefined;
@@ -220,7 +244,20 @@ function reconcileLocalSteerTextChunk(
     state.localSteerTextByMessageId.set(message.id, nextText);
   }
 
-  message.content = [{ ...content, text: nextText }, ...message.content.slice(1)];
-  message.metadata = { ...message.metadata, steer: true };
+  replaceMessage(state, message, {
+    ...message,
+    content: [{ ...content, text: nextText }, ...message.content.slice(1)],
+    metadata: { ...message.metadata, steer: true },
+  });
   return true;
+}
+
+export function replaceMessage(state: AdapterState, previous: Message, next: Message): Message {
+  const index = state.messages.indexOf(previous);
+  if (index === -1) {
+    state.messages.push(next);
+    return next;
+  }
+  state.messages[index] = next;
+  return next;
 }

--- a/ui/desktop/src/acp/adapter/shared.ts
+++ b/ui/desktop/src/acp/adapter/shared.ts
@@ -57,6 +57,40 @@ export function cloneMessage(message: Message): Message {
   };
 }
 
+export function cloneMessagesSharingUnchanged(
+  nextLive: Message[],
+  publishedByLive?: Map<Message, Message>,
+  previousPublished?: Message[]
+): Message[] {
+  if (!publishedByLive || publishedByLive.size === 0) {
+    return nextLive.map(cloneMessage);
+  }
+
+  if (!previousPublished || previousPublished.length === 0) {
+    return nextLive.map((message) => publishedByLive.get(message) ?? cloneMessage(message));
+  }
+
+  let prefixUnchanged = previousPublished.length === nextLive.length;
+  let lastChanged = false;
+  const nextPublished = nextLive.map((message, index) => {
+    const published = publishedByLive.get(message) ?? cloneMessage(message);
+    if (previousPublished[index] !== published) {
+      if (index === nextLive.length - 1) {
+        lastChanged = true;
+      } else {
+        prefixUnchanged = false;
+      }
+    }
+    return published;
+  });
+
+  if (prefixUnchanged && !lastChanged && previousPublished.length === nextPublished.length) {
+    return previousPublished;
+  }
+
+  return nextPublished;
+}
+
 export function getGooseMessageMeta(update: { _meta?: unknown }): GooseMessageMeta {
   if (!isRecord(update._meta)) {
     return {};

--- a/ui/desktop/src/acp/adapter/tools.ts
+++ b/ui/desktop/src/acp/adapter/tools.ts
@@ -5,7 +5,7 @@ import type {
 } from '@agentclientprotocol/sdk';
 import type { Message } from '../../types/message';
 import type { ContentBlock as GooseContentBlock } from '../../types/message';
-import { findMessageForChunk } from './messages';
+import { findMessageForChunk, replaceMessage } from './messages';
 import { toolNotificationChange } from './toolNotifications';
 import {
   type AcpChatStateChange,
@@ -38,18 +38,24 @@ export function applyToolCall(state: AdapterState, update: ToolCall): AcpChatSta
   const identity = toolIdentity(update);
   const metadata = toolRequestMetadata(update, identity);
 
-  message.content.push({
-    type: 'toolRequest',
-    id: update.toolCallId,
-    toolCall: {
-      status: 'success',
-      value: {
-        name: identity.toolName ?? update.title,
-        arguments: rawInputToArguments(update.rawInput),
+  replaceMessage(state, message, {
+    ...message,
+    content: [
+      ...message.content,
+      {
+        type: 'toolRequest',
+        id: update.toolCallId,
+        toolCall: {
+          status: 'success',
+          value: {
+            name: identity.toolName ?? update.title,
+            arguments: rawInputToArguments(update.rawInput),
+          },
+        },
+        ...(metadata ? { metadata } : {}),
+        ...(update._meta ? { _meta: update._meta } : {}),
       },
-    },
-    ...(metadata ? { metadata } : {}),
-    ...(update._meta ? { _meta: update._meta } : {}),
+    ],
   });
 
   return messagesChange(state);
@@ -77,17 +83,23 @@ export function applyToolCallUpdate(
   const identity = toolIdentity(update);
   const metadata = toolResponseMetadata(toolCallState, identity);
 
-  message.content.push({
-    type: 'toolResponse',
-    id: update.toolCallId,
-    toolResult:
-      toolCallState.status === 'failed'
-        ? { status: 'error', error: toolError(toolCallState) }
-        : {
-            status: 'success',
-            value: toolResultValue(toolCallState, mcpAppMetadata(update)),
-          },
-    ...(metadata ? { metadata } : {}),
+  replaceMessage(state, message, {
+    ...message,
+    content: [
+      ...message.content,
+      {
+        type: 'toolResponse',
+        id: update.toolCallId,
+        toolResult:
+          toolCallState.status === 'failed'
+            ? { status: 'error', error: toolError(toolCallState) }
+            : {
+                status: 'success',
+                value: toolResultValue(toolCallState, mcpAppMetadata(update)),
+              },
+        ...(metadata ? { metadata } : {}),
+      },
+    ],
   });
 
   state.toolCallStatesById.delete(update.toolCallId);

--- a/ui/desktop/src/acp/chatSessionController.ts
+++ b/ui/desktop/src/acp/chatSessionController.ts
@@ -162,6 +162,7 @@ async function loadSessionFromServer(
       new CustomEvent(AppEvents.SESSION_EXTENSIONS_LOADED, { detail: { sessionId } })
     );
     acpChatSessionActions.finishSessionLoad(sessionId, sessionInfoToSession(sessionInfo, meta));
+    acpChatSessionActions.setHasEarlierMessages(sessionId, meta.hasEarlier === true);
     options.onSessionLoaded?.();
   } catch (error) {
     console.error('Failed to load ACP session:', error);

--- a/ui/desktop/src/acp/chatSessionStore.ts
+++ b/ui/desktop/src/acp/chatSessionStore.ts
@@ -11,7 +11,7 @@ import {
   type AcpSessionNotificationAdapter,
 } from './sessionNotificationAdapter';
 import type { ElicitationStatus } from './adapter/elicitations';
-import { cloneMessage } from './adapter/shared';
+import { cloneMessage, cloneMessagesSharingUnchanged } from './adapter/shared';
 import type { AcpElicitationRequest } from './elicitationRequests';
 
 export interface AcpChatSessionSnapshot {
@@ -43,6 +43,7 @@ interface StoreEntry extends AcpChatSessionSnapshot {
   // in flight so per-notification reads don't deep-clone the growing message
   // array (see applyAcpSessionNotification / getSnapshot).
   lastSnapshot?: AcpChatSessionSnapshot;
+  publishedByLiveMessage: Map<Message, Message>;
 }
 
 const initialTokenState: TokenState = {
@@ -180,6 +181,7 @@ function createAcpChatSessionStoreInternal(): AcpChatSessionStoreInternal {
       pendingUserInputRequestIds: new Set(),
       pendingLocalSteerMessageIds: new Set(),
       preConfirmedSteerMessageIds: new Set(),
+      publishedByLiveMessage: new Map(),
       adapter: createAcpSessionNotificationAdapter(),
     };
     sessionsById.set(sessionId, entry);
@@ -219,9 +221,13 @@ function createAcpChatSessionStoreInternal(): AcpChatSessionStoreInternal {
     entry.sessionLoadError = undefined;
     entry.progressMessage = undefined;
     // Materialize the replayed conversation in one pass (the per-notification
-    // fast path above skips message copies while loading).
-    entry.messages = entry.adapter.getMessages();
-    retainPendingLocalSteerMessageIds(entry);
+    // fast path below skips message copies while loading). Keep any messages
+    // already written via setMessages when the adapter has nothing yet.
+    const replayedMessages = entry.adapter.getMessages();
+    if (replayedMessages.length > 0) {
+      entry.messages = replayedMessages;
+      retainPendingLocalSteerMessageIds(entry);
+    }
     entry.chatState = entry.activePromptAttemptId ? ChatState.Streaming : ChatState.Idle;
     return notify(sessionId, entry);
   };
@@ -627,7 +633,9 @@ function applyChatStateChanges(entry: StoreEntry, changes: AcpChatStateChange[])
   for (const change of changes) {
     switch (change.type) {
       case 'messages':
-        entry.messages = cloneMessages(change.messages);
+        // Adapter replaces only changed messages and returns the live array.
+        // Unchanged objects keep their identity so React can skip those rows.
+        entry.messages = change.messages;
         retainPendingLocalSteerMessageIds(entry);
         break;
       case 'tokenState':
@@ -678,6 +686,8 @@ function resetReplayState(entry: StoreEntry): void {
   entry.pendingUserInputRequestIds.clear();
   entry.pendingLocalSteerMessageIds.clear();
   entry.preConfirmedSteerMessageIds.clear();
+  entry.publishedByLiveMessage = new Map();
+  entry.lastSnapshot = undefined;
   entry.adapter = createAcpSessionNotificationAdapter();
 }
 
@@ -741,11 +751,33 @@ function confirmedLocalSteerTextByMessageId(entry: StoreEntry): Map<string, stri
 }
 
 function snapshotFromEntry(entry: StoreEntry): AcpChatSessionSnapshot {
+  const messages = cloneMessagesSharingUnchanged(
+    entry.messages,
+    entry.publishedByLiveMessage,
+    entry.lastSnapshot?.messages
+  );
+  entry.publishedByLiveMessage = new Map(
+    entry.messages.map((live, index) => [live, messages[index]])
+  );
+  const previous = entry.lastSnapshot;
+  const notifications =
+    previous &&
+    previous.notifications.length === entry.notifications.length &&
+    previous.notifications.every(
+      (notification, index) => notification === entry.notifications[index]
+    )
+      ? previous.notifications
+      : [...entry.notifications];
+  const tokenState =
+    previous && shallowEqualTokenState(previous.tokenState, entry.tokenState)
+      ? previous.tokenState
+      : { ...entry.tokenState };
+
   return {
     session: entry.session,
-    messages: cloneMessages(entry.messages),
-    tokenState: { ...entry.tokenState },
-    notifications: [...entry.notifications],
+    messages,
+    tokenState,
+    notifications,
     progressMessage: entry.progressMessage,
     chatState: entry.chatState,
     sessionLoadError: entry.sessionLoadError,
@@ -753,6 +785,22 @@ function snapshotFromEntry(entry: StoreEntry): AcpChatSessionSnapshot {
     activeRunId: entry.activeRunId,
     pendingCancelPromptAttemptId: entry.pendingCancelPromptAttemptId,
   };
+}
+
+function shallowEqualTokenState(left: TokenState, right: TokenState): boolean {
+  return (
+    left.inputTokens === right.inputTokens &&
+    left.outputTokens === right.outputTokens &&
+    left.totalTokens === right.totalTokens &&
+    left.accumulatedInputTokens === right.accumulatedInputTokens &&
+    left.accumulatedOutputTokens === right.accumulatedOutputTokens &&
+    left.accumulatedTotalTokens === right.accumulatedTotalTokens &&
+    left.accumulatedCost === right.accumulatedCost &&
+    left.cacheReadTokens === right.cacheReadTokens &&
+    left.cacheWriteTokens === right.cacheWriteTokens &&
+    left.accumulatedCacheReadTokens === right.accumulatedCacheReadTokens &&
+    left.accumulatedCacheWriteTokens === right.accumulatedCacheWriteTokens
+  );
 }
 
 function cloneMessages(messages: Message[]): Message[] {

--- a/ui/desktop/src/acp/chatSessionStore.ts
+++ b/ui/desktop/src/acp/chatSessionStore.ts
@@ -17,6 +17,7 @@ import type { AcpElicitationRequest } from './elicitationRequests';
 export interface AcpChatSessionSnapshot {
   session: Session | undefined;
   messages: Message[];
+  hasEarlierMessages: boolean;
   tokenState: TokenState;
   notifications: NotificationEvent[];
   progressMessage: string | undefined;
@@ -84,6 +85,8 @@ export interface AcpChatSessionActions {
   ): AcpChatSessionSnapshot;
 
   setMessages(sessionId: string, messages: Message[]): AcpChatSessionSnapshot;
+  prependMessages(sessionId: string, messages: Message[]): AcpChatSessionSnapshot;
+  setHasEarlierMessages(sessionId: string, hasEarlierMessages: boolean): AcpChatSessionSnapshot;
   addPendingLocalSteerMessage(sessionId: string, message: Message): AcpChatSessionSnapshot;
   setChatState(sessionId: string, chatState: ChatState): AcpChatSessionSnapshot;
   resolveUserInputRequest(
@@ -169,6 +172,7 @@ function createAcpChatSessionStoreInternal(): AcpChatSessionStoreInternal {
     const entry: StoreEntry = {
       session: undefined,
       messages: [],
+      hasEarlierMessages: false,
       tokenState: { ...initialTokenState },
       notifications: [],
       progressMessage: undefined,
@@ -228,6 +232,7 @@ function createAcpChatSessionStoreInternal(): AcpChatSessionStoreInternal {
       entry.messages = replayedMessages;
       retainPendingLocalSteerMessageIds(entry);
     }
+    entry.hasEarlierMessages = session.message_count > replayedMessages.length;
     entry.chatState = entry.activePromptAttemptId ? ChatState.Streaming : ChatState.Idle;
     return notify(sessionId, entry);
   };
@@ -248,6 +253,28 @@ function createAcpChatSessionStoreInternal(): AcpChatSessionStoreInternal {
     entry.messages = cloneMessages(messages);
     retainPendingLocalSteerMessageIds(entry);
     entry.adapter = createAdapterForEntry(entry);
+    return notify(sessionId, entry);
+  };
+
+  const prependMessages: AcpChatSessionActions['prependMessages'] = (sessionId, messages) => {
+    const entry = getOrCreateEntry(sessionId);
+    if (messages.length === 0) {
+      return notify(sessionId, entry);
+    }
+    const existingIds = new Set(entry.messages.map((message) => message.id).filter(Boolean));
+    const older = messages.filter((message) => !message.id || !existingIds.has(message.id));
+    entry.messages = [...cloneMessages(older), ...entry.messages];
+    retainPendingLocalSteerMessageIds(entry);
+    entry.adapter = createAdapterForEntry(entry);
+    return notify(sessionId, entry);
+  };
+
+  const setHasEarlierMessages: AcpChatSessionActions['setHasEarlierMessages'] = (
+    sessionId,
+    hasEarlierMessages
+  ) => {
+    const entry = getOrCreateEntry(sessionId);
+    entry.hasEarlierMessages = hasEarlierMessages;
     return notify(sessionId, entry);
   };
 
@@ -537,6 +564,8 @@ function createAcpChatSessionStoreInternal(): AcpChatSessionStoreInternal {
     failSessionLoad,
     setSessionLoadError,
     setMessages,
+    prependMessages,
+    setHasEarlierMessages,
     addPendingLocalSteerMessage,
     setChatState,
     resolveUserInputRequest,
@@ -615,6 +644,8 @@ function actionsFromStore(store: AcpChatSessionStoreInternal): AcpChatSessionAct
     failSessionLoad: store.failSessionLoad,
     setSessionLoadError: store.setSessionLoadError,
     setMessages: store.setMessages,
+    prependMessages: store.prependMessages,
+    setHasEarlierMessages: store.setHasEarlierMessages,
     addPendingLocalSteerMessage: store.addPendingLocalSteerMessage,
     setChatState: store.setChatState,
     resolveUserInputRequest: store.resolveUserInputRequest,
@@ -677,6 +708,7 @@ function shouldClearProgressMessage(notification: SessionNotification): boolean 
 
 function resetReplayState(entry: StoreEntry): void {
   entry.messages = [];
+  entry.hasEarlierMessages = false;
   entry.tokenState = { ...initialTokenState };
   entry.notifications = [];
   entry.progressMessage = undefined;
@@ -776,6 +808,7 @@ function snapshotFromEntry(entry: StoreEntry): AcpChatSessionSnapshot {
   return {
     session: entry.session,
     messages,
+    hasEarlierMessages: entry.hasEarlierMessages,
     tokenState,
     notifications,
     progressMessage: entry.progressMessage,

--- a/ui/desktop/src/acp/chatSessionStore.ts
+++ b/ui/desktop/src/acp/chatSessionStore.ts
@@ -18,6 +18,7 @@ export interface AcpChatSessionSnapshot {
   session: Session | undefined;
   messages: Message[];
   hasEarlierMessages: boolean;
+  hasLaterMessages: boolean;
   tokenState: TokenState;
   notifications: NotificationEvent[];
   progressMessage: string | undefined;
@@ -86,7 +87,14 @@ export interface AcpChatSessionActions {
 
   setMessages(sessionId: string, messages: Message[]): AcpChatSessionSnapshot;
   prependMessages(sessionId: string, messages: Message[]): AcpChatSessionSnapshot;
+  appendMessages(sessionId: string, messages: Message[]): AcpChatSessionSnapshot;
+  replaceWindow(
+    sessionId: string,
+    messages: Message[],
+    flags?: { hasEarlier?: boolean; hasLater?: boolean }
+  ): AcpChatSessionSnapshot;
   setHasEarlierMessages(sessionId: string, hasEarlierMessages: boolean): AcpChatSessionSnapshot;
+  setHasLaterMessages(sessionId: string, hasLaterMessages: boolean): AcpChatSessionSnapshot;
   addPendingLocalSteerMessage(sessionId: string, message: Message): AcpChatSessionSnapshot;
   setChatState(sessionId: string, chatState: ChatState): AcpChatSessionSnapshot;
   resolveUserInputRequest(
@@ -115,11 +123,15 @@ export interface AcpChatSessionActions {
 
 interface AcpChatSessionStoreInternal extends AcpChatSessionStore, AcpChatSessionActions {
   subscribe(sessionId: string, listener: (snapshot: AcpChatSessionSnapshot) => void): () => void;
+  flushPendingNotifications(sessionId?: string): void;
 }
+
+const ACP_NOTIFY_FLUSH_MS = 32;
 
 function createAcpChatSessionStoreInternal(): AcpChatSessionStoreInternal {
   const sessionsById = new Map<string, StoreEntry>();
   const listenersBySessionId = new Map<string, Set<SnapshotListener>>();
+  const pendingFlushBySessionId = new Map<string, ReturnType<typeof setTimeout>>();
 
   const getSnapshot: AcpChatSessionStore['getSnapshot'] = (sessionId) => {
     const entry = sessionsById.get(sessionId);
@@ -160,6 +172,11 @@ function createAcpChatSessionStoreInternal(): AcpChatSessionStoreInternal {
   };
 
   const deleteSnapshot: AcpChatSessionActions['deleteSnapshot'] = (sessionId) => {
+    const pending = pendingFlushBySessionId.get(sessionId);
+    if (pending !== undefined) {
+      clearTimeout(pending);
+      pendingFlushBySessionId.delete(sessionId);
+    }
     sessionsById.delete(sessionId);
   };
 
@@ -173,6 +190,7 @@ function createAcpChatSessionStoreInternal(): AcpChatSessionStoreInternal {
       session: undefined,
       messages: [],
       hasEarlierMessages: false,
+      hasLaterMessages: false,
       tokenState: { ...initialTokenState },
       notifications: [],
       progressMessage: undefined,
@@ -192,7 +210,7 @@ function createAcpChatSessionStoreInternal(): AcpChatSessionStoreInternal {
     return entry;
   };
 
-  const notify = (sessionId: string, entry: StoreEntry): AcpChatSessionSnapshot => {
+  const publish = (sessionId: string, entry: StoreEntry): AcpChatSessionSnapshot => {
     const snapshot = snapshotFromEntry(entry);
     entry.lastSnapshot = snapshot;
     const listeners = listenersBySessionId.get(sessionId);
@@ -202,6 +220,47 @@ function createAcpChatSessionStoreInternal(): AcpChatSessionStoreInternal {
       }
     }
     return snapshot;
+  };
+
+  const notify = (sessionId: string, entry: StoreEntry): AcpChatSessionSnapshot => {
+    const snapshot = snapshotFromEntry(entry);
+    entry.lastSnapshot = snapshot;
+    if (pendingFlushBySessionId.has(sessionId)) {
+      return snapshot;
+    }
+    pendingFlushBySessionId.set(
+      sessionId,
+      setTimeout(() => {
+        pendingFlushBySessionId.delete(sessionId);
+        const current = sessionsById.get(sessionId);
+        if (current) {
+          publish(sessionId, current);
+        }
+      }, ACP_NOTIFY_FLUSH_MS)
+    );
+    return snapshot;
+  };
+
+  const flushPendingNotifications = (sessionId?: string) => {
+    const flushOne = (id: string) => {
+      const pending = pendingFlushBySessionId.get(id);
+      if (pending === undefined) {
+        return;
+      }
+      clearTimeout(pending);
+      pendingFlushBySessionId.delete(id);
+      const current = sessionsById.get(id);
+      if (current) {
+        publish(id, current);
+      }
+    };
+    if (sessionId) {
+      flushOne(sessionId);
+      return;
+    }
+    for (const id of [...pendingFlushBySessionId.keys()]) {
+      flushOne(id);
+    }
   };
 
   const setSessionMetadata: AcpChatSessionActions['setSessionMetadata'] = (sessionId, session) => {
@@ -233,6 +292,7 @@ function createAcpChatSessionStoreInternal(): AcpChatSessionStoreInternal {
       retainPendingLocalSteerMessageIds(entry);
     }
     entry.hasEarlierMessages = session.message_count > replayedMessages.length;
+    entry.hasLaterMessages = false;
     entry.chatState = entry.activePromptAttemptId ? ChatState.Streaming : ChatState.Idle;
     return notify(sessionId, entry);
   };
@@ -269,12 +329,52 @@ function createAcpChatSessionStoreInternal(): AcpChatSessionStoreInternal {
     return notify(sessionId, entry);
   };
 
+  const appendMessages: AcpChatSessionActions['appendMessages'] = (sessionId, messages) => {
+    const entry = getOrCreateEntry(sessionId);
+    if (messages.length === 0) {
+      return notify(sessionId, entry);
+    }
+    const existingIds = new Set(entry.messages.map((message) => message.id).filter(Boolean));
+    const newer = messages.filter((message) => !message.id || !existingIds.has(message.id));
+    entry.messages = [...entry.messages, ...cloneMessages(newer)];
+    retainPendingLocalSteerMessageIds(entry);
+    entry.adapter = createAdapterForEntry(entry);
+    return notify(sessionId, entry);
+  };
+
+  const replaceWindow: AcpChatSessionActions['replaceWindow'] = (
+    sessionId,
+    messages,
+    flags
+  ) => {
+    const entry = getOrCreateEntry(sessionId);
+    entry.messages = cloneMessages(messages);
+    retainPendingLocalSteerMessageIds(entry);
+    entry.adapter = createAdapterForEntry(entry);
+    if (flags?.hasEarlier !== undefined) {
+      entry.hasEarlierMessages = flags.hasEarlier;
+    }
+    if (flags?.hasLater !== undefined) {
+      entry.hasLaterMessages = flags.hasLater;
+    }
+    return notify(sessionId, entry);
+  };
+
   const setHasEarlierMessages: AcpChatSessionActions['setHasEarlierMessages'] = (
     sessionId,
     hasEarlierMessages
   ) => {
     const entry = getOrCreateEntry(sessionId);
     entry.hasEarlierMessages = hasEarlierMessages;
+    return notify(sessionId, entry);
+  };
+
+  const setHasLaterMessages: AcpChatSessionActions['setHasLaterMessages'] = (
+    sessionId,
+    hasLaterMessages
+  ) => {
+    const entry = getOrCreateEntry(sessionId);
+    entry.hasLaterMessages = hasLaterMessages;
     return notify(sessionId, entry);
   };
 
@@ -523,7 +623,9 @@ function createAcpChatSessionStoreInternal(): AcpChatSessionStoreInternal {
       acpPermissionUserInputRequestId(request.toolCall.toolCallId)
     );
     entry.chatState = ChatState.WaitingForUserInput;
-    return notify(request.sessionId, entry);
+    const snapshot = notify(request.sessionId, entry);
+    flushPendingNotifications(request.sessionId);
+    return snapshot;
   };
 
   const applyElicitationRequest: AcpChatSessionActions['applyElicitationRequest'] = (request) => {
@@ -532,7 +634,9 @@ function createAcpChatSessionStoreInternal(): AcpChatSessionStoreInternal {
     applyChatStateChanges(entry, changes);
     entry.pendingUserInputRequestIds.add(acpElicitationUserInputRequestId(request.id));
     entry.chatState = ChatState.WaitingForUserInput;
-    return notify(request.sessionId, entry);
+    const snapshot = notify(request.sessionId, entry);
+    flushPendingNotifications(request.sessionId);
+    return snapshot;
   };
 
   const setElicitationStatus: AcpChatSessionActions['setElicitationStatus'] = (
@@ -565,7 +669,10 @@ function createAcpChatSessionStoreInternal(): AcpChatSessionStoreInternal {
     setSessionLoadError,
     setMessages,
     prependMessages,
+    appendMessages,
+    replaceWindow,
     setHasEarlierMessages,
+    setHasLaterMessages,
     addPendingLocalSteerMessage,
     setChatState,
     resolveUserInputRequest,
@@ -582,6 +689,7 @@ function createAcpChatSessionStoreInternal(): AcpChatSessionStoreInternal {
     applyPermissionRequest,
     applyElicitationRequest,
     setElicitationStatus,
+    flushPendingNotifications,
   };
 }
 
@@ -594,6 +702,10 @@ export const acpChatSessionStore: AcpChatSessionStore = storeFromInternal(
 export const acpChatSessionActions: AcpChatSessionActions = actionsFromStore(
   acpChatSessionStoreInternal
 );
+
+export function flushAcpChatSessionNotifications(sessionId?: string): void {
+  acpChatSessionStoreInternal.flushPendingNotifications(sessionId);
+}
 
 interface AcpChatSessionSnapshotState {
   sessionId: string;
@@ -645,7 +757,10 @@ function actionsFromStore(store: AcpChatSessionStoreInternal): AcpChatSessionAct
     setSessionLoadError: store.setSessionLoadError,
     setMessages: store.setMessages,
     prependMessages: store.prependMessages,
+    appendMessages: store.appendMessages,
+    replaceWindow: store.replaceWindow,
     setHasEarlierMessages: store.setHasEarlierMessages,
+    setHasLaterMessages: store.setHasLaterMessages,
     addPendingLocalSteerMessage: store.addPendingLocalSteerMessage,
     setChatState: store.setChatState,
     resolveUserInputRequest: store.resolveUserInputRequest,
@@ -709,6 +824,7 @@ function shouldClearProgressMessage(notification: SessionNotification): boolean 
 function resetReplayState(entry: StoreEntry): void {
   entry.messages = [];
   entry.hasEarlierMessages = false;
+  entry.hasLaterMessages = false;
   entry.tokenState = { ...initialTokenState };
   entry.notifications = [];
   entry.progressMessage = undefined;
@@ -809,6 +925,7 @@ function snapshotFromEntry(entry: StoreEntry): AcpChatSessionSnapshot {
     session: entry.session,
     messages,
     hasEarlierMessages: entry.hasEarlierMessages,
+    hasLaterMessages: entry.hasLaterMessages,
     tokenState,
     notifications,
     progressMessage: entry.progressMessage,

--- a/ui/desktop/src/acp/sessions.ts
+++ b/ui/desktop/src/acp/sessions.ts
@@ -10,6 +10,7 @@ import type { GooseExtension, SessionExportFormat, SessionImportSource } from '@
 import { getAcpClient } from './acpConnection';
 import type { ExtensionLoadResult } from '../types/extensions';
 import type { Session } from '../types/session';
+import type { Message } from '../types/message';
 import type { Recipe } from '../recipe';
 
 interface GooseSessionInfoMeta {
@@ -52,6 +53,7 @@ export interface LoadSessionMeta {
   userRecipeValues?: Record<string, string> | null;
   extensionResults?: ExtensionLoadResult[] | null;
   workingDir?: string;
+  hasEarlier?: boolean;
 }
 
 export interface AcpLoadSessionResult {
@@ -69,6 +71,7 @@ function parseSessionResponseMeta(rawMeta: unknown): LoadSessionMeta {
     userRecipeValues: meta.userRecipeValues,
     extensionResults: meta.extensionResults,
     workingDir: typeof meta.workingDir === 'string' ? meta.workingDir : undefined,
+    hasEarlier: meta.hasEarlier === true,
   };
 }
 
@@ -175,6 +178,28 @@ export async function acpGetSessionListItem(sessionId: string): Promise<SessionL
   const client = await getAcpClient();
   const response = await client.goose.sessionInfo_unstable({ sessionId });
   return sessionInfoToListItem(response.session);
+}
+
+export async function acpGetSessionConversation(
+  sessionId: string,
+  before?: number | null,
+  limit = 80
+): Promise<{ messages: Message[]; hasEarlier: boolean; nextBefore: number | null }> {
+  const client = await getAcpClient();
+  const response = await client.connection.agent.request<{
+    messages?: Message[];
+    hasEarlier?: boolean;
+    nextBefore?: number | null;
+  }>('_goose/unstable/session/conversation/get', {
+    sessionId,
+    ...(before != null ? { before } : {}),
+    limit,
+  });
+  return {
+    messages: Array.isArray(response.messages) ? response.messages : [],
+    hasEarlier: response.hasEarlier === true,
+    nextBefore: typeof response.nextBefore === 'number' ? response.nextBefore : null,
+  };
 }
 
 export async function acpLoadSession(sessionId: string): Promise<AcpLoadSessionResult> {

--- a/ui/desktop/src/acp/sessions.ts
+++ b/ui/desktop/src/acp/sessions.ts
@@ -180,24 +180,65 @@ export async function acpGetSessionListItem(sessionId: string): Promise<SessionL
   return sessionInfoToListItem(response.session);
 }
 
-export async function acpGetSessionConversation(
+export async function acpSearchSessionConversation(
   sessionId: string,
-  before?: number | null,
+  query: string,
   limit = 80
-): Promise<{ messages: Message[]; hasEarlier: boolean; nextBefore: number | null }> {
+): Promise<{
+  messages: Message[];
+  hasEarlier: boolean;
+  hasLater: boolean;
+  matchId: string | null;
+  matchCreated: number | null;
+}> {
   const client = await getAcpClient();
   const response = await client.connection.agent.request<{
     messages?: Message[];
     hasEarlier?: boolean;
-    nextBefore?: number | null;
-  }>('_goose/unstable/session/conversation/get', {
+    hasLater?: boolean;
+    matchId?: string | null;
+    matchCreated?: number | null;
+  }>('_goose/unstable/session/conversation/search', {
     sessionId,
-    ...(before != null ? { before } : {}),
+    query,
     limit,
   });
   return {
     messages: Array.isArray(response.messages) ? response.messages : [],
     hasEarlier: response.hasEarlier === true,
+    hasLater: response.hasLater === true,
+    matchId: typeof response.matchId === 'string' ? response.matchId : null,
+    matchCreated: typeof response.matchCreated === 'number' ? response.matchCreated : null,
+  };
+}
+
+export async function acpGetSessionConversation(
+  sessionId: string,
+  before?: number | null,
+  limit = 80,
+  after?: number | null
+): Promise<{
+  messages: Message[];
+  hasEarlier: boolean;
+  hasLater: boolean;
+  nextBefore: number | null;
+}> {
+  const client = await getAcpClient();
+  const response = await client.connection.agent.request<{
+    messages?: Message[];
+    hasEarlier?: boolean;
+    hasLater?: boolean;
+    nextBefore?: number | null;
+  }>('_goose/unstable/session/conversation/get', {
+    sessionId,
+    ...(before != null ? { before } : {}),
+    ...(after != null ? { after } : {}),
+    limit,
+  });
+  return {
+    messages: Array.isArray(response.messages) ? response.messages : [],
+    hasEarlier: response.hasEarlier === true,
+    hasLater: response.hasLater === true,
     nextBefore: typeof response.nextBefore === 'number' ? response.nextBefore : null,
   };
 }

--- a/ui/desktop/src/components/BaseChat.tsx
+++ b/ui/desktop/src/components/BaseChat.tsx
@@ -118,6 +118,8 @@ export default function BaseChat({
     pauseQueueOnStop,
     queueProcessingBlocked,
     onMessageUpdate,
+    hasEarlierMessages,
+    loadEarlierMessages,
   } = useChatSession({
     sessionId,
     onStreamFinish,
@@ -487,6 +489,8 @@ export default function BaseChat({
                     onRenderingComplete={handleRenderingComplete}
                     onMessageUpdate={onMessageUpdate}
                     submitElicitationResponse={submitElicitationResponse}
+                    hasEarlierMessages={hasEarlierMessages}
+                    onLoadEarlierMessages={loadEarlierMessages}
                   />
                 </SearchView>
 

--- a/ui/desktop/src/components/BaseChat.tsx
+++ b/ui/desktop/src/components/BaseChat.tsx
@@ -266,6 +266,16 @@ export default function BaseChat({
   const initialRenderRef = useRef(true);
 
   // Auto-scroll when messages are loaded (for session resuming)
+  const appendMessage = useCallback(
+    (text: string) => {
+      handleSubmit({ msg: text, images: [] });
+    },
+    [handleSubmit]
+  );
+
+  const isUserMessage = useCallback((message: Message) => message.role === 'user', []);
+  const chat = useMemo(() => ({ sessionId }), [sessionId]);
+
   const handleRenderingComplete = React.useCallback(() => {
     // Only force scroll on the very first render
     if (initialRenderRef.current && messages.length > 0) {
@@ -455,7 +465,7 @@ export default function BaseChat({
             {recipe && (
               <div className={hasStartedUsingRecipe ? 'mb-6' : ''}>
                 <RecipeActivities
-                  append={(text: string) => handleSubmit({ msg: text, images: [] })}
+                  append={appendMessage}
                   activities={Array.isArray(recipe.activities) ? recipe.activities : null}
                   title={recipe.title}
                   parameterValues={session?.user_recipe_values || {}}
@@ -467,11 +477,12 @@ export default function BaseChat({
               <>
                 <SearchView>
                   <ProgressiveMessageList
+                    key={sessionId}
                     messages={messages}
-                    chat={{ sessionId }}
+                    chat={chat}
                     toolCallNotifications={toolCallNotifications}
-                    append={(text: string) => handleSubmit({ msg: text, images: [] })}
-                    isUserMessage={(m: Message) => m.role === 'user'}
+                    append={appendMessage}
+                    isUserMessage={isUserMessage}
                     isStreamingMessage={chatState !== ChatState.Idle}
                     onRenderingComplete={handleRenderingComplete}
                     onMessageUpdate={onMessageUpdate}

--- a/ui/desktop/src/components/BaseChat.tsx
+++ b/ui/desktop/src/components/BaseChat.tsx
@@ -91,6 +91,8 @@ export default function BaseChat({
   const [hasNotAcceptedRecipe, setHasNotAcceptedRecipe] = useState<boolean>();
   const [hasRecipeSecurityWarnings, setHasRecipeSecurityWarnings] = useState(false);
   const [acpRecovering, setAcpRecovering] = useState(isAcpRecovering);
+  const [searchMatchKey, setSearchMatchKey] = useState<string | null>(null);
+  const searchRequestIdRef = useRef(0);
   const isMobile = useIsMobile();
   const navContext = useNavigationContextSafe();
   const setView = useNavigation();
@@ -119,11 +121,42 @@ export default function BaseChat({
     queueProcessingBlocked,
     onMessageUpdate,
     hasEarlierMessages,
+    hasLaterMessages,
     loadEarlierMessages,
+    loadLaterMessages,
+    searchMessages,
   } = useChatSession({
     sessionId,
     onStreamFinish,
   });
+
+  useEffect(() => {
+    setSearchMatchKey(null);
+    searchRequestIdRef.current += 1;
+  }, [sessionId]);
+
+  const handleTranscriptSearch = useCallback(
+    (term: string) => {
+      const requestId = ++searchRequestIdRef.current;
+      window.setTimeout(() => {
+        void (async () => {
+          if (searchRequestIdRef.current !== requestId) {
+            return;
+          }
+          if (!term.trim()) {
+            setSearchMatchKey(null);
+            await searchMessages('');
+            return;
+          }
+          const matchKey = await searchMessages(term);
+          if (searchRequestIdRef.current === requestId) {
+            setSearchMatchKey(matchKey);
+          }
+        })();
+      }, 200);
+    },
+    [searchMessages]
+  );
 
   const handleWorkingDirChange = useCallback(
     async (newDir: string) => {
@@ -279,18 +312,24 @@ export default function BaseChat({
   const chat = useMemo(() => ({ sessionId }), [sessionId]);
 
   const handleRenderingComplete = React.useCallback(() => {
-    // Only force scroll on the very first render
     if (initialRenderRef.current && messages.length > 0) {
       initialRenderRef.current = false;
-      if (scrollRef.current?.scrollToBottom) {
-        scrollRef.current.scrollToBottom();
-      }
-    } else if (scrollRef.current?.isFollowing) {
-      if (scrollRef.current?.scrollToBottom) {
-        scrollRef.current.scrollToBottom();
-      }
+      scrollRef.current?.scrollToBottom();
+      return;
+    }
+    if (scrollRef.current?.isFollowing) {
+      scrollRef.current.scrollToBottom();
     }
   }, [messages.length]);
+
+  useEffect(() => {
+    if (chatState !== ChatState.Idle) {
+      return;
+    }
+    if (scrollRef.current?.isFollowing) {
+      scrollRef.current.scrollToBottom();
+    }
+  }, [chatState]);
 
   // Listen for global scroll-to-bottom requests (e.g., from MCP App message actions)
   useEffect(() => {
@@ -477,7 +516,7 @@ export default function BaseChat({
 
             {messages.length > 0 || recipe ? (
               <>
-                <SearchView>
+                <SearchView onSearch={handleTranscriptSearch}>
                   <ProgressiveMessageList
                     key={sessionId}
                     messages={messages}
@@ -490,7 +529,10 @@ export default function BaseChat({
                     onMessageUpdate={onMessageUpdate}
                     submitElicitationResponse={submitElicitationResponse}
                     hasEarlierMessages={hasEarlierMessages}
+                    hasLaterMessages={hasLaterMessages}
                     onLoadEarlierMessages={loadEarlierMessages}
+                    onLoadLaterMessages={loadLaterMessages}
+                    searchMatchKey={searchMatchKey}
                   />
                 </SearchView>
 

--- a/ui/desktop/src/components/GooseMessage.tsx
+++ b/ui/desktop/src/components/GooseMessage.tsx
@@ -9,12 +9,9 @@ import {
   getTextAndImageContent,
   getThinkingContent,
   getToolRequests,
-  getToolResponses,
   getToolConfirmationContent,
   getElicitationContent,
-  getPendingToolConfirmationIds,
   getAnyToolConfirmationData,
-  ToolConfirmationData,
   NotificationEvent,
   type Message,
 } from '../types/message';
@@ -23,16 +20,23 @@ import ElicitationRequest from './ElicitationRequest';
 import MessageCopyLink from './MessageCopyLink';
 import MessageUsageStats from './MessageUsageStats';
 import { cn } from '../utils';
-import { identifyConsecutiveToolCalls, shouldHideTimestamp } from '../utils/toolCallChaining';
+import { laterPairingChanged } from '../utils/messagePairing';
+import {
+  messageNotificationsChanged,
+  messageToolLookupsChanged,
+  type ToolCallLookups,
+} from '../utils/toolCallChaining';
 
-interface GooseMessageProps {
+export interface GooseMessageProps {
   sessionId: string;
   message: Message;
-  messages: Message[];
+  messages?: Message[];
+  lookups?: ToolCallLookups;
   metadata?: string[];
   toolCallNotifications: Map<string, NotificationEvent[]>;
   append: (value: string) => void;
   isStreaming: boolean;
+  hideTimestamp?: boolean;
   submitElicitationResponse?: (
     elicitationId: string,
     userData: Record<string, unknown>
@@ -42,10 +46,11 @@ interface GooseMessageProps {
 function GooseMessage({
   sessionId,
   message,
-  messages,
+  lookups,
   toolCallNotifications,
   append,
   isStreaming,
+  hideTimestamp,
   submitElicitationResponse,
 }: GooseMessageProps) {
   const contentRef = useRef<HTMLDivElement | null>(null);
@@ -60,26 +65,9 @@ function GooseMessage({
 
   const timestamp = useMemo(() => formatMessageTimestamp(message.created), [message.created]);
   const toolRequests = getToolRequests(message);
-  const messageIndex = messages.findIndex((msg) => msg.id === message.id);
   const toolConfirmationContent = getToolConfirmationContent(message);
   const elicitationContent = getElicitationContent(message);
-
-  const findConfirmationForToolAcrossMessages = (
-    toolRequestId: string
-  ): ToolConfirmationData | undefined => {
-    for (const msg of messages) {
-      const confirmationData = getAnyToolConfirmationData(msg);
-      if (confirmationData && confirmationData.id === toolRequestId) {
-        return confirmationData;
-      }
-    }
-    return undefined;
-  };
-  const toolCallChains = useMemo(() => identifyConsecutiveToolCalls(messages), [messages]);
-  const hideTimestamp = useMemo(
-    () => shouldHideTimestamp(messageIndex, toolCallChains),
-    [messageIndex, toolCallChains]
-  );
+  const shouldHideMessageTimestamp = hideTimestamp ?? false;
   const hasToolConfirmation = toolConfirmationContent !== undefined;
   const hasElicitation = elicitationContent !== undefined;
   const outputTokenLimitNotice = isOutputTokenLimitFallback
@@ -93,40 +81,11 @@ function GooseMessage({
         })
       : undefined;
 
-  const toolConfirmationShownInline = useMemo(() => {
-    if (!toolConfirmationContent) return false;
-    const confirmationData = getAnyToolConfirmationData(message);
-    if (!confirmationData) return false;
-
-    for (const msg of messages) {
-      const requests = getToolRequests(msg);
-      if (requests.some((req) => req.id === confirmationData.id)) {
-        return true;
-      }
-    }
-    return false;
-  }, [toolConfirmationContent, message, messages]);
-
-  const toolResponsesMap = useMemo(() => {
-    const responseMap = new Map();
-
-    if (messageIndex !== undefined && messageIndex >= 0) {
-      for (let i = messageIndex + 1; i < messages.length; i++) {
-        const responses = getToolResponses(messages[i]);
-
-        for (const response of responses) {
-          const matchingRequest = toolRequests.find((req) => req.id === response.id);
-          if (matchingRequest) {
-            responseMap.set(response.id, response);
-          }
-        }
-      }
-    }
-
-    return responseMap;
-  }, [messages, messageIndex, toolRequests]);
-
-  const pendingConfirmationIds = getPendingToolConfirmationIds(messages);
+  const confirmationData = getAnyToolConfirmationData(message);
+  const toolConfirmationShownInline = Boolean(
+    confirmationData && lookups?.requestIds.has(confirmationData.id)
+  );
+  const pendingConfirmationIds = lookups?.pendingConfirmationIds;
 
   return (
     <div className="goose-message flex w-[90%] justify-start min-w-0">
@@ -186,17 +145,20 @@ function GooseMessage({
             <div className="relative flex flex-col w-full group">
               <div className="flex flex-col gap-3">
                 {toolRequests.map((toolRequest) => {
-                  const hasResponse = toolResponsesMap.has(toolRequest.id);
-                  const isPending = pendingConfirmationIds.has(toolRequest.id);
-                  const confirmationContent = findConfirmationForToolAcrossMessages(toolRequest.id);
-                  const isApprovalClicked = confirmationContent && !isPending && hasResponse;
+                  const toolResponse = lookups?.responsesById.get(toolRequest.id);
+                  const hasResponse = toolResponse !== undefined;
+                  const isPending = pendingConfirmationIds?.has(toolRequest.id) ?? false;
+                  const confirmationContent = lookups?.confirmationsById.get(toolRequest.id);
+                  const isApprovalClicked = Boolean(
+                    confirmationContent && !isPending && hasResponse
+                  );
                   return (
                     <div className="goose-message-tool" key={toolRequest.id}>
                       <ToolCallWithResponse
                         sessionId={sessionId}
                         isCancelledMessage={false}
                         toolRequest={toolRequest}
-                        toolResponse={toolResponsesMap.get(toolRequest.id)}
+                        toolResponse={toolResponse}
                         notifications={toolCallNotifications.get(toolRequest.id)}
                         isStreamingMessage={isStreaming}
                         isPendingApproval={isPending}
@@ -216,7 +178,7 @@ function GooseMessage({
                       'transition-all duration-200 group-hover:-translate-y-4 group-hover:opacity-0'
                   )}
                 >
-                  {!isStreaming && !hideTimestamp && timestamp}
+                  {!isStreaming && !shouldHideMessageTimestamp && timestamp}
                 </div>
                 {!isStreaming && message.metadata.usage && (
                   <div className="pt-1 transition-all duration-200 opacity-0 group-hover:opacity-100 -translate-y-4 group-hover:translate-y-0">
@@ -256,4 +218,44 @@ function GooseMessage({
   );
 }
 
-export default memo(GooseMessage);
+function gooseMessagePropsAreEqual(
+  previous: GooseMessageProps,
+  next: GooseMessageProps
+): boolean {
+  if (
+    previous.message !== next.message ||
+    previous.sessionId !== next.sessionId ||
+    previous.isStreaming !== next.isStreaming ||
+    previous.hideTimestamp !== next.hideTimestamp ||
+    previous.append !== next.append ||
+    previous.submitElicitationResponse !== next.submitElicitationResponse
+  ) {
+    return false;
+  }
+
+  if (
+    previous.lookups &&
+    next.lookups &&
+    messageToolLookupsChanged(next.message, previous.lookups, next.lookups)
+  ) {
+    return false;
+  }
+
+  if (
+    messageNotificationsChanged(
+      next.message,
+      previous.toolCallNotifications,
+      next.toolCallNotifications
+    )
+  ) {
+    return false;
+  }
+
+  if (!previous.messages || !next.messages || previous.messages === next.messages) {
+    return true;
+  }
+
+  return !laterPairingChanged(previous.messages, next.messages, next.message);
+}
+
+export default memo(GooseMessage, gooseMessagePropsAreEqual);

--- a/ui/desktop/src/components/ProgressiveMessageList.test.tsx
+++ b/ui/desktop/src/components/ProgressiveMessageList.test.tsx
@@ -1,0 +1,188 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Message } from '../types/message';
+import { IntlTestWrapper } from '../i18n/test-utils';
+import ProgressiveMessageList from './ProgressiveMessageList';
+
+const gooseMessageRenderCounts = new Map<string, number>();
+
+vi.mock('./GooseMessage', async () => {
+  const React = await import('react');
+  const MockGooseMessage = ({ message }: { message: Message }) => {
+    const id = message.id ?? 'unknown';
+    gooseMessageRenderCounts.set(id, (gooseMessageRenderCounts.get(id) ?? 0) + 1);
+    return <div data-testid={`assistant-${id}`}>{id}</div>;
+  };
+  return { default: React.memo(MockGooseMessage) };
+});
+
+vi.mock('./UserMessage', () => ({
+  default: ({ message }: { message: Message }) => (
+    <div data-testid={`user-${message.id}`}>{message.id}</div>
+  ),
+}));
+
+function visibleMessage(id: string, role: Message['role'] = 'user'): Message {
+  return {
+    id,
+    role,
+    created: 1,
+    content: [{ type: 'text', text: id }],
+    metadata: { userVisible: true, agentVisible: true },
+  };
+}
+
+function renderList(messages: Message[], visibleWindow = 2) {
+  return render(
+    <ProgressiveMessageList
+      messages={messages}
+      chat={{ sessionId: 'session-1' }}
+      isUserMessage={(message) => message.role === 'user'}
+      visibleWindow={visibleWindow}
+    />,
+    { wrapper: IntlTestWrapper }
+  );
+}
+
+describe('ProgressiveMessageList', () => {
+  beforeEach(() => {
+    gooseMessageRenderCounts.clear();
+  });
+
+  it('renders only the latest window of a long transcript', () => {
+    renderList(
+      [
+        visibleMessage('m1'),
+        visibleMessage('m2', 'assistant'),
+        visibleMessage('m3'),
+        visibleMessage('m4', 'assistant'),
+        visibleMessage('m5'),
+      ],
+      2
+    );
+
+    expect(screen.queryByTestId('user-m1')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('assistant-m2')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('user-m3')).not.toBeInTheDocument();
+    expect(screen.getByTestId('assistant-m4')).toBeInTheDocument();
+    expect(screen.getByTestId('user-m5')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /3 hidden/i })).toBeInTheDocument();
+  });
+
+  it('pages earlier messages in without mounting the full history', async () => {
+    const user = userEvent.setup();
+    renderList(
+      Array.from({ length: 5 }, (_, index) =>
+        visibleMessage(`m${index + 1}`, index % 2 === 0 ? 'user' : 'assistant')
+      ),
+      2
+    );
+
+    await user.click(screen.getByRole('button', { name: /3 hidden/i }));
+
+    expect(screen.queryByTestId('user-m1')).not.toBeInTheDocument();
+    expect(screen.getByTestId('assistant-m2')).toBeInTheDocument();
+    expect(screen.getByTestId('user-m5')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /1 hidden/i })).toBeInTheDocument();
+  });
+
+  it('keeps following the live edge until the user expands history', () => {
+    const { rerender } = renderList(
+      [visibleMessage('m1'), visibleMessage('m2', 'assistant'), visibleMessage('m3')],
+      2
+    );
+
+    expect(screen.queryByTestId('user-m1')).not.toBeInTheDocument();
+    expect(screen.getByTestId('assistant-m2')).toBeInTheDocument();
+    expect(screen.getByTestId('user-m3')).toBeInTheDocument();
+
+    rerender(
+      <ProgressiveMessageList
+        messages={[
+          visibleMessage('m1'),
+          visibleMessage('m2', 'assistant'),
+          visibleMessage('m3'),
+          visibleMessage('m4', 'assistant'),
+        ]}
+        chat={{ sessionId: 'session-1' }}
+        isUserMessage={(message) => message.role === 'user'}
+        visibleWindow={2}
+      />
+    );
+
+    expect(screen.queryByTestId('user-m1')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('assistant-m2')).not.toBeInTheDocument();
+    expect(screen.getByTestId('user-m3')).toBeInTheDocument();
+    expect(screen.getByTestId('assistant-m4')).toBeInTheDocument();
+  });
+
+  it('keeps an expanded earlier page visible when a new message arrives', async () => {
+    const user = userEvent.setup();
+    const { rerender } = renderList(
+      Array.from({ length: 5 }, (_, index) =>
+        visibleMessage(`m${index + 1}`, index % 2 === 0 ? 'user' : 'assistant')
+      ),
+      2
+    );
+
+    await user.click(screen.getByRole('button', { name: /3 hidden/i }));
+    expect(screen.getByTestId('assistant-m2')).toBeInTheDocument();
+
+    rerender(
+      <ProgressiveMessageList
+        messages={Array.from({ length: 6 }, (_, index) =>
+          visibleMessage(`m${index + 1}`, index % 2 === 0 ? 'user' : 'assistant')
+        )}
+        chat={{ sessionId: 'session-1' }}
+        isUserMessage={(message) => message.role === 'user'}
+        visibleWindow={2}
+      />
+    );
+
+    expect(screen.getByTestId('assistant-m2')).toBeInTheDocument();
+    expect(screen.getByTestId('assistant-m6')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /1 hidden/i })).toBeInTheDocument();
+  });
+
+  it('does not remount earlier assistant rows when only the last message streams', () => {
+    const first = visibleMessage('m1');
+    const earlierAssistant = visibleMessage('m2', 'assistant');
+    const streaming = visibleMessage('m3', 'assistant');
+
+    const { rerender } = renderList([first, earlierAssistant, streaming], 3);
+    expect(gooseMessageRenderCounts.get('m2')).toBe(1);
+    expect(gooseMessageRenderCounts.get('m3')).toBe(1);
+
+    rerender(
+      <ProgressiveMessageList
+        messages={[first, earlierAssistant, visibleMessage('m3', 'assistant')]}
+        chat={{ sessionId: 'session-1' }}
+        isUserMessage={(message) => message.role === 'user'}
+        visibleWindow={3}
+      />
+    );
+
+    expect(gooseMessageRenderCounts.get('m2')).toBe(1);
+    expect(gooseMessageRenderCounts.get('m3')).toBe(2);
+  });
+
+  it('expands the full transcript when search is triggered', async () => {
+    const user = userEvent.setup();
+    renderList(
+      [
+        visibleMessage('m1'),
+        visibleMessage('m2', 'assistant'),
+        visibleMessage('m3'),
+        visibleMessage('m4', 'assistant'),
+      ],
+      2
+    );
+
+    await user.keyboard('{Meta>}f{/Meta}');
+
+    expect(screen.getByTestId('user-m1')).toBeInTheDocument();
+    expect(screen.getByTestId('assistant-m4')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /hidden/i })).not.toBeInTheDocument();
+  });
+});

--- a/ui/desktop/src/components/ProgressiveMessageList.test.tsx
+++ b/ui/desktop/src/components/ProgressiveMessageList.test.tsx
@@ -85,6 +85,7 @@ describe('ProgressiveMessageList', () => {
     expect(screen.getByTestId('assistant-m2')).toBeInTheDocument();
     expect(screen.getByTestId('user-m5')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /1 hidden/i })).toBeInTheDocument();
+    expect(document.querySelector('[data-transcript-anchor="m4"]')).toBeInTheDocument();
   });
 
   it('keeps following the live edge until the user expands history', () => {

--- a/ui/desktop/src/components/ProgressiveMessageList.test.tsx
+++ b/ui/desktop/src/components/ProgressiveMessageList.test.tsx
@@ -83,9 +83,11 @@ describe('ProgressiveMessageList', () => {
 
     expect(screen.queryByTestId('user-m1')).not.toBeInTheDocument();
     expect(screen.getByTestId('assistant-m2')).toBeInTheDocument();
-    expect(screen.getByTestId('user-m5')).toBeInTheDocument();
+    expect(screen.getByTestId('user-m3')).toBeInTheDocument();
+    expect(screen.queryByTestId('user-m5')).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: /1 hidden/i })).toBeInTheDocument();
-    expect(document.querySelector('[data-transcript-anchor="m4"]')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /later/i })).toBeInTheDocument();
+    expect(document.querySelector('[data-transcript-anchor="m2"]')).toBeInTheDocument();
   });
 
   it('keeps following the live edge until the user expands history', () => {
@@ -142,8 +144,10 @@ describe('ProgressiveMessageList', () => {
     );
 
     expect(screen.getByTestId('assistant-m2')).toBeInTheDocument();
-    expect(screen.getByTestId('assistant-m6')).toBeInTheDocument();
+    expect(screen.getByTestId('user-m3')).toBeInTheDocument();
+    expect(screen.queryByTestId('assistant-m6')).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: /1 hidden/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /later/i })).toBeInTheDocument();
   });
 
   it('does not remount earlier assistant rows when only the last message streams', () => {
@@ -215,22 +219,65 @@ describe('ProgressiveMessageList', () => {
     expect(gooseMessageRenderCounts.get('m80')).toBe(2);
   });
 
-  it('expands the full transcript when search is triggered', async () => {
-    const user = userEvent.setup();
-    renderList(
-      [
-        visibleMessage('m1'),
-        visibleMessage('m2', 'assistant'),
-        visibleMessage('m3'),
-        visibleMessage('m4', 'assistant'),
-      ],
-      2
+  it('notifies the parent when a streaming turn finishes so the live edge can re-pin', () => {
+    vi.useFakeTimers();
+    const onRenderingComplete = vi.fn();
+    const messages = [
+      visibleMessage('m1'),
+      visibleMessage('m2', 'assistant'),
+    ];
+
+    const { rerender } = render(
+      <ProgressiveMessageList
+        messages={messages}
+        chat={{ sessionId: 'session-1' }}
+        isUserMessage={(message) => message.role === 'user'}
+        isStreamingMessage
+        onRenderingComplete={onRenderingComplete}
+      />,
+      { wrapper: IntlTestWrapper }
     );
 
-    await user.keyboard('{Meta>}f{/Meta}');
+    vi.advanceTimersByTime(50);
+    expect(onRenderingComplete).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <ProgressiveMessageList
+        messages={messages}
+        chat={{ sessionId: 'session-1' }}
+        isUserMessage={(message) => message.role === 'user'}
+        isStreamingMessage={false}
+        onRenderingComplete={onRenderingComplete}
+      />
+    );
+
+    vi.advanceTimersByTime(50);
+    expect(onRenderingComplete).toHaveBeenCalledTimes(2);
+    vi.useRealTimers();
+  });
+
+  it('jumps to a search match without mounting the full transcript', () => {
+    const messages = Array.from({ length: 8 }, (_, index) =>
+      visibleMessage(`m${index + 1}`, index % 2 === 0 ? 'user' : 'assistant')
+    );
+
+    const { rerender } = renderList(messages, 2);
+    expect(screen.queryByTestId('assistant-m2')).not.toBeInTheDocument();
+
+    rerender(
+      <ProgressiveMessageList
+        messages={messages}
+        chat={{ sessionId: 'session-1' }}
+        isUserMessage={(message) => message.role === 'user'}
+        visibleWindow={2}
+        searchMatchKey="m2"
+      />
+    );
 
     expect(screen.getByTestId('user-m1')).toBeInTheDocument();
-    expect(screen.getByTestId('assistant-m4')).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: /hidden/i })).not.toBeInTheDocument();
+    expect(screen.getByTestId('assistant-m2')).toBeInTheDocument();
+    expect(screen.queryByTestId('user-m3')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('assistant-m8')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /later/i })).toBeInTheDocument();
   });
 });

--- a/ui/desktop/src/components/ProgressiveMessageList.test.tsx
+++ b/ui/desktop/src/components/ProgressiveMessageList.test.tsx
@@ -167,6 +167,53 @@ describe('ProgressiveMessageList', () => {
     expect(gooseMessageRenderCounts.get('m3')).toBe(2);
   });
 
+  it('keeps a 241-message session inside the default 80-message window', () => {
+    const messages = Array.from({ length: 241 }, (_, index) =>
+      visibleMessage(`m${index + 1}`, index % 2 === 0 ? 'user' : 'assistant')
+    );
+
+    render(
+      <ProgressiveMessageList
+        messages={messages}
+        chat={{ sessionId: 'session-1' }}
+        isUserMessage={(message) => message.role === 'user'}
+      />,
+      { wrapper: IntlTestWrapper }
+    );
+
+    expect(screen.queryByTestId('user-m1')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('assistant-m161')).not.toBeInTheDocument();
+    expect(screen.getByTestId('assistant-m162')).toBeInTheDocument();
+    expect(screen.getByTestId('user-m241')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /161 hidden/i })).toBeInTheDocument();
+    expect(screen.getAllByTestId(/^(user|assistant)-m\d+$/)).toHaveLength(80);
+  });
+
+  it('does not remount earlier rows while a long session streams', () => {
+    const messages = Array.from({ length: 80 }, (_, index) =>
+      visibleMessage(`m${index + 1}`, index % 2 === 0 ? 'user' : 'assistant')
+    );
+    const earlierAssistant = messages[77];
+    const streaming = messages[79];
+
+    const { rerender } = renderList(messages, 80);
+    expect(gooseMessageRenderCounts.get(earlierAssistant.id ?? '')).toBe(1);
+    expect(gooseMessageRenderCounts.get(streaming.id ?? '')).toBe(1);
+
+    const nextMessages = messages.slice(0, -1).concat([visibleMessage('m80', 'assistant')]);
+    rerender(
+      <ProgressiveMessageList
+        messages={nextMessages}
+        chat={{ sessionId: 'session-1' }}
+        isUserMessage={(message) => message.role === 'user'}
+        visibleWindow={80}
+      />
+    );
+
+    expect(gooseMessageRenderCounts.get(earlierAssistant.id ?? '')).toBe(1);
+    expect(gooseMessageRenderCounts.get('m80')).toBe(2);
+  });
+
   it('expands the full transcript when search is triggered', async () => {
     const user = userEvent.setup();
     renderList(

--- a/ui/desktop/src/components/ProgressiveMessageList.tsx
+++ b/ui/desktop/src/components/ProgressiveMessageList.tsx
@@ -1,20 +1,12 @@
 /**
  * ProgressiveMessageList Component
  *
- * A performance-optimized message list that renders messages progressively
- * to prevent UI blocking when loading long chat sessions. This component
- * renders messages in batches with a loading indicator, maintaining full
- * compatibility with the search functionality.
- *
- * Key Features:
- * - Progressive rendering in configurable batches
- * - Loading indicator during batch processing
- * - Maintains search functionality compatibility
- * - Smooth user experience with responsive UI
- * - Configurable batch size and delay
+ * Renders a window of the transcript instead of mounting every historical
+ * message. Long sessions start at the latest N messages; older history is
+ * paged in with "Show earlier" or expanded fully for search.
  */
 
-import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Fragment, memo, useEffect, useMemo, useState } from 'react';
 import { defineMessages, useIntl } from '../i18n';
 import GooseMessage from './GooseMessage';
 import UserMessage from './UserMessage';
@@ -32,15 +24,29 @@ import type {
   NotificationEvent,
   SystemNotificationContent,
 } from '../types/message';
-import LoadingGoose from './LoadingGoose';
 import { ChatType } from '../types/chat';
-import { identifyConsecutiveToolCalls, isInChain } from '../utils/toolCallChaining';
+import {
+  buildToolCallLookups,
+  getPreviousResolvedModels,
+  identifyConsecutiveToolCalls,
+  isInChain,
+  messageNotificationsChanged,
+  messageToolLookupsChanged,
+  shouldHideTimestamp,
+  type ToolCallLookups,
+} from '../utils/toolCallChaining';
 import { getModelDisplayName } from './settings/models/predefinedModelsUtils';
+import {
+  DEFAULT_VISIBLE_MESSAGE_WINDOW,
+  earlierTranscriptWindowStart,
+  initialTranscriptWindowStart,
+  visibleTranscriptWindowStart,
+} from '../utils/transcriptWindow';
 
 const i18n = defineMessages({
-  loadingMessages: {
-    id: 'progressiveMessageList.loadingMessages',
-    defaultMessage: 'Loading messages... ({renderedCount}/{totalCount})',
+  showEarlier: {
+    id: 'progressiveMessageList.showEarlier',
+    defaultMessage: 'Show earlier messages ({hiddenCount} hidden)',
   },
   searchHint: {
     id: 'progressiveMessageList.searchHint',
@@ -55,197 +61,239 @@ const i18n = defineMessages({
 interface ProgressiveMessageListProps {
   messages: Message[];
   chat: Pick<ChatType, 'sessionId'>;
-  toolCallNotifications?: Map<string, NotificationEvent[]>; // Make optional
-  append?: (value: string) => void; // Make optional
+  toolCallNotifications?: Map<string, NotificationEvent[]>;
+  append?: (value: string) => void;
   isUserMessage: (message: Message) => boolean;
-  batchSize?: number;
-  batchDelay?: number;
-  showLoadingThreshold?: number; // Only show loading if more than X messages
-  // Custom render function for messages
+  visibleWindow?: number;
   renderMessage?: (message: Message, index: number) => React.ReactNode | null;
-  isStreamingMessage?: boolean; // Whether messages are currently being streamed
+  isStreamingMessage?: boolean;
   onMessageUpdate?: (
     messageId: string,
     newContent: string,
     editType: 'fork' | 'edit',
     retainedImages: ImageData[]
   ) => void;
-  onRenderingComplete?: () => void; // Callback when all messages are rendered
+  onRenderingComplete?: () => void;
   submitElicitationResponse?: (
     elicitationId: string,
     userData: Record<string, unknown>
   ) => Promise<boolean>;
 }
 
-export default function ProgressiveMessageList({
+const EMPTY_TOOL_CALL_NOTIFICATIONS = new Map<string, NotificationEvent[]>();
+
+function noopAppend() {}
+
+function hasOnlyToolResponses(message: Message) {
+  return message.content.every((content) => content.type === 'toolResponse');
+}
+
+function getSystemNotification(message: Message): SystemNotificationContent | undefined {
+  return getCreditsExhaustedNotification(message) ?? getInlineSystemNotification(message);
+}
+
+function renderSystemNotification(notification: SystemNotificationContent) {
+  switch (notification.notificationType) {
+    case 'creditsExhausted':
+      return <CreditsExhaustedNotification notification={notification} />;
+    case 'inlineMessage':
+      return <SystemNotificationInline notification={notification} />;
+    default:
+      return null;
+  }
+}
+
+interface MessageRowProps {
+  message: Message;
+  index: number;
+  chatSessionId: string;
+  isUser: boolean;
+  messageIsInChain: boolean;
+  hideTimestamp: boolean;
+  currentResolvedModel: string | null;
+  previousResolvedModel: string | null;
+  lookups: ToolCallLookups;
+  toolCallNotifications: Map<string, NotificationEvent[]>;
+  append: (value: string) => void;
+  isStreaming: boolean;
+  onMessageUpdate?: ProgressiveMessageListProps['onMessageUpdate'];
+  submitElicitationResponse?: ProgressiveMessageListProps['submitElicitationResponse'];
+}
+
+function messageRowPropsAreEqual(previous: MessageRowProps, next: MessageRowProps): boolean {
+  if (
+    previous.message !== next.message ||
+    previous.index !== next.index ||
+    previous.chatSessionId !== next.chatSessionId ||
+    previous.isUser !== next.isUser ||
+    previous.messageIsInChain !== next.messageIsInChain ||
+    previous.hideTimestamp !== next.hideTimestamp ||
+    previous.currentResolvedModel !== next.currentResolvedModel ||
+    previous.previousResolvedModel !== next.previousResolvedModel ||
+    previous.append !== next.append ||
+    previous.isStreaming !== next.isStreaming ||
+    previous.onMessageUpdate !== next.onMessageUpdate ||
+    previous.submitElicitationResponse !== next.submitElicitationResponse
+  ) {
+    return false;
+  }
+
+  return (
+    !messageToolLookupsChanged(next.message, previous.lookups, next.lookups) &&
+    !messageNotificationsChanged(
+      next.message,
+      previous.toolCallNotifications,
+      next.toolCallNotifications
+    )
+  );
+}
+
+const MessageRow = memo(function MessageRow({
+  message,
+  index,
+  chatSessionId,
+  isUser,
+  messageIsInChain,
+  hideTimestamp,
+  currentResolvedModel,
+  previousResolvedModel,
+  lookups,
+  toolCallNotifications,
+  append,
+  isStreaming,
+  onMessageUpdate,
+  submitElicitationResponse,
+}: MessageRowProps) {
+  const intl = useIntl();
+  const notification = getSystemNotification(message);
+  if (notification) {
+    return (
+      <div
+        className={`relative ${index === 0 ? 'mt-0' : 'mt-4'} assistant`}
+        data-testid="message-container"
+      >
+        {renderSystemNotification(notification)}
+      </div>
+    );
+  }
+
+  const showModelChangeDisclosure = Boolean(
+    currentResolvedModel && previousResolvedModel && currentResolvedModel !== previousResolvedModel
+  );
+
+  return (
+    <Fragment>
+      {showModelChangeDisclosure && currentResolvedModel && previousResolvedModel && (
+        <SystemNotificationInline
+          notification={{
+            msg: intl.formatMessage(i18n.modelChanged, {
+              previousModel: getModelDisplayName(previousResolvedModel),
+              currentModel: getModelDisplayName(currentResolvedModel),
+            }),
+            notificationType: 'inlineMessage',
+          }}
+        />
+      )}
+      <div
+        className={`relative ${index === 0 ? 'mt-0' : 'mt-4'} ${isUser ? 'user' : 'assistant'} ${messageIsInChain ? 'in-chain' : ''}`}
+        data-testid="message-container"
+      >
+        {isUser ? (
+          !hasOnlyToolResponses(message) && (
+            <UserMessage message={message} onMessageUpdate={onMessageUpdate} />
+          )
+        ) : (
+          <GooseMessage
+            sessionId={chatSessionId}
+            message={message}
+            lookups={lookups}
+            append={append}
+            toolCallNotifications={toolCallNotifications}
+            hideTimestamp={hideTimestamp}
+            isStreaming={isStreaming}
+            submitElicitationResponse={submitElicitationResponse}
+          />
+        )}
+      </div>
+    </Fragment>
+  );
+}, messageRowPropsAreEqual);
+
+function ProgressiveMessageList({
   messages,
   chat,
-  toolCallNotifications = new Map(),
-  append = () => {},
+  toolCallNotifications = EMPTY_TOOL_CALL_NOTIFICATIONS,
+  append = noopAppend,
   isUserMessage,
-  batchSize = 20,
-  batchDelay = 20,
-  showLoadingThreshold = 50,
-  renderMessage, // Custom render function
-  isStreamingMessage = false, // Whether messages are currently being streamed
+  visibleWindow = DEFAULT_VISIBLE_MESSAGE_WINDOW,
+  renderMessage,
+  isStreamingMessage = false,
   onMessageUpdate,
   onRenderingComplete,
   submitElicitationResponse,
 }: ProgressiveMessageListProps) {
   const intl = useIntl();
-  const [renderedCount, setRenderedCount] = useState(() => {
-    // Initialize with either all messages (if small) or first batch (if large)
-    return messages.length <= showLoadingThreshold
-      ? messages.length
-      : Math.min(batchSize, messages.length);
+  const [showAllMessages, setShowAllMessages] = useState(false);
+  const [pinnedToLiveEdge, setPinnedToLiveEdge] = useState(true);
+  const [windowStart, setWindowStart] = useState(() =>
+    initialTranscriptWindowStart(messages.length, visibleWindow)
+  );
+
+  const effectiveWindowStart = visibleTranscriptWindowStart({
+    messageCount: messages.length,
+    showAll: showAllMessages,
+    pinnedToLiveEdge,
+    windowStart,
+    visibleWindow,
   });
-  const [isLoading, setIsLoading] = useState(() => messages.length > showLoadingThreshold);
-  const timeoutRef = useRef<number | null>(null);
-  const mountedRef = useRef(true);
-  const hasOnlyToolResponses = (message: Message) =>
-    message.content.every((c) => c.type === 'toolResponse');
 
-  const getResolvedModel = useCallback((message: Message): string | null => {
-    if (message.role !== 'assistant' || !message.metadata.userVisible) return null;
-    return message.metadata.inference?.resolvedModel ?? null;
-  }, []);
-
-  const getPreviousResolvedModel = useCallback(
-    (index: number): string | null => {
-      for (let i = index - 1; i >= 0; i--) {
-        const model = getResolvedModel(messages[i]);
-        if (model) return model;
-      }
-      return null;
-    },
-    [getResolvedModel, messages]
-  );
-
-  const renderModelChangeDisclosure = useCallback(
-    (previousModel: string, currentModel: string) => (
-      <SystemNotificationInline
-        notification={{
-          msg: intl.formatMessage(i18n.modelChanged, {
-            previousModel: getModelDisplayName(previousModel),
-            currentModel: getModelDisplayName(currentModel),
-          }),
-          notificationType: 'inlineMessage',
-        }}
-      />
-    ),
-    [intl]
-  );
-
-  const getSystemNotification = (message: Message): SystemNotificationContent | undefined => {
-    return getCreditsExhaustedNotification(message) ?? getInlineSystemNotification(message);
-  };
-
-  const renderSystemNotification = (notification: SystemNotificationContent) => {
-    switch (notification.notificationType) {
-      case 'creditsExhausted':
-        return <CreditsExhaustedNotification notification={notification} />;
-      case 'inlineMessage':
-        return <SystemNotificationInline notification={notification} />;
-      default:
-        return null;
-    }
-  };
-
-  // Simple progressive loading - start immediately when component mounts if needed
   useEffect(() => {
-    if (messages.length <= showLoadingThreshold) {
-      setRenderedCount(messages.length);
-      setIsLoading(false);
-      // For small lists, call completion callback immediately
-      if (onRenderingComplete) {
-        setTimeout(() => onRenderingComplete(), 50);
-      }
+    if (!onRenderingComplete) {
       return;
     }
+    const timeoutId = window.setTimeout(() => onRenderingComplete(), 50);
+    return () => window.clearTimeout(timeoutId);
+  }, [messages.length, onRenderingComplete, windowStart]);
 
-    // Large list - start progressive loading
-    const loadNextBatch = () => {
-      setRenderedCount((current) => {
-        const nextCount = Math.min(current + batchSize, messages.length);
-
-        if (nextCount >= messages.length) {
-          setIsLoading(false);
-          // Call the completion callback after a brief delay to ensure DOM is updated
-          if (onRenderingComplete) {
-            setTimeout(() => onRenderingComplete(), 50);
-          }
-        } else {
-          // Schedule next batch
-          timeoutRef.current = window.setTimeout(loadNextBatch, batchDelay);
-        }
-
-        return nextCount;
-      });
-    };
-
-    // Start loading after a short delay
-    timeoutRef.current = window.setTimeout(loadNextBatch, batchDelay);
-
-    return () => {
-      if (timeoutRef.current) {
-        window.clearTimeout(timeoutRef.current);
-        timeoutRef.current = null;
-      }
-    };
-  }, [
-    messages.length,
-    batchSize,
-    batchDelay,
-    showLoadingThreshold,
-    renderedCount,
-    onRenderingComplete,
-  ]);
-
-  // Cleanup on unmount
   useEffect(() => {
-    mountedRef.current = true;
-    return () => {
-      mountedRef.current = false;
-      if (timeoutRef.current) {
-        window.clearTimeout(timeoutRef.current);
-      }
-    };
-  }, []);
-
-  // Force complete rendering when search is active
-  useEffect(() => {
-    // Only add listener if we're actually loading
-    if (!isLoading) {
-      return;
-    }
-
-    const handleKeyDown = (e: KeyboardEvent) => {
+    const handleKeyDown = (event: KeyboardEvent) => {
       const isMac = window.electron.platform === 'darwin';
-      const isSearchShortcut = (isMac ? e.metaKey : e.ctrlKey) && e.key === 'f';
-
+      const isSearchShortcut = (isMac ? event.metaKey : event.ctrlKey) && event.key === 'f';
       if (isSearchShortcut) {
-        // Immediately render all messages when search is triggered
-        setRenderedCount(messages.length);
-        setIsLoading(false);
-        if (timeoutRef.current) {
-          window.clearTimeout(timeoutRef.current);
-          timeoutRef.current = null;
-        }
+        setShowAllMessages(true);
       }
     };
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [isLoading, messages.length]);
+  }, []);
 
-  // Detect tool call chains
   const toolCallChains = useMemo(() => identifyConsecutiveToolCalls(messages), [messages]);
+  const previousResolvedModels = useMemo(() => getPreviousResolvedModels(messages), [messages]);
+  const toolCallLookups = useMemo(() => buildToolCallLookups(messages), [messages]);
+  const hiddenCount = effectiveWindowStart;
+  const messagesToRender = messages.slice(effectiveWindowStart);
 
-  // Render messages up to the current rendered count
-  const renderMessages = useCallback(() => {
-    const messagesToRender = messages.slice(0, renderedCount);
-    return messagesToRender
-      .map((message, index) => {
+  return (
+    <>
+      {hiddenCount > 0 && (
+        <div className="flex flex-col items-center justify-center py-3">
+          <button
+            type="button"
+            className="text-xs text-text-secondary hover:text-text-primary underline-offset-2 hover:underline"
+            onClick={() => {
+              setPinnedToLiveEdge(false);
+              setWindowStart(earlierTranscriptWindowStart(effectiveWindowStart, visibleWindow));
+            }}
+          >
+            {intl.formatMessage(i18n.showEarlier, { hiddenCount })}
+          </button>
+          <div className="text-xs text-text-muted mt-1">{intl.formatMessage(i18n.searchHint)}</div>
+        </div>
+      )}
+
+      {messagesToRender.map((message, windowIndex) => {
+        const index = effectiveWindowStart + windowIndex;
         if (!message.metadata.userVisible) {
           return null;
         }
@@ -253,109 +301,40 @@ export default function ProgressiveMessageList({
           return renderMessage(message, index);
         }
 
-        // Default rendering logic (for BaseChat)
-        if (!chat) {
-          console.warn(
-            'ProgressiveMessageList: chat prop is required when not using custom renderMessage'
-          );
-          return null;
-        }
-
-        const notification = getSystemNotification(message);
-        if (notification) {
-          return (
-            <div
-              key={`notification-${message.id ?? `msg-${index}-${message.created}`}`}
-              className={`relative ${index === 0 ? 'mt-0' : 'mt-4'} assistant`}
-              data-testid="message-container"
-            >
-              {renderSystemNotification(notification)}
-            </div>
-          );
-        }
-
-        const isUser = isUserMessage(message);
-        const messageIsInChain = isInChain(index, toolCallChains);
-        const currentResolvedModel = getResolvedModel(message);
-        const previousResolvedModel = currentResolvedModel ? getPreviousResolvedModel(index) : null;
-        const showModelChangeDisclosure = Boolean(
-          currentResolvedModel &&
-          previousResolvedModel &&
-          currentResolvedModel !== previousResolvedModel
-        );
-
+        const currentResolvedModel =
+          message.role === 'assistant' && message.metadata.userVisible
+            ? (message.metadata.inference?.resolvedModel ?? null)
+            : null;
         const messageKey = message.id ?? `msg-${index}-${message.created}`;
 
         return (
-          <Fragment key={messageKey}>
-            {showModelChangeDisclosure &&
-              currentResolvedModel &&
-              previousResolvedModel &&
-              renderModelChangeDisclosure(previousResolvedModel, currentResolvedModel)}
-            <div
-              className={`relative ${index === 0 ? 'mt-0' : 'mt-4'} ${isUser ? 'user' : 'assistant'} ${messageIsInChain ? 'in-chain' : ''}`}
-              data-testid="message-container"
-            >
-              {isUser ? (
-                !hasOnlyToolResponses(message) && (
-                  <UserMessage message={message} onMessageUpdate={onMessageUpdate} />
-                )
-              ) : (
-                <GooseMessage
-                  sessionId={chat.sessionId}
-                  message={message}
-                  messages={messages}
-                  append={append}
-                  toolCallNotifications={toolCallNotifications}
-                  isStreaming={
-                    isStreamingMessage &&
-                    !isUser &&
-                    index === messagesToRender.length - 1 &&
-                    message.role === 'assistant'
-                  }
-                  submitElicitationResponse={submitElicitationResponse}
-                />
-              )}
-            </div>
-          </Fragment>
-        );
-      })
-      .filter(Boolean);
-  }, [
-    messages,
-    renderedCount,
-    renderMessage,
-    isUserMessage,
-    chat,
-    append,
-    toolCallNotifications,
-    isStreamingMessage,
-    onMessageUpdate,
-    toolCallChains,
-    submitElicitationResponse,
-    getPreviousResolvedModel,
-    getResolvedModel,
-    renderModelChangeDisclosure,
-  ]);
-
-  return (
-    <>
-      {renderMessages()}
-
-      {/* Loading indicator when progressively rendering */}
-      {isLoading && (
-        <div className="flex flex-col items-center justify-center py-8">
-          <LoadingGoose
-            message={intl.formatMessage(i18n.loadingMessages, {
-              renderedCount,
-              totalCount: messages.length,
-            })}
+          <MessageRow
+            key={messageKey}
+            message={message}
+            index={index}
+            chatSessionId={chat.sessionId}
+            isUser={isUserMessage(message)}
+            messageIsInChain={isInChain(index, toolCallChains)}
+            hideTimestamp={shouldHideTimestamp(index, toolCallChains)}
+            currentResolvedModel={currentResolvedModel}
+            previousResolvedModel={
+              currentResolvedModel ? (previousResolvedModels[index] ?? null) : null
+            }
+            lookups={toolCallLookups}
+            toolCallNotifications={toolCallNotifications}
+            append={append}
+            isStreaming={
+              isStreamingMessage &&
+              index === messages.length - 1 &&
+              message.role === 'assistant'
+            }
+            onMessageUpdate={onMessageUpdate}
+            submitElicitationResponse={submitElicitationResponse}
           />
-          <div className="text-xs text-text-secondary mt-2">
-            {intl.formatMessage(i18n.searchHint)}
-          </div>
-        </div>
-      )}
+        );
+      })}
     </>
   );
 }
+
+export default memo(ProgressiveMessageList);

--- a/ui/desktop/src/components/ProgressiveMessageList.tsx
+++ b/ui/desktop/src/components/ProgressiveMessageList.tsx
@@ -6,7 +6,7 @@
  * paged in with "Show earlier" or expanded fully for search.
  */
 
-import { Fragment, memo, useEffect, useMemo, useState } from 'react';
+import { Fragment, memo, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { defineMessages, useIntl } from '../i18n';
 import GooseMessage from './GooseMessage';
 import UserMessage from './UserMessage';
@@ -40,6 +40,7 @@ import {
   DEFAULT_VISIBLE_MESSAGE_WINDOW,
   earlierTranscriptWindowStart,
   initialTranscriptWindowStart,
+  transcriptMessageKey,
   visibleTranscriptWindowStart,
 } from '../utils/transcriptWindow';
 
@@ -106,6 +107,7 @@ function renderSystemNotification(notification: SystemNotificationContent) {
 interface MessageRowProps {
   message: Message;
   index: number;
+  transcriptAnchor?: string;
   chatSessionId: string;
   isUser: boolean;
   messageIsInChain: boolean;
@@ -124,6 +126,7 @@ function messageRowPropsAreEqual(previous: MessageRowProps, next: MessageRowProp
   if (
     previous.message !== next.message ||
     previous.index !== next.index ||
+    previous.transcriptAnchor !== next.transcriptAnchor ||
     previous.chatSessionId !== next.chatSessionId ||
     previous.isUser !== next.isUser ||
     previous.messageIsInChain !== next.messageIsInChain ||
@@ -151,6 +154,7 @@ function messageRowPropsAreEqual(previous: MessageRowProps, next: MessageRowProp
 const MessageRow = memo(function MessageRow({
   message,
   index,
+  transcriptAnchor,
   chatSessionId,
   isUser,
   messageIsInChain,
@@ -171,6 +175,7 @@ const MessageRow = memo(function MessageRow({
       <div
         className={`relative ${index === 0 ? 'mt-0' : 'mt-4'} assistant`}
         data-testid="message-container"
+        data-transcript-anchor={transcriptAnchor}
       >
         {renderSystemNotification(notification)}
       </div>
@@ -197,6 +202,7 @@ const MessageRow = memo(function MessageRow({
       <div
         className={`relative ${index === 0 ? 'mt-0' : 'mt-4'} ${isUser ? 'user' : 'assistant'} ${messageIsInChain ? 'in-chain' : ''}`}
         data-testid="message-container"
+        data-transcript-anchor={transcriptAnchor}
       >
         {isUser ? (
           !hasOnlyToolResponses(message) && (
@@ -238,6 +244,7 @@ function ProgressiveMessageList({
   const [windowStart, setWindowStart] = useState(() =>
     initialTranscriptWindowStart(messages.length, visibleWindow)
   );
+  const pendingScrollRestoreKeyRef = useRef<string | null>(null);
 
   const effectiveWindowStart = visibleTranscriptWindowStart({
     messageCount: messages.length,
@@ -273,6 +280,19 @@ function ProgressiveMessageList({
   const toolCallLookups = useMemo(() => buildToolCallLookups(messages), [messages]);
   const hiddenCount = effectiveWindowStart;
   const messagesToRender = messages.slice(effectiveWindowStart);
+  useLayoutEffect(() => {
+    const restoreKey = pendingScrollRestoreKeyRef.current;
+    if (!restoreKey) {
+      return;
+    }
+    pendingScrollRestoreKeyRef.current = null;
+    const anchor = document.querySelector(
+      `[data-transcript-anchor="${restoreKey.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"]`
+    );
+    if (anchor instanceof HTMLElement && typeof anchor.scrollIntoView === 'function') {
+      anchor.scrollIntoView({ block: 'start' });
+    }
+  }, [hiddenCount]);
 
   return (
     <>
@@ -282,6 +302,10 @@ function ProgressiveMessageList({
             type="button"
             className="text-xs text-text-secondary hover:text-text-primary underline-offset-2 hover:underline"
             onClick={() => {
+              const firstVisible = messages[effectiveWindowStart];
+              pendingScrollRestoreKeyRef.current = firstVisible
+                ? transcriptMessageKey(firstVisible)
+                : null;
               setPinnedToLiveEdge(false);
               setWindowStart(earlierTranscriptWindowStart(effectiveWindowStart, visibleWindow));
             }}
@@ -305,13 +329,14 @@ function ProgressiveMessageList({
           message.role === 'assistant' && message.metadata.userVisible
             ? (message.metadata.inference?.resolvedModel ?? null)
             : null;
-        const messageKey = message.id ?? `msg-${index}-${message.created}`;
+        const messageKey = transcriptMessageKey(message);
 
         return (
           <MessageRow
             key={messageKey}
             message={message}
             index={index}
+            transcriptAnchor={messageKey}
             chatSessionId={chat.sessionId}
             isUser={isUserMessage(message)}
             messageIsInChain={isInChain(index, toolCallChains)}

--- a/ui/desktop/src/components/ProgressiveMessageList.tsx
+++ b/ui/desktop/src/components/ProgressiveMessageList.tsx
@@ -39,9 +39,11 @@ import { getModelDisplayName } from './settings/models/predefinedModelsUtils';
 import {
   DEFAULT_VISIBLE_MESSAGE_WINDOW,
   earlierTranscriptWindowStart,
+  laterTranscriptWindowStart,
   initialTranscriptWindowStart,
   transcriptMessageKey,
-  visibleTranscriptWindowStart,
+  transcriptWindowForIndex,
+  visibleTranscriptRange,
 } from '../utils/transcriptWindow';
 
 const i18n = defineMessages({
@@ -51,7 +53,11 @@ const i18n = defineMessages({
   },
   searchHint: {
     id: 'progressiveMessageList.searchHint',
-    defaultMessage: 'Press Cmd/Ctrl+F to load all messages immediately for search',
+    defaultMessage: 'Press Cmd/Ctrl+F to search the full conversation',
+  },
+  showLater: {
+    id: 'progressiveMessageList.showLater',
+    defaultMessage: 'Show later messages',
   },
   modelChanged: {
     id: 'progressiveMessageList.modelChanged',
@@ -80,7 +86,10 @@ interface ProgressiveMessageListProps {
     userData: Record<string, unknown>
   ) => Promise<boolean>;
   hasEarlierMessages?: boolean;
+  hasLaterMessages?: boolean;
   onLoadEarlierMessages?: () => Promise<void> | void;
+  onLoadLaterMessages?: () => Promise<void> | void;
+  searchMatchKey?: string | null;
 }
 
 const EMPTY_TOOL_CALL_NOTIFICATIONS = new Map<string, NotificationEvent[]>();
@@ -240,19 +249,21 @@ function ProgressiveMessageList({
   onRenderingComplete,
   submitElicitationResponse,
   hasEarlierMessages = false,
+  hasLaterMessages = false,
   onLoadEarlierMessages,
+  onLoadLaterMessages,
+  searchMatchKey,
 }: ProgressiveMessageListProps) {
   const intl = useIntl();
-  const [showAllMessages, setShowAllMessages] = useState(false);
   const [pinnedToLiveEdge, setPinnedToLiveEdge] = useState(true);
   const [windowStart, setWindowStart] = useState(() =>
     initialTranscriptWindowStart(messages.length, visibleWindow)
   );
   const pendingScrollRestoreKeyRef = useRef<string | null>(null);
 
-  const effectiveWindowStart = visibleTranscriptWindowStart({
+  const { start: effectiveWindowStart, end: effectiveWindowEnd } = visibleTranscriptRange({
     messageCount: messages.length,
-    showAll: showAllMessages,
+    showAll: false,
     pinnedToLiveEdge,
     windowStart,
     visibleWindow,
@@ -264,26 +275,29 @@ function ProgressiveMessageList({
     }
     const timeoutId = window.setTimeout(() => onRenderingComplete(), 50);
     return () => window.clearTimeout(timeoutId);
-  }, [messages.length, onRenderingComplete, windowStart]);
+  }, [isStreamingMessage, messages.length, onRenderingComplete, windowStart]);
 
   useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      const isMac = window.electron.platform === 'darwin';
-      const isSearchShortcut = (isMac ? event.metaKey : event.ctrlKey) && event.key === 'f';
-      if (isSearchShortcut) {
-        setShowAllMessages(true);
-      }
-    };
-
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
-  }, []);
+    if (!searchMatchKey) {
+      return;
+    }
+    const matchIndex = messages.findIndex(
+      (message) => transcriptMessageKey(message) === searchMatchKey
+    );
+    if (matchIndex < 0) {
+      return;
+    }
+    setPinnedToLiveEdge(false);
+    setWindowStart(transcriptWindowForIndex(matchIndex, messages.length, visibleWindow));
+    pendingScrollRestoreKeyRef.current = searchMatchKey;
+  }, [messages, searchMatchKey, visibleWindow]);
 
   const toolCallChains = useMemo(() => identifyConsecutiveToolCalls(messages), [messages]);
   const previousResolvedModels = useMemo(() => getPreviousResolvedModels(messages), [messages]);
   const toolCallLookups = useMemo(() => buildToolCallLookups(messages), [messages]);
   const hiddenCount = effectiveWindowStart;
-  const messagesToRender = messages.slice(effectiveWindowStart);
+  const laterCount = messages.length - effectiveWindowEnd;
+  const messagesToRender = messages.slice(effectiveWindowStart, effectiveWindowEnd);
   useLayoutEffect(() => {
     const restoreKey = pendingScrollRestoreKeyRef.current;
     if (!restoreKey) {
@@ -370,6 +384,37 @@ function ProgressiveMessageList({
           />
         );
       })}
+
+      {(laterCount > 0 || hasLaterMessages) && (
+        <div className="flex flex-col items-center justify-center py-3">
+          <button
+            type="button"
+            className="text-xs text-text-secondary hover:text-text-primary underline-offset-2 hover:underline"
+            onClick={() => {
+              const lastVisible = messages[effectiveWindowEnd - 1];
+              pendingScrollRestoreKeyRef.current = lastVisible
+                ? transcriptMessageKey(lastVisible)
+                : null;
+              if (laterCount === 0 && hasLaterMessages) {
+                setPinnedToLiveEdge(false);
+                void onLoadLaterMessages?.();
+                return;
+              }
+              setPinnedToLiveEdge(false);
+              setWindowStart(
+                laterTranscriptWindowStart(
+                  effectiveWindowStart,
+                  messages.length,
+                  visibleWindow,
+                  visibleWindow
+                )
+              );
+            }}
+          >
+            {intl.formatMessage(i18n.showLater)}
+          </button>
+        </div>
+      )}
     </>
   );
 }

--- a/ui/desktop/src/components/ProgressiveMessageList.tsx
+++ b/ui/desktop/src/components/ProgressiveMessageList.tsx
@@ -79,6 +79,8 @@ interface ProgressiveMessageListProps {
     elicitationId: string,
     userData: Record<string, unknown>
   ) => Promise<boolean>;
+  hasEarlierMessages?: boolean;
+  onLoadEarlierMessages?: () => Promise<void> | void;
 }
 
 const EMPTY_TOOL_CALL_NOTIFICATIONS = new Map<string, NotificationEvent[]>();
@@ -237,6 +239,8 @@ function ProgressiveMessageList({
   onMessageUpdate,
   onRenderingComplete,
   submitElicitationResponse,
+  hasEarlierMessages = false,
+  onLoadEarlierMessages,
 }: ProgressiveMessageListProps) {
   const intl = useIntl();
   const [showAllMessages, setShowAllMessages] = useState(false);
@@ -292,11 +296,11 @@ function ProgressiveMessageList({
     if (anchor instanceof HTMLElement && typeof anchor.scrollIntoView === 'function') {
       anchor.scrollIntoView({ block: 'start' });
     }
-  }, [hiddenCount]);
+  }, [hiddenCount, messages.length]);
 
   return (
     <>
-      {hiddenCount > 0 && (
+      {(hiddenCount > 0 || hasEarlierMessages) && (
         <div className="flex flex-col items-center justify-center py-3">
           <button
             type="button"
@@ -306,11 +310,19 @@ function ProgressiveMessageList({
               pendingScrollRestoreKeyRef.current = firstVisible
                 ? transcriptMessageKey(firstVisible)
                 : null;
+              if (hiddenCount === 0 && hasEarlierMessages) {
+                setPinnedToLiveEdge(false);
+                setWindowStart(0);
+                void onLoadEarlierMessages?.();
+                return;
+              }
               setPinnedToLiveEdge(false);
               setWindowStart(earlierTranscriptWindowStart(effectiveWindowStart, visibleWindow));
             }}
           >
-            {intl.formatMessage(i18n.showEarlier, { hiddenCount })}
+            {intl.formatMessage(i18n.showEarlier, {
+              hiddenCount: hiddenCount > 0 ? hiddenCount : 'more',
+            })}
           </button>
           <div className="text-xs text-text-muted mt-1">{intl.formatMessage(i18n.searchHint)}</div>
         </div>

--- a/ui/desktop/src/components/sessions/SessionListView.tsx
+++ b/ui/desktop/src/components/sessions/SessionListView.tsx
@@ -306,7 +306,7 @@ interface SessionListViewProps {
 const SessionListView: React.FC<SessionListViewProps> = React.memo(({ onSelectSession }) => {
   const intl = useIntl();
   const [sessions, setSessions] = useState<SessionListItem[]>([]);
-  const [isPrefetchingSessions, setIsPrefetchingSessions] = useState(false);
+  const [isLoadingMoreSessions, setIsLoadingMoreSessions] = useState(false);
   const [dateGroups, setDateGroups] = useState<DateGroup[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [showSkeleton, setShowSkeleton] = useState(true);
@@ -360,34 +360,34 @@ const SessionListView: React.FC<SessionListViewProps> = React.memo(({ onSelectSe
     }
   }, [debouncedSearchTerm, dateGroups.length]);
 
-  const loadRemainingSessionPages = useCallback(
-    async (initialCursor: string, loadId: number, keyword?: string) => {
-      let cursor: string | null = initialCursor;
-      setIsPrefetchingSessions(true);
+  const nextCursorRef = useRef<string | null>(null);
 
-      try {
-        while (cursor && loadGenerationRef.current === loadId) {
-          const resp = await acpListSessions(cursor, { keyword });
-          if (loadGenerationRef.current !== loadId) return;
+  const loadNextSessionPage = useCallback(async (loadId: number, keyword?: string) => {
+    const cursor = nextCursorRef.current;
+    if (!cursor || loadGenerationRef.current !== loadId) {
+      return;
+    }
 
-          cursor = resp.nextCursor;
-          startTransition(() => {
-            setSessions((prev) => {
-              const seen = new Set(prev.map((s) => s.id));
-              return [...prev, ...resp.sessions.filter((s) => !seen.has(s.id))];
-            });
-          });
-        }
-      } catch (err) {
-        console.error('Failed to load remaining sessions:', err);
-      } finally {
-        if (loadGenerationRef.current === loadId) {
-          setIsPrefetchingSessions(false);
-        }
+    setIsLoadingMoreSessions(true);
+    try {
+      const resp = await acpListSessions(cursor, { keyword });
+      if (loadGenerationRef.current !== loadId) return;
+
+      nextCursorRef.current = resp.nextCursor;
+      startTransition(() => {
+        setSessions((prev) => {
+          const seen = new Set(prev.map((s) => s.id));
+          return [...prev, ...resp.sessions.filter((s) => !seen.has(s.id))];
+        });
+      });
+    } catch (err) {
+      console.error('Failed to load remaining sessions:', err);
+    } finally {
+      if (loadGenerationRef.current === loadId) {
+        setIsLoadingMoreSessions(false);
       }
-    },
-    []
-  );
+    }
+  }, []);
 
   const loadSessions = useCallback(
     async (keyword: string = debouncedSearchTermRef.current) => {
@@ -396,7 +396,8 @@ const SessionListView: React.FC<SessionListViewProps> = React.memo(({ onSelectSe
       // Only show the skeleton on the first load; subsequent loads (e.g. typing a
       // search keyword) update the list in place without flashing the skeleton.
       const isFirstLoad = !hasLoadedRef.current;
-      setIsPrefetchingSessions(false);
+      setIsLoadingMoreSessions(false);
+      nextCursorRef.current = null;
       setError(null);
       if (isFirstLoad) {
         setIsLoading(true);
@@ -408,13 +409,10 @@ const SessionListView: React.FC<SessionListViewProps> = React.memo(({ onSelectSe
         if (loadGenerationRef.current !== loadId) return;
         hasLoadedRef.current = true;
 
+        nextCursorRef.current = resp.nextCursor;
         startTransition(() => {
           setSessions(resp.sessions);
         });
-
-        if (resp.nextCursor) {
-          void loadRemainingSessionPages(resp.nextCursor, loadId, keyword);
-        }
       } catch (err) {
         if (loadGenerationRef.current !== loadId) return;
 
@@ -427,7 +425,7 @@ const SessionListView: React.FC<SessionListViewProps> = React.memo(({ onSelectSe
         }
       }
     },
-    [loadRemainingSessionPages]
+    []
   );
 
   const handleScroll = useCallback(
@@ -439,9 +437,14 @@ const SessionListView: React.FC<SessionListViewProps> = React.memo(({ onSelectSe
 
       if (visibleGroupsCount < dateGroups.length) {
         setVisibleGroupsCount((prev) => Math.min(prev + 5, dateGroups.length));
+        return;
+      }
+
+      if (nextCursorRef.current && !isLoadingMoreSessions) {
+        void loadNextSessionPage(loadGenerationRef.current, debouncedSearchTermRef.current);
       }
     },
-    [visibleGroupsCount, dateGroups.length]
+    [visibleGroupsCount, dateGroups.length, isLoadingMoreSessions, loadNextSessionPage]
   );
 
   useEffect(() => {
@@ -972,7 +975,7 @@ const SessionListView: React.FC<SessionListViewProps> = React.memo(({ onSelectSe
           </div>
         ))}
 
-        {isPrefetchingSessions && (
+        {isLoadingMoreSessions && (
           <div className="flex justify-center py-8">
             <div className="flex items-center space-x-2 text-text-secondary">
               <div className="animate-spin rounded-full h-4 w-4 border-b-2"></div>

--- a/ui/desktop/src/components/sessions/SessionListView.tsx
+++ b/ui/desktop/src/components/sessions/SessionListView.tsx
@@ -299,6 +299,8 @@ function useDebounce<T>(value: T, delay: number): T {
   return debouncedValue;
 }
 
+const MAX_LOADED_SESSIONS = 200;
+
 interface SessionListViewProps {
   onSelectSession: (sessionId: string) => void;
 }
@@ -354,7 +356,7 @@ const SessionListView: React.FC<SessionListViewProps> = React.memo(({ onSelectSe
     previousSearchTermRef.current = debouncedSearchTerm;
 
     if (isSearching) {
-      setVisibleGroupsCount(dateGroups.length);
+      setVisibleGroupsCount(Math.min(dateGroups.length, 15));
     } else if (wasSearching) {
       setVisibleGroupsCount(15);
     }
@@ -377,7 +379,10 @@ const SessionListView: React.FC<SessionListViewProps> = React.memo(({ onSelectSe
       startTransition(() => {
         setSessions((prev) => {
           const seen = new Set(prev.map((s) => s.id));
-          return [...prev, ...resp.sessions.filter((s) => !seen.has(s.id))];
+          const next = [...prev, ...resp.sessions.filter((s) => !seen.has(s.id))];
+          return next.length > MAX_LOADED_SESSIONS
+            ? next.slice(next.length - MAX_LOADED_SESSIONS)
+            : next;
         });
       });
     } catch (err) {

--- a/ui/desktop/src/components/ui/scroll-area.tsx
+++ b/ui/desktop/src/components/ui/scroll-area.tsx
@@ -4,6 +4,11 @@ import * as ScrollAreaPrimitive from '@radix-ui/react-scroll-area';
 type ScrollBehavior = 'auto' | 'smooth';
 
 import { cn } from '../../utils';
+import {
+  BOTTOM_SCROLL_THRESHOLD,
+  isViewportAtBottom,
+  shouldUnfollowOnScroll,
+} from '../../utils/scrollFollow';
 
 export interface ScrollAreaHandle {
   scrollToBottom: () => void;
@@ -44,36 +49,41 @@ const ScrollArea = React.forwardRef<ScrollAreaHandle, ScrollAreaProps>(
     const [isScrolled, setIsScrolled] = React.useState(false);
     const userScrolledUpRef = React.useRef(false);
     const lastScrollHeightRef = React.useRef(0);
+    const lastScrollTopRef = React.useRef(0);
     const isActivelyScrollingRef = React.useRef(false);
+    const isProgrammaticScrollRef = React.useRef(false);
     const scrollTimeoutRef = React.useRef<number | null>(null);
-
-    const BOTTOM_SCROLL_THRESHOLD = 200;
+    const isFollowingRef = React.useRef(true);
 
     const isAtBottom = React.useCallback(() => {
       if (!viewportRef.current) return false;
+      return isViewportAtBottom(viewportRef.current, BOTTOM_SCROLL_THRESHOLD);
+    }, []);
 
+    const pinToLiveEdge = React.useCallback(() => {
       const viewport = viewportRef.current;
-      const { scrollHeight, scrollTop, clientHeight } = viewport;
-      const distanceFromBottom = scrollHeight - scrollTop - clientHeight;
-
-      return distanceFromBottom <= BOTTOM_SCROLL_THRESHOLD;
+      if (!viewport) {
+        return;
+      }
+      isProgrammaticScrollRef.current = true;
+      viewport.scrollTo({
+        top: viewport.scrollHeight,
+        behavior: 'auto',
+      });
+      lastScrollTopRef.current = viewport.scrollTop;
+      lastScrollHeightRef.current = viewport.scrollHeight;
+      window.setTimeout(() => {
+        isProgrammaticScrollRef.current = false;
+      }, 0);
     }, []);
 
     const scrollToBottom = React.useCallback(() => {
-      if (viewportRef.current) {
-        // Jump instantly rather than animating: a smooth programmatic scroll
-        // emits intermediate scroll events that handleScroll mistakes for a
-        // manual scroll-up, which disables auto-follow mid-animation.
-        viewportRef.current.scrollTo({
-          top: viewportRef.current.scrollHeight,
-          behavior: 'auto',
-        });
-        // When explicitly scrolling to bottom, reset the following state
-        setIsFollowing(true);
-        userScrolledUpRef.current = false;
-        onScrollChange?.(true);
-      }
-    }, [onScrollChange]);
+      pinToLiveEdge();
+      isFollowingRef.current = true;
+      setIsFollowing(true);
+      userScrolledUpRef.current = false;
+      onScrollChange?.(true);
+    }, [onScrollChange, pinToLiveEdge]);
 
     const scrollToPosition = React.useCallback(
       ({ top, behavior = 'smooth' }: { top: number; behavior?: ScrollBehavior }) => {
@@ -87,7 +97,6 @@ const ScrollArea = React.forwardRef<ScrollAreaHandle, ScrollAreaProps>(
       []
     );
 
-    // Expose the scroll methods to parent components
     React.useImperativeHandle(
       ref,
       () => ({
@@ -100,29 +109,30 @@ const ScrollArea = React.forwardRef<ScrollAreaHandle, ScrollAreaProps>(
       [scrollToBottom, scrollToPosition, isAtBottom, isFollowing]
     );
 
-    // track last scroll position to detect user-initiated scrolling
-    const lastScrollTopRef = React.useRef(0);
-
-    // Handle scroll events to update isFollowing state
     const handleScroll = React.useCallback(() => {
       if (!viewportRef.current) return;
 
       const viewport = viewportRef.current;
       const { scrollTop } = viewport;
       const currentIsAtBottom = isAtBottom();
+      const isProgrammatic = isProgrammaticScrollRef.current;
 
-      // detect if this is a user-initiated scroll (position changed from last known position)
+      if (isProgrammatic) {
+        isProgrammaticScrollRef.current = false;
+        lastScrollTopRef.current = scrollTop;
+        setIsScrolled(scrollTop > 0);
+        if (handleScrollProp) {
+          handleScrollProp(viewport);
+        }
+        return;
+      }
+
       const scrollDelta = Math.abs(scrollTop - lastScrollTopRef.current);
       if (scrollDelta > 0) {
-        // Mark that user is actively scrolling immediately
         isActivelyScrollingRef.current = true;
-
-        // clear any existing timeout and set a new one
         if (scrollTimeoutRef.current) {
           clearTimeout(scrollTimeoutRef.current);
         }
-
-        // mark as not actively scrolling
         scrollTimeoutRef.current = window.setTimeout(() => {
           isActivelyScrollingRef.current = false;
         }, 100);
@@ -130,15 +140,20 @@ const ScrollArea = React.forwardRef<ScrollAreaHandle, ScrollAreaProps>(
 
       lastScrollTopRef.current = scrollTop;
 
-      // Detect if user manually scrolled up from the bottom
-      if (!currentIsAtBottom && isFollowing) {
-        // user scrolled up, disabling auto-scroll
+      if (
+        shouldUnfollowOnScroll({
+          isFollowing: isFollowingRef.current,
+          isProgrammatic: false,
+          isAtBottom: currentIsAtBottom,
+        })
+      ) {
         userScrolledUpRef.current = true;
+        isFollowingRef.current = false;
         setIsFollowing(false);
         onScrollChange?.(false);
       } else if (currentIsAtBottom && userScrolledUpRef.current) {
-        // user scrolled back to bottom
         userScrolledUpRef.current = false;
+        isFollowingRef.current = true;
         setIsFollowing(true);
         onScrollChange?.(true);
       }
@@ -148,43 +163,29 @@ const ScrollArea = React.forwardRef<ScrollAreaHandle, ScrollAreaProps>(
       if (handleScrollProp) {
         handleScrollProp(viewport);
       }
-    }, [isAtBottom, isFollowing, onScrollChange, handleScrollProp]);
+    }, [isAtBottom, onScrollChange, handleScrollProp]);
 
-    // Auto-scroll when content changes and user is following
     React.useEffect(() => {
       if (!autoScroll || !viewportRef.current) return;
 
       const viewport = viewportRef.current;
       const currentScrollHeight = viewport.scrollHeight;
 
-      // Only auto-scroll if:
-      // 1. Content has actually grown (new content added)
-      // 2. User was following (at the bottom)
-      // 3. User hasn't manually scrolled up
-      // 4. User is not actively scrolling
       if (
         currentScrollHeight > lastScrollHeightRef.current &&
-        isFollowing &&
-        !userScrolledUpRef.current &&
-        !isActivelyScrollingRef.current
+        isFollowingRef.current &&
+        !userScrolledUpRef.current
       ) {
-        // Use requestAnimationFrame to ensure DOM has updated
         requestAnimationFrame(() => {
-          if (viewportRef.current && !isActivelyScrollingRef.current) {
-            viewportRef.current.scrollTo({
-              top: viewportRef.current.scrollHeight,
-              behavior: 'auto',
-            });
+          if (viewportRef.current && isFollowingRef.current && !userScrolledUpRef.current) {
+            pinToLiveEdge();
           }
         });
       }
 
       lastScrollHeightRef.current = currentScrollHeight;
-    }, [children, autoScroll, isFollowing]);
+    }, [autoScroll, children, pinToLiveEdge]);
 
-    // Keep pinned to the bottom when content grows from async media (images,
-    // syntax highlighting) that resizes after paint without a React re-render,
-    // so it isn't covered by the [children] effect above.
     React.useEffect(() => {
       if (!autoScroll) return;
       const viewport = viewportRef.current;
@@ -192,17 +193,14 @@ const ScrollArea = React.forwardRef<ScrollAreaHandle, ScrollAreaProps>(
       if (!viewport || !content || typeof ResizeObserver === 'undefined') return;
 
       const observer = new ResizeObserver(() => {
-        // Mirror the [children] effect's guards, including isActivelyScrolling, so
-        // the re-pin doesn't fight a user scrolling up while content is still growing.
-        if (isFollowing && !userScrolledUpRef.current && !isActivelyScrollingRef.current) {
-          viewport.scrollTo({ top: viewport.scrollHeight, behavior: 'auto' });
+        if (isFollowingRef.current && !userScrolledUpRef.current) {
+          pinToLiveEdge();
         }
       });
       observer.observe(content);
       return () => observer.disconnect();
-    }, [autoScroll, isFollowing]);
+    }, [autoScroll, pinToLiveEdge]);
 
-    // Add scroll event listener
     React.useEffect(() => {
       const viewport = viewportRef.current;
       if (!viewport) return;
@@ -227,6 +225,7 @@ const ScrollArea = React.forwardRef<ScrollAreaHandle, ScrollAreaProps>(
         <ScrollAreaPrimitive.Viewport
           ref={viewportRef}
           className="h-full w-full rounded-[inherit] [&>div]:!block"
+          style={{ overflowAnchor: 'none' }}
         >
           <div
             ref={contentRef}

--- a/ui/desktop/src/hooks/useChatSession.ts
+++ b/ui/desktop/src/hooks/useChatSession.ts
@@ -23,6 +23,7 @@ import {
   acpChatSessionStore,
   useAcpChatSessionSnapshot,
 } from '../acp/chatSessionStore';
+import { acpGetSessionConversation } from '../acp/sessions';
 import { acpSteerSession } from '../acp/prompt';
 import { isAcpRecovering } from '../acp/acpConnection';
 
@@ -327,6 +328,15 @@ export function useChatSession({
     },
     [getCurrentSnapshot, sessionId]
   );
+  const hasEarlierMessages = acpSnapshot?.hasEarlierMessages ?? false;
+  const loadEarlierMessages = useCallback(async () => {
+    const currentMessages = getCurrentSnapshot()?.messages ?? [];
+    const before = currentMessages[0]?.created;
+    const page = await acpGetSessionConversation(sessionId, before, 80);
+    acpChatSessionActions.prependMessages(sessionId, page.messages);
+    acpChatSessionActions.setHasEarlierMessages(sessionId, page.hasEarlier);
+  }, [getCurrentSnapshot, sessionId]);
+
   const notificationsMap = useMemo(() => {
     return (acpSnapshot?.notifications ?? []).reduce((map, notification) => {
       const key = notification.request_id;
@@ -355,5 +365,7 @@ export function useChatSession({
     pauseQueueOnStop: false,
     queueProcessingBlocked,
     onMessageUpdate,
+    hasEarlierMessages,
+    loadEarlierMessages,
   };
 }

--- a/ui/desktop/src/hooks/useChatSession.ts
+++ b/ui/desktop/src/hooks/useChatSession.ts
@@ -23,7 +23,7 @@ import {
   acpChatSessionStore,
   useAcpChatSessionSnapshot,
 } from '../acp/chatSessionStore';
-import { acpGetSessionConversation } from '../acp/sessions';
+import { acpGetSessionConversation, acpSearchSessionConversation } from '../acp/sessions';
 import { acpSteerSession } from '../acp/prompt';
 import { isAcpRecovering } from '../acp/acpConnection';
 
@@ -329,6 +329,7 @@ export function useChatSession({
     [getCurrentSnapshot, sessionId]
   );
   const hasEarlierMessages = acpSnapshot?.hasEarlierMessages ?? false;
+  const hasLaterMessages = acpSnapshot?.hasLaterMessages ?? false;
   const loadEarlierMessages = useCallback(async () => {
     const currentMessages = getCurrentSnapshot()?.messages ?? [];
     const before = currentMessages[0]?.created;
@@ -336,6 +337,41 @@ export function useChatSession({
     acpChatSessionActions.prependMessages(sessionId, page.messages);
     acpChatSessionActions.setHasEarlierMessages(sessionId, page.hasEarlier);
   }, [getCurrentSnapshot, sessionId]);
+  const loadLaterMessages = useCallback(async () => {
+    const currentMessages = getCurrentSnapshot()?.messages ?? [];
+    const after = currentMessages[currentMessages.length - 1]?.created;
+    const page = await acpGetSessionConversation(sessionId, undefined, 80, after);
+    acpChatSessionActions.appendMessages(sessionId, page.messages);
+    acpChatSessionActions.setHasLaterMessages(sessionId, page.hasLater);
+  }, [getCurrentSnapshot, sessionId]);
+
+  const searchMessages = useCallback(
+    async (query: string): Promise<string | null> => {
+      const trimmed = query.trim();
+      if (!trimmed) {
+        const latest = await acpGetSessionConversation(sessionId, undefined, 80);
+        acpChatSessionActions.replaceWindow(sessionId, latest.messages, {
+          hasEarlier: latest.hasEarlier,
+          hasLater: false,
+        });
+        return null;
+      }
+      const page = await acpSearchSessionConversation(sessionId, trimmed, 80);
+      if (page.messages.length === 0) {
+        return null;
+      }
+      acpChatSessionActions.replaceWindow(sessionId, page.messages, {
+        hasEarlier: page.hasEarlier,
+        hasLater: page.hasLater,
+      });
+      return (
+        page.matchId ??
+        page.messages.find((message) => message.id)?.id ??
+        null
+      );
+    },
+    [sessionId]
+  );
 
   const notificationsMap = useMemo(() => {
     return (acpSnapshot?.notifications ?? []).reduce((map, notification) => {
@@ -366,6 +402,9 @@ export function useChatSession({
     queueProcessingBlocked,
     onMessageUpdate,
     hasEarlierMessages,
+    hasLaterMessages,
     loadEarlierMessages,
+    loadLaterMessages,
+    searchMessages,
   };
 }

--- a/ui/desktop/src/hooks/useChatSessionTypes.ts
+++ b/ui/desktop/src/hooks/useChatSessionTypes.ts
@@ -35,5 +35,8 @@ export interface UseChatSessionResult {
     retainedImages: ImageData[]
   ) => Promise<void>;
   hasEarlierMessages: boolean;
+  hasLaterMessages: boolean;
   loadEarlierMessages: () => Promise<void>;
+  loadLaterMessages: () => Promise<void>;
+  searchMessages: (query: string) => Promise<string | null>;
 }

--- a/ui/desktop/src/hooks/useChatSessionTypes.ts
+++ b/ui/desktop/src/hooks/useChatSessionTypes.ts
@@ -34,4 +34,6 @@ export interface UseChatSessionResult {
     editType: 'fork' | 'edit',
     retainedImages: ImageData[]
   ) => Promise<void>;
+  hasEarlierMessages: boolean;
+  loadEarlierMessages: () => Promise<void>;
 }

--- a/ui/desktop/src/i18n/messages/de.json
+++ b/ui/desktop/src/i18n/messages/de.json
@@ -2633,6 +2633,9 @@
   "progressiveMessageList.showEarlier": {
     "defaultMessage": "Frühere Nachrichten anzeigen ({hiddenCount} ausgeblendet)"
   },
+  "progressiveMessageList.showLater": {
+    "defaultMessage": "Show later messages"
+  },
   "progressiveMessageList.modelChanged": {
     "defaultMessage": "Modell geändert: {previousModel} → {currentModel}"
   },

--- a/ui/desktop/src/i18n/messages/de.json
+++ b/ui/desktop/src/i18n/messages/de.json
@@ -2630,8 +2630,8 @@
   "privacyInfoModal.whatWeCollect": {
     "defaultMessage": "Was wir erfassen:"
   },
-  "progressiveMessageList.loadingMessages": {
-    "defaultMessage": "Nachrichten werden geladen... ({renderedCount}/{totalCount})"
+  "progressiveMessageList.showEarlier": {
+    "defaultMessage": "Frühere Nachrichten anzeigen ({hiddenCount} ausgeblendet)"
   },
   "progressiveMessageList.modelChanged": {
     "defaultMessage": "Modell geändert: {previousModel} → {currentModel}"

--- a/ui/desktop/src/i18n/messages/en.json
+++ b/ui/desktop/src/i18n/messages/en.json
@@ -2654,14 +2654,14 @@
   "privacyInfoModal.whatWeCollect": {
     "defaultMessage": "What we collect:"
   },
-  "progressiveMessageList.loadingMessages": {
-    "defaultMessage": "Loading messages... ({renderedCount}/{totalCount})"
-  },
   "progressiveMessageList.modelChanged": {
     "defaultMessage": "Model changed: {previousModel} → {currentModel}"
   },
   "progressiveMessageList.searchHint": {
     "defaultMessage": "Press Cmd/Ctrl+F to load all messages immediately for search"
+  },
+  "progressiveMessageList.showEarlier": {
+    "defaultMessage": "Show earlier messages ({hiddenCount} hidden)"
   },
   "promptsSettings.allPromptsReset": {
     "defaultMessage": "All prompts reset to defaults"

--- a/ui/desktop/src/i18n/messages/en.json
+++ b/ui/desktop/src/i18n/messages/en.json
@@ -2658,10 +2658,13 @@
     "defaultMessage": "Model changed: {previousModel} → {currentModel}"
   },
   "progressiveMessageList.searchHint": {
-    "defaultMessage": "Press Cmd/Ctrl+F to load all messages immediately for search"
+    "defaultMessage": "Press Cmd/Ctrl+F to search the full conversation"
   },
   "progressiveMessageList.showEarlier": {
     "defaultMessage": "Show earlier messages ({hiddenCount} hidden)"
+  },
+  "progressiveMessageList.showLater": {
+    "defaultMessage": "Show later messages"
   },
   "promptsSettings.allPromptsReset": {
     "defaultMessage": "All prompts reset to defaults"

--- a/ui/desktop/src/i18n/messages/es.json
+++ b/ui/desktop/src/i18n/messages/es.json
@@ -2633,6 +2633,9 @@
   "progressiveMessageList.showEarlier": {
     "defaultMessage": "Mostrar mensajes anteriores ({hiddenCount} ocultos)"
   },
+  "progressiveMessageList.showLater": {
+    "defaultMessage": "Show later messages"
+  },
   "progressiveMessageList.modelChanged": {
     "defaultMessage": "Modelo cambiado: {previousModel} → {currentModel}"
   },

--- a/ui/desktop/src/i18n/messages/es.json
+++ b/ui/desktop/src/i18n/messages/es.json
@@ -2630,8 +2630,8 @@
   "privacyInfoModal.whatWeCollect": {
     "defaultMessage": "Lo que recopilamos:"
   },
-  "progressiveMessageList.loadingMessages": {
-    "defaultMessage": "Cargando mensajes... ({renderedCount}/{totalCount})"
+  "progressiveMessageList.showEarlier": {
+    "defaultMessage": "Mostrar mensajes anteriores ({hiddenCount} ocultos)"
   },
   "progressiveMessageList.modelChanged": {
     "defaultMessage": "Modelo cambiado: {previousModel} → {currentModel}"

--- a/ui/desktop/src/i18n/messages/fr.json
+++ b/ui/desktop/src/i18n/messages/fr.json
@@ -2633,6 +2633,9 @@
   "progressiveMessageList.showEarlier": {
     "defaultMessage": "Afficher les messages précédents ({hiddenCount} masqués)"
   },
+  "progressiveMessageList.showLater": {
+    "defaultMessage": "Show later messages"
+  },
   "progressiveMessageList.modelChanged": {
     "defaultMessage": "Modèle modifié : {previousModel} → {currentModel}"
   },

--- a/ui/desktop/src/i18n/messages/fr.json
+++ b/ui/desktop/src/i18n/messages/fr.json
@@ -2630,8 +2630,8 @@
   "privacyInfoModal.whatWeCollect": {
     "defaultMessage": "Ce que nous collectons :"
   },
-  "progressiveMessageList.loadingMessages": {
-    "defaultMessage": "Chargement des messages... ({renderedCount}/{totalCount})"
+  "progressiveMessageList.showEarlier": {
+    "defaultMessage": "Afficher les messages précédents ({hiddenCount} masqués)"
   },
   "progressiveMessageList.modelChanged": {
     "defaultMessage": "Modèle modifié : {previousModel} → {currentModel}"

--- a/ui/desktop/src/i18n/messages/hi.json
+++ b/ui/desktop/src/i18n/messages/hi.json
@@ -2630,8 +2630,8 @@
   "privacyInfoModal.whatWeCollect": {
     "defaultMessage": "हम क्या एकत्र करते हैं:"
   },
-  "progressiveMessageList.loadingMessages": {
-    "defaultMessage": "संदेश लोड हो रहे हैं... ({renderedCount}/{totalCount})"
+  "progressiveMessageList.showEarlier": {
+    "defaultMessage": "पहले के संदेश दिखाएँ ({hiddenCount} छिपे हुए)"
   },
   "progressiveMessageList.modelChanged": {
     "defaultMessage": "मॉडल बदला गया: {previousModel} → {currentModel}"

--- a/ui/desktop/src/i18n/messages/hi.json
+++ b/ui/desktop/src/i18n/messages/hi.json
@@ -2633,6 +2633,9 @@
   "progressiveMessageList.showEarlier": {
     "defaultMessage": "पहले के संदेश दिखाएँ ({hiddenCount} छिपे हुए)"
   },
+  "progressiveMessageList.showLater": {
+    "defaultMessage": "Show later messages"
+  },
   "progressiveMessageList.modelChanged": {
     "defaultMessage": "मॉडल बदला गया: {previousModel} → {currentModel}"
   },

--- a/ui/desktop/src/i18n/messages/id.json
+++ b/ui/desktop/src/i18n/messages/id.json
@@ -2630,8 +2630,8 @@
   "privacyInfoModal.whatWeCollect": {
     "defaultMessage": "Apa yang kami kumpulkan:"
   },
-  "progressiveMessageList.loadingMessages": {
-    "defaultMessage": "Memuat pesan... ({renderedCount}/{totalCount})"
+  "progressiveMessageList.showEarlier": {
+    "defaultMessage": "Tampilkan pesan sebelumnya ({hiddenCount} tersembunyi)"
   },
   "progressiveMessageList.modelChanged": {
     "defaultMessage": "Model diubah: {previousModel} → {currentModel}"

--- a/ui/desktop/src/i18n/messages/id.json
+++ b/ui/desktop/src/i18n/messages/id.json
@@ -2633,6 +2633,9 @@
   "progressiveMessageList.showEarlier": {
     "defaultMessage": "Tampilkan pesan sebelumnya ({hiddenCount} tersembunyi)"
   },
+  "progressiveMessageList.showLater": {
+    "defaultMessage": "Show later messages"
+  },
   "progressiveMessageList.modelChanged": {
     "defaultMessage": "Model diubah: {previousModel} → {currentModel}"
   },

--- a/ui/desktop/src/i18n/messages/it.json
+++ b/ui/desktop/src/i18n/messages/it.json
@@ -2633,6 +2633,9 @@
   "progressiveMessageList.showEarlier": {
     "defaultMessage": "Mostra i messaggi precedenti ({hiddenCount} nascosti)"
   },
+  "progressiveMessageList.showLater": {
+    "defaultMessage": "Show later messages"
+  },
   "progressiveMessageList.modelChanged": {
     "defaultMessage": "Modello cambiato: {previousModel} → {currentModel}"
   },

--- a/ui/desktop/src/i18n/messages/it.json
+++ b/ui/desktop/src/i18n/messages/it.json
@@ -2630,8 +2630,8 @@
   "privacyInfoModal.whatWeCollect": {
     "defaultMessage": "Cosa raccogliamo:"
   },
-  "progressiveMessageList.loadingMessages": {
-    "defaultMessage": "Caricamento messaggi... ({renderedCount}/{totalCount})"
+  "progressiveMessageList.showEarlier": {
+    "defaultMessage": "Mostra i messaggi precedenti ({hiddenCount} nascosti)"
   },
   "progressiveMessageList.modelChanged": {
     "defaultMessage": "Modello cambiato: {previousModel} → {currentModel}"

--- a/ui/desktop/src/i18n/messages/ja.json
+++ b/ui/desktop/src/i18n/messages/ja.json
@@ -2630,8 +2630,8 @@
   "privacyInfoModal.whatWeCollect": {
     "defaultMessage": "収集する内容:"
   },
-  "progressiveMessageList.loadingMessages": {
-    "defaultMessage": "メッセージを読み込み中...（{renderedCount}/{totalCount}）"
+  "progressiveMessageList.showEarlier": {
+    "defaultMessage": "以前のメッセージを表示（{hiddenCount} 件非表示）"
   },
   "progressiveMessageList.modelChanged": {
     "defaultMessage": "モデルを変更しました: {previousModel} → {currentModel}"

--- a/ui/desktop/src/i18n/messages/ja.json
+++ b/ui/desktop/src/i18n/messages/ja.json
@@ -2633,6 +2633,9 @@
   "progressiveMessageList.showEarlier": {
     "defaultMessage": "以前のメッセージを表示（{hiddenCount} 件非表示）"
   },
+  "progressiveMessageList.showLater": {
+    "defaultMessage": "Show later messages"
+  },
   "progressiveMessageList.modelChanged": {
     "defaultMessage": "モデルを変更しました: {previousModel} → {currentModel}"
   },

--- a/ui/desktop/src/i18n/messages/ko.json
+++ b/ui/desktop/src/i18n/messages/ko.json
@@ -2633,6 +2633,9 @@
   "progressiveMessageList.showEarlier": {
     "defaultMessage": "이전 메시지 보기 ({hiddenCount}개 숨김)"
   },
+  "progressiveMessageList.showLater": {
+    "defaultMessage": "Show later messages"
+  },
   "progressiveMessageList.modelChanged": {
     "defaultMessage": "모델 변경: {previousModel} → {currentModel}"
   },

--- a/ui/desktop/src/i18n/messages/ko.json
+++ b/ui/desktop/src/i18n/messages/ko.json
@@ -2630,8 +2630,8 @@
   "privacyInfoModal.whatWeCollect": {
     "defaultMessage": "수집하는 항목:"
   },
-  "progressiveMessageList.loadingMessages": {
-    "defaultMessage": "메시지 로드 중... ({renderedCount}/{totalCount})"
+  "progressiveMessageList.showEarlier": {
+    "defaultMessage": "이전 메시지 보기 ({hiddenCount}개 숨김)"
   },
   "progressiveMessageList.modelChanged": {
     "defaultMessage": "모델 변경: {previousModel} → {currentModel}"

--- a/ui/desktop/src/i18n/messages/ms.json
+++ b/ui/desktop/src/i18n/messages/ms.json
@@ -2630,8 +2630,8 @@
   "privacyInfoModal.whatWeCollect": {
     "defaultMessage": "Apa yang kami kumpul:"
   },
-  "progressiveMessageList.loadingMessages": {
-    "defaultMessage": "Memuatkan mesej... ({renderedCount}/{totalCount})"
+  "progressiveMessageList.showEarlier": {
+    "defaultMessage": "Tunjukkan mesej terdahulu ({hiddenCount} tersembunyi)"
   },
   "progressiveMessageList.modelChanged": {
     "defaultMessage": "Model ditukar: {previousModel} → {currentModel}"

--- a/ui/desktop/src/i18n/messages/ms.json
+++ b/ui/desktop/src/i18n/messages/ms.json
@@ -2633,6 +2633,9 @@
   "progressiveMessageList.showEarlier": {
     "defaultMessage": "Tunjukkan mesej terdahulu ({hiddenCount} tersembunyi)"
   },
+  "progressiveMessageList.showLater": {
+    "defaultMessage": "Show later messages"
+  },
   "progressiveMessageList.modelChanged": {
     "defaultMessage": "Model ditukar: {previousModel} → {currentModel}"
   },

--- a/ui/desktop/src/i18n/messages/pt.json
+++ b/ui/desktop/src/i18n/messages/pt.json
@@ -2630,8 +2630,8 @@
   "privacyInfoModal.whatWeCollect": {
     "defaultMessage": "O que recolhemos:"
   },
-  "progressiveMessageList.loadingMessages": {
-    "defaultMessage": "A carregar mensagens... ({renderedCount}/{totalCount})"
+  "progressiveMessageList.showEarlier": {
+    "defaultMessage": "Mostrar mensagens anteriores ({hiddenCount} ocultas)"
   },
   "progressiveMessageList.modelChanged": {
     "defaultMessage": "Modelo alterado: {previousModel} → {currentModel}"

--- a/ui/desktop/src/i18n/messages/pt.json
+++ b/ui/desktop/src/i18n/messages/pt.json
@@ -2633,6 +2633,9 @@
   "progressiveMessageList.showEarlier": {
     "defaultMessage": "Mostrar mensagens anteriores ({hiddenCount} ocultas)"
   },
+  "progressiveMessageList.showLater": {
+    "defaultMessage": "Show later messages"
+  },
   "progressiveMessageList.modelChanged": {
     "defaultMessage": "Modelo alterado: {previousModel} → {currentModel}"
   },

--- a/ui/desktop/src/i18n/messages/ru.json
+++ b/ui/desktop/src/i18n/messages/ru.json
@@ -2633,6 +2633,9 @@
   "progressiveMessageList.showEarlier": {
     "defaultMessage": "Показать более ранние сообщения (скрыто: {hiddenCount})"
   },
+  "progressiveMessageList.showLater": {
+    "defaultMessage": "Show later messages"
+  },
   "progressiveMessageList.modelChanged": {
     "defaultMessage": "Модель изменена: {previousModel} → {currentModel}"
   },

--- a/ui/desktop/src/i18n/messages/ru.json
+++ b/ui/desktop/src/i18n/messages/ru.json
@@ -2630,8 +2630,8 @@
   "privacyInfoModal.whatWeCollect": {
     "defaultMessage": "Что мы собираем:"
   },
-  "progressiveMessageList.loadingMessages": {
-    "defaultMessage": "Загрузка сообщений... ({renderedCount}/{totalCount})"
+  "progressiveMessageList.showEarlier": {
+    "defaultMessage": "Показать более ранние сообщения (скрыто: {hiddenCount})"
   },
   "progressiveMessageList.modelChanged": {
     "defaultMessage": "Модель изменена: {previousModel} → {currentModel}"

--- a/ui/desktop/src/i18n/messages/tr.json
+++ b/ui/desktop/src/i18n/messages/tr.json
@@ -2630,8 +2630,8 @@
   "privacyInfoModal.whatWeCollect": {
     "defaultMessage": "Ne topluyoruz:"
   },
-  "progressiveMessageList.loadingMessages": {
-    "defaultMessage": "Mesajlar yükleniyor... ({renderedCount}/{totalCount})"
+  "progressiveMessageList.showEarlier": {
+    "defaultMessage": "Daha önceki iletileri göster ({hiddenCount} gizli)"
   },
   "progressiveMessageList.modelChanged": {
     "defaultMessage": "Model değişti: {previousModel} → {currentModel}"

--- a/ui/desktop/src/i18n/messages/tr.json
+++ b/ui/desktop/src/i18n/messages/tr.json
@@ -2633,6 +2633,9 @@
   "progressiveMessageList.showEarlier": {
     "defaultMessage": "Daha önceki iletileri göster ({hiddenCount} gizli)"
   },
+  "progressiveMessageList.showLater": {
+    "defaultMessage": "Show later messages"
+  },
   "progressiveMessageList.modelChanged": {
     "defaultMessage": "Model değişti: {previousModel} → {currentModel}"
   },

--- a/ui/desktop/src/i18n/messages/vi.json
+++ b/ui/desktop/src/i18n/messages/vi.json
@@ -2630,8 +2630,8 @@
   "privacyInfoModal.whatWeCollect": {
     "defaultMessage": "Những gì chúng tôi thu thập:"
   },
-  "progressiveMessageList.loadingMessages": {
-    "defaultMessage": "Đang tải tin nhắn... ({renderedCount}/{totalCount})"
+  "progressiveMessageList.showEarlier": {
+    "defaultMessage": "Hiện tin nhắn trước đó (đã ẩn {hiddenCount})"
   },
   "progressiveMessageList.modelChanged": {
     "defaultMessage": "Mô hình đã thay đổi: {previousModel} → {currentModel}"

--- a/ui/desktop/src/i18n/messages/vi.json
+++ b/ui/desktop/src/i18n/messages/vi.json
@@ -2633,6 +2633,9 @@
   "progressiveMessageList.showEarlier": {
     "defaultMessage": "Hiện tin nhắn trước đó (đã ẩn {hiddenCount})"
   },
+  "progressiveMessageList.showLater": {
+    "defaultMessage": "Show later messages"
+  },
   "progressiveMessageList.modelChanged": {
     "defaultMessage": "Mô hình đã thay đổi: {previousModel} → {currentModel}"
   },

--- a/ui/desktop/src/i18n/messages/zh-CN.json
+++ b/ui/desktop/src/i18n/messages/zh-CN.json
@@ -2630,8 +2630,8 @@
   "privacyInfoModal.whatWeCollect": {
     "defaultMessage": "我们采集的内容："
   },
-  "progressiveMessageList.loadingMessages": {
-    "defaultMessage": "正在加载消息…（{renderedCount}/{totalCount}）"
+  "progressiveMessageList.showEarlier": {
+    "defaultMessage": "显示更早的消息（已隐藏 {hiddenCount} 条）"
   },
   "progressiveMessageList.modelChanged": {
     "defaultMessage": "模型已更改：{previousModel} → {currentModel}"

--- a/ui/desktop/src/i18n/messages/zh-CN.json
+++ b/ui/desktop/src/i18n/messages/zh-CN.json
@@ -2633,6 +2633,9 @@
   "progressiveMessageList.showEarlier": {
     "defaultMessage": "显示更早的消息（已隐藏 {hiddenCount} 条）"
   },
+  "progressiveMessageList.showLater": {
+    "defaultMessage": "Show later messages"
+  },
   "progressiveMessageList.modelChanged": {
     "defaultMessage": "模型已更改：{previousModel} → {currentModel}"
   },

--- a/ui/desktop/src/i18n/messages/zh-TW.json
+++ b/ui/desktop/src/i18n/messages/zh-TW.json
@@ -2630,8 +2630,8 @@
   "privacyInfoModal.whatWeCollect": {
     "defaultMessage": "我們收集的內容："
   },
-  "progressiveMessageList.loadingMessages": {
-    "defaultMessage": "正在載入訊息... ({renderedCount}/{totalCount})"
+  "progressiveMessageList.showEarlier": {
+    "defaultMessage": "顯示更早的訊息（已隱藏 {hiddenCount} 則）"
   },
   "progressiveMessageList.modelChanged": {
     "defaultMessage": "模型已變更：{previousModel} → {currentModel}"

--- a/ui/desktop/src/i18n/messages/zh-TW.json
+++ b/ui/desktop/src/i18n/messages/zh-TW.json
@@ -2633,6 +2633,9 @@
   "progressiveMessageList.showEarlier": {
     "defaultMessage": "顯示更早的訊息（已隱藏 {hiddenCount} 則）"
   },
+  "progressiveMessageList.showLater": {
+    "defaultMessage": "Show later messages"
+  },
   "progressiveMessageList.modelChanged": {
     "defaultMessage": "模型已變更：{previousModel} → {currentModel}"
   },

--- a/ui/desktop/src/styles/main.css
+++ b/ui/desktop/src/styles/main.css
@@ -462,6 +462,7 @@
 [data-radix-scroll-area-viewport] {
   scrollbar-width: none !important;
   -ms-overflow-style: none !important;
+  overflow-anchor: none;
 }
 
 [data-radix-scroll-area-viewport]::-webkit-scrollbar {

--- a/ui/desktop/src/utils/__tests__/messagePairing.test.ts
+++ b/ui/desktop/src/utils/__tests__/messagePairing.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import type { Message } from '../../types/message';
+import { laterPairingChanged, onlyLastMessageChanged } from '../messagePairing';
+
+function textMessage(id: string, text: string): Message {
+  return {
+    id,
+    role: 'assistant',
+    created: 1,
+    content: [{ type: 'text', text }],
+    metadata: { userVisible: true, agentVisible: true },
+  };
+}
+
+function toolResponseMessage(id: string): Message {
+  return {
+    id,
+    role: 'user',
+    created: 1,
+    content: [
+      {
+        type: 'toolResponse',
+        id: `${id}-tool`,
+        toolResult: { status: 'success' },
+      },
+    ],
+    metadata: { userVisible: true, agentVisible: true },
+  };
+}
+
+describe('messagePairing', () => {
+  it('detects a last-message-only identity change', () => {
+    const first = textMessage('one', 'hello');
+    const previousLast = textMessage('two', 'wor');
+    const nextLast = textMessage('two', 'world');
+
+    expect(onlyLastMessageChanged([first, previousLast], [first, nextLast])).toBe(true);
+    expect(onlyLastMessageChanged([first, previousLast], [textMessage('one', 'hello'), nextLast])).toBe(
+      false
+    );
+  });
+
+  it('ignores streamed text updates for earlier messages', () => {
+    const first = textMessage('one', 'hello');
+    const previousLast = textMessage('two', 'wor');
+    const nextLast = textMessage('two', 'world');
+
+    expect(laterPairingChanged([first, previousLast], [first, nextLast], first)).toBe(false);
+  });
+
+  it('treats a later tool response as a pairing change', () => {
+    const first = textMessage('one', 'hello');
+    const previousLast = textMessage('two', 'world');
+    const nextLast = toolResponseMessage('two');
+
+    expect(laterPairingChanged([first, previousLast], [first, nextLast], first)).toBe(true);
+  });
+});

--- a/ui/desktop/src/utils/__tests__/scrollFollow.test.ts
+++ b/ui/desktop/src/utils/__tests__/scrollFollow.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import {
+  BOTTOM_SCROLL_THRESHOLD,
+  distanceFromBottom,
+  isViewportAtBottom,
+  shouldUnfollowOnScroll,
+} from '../scrollFollow';
+
+describe('scrollFollow', () => {
+  it('measures the remaining distance to the end of the transcript', () => {
+    expect(
+      distanceFromBottom({
+        scrollHeight: 2000,
+        scrollTop: 1400,
+        clientHeight: 400,
+      })
+    ).toBe(200);
+  });
+
+  it('treats the live edge as the bottom of the latest bubble', () => {
+    expect(
+      isViewportAtBottom({
+        scrollHeight: 2000,
+        scrollTop: 1600,
+        clientHeight: 400,
+      })
+    ).toBe(true);
+    expect(
+      isViewportAtBottom({
+        scrollHeight: 2000,
+        scrollTop: 1399,
+        clientHeight: 400,
+      })
+    ).toBe(false);
+    expect(BOTTOM_SCROLL_THRESHOLD).toBe(200);
+  });
+
+  it('does not treat programmatic growth as a user scroll-up', () => {
+    expect(
+      shouldUnfollowOnScroll({
+        isFollowing: true,
+        isProgrammatic: true,
+        isAtBottom: false,
+      })
+    ).toBe(false);
+  });
+
+  it('unfollows only when the user actually leaves the live edge', () => {
+    expect(
+      shouldUnfollowOnScroll({
+        isFollowing: true,
+        isProgrammatic: false,
+        isAtBottom: false,
+      })
+    ).toBe(true);
+    expect(
+      shouldUnfollowOnScroll({
+        isFollowing: true,
+        isProgrammatic: false,
+        isAtBottom: true,
+      })
+    ).toBe(false);
+  });
+});

--- a/ui/desktop/src/utils/__tests__/toolCallChaining.lookups.test.ts
+++ b/ui/desktop/src/utils/__tests__/toolCallChaining.lookups.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+import type { Message } from '../../types/message';
+import {
+  buildToolCallLookups,
+  getPreviousResolvedModels,
+  identifyConsecutiveToolCalls,
+  messageToolLookupsChanged,
+} from '../toolCallChaining';
+
+function textMessage(id: string, text: string): Message {
+  return {
+    id,
+    role: 'assistant',
+    created: 1,
+    content: [{ type: 'text', text }],
+    metadata: { userVisible: true, agentVisible: true },
+  };
+}
+
+describe('toolCallChaining caches', () => {
+  it('reuses tool lookups when only a text message identity changes', () => {
+    const first = textMessage('one', 'hello');
+    const second = textMessage('two', 'wor');
+    const initial = buildToolCallLookups([first, second]);
+    const next = buildToolCallLookups([first, textMessage('two', 'world')]);
+
+    expect(next).toBe(initial);
+  });
+
+  it('reuses tool lookups when a non-tool message is appended', () => {
+    const first = textMessage('one', 'hello');
+    const initial = buildToolCallLookups([first]);
+    const next = buildToolCallLookups([first, textMessage('two', 'world')]);
+
+    expect(next).toBe(initial);
+  });
+
+  it('reuses tool-call chains when only the last text message changes', () => {
+    const first = textMessage('one', 'hello');
+    const second = textMessage('two', 'wor');
+    const initial = identifyConsecutiveToolCalls([first, second]);
+    const next = identifyConsecutiveToolCalls([first, textMessage('two', 'world')]);
+
+    expect(next).toBe(initial);
+  });
+
+  it('extends previous resolved models when a new message is appended', () => {
+    const first: Message = {
+      id: 'one',
+      role: 'assistant',
+      created: 1,
+      content: [{ type: 'text', text: 'hello' }],
+      metadata: {
+        userVisible: true,
+        agentVisible: true,
+        inference: { resolvedModel: 'gpt-test', requestedModel: 'gpt-test', provider: 'test' },
+      },
+    };
+    const second = textMessage('two', 'world');
+    const initial = getPreviousResolvedModels([first]);
+    const next = getPreviousResolvedModels([first, second]);
+
+    expect(initial).toEqual([null]);
+    expect(next[0]).toBe(initial[0]);
+    expect(next[1]).toBe('gpt-test');
+  });
+
+  it('ignores lookup rebuilds for messages that do not use the changed tool data', () => {
+    const request: Message = {
+      id: 'request',
+      role: 'assistant',
+      created: 1,
+      content: [
+        {
+          type: 'toolRequest',
+          id: 'tool-1',
+          toolCall: { name: 'developer__shell' },
+        },
+      ],
+      metadata: { userVisible: true, agentVisible: true },
+    };
+    const other = textMessage('other', 'hello');
+    const previous = buildToolCallLookups([request, other]);
+    const next = buildToolCallLookups([
+      request,
+      {
+        id: 'response',
+        role: 'user',
+        created: 2,
+        content: [
+          {
+            type: 'toolResponse',
+            id: 'tool-1',
+            toolResult: { status: 'success' },
+          },
+        ],
+        metadata: { userVisible: true, agentVisible: true },
+      },
+    ]);
+
+    expect(messageToolLookupsChanged(other, previous, next)).toBe(false);
+    expect(messageToolLookupsChanged(request, previous, next)).toBe(true);
+  });
+
+  it('reuses previous resolved models when only the last text message changes', () => {
+    const first: Message = {
+      id: 'one',
+      role: 'assistant',
+      created: 1,
+      content: [{ type: 'text', text: 'hello' }],
+      metadata: {
+        userVisible: true,
+        agentVisible: true,
+        inference: { resolvedModel: 'gpt-test', requestedModel: 'gpt-test', provider: 'test' },
+      },
+    };
+    const second = textMessage('two', 'wor');
+    const initial = getPreviousResolvedModels([first, second]);
+    const next = getPreviousResolvedModels([first, textMessage('two', 'world')]);
+
+    expect(next).toBe(initial);
+    expect(next[1]).toBe('gpt-test');
+  });
+});

--- a/ui/desktop/src/utils/__tests__/transcriptWindow.test.ts
+++ b/ui/desktop/src/utils/__tests__/transcriptWindow.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_VISIBLE_MESSAGE_WINDOW,
+  EARLIER_MESSAGE_PAGE_SIZE,
+  earlierTranscriptWindowStart,
+  initialTranscriptWindowStart,
+  visibleTranscriptWindowStart,
+} from '../transcriptWindow';
+
+describe('transcriptWindow', () => {
+  it('keeps short transcripts fully visible', () => {
+    expect(initialTranscriptWindowStart(12)).toBe(0);
+    expect(initialTranscriptWindowStart(DEFAULT_VISIBLE_MESSAGE_WINDOW)).toBe(0);
+  });
+
+  it('pins long transcripts to the latest visible window', () => {
+    expect(initialTranscriptWindowStart(241)).toBe(161);
+    expect(initialTranscriptWindowStart(80, 20)).toBe(60);
+  });
+
+  it('pages earlier history without jumping to the start', () => {
+    expect(earlierTranscriptWindowStart(161)).toBe(81);
+    expect(earlierTranscriptWindowStart(81)).toBe(1);
+    expect(earlierTranscriptWindowStart(1)).toBe(0);
+    expect(earlierTranscriptWindowStart(40, EARLIER_MESSAGE_PAGE_SIZE)).toBe(0);
+  });
+
+  it('follows the live edge until the user expands history', () => {
+    expect(
+      visibleTranscriptWindowStart({
+        messageCount: 82,
+        showAll: false,
+        pinnedToLiveEdge: true,
+        windowStart: 1,
+      })
+    ).toBe(2);
+  });
+
+  it('keeps an expanded earlier page in place when a new message arrives', () => {
+    expect(
+      visibleTranscriptWindowStart({
+        messageCount: 242,
+        showAll: false,
+        pinnedToLiveEdge: false,
+        windowStart: 81,
+      })
+    ).toBe(81);
+  });
+
+  it('opens the full transcript when search expands it', () => {
+    expect(
+      visibleTranscriptWindowStart({
+        messageCount: 241,
+        showAll: true,
+        pinnedToLiveEdge: false,
+        windowStart: 161,
+      })
+    ).toBe(0);
+  });
+});

--- a/ui/desktop/src/utils/__tests__/transcriptWindow.test.ts
+++ b/ui/desktop/src/utils/__tests__/transcriptWindow.test.ts
@@ -3,8 +3,11 @@ import {
   DEFAULT_VISIBLE_MESSAGE_WINDOW,
   EARLIER_MESSAGE_PAGE_SIZE,
   earlierTranscriptWindowStart,
+  laterTranscriptWindowStart,
   initialTranscriptWindowStart,
   transcriptMessageKey,
+  transcriptWindowForIndex,
+  visibleTranscriptRange,
   visibleTranscriptWindowStart,
 } from '../transcriptWindow';
 
@@ -62,5 +65,22 @@ describe('transcriptWindow', () => {
         windowStart: 161,
       })
     ).toBe(0);
+  });
+
+  it('keeps a search jump inside an 80-message mounted window', () => {
+    expect(transcriptWindowForIndex(10, 241)).toBe(0);
+    expect(transcriptWindowForIndex(120, 241)).toBe(80);
+    expect(transcriptWindowForIndex(240, 241)).toBe(161);
+    expect(visibleTranscriptRange({
+      messageCount: 241,
+      showAll: false,
+      pinnedToLiveEdge: false,
+      windowStart: 80,
+    })).toEqual({ start: 80, end: 160 });
+  });
+
+  it('pages later history without jumping to the live edge', () => {
+    expect(laterTranscriptWindowStart(81, 242)).toBe(161);
+    expect(laterTranscriptWindowStart(161, 242)).toBe(162);
   });
 });

--- a/ui/desktop/src/utils/__tests__/transcriptWindow.test.ts
+++ b/ui/desktop/src/utils/__tests__/transcriptWindow.test.ts
@@ -4,6 +4,7 @@ import {
   EARLIER_MESSAGE_PAGE_SIZE,
   earlierTranscriptWindowStart,
   initialTranscriptWindowStart,
+  transcriptMessageKey,
   visibleTranscriptWindowStart,
 } from '../transcriptWindow';
 
@@ -45,6 +46,11 @@ describe('transcriptWindow', () => {
         windowStart: 81,
       })
     ).toBe(81);
+  });
+
+  it('keeps restore keys stable when a message has no id', () => {
+    expect(transcriptMessageKey({ role: 'assistant', created: 42 })).toBe('assistant:42');
+    expect(transcriptMessageKey({ id: 'msg-1', role: 'assistant', created: 42 })).toBe('msg-1');
   });
 
   it('opens the full transcript when search expands it', () => {

--- a/ui/desktop/src/utils/messagePairing.ts
+++ b/ui/desktop/src/utils/messagePairing.ts
@@ -1,0 +1,65 @@
+import type { Message } from '../types/message';
+
+function hasPairingContent(message: Message): boolean {
+  return message.content.some(
+    (content) => content.type === 'toolResponse' || content.type === 'actionRequired'
+  );
+}
+
+export function onlyLastMessageChanged(
+  previousMessages: Message[],
+  nextMessages: Message[]
+): boolean {
+  if (previousMessages.length !== nextMessages.length || nextMessages.length === 0) {
+    return false;
+  }
+
+  for (let index = 0; index < nextMessages.length - 1; index++) {
+    if (previousMessages[index] !== nextMessages[index]) {
+      return false;
+    }
+  }
+
+  return previousMessages[previousMessages.length - 1] !== nextMessages[nextMessages.length - 1];
+}
+
+export function laterPairingChanged(
+  previousMessages: Message[],
+  nextMessages: Message[],
+  message: Message
+): boolean {
+  const previousIndex = previousMessages.indexOf(message);
+  const nextIndex = nextMessages.indexOf(message);
+  if (previousIndex === -1 || nextIndex === -1) {
+    return true;
+  }
+
+  if (onlyLastMessageChanged(previousMessages, nextMessages)) {
+    if (nextIndex === nextMessages.length - 1) {
+      return true;
+    }
+    return (
+      hasPairingContent(previousMessages[previousMessages.length - 1]) ||
+      hasPairingContent(nextMessages[nextMessages.length - 1])
+    );
+  }
+
+  const previousPairing = pairingContentAfter(previousMessages, previousIndex);
+  const nextPairing = pairingContentAfter(nextMessages, nextIndex);
+  if (previousPairing.length !== nextPairing.length) {
+    return true;
+  }
+  return previousPairing.some((content, index) => content !== nextPairing[index]);
+}
+
+function pairingContentAfter(messages: Message[], index: number) {
+  const pairing: Message['content'][number][] = [];
+  for (let i = index + 1; i < messages.length; i++) {
+    for (const content of messages[i].content) {
+      if (content.type === 'toolResponse' || content.type === 'actionRequired') {
+        pairing.push(content);
+      }
+    }
+  }
+  return pairing;
+}

--- a/ui/desktop/src/utils/scrollFollow.ts
+++ b/ui/desktop/src/utils/scrollFollow.ts
@@ -1,0 +1,28 @@
+export const BOTTOM_SCROLL_THRESHOLD = 200;
+
+export function distanceFromBottom(viewport: {
+  scrollHeight: number;
+  scrollTop: number;
+  clientHeight: number;
+}): number {
+  return viewport.scrollHeight - viewport.scrollTop - viewport.clientHeight;
+}
+
+export function isViewportAtBottom(
+  viewport: {
+    scrollHeight: number;
+    scrollTop: number;
+    clientHeight: number;
+  },
+  threshold: number = BOTTOM_SCROLL_THRESHOLD
+): boolean {
+  return distanceFromBottom(viewport) <= threshold;
+}
+
+export function shouldUnfollowOnScroll(input: {
+  isFollowing: boolean;
+  isProgrammatic: boolean;
+  isAtBottom: boolean;
+}): boolean {
+  return input.isFollowing && !input.isProgrammatic && !input.isAtBottom;
+}

--- a/ui/desktop/src/utils/toolCallChaining.ts
+++ b/ui/desktop/src/utils/toolCallChaining.ts
@@ -1,11 +1,82 @@
 import {
-  getToolRequests,
+  getAnyToolConfirmationData,
   getTextAndImageContent,
+  getToolRequests,
   getToolResponses,
   type Message,
+  type NotificationEvent,
+  type ToolConfirmationData,
+  type ToolResponse,
 } from '../types/message';
 
+function messageHasVisibleText(message: Message): boolean {
+  const { textContent } = getTextAndImageContent(message);
+  return textContent.trim().length > 0;
+}
+
+function messageAffectsToolLookups(message: Message): boolean {
+  return message.content.some(
+    (content) =>
+      content.type === 'toolRequest' ||
+      content.type === 'toolResponse' ||
+      content.type === 'toolConfirmationRequest' ||
+      (content.type === 'actionRequired' && content.data.actionType === 'toolConfirmation')
+  );
+}
+
+function sameMessageIdentities(left: Message[], right: Message[]): boolean {
+  if (left === right) {
+    return true;
+  }
+  if (left.length !== right.length) {
+    return false;
+  }
+  return left.every((message, index) => message === right[index]);
+}
+
+let cachedToolCallChains: { messages: Message[]; chains: number[][] } | undefined;
+
 export function identifyConsecutiveToolCalls(messages: Message[]): number[][] {
+  if (cachedToolCallChains && sameMessageIdentities(cachedToolCallChains.messages, messages)) {
+    return cachedToolCallChains.chains;
+  }
+
+  if (cachedToolCallChains && cachedToolCallChains.messages.length === messages.length) {
+    let onlyLastChanged = true;
+    for (let i = 0; i < messages.length - 1; i++) {
+      if (cachedToolCallChains.messages[i] !== messages[i]) {
+        onlyLastChanged = false;
+        break;
+      }
+    }
+    if (onlyLastChanged) {
+      const previousLast = cachedToolCallChains.messages[messages.length - 1];
+      const nextLast = messages[messages.length - 1];
+      if (
+        previousLast &&
+        nextLast &&
+        !messageAffectsToolLookups(previousLast) &&
+        !messageAffectsToolLookups(nextLast) &&
+        messageHasVisibleText(previousLast) === messageHasVisibleText(nextLast)
+      ) {
+        cachedToolCallChains = { messages, chains: cachedToolCallChains.chains };
+        return cachedToolCallChains.chains;
+      }
+    }
+  }
+
+  if (
+    cachedToolCallChains &&
+    cachedToolCallChains.messages.length + 1 === messages.length &&
+    cachedToolCallChains.messages.every((message, index) => message === messages[index])
+  ) {
+    const appended = messages[messages.length - 1];
+    if (appended && !messageAffectsToolLookups(appended) && !messageHasVisibleText(appended)) {
+      cachedToolCallChains = { messages, chains: cachedToolCallChains.chains };
+      return cachedToolCallChains.chains;
+    }
+  }
+
   const chains: number[][] = [];
   let currentChain: number[] = [];
 
@@ -13,8 +84,7 @@ export function identifyConsecutiveToolCalls(messages: Message[]): number[][] {
     const message = messages[i];
     const toolRequests = getToolRequests(message);
     const toolResponses = getToolResponses(message);
-    const { textContent } = getTextAndImageContent(message);
-    const hasText = textContent.trim().length > 0;
+    const hasText = messageHasVisibleText(message);
 
     if (toolResponses.length > 0 && toolRequests.length === 0) {
       continue;
@@ -22,10 +92,8 @@ export function identifyConsecutiveToolCalls(messages: Message[]): number[][] {
 
     if (toolRequests.length > 0) {
       if (hasText) {
-        if (currentChain.length > 0) {
-          if (currentChain.length > 1) {
-            chains.push([...currentChain]);
-          }
+        if (currentChain.length > 1) {
+          chains.push([...currentChain]);
         }
         currentChain = [i];
       } else {
@@ -48,19 +116,237 @@ export function identifyConsecutiveToolCalls(messages: Message[]): number[][] {
     chains.push(currentChain);
   }
 
+  cachedToolCallChains = { messages, chains };
   return chains;
 }
 
-export function shouldHideTimestamp(messageIndex: number, chains: number[][]): boolean {
+const lastIndexByChain = new WeakMap<number[][], Set<number>>();
+const membershipByChain = new WeakMap<number[][], Set<number>>();
+
+function chainSets(chains: number[][]): { membership: Set<number>; lastIndexes: Set<number> } {
+  const cachedMembership = membershipByChain.get(chains);
+  const cachedLastIndexes = lastIndexByChain.get(chains);
+  if (cachedMembership && cachedLastIndexes) {
+    return { membership: cachedMembership, lastIndexes: cachedLastIndexes };
+  }
+
+  const membership = new Set<number>();
+  const lastIndexes = new Set<number>();
   for (const chain of chains) {
-    if (chain.includes(messageIndex)) {
-      // Hide timestamp for all but the last message in the chain
-      return chain[chain.length - 1] !== messageIndex;
+    if (chain.length === 0) {
+      continue;
+    }
+    lastIndexes.add(chain[chain.length - 1]);
+    for (const index of chain) {
+      membership.add(index);
     }
   }
-  return false;
+  membershipByChain.set(chains, membership);
+  lastIndexByChain.set(chains, lastIndexes);
+  return { membership, lastIndexes };
 }
 
 export function isInChain(messageIndex: number, chains: number[][]): boolean {
-  return chains.some((chain) => chain.includes(messageIndex));
+  return chainSets(chains).membership.has(messageIndex);
+}
+
+export function shouldHideTimestamp(messageIndex: number, chains: number[][]): boolean {
+  const { membership, lastIndexes } = chainSets(chains);
+  return membership.has(messageIndex) && !lastIndexes.has(messageIndex);
+}
+
+function resolvedModelFromMessage(message: Message | undefined): string | null {
+  if (!message || message.role !== 'assistant' || !message.metadata.userVisible) {
+    return null;
+  }
+  return message.metadata.inference?.resolvedModel ?? null;
+}
+
+let cachedPreviousResolvedModels: { messages: Message[]; models: Array<string | null> } | undefined;
+
+export function getPreviousResolvedModels(messages: Message[]): Array<string | null> {
+  if (
+    cachedPreviousResolvedModels &&
+    sameMessageIdentities(cachedPreviousResolvedModels.messages, messages)
+  ) {
+    return cachedPreviousResolvedModels.models;
+  }
+
+  if (
+    cachedPreviousResolvedModels &&
+    cachedPreviousResolvedModels.messages.length === messages.length
+  ) {
+    let onlyLastChanged = true;
+    for (let i = 0; i < messages.length - 1; i++) {
+      if (cachedPreviousResolvedModels.messages[i] !== messages[i]) {
+        onlyLastChanged = false;
+        break;
+      }
+    }
+    if (onlyLastChanged) {
+      cachedPreviousResolvedModels = {
+        messages,
+        models: cachedPreviousResolvedModels.models,
+      };
+      return cachedPreviousResolvedModels.models;
+    }
+  }
+
+  if (
+    cachedPreviousResolvedModels &&
+    cachedPreviousResolvedModels.messages.length + 1 === messages.length &&
+    cachedPreviousResolvedModels.messages.every((message, index) => message === messages[index])
+  ) {
+    const previousModels = cachedPreviousResolvedModels.models;
+    const lastResolved =
+      resolvedModelFromMessage(messages[messages.length - 2]) ??
+      previousModels[previousModels.length - 1] ??
+      null;
+    const models = [...previousModels, lastResolved];
+    cachedPreviousResolvedModels = { messages, models };
+    return models;
+  }
+
+  const models: Array<string | null> = new Array(messages.length);
+  let lastResolvedModel: string | null = null;
+  for (let i = 0; i < messages.length; i++) {
+    models[i] = lastResolvedModel;
+    const model = resolvedModelFromMessage(messages[i]);
+    if (model) {
+      lastResolvedModel = model;
+    }
+  }
+  cachedPreviousResolvedModels = { messages, models };
+  return models;
+}
+
+export type ToolCallLookups = {
+  responsesById: Map<string, ToolResponse & { type: 'toolResponse' }>;
+  confirmationsById: Map<string, ToolConfirmationData>;
+  requestIds: Set<string>;
+  pendingConfirmationIds: Set<string>;
+};
+
+let cachedLookups: { messages: Message[]; lookups: ToolCallLookups } | undefined;
+
+export function buildToolCallLookups(messages: Message[]): ToolCallLookups {
+  if (cachedLookups && sameMessageIdentities(cachedLookups.messages, messages)) {
+    return cachedLookups.lookups;
+  }
+
+  if (cachedLookups && cachedLookups.messages.length === messages.length) {
+    let toolRelatedChange = false;
+    for (let i = 0; i < messages.length; i++) {
+      if (cachedLookups.messages[i] === messages[i]) {
+        continue;
+      }
+      if (
+        messageAffectsToolLookups(cachedLookups.messages[i]) ||
+        messageAffectsToolLookups(messages[i])
+      ) {
+        toolRelatedChange = true;
+        break;
+      }
+    }
+    if (!toolRelatedChange) {
+      cachedLookups = { messages, lookups: cachedLookups.lookups };
+      return cachedLookups.lookups;
+    }
+  }
+
+  if (
+    cachedLookups &&
+    cachedLookups.messages.length + 1 === messages.length &&
+    cachedLookups.messages.every((message, index) => message === messages[index])
+  ) {
+    const appended = messages[messages.length - 1];
+    if (appended && !messageAffectsToolLookups(appended)) {
+      cachedLookups = { messages, lookups: cachedLookups.lookups };
+      return cachedLookups.lookups;
+    }
+  }
+
+  const responsesById = new Map<string, ToolResponse & { type: 'toolResponse' }>();
+  const confirmationsById = new Map<string, ToolConfirmationData>();
+  const requestIds = new Set<string>();
+  const respondedIds = new Set<string>();
+  const pendingConfirmationIds = new Set<string>();
+
+  for (const message of messages) {
+    for (const request of getToolRequests(message)) {
+      requestIds.add(request.id);
+    }
+    for (const response of getToolResponses(message)) {
+      responsesById.set(response.id, response);
+      respondedIds.add(response.id);
+    }
+
+    const confirmation = getAnyToolConfirmationData(message);
+    if (confirmation) {
+      confirmationsById.set(confirmation.id, confirmation);
+    }
+  }
+
+  for (const confirmationId of confirmationsById.keys()) {
+    if (!respondedIds.has(confirmationId)) {
+      pendingConfirmationIds.add(confirmationId);
+    }
+  }
+
+  const lookups = {
+    responsesById,
+    confirmationsById,
+    requestIds,
+    pendingConfirmationIds,
+  };
+  cachedLookups = { messages, lookups };
+  return lookups;
+}
+
+export function messageToolLookupsChanged(
+  message: Message,
+  previous: ToolCallLookups,
+  next: ToolCallLookups
+): boolean {
+  if (previous === next) {
+    return false;
+  }
+
+  const confirmation = getAnyToolConfirmationData(message);
+  if (
+    confirmation &&
+    previous.requestIds.has(confirmation.id) !== next.requestIds.has(confirmation.id)
+  ) {
+    return true;
+  }
+
+  for (const request of getToolRequests(message)) {
+    if (
+      previous.responsesById.get(request.id) !== next.responsesById.get(request.id) ||
+      previous.confirmationsById.get(request.id) !== next.confirmationsById.get(request.id) ||
+      previous.pendingConfirmationIds.has(request.id) !== next.pendingConfirmationIds.has(request.id)
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+export function messageNotificationsChanged(
+  message: Message,
+  previous: Map<string, NotificationEvent[]>,
+  next: Map<string, NotificationEvent[]>
+): boolean {
+  if (previous === next) {
+    return false;
+  }
+
+  for (const request of getToolRequests(message)) {
+    if (previous.get(request.id) !== next.get(request.id)) {
+      return true;
+    }
+  }
+
+  return false;
 }

--- a/ui/desktop/src/utils/transcriptWindow.ts
+++ b/ui/desktop/src/utils/transcriptWindow.ts
@@ -46,3 +46,43 @@ export function visibleTranscriptWindowStart(input: {
 
   return Math.max(0, Math.min(input.windowStart, latestStart));
 }
+
+export function laterTranscriptWindowStart(
+  windowStart: number,
+  messageCount: number,
+  pageSize: number = EARLIER_MESSAGE_PAGE_SIZE,
+  visibleWindow: number = DEFAULT_VISIBLE_MESSAGE_WINDOW
+): number {
+  const latestStart = initialTranscriptWindowStart(messageCount, visibleWindow);
+  return Math.min(latestStart, windowStart + pageSize);
+}
+
+export function transcriptWindowForIndex(
+  messageIndex: number,
+  messageCount: number,
+  visibleWindow: number = DEFAULT_VISIBLE_MESSAGE_WINDOW
+): number {
+  if (messageCount <= visibleWindow) {
+    return 0;
+  }
+  const centered = messageIndex - Math.floor(visibleWindow / 2);
+  return Math.max(0, Math.min(centered, messageCount - visibleWindow));
+}
+
+export function visibleTranscriptRange(input: {
+  messageCount: number;
+  showAll: boolean;
+  pinnedToLiveEdge: boolean;
+  windowStart: number;
+  visibleWindow?: number;
+}): { start: number; end: number } {
+  const visibleWindow = input.visibleWindow ?? DEFAULT_VISIBLE_MESSAGE_WINDOW;
+  if (input.showAll) {
+    return { start: 0, end: input.messageCount };
+  }
+  const start = visibleTranscriptWindowStart({ ...input, visibleWindow });
+  return {
+    start,
+    end: Math.min(input.messageCount, start + visibleWindow),
+  };
+}

--- a/ui/desktop/src/utils/transcriptWindow.ts
+++ b/ui/desktop/src/utils/transcriptWindow.ts
@@ -1,0 +1,41 @@
+export const DEFAULT_VISIBLE_MESSAGE_WINDOW = 80;
+export const EARLIER_MESSAGE_PAGE_SIZE = 80;
+
+export function initialTranscriptWindowStart(
+  messageCount: number,
+  visibleWindow: number = DEFAULT_VISIBLE_MESSAGE_WINDOW
+): number {
+  if (messageCount <= visibleWindow) {
+    return 0;
+  }
+  return messageCount - visibleWindow;
+}
+
+export function earlierTranscriptWindowStart(
+  windowStart: number,
+  pageSize: number = EARLIER_MESSAGE_PAGE_SIZE
+): number {
+  return Math.max(0, windowStart - pageSize);
+}
+
+export function visibleTranscriptWindowStart(input: {
+  messageCount: number;
+  showAll: boolean;
+  pinnedToLiveEdge: boolean;
+  windowStart: number;
+  visibleWindow?: number;
+}): number {
+  if (input.showAll) {
+    return 0;
+  }
+
+  const latestStart = initialTranscriptWindowStart(
+    input.messageCount,
+    input.visibleWindow ?? DEFAULT_VISIBLE_MESSAGE_WINDOW
+  );
+  if (input.pinnedToLiveEdge) {
+    return latestStart;
+  }
+
+  return Math.max(0, Math.min(input.windowStart, latestStart));
+}

--- a/ui/desktop/src/utils/transcriptWindow.ts
+++ b/ui/desktop/src/utils/transcriptWindow.ts
@@ -18,6 +18,13 @@ export function earlierTranscriptWindowStart(
   return Math.max(0, windowStart - pageSize);
 }
 
+export function transcriptMessageKey(message: { id?: string | null; role: string; created: number }): string {
+  if (message.id) {
+    return message.id;
+  }
+  return `${message.role}:${message.created}`;
+}
+
 export function visibleTranscriptWindowStart(input: {
   messageCount: number;
   showAll: boolean;


### PR DESCRIPTION
## Summary

Desktop still opens large chats from the oldest message and then keeps that cost around after first paint. This change treats the transcript as a reverse-paginated log:

- ACP restore loads the latest 80 user-visible messages instead of hydrating and replaying the full conversation oldest-first
- the renderer mounts only that window and pages earlier / later history on demand
- Cmd/F searches the server and jumps to a window around the hit
- streaming reuses unchanged message identities and coalesces ACP notifies
- first-turn detection uses an `EXISTS` query instead of loading every message
- after a turn finishes, the viewport stays pinned to the **end** of the last bubble unless the user has scrolled away

Session-list SQL counters stay in #11288. This PR does **not** bump `CURRENT_SCHEMA_VERSION` (still 16 on `main`).

### Testing

- `cargo test -p goose --lib session::session_manager` — 45 passed
- `cargo clippy -p goose -p goose-sdk-types --all-targets -- -D warnings` — clean
- `cargo fmt`
- vitest: `scrollFollow`, `transcriptWindow`, `ProgressiveMessageList`, `chatSessionStore`, `chatNotifications`, `chatSessionController`, `cloneMessagesSharingUnchanged` — 68 passed

Live desktop verification is **not** complete. Isolated Electron could not finish a TLS session against an already-running Goose, and the six GUI checks have not been signed off on a normal relaunch of this branch. The one qualitative failure already seen on a pre-scroll-fix build was the finished bubble showing from the top.

The first-turn `EXISTS` check is on the legacy agent loop. The state-machine path still hydrates the conversation through `SessionLoader` because the model needs it. Reply still calls `get_session(..., true)` for the model; last-N context is out of scope.

### Related Issues
Relates to #11348
Related, not solved here: #11287 / #11288 (session-list SQL), #10664 (O(n²) clone freeze, already closed), #10764 (ACP handoff memo)

### Screenshots/Demos (for UX changes)
Before: large sessions fill from message 1; after a turn the last bubble is often left showing its top.

After: open should land on the latest 80 messages; Show earlier / Show later page; Cmd/F jumps to a server window; finished turns should stay pinned at the live edge.

Draft until #11348 is triaged / Ready. CONTRIBUTING says not to open a PR before Ready; opening as draft so the rebased solution is reviewable against current `main`.
