### PR TITLE
Add Simplepages remote MCP server to the extensions directory

### DIFF
--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -671,6 +671,18 @@
     "environmentVariables": []
   },
   {
+    "id": "simplepages",
+    "name": "Simplepages",
+    "description": "Build and edit landing pages and websites, and pull how they are performing",
+    "url": "https://simplepages.ai/api/mcp",
+    "link": "https://github.com/simplepages-ai/simplepages-mcp",
+    "installation_notes": "Sign in with your Simplepages account when prompted. Auth is OAuth 2.0 with dynamic client registration, so there is no API key or environment variable to set.",
+    "is_builtin": false,
+    "endorsed": false,
+    "environmentVariables": [],
+    "type": "streamable-http"
+  },
+  {
     "id": "square-mcp",
     "name": "Square",
     "description": "Square API for payments and business management",


### PR DESCRIPTION
## Summary

Adds Simplepages to the extensions directory as a remote MCP server.

Simplepages is an AI landing page and website builder. With the extension enabled, goose can create a page in your workspace from a plain description, change an existing one from a natural-language instruction, and read back visitor, lead and revenue numbers.

Seven tools. `create_page` and `edit_page` write; `list_pages`, `list_sites`, `get_page`, `get_page_analytics` and `get_workspace_analytics` are read only. Pages are created as drafts, so nothing is published without an explicit action by the user.

- Endpoint: `https://simplepages.ai/api/mcp`
- Transport: streamable HTTP
- Auth: OAuth 2.0 with dynamic client registration and PKCE S256, so there is no API key and `environmentVariables` is empty
- Manifests repo (MIT): https://github.com/simplepages-ai/simplepages-mcp
- Docs: https://simplepages.ai/mcp
- Also published to the official MCP Registry as `ai.simplepages/simplepages`

### Testing

Verified the endpoint returns HTTP 401 with a `WWW-Authenticate: Bearer` header and a `resource_metadata` pointer for unauthenticated requests, per RFC 9728, so OAuth discovery works from a standard client. The server is already connected and in use through Claude, Cursor and Smithery, where all seven tools enumerate correctly after authorisation.

The edited `servers.json` was validated as JSON and the diff is a single 12-line insertion, placed alphabetically between Selenium and Square. No other entries were touched or reformatted.

### Related Issues

None.

### Screenshots/Demos (for UX changes)

Not applicable, this is a directory metadata change only.