### PR TITLE
WIP: Azure Foundry interactive Entra device authentication

### DIFF
--- a/crates/goose-providers/src/azure_foundry.rs
+++ b/crates/goose-providers/src/azure_foundry.rs
@@ -150,6 +150,8 @@ impl ProviderDescriptor for AzureFoundryProvider {
                 ConfigKey::new("AZURE_FOUNDRY_ENDPOINT", true, false, None, true),
                 ConfigKey::new("AZURE_FOUNDRY_API_KEY", false, true, Some(""), true),
                 ConfigKey::new("AZURE_FOUNDRY_AD_TOKEN", false, true, Some(""), false),
+                ConfigKey::new("AZURE_FOUNDRY_ENTRA_TENANT_ID", false, false, None, false),
+                ConfigKey::new("AZURE_FOUNDRY_ENTRA_CLIENT_ID", false, false, None, false),
                 ConfigKey::new("AZURE_FOUNDRY_MODEL", false, false, None, true),
                 ConfigKey::new("AZURE_FOUNDRY_API_VERSION", false, false, None, false),
             ],

--- a/crates/goose/src/providers/azure_foundry_def.rs
+++ b/crates/goose/src/providers/azure_foundry_def.rs
@@ -8,7 +8,7 @@ use goose_providers::azure_foundry::{endpoint_kind, AzureFoundryProvider, Endpoi
 use goose_providers::base::{ProviderDescriptor, ProviderMetadata};
 
 use crate::config::{Config, ExtensionConfig};
-use crate::providers::azureauth::{AzureAuth, AzureCredentials};
+use crate::providers::azureauth::{AzureAuth, AzureCredentials, EntraDeviceCodeConfig};
 use crate::providers::base::ProviderDef;
 
 const AZURE_PROJECT_ENTRA_RESOURCE: &str = "https://ai.azure.com";
@@ -78,16 +78,22 @@ pub async fn from_env(tls_config: Option<TlsConfig>) -> Result<AzureFoundryProvi
         .get_secret::<String>("AZURE_FOUNDRY_AD_TOKEN")
         .ok()
         .filter(|token| !token.is_empty());
+    let tenant_id = config
+        .get_param::<String>("AZURE_FOUNDRY_ENTRA_TENANT_ID")
+        .ok()
+        .filter(|value| !value.trim().is_empty());
+    let client_id = config
+        .get_param::<String>("AZURE_FOUNDRY_ENTRA_CLIENT_ID")
+        .ok()
+        .filter(|value| !value.trim().is_empty());
     let endpoint_kind = endpoint_kind(&endpoint);
     let resource = if endpoint_kind == EndpointKind::Maas {
         AZURE_MAAS_ENTRA_RESOURCE
     } else {
         AZURE_PROJECT_ENTRA_RESOURCE
     };
-    let auth = Arc::new(AzureAuth::new_with_resource(
-        api_key,
-        ad_token,
-        resource.to_string(),
+    let auth = Arc::new(build_auth(
+        api_key, ad_token, tenant_id, client_id, resource,
     )?);
     let auth_method = |header| {
         AuthMethod::Custom(Box::new(AzureFoundryAuthProvider {
@@ -122,6 +128,41 @@ pub async fn from_env(tls_config: Option<TlsConfig>) -> Result<AzureFoundryProvi
         tls_config,
         Some(crate::session_context::session_id_request_builder()),
     )
+}
+
+fn build_auth(
+    api_key: Option<String>,
+    ad_token: Option<String>,
+    tenant_id: Option<String>,
+    client_id: Option<String>,
+    resource: &str,
+) -> Result<AzureAuth> {
+    let device_code = match (tenant_id, client_id) {
+        (Some(tenant_id), Some(client_id)) => Some(EntraDeviceCodeConfig::new(
+            tenant_id,
+            client_id,
+            resource.to_string(),
+        )),
+        (None, None) => None,
+        _ => anyhow::bail!(
+            "AZURE_FOUNDRY_ENTRA_TENANT_ID and AZURE_FOUNDRY_ENTRA_CLIENT_ID must be configured together"
+        ),
+    };
+    if ad_token.is_some() || api_key.is_some() {
+        return Ok(AzureAuth::new_with_resource(
+            api_key,
+            ad_token,
+            resource.to_string(),
+        )?);
+    }
+    if let Some(device_code) = device_code {
+        return Ok(AzureAuth::new_with_device_code(device_code)?);
+    }
+    Ok(AzureAuth::new_with_resource(
+        None,
+        None,
+        resource.to_string(),
+    )?)
 }
 
 #[cfg(test)]
@@ -169,5 +210,49 @@ mod tests {
             header(None, Some("token"), AuthHeader::Bearer).await,
             ("Authorization".to_string(), "Bearer token".to_string())
         );
+    }
+    #[test]
+    fn partial_device_configuration_is_rejected() {
+        let error = build_auth(
+            None,
+            None,
+            Some("tenant".to_string()),
+            None,
+            AZURE_PROJECT_ENTRA_RESOURCE,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("must be configured together"));
+    }
+
+    #[test]
+    fn static_credentials_take_precedence_over_device_configuration() {
+        let auth = build_auth(
+            Some("key".to_string()),
+            Some("token".to_string()),
+            Some("tenant".to_string()),
+            Some("client".to_string()),
+            AZURE_PROJECT_ENTRA_RESOURCE,
+        )
+        .unwrap();
+        assert!(matches!(
+            auth.credential_type(),
+            AzureCredentials::BearerToken(_)
+        ));
+    }
+
+    #[test]
+    fn complete_device_configuration_selects_interactive_auth() {
+        let auth = build_auth(
+            None,
+            None,
+            Some("tenant".to_string()),
+            Some("client".to_string()),
+            AZURE_PROJECT_ENTRA_RESOURCE,
+        )
+        .unwrap();
+        assert!(matches!(
+            auth.credential_type(),
+            AzureCredentials::DefaultCredential
+        ));
     }
 }

--- a/crates/goose/src/providers/azureauth.rs
+++ b/crates/goose/src/providers/azureauth.rs
@@ -15,25 +15,35 @@ use tokio::sync::RwLock;
 const DEFAULT_RESOURCE: &str = "https://cognitiveservices.azure.com";
 const TOKEN_EXPIRY_SKEW_SECS: i64 = 30;
 
+/// Represents errors that can occur during Azure authentication.
 #[derive(Debug, thiserror::Error)]
 pub enum AuthError {
+    /// Error when loading credentials from the filesystem or environment
     #[error("Failed to load credentials: {0}")]
     Credentials(String),
 
+    /// Error during token exchange
     #[error("Token exchange failed: {0}")]
     TokenExchange(String),
 }
 
+/// Represents an authentication token with its type and value.
 #[derive(Debug, Clone)]
 pub struct AuthToken {
+    /// The type of the token (e.g., "Bearer")
     pub token_type: String,
+    /// The actual token value
     pub token_value: String,
 }
 
+/// Represents the types of Azure credentials supported.
 #[derive(Debug, Clone)]
 pub enum AzureCredentials {
+    /// API key based authentication
     ApiKey(String),
+    /// Pre-acquired Microsoft Entra ID access token (e.g. AZURE_OPENAI_AD_TOKEN)
     BearerToken(String),
+    /// Azure CLI based authentication
     DefaultCredential,
 }
 
@@ -84,12 +94,14 @@ impl EntraDeviceCodeConfig {
     }
 }
 
+/// Holds a cached token and its expiration time.
 #[derive(Debug, Clone)]
 struct CachedToken {
     token: AuthToken,
     expires_at: Instant,
 }
 
+/// Response from Azure token endpoint
 #[derive(Debug, Clone, Deserialize)]
 struct TokenResponse {
     #[serde(rename = "accessToken")]
@@ -107,6 +119,7 @@ struct PersistedDeviceCodeTokens {
     expires_at: Option<DateTime<Utc>>,
 }
 
+/// Azure authentication handler that manages credentials and token caching.
 #[derive(Debug)]
 pub struct AzureAuth {
     credentials: AzureCredentials,
@@ -118,6 +131,10 @@ pub struct AzureAuth {
 }
 
 impl AzureAuth {
+    /// Creates a new Azure authentication handler.
+    ///
+    /// Selects a static bearer token, API key, or Azure CLI fallback and initializes
+    /// the in-memory token cache.
     pub fn new(api_key: Option<String>, ad_token: Option<String>) -> Result<Self, AuthError> {
         Self::new_with_resource(api_key, ad_token, DEFAULT_RESOURCE.to_string())
     }
@@ -163,6 +180,7 @@ impl AzureAuth {
         })
     }
 
+    /// Returns the type of credentials being used.
     pub fn credential_type(&self) -> &AzureCredentials {
         &self.credentials
     }
@@ -172,6 +190,10 @@ impl AzureAuth {
         *self.cached_token.write().await = None;
     }
 
+    /// Retrieves a valid authentication token.
+    ///
+    /// Static credentials are returned directly. Device Code and Azure CLI tokens
+    /// are cached and refreshed when needed using double-checked locking.
     pub async fn get_token(&self) -> Result<AuthToken, AuthError> {
         if let Some(config) = &self.device_code {
             return self.get_device_code_token(config).await;
@@ -263,13 +285,17 @@ impl AzureAuth {
     }
 
     async fn get_default_credential_token(&self) -> Result<AuthToken, AuthError> {
+        // Try read lock first for better concurrency
         if let Some(cached) = self.cached_token.read().await.as_ref() {
             if cached.expires_at > Instant::now() {
                 return Ok(cached.token.clone());
             }
         }
 
+        // Take write lock only if needed
         let mut token_guard = self.cached_token.write().await;
+
+        // Double-check expiration after acquiring write lock
         if let Some(cached) = token_guard.as_ref() {
             if cached.expires_at > Instant::now() {
                 return Ok(cached.token.clone());

--- a/crates/goose/src/providers/azureauth.rs
+++ b/crates/goose/src/providers/azureauth.rs
@@ -139,7 +139,7 @@ impl AzureAuth {
     /// 3. Initializing the token cache
     ///
     /// # Returns
-    /// *  - A new AzureAuth instance or an error if initialization fails
+    /// * `Result<Self, AuthError>` - A new AzureAuth instance or an error if initialization fails
     pub fn new(api_key: Option<String>, ad_token: Option<String>) -> Result<Self, AuthError> {
         Self::new_with_resource(api_key, ad_token, DEFAULT_RESOURCE.to_string())
     }
@@ -209,7 +209,7 @@ impl AzureAuth {
     ///    before starting an interactive flow.
     ///
     /// # Returns
-    /// *  - A valid authentication token or an error
+    /// * `Result<AuthToken, AuthError>` - A valid authentication token or an error
     pub async fn get_token(&self) -> Result<AuthToken, AuthError> {
         if let Some(config) = &self.device_code {
             return self.get_device_code_token(config).await;

--- a/crates/goose/src/providers/azureauth.rs
+++ b/crates/goose/src/providers/azureauth.rs
@@ -1,50 +1,95 @@
+use crate::config::Config;
+use crate::providers::oauth_device_flow::{
+    refresh_device_flow_token, run_device_flow, DeviceFlowConfig, DeviceFlowTokenRefreshError,
+    DeviceFlowTokens, RequestEncoding,
+};
 use crate::subprocess::SubprocessExt;
-use chrono;
-use serde::Deserialize;
+use chrono::{DateTime, Utc};
+use reqwest::header::HeaderMap;
+use serde::{Deserialize, Serialize};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::RwLock;
 
-/// Represents errors that can occur during Azure authentication.
+const DEFAULT_RESOURCE: &str = "https://cognitiveservices.azure.com";
+const TOKEN_EXPIRY_SKEW_SECS: i64 = 30;
+
 #[derive(Debug, thiserror::Error)]
 pub enum AuthError {
-    /// Error when loading credentials from the filesystem or environment
     #[error("Failed to load credentials: {0}")]
     Credentials(String),
 
-    /// Error during token exchange
     #[error("Token exchange failed: {0}")]
     TokenExchange(String),
 }
 
-/// Represents an authentication token with its type and value.
 #[derive(Debug, Clone)]
 pub struct AuthToken {
-    /// The type of the token (e.g., "Bearer")
     pub token_type: String,
-    /// The actual token value
     pub token_value: String,
 }
 
-/// Represents the types of Azure credentials supported.
 #[derive(Debug, Clone)]
 pub enum AzureCredentials {
-    /// API key based authentication
     ApiKey(String),
-    /// Pre-acquired Microsoft Entra ID access token (e.g. AZURE_OPENAI_AD_TOKEN)
     BearerToken(String),
-    /// Azure credential chain based authentication
     DefaultCredential,
 }
 
-/// Holds a cached token and its expiration time.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EntraDeviceCodeConfig {
+    pub tenant_id: String,
+    pub client_id: String,
+    pub resource: String,
+}
+
+impl EntraDeviceCodeConfig {
+    pub fn new(tenant_id: String, client_id: String, resource: String) -> Self {
+        Self {
+            tenant_id,
+            client_id,
+            resource,
+        }
+    }
+
+    fn device_auth_url(&self) -> String {
+        format!(
+            "https://login.microsoftonline.com/{}/oauth2/v2.0/devicecode",
+            self.tenant_id
+        )
+    }
+
+    fn token_url(&self) -> String {
+        format!(
+            "https://login.microsoftonline.com/{}/oauth2/v2.0/token",
+            self.tenant_id
+        )
+    }
+
+    fn scopes(&self) -> String {
+        format!(
+            "{}/.default openid profile offline_access",
+            self.resource.trim_end_matches('/')
+        )
+    }
+
+    fn secret_key(&self) -> String {
+        let identity = format!("{}:{}:{}", self.tenant_id, self.client_id, self.resource);
+        let encoded = identity
+            .bytes()
+            .map(|byte| format!("{byte:02x}"))
+            .collect::<String>();
+        format!("azure_entra_device_code_{encoded}")
+    }
+}
+
 #[derive(Debug, Clone)]
 struct CachedToken {
     token: AuthToken,
     expires_at: Instant,
 }
 
-/// Response from Azure token endpoint
 #[derive(Debug, Clone, Deserialize)]
 struct TokenResponse {
     #[serde(rename = "accessToken")]
@@ -55,30 +100,26 @@ struct TokenResponse {
     expires_on: u64,
 }
 
-/// Azure authentication handler that manages credentials and token caching.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PersistedDeviceCodeTokens {
+    access_token: String,
+    refresh_token: Option<String>,
+    expires_at: Option<DateTime<Utc>>,
+}
+
 #[derive(Debug)]
 pub struct AzureAuth {
     credentials: AzureCredentials,
     resource: String,
+    device_code: Option<EntraDeviceCodeConfig>,
+    client: reqwest::Client,
     cached_token: Arc<RwLock<Option<CachedToken>>>,
+    force_refresh: AtomicBool,
 }
 
 impl AzureAuth {
-    /// Creates a new Azure authentication handler.
-    ///
-    /// Initializes the authentication handler by:
-    /// 1. Loading credentials from environment
-    /// 2. Setting up an HTTP client for token requests
-    /// 3. Initializing the token cache
-    ///
-    /// # Returns
-    /// * `Result<Self, AuthError>` - A new AzureAuth instance or an error if initialization fails
     pub fn new(api_key: Option<String>, ad_token: Option<String>) -> Result<Self, AuthError> {
-        Self::new_with_resource(
-            api_key,
-            ad_token,
-            "https://cognitiveservices.azure.com".to_string(),
-        )
+        Self::new_with_resource(api_key, ad_token, DEFAULT_RESOURCE.to_string())
     }
 
     pub fn new_with_resource(
@@ -95,33 +136,47 @@ impl AzureAuth {
         Ok(Self {
             credentials,
             resource,
+            device_code: None,
+            client: reqwest::Client::new(),
             cached_token: Arc::new(RwLock::new(None)),
+            force_refresh: AtomicBool::new(false),
         })
     }
 
-    /// Returns the type of credentials being used.
+    pub fn new_with_device_code(config: EntraDeviceCodeConfig) -> Result<Self, AuthError> {
+        if config.tenant_id.trim().is_empty()
+            || config.client_id.trim().is_empty()
+            || config.resource.trim().is_empty()
+        {
+            return Err(AuthError::Credentials(
+                "tenant_id, client_id, and resource are required".to_string(),
+            ));
+        }
+
+        Ok(Self {
+            credentials: AzureCredentials::DefaultCredential,
+            resource: config.resource.clone(),
+            device_code: Some(config),
+            client: reqwest::Client::new(),
+            cached_token: Arc::new(RwLock::new(None)),
+            force_refresh: AtomicBool::new(false),
+        })
+    }
+
     pub fn credential_type(&self) -> &AzureCredentials {
         &self.credentials
     }
 
     pub async fn invalidate_token(&self) {
+        self.force_refresh.store(true, Ordering::Release);
         *self.cached_token.write().await = None;
     }
 
-    /// Retrieves a valid authentication token.
-    ///
-    /// This method implements an efficient token management strategy:
-    /// 1. For API key auth, returns the API key directly
-    /// 2. For bearer token auth, returns the pre-acquired token directly
-    /// 3. For Azure credential chain:
-    ///    a. Checks the cache for a valid token
-    ///    b. Returns the cached token if not expired
-    ///    c. Obtains a new token if needed or expired
-    ///    d. Uses double-checked locking for thread safety
-    ///
-    /// # Returns
-    /// * `Result<AuthToken, AuthError>` - A valid authentication token or an error
     pub async fn get_token(&self) -> Result<AuthToken, AuthError> {
+        if let Some(config) = &self.device_code {
+            return self.get_device_code_token(config).await;
+        }
+
         match &self.credentials {
             AzureCredentials::ApiKey(key) => Ok(AuthToken {
                 token_type: "Bearer".to_string(),
@@ -135,18 +190,86 @@ impl AzureAuth {
         }
     }
 
+    async fn get_device_code_token(
+        &self,
+        config: &EntraDeviceCodeConfig,
+    ) -> Result<AuthToken, AuthError> {
+        if let Some(cached) = self.cached_token.read().await.as_ref() {
+            if cached.expires_at > Instant::now() && !self.force_refresh.load(Ordering::Acquire) {
+                return Ok(cached.token.clone());
+            }
+        }
+
+        let mut token_guard = self.cached_token.write().await;
+        if let Some(cached) = token_guard.as_ref() {
+            if cached.expires_at > Instant::now() && !self.force_refresh.load(Ordering::Acquire) {
+                return Ok(cached.token.clone());
+            }
+        }
+
+        let persisted = Config::global()
+            .get_secret::<PersistedDeviceCodeTokens>(&config.secret_key())
+            .ok();
+        let force_refresh = self.force_refresh.load(Ordering::Acquire);
+        if !force_refresh {
+            if let Some(tokens) = persisted.as_ref().filter(|tokens| tokens_are_valid(tokens)) {
+                let cached = cache_device_token(tokens)?;
+                let token = cached.token.clone();
+                *token_guard = Some(cached);
+                return Ok(token);
+            }
+        }
+
+        let device_auth_url = config.device_auth_url();
+        let token_url = config.token_url();
+        let scopes = config.scopes();
+        let flow_config = DeviceFlowConfig {
+            device_auth_url: Some(&device_auth_url),
+            token_url: &token_url,
+            client_id: &config.client_id,
+            scopes: Some(&scopes),
+            extra_headers: HeaderMap::new(),
+            encoding: RequestEncoding::Form,
+        };
+
+        let old_refresh_token = persisted
+            .as_ref()
+            .and_then(|tokens| tokens.refresh_token.as_deref());
+        let issued = if let Some(refresh_token) = old_refresh_token {
+            match refresh_device_flow_token(&self.client, &flow_config, refresh_token).await {
+                Ok(tokens) => tokens,
+                Err(error) if refresh_requires_login(&error) => {
+                    run_device_flow(&self.client, &flow_config)
+                        .await
+                        .map_err(token_exchange_error)?
+                }
+                Err(error) => return Err(token_exchange_error(error)),
+            }
+        } else {
+            run_device_flow(&self.client, &flow_config)
+                .await
+                .map_err(token_exchange_error)?
+        };
+
+        let persisted = persisted_tokens(issued, old_refresh_token);
+        Config::global()
+            .set_secret(&config.secret_key(), &persisted)
+            .map_err(|error| AuthError::Credentials(error.to_string()))?;
+        let cached = cache_device_token(&persisted)?;
+        let token = cached.token.clone();
+        *token_guard = Some(cached);
+        self.force_refresh.store(false, Ordering::Release);
+        Ok(token)
+    }
+
     async fn get_default_credential_token(&self) -> Result<AuthToken, AuthError> {
-        // Try read lock first for better concurrency
         if let Some(cached) = self.cached_token.read().await.as_ref() {
             if cached.expires_at > Instant::now() {
                 return Ok(cached.token.clone());
             }
         }
 
-        // Take write lock only if needed
         let mut token_guard = self.cached_token.write().await;
-
-        // Double-check expiration after acquiring write lock
         if let Some(cached) = token_guard.as_ref() {
             if cached.expires_at > Instant::now() {
                 return Ok(cached.token.clone());
@@ -159,7 +282,7 @@ impl AzureAuth {
             .set_no_window()
             .output()
             .await
-            .map_err(|e| AuthError::TokenExchange(format!("Failed to execute Azure CLI: {}", e)))?;
+            .map_err(|e| AuthError::TokenExchange(format!("Failed to execute Azure CLI: {e}")))?;
 
         if !output.status.success() {
             return Err(AuthError::TokenExchange(
@@ -168,33 +291,85 @@ impl AzureAuth {
         }
 
         let token_response: TokenResponse = serde_json::from_slice(&output.stdout)
-            .map_err(|e| AuthError::TokenExchange(format!("Invalid token response: {}", e)))?;
-
+            .map_err(|e| AuthError::TokenExchange(format!("Invalid token response: {e}")))?;
         let auth_token = AuthToken {
             token_type: token_response.token_type,
             token_value: token_response.access_token,
         };
-
         let expires_at = Instant::now()
             + Duration::from_secs(
                 token_response
                     .expires_on
-                    .saturating_sub(chrono::Utc::now().timestamp() as u64)
-                    .saturating_sub(30),
+                    .saturating_sub(Utc::now().timestamp() as u64)
+                    .saturating_sub(TOKEN_EXPIRY_SKEW_SECS as u64),
             );
-
         *token_guard = Some(CachedToken {
             token: auth_token.clone(),
             expires_at,
         });
-
         Ok(auth_token)
     }
+}
+
+fn persisted_tokens(
+    tokens: DeviceFlowTokens,
+    old_refresh_token: Option<&str>,
+) -> PersistedDeviceCodeTokens {
+    PersistedDeviceCodeTokens {
+        access_token: tokens.access_token,
+        refresh_token: tokens
+            .refresh_token
+            .or_else(|| old_refresh_token.map(str::to_string)),
+        expires_at: tokens.expires_at,
+    }
+}
+
+fn tokens_are_valid(tokens: &PersistedDeviceCodeTokens) -> bool {
+    tokens.expires_at.is_some_and(|expires_at| {
+        expires_at > Utc::now() + chrono::Duration::seconds(TOKEN_EXPIRY_SKEW_SECS)
+    })
+}
+
+fn cache_device_token(tokens: &PersistedDeviceCodeTokens) -> Result<CachedToken, AuthError> {
+    let expires_at = tokens
+        .expires_at
+        .ok_or_else(|| AuthError::TokenExchange("token response missing expires_in".to_string()))?;
+    let remaining = (expires_at - Utc::now() - chrono::Duration::seconds(TOKEN_EXPIRY_SKEW_SECS))
+        .to_std()
+        .unwrap_or_default();
+    Ok(CachedToken {
+        token: AuthToken {
+            token_type: "Bearer".to_string(),
+            token_value: tokens.access_token.clone(),
+        },
+        expires_at: Instant::now() + remaining,
+    })
+}
+
+fn refresh_requires_login(error: &anyhow::Error) -> bool {
+    error
+        .downcast_ref::<DeviceFlowTokenRefreshError>()
+        .is_some_and(|error| {
+            error.status == reqwest::StatusCode::BAD_REQUEST
+                || error.status == reqwest::StatusCode::UNAUTHORIZED
+        })
+}
+
+fn token_exchange_error(error: anyhow::Error) -> AuthError {
+    AuthError::TokenExchange(error.to_string())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn device_config() -> EntraDeviceCodeConfig {
+        EntraDeviceCodeConfig::new(
+            "organizations".to_string(),
+            "client-id".to_string(),
+            "https://example.azure.com/".to_string(),
+        )
+    }
 
     #[test]
     fn test_ad_token_takes_precedence_over_api_key() {
@@ -229,5 +404,54 @@ mod tests {
         let token = auth.get_token().await.unwrap();
         assert_eq!(token.token_type, "Bearer");
         assert_eq!(token.token_value, "my-token");
+    }
+
+    #[test]
+    fn device_code_configuration_uses_entra_v2_endpoints_and_default_scope() {
+        let config = device_config();
+        assert_eq!(
+            config.device_auth_url(),
+            "https://login.microsoftonline.com/organizations/oauth2/v2.0/devicecode"
+        );
+        assert_eq!(
+            config.token_url(),
+            "https://login.microsoftonline.com/organizations/oauth2/v2.0/token"
+        );
+        assert_eq!(
+            config.scopes(),
+            "https://example.azure.com/.default openid profile offline_access"
+        );
+    }
+
+    #[test]
+    fn device_code_constructor_selects_device_mode_without_changing_header_selection() {
+        let auth = AzureAuth::new_with_device_code(device_config()).unwrap();
+        assert!(auth.device_code.is_some());
+        assert!(matches!(
+            auth.credential_type(),
+            AzureCredentials::DefaultCredential
+        ));
+    }
+
+    #[test]
+    fn refresh_response_preserves_an_existing_refresh_token() {
+        let persisted = persisted_tokens(
+            DeviceFlowTokens {
+                access_token: "new-access".to_string(),
+                refresh_token: None,
+                expires_at: Some(Utc::now() + chrono::Duration::hours(1)),
+            },
+            Some("old-refresh"),
+        );
+        assert_eq!(persisted.refresh_token.as_deref(), Some("old-refresh"));
+    }
+
+    #[test]
+    fn device_credentials_are_scoped_by_configuration() {
+        let first = device_config();
+        let mut second = device_config();
+        second.resource = "https://other.azure.com".to_string();
+        assert_ne!(first.secret_key(), second.secret_key());
+        assert!(first.secret_key().starts_with("azure_entra_device_code_"));
     }
 }

--- a/crates/goose/src/providers/azureauth.rs
+++ b/crates/goose/src/providers/azureauth.rs
@@ -43,7 +43,7 @@ pub enum AzureCredentials {
     ApiKey(String),
     /// Pre-acquired Microsoft Entra ID access token (e.g. AZURE_OPENAI_AD_TOKEN)
     BearerToken(String),
-    /// Azure CLI based authentication
+    /// Azure credential chain based authentication
     DefaultCredential,
 }
 
@@ -133,8 +133,13 @@ pub struct AzureAuth {
 impl AzureAuth {
     /// Creates a new Azure authentication handler.
     ///
-    /// Selects a static bearer token, API key, or Azure CLI fallback and initializes
-    /// the in-memory token cache.
+    /// Initializes the authentication handler by:
+    /// 1. Loading credentials from environment
+    /// 2. Setting up an HTTP client for token requests
+    /// 3. Initializing the token cache
+    ///
+    /// # Returns
+    /// *  - A new AzureAuth instance or an error if initialization fails
     pub fn new(api_key: Option<String>, ad_token: Option<String>) -> Result<Self, AuthError> {
         Self::new_with_resource(api_key, ad_token, DEFAULT_RESOURCE.to_string())
     }
@@ -192,8 +197,19 @@ impl AzureAuth {
 
     /// Retrieves a valid authentication token.
     ///
-    /// Static credentials are returned directly. Device Code and Azure CLI tokens
-    /// are cached and refreshed when needed using double-checked locking.
+    /// This method implements an efficient token management strategy:
+    /// 1. For API key auth, returns the API key directly
+    /// 2. For bearer token auth, returns the pre-acquired token directly
+    /// 3. For Azure credential chain:
+    ///    a. Checks the cache for a valid token
+    ///    b. Returns the cached token if not expired
+    ///    c. Obtains a new token if needed or expired
+    ///    d. Uses double-checked locking for thread safety
+    /// 4. For Entra Device Code auth, restores or refreshes securely stored tokens
+    ///    before starting an interactive flow.
+    ///
+    /// # Returns
+    /// *  - A valid authentication token or an error
     pub async fn get_token(&self) -> Result<AuthToken, AuthError> {
         if let Some(config) = &self.device_code {
             return self.get_device_code_token(config).await;

--- a/documentation/docs/getting-started/providers.md
+++ b/documentation/docs/getting-started/providers.md
@@ -1576,3 +1576,16 @@ If you have any questions or need help with a specific provider, feel free to re
 
 [providers]: /docs/getting-started/providers
 [function-calling-leaderboard]: https://gorilla.cs.berkeley.edu/leaderboard.html
+
+### Azure Foundry Device Code authentication
+
+Azure Foundry supports end-user Microsoft Entra Device Code authentication without Azure CLI. Configure the optional `AZURE_FOUNDRY_ENTRA_TENANT_ID` and `AZURE_FOUNDRY_ENTRA_CLIENT_ID` settings with the tenant ID and application (client) ID of your Entra app registration.
+
+The app registration must be a **public client** with Device Code flow enabled; this flow must not use a client secret. Give the registration the delegated API permission matching the endpoint:
+
+- Foundry project resources: `https://ai.azure.com/.default`
+- Models-as-a-Service (MaaS): `https://ml.azure.com/.default`
+
+Credential precedence is a static Entra token first, an API key second, configured Entra Device Code credentials third, and an existing Azure CLI login last. Device Code is the recommended interactive end-user flow; static tokens and Azure CLI remain available as advanced alternatives.
+
+`AADSTS650057` indicates that the requested resource is not configured as an allowed delegated API permission for the app registration (or consent has not been granted). This is distinct from Azure RBAC: after Entra issues a token, the signed-in user still needs an appropriate role assignment on the Foundry project or parent resource. See the [Azure Foundry provider guide](../guides/azure-foundry-provider.md) for setup and troubleshooting details.

--- a/documentation/docs/guides/azure-foundry-provider.md
+++ b/documentation/docs/guides/azure-foundry-provider.md
@@ -99,3 +99,38 @@ Azure pricing depends on region, SKU, offer, deployment type, and contract. The 
 ### Wrong protocol for a custom deployment name
 
 Refresh the provider model list so goose can retrieve `modelPublisher`. Without deployment metadata, routing can only use recognizable model-name prefixes.
+
+## Authenticate with Microsoft Entra ID
+
+For end-user authentication without installing or signing in through the Azure CLI, configure Device Code authentication. This flow opens a browser-based sign-in and does not require storing a client secret.
+
+Set the following optional provider variables:
+
+- `AZURE_FOUNDRY_ENTRA_TENANT_ID`: the Microsoft Entra tenant ID for the app registration.
+- `AZURE_FOUNDRY_ENTRA_CLIENT_ID`: the application (client) ID of the app registration.
+
+The app registration must be configured as a **public client** and must allow the Device Code flow. Do not create or configure a client secret for this end-user flow.
+
+The token scope depends on the endpoint type:
+
+- Foundry project resource endpoints use `https://ai.azure.com/.default`.
+- Models-as-a-Service (MaaS) endpoints use `https://ml.azure.com/.default`.
+
+Add the corresponding API as a **delegated API permission** on the Entra app registration, and grant any consent required by your tenant. The requested token scope and delegated permission must refer to the same resource.
+
+### Credential precedence
+
+Goose resolves Azure Foundry credentials in this order:
+
+1. A configured static Entra token.
+2. A configured API key.
+3. Device Code authentication when the Entra tenant and client settings are configured.
+4. An Azure CLI credential from an existing `az login` session.
+
+Device Code authentication is the recommended interactive option for end users. Static tokens and Azure CLI credentials remain supported as advanced alternatives, for example in automation or an existing developer environment.
+
+### Troubleshooting authentication and authorization
+
+**`AADSTS650057: Invalid resource`** is an Entra app-registration or consent problem. It means the app is requesting a resource such as `https://ai.azure.com` or `https://ml.azure.com` that is not represented by an allowed delegated API permission for that client. Add the delegated permission corresponding to the endpoint scope, grant consent if required, and authenticate again.
+
+**Azure RBAC errors are separate.** A successfully issued token does not grant access to a Foundry project or model deployment by itself. If authentication succeeds but the service returns an authorization, forbidden, or insufficient-permissions response, assign the signed-in user an appropriate Azure role on the relevant Foundry project or parent resource. Changing delegated API permissions does not replace the required Azure RBAC assignment.


### PR DESCRIPTION
## WIP: Azure AI Foundry interactive Entra authentication

> [!IMPORTANT]
> This is an early proof of concept for discussion and is not ready to merge. It is intentionally Azure/Entra-specific; it does not yet provide a generic OAuth abstraction for GCP, AWS, Scaleway, or custom providers.

## Problem

Azure OpenAI and Azure AI Foundry can currently use a pre-acquired Entra token or fall back to `az account get-access-token`. Requiring Azure CLI is not an accessible sign-in experience for most desktop and CLI end users.

This PoC validates using the OAuth 2.0 Device Authorization Grant directly from goose for Azure AI Foundry, without a client secret or Azure CLI.

## What this PoC does

- reuses the existing shared RFC 8628 device-flow helper;
- adds an Entra device-code credential mode to `AzureAuth`;
- selects it for Azure Foundry when both of these are configured:
  - `AZURE_FOUNDRY_ENTRA_TENANT_ID`
  - `AZURE_FOUNDRY_ENTRA_CLIENT_ID`
- requests the endpoint-specific scope:
  - Foundry project/resource: `https://ai.azure.com/.default`
  - MaaS: `https://ml.azure.com/.default`
- requests `openid profile offline_access`;
- stores access/refresh credentials through goose's secure `Config` secret storage;
- refreshes expired credentials and preserves the previous refresh token when the token endpoint omits a replacement;
- serializes concurrent token acquisition through the existing token lock;
- sends the resulting token through the existing `AuthProvider`/`ApiClient` bearer-header path;
- preserves the existing authentication paths.

Current precedence is:

1. static Entra token;
2. API key;
3. configured Entra Device Code flow;
4. Azure CLI fallback.

## Example configuration

```bash
export AZURE_FOUNDRY_ENDPOINT="https://<resource>.services.ai.azure.com/api/projects/<project>"
export AZURE_FOUNDRY_ENTRA_TENANT_ID="<tenant-id>"
export AZURE_FOUNDRY_ENTRA_CLIENT_ID="<public-client-id>"

unset AZURE_FOUNDRY_AD_TOKEN
unset AZURE_FOUNDRY_API_KEY
```

The Entra registration must be a public client with Device Code flow enabled. No client secret is used. It must also have the delegated API permission corresponding to the requested Foundry resource, plus any required tenant consent. Azure RBAC on the Foundry project remains a separate requirement.

## Validation performed

```text
cargo test -p goose azureauth --lib                 # 8 passed
cargo test -p goose azure_foundry_def --lib         # 6 passed
cargo test -p goose-providers azure_foundry --lib   # 19 passed
cargo clippy -p goose -p goose-providers --all-targets -- -D warnings
cargo fmt
git diff --check
```

A live device authorization request successfully reached Microsoft Entra and produced a user code. Token issuance is currently blocked by the test app registration with `AADSTS650057`: the delegated permission for `https://ai.azure.com` has not yet been added. That external configuration is required before completing the end-to-end Foundry request test.

## Open design questions / follow-up

- Should interactive auth first remain Azure-specific or be extracted into a generic OAuth bearer-token provider?
- Should desktop use Authorization Code + PKCE while CLI/headless uses Device Code?
- How should login/status/logout be exposed through provider setup and ACP?
- Should Azure CLI become an explicit advanced mode rather than an implicit fallback?
- How should legacy provider token caches migrate to the shared secure credential store?
- Add fully isolated end-to-end mocked tests around persistence, refresh failure, and reauthentication.

## Non-goals of this PoC

- generic multi-cloud authentication;
- AWS IAM Identity Center and SigV4;
- Google OAuth integration;
- Scaleway authentication;
- production UI/UX;
- embedding any tenant ID, client ID, endpoint, or client secret in goose.

## Tracking

Local branch-scoped Beads ticket: `goose-dzf`. A corresponding upstream Ready issue is still required before this is considered mergeable.
