### PR TITLE
fix(deps): repair dangling syn reference in Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13095,7 +13095,7 @@ checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

`main` CI is currently red on every commit, and has been since #11248 merged. This is a one-line lockfile fix.

The `visibility 0.1.1` entry in `Cargo.lock` references `syn 2.0.118`, which no longer exists as a package: #10855 bumped `syn` to `3.0.3`, leaving `1.0.109`, `2.0.119`, and `3.0.3` as the only `syn` packages in the lockfile.

#11248 (`rubato` 0.16.2 → 5.0.0) then added `visibility 0.1.1` as a new transitive dependency — `rubato` 5.0.0 depends on it — and wrote its dependency edge as `syn 2.0.118`, a version that had already been removed from the lockfile ~1.5h earlier. The stale edge arrived together with the crate that introduced it.

For scale: of the 108 `syn` references in the lockfile, 93 point at `2.0.119`, 13 at `3.0.3`, 1 at `1.0.109`, and exactly **one** — this `visibility` edge — points at a package that does not exist.

Because the reference dangles, **any** cargo invocation passing `--locked` refuses to proceed:

```
error: cannot update the lock file /home/runner/work/goose/goose/Cargo.lock because --locked was passed to prevent this
```

## Impact

Two required checks fail on `main` and on every open PR branched from it:

- **Check MSRV** — `cargo check --workspace --locked --all-targets`
- **Check goose-sdk UniFFI** — `cargo check -p goose-sdk --features uniffi --locked` and the matching `cargo test`

Verified failing on `main` at `5a01b1ad`, `4de6fe20`, `01f5ed7f`, `bc680492`, and `6cd26647` — the five most recent CI runs on `main`, all red with this same error. It is not PR-specific; contributors hitting it on their own branches cannot fix it from there.

## Fix

Regenerated the lockfile. The single stale reference becomes `syn 2.0.119` — the version already resolved and present in the lockfile, so **no dependency versions change**. The entire diff:

```diff
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
```

## Verification

Both previously-failing CI commands were run locally at this commit and now succeed:

- `cargo metadata --locked` — was failing, now OK
- `cargo check --workspace --locked --all-targets` — the Check MSRV command, clean
- `cargo check -p goose-sdk --features uniffi --locked` — the UniFFI command, clean

Bisected to confirm the origin, checking both the dangling reference and the `visibility` package entry per commit:

| commit | PR | `"syn 2.0.118"` refs | `visibility` entry |
|---|---|---|---|
| `9373ae08` | #10855 syn → 3.0.3 | 0 | absent |
| `af016f0a` | #11246 pkcs8 | 0 | absent |
| `1f8f57c8` | #11242 comfy-table | 0 | absent |
| `9e4ac726` | **#11248 rubato → 5.0.0** | **1** | **added** |
| `b55a28b1` | #11243 nostr | 1 | present |
| `c13aa86a` | #11207 | 1 | present |

Both appear for the first time in `9e4ac726`, and `git show 9e4ac726 -- Cargo.lock` shows `+ "visibility"`, `+name = "visibility"`, and `+ "syn 2.0.118"` added in that single commit. It persists on every commit since.

## Related Issues

None — unblocking maintenance, no Ready issue. Flagging rather than assuming: `cargo update`-style lockfile repairs are the kind of thing a maintainer may prefer to land directly or fold into a dependabot run.

