### PR TITLE
chore(deps): bump h2 to 0.4.17 for RUSTSEC-2026-0258

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5323,9 +5323,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "9f877e75f39e9827ec50a572dd592684ac28c029578726c85f1b2aa6ab807449"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
## The `deny` gate is red for everyone

`cargo-deny.yml` has failed on **every one of its last 12 runs**, including runs on `main` itself:

```
failure  refactor: share `axum-server` via `workspace.dependencies` (#11326)  main  32292024545
failure  chore(deps): bump syn from 2.0.118 to 3.0.3 (#10855)                main  32288433057
```

Same cause every time:

```
error[vulnerability]: h2 unbounded empty DATA frames
  Cargo.lock:415  h2 0.4.15
  ID: RUSTSEC-2026-0258
  Solution: Upgrade to >=0.4.16
```

A gate that is red on every PR is signalling nothing — nobody can tell a real new advisory from the standing failure. That is the actual cost here; the advisory itself is Low severity.

## The change

Lock-file only, two lines. `h2` is transitive (`hyper` → `axum`/`reqwest`/`tonic`/`rmcp`/`wiremock`), so no manifest change is needed.

I hand-edited the single `h2` entry rather than running `cargo update -p h2`, because that command also rewound **13 unrelated `windows-sys` pins** from 0.61.2 back to 0.52.0/0.59.0/0.60.2 — 30 lines of churn with nothing to do with this advisory, and a real risk on the Windows build.

## Verification (repo-pinned 1.96.1 from `rust-toolchain.toml`)

- `cargo metadata --locked` — passes, so the hand-edit leaves a self-consistent lock file
- `cargo check --locked -p goose-cli` — builds clean

## Not fixed here

The same `deny` run emits two `advisory-not-detected` warnings for `RUSTSEC-2026-0194` and `RUSTSEC-2026-0195` (`deny.toml:17-18`) — quick-xml ignores that no longer match any crate. They are warnings, not the failure, and pruning them is a separate call for whoever owns the dep. Left alone deliberately.

Found while triaging #10515, whose only failing check was this.