### PR TITLE
fix(security): fail closed on invalid Codex ACP mode

### DIFF
--- a/crates/goose/src/config/base.rs
+++ b/crates/goose/src/config/base.rs
@@ -523,8 +523,10 @@ impl Config {
         let mut merged = Mapping::new();
 
         for path in &self.config_paths {
-            if !path.try_exists()? {
-                continue;
+            match std::fs::symlink_metadata(path) {
+                Ok(_) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(error) => return Err(error.into()),
             }
             let content = std::fs::read_to_string(path)?;
             let layer = parse_yaml_content(&content)?;

--- a/crates/goose/src/config/base.rs
+++ b/crates/goose/src/config/base.rs
@@ -523,7 +523,7 @@ impl Config {
         let mut merged = Mapping::new();
 
         for path in &self.config_paths {
-            if !path.exists() {
+            if !path.try_exists()? {
                 continue;
             }
             let content = std::fs::read_to_string(path)?;

--- a/crates/goose/src/config/base.rs
+++ b/crates/goose/src/config/base.rs
@@ -519,6 +519,23 @@ impl Config {
         Ok(merged)
     }
 
+    fn load_strict(&self) -> Result<Mapping, ConfigError> {
+        let mut merged = Mapping::new();
+
+        for path in &self.config_paths {
+            if !path.exists() {
+                continue;
+            }
+            let content = std::fs::read_to_string(path)?;
+            let layer = parse_yaml_content(&content)?;
+            merge_config_values(&mut merged, layer);
+        }
+
+        crate::config::migrations::run_read_migrations(&mut merged);
+
+        Ok(merged)
+    }
+
     pub fn all_values(&self) -> Result<HashMap<String, Value>, ConfigError> {
         let config_values = self.load()?;
         let mut map = HashMap::from_iter(config_values.into_iter().filter_map(|(k, v)| {
@@ -1107,6 +1124,26 @@ config_value!(CHATGPT_CODEX_REASONING_EFFORT, String, "medium");
 
 config_value!(GOOSE_SEARCH_PATHS, Vec<String>);
 config_value!(GOOSE_MODE, GooseMode);
+impl Config {
+    pub(crate) fn get_goose_mode_strict(&self) -> Result<GooseMode, ConfigError> {
+        match env::var("GOOSE_MODE") {
+            Ok(value) => {
+                let value = Self::parse_env_value(&value)?;
+                Ok(serde_json::from_value(value)?)
+            }
+            Err(env::VarError::NotPresent) => {
+                let values = self.load_strict()?;
+                let value = values
+                    .get("GOOSE_MODE")
+                    .ok_or_else(|| ConfigError::NotFound("GOOSE_MODE".to_string()))?;
+                Ok(serde_yaml::from_value(value.clone())?)
+            }
+            Err(env::VarError::NotUnicode(_)) => Err(ConfigError::DeserializeError(
+                "GOOSE_MODE contains non-Unicode data".to_string(),
+            )),
+        }
+    }
+}
 // GOOSE_PROVIDER and GOOSE_MODEL are handled by crate::config::providers
 // which checks the structured `providers:` block first and falls back to
 // the legacy flat keys. The accessors below delegate to that module.

--- a/crates/goose/src/config/base.rs
+++ b/crates/goose/src/config/base.rs
@@ -150,7 +150,15 @@ enum SecretStorage {
 // Global instance
 static GLOBAL_CONFIG: OnceCell<Config> = OnceCell::new();
 
+#[cfg(test)]
+pub(crate) const TEST_SYSTEM_CONFIG_PATH_ENV: &str = "GOOSE_TEST_SYSTEM_CONFIG_PATH";
+
 fn system_config_path() -> PathBuf {
+    #[cfg(test)]
+    if let Some(path) = env::var_os(TEST_SYSTEM_CONFIG_PATH_ENV) {
+        return path.into();
+    }
+
     #[cfg(unix)]
     {
         PathBuf::from("/etc/goose/config.yaml")

--- a/crates/goose/src/config/base.rs
+++ b/crates/goose/src/config/base.rs
@@ -525,7 +525,19 @@ impl Config {
         for path in &self.config_paths {
             match std::fs::symlink_metadata(path) {
                 Ok(_) => {}
-                Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                    for ancestor in path.ancestors().skip(1) {
+                        match std::fs::symlink_metadata(ancestor) {
+                            Ok(metadata) if metadata.file_type().is_symlink() => {
+                                std::fs::metadata(ancestor)?;
+                            }
+                            Ok(_) => {}
+                            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                            Err(error) => return Err(error.into()),
+                        }
+                    }
+                    continue;
+                }
                 Err(error) => return Err(error.into()),
             }
             let content = std::fs::read_to_string(path)?;

--- a/crates/goose/src/config/base.rs
+++ b/crates/goose/src/config/base.rs
@@ -169,6 +169,25 @@ fn additional_config_paths_from_env() -> Vec<PathBuf> {
         .unwrap_or_default()
 }
 
+fn metadata_is_symlink_or_reparse_point(metadata: &std::fs::Metadata) -> bool {
+    if metadata.file_type().is_symlink() {
+        return true;
+    }
+
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::MetadataExt;
+
+        const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x400;
+        metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0
+    }
+
+    #[cfg(not(windows))]
+    {
+        false
+    }
+}
+
 impl Default for Config {
     fn default() -> Self {
         let config_dir = Paths::config_dir();
@@ -528,7 +547,7 @@ impl Config {
                 Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
                     for ancestor in path.ancestors().skip(1) {
                         match std::fs::symlink_metadata(ancestor) {
-                            Ok(metadata) if metadata.file_type().is_symlink() => {
+                            Ok(metadata) if metadata_is_symlink_or_reparse_point(&metadata) => {
                                 std::fs::metadata(ancestor)?;
                             }
                             Ok(_) => {}

--- a/crates/goose/src/providers/codex_acp.rs
+++ b/crates/goose/src/providers/codex_acp.rs
@@ -257,6 +257,11 @@ mod tests {
                 .env("GOOSE_SEARCH_PATHS", &search_paths)
                 .env("GOOSE_CODEX_ACP_MARKER", &marker)
                 .env("GOOSE_PATH_ROOT", &path_root)
+                .env(
+                    crate::config::base::TEST_SYSTEM_CONFIG_PATH_ENV,
+                    path_root.join("system-config.yaml"),
+                )
+                .env_remove("GOOSE_ADDITIONAL_CONFIG_FILES")
                 .env("GOOSE_DISABLE_KEYRING", "1");
             if should_launch {
                 command.env_remove(EXPECT_CONFIG_ERROR_ENV);

--- a/crates/goose/src/providers/codex_acp.rs
+++ b/crates/goose/src/providers/codex_acp.rs
@@ -120,6 +120,15 @@ mod tests {
     #[cfg(unix)]
     const EXPECT_CONFIG_ERROR_ENV: &str = "GOOSE_CODEX_ACP_EXPECT_CONFIG_ERROR";
 
+    #[cfg(unix)]
+    #[derive(Clone, Copy)]
+    enum ConfigFixture {
+        Absent,
+        File(&'static str),
+        Directory,
+        InaccessibleParent,
+    }
+
     #[test]
     fn missing_goose_mode_defaults_to_auto() {
         assert_eq!(
@@ -183,32 +192,51 @@ mod tests {
         fs::set_permissions(&executable, fs::Permissions::from_mode(0o700)).unwrap();
 
         let search_paths = serde_json::to_string(&vec![fixture.path()]).unwrap();
-        for (name, mode, config_content, config_is_directory, should_launch) in [
-            ("unset", None, None, false, true),
-            ("auto", Some("auto"), None, false, true),
-            ("smart_approve", Some("smart_approve"), None, false, true),
-            ("approve", Some("approve"), None, false, true),
-            ("chat", Some("chat"), None, false, true),
-            ("invalid", Some("invalid"), None, false, false),
+        for (name, mode, config_fixture, should_launch) in [
+            ("unset", None, ConfigFixture::Absent, true),
+            ("auto", Some("auto"), ConfigFixture::Absent, true),
+            (
+                "smart_approve",
+                Some("smart_approve"),
+                ConfigFixture::Absent,
+                true,
+            ),
+            ("approve", Some("approve"), ConfigFixture::Absent, true),
+            ("chat", Some("chat"), ConfigFixture::Absent, true),
+            ("invalid", Some("invalid"), ConfigFixture::Absent, false),
             (
                 "configured_file",
                 None,
-                Some("GOOSE_MODE: approve\n"),
-                false,
+                ConfigFixture::File("GOOSE_MODE: approve\n"),
                 true,
             ),
-            ("malformed_file", None, Some("GOOSE_MODE: ["), false, false),
-            ("unreadable_file", None, None, true, false),
+            (
+                "malformed_file",
+                None,
+                ConfigFixture::File("GOOSE_MODE: ["),
+                false,
+            ),
+            ("unreadable_file", None, ConfigFixture::Directory, false),
+            (
+                "inaccessible_parent",
+                None,
+                ConfigFixture::InaccessibleParent,
+                false,
+            ),
         ] {
             let marker = fixture.path().join(format!("launched-{name}"));
             let path_root = fixture.path().join(format!("config-{name}"));
             let config_dir = path_root.join("config");
             fs::create_dir_all(&config_dir).unwrap();
             let config_path = config_dir.join("config.yaml");
-            if let Some(content) = config_content {
-                fs::write(&config_path, content).unwrap();
-            } else if config_is_directory {
-                fs::create_dir(&config_path).unwrap();
+            match config_fixture {
+                ConfigFixture::Absent => {}
+                ConfigFixture::File(content) => fs::write(&config_path, content).unwrap(),
+                ConfigFixture::Directory => fs::create_dir(&config_path).unwrap(),
+                ConfigFixture::InaccessibleParent => {
+                    fs::write(&config_path, "GOOSE_MODE: approve\n").unwrap();
+                    fs::set_permissions(&config_dir, fs::Permissions::from_mode(0o000)).unwrap();
+                }
             }
             let mut command = Command::new(std::env::current_exe().unwrap());
             command
@@ -234,6 +262,9 @@ mod tests {
                 }
             }
             let output = command.output().unwrap();
+            if matches!(config_fixture, ConfigFixture::InaccessibleParent) {
+                fs::set_permissions(&config_dir, fs::Permissions::from_mode(0o700)).unwrap();
+            }
 
             assert!(
                 output.status.success(),

--- a/crates/goose/src/providers/codex_acp.rs
+++ b/crates/goose/src/providers/codex_acp.rs
@@ -127,6 +127,7 @@ mod tests {
         File(&'static str),
         Directory,
         DanglingSymlink,
+        DanglingParentSymlink,
     }
 
     #[test]
@@ -223,6 +224,12 @@ mod tests {
                 ConfigFixture::DanglingSymlink,
                 false,
             ),
+            (
+                "dangling_parent_symlink",
+                None,
+                ConfigFixture::DanglingParentSymlink,
+                false,
+            ),
         ] {
             let marker = fixture.path().join(format!("launched-{name}"));
             let path_root = fixture.path().join(format!("config-{name}"));
@@ -235,6 +242,10 @@ mod tests {
                 ConfigFixture::Directory => fs::create_dir(&config_path).unwrap(),
                 ConfigFixture::DanglingSymlink => {
                     symlink(config_dir.join("missing.yaml"), &config_path).unwrap()
+                }
+                ConfigFixture::DanglingParentSymlink => {
+                    fs::remove_dir(&config_dir).unwrap();
+                    symlink(path_root.join("missing-config"), &config_dir).unwrap();
                 }
             }
             let mut command = Command::new(std::env::current_exe().unwrap());

--- a/crates/goose/src/providers/codex_acp.rs
+++ b/crates/goose/src/providers/codex_acp.rs
@@ -75,7 +75,7 @@ impl ProviderDef for CodexAcpProvider {
             let resolved_command = SearchPaths::builder()
                 .with_npm()
                 .resolve(CODEX_ACP_PROVIDER_NAME)?;
-            let goose_mode = resolve_goose_mode(config.get_goose_mode())?;
+            let goose_mode = resolve_goose_mode(config.get_goose_mode_strict())?;
             let mcp_servers = extension_configs_to_mcp_servers(&extensions);
 
             let mode_mapping = HashMap::from([
@@ -117,6 +117,8 @@ mod tests {
 
     #[cfg(unix)]
     const CHILD_ENV: &str = "GOOSE_CODEX_ACP_MODE_TEST_CHILD";
+    #[cfg(unix)]
+    const EXPECT_CONFIG_ERROR_ENV: &str = "GOOSE_CODEX_ACP_EXPECT_CONFIG_ERROR";
 
     #[test]
     fn missing_goose_mode_defaults_to_auto() {
@@ -161,11 +163,11 @@ mod tests {
                 .expect_err("marker executable should fail ACP initialization");
             let is_config_error = matches!(
                 error.downcast_ref::<ConfigError>(),
-                Some(ConfigError::DeserializeError(_))
+                Some(ConfigError::DeserializeError(_) | ConfigError::FileError(_))
             );
             assert_eq!(
                 is_config_error,
-                std::env::var("GOOSE_MODE").as_deref() == Ok("invalid"),
+                std::env::var_os(EXPECT_CONFIG_ERROR_ENV).is_some(),
                 "unexpected provider error: {error:#}"
             );
             return;
@@ -181,15 +183,33 @@ mod tests {
         fs::set_permissions(&executable, fs::Permissions::from_mode(0o700)).unwrap();
 
         let search_paths = serde_json::to_string(&vec![fixture.path()]).unwrap();
-        for (name, mode, should_launch) in [
-            ("unset", None, true),
-            ("auto", Some("auto"), true),
-            ("smart_approve", Some("smart_approve"), true),
-            ("approve", Some("approve"), true),
-            ("chat", Some("chat"), true),
-            ("invalid", Some("invalid"), false),
+        for (name, mode, config_content, config_is_directory, should_launch) in [
+            ("unset", None, None, false, true),
+            ("auto", Some("auto"), None, false, true),
+            ("smart_approve", Some("smart_approve"), None, false, true),
+            ("approve", Some("approve"), None, false, true),
+            ("chat", Some("chat"), None, false, true),
+            ("invalid", Some("invalid"), None, false, false),
+            (
+                "configured_file",
+                None,
+                Some("GOOSE_MODE: approve\n"),
+                false,
+                true,
+            ),
+            ("malformed_file", None, Some("GOOSE_MODE: ["), false, false),
+            ("unreadable_file", None, None, true, false),
         ] {
             let marker = fixture.path().join(format!("launched-{name}"));
+            let path_root = fixture.path().join(format!("config-{name}"));
+            let config_dir = path_root.join("config");
+            fs::create_dir_all(&config_dir).unwrap();
+            let config_path = config_dir.join("config.yaml");
+            if let Some(content) = config_content {
+                fs::write(&config_path, content).unwrap();
+            } else if config_is_directory {
+                fs::create_dir(&config_path).unwrap();
+            }
             let mut command = Command::new(std::env::current_exe().unwrap());
             command
                 .arg("--exact")
@@ -198,11 +218,13 @@ mod tests {
                 .env(CHILD_ENV, "1")
                 .env("GOOSE_SEARCH_PATHS", &search_paths)
                 .env("GOOSE_CODEX_ACP_MARKER", &marker)
-                .env(
-                    "GOOSE_PATH_ROOT",
-                    fixture.path().join(format!("config-{name}")),
-                )
+                .env("GOOSE_PATH_ROOT", &path_root)
                 .env("GOOSE_DISABLE_KEYRING", "1");
+            if should_launch {
+                command.env_remove(EXPECT_CONFIG_ERROR_ENV);
+            } else {
+                command.env(EXPECT_CONFIG_ERROR_ENV, "1");
+            }
             match mode {
                 Some(mode) => {
                     command.env("GOOSE_MODE", mode);

--- a/crates/goose/src/providers/codex_acp.rs
+++ b/crates/goose/src/providers/codex_acp.rs
@@ -7,7 +7,7 @@ use crate::acp::{
     extension_configs_to_mcp_servers, AcpProvider, AcpProviderConfig, ACP_CURRENT_MODEL,
 };
 use crate::config::search_path::SearchPaths;
-use crate::config::{Config, GooseMode};
+use crate::config::{Config, ConfigError, GooseMode};
 use crate::providers::base::{
     current_working_dir, ProviderDef, ProviderDescriptor, ProviderMetadata,
 };
@@ -17,6 +17,16 @@ pub(crate) const CODEX_ACP_PROVIDER_NAME: &str = "codex-acp";
 const CODEX_ACP_DOC_URL: &str = "https://github.com/agentclientprotocol/codex-acp";
 
 pub struct CodexAcpProvider;
+
+fn resolve_goose_mode(
+    configured_mode: Result<GooseMode, ConfigError>,
+) -> Result<GooseMode, ConfigError> {
+    match configured_mode {
+        Ok(mode) => Ok(mode),
+        Err(ConfigError::NotFound(_)) => Ok(GooseMode::Auto),
+        Err(error) => Err(error),
+    }
+}
 
 impl goose_providers::base::ProviderDescriptor for CodexAcpProvider {
     fn metadata() -> ProviderMetadata {
@@ -65,7 +75,7 @@ impl ProviderDef for CodexAcpProvider {
             let resolved_command = SearchPaths::builder()
                 .with_npm()
                 .resolve(CODEX_ACP_PROVIDER_NAME)?;
-            let goose_mode = config.get_goose_mode().unwrap_or(GooseMode::Auto);
+            let goose_mode = resolve_goose_mode(config.get_goose_mode())?;
             let mcp_servers = extension_configs_to_mcp_servers(&extensions);
 
             let mode_mapping = HashMap::from([
@@ -92,5 +102,128 @@ impl ProviderDef for CodexAcpProvider {
             let metadata = Self::metadata();
             AcpProvider::connect(metadata.name, goose_mode, provider_config).await
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[cfg(unix)]
+    use std::fs;
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
+    #[cfg(unix)]
+    use std::process::Command;
+
+    #[cfg(unix)]
+    const CHILD_ENV: &str = "GOOSE_CODEX_ACP_MODE_TEST_CHILD";
+
+    #[test]
+    fn missing_goose_mode_defaults_to_auto() {
+        assert_eq!(
+            resolve_goose_mode(Err(ConfigError::NotFound("GOOSE_MODE".to_string()))).unwrap(),
+            GooseMode::Auto
+        );
+    }
+
+    #[test]
+    fn configured_goose_modes_are_preserved() {
+        for mode in [
+            GooseMode::Auto,
+            GooseMode::SmartApprove,
+            GooseMode::Approve,
+            GooseMode::Chat,
+        ] {
+            assert_eq!(resolve_goose_mode(Ok(mode)).unwrap(), mode);
+        }
+    }
+
+    #[test]
+    fn invalid_goose_mode_errors_are_preserved() {
+        assert!(matches!(
+            resolve_goose_mode(Err(ConfigError::DeserializeError("invalid".to_string()))),
+            Err(ConfigError::DeserializeError(_))
+        ));
+        assert!(matches!(
+            resolve_goose_mode(Err(ConfigError::FileError(std::io::Error::other(
+                "unreadable"
+            )))),
+            Err(ConfigError::FileError(_))
+        ));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn goose_mode_validation_precedes_codex_acp_launch() {
+        if std::env::var_os(CHILD_ENV).is_some() {
+            let error = CodexAcpProvider::from_env(vec![], None)
+                .await
+                .expect_err("marker executable should fail ACP initialization");
+            let is_config_error = matches!(
+                error.downcast_ref::<ConfigError>(),
+                Some(ConfigError::DeserializeError(_))
+            );
+            assert_eq!(
+                is_config_error,
+                std::env::var("GOOSE_MODE").as_deref() == Ok("invalid"),
+                "unexpected provider error: {error:#}"
+            );
+            return;
+        }
+
+        let fixture = tempfile::tempdir().unwrap();
+        let executable = fixture.path().join(CODEX_ACP_PROVIDER_NAME);
+        fs::write(
+            &executable,
+            "#!/bin/sh\n: > \"$GOOSE_CODEX_ACP_MARKER\"\nexit 1\n",
+        )
+        .unwrap();
+        fs::set_permissions(&executable, fs::Permissions::from_mode(0o700)).unwrap();
+
+        let search_paths = serde_json::to_string(&vec![fixture.path()]).unwrap();
+        for (name, mode, should_launch) in [
+            ("unset", None, true),
+            ("auto", Some("auto"), true),
+            ("smart_approve", Some("smart_approve"), true),
+            ("approve", Some("approve"), true),
+            ("chat", Some("chat"), true),
+            ("invalid", Some("invalid"), false),
+        ] {
+            let marker = fixture.path().join(format!("launched-{name}"));
+            let mut command = Command::new(std::env::current_exe().unwrap());
+            command
+                .arg("--exact")
+                .arg("providers::codex_acp::tests::goose_mode_validation_precedes_codex_acp_launch")
+                .arg("--nocapture")
+                .env(CHILD_ENV, "1")
+                .env("GOOSE_SEARCH_PATHS", &search_paths)
+                .env("GOOSE_CODEX_ACP_MARKER", &marker)
+                .env(
+                    "GOOSE_PATH_ROOT",
+                    fixture.path().join(format!("config-{name}")),
+                )
+                .env("GOOSE_DISABLE_KEYRING", "1");
+            match mode {
+                Some(mode) => {
+                    command.env("GOOSE_MODE", mode);
+                }
+                None => {
+                    command.env_remove("GOOSE_MODE");
+                }
+            }
+            let output = command.output().unwrap();
+
+            assert!(
+                output.status.success(),
+                "{name} child test failed:\nstdout:\n{}\nstderr:\n{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+            assert_eq!(
+                marker.exists(),
+                should_launch,
+                "unexpected codex-acp launch result for {name} GOOSE_MODE"
+            );
+        }
     }
 }

--- a/crates/goose/src/providers/codex_acp.rs
+++ b/crates/goose/src/providers/codex_acp.rs
@@ -127,7 +127,6 @@ mod tests {
         File(&'static str),
         Directory,
         DanglingSymlink,
-        InaccessibleParent,
     }
 
     #[test]
@@ -224,12 +223,6 @@ mod tests {
                 ConfigFixture::DanglingSymlink,
                 false,
             ),
-            (
-                "inaccessible_parent",
-                None,
-                ConfigFixture::InaccessibleParent,
-                false,
-            ),
         ] {
             let marker = fixture.path().join(format!("launched-{name}"));
             let path_root = fixture.path().join(format!("config-{name}"));
@@ -242,10 +235,6 @@ mod tests {
                 ConfigFixture::Directory => fs::create_dir(&config_path).unwrap(),
                 ConfigFixture::DanglingSymlink => {
                     symlink(config_dir.join("missing.yaml"), &config_path).unwrap()
-                }
-                ConfigFixture::InaccessibleParent => {
-                    fs::write(&config_path, "GOOSE_MODE: approve\n").unwrap();
-                    fs::set_permissions(&config_dir, fs::Permissions::from_mode(0o000)).unwrap();
                 }
             }
             let mut command = Command::new(std::env::current_exe().unwrap());
@@ -272,9 +261,6 @@ mod tests {
                 }
             }
             let output = command.output().unwrap();
-            if matches!(config_fixture, ConfigFixture::InaccessibleParent) {
-                fs::set_permissions(&config_dir, fs::Permissions::from_mode(0o700)).unwrap();
-            }
 
             assert!(
                 output.status.success(),

--- a/crates/goose/src/providers/codex_acp.rs
+++ b/crates/goose/src/providers/codex_acp.rs
@@ -111,7 +111,7 @@ mod tests {
     #[cfg(unix)]
     use std::fs;
     #[cfg(unix)]
-    use std::os::unix::fs::PermissionsExt;
+    use std::os::unix::fs::{symlink, PermissionsExt};
     #[cfg(unix)]
     use std::process::Command;
 
@@ -126,6 +126,7 @@ mod tests {
         Absent,
         File(&'static str),
         Directory,
+        DanglingSymlink,
         InaccessibleParent,
     }
 
@@ -218,6 +219,12 @@ mod tests {
             ),
             ("unreadable_file", None, ConfigFixture::Directory, false),
             (
+                "dangling_symlink",
+                None,
+                ConfigFixture::DanglingSymlink,
+                false,
+            ),
+            (
                 "inaccessible_parent",
                 None,
                 ConfigFixture::InaccessibleParent,
@@ -233,6 +240,9 @@ mod tests {
                 ConfigFixture::Absent => {}
                 ConfigFixture::File(content) => fs::write(&config_path, content).unwrap(),
                 ConfigFixture::Directory => fs::create_dir(&config_path).unwrap(),
+                ConfigFixture::DanglingSymlink => {
+                    symlink(config_dir.join("missing.yaml"), &config_path).unwrap()
+                }
                 ConfigFixture::InaccessibleParent => {
                     fs::write(&config_path, "GOOSE_MODE: approve\n").unwrap();
                     fs::set_permissions(&config_dir, fs::Permissions::from_mode(0o000)).unwrap();


### PR DESCRIPTION
## Summary

- default Codex ACP to Auto only when `GOOSE_MODE` is genuinely absent
- read the permission mode through a strict configuration path that propagates malformed or unreadable layers
- preserve environment precedence and every supported configured permission mode
- verify real loader failures prevent the Codex ACP process from starting

## Security invariant

Invalid permission configuration must fail before Codex ACP starts with full-access permissions.

## Security context

Implements [project-loupe/audit-goose#914](https://github.com/project-loupe/audit-goose/issues/914).

## Verification

- `cargo fmt --all`
- `cargo test -p goose providers::codex_acp::tests --lib` (4 passed)
- `cargo build -p goose`
- `cargo clippy -p goose --all-targets -- -D warnings`
- `git diff --check`

*This finding was discovered by [Project Loupe](https://github.com/project-loupe/loupe)*
