### PR TITLE
feat(providers): add Lynkr as a declarative OpenAI-compatible provider

### DIFF
--- a/crates/goose-providers/src/declarative.rs
+++ b/crates/goose-providers/src/declarative.rs
@@ -28,6 +28,7 @@ pub(crate) mod declarative_providers {
         inception,
         llama_swap,
         lmstudio,
+        lynkr,
         meta,
         minimax,
         mistral,

--- a/crates/goose-providers/src/declarative/definitions/lynkr.json
+++ b/crates/goose-providers/src/declarative/definitions/lynkr.json
@@ -1,0 +1,24 @@
+{
+  "name": "lynkr",
+  "engine": "openai",
+  "display_name": "Lynkr",
+  "description": "Self-hosted, OpenAI-compatible LLM gateway that adds tier routing, token compression, and semantic caching in front of any backend.",
+  "api_key_env": "LYNKR_API_KEY",
+  "base_url": "${LYNKR_HOST}/v1/chat/completions",
+  "env_vars": [
+    {
+      "name": "LYNKR_HOST",
+      "required": false,
+      "secret": false,
+      "primary": true,
+      "default": "http://localhost:8081",
+      "description": "Base URL of the Lynkr gateway (default: http://localhost:8081)"
+    }
+  ],
+  "dynamic_models": true,
+  "models": [],
+  "supports_streaming": true,
+  "requires_auth": false,
+  "skip_canonical_filtering": true,
+  "model_doc_link": "https://github.com/Fast-Editor/Lynkr"
+}


### PR DESCRIPTION
### What

Adds **Lynkr** as a declarative provider, per @michaelneale's suggestion on #10397 that providers be added via the declarative mechanism rather than a manual docs-table edit.

Lynkr is an Apache-2.0, self-hosted, **OpenAI-compatible** LLM gateway (tier routing, token compression, semantic caching) that sits in front of any backend. Because it speaks the OpenAI wire format and serves `/v1/models`, it drops straight into the declarative provider system.

### Changes
- New `crates/goose-providers/src/declarative/definitions/lynkr.json`
- Registered `lynkr` in the `expose_declarative_providers!` macro in `declarative.rs`

Modeled on the existing `llama_swap` definition (also a local OpenAI-compatible proxy):
- `engine: openai`
- Configurable `${LYNKR_HOST}` env var, default `http://localhost:8081`
- `requires_auth: false` (local gateway; optional `LYNKR_API_KEY`)
- `dynamic_models: true` so models are fetched from the gateway's `/v1/models`

### Testing
- Previously verified end-to-end with Goose CLI 1.41.0 (chat + tool use) against a running Lynkr instance (see #10397).
- `lynkr.json` validated as well-formed and matches the `DeclarativeProviderConfig` schema; provider id `lynkr` passes `validate_provider_id`; added to both the definitions dir and the macro list so `expose_declarative_providers_enumerates_all_bundled_json_files` stays green.

Refs #10397

