### PR TITLE
fix(config): preserve permission revocations across managers

### DIFF
--- a/crates/goose/src/config/permission.rs
+++ b/crates/goose/src/config/permission.rs
@@ -198,7 +198,8 @@ impl PermissionManager {
         F: FnOnce(&mut HashMap<String, PermissionConfig>),
     {
         let mut in_memory_map = self.permission_map.write().unwrap();
-        let lock_path = self.config_path.with_extension("yaml.lock");
+        let storage_path = Self::permission_storage_path(&self.config_path);
+        let lock_path = storage_path.with_extension("yaml.lock");
         let lock_file = OpenOptions::new()
             .read(true)
             .write(true)
@@ -210,13 +211,13 @@ impl PermissionManager {
             .lock_exclusive()
             .expect("Failed to lock permission.yaml");
 
-        let mut latest_map = if self.config_path.exists() {
-            Self::load_permission_map(&self.config_path)
+        let mut latest_map = if storage_path.exists() {
+            Self::load_permission_map(&storage_path)
         } else {
             HashMap::new()
         };
         mutation(&mut latest_map);
-        self.write_permission_map(&latest_map);
+        Self::write_permission_map(&storage_path, &latest_map);
         *in_memory_map = latest_map;
     }
 
@@ -236,27 +237,30 @@ impl PermissionManager {
         })
     }
 
-    fn write_permission_map(&self, map: &HashMap<String, PermissionConfig>) {
-        let yaml_content =
-            serde_yaml::to_string(map).expect("Failed to serialize permission config");
-        let write_path = match fs::symlink_metadata(&self.config_path) {
+    fn permission_storage_path(config_path: &Path) -> PathBuf {
+        match fs::symlink_metadata(config_path) {
             Ok(metadata) if metadata.file_type().is_symlink() => {
-                let target = fs::read_link(&self.config_path)
-                    .expect("Failed to resolve permission.yaml symlink");
+                let target =
+                    fs::read_link(config_path).expect("Failed to resolve permission.yaml symlink");
                 if target.is_absolute() {
                     target
                 } else {
-                    self.config_path
+                    config_path
                         .parent()
                         .expect("permission.yaml must have a parent directory")
                         .join(target)
                 }
             }
-            Ok(_) => self.config_path.clone(),
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => self.config_path.clone(),
+            Ok(_) => config_path.to_path_buf(),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => config_path.to_path_buf(),
             Err(error) => panic!("Failed to inspect permission.yaml: {error}"),
-        };
-        let config_dir = write_path
+        }
+    }
+
+    fn write_permission_map(storage_path: &Path, map: &HashMap<String, PermissionConfig>) {
+        let yaml_content =
+            serde_yaml::to_string(map).expect("Failed to serialize permission config");
+        let config_dir = storage_path
             .parent()
             .expect("permission.yaml must have a parent directory");
         let mut temporary_file =
@@ -269,7 +273,7 @@ impl PermissionManager {
             .sync_all()
             .expect("Failed to write to permission.yaml");
         temporary_file
-            .persist(write_path)
+            .persist(storage_path)
             .expect("Failed to write to permission.yaml");
     }
 
@@ -442,6 +446,76 @@ mod tests {
         let permission_path = temp_dir.path().join(PERMISSION_FILE);
         fs::write(&permission_path, "{{invalid yaml: [broken").unwrap();
         PermissionManager::new(temp_dir.path().to_path_buf());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlink_and_target_managers_share_storage_lock() {
+        use std::os::unix::fs::symlink;
+        use std::sync::mpsc;
+        use std::thread;
+
+        let root = TempDir::new().unwrap();
+        let symlink_config_dir = root.path().join("symlink-config");
+        let target_config_dir = root.path().join("target-config");
+        fs::create_dir_all(&symlink_config_dir).unwrap();
+        fs::create_dir_all(&target_config_dir).unwrap();
+
+        let symlink_path = symlink_config_dir.join(PERMISSION_FILE);
+        let target_path = target_config_dir.join(PERMISSION_FILE);
+        fs::write(&target_path, "{}\n").unwrap();
+        symlink("../target-config/permission.yaml", &symlink_path).unwrap();
+
+        let symlink_manager = PermissionManager::new(symlink_config_dir);
+        let target_manager = PermissionManager::new(target_config_dir.clone());
+        let (symlink_locked_tx, symlink_locked_rx) = mpsc::channel();
+        let (release_symlink_tx, release_symlink_rx) = mpsc::channel();
+
+        let symlink_thread = thread::spawn(move || {
+            symlink_manager.mutate_permission_map(|map| {
+                map.entry(USER_PERMISSION.to_string())
+                    .or_default()
+                    .always_allow
+                    .push("symlink_tool".to_string());
+                symlink_locked_tx.send(()).unwrap();
+                release_symlink_rx.recv().unwrap();
+            });
+        });
+        symlink_locked_rx.recv().unwrap();
+
+        let (target_started_tx, target_started_rx) = mpsc::channel();
+        let target_thread = thread::spawn(move || {
+            target_started_tx.send(()).unwrap();
+            target_manager.update_user_permission("target_tool", PermissionLevel::AskBefore);
+        });
+        target_started_rx.recv().unwrap();
+
+        let target_lock = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(target_path.with_extension("yaml.lock"))
+            .unwrap();
+        let target_lock_is_held = target_lock.try_lock_exclusive().is_err();
+        drop(target_lock);
+
+        release_symlink_tx.send(()).unwrap();
+        symlink_thread.join().unwrap();
+        target_thread.join().unwrap();
+
+        assert!(target_lock_is_held);
+        assert!(fs::symlink_metadata(&symlink_path)
+            .unwrap()
+            .file_type()
+            .is_symlink());
+        let reloaded_manager = PermissionManager::new(target_config_dir);
+        assert_eq!(
+            reloaded_manager.get_user_permission("symlink_tool"),
+            Some(PermissionLevel::AlwaysAllow)
+        );
+        assert_eq!(
+            reloaded_manager.get_user_permission("target_tool"),
+            Some(PermissionLevel::AskBefore)
+        );
     }
 
     use test_case::test_case;

--- a/crates/goose/src/config/permission.rs
+++ b/crates/goose/src/config/permission.rs
@@ -239,8 +239,24 @@ impl PermissionManager {
     fn write_permission_map(&self, map: &HashMap<String, PermissionConfig>) {
         let yaml_content =
             serde_yaml::to_string(map).expect("Failed to serialize permission config");
-        let config_dir = self
-            .config_path
+        let write_path = match fs::symlink_metadata(&self.config_path) {
+            Ok(metadata) if metadata.file_type().is_symlink() => {
+                let target = fs::read_link(&self.config_path)
+                    .expect("Failed to resolve permission.yaml symlink");
+                if target.is_absolute() {
+                    target
+                } else {
+                    self.config_path
+                        .parent()
+                        .expect("permission.yaml must have a parent directory")
+                        .join(target)
+                }
+            }
+            Ok(_) => self.config_path.clone(),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => self.config_path.clone(),
+            Err(error) => panic!("Failed to inspect permission.yaml: {error}"),
+        };
+        let config_dir = write_path
             .parent()
             .expect("permission.yaml must have a parent directory");
         let mut temporary_file =
@@ -253,7 +269,7 @@ impl PermissionManager {
             .sync_all()
             .expect("Failed to write to permission.yaml");
         temporary_file
-            .persist(&self.config_path)
+            .persist(write_path)
             .expect("Failed to write to permission.yaml");
     }
 

--- a/crates/goose/src/config/permission.rs
+++ b/crates/goose/src/config/permission.rs
@@ -1,10 +1,13 @@
 use crate::config::paths::Paths;
+use fs2::FileExt;
 use rmcp::model::Tool;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::fs;
+use std::fs::{self, OpenOptions};
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, LazyLock, RwLock};
+use tempfile::NamedTempFile;
 use tracing;
 
 const PERMISSION_FILE: &str = "permission.yaml";
@@ -44,19 +47,7 @@ impl PermissionManager {
     pub fn new(config_dir: PathBuf) -> Self {
         let permission_path = config_dir.join(PERMISSION_FILE);
         let permission_map = if permission_path.exists() {
-            let file_contents =
-                fs::read_to_string(&permission_path).expect("Failed to read permission.yaml");
-            serde_yaml::from_str(&file_contents).unwrap_or_else(|e| {
-                tracing::error!(
-                    "Failed to parse {}: {}. Refusing to start with corrupted permission config.",
-                    permission_path.display(),
-                    e,
-                );
-                panic!(
-                    "Corrupted permission config at {}. Fix or remove the file to continue.",
-                    permission_path.display(),
-                );
-            })
+            Self::load_permission_map(&permission_path)
         } else {
             // Consolidate directory creation for re-use in global singleton or ACP.
             fs::create_dir_all(&config_dir).expect("Failed to create config directory");
@@ -116,30 +107,27 @@ impl PermissionManager {
     }
 
     fn bulk_update_smart_approve_permissions(&self, tool_names: &[String], level: PermissionLevel) {
-        let mut map = self.permission_map.write().unwrap();
-        let permission_config = map.entry(SMART_APPROVE_PERMISSION.to_string()).or_default();
+        self.mutate_permission_map(|map| {
+            let permission_config = map.entry(SMART_APPROVE_PERMISSION.to_string()).or_default();
 
-        for tool_name in tool_names {
-            // Remove from all lists to avoid duplicates
-            permission_config.always_allow.retain(|p| p != tool_name);
-            permission_config.ask_before.retain(|p| p != tool_name);
-            permission_config.never_allow.retain(|p| p != tool_name);
+            for tool_name in tool_names {
+                permission_config.always_allow.retain(|p| p != tool_name);
+                permission_config.ask_before.retain(|p| p != tool_name);
+                permission_config.never_allow.retain(|p| p != tool_name);
 
-            // Add to the appropriate list
-            match &level {
-                PermissionLevel::AlwaysAllow => {
-                    permission_config.always_allow.push(tool_name.clone())
-                }
-                PermissionLevel::AskBefore => permission_config.ask_before.push(tool_name.clone()),
-                PermissionLevel::NeverAllow => {
-                    permission_config.never_allow.push(tool_name.clone())
+                match &level {
+                    PermissionLevel::AlwaysAllow => {
+                        permission_config.always_allow.push(tool_name.clone())
+                    }
+                    PermissionLevel::AskBefore => {
+                        permission_config.ask_before.push(tool_name.clone())
+                    }
+                    PermissionLevel::NeverAllow => {
+                        permission_config.never_allow.push(tool_name.clone())
+                    }
                 }
             }
-        }
-
-        let yaml_content =
-            serde_yaml::to_string(&*map).expect("Failed to serialize permission config");
-        fs::write(&self.config_path, yaml_content).expect("Failed to write to permission.yaml");
+        });
     }
 
     /// Helper function to retrieve the permission level for a specific permission category and tool.
@@ -180,64 +168,113 @@ impl PermissionManager {
 
     /// Helper function to update a permission level for a specific tool in a given permission category.
     fn update_permission(&self, name: &str, principal_name: &str, level: PermissionLevel) {
-        let mut map = self.permission_map.write().unwrap();
-        // Get or create a new PermissionConfig for the specified category
-        let permission_config = map.entry(name.to_string()).or_default();
+        self.mutate_permission_map(|map| {
+            let permission_config = map.entry(name.to_string()).or_default();
 
-        // Remove the principal from all existing lists to avoid duplicates
-        permission_config
-            .always_allow
-            .retain(|p| p != principal_name);
-        permission_config.ask_before.retain(|p| p != principal_name);
-        permission_config
-            .never_allow
-            .retain(|p| p != principal_name);
-
-        // Add the principal to the appropriate list
-        match level {
-            PermissionLevel::AlwaysAllow => permission_config
+            permission_config
                 .always_allow
-                .push(principal_name.to_string()),
-            PermissionLevel::AskBefore => permission_config
-                .ask_before
-                .push(principal_name.to_string()),
-            PermissionLevel::NeverAllow => permission_config
+                .retain(|p| p != principal_name);
+            permission_config.ask_before.retain(|p| p != principal_name);
+            permission_config
                 .never_allow
-                .push(principal_name.to_string()),
-        }
+                .retain(|p| p != principal_name);
 
-        // Serialize the updated permission map and write it back to the config file
+            match level {
+                PermissionLevel::AlwaysAllow => permission_config
+                    .always_allow
+                    .push(principal_name.to_string()),
+                PermissionLevel::AskBefore => permission_config
+                    .ask_before
+                    .push(principal_name.to_string()),
+                PermissionLevel::NeverAllow => permission_config
+                    .never_allow
+                    .push(principal_name.to_string()),
+            }
+        });
+    }
+
+    fn mutate_permission_map<F>(&self, mutation: F)
+    where
+        F: FnOnce(&mut HashMap<String, PermissionConfig>),
+    {
+        let mut in_memory_map = self.permission_map.write().unwrap();
+        let lock_path = self.config_path.with_extension("yaml.lock");
+        let lock_file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(lock_path)
+            .expect("Failed to open permission.yaml lock file");
+        lock_file
+            .lock_exclusive()
+            .expect("Failed to lock permission.yaml");
+
+        let mut latest_map = if self.config_path.exists() {
+            Self::load_permission_map(&self.config_path)
+        } else {
+            HashMap::new()
+        };
+        mutation(&mut latest_map);
+        self.write_permission_map(&latest_map);
+        *in_memory_map = latest_map;
+    }
+
+    fn load_permission_map(config_path: &Path) -> HashMap<String, PermissionConfig> {
+        let file_contents =
+            fs::read_to_string(config_path).expect("Failed to read permission.yaml");
+        serde_yaml::from_str(&file_contents).unwrap_or_else(|error| {
+            tracing::error!(
+                "Failed to parse {}: {}. Refusing to start with corrupted permission config.",
+                config_path.display(),
+                error,
+            );
+            panic!(
+                "Corrupted permission config at {}. Fix or remove the file to continue.",
+                config_path.display(),
+            );
+        })
+    }
+
+    fn write_permission_map(&self, map: &HashMap<String, PermissionConfig>) {
         let yaml_content =
-            serde_yaml::to_string(&*map).expect("Failed to serialize permission config");
-        fs::write(&self.config_path, yaml_content).expect("Failed to write to permission.yaml");
+            serde_yaml::to_string(map).expect("Failed to serialize permission config");
+        let config_dir = self
+            .config_path
+            .parent()
+            .expect("permission.yaml must have a parent directory");
+        let mut temporary_file =
+            NamedTempFile::new_in(config_dir).expect("Failed to write to permission.yaml");
+        temporary_file
+            .write_all(yaml_content.as_bytes())
+            .expect("Failed to write to permission.yaml");
+        temporary_file
+            .as_file()
+            .sync_all()
+            .expect("Failed to write to permission.yaml");
+        temporary_file
+            .persist(&self.config_path)
+            .expect("Failed to write to permission.yaml");
     }
 
     pub fn remove_extension(&self, extension_name: &str) {
-        let mut map = self.permission_map.write().unwrap();
-        for permission_config in map.values_mut() {
-            permission_config
-                .always_allow
-                .retain(|p| !Self::belongs_to_extension(p, extension_name));
-            permission_config
-                .ask_before
-                .retain(|p| !Self::belongs_to_extension(p, extension_name));
-            permission_config
-                .never_allow
-                .retain(|p| !Self::belongs_to_extension(p, extension_name));
-        }
-
-        let yaml_content =
-            serde_yaml::to_string(&*map).expect("Failed to serialize permission config");
-        fs::write(&self.config_path, yaml_content).expect("Failed to write to permission.yaml");
+        self.mutate_permission_map(|map| {
+            for permission_config in map.values_mut() {
+                permission_config
+                    .always_allow
+                    .retain(|p| !Self::belongs_to_extension(p, extension_name));
+                permission_config
+                    .ask_before
+                    .retain(|p| !Self::belongs_to_extension(p, extension_name));
+                permission_config
+                    .never_allow
+                    .retain(|p| !Self::belongs_to_extension(p, extension_name));
+            }
+        });
     }
 
     pub fn clear_permissions(&self) {
-        let mut map = self.permission_map.write().unwrap();
-        map.clear();
-
-        let yaml_content =
-            serde_yaml::to_string(&*map).expect("Failed to serialize permission config");
-        fs::write(&self.config_path, yaml_content).expect("Failed to write to permission.yaml");
+        self.mutate_permission_map(HashMap::clear);
     }
 
     fn belongs_to_extension(principal_name: &str, extension_name: &str) -> bool {

--- a/crates/goose/tests/permission_persistence.rs
+++ b/crates/goose/tests/permission_persistence.rs
@@ -82,6 +82,31 @@ fn permission_updates_atomically_replace_storage_file() {
     );
 }
 
+#[cfg(unix)]
+#[test]
+fn permission_updates_preserve_storage_symlink() {
+    use std::os::unix::fs::symlink;
+
+    let config_dir = tempfile::tempdir().unwrap();
+    let permission_path = config_dir.path().join("permission.yaml");
+    let target_path = config_dir.path().join("managed-permissions.yaml");
+    std::fs::write(&target_path, "{}\n").unwrap();
+    symlink("managed-permissions.yaml", &permission_path).unwrap();
+
+    let manager = PermissionManager::new(config_dir.path().to_path_buf());
+    manager.update_user_permission("user_tool", PermissionLevel::AlwaysAllow);
+
+    assert!(std::fs::symlink_metadata(&permission_path)
+        .unwrap()
+        .file_type()
+        .is_symlink());
+    let persisted = PermissionManager::new(config_dir.path().to_path_buf());
+    assert_eq!(
+        persisted.get_user_permission("user_tool"),
+        Some(PermissionLevel::AlwaysAllow)
+    );
+}
+
 #[test]
 fn permission_removal_and_clear_persist() {
     let config_dir = tempfile::tempdir().unwrap();

--- a/crates/goose/tests/permission_persistence.rs
+++ b/crates/goose/tests/permission_persistence.rs
@@ -1,0 +1,104 @@
+use goose::config::permission::{PermissionConfig, PermissionLevel, PermissionManager};
+use std::collections::HashMap;
+
+#[test]
+fn stale_manager_cannot_restore_revoked_permission() {
+    let config_dir = tempfile::tempdir().unwrap();
+    let current_manager = PermissionManager::new(config_dir.path().to_path_buf());
+
+    current_manager.update_user_permission("dangerous_tool", PermissionLevel::AlwaysAllow);
+    let stale_manager = PermissionManager::new(config_dir.path().to_path_buf());
+
+    current_manager.update_user_permission("dangerous_tool", PermissionLevel::NeverAllow);
+    stale_manager.update_user_permission("unrelated_tool", PermissionLevel::AlwaysAllow);
+
+    assert_eq!(
+        stale_manager.get_user_permission("dangerous_tool"),
+        Some(PermissionLevel::NeverAllow)
+    );
+
+    let reloaded_manager = PermissionManager::new(config_dir.path().to_path_buf());
+    assert_eq!(
+        reloaded_manager.get_user_permission("dangerous_tool"),
+        Some(PermissionLevel::NeverAllow)
+    );
+    assert_eq!(
+        reloaded_manager.get_user_permission("unrelated_tool"),
+        Some(PermissionLevel::AlwaysAllow)
+    );
+}
+
+#[test]
+fn permission_updates_persist_across_manager_instances() {
+    let config_dir = tempfile::tempdir().unwrap();
+    let manager = PermissionManager::new(config_dir.path().to_path_buf());
+
+    manager.update_user_permission("user_tool", PermissionLevel::AskBefore);
+    manager.update_smart_approve_permission("smart_tool", PermissionLevel::NeverAllow);
+
+    let reloaded_manager = PermissionManager::new(config_dir.path().to_path_buf());
+    assert_eq!(
+        reloaded_manager.get_user_permission("user_tool"),
+        Some(PermissionLevel::AskBefore)
+    );
+    assert_eq!(
+        reloaded_manager.get_smart_approve_permission("smart_tool"),
+        Some(PermissionLevel::NeverAllow)
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn permission_updates_atomically_replace_storage_file() {
+    use std::os::unix::fs::MetadataExt;
+
+    let config_dir = tempfile::tempdir().unwrap();
+    let manager = PermissionManager::new(config_dir.path().to_path_buf());
+    manager.update_user_permission("first_tool", PermissionLevel::AlwaysAllow);
+
+    let permission_path = manager.get_config_path();
+    let old_file = std::fs::File::open(permission_path).unwrap();
+    let old_inode = old_file.metadata().unwrap().ino();
+
+    manager.update_user_permission("second_tool", PermissionLevel::AskBefore);
+
+    assert_ne!(std::fs::metadata(permission_path).unwrap().ino(), old_inode);
+    let old_values: HashMap<String, PermissionConfig> = serde_yaml::from_reader(old_file).unwrap();
+    assert!(old_values["user"]
+        .always_allow
+        .contains(&"first_tool".to_string()));
+    assert!(!old_values["user"]
+        .ask_before
+        .contains(&"second_tool".to_string()));
+
+    let current_manager = PermissionManager::new(config_dir.path().to_path_buf());
+    assert_eq!(
+        current_manager.get_user_permission("first_tool"),
+        Some(PermissionLevel::AlwaysAllow)
+    );
+    assert_eq!(
+        current_manager.get_user_permission("second_tool"),
+        Some(PermissionLevel::AskBefore)
+    );
+}
+
+#[test]
+fn permission_removal_and_clear_persist() {
+    let config_dir = tempfile::tempdir().unwrap();
+    let manager = PermissionManager::new(config_dir.path().to_path_buf());
+
+    manager.update_user_permission("git__status", PermissionLevel::AlwaysAllow);
+    manager.update_user_permission("github__status", PermissionLevel::AskBefore);
+    manager.remove_extension("git");
+
+    let reloaded_manager = PermissionManager::new(config_dir.path().to_path_buf());
+    assert_eq!(reloaded_manager.get_user_permission("git__status"), None);
+    assert_eq!(
+        reloaded_manager.get_user_permission("github__status"),
+        Some(PermissionLevel::AskBefore)
+    );
+
+    reloaded_manager.clear_permissions();
+    let cleared_manager = PermissionManager::new(config_dir.path().to_path_buf());
+    assert!(cleared_manager.get_permission_names().is_empty());
+}


### PR DESCRIPTION
## Summary

- serialize permission-map mutations across Goose processes with an adjacent file lock
- reload the latest on-disk permissions while holding the lock so a stale manager cannot restore an earlier permission value
- atomically replace `permission.yaml` and refresh the writing manager's in-memory view
- preserve absolute and relative `permission.yaml` symlinks by replacing their managed target
- cover stale-manager revocation, ordinary persistence, atomic replacement, symlink compatibility, extension removal, and clearing

## Security invariant

An unrelated permission update from a stale process must not roll back a newer permission revocation persisted by another process.

This intentionally does not change live read caches in already-running processes; it prevents stale writers from making their older snapshot durable for later readers.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p goose --test permission_persistence` — 5 passed
- `cargo test -p goose config::permission::tests --lib` — 11 passed
- `cargo build -p goose`
- `cargo clippy -p goose --all-targets -- -D warnings`
- `git diff --check`

*This finding was discovered by [Project Loupe](https://github.com/project-loupe/loupe)*
