### PR TITLE
fix(openrouter): send session_id body field for provider sticky routing

### DIFF
--- a/crates/goose/src/providers/openrouter.rs
+++ b/crates/goose/src/providers/openrouter.rs
@@ -276,10 +276,13 @@ impl Provider for OpenRouterProvider {
             true,
         )?;
 
-        // Add user field for OpenRouter attribution/rate-limiting
+        // `user` is for OpenRouter attribution/rate-limiting; `session_id`
+        // activates provider sticky routing so every turn in a session lands
+        // on the endpoint holding the warm prompt cache.
         if !session_id.is_empty() {
             if let Some(obj) = payload.as_object_mut() {
-                obj.insert("user".to_string(), Value::String(session_id.to_string()));
+                obj.insert("user".to_string(), Value::String(session_id.clone()));
+                obj.insert("session_id".to_string(), Value::String(session_id.clone()));
             }
         }
 
@@ -455,5 +458,98 @@ mod tests {
             .stream(&config, "system", &[Message::user().with_text("hi")], &[])
             .await
             .unwrap();
+    }
+
+    #[tokio::test]
+    async fn stream_sends_session_id_body_field_for_sticky_routing() {
+        use wiremock::matchers::{body_partial_json, method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/v1/chat/completions"))
+            .and(body_partial_json(
+                json!({ "user": "20260809_29", "session_id": "20260809_29" }),
+            ))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string("data: [DONE]\n\n"),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let provider = OpenRouterProvider {
+            api_client: ApiClient::new_with_tls(
+                server.uri(),
+                AuthMethod::BearerToken("test-key".to_string()),
+                None,
+            )
+            .unwrap(),
+            supports_streaming: true,
+            name: OPENROUTER_PROVIDER_NAME.to_string(),
+            configured_parameters: None,
+        };
+
+        let config = model_config("z-ai/glm-5.2");
+
+        let _stream = crate::session_context::with_session_id(
+            Some("20260809_29".to_string()),
+            provider.stream(&config, "system", &[Message::user().with_text("hi")], &[]),
+        )
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn stream_omits_session_id_body_field_without_session() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/v1/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string("data: [DONE]\n\n"),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let provider = OpenRouterProvider {
+            api_client: ApiClient::new_with_tls(
+                server.uri(),
+                AuthMethod::BearerToken("test-key".to_string()),
+                None,
+            )
+            .unwrap(),
+            supports_streaming: true,
+            name: OPENROUTER_PROVIDER_NAME.to_string(),
+            configured_parameters: None,
+        };
+
+        let config = model_config("z-ai/glm-5.2");
+
+        let _stream = provider
+            .stream(&config, "system", &[Message::user().with_text("hi")], &[])
+            .await
+            .unwrap();
+
+        let received = server.received_requests().await.unwrap();
+        assert_eq!(received.len(), 1);
+        let body: serde_json::Value = serde_json::from_slice(&received[0].body).unwrap();
+        assert!(
+            body.get("session_id").is_none(),
+            "session_id must not be set without an in-scope session, got body: {}",
+            body
+        );
+        assert!(
+            body.get("user").is_none(),
+            "user must not be set without an in-scope session, got body: {}",
+            body
+        );
     }
 }


### PR DESCRIPTION
## Summary
OpenRouter uses the `session_id` body field for provider sticky routing, which routes all requests in a session to the same provider endpoint that holds the warm prompt cache. Without it, sticky routing falls back to account-level affinity, which only sticks after a detected cache hit rather than from the first turn.

Goose already reads the session ID via `session_context::current_session_id()` and sets it as the `user` field for OpenRouter attribution/rate-limiting, but never sets `session_id`. The existing `agent-session-id` HTTP header is not what OpenRouter expects for sticky routing (OpenRouter reads `x-session-id` / body `session_id`), so it remains inert for that purpose.

This PR adds `session_id` alongside the existing `user` field inside the same `if !session_id.is_empty()` guard in `crates/goose/src/providers/openrouter.rs`. The session ID format is `%Y%m%d_<n>` (~12 chars), well under OpenRouter's 256-char cap.

### Testing
- `cargo check -p goose --lib --tests` — ok
- `cargo test -p goose --lib providers::openrouter` — 8 passed (2 new)
- `cargo clippy -p goose --lib --tests -- -D warnings` — ok
- `cargo fmt --check` — ok
- New tests:
  - `stream_sends_session_id_body_field_for_sticky_routing` — wiremock asserts `body_partial_json({"user":"20260809_29","session_id":"20260809_29"})` under `with_session_id(Some(...))`
  - `stream_omits_session_id_body_field_without_session` — verifies neither field is sent when no session is in scope via `received_requests()`

### Related Issues
Fixes #11066
