### PR TITLE
feat(providers): extract device-code OAuth into goose-providers for gdk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5283,12 +5283,14 @@ dependencies = [
  "serde_json",
  "tempfile",
  "test-case",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-stream",
  "tokio-util",
  "tracing",
  "url",
  "urlencoding",
+ "uuid",
  "wiremock",
 ]
 

--- a/crates/goose-providers/Cargo.toml
+++ b/crates/goose-providers/Cargo.toml
@@ -51,6 +51,8 @@ pem = { version = "4.0.0", default-features = false, features = ["std"], optiona
 pkcs8 = { version = "0.11", default-features = false, features = ["alloc", "std"], optional = true }
 sec1 = { version = "0.8", default-features = false, features = ["der", "std"], optional = true }
 include_dir = { workspace = true }
+thiserror.workspace = true
+uuid = { workspace = true, features = ["v4", "std"] }
 
 [dev-dependencies]
 test-case = { workspace = true }

--- a/crates/goose-providers/src/lib.rs
+++ b/crates/goose-providers/src/lib.rs
@@ -19,4 +19,5 @@ pub mod openai_compatible;
 
 pub use declarative::declarative_providers::*;
 
+pub mod oauth;
 pub mod snowflake;

--- a/crates/goose-providers/src/oauth/copilot.rs
+++ b/crates/goose-providers/src/oauth/copilot.rs
@@ -1,0 +1,128 @@
+//! GitHub Copilot's second hop: GitHub OAuth token → Copilot API token.
+//!
+//! Device-code login against github.com yields a GitHub access token, not a
+//! Copilot inference token. Hosts must exchange it here (or the Copilot
+//! provider in goose does the same against `copilot_internal/v2/token`).
+
+use std::fmt;
+
+use anyhow::{anyhow, Result};
+use chrono::{DateTime, Duration, Utc};
+use reqwest::header::{HeaderValue, AUTHORIZATION};
+use serde::Deserialize;
+
+use super::http_client;
+use super::registry::github_copilot_headers;
+
+const COPILOT_TOKEN_URL: &str = "https://api.github.com/copilot_internal/v2/token";
+
+#[derive(Clone)]
+pub struct CopilotApiToken {
+    pub token: String,
+    pub api_endpoint: String,
+    pub expires_at: DateTime<Utc>,
+}
+
+impl fmt::Debug for CopilotApiToken {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CopilotApiToken")
+            .field("token", &"[redacted]")
+            .field("api_endpoint", &self.api_endpoint)
+            .field("expires_at", &self.expires_at)
+            .finish()
+    }
+}
+
+#[derive(Deserialize)]
+struct CopilotTokenEndpoints {
+    api: String,
+}
+
+#[derive(Deserialize)]
+struct CopilotTokenResponse {
+    token: String,
+    refresh_in: i64,
+    endpoints: CopilotTokenEndpoints,
+}
+
+/// Exchange a GitHub OAuth access token for a short-lived Copilot API token.
+pub async fn exchange_github_copilot_token(github_token: &str) -> Result<CopilotApiToken> {
+    let mut headers = github_copilot_headers();
+    let auth = format!("bearer {github_token}");
+    headers.insert(
+        AUTHORIZATION,
+        HeaderValue::from_str(&auth)
+            .map_err(|e| anyhow!("invalid GitHub token for header: {e}"))?,
+    );
+
+    let response = http_client()?
+        .get(COPILOT_TOKEN_URL)
+        .timeout(std::time::Duration::from_secs(
+            crate::api_client::DEFAULT_PROVIDER_TIMEOUT_SECS,
+        ))
+        .headers(headers)
+        .send()
+        .await?;
+    let status = response.status();
+    if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
+        anyhow::bail!("GitHub Copilot token request failed ({status})");
+    }
+    let body = response
+        .error_for_status()?
+        .json::<CopilotTokenResponse>()
+        .await?;
+
+    ensure_copilot_api_endpoint(&body.endpoints.api)?;
+    Ok(CopilotApiToken {
+        token: body.token,
+        api_endpoint: body.endpoints.api,
+        expires_at: Utc::now() + Duration::seconds(body.refresh_in),
+    })
+}
+
+pub fn ensure_copilot_api_endpoint(endpoint: &str) -> Result<()> {
+    let url = url::Url::parse(endpoint).map_err(|_| anyhow!("invalid Copilot API endpoint"))?;
+    let host = url
+        .host()
+        .ok_or_else(|| anyhow!("invalid Copilot API endpoint"))?;
+    let loopback = match host {
+        url::Host::Domain(host) => host.eq_ignore_ascii_case("localhost"),
+        url::Host::Ipv4(addr) => addr.is_loopback(),
+        url::Host::Ipv6(addr) => addr.is_loopback(),
+    };
+    if url.scheme() == "https" || (url.scheme() == "http" && loopback) {
+        Ok(())
+    } else {
+        Err(anyhow!(
+            "Copilot API endpoint must use HTTPS unless it targets loopback"
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_plaintext_remote_copilot_endpoint() {
+        let err = ensure_copilot_api_endpoint("http://api.example.com").unwrap_err();
+        assert!(err.to_string().contains("HTTPS"), "got: {err}");
+    }
+
+    #[test]
+    fn accepts_https_and_loopback_copilot_endpoint() {
+        ensure_copilot_api_endpoint("https://api.githubcopilot.com").unwrap();
+        ensure_copilot_api_endpoint("http://127.0.0.1:8080").unwrap();
+    }
+
+    #[test]
+    fn copilot_token_debug_redacts_secret() {
+        let token = CopilotApiToken {
+            token: "secret-copilot".to_string(),
+            api_endpoint: "https://api.githubcopilot.com".to_string(),
+            expires_at: Utc::now(),
+        };
+        let rendered = format!("{token:?}");
+        assert!(!rendered.contains("secret-copilot"), "{rendered}");
+    }
+}

--- a/crates/goose-providers/src/oauth/device_flow.rs
+++ b/crates/goose-providers/src/oauth/device_flow.rs
@@ -1,0 +1,680 @@
+//! Shared OAuth 2.0 Device Authorization Grant (RFC 8628) helper.
+//!
+//! Protocol only: request a device code, poll the token endpoint, and refresh.
+//! Hosts own browser/clipboard UI and token persistence.
+
+use std::fmt;
+
+use anyhow::{anyhow, Result};
+use chrono::{DateTime, Duration, Utc};
+use reqwest::header::HeaderMap;
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+
+use crate::api_client::DEFAULT_PROVIDER_TIMEOUT_SECS;
+
+/// Fallback poll interval when the server omits `interval` (RFC 8628 §3.2).
+pub const DEFAULT_POLL_INTERVAL_SECS: u64 = 5;
+
+/// Fallback device-code window when the server omits `expires_in` (RFC 8628 §3.2).
+pub const DEFAULT_DEVICE_CODE_LIFETIME_SECS: u64 = 300;
+
+/// Extra seconds added to the poll interval after an RFC 8628 `slow_down`.
+pub const SLOW_DOWN_BACKOFF_SECS: u64 = 5;
+
+/// How a provider expects the device-authorization and token request bodies to
+/// be encoded. RFC 8628 §3.1 specifies `application/x-www-form-urlencoded`, but
+/// GitHub accepts JSON when `Accept: application/json` is set.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RequestEncoding {
+    Form,
+    Json,
+}
+
+/// Connection details for a provider's device flow.
+///
+/// The `Client` passed to [`request_device_code`], [`poll_once`], and
+/// [`refresh_device_flow_token`] must not follow redirects: a 307/308 would
+/// forward `device_code` / `refresh_token` in the body. gdk's client already
+/// uses `Policy::none()`.
+#[derive(Debug, Clone)]
+pub struct DeviceFlowConfig<'a> {
+    /// `device_authorization_endpoint` (RFC 8628 §3.1).
+    /// `None` when only the refresh grant is needed.
+    pub device_auth_url: Option<&'a str>,
+    /// `token_endpoint` used for both device-code polling and refresh grants.
+    pub token_url: &'a str,
+    /// Public OAuth client identifier (installed-app credential, not a secret).
+    pub client_id: &'a str,
+    /// Space-separated scope string, or `None` to omit the parameter.
+    pub scopes: Option<&'a str>,
+    /// Provider-specific headers (user-agent, platform markers, `Accept`, etc.).
+    pub extra_headers: HeaderMap,
+    /// Body encoding for device-auth, polling, and refresh requests.
+    pub encoding: RequestEncoding,
+}
+
+/// Fields returned by `/device_authorization` (RFC 8628 §3.2).
+#[derive(Clone, Deserialize)]
+pub struct DeviceCodeResponse {
+    pub device_code: String,
+    pub user_code: String,
+    pub verification_uri: String,
+    /// Pre-populated URI with user_code embedded, used when the provider
+    /// supports it (e.g. Kimi). Fall back to `verification_uri` otherwise.
+    pub verification_uri_complete: Option<String>,
+    pub interval: Option<u64>,
+    pub expires_in: Option<u64>,
+}
+
+impl DeviceCodeResponse {
+    /// URI the user should visit. Prefers the `_complete` form when present.
+    pub fn verification_url(&self) -> &str {
+        self.verification_uri_complete
+            .as_deref()
+            .unwrap_or(&self.verification_uri)
+    }
+
+    pub fn poll_interval_secs(&self) -> u64 {
+        self.interval.unwrap_or(DEFAULT_POLL_INTERVAL_SECS)
+    }
+
+    pub fn lifetime_secs(&self) -> u64 {
+        self.expires_in.unwrap_or(DEFAULT_DEVICE_CODE_LIFETIME_SECS)
+    }
+}
+
+impl fmt::Debug for DeviceCodeResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DeviceCodeResponse")
+            .field("device_code", &"[redacted]")
+            .field("user_code", &self.user_code)
+            .field("verification_uri", &self.verification_uri)
+            .field("verification_uri_complete", &self.verification_uri_complete)
+            .field("interval", &self.interval)
+            .field("expires_in", &self.expires_in)
+            .finish()
+    }
+}
+
+/// Access + optional refresh credentials from a device-code exchange.
+#[derive(Clone)]
+pub struct DeviceFlowTokens {
+    pub access_token: String,
+    /// Some providers (GitHub Copilot) do not issue a refresh token.
+    pub refresh_token: Option<String>,
+    /// Derived from `expires_in` on the token response. `None` when the server
+    /// omits it (RFC 6749 §5.1 permits that).
+    pub expires_at: Option<DateTime<Utc>>,
+}
+
+impl fmt::Debug for DeviceFlowTokens {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DeviceFlowTokens")
+            .field("access_token", &"[redacted]")
+            .field(
+                "refresh_token",
+                &self.refresh_token.as_ref().map(|_| "[redacted]"),
+            )
+            .field("expires_at", &self.expires_at)
+            .finish()
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("token refresh failed ({status})")]
+pub struct DeviceFlowTokenRefreshError {
+    pub status: reqwest::StatusCode,
+    pub error: Option<String>,
+}
+
+/// One token-endpoint poll without sleeping. Hosts drive the wait loop.
+#[derive(Debug)]
+pub enum DevicePollStatus {
+    Pending,
+    SlowDown,
+    Success(DeviceFlowTokens),
+    Denied,
+    Expired,
+}
+
+// ── Public entry points ──────────────────────────────────────────────────────
+
+/// Request a device code from the authorization server.
+pub async fn request_device_code(
+    client: &Client,
+    cfg: &DeviceFlowConfig<'_>,
+) -> Result<DeviceCodeResponse> {
+    #[derive(Serialize)]
+    struct DeviceAuthReq<'a> {
+        client_id: &'a str,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        scope: Option<&'a str>,
+    }
+
+    let body = DeviceAuthReq {
+        client_id: cfg.client_id,
+        scope: cfg.scopes,
+    };
+
+    let url = cfg
+        .device_auth_url
+        .ok_or_else(|| anyhow!("device_auth_url is required for device code request"))?;
+    send_request(client, cfg, url, &body)
+        .await?
+        .error_for_status()?
+        .json::<DeviceCodeResponse>()
+        .await
+        .map_err(Into::into)
+}
+
+/// Single token-endpoint poll. Does not sleep; callers wait `interval` themselves.
+pub async fn poll_once(
+    client: &Client,
+    cfg: &DeviceFlowConfig<'_>,
+    device_code: &str,
+) -> Result<DevicePollStatus> {
+    #[derive(Serialize)]
+    struct PollReq<'a> {
+        client_id: &'a str,
+        device_code: &'a str,
+        grant_type: &'static str,
+    }
+
+    let req = PollReq {
+        client_id: cfg.client_id,
+        device_code,
+        grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+    };
+
+    let response = send_request(client, cfg, cfg.token_url, &req).await?;
+
+    Ok(match parse_token_response(response).await? {
+        TokenPollOutcome::Issued(tokens) => DevicePollStatus::Success(tokens),
+        TokenPollOutcome::Pending => DevicePollStatus::Pending,
+        TokenPollOutcome::SlowDown => DevicePollStatus::SlowDown,
+        TokenPollOutcome::Denied => DevicePollStatus::Denied,
+        TokenPollOutcome::Expired => DevicePollStatus::Expired,
+        TokenPollOutcome::Failed(err) => {
+            return Err(anyhow!("authorization failed: {}", err));
+        }
+    })
+}
+
+/// Poll the token endpoint until the user authorizes (or the device code expires).
+/// Implements RFC 8628 §3.5 — handles `authorization_pending` and `slow_down`.
+pub async fn poll_for_tokens(
+    client: &Client,
+    cfg: &DeviceFlowConfig<'_>,
+    device_code: &str,
+    interval_secs: u64,
+    expires_in_secs: u64,
+) -> Result<DeviceFlowTokens> {
+    let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(expires_in_secs);
+    let mut effective_interval = interval_secs;
+
+    loop {
+        if tokio::time::Instant::now() >= deadline {
+            return Err(anyhow!("timed out waiting for user authorization"));
+        }
+        tokio::time::sleep(tokio::time::Duration::from_secs(effective_interval)).await;
+
+        match poll_once(client, cfg, device_code).await? {
+            DevicePollStatus::Success(tokens) => return Ok(tokens),
+            DevicePollStatus::Pending => {
+                tracing::debug!("authorization pending, continuing to poll");
+            }
+            DevicePollStatus::SlowDown => {
+                tracing::debug!("slow_down received, increasing poll interval");
+                effective_interval += SLOW_DOWN_BACKOFF_SECS;
+            }
+            DevicePollStatus::Denied => {
+                return Err(anyhow!("authorization failed: access_denied"));
+            }
+            DevicePollStatus::Expired => {
+                return Err(anyhow!("authorization failed: expired_token"));
+            }
+        }
+    }
+}
+
+/// Exchange a refresh token for a new access token (RFC 6749 §6).
+pub async fn refresh_device_flow_token(
+    client: &Client,
+    cfg: &DeviceFlowConfig<'_>,
+    refresh_token: &str,
+) -> Result<DeviceFlowTokens> {
+    #[derive(Serialize)]
+    struct RefreshReq<'a> {
+        client_id: &'a str,
+        grant_type: &'static str,
+        refresh_token: &'a str,
+    }
+
+    let req = RefreshReq {
+        client_id: cfg.client_id,
+        grant_type: "refresh_token",
+        refresh_token,
+    };
+
+    let response = send_request(client, cfg, cfg.token_url, &req).await?;
+    let status = response.status();
+    let bytes = response.bytes().await?;
+    let raw = serde_json::from_slice::<TokenResponseBody>(&bytes);
+
+    if !status.is_success() {
+        return Err(anyhow::Error::new(DeviceFlowTokenRefreshError {
+            status,
+            error: raw.ok().and_then(|body| body.error),
+        }));
+    }
+
+    let raw = raw?;
+
+    let access_token = raw
+        .access_token
+        .ok_or_else(|| anyhow!("refresh response missing access_token"))?;
+    Ok(DeviceFlowTokens {
+        access_token,
+        refresh_token: raw.refresh_token,
+        expires_at: raw
+            .expires_in
+            .map(|secs| Utc::now() + Duration::seconds(secs)),
+    })
+}
+
+// ── Internals ────────────────────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+struct TokenResponseBody {
+    access_token: Option<String>,
+    refresh_token: Option<String>,
+    expires_in: Option<i64>,
+    error: Option<String>,
+}
+
+enum TokenPollOutcome {
+    Issued(DeviceFlowTokens),
+    Pending,
+    SlowDown,
+    Denied,
+    Expired,
+    Failed(String),
+}
+
+async fn parse_token_response(response: reqwest::Response) -> Result<TokenPollOutcome> {
+    let status = response.status();
+    let bytes = response.bytes().await?;
+
+    let body: TokenResponseBody = match serde_json::from_slice(&bytes) {
+        Ok(p) => p,
+        Err(e) => {
+            if !status.is_success() {
+                return Err(anyhow!("token poll HTTP {}", status.as_u16()));
+            }
+            return Err(e.into());
+        }
+    };
+
+    if let Some(access_token) = body.access_token {
+        return Ok(TokenPollOutcome::Issued(DeviceFlowTokens {
+            access_token,
+            refresh_token: body.refresh_token,
+            expires_at: body
+                .expires_in
+                .map(|secs| Utc::now() + Duration::seconds(secs)),
+        }));
+    }
+
+    Ok(match body.error.as_deref() {
+        Some("authorization_pending") => TokenPollOutcome::Pending,
+        Some("slow_down") => TokenPollOutcome::SlowDown,
+        Some("access_denied") | Some("authorization_denied") => TokenPollOutcome::Denied,
+        Some("expired_token") => TokenPollOutcome::Expired,
+        Some(err) => TokenPollOutcome::Failed(err.to_string()),
+        None => TokenPollOutcome::Failed(
+            "unexpected token response: no access_token and no error code".to_string(),
+        ),
+    })
+}
+
+fn ensure_oauth_url(url: &str) -> Result<()> {
+    let parsed = url::Url::parse(url).map_err(|e| anyhow!("invalid OAuth URL: {e}"))?;
+    let https = parsed.scheme() == "https";
+    let loopback_http = parsed.scheme() == "http"
+        && parsed.host().is_some_and(|host| match host {
+            url::Host::Ipv4(addr) => addr.is_loopback(),
+            url::Host::Ipv6(addr) => addr.is_loopback(),
+            url::Host::Domain(domain) => domain.eq_ignore_ascii_case("localhost"),
+        });
+    if https || loopback_http {
+        Ok(())
+    } else {
+        Err(anyhow!("OAuth endpoint must use HTTPS"))
+    }
+}
+
+async fn send_request<T: Serialize + ?Sized>(
+    client: &Client,
+    cfg: &DeviceFlowConfig<'_>,
+    url: &str,
+    body: &T,
+) -> Result<reqwest::Response> {
+    ensure_oauth_url(url)?;
+    let builder = client
+        .post(url)
+        .timeout(std::time::Duration::from_secs(
+            DEFAULT_PROVIDER_TIMEOUT_SECS,
+        ))
+        .headers(cfg.extra_headers.clone());
+    let builder = match cfg.encoding {
+        RequestEncoding::Form => builder.form(body),
+        RequestEncoding::Json => builder.json(body),
+    };
+    builder.send().await.map_err(Into::into)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn make_cfg<'a>(device_auth_url: Option<&'a str>, token_url: &'a str) -> DeviceFlowConfig<'a> {
+        DeviceFlowConfig {
+            device_auth_url,
+            token_url,
+            client_id: "test-client",
+            scopes: None,
+            extra_headers: HeaderMap::new(),
+            encoding: RequestEncoding::Form,
+        }
+    }
+
+    #[tokio::test]
+    async fn poll_returns_issued_tokens_when_server_responds_immediately() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "access_token": "the_token",
+                "refresh_token": "the_refresh",
+                "expires_in": 1800,
+            })))
+            .mount(&server)
+            .await;
+
+        let token_url = format!("{}/token", server.uri());
+        let cfg = make_cfg(None, &token_url);
+
+        let client = Client::new();
+        let tokens = poll_for_tokens(&client, &cfg, "device-abc", 0, 30)
+            .await
+            .unwrap();
+        assert_eq!(tokens.access_token, "the_token");
+        assert_eq!(tokens.refresh_token.as_deref(), Some("the_refresh"));
+        assert!(tokens.expires_at.is_some());
+    }
+
+    #[tokio::test]
+    async fn poll_handles_authorization_pending_then_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/token"))
+            .respond_with(ResponseTemplate::new(400).set_body_json(json!({
+                "error": "authorization_pending",
+            })))
+            .up_to_n_times(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "access_token": "issued",
+                "expires_in": 900,
+            })))
+            .mount(&server)
+            .await;
+
+        let token_url = format!("{}/token", server.uri());
+        let cfg = make_cfg(None, &token_url);
+
+        let client = Client::new();
+        let tokens = poll_for_tokens(&client, &cfg, "device-abc", 0, 30)
+            .await
+            .unwrap();
+        assert_eq!(tokens.access_token, "issued");
+        assert!(tokens.refresh_token.is_none());
+    }
+
+    #[tokio::test]
+    async fn poll_handles_slow_down_then_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/token"))
+            .respond_with(ResponseTemplate::new(400).set_body_json(json!({
+                "error": "slow_down",
+            })))
+            .up_to_n_times(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "access_token": "issued",
+                "expires_in": 900,
+            })))
+            .mount(&server)
+            .await;
+
+        let token_url = format!("{}/token", server.uri());
+        let cfg = make_cfg(None, &token_url);
+
+        let client = Client::new();
+        let tokens = poll_for_tokens(&client, &cfg, "device-abc", 0, 30)
+            .await
+            .unwrap();
+        assert_eq!(tokens.access_token, "issued");
+    }
+
+    #[tokio::test]
+    async fn poll_times_out_when_user_never_authorizes() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/token"))
+            .respond_with(ResponseTemplate::new(400).set_body_json(json!({
+                "error": "authorization_pending",
+            })))
+            .mount(&server)
+            .await;
+
+        let token_url = format!("{}/token", server.uri());
+        let cfg = make_cfg(None, &token_url);
+
+        let client = Client::new();
+        let err = poll_for_tokens(&client, &cfg, "device-abc", 0, 0)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("timed out"), "got: {}", err);
+    }
+
+    #[tokio::test]
+    async fn poll_surfaces_http_status_on_unparseable_body() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/token"))
+            .respond_with(ResponseTemplate::new(502).set_body_string("Bad Gateway"))
+            .mount(&server)
+            .await;
+
+        let token_url = format!("{}/token", server.uri());
+        let cfg = make_cfg(None, &token_url);
+
+        let client = Client::new();
+        let err = poll_for_tokens(&client, &cfg, "device-abc", 0, 5)
+            .await
+            .unwrap_err();
+        let msg = format!("{:#}", err);
+        assert!(msg.contains("502"), "expected status in error: {}", msg);
+        assert!(
+            !msg.to_ascii_lowercase().contains("bad gateway"),
+            "raw HTTP body must not leak: {}",
+            msg
+        );
+    }
+
+    #[tokio::test]
+    async fn poll_surfaces_server_error_message() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/token"))
+            .respond_with(ResponseTemplate::new(400).set_body_json(json!({
+                "error": "access_denied",
+            })))
+            .mount(&server)
+            .await;
+
+        let token_url = format!("{}/token", server.uri());
+        let cfg = make_cfg(None, &token_url);
+
+        let client = Client::new();
+        let err = poll_for_tokens(&client, &cfg, "device-abc", 0, 5)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("access_denied"), "got: {}", err);
+    }
+
+    #[tokio::test]
+    async fn request_device_code_parses_complete_response() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/device_authorization"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "device_code": "dc",
+                "user_code": "UC-1",
+                "verification_uri": "https://example.com/activate",
+                "verification_uri_complete": "https://example.com/activate?user_code=UC-1",
+                "interval": 3,
+                "expires_in": 600,
+            })))
+            .mount(&server)
+            .await;
+
+        let device_url = format!("{}/device_authorization", server.uri());
+        let cfg = make_cfg(Some(&device_url), "");
+
+        let client = Client::new();
+        let resp = request_device_code(&client, &cfg).await.unwrap();
+        assert_eq!(resp.device_code, "dc");
+        assert_eq!(resp.user_code, "UC-1");
+        assert_eq!(
+            resp.verification_url(),
+            "https://example.com/activate?user_code=UC-1"
+        );
+        assert_eq!(resp.interval, Some(3));
+    }
+
+    #[tokio::test]
+    async fn refresh_token_returns_new_credentials() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "access_token": "new_access",
+                "refresh_token": "new_refresh",
+                "expires_in": 3600,
+            })))
+            .mount(&server)
+            .await;
+
+        let token_url = format!("{}/token", server.uri());
+        let cfg = make_cfg(None, &token_url);
+
+        let client = Client::new();
+        let tokens = refresh_device_flow_token(&client, &cfg, "old_refresh")
+            .await
+            .unwrap();
+        assert_eq!(tokens.access_token, "new_access");
+        assert_eq!(tokens.refresh_token.as_deref(), Some("new_refresh"));
+    }
+
+    #[tokio::test]
+    async fn refresh_token_allows_server_to_omit_refresh_token() {
+        // RFC 6749 §6: server MAY omit refresh_token; caller should reuse prior.
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "access_token": "new_access",
+                "expires_in": 3600,
+            })))
+            .mount(&server)
+            .await;
+
+        let token_url = format!("{}/token", server.uri());
+        let cfg = make_cfg(None, &token_url);
+
+        let client = Client::new();
+        let tokens = refresh_device_flow_token(&client, &cfg, "old_refresh")
+            .await
+            .unwrap();
+        assert_eq!(tokens.access_token, "new_access");
+        assert!(tokens.refresh_token.is_none());
+    }
+
+    #[tokio::test]
+    async fn poll_once_returns_pending_without_sleeping() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/token"))
+            .respond_with(ResponseTemplate::new(400).set_body_json(json!({
+                "error": "authorization_pending",
+            })))
+            .mount(&server)
+            .await;
+
+        let token_url = format!("{}/token", server.uri());
+        let cfg = make_cfg(None, &token_url);
+        let status = poll_once(&Client::new(), &cfg, "device-abc").await.unwrap();
+        assert!(matches!(status, DevicePollStatus::Pending));
+    }
+
+    #[tokio::test]
+    async fn poll_once_maps_denied_and_expired() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/token"))
+            .respond_with(ResponseTemplate::new(400).set_body_json(json!({
+                "error": "expired_token",
+            })))
+            .mount(&server)
+            .await;
+
+        let token_url = format!("{}/token", server.uri());
+        let cfg = make_cfg(None, &token_url);
+        let status = poll_once(&Client::new(), &cfg, "device-abc").await.unwrap();
+        assert!(matches!(status, DevicePollStatus::Expired));
+    }
+
+    #[tokio::test]
+    async fn rejects_non_https_remote_token_url() {
+        let cfg = make_cfg(None, "http://example.com/token");
+        let err = poll_once(&Client::new(), &cfg, "dc").await.unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("HTTPS"), "got: {msg}");
+    }
+
+    #[test]
+    fn tokens_debug_redacts_secrets() {
+        let tokens = DeviceFlowTokens {
+            access_token: "secret-access".to_string(),
+            refresh_token: Some("secret-refresh".to_string()),
+            expires_at: None,
+        };
+        let rendered = format!("{:?}", tokens);
+        assert!(!rendered.contains("secret-access"), "{rendered}");
+        assert!(!rendered.contains("secret-refresh"), "{rendered}");
+        assert!(rendered.contains("[redacted]"), "{rendered}");
+    }
+}

--- a/crates/goose-providers/src/oauth/mod.rs
+++ b/crates/goose-providers/src/oauth/mod.rs
@@ -1,0 +1,48 @@
+//! Host-agnostic OAuth helpers for goose-providers.
+//!
+//! Device-code protocol and public installed-app client IDs live here. Browser
+//! UI, clipboard, goose `Config` / `Paths`, and PKCE loopback do not.
+
+pub mod copilot;
+pub mod device_flow;
+pub mod registry;
+
+pub use copilot::{ensure_copilot_api_endpoint, exchange_github_copilot_token, CopilotApiToken};
+pub use device_flow::{
+    poll_for_tokens, poll_once, refresh_device_flow_token, request_device_code, DeviceCodeResponse,
+    DeviceFlowConfig, DeviceFlowTokenRefreshError, DeviceFlowTokens, DevicePollStatus,
+    RequestEncoding, DEFAULT_DEVICE_CODE_LIFETIME_SECS, DEFAULT_POLL_INTERVAL_SECS,
+    SLOW_DOWN_BACKOFF_SECS,
+};
+pub use registry::{
+    github_copilot_headers, kimi_headers, list_oauth_providers, poll_device_flow,
+    refresh_oauth_token, start_device_flow, DeviceAuthSession, OAuthGrant, OAuthProviderId,
+    OAuthProviderInfo, GITHUB_COPILOT_CLIENT_ID, KIMI_CODE_CLIENT_ID,
+};
+
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use reqwest::redirect::Policy;
+use reqwest::Client;
+
+use crate::api_client::DEFAULT_PROVIDER_TIMEOUT_SECS;
+
+/// HTTP client for OAuth token endpoints. Does not follow redirects so a
+/// 307/308 cannot forward `device_code` / `refresh_token` in the body.
+pub(crate) fn oauth_http_client() -> anyhow::Result<Client> {
+    Client::builder()
+        .redirect(Policy::none())
+        .timeout(Duration::from_secs(DEFAULT_PROVIDER_TIMEOUT_SECS))
+        .build()
+        .map_err(Into::into)
+}
+
+pub(crate) fn http_client() -> anyhow::Result<&'static Client> {
+    static CLIENT: OnceLock<Client> = OnceLock::new();
+    if let Some(client) = CLIENT.get() {
+        return Ok(client);
+    }
+    let client = oauth_http_client()?;
+    Ok(CLIENT.get_or_init(|| client))
+}

--- a/crates/goose-providers/src/oauth/registry.rs
+++ b/crates/goose-providers/src/oauth/registry.rs
@@ -1,0 +1,418 @@
+//! Device-code OAuth facades for providers that gdk hosts can start.
+//!
+//! Client IDs here are public installed-app credentials, not secrets.
+//! Token persistence and browser/user-code UI stay in the host.
+
+use std::fmt;
+use std::str::FromStr;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::OnceLock;
+
+use anyhow::{anyhow, Result};
+use chrono::{DateTime, Utc};
+use reqwest::header::{HeaderMap, HeaderValue, ACCEPT, CONTENT_TYPE, USER_AGENT};
+use reqwest::Client;
+use uuid::Uuid;
+
+use super::device_flow::{
+    poll_once, refresh_device_flow_token, request_device_code, DeviceFlowConfig, DeviceFlowTokens,
+    DevicePollStatus, RequestEncoding, DEFAULT_DEVICE_CODE_LIFETIME_SECS,
+    DEFAULT_POLL_INTERVAL_SECS, SLOW_DOWN_BACKOFF_SECS,
+};
+use super::http_client;
+
+/// Public GitHub Copilot OAuth app client id (`Iv1.` prefix). Not a secret.
+pub const GITHUB_COPILOT_CLIENT_ID: &str = "Iv1.b507a08c87ecfe98";
+/// Public Kimi Code installed-app client id. Not a secret.
+pub const KIMI_CODE_CLIENT_ID: &str = "17e5f671-d194-4dfb-9706-5516cb48c098";
+
+const GITHUB_DEVICE_AUTH_URL: &str = "https://github.com/login/device/code";
+const GITHUB_TOKEN_URL: &str = "https://github.com/login/oauth/access_token";
+const KIMI_DEVICE_AUTH_URL: &str = "https://auth.kimi.com/api/oauth/device_authorization";
+const KIMI_TOKEN_URL: &str = "https://auth.kimi.com/api/oauth/token";
+
+/// Grants a host may offer. `PkceLoopback` is listed so clients can branch;
+/// this crate does not implement the loopback callback.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OAuthGrant {
+    DeviceCode,
+    PkceLoopback,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OAuthProviderId {
+    GitHubCopilot,
+    KimiCode,
+}
+
+impl OAuthProviderId {
+    const ALL: [Self; 2] = [Self::GitHubCopilot, Self::KimiCode];
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::GitHubCopilot => "github_copilot",
+            Self::KimiCode => "kimi_code",
+        }
+    }
+
+    pub fn display_name(self) -> &'static str {
+        match self {
+            Self::GitHubCopilot => "GitHub Copilot",
+            Self::KimiCode => "Kimi Code",
+        }
+    }
+
+    pub fn supports_refresh(self) -> bool {
+        matches!(self, Self::KimiCode)
+    }
+}
+
+impl fmt::Display for OAuthProviderId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for OAuthProviderId {
+    type Err = anyhow::Error;
+
+    fn from_str(value: &str) -> Result<Self> {
+        match value {
+            "github_copilot" => Ok(Self::GitHubCopilot),
+            "kimi_code" => Ok(Self::KimiCode),
+            other => Err(anyhow!("unknown OAuth provider: {other}")),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OAuthProviderInfo {
+    pub id: OAuthProviderId,
+    pub name: String,
+    pub grants: Vec<OAuthGrant>,
+    pub supports_refresh: bool,
+}
+
+/// Host-driven device-code session. `device_code` is not exposed so it is
+/// harder to accidentally log.
+pub struct DeviceAuthSession {
+    provider: OAuthProviderId,
+    device_code: String,
+    user_code: String,
+    verification_uri: String,
+    verification_uri_complete: Option<String>,
+    interval_secs: AtomicU64,
+    expires_at: DateTime<Utc>,
+    token_url: String,
+    client_id: String,
+    scopes: Option<String>,
+    extra_headers: HeaderMap,
+    encoding: RequestEncoding,
+}
+
+impl fmt::Debug for DeviceAuthSession {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DeviceAuthSession")
+            .field("provider", &self.provider)
+            .field("device_code", &"[redacted]")
+            .field("user_code", &self.user_code)
+            .field("verification_uri", &self.verification_uri)
+            .field("interval_secs", &self.interval_secs())
+            .field("expires_at", &self.expires_at)
+            .finish()
+    }
+}
+
+impl DeviceAuthSession {
+    pub fn provider(&self) -> OAuthProviderId {
+        self.provider
+    }
+
+    pub fn user_code(&self) -> &str {
+        &self.user_code
+    }
+
+    pub fn verification_uri(&self) -> &str {
+        self.verification_uri_complete
+            .as_deref()
+            .unwrap_or(&self.verification_uri)
+    }
+
+    pub fn interval_secs(&self) -> u64 {
+        self.interval_secs.load(Ordering::Relaxed)
+    }
+
+    pub fn expires_at(&self) -> DateTime<Utc> {
+        self.expires_at
+    }
+
+    pub fn is_expired(&self) -> bool {
+        Utc::now() >= self.expires_at
+    }
+
+    fn config(&self) -> DeviceFlowConfig<'_> {
+        DeviceFlowConfig {
+            device_auth_url: None,
+            token_url: &self.token_url,
+            client_id: &self.client_id,
+            scopes: self.scopes.as_deref(),
+            extra_headers: self.extra_headers.clone(),
+            encoding: self.encoding,
+        }
+    }
+}
+
+pub fn list_oauth_providers() -> Vec<OAuthProviderInfo> {
+    OAuthProviderId::ALL
+        .into_iter()
+        .map(|id| OAuthProviderInfo {
+            id,
+            name: id.display_name().to_string(),
+            grants: vec![OAuthGrant::DeviceCode],
+            supports_refresh: id.supports_refresh(),
+        })
+        .collect()
+}
+
+pub async fn start_device_flow(provider: OAuthProviderId) -> Result<DeviceAuthSession> {
+    start_device_flow_with(provider, http_client()?, &provider_config(provider)).await
+}
+
+pub async fn poll_device_flow(session: &DeviceAuthSession) -> Result<DevicePollStatus> {
+    if session.is_expired() {
+        return Ok(DevicePollStatus::Expired);
+    }
+    let status = poll_once(http_client()?, &session.config(), &session.device_code).await?;
+    if matches!(status, DevicePollStatus::SlowDown) {
+        session
+            .interval_secs
+            .fetch_add(SLOW_DOWN_BACKOFF_SECS, Ordering::Relaxed);
+    }
+    Ok(status)
+}
+
+pub async fn refresh_oauth_token(
+    provider: OAuthProviderId,
+    refresh_token: &str,
+) -> Result<DeviceFlowTokens> {
+    if !provider.supports_refresh() {
+        anyhow::bail!("refresh is not supported for {provider}");
+    }
+    let cfg = provider_config(provider);
+    let flow = DeviceFlowConfig {
+        device_auth_url: None,
+        token_url: &cfg.token_url,
+        client_id: &cfg.client_id,
+        scopes: cfg.scopes.as_deref(),
+        extra_headers: cfg.extra_headers.clone(),
+        encoding: cfg.encoding,
+    };
+    refresh_device_flow_token(http_client()?, &flow, refresh_token).await
+}
+
+struct ProviderEndpoints {
+    device_auth_url: String,
+    token_url: String,
+    client_id: String,
+    scopes: Option<String>,
+    extra_headers: HeaderMap,
+    encoding: RequestEncoding,
+}
+
+fn provider_config(provider: OAuthProviderId) -> ProviderEndpoints {
+    match provider {
+        OAuthProviderId::GitHubCopilot => ProviderEndpoints {
+            device_auth_url: GITHUB_DEVICE_AUTH_URL.to_string(),
+            token_url: GITHUB_TOKEN_URL.to_string(),
+            client_id: GITHUB_COPILOT_CLIENT_ID.to_string(),
+            scopes: Some("read:user".to_string()),
+            extra_headers: github_copilot_headers(),
+            encoding: RequestEncoding::Json,
+        },
+        OAuthProviderId::KimiCode => ProviderEndpoints {
+            device_auth_url: KIMI_DEVICE_AUTH_URL.to_string(),
+            token_url: KIMI_TOKEN_URL.to_string(),
+            client_id: KIMI_CODE_CLIENT_ID.to_string(),
+            scopes: None,
+            extra_headers: kimi_headers(),
+            encoding: RequestEncoding::Form,
+        },
+    }
+}
+
+pub fn github_copilot_headers() -> HeaderMap {
+    let mut headers = HeaderMap::new();
+    headers.insert(ACCEPT, HeaderValue::from_static("application/json"));
+    headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+    headers.insert(
+        USER_AGENT,
+        HeaderValue::from_static("GithubCopilot/1.155.0"),
+    );
+    headers.insert("editor-version", HeaderValue::from_static("vscode/1.85.1"));
+    headers.insert(
+        "editor-plugin-version",
+        HeaderValue::from_static("copilot/1.155.0"),
+    );
+    headers
+}
+
+fn kimi_device_id() -> &'static str {
+    static ID: OnceLock<String> = OnceLock::new();
+    ID.get_or_init(|| Uuid::new_v4().simple().to_string())
+}
+
+pub fn kimi_headers() -> HeaderMap {
+    let mut headers = HeaderMap::new();
+    headers.insert("X-Msh-Platform", HeaderValue::from_static("kimi_cli"));
+    headers.insert("X-Msh-Version", HeaderValue::from_static("0.1.0"));
+    if let Ok(value) = HeaderValue::from_str(kimi_device_id()) {
+        headers.insert("X-Msh-Device-Id", value);
+    }
+    headers
+}
+
+fn ensure_https_or_loopback_uri(uri: &str) -> Result<()> {
+    let parsed = url::Url::parse(uri).map_err(|e| anyhow!("invalid verification URI: {e}"))?;
+    let https = parsed.scheme() == "https";
+    let loopback_http = parsed.scheme() == "http"
+        && parsed.host().is_some_and(|host| match host {
+            url::Host::Ipv4(addr) => addr.is_loopback(),
+            url::Host::Ipv6(addr) => addr.is_loopback(),
+            url::Host::Domain(domain) => domain.eq_ignore_ascii_case("localhost"),
+        });
+    if https || loopback_http {
+        Ok(())
+    } else {
+        Err(anyhow!("verification URI must use HTTPS"))
+    }
+}
+
+async fn start_device_flow_with(
+    provider: OAuthProviderId,
+    client: &Client,
+    endpoints: &ProviderEndpoints,
+) -> Result<DeviceAuthSession> {
+    let cfg = DeviceFlowConfig {
+        device_auth_url: Some(&endpoints.device_auth_url),
+        token_url: &endpoints.token_url,
+        client_id: &endpoints.client_id,
+        scopes: endpoints.scopes.as_deref(),
+        extra_headers: endpoints.extra_headers.clone(),
+        encoding: endpoints.encoding,
+    };
+    let device = request_device_code(client, &cfg).await?;
+    ensure_https_or_loopback_uri(device.verification_url())?;
+    let lifetime = device
+        .expires_in
+        .unwrap_or(DEFAULT_DEVICE_CODE_LIFETIME_SECS);
+    Ok(DeviceAuthSession {
+        provider,
+        device_code: device.device_code,
+        user_code: device.user_code,
+        verification_uri: device.verification_uri,
+        verification_uri_complete: device.verification_uri_complete,
+        interval_secs: AtomicU64::new(device.interval.unwrap_or(DEFAULT_POLL_INTERVAL_SECS)),
+        expires_at: Utc::now() + chrono::Duration::seconds(lifetime as i64),
+        token_url: endpoints.token_url.clone(),
+        client_id: endpoints.client_id.clone(),
+        scopes: endpoints.scopes.clone(),
+        extra_headers: endpoints.extra_headers.clone(),
+        encoding: endpoints.encoding,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[test]
+    fn kimi_headers_include_device_id() {
+        let headers = kimi_headers();
+        assert!(headers.get("X-Msh-Device-Id").is_some());
+        assert_eq!(
+            headers.get("X-Msh-Platform").and_then(|v| v.to_str().ok()),
+            Some("kimi_cli")
+        );
+    }
+
+    #[test]
+    fn lists_device_code_providers_and_shapes_pkce_grant() {
+        let listed = list_oauth_providers();
+        assert_eq!(listed.len(), 2);
+        assert!(listed
+            .iter()
+            .any(|p| p.id == OAuthProviderId::GitHubCopilot && !p.supports_refresh));
+        assert!(listed
+            .iter()
+            .any(|p| p.id == OAuthProviderId::KimiCode && p.supports_refresh));
+        assert!(listed.iter().all(|p| p.grants == [OAuthGrant::DeviceCode]));
+        let _ = OAuthGrant::PkceLoopback;
+    }
+
+    #[test]
+    fn parses_provider_ids() {
+        assert_eq!(
+            "github_copilot".parse::<OAuthProviderId>().unwrap(),
+            OAuthProviderId::GitHubCopilot
+        );
+        assert_eq!(
+            "kimi_code".parse::<OAuthProviderId>().unwrap(),
+            OAuthProviderId::KimiCode
+        );
+        assert!("chatgpt_codex".parse::<OAuthProviderId>().is_err());
+    }
+
+    #[tokio::test]
+    async fn copilot_refresh_is_unsupported() {
+        let err = refresh_oauth_token(OAuthProviderId::GitHubCopilot, "rt")
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("not supported"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn start_and_poll_against_mock_server() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/device"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "device_code": "dc-secret",
+                "user_code": "ABCD-EFGH",
+                "verification_uri": "https://example.com/activate",
+                "interval": 5,
+                "expires_in": 600,
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/token"))
+            .respond_with(ResponseTemplate::new(400).set_body_json(json!({
+                "error": "authorization_pending",
+            })))
+            .mount(&server)
+            .await;
+
+        let endpoints = ProviderEndpoints {
+            device_auth_url: format!("{}/device", server.uri()),
+            token_url: format!("{}/token", server.uri()),
+            client_id: GITHUB_COPILOT_CLIENT_ID.to_string(),
+            scopes: Some("read:user".to_string()),
+            extra_headers: HeaderMap::new(),
+            encoding: RequestEncoding::Json,
+        };
+        let session =
+            start_device_flow_with(OAuthProviderId::GitHubCopilot, &Client::new(), &endpoints)
+                .await
+                .unwrap();
+        assert_eq!(session.user_code(), "ABCD-EFGH");
+        assert_eq!(session.verification_uri(), "https://example.com/activate");
+        let debug = format!("{session:?}");
+        assert!(!debug.contains("dc-secret"), "{debug}");
+
+        let status = poll_device_flow(&session).await.unwrap();
+        assert!(matches!(status, DevicePollStatus::Pending));
+    }
+}

--- a/crates/goose-providers/src/openai.rs
+++ b/crates/goose-providers/src/openai.rs
@@ -515,6 +515,12 @@ impl OpenAiProvider {
         if Self::PROVIDERS_NEEDING_STANDARD_CHAT_PARAMS.contains(&self.name.as_str()) {
             return false;
         }
+        // Copilot's host is versionless (`chat/completions` / `responses`),
+        // but unlike generic versionless gateways it does speak Responses for
+        // gpt-5 / o-series. Route by model family, not by path.
+        if self.name == "github_copilot" {
+            return Self::is_responses_model(model_name);
+        }
 
         Self::should_use_responses_api(model_name, &self.base_path)
     }
@@ -1303,6 +1309,28 @@ mod tests {
             "gpt-5-codex",
             "chat/completions"
         ));
+    }
+
+    #[test]
+    fn github_copilot_versionless_path_still_routes_gpt5_to_responses() {
+        let provider = OpenAiProviderBuilder::new(
+            ApiClient::new_with_tls("http://localhost".to_string(), AuthMethod::NoAuth, None)
+                .unwrap(),
+        )
+        .name("github_copilot")
+        .base_path(OPEN_AI_VERSIONLESS_BASE_PATH)
+        .build();
+
+        assert!(provider.should_use_responses_api_for_provider("gpt-5"));
+        assert!(!provider.should_use_responses_api_for_provider("gpt-4.1"));
+        assert_eq!(
+            OpenAiProvider::map_base_path(
+                OPEN_AI_VERSIONLESS_BASE_PATH,
+                "responses",
+                "v1/responses",
+            ),
+            "responses"
+        );
     }
 
     #[test]

--- a/crates/goose-sdk/examples/uniffi/README.md
+++ b/crates/goose-sdk/examples/uniffi/README.md
@@ -30,6 +30,22 @@ just --justfile crates/goose-sdk/justfile _generate python
 
 This writes generated bindings and the debug native library under `crates/goose-sdk/generated/`.
 
+## Python OAuth device-code example
+
+Lists gdk OAuth providers (GitHub Copilot, Kimi Code) without opening a
+browser. Live login is opt-in via `GOOSE_OAUTH_PROVIDER`.
+
+```bash
+just --justfile crates/goose-sdk/justfile _generate python
+DYLD_LIBRARY_PATH=target/debug LD_LIBRARY_PATH=target/debug \
+  uv run --script crates/goose-sdk/examples/uniffi/oauth_device_flow.py
+```
+
+The host owns UI and token storage. gdk returns verification URL + user code,
+then host-driven poll results. For GitHub Copilot, poll success is a GitHub
+OAuth token — call `exchange_github_copilot_token` before using it as an API
+key. PKCE loopback is listed as a grant and is not implemented in this crate.
+
 ## Python provider example
 
 ```bash

--- a/crates/goose-sdk/examples/uniffi/oauth_device_flow.py
+++ b/crates/goose-sdk/examples/uniffi/oauth_device_flow.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env -S uv run --script
+"""Goose SDK demo: host-driven OAuth device-code flow.
+
+This example lists OAuth providers and starts a device-code session. It does
+not open a browser and does not persist tokens — that is the host's job.
+
+Live login is skipped unless GOOSE_OAUTH_PROVIDER is set (github_copilot or
+kimi_code). CI should run without that env var.
+"""
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE.parent.parent / "generated"))
+
+from goose import (  # noqa: E402
+    DevicePollResult,
+    exchange_github_copilot_token,
+    github_copilot_provider,
+    kimi_code_provider,
+    list_oauth_grants,
+    list_oauth_providers,
+    poll_device_flow,
+    start_device_flow,
+)
+
+
+async def main() -> None:
+    providers = list_oauth_providers()
+    print("oauth providers:")
+    for info in providers:
+        print(
+            f"  {info.id}: {info.name} grants={info.grants} refresh={info.supports_refresh}"
+        )
+    print("known grants:", list_oauth_grants())
+
+    provider_id = os.environ.get("GOOSE_OAUTH_PROVIDER")
+    if not provider_id:
+        print("set GOOSE_OAUTH_PROVIDER=github_copilot|kimi_code to run a live flow")
+        return
+
+    session = await start_device_flow(provider_id)
+    print(f"visit {session.verification_uri()} and enter {session.user_code()}")
+    print(f"poll every {session.interval_secs()}s")
+    # RFC 8628: wait `interval` before the first token poll.
+    await asyncio.sleep(session.interval_secs())
+
+    while True:
+        result = await poll_device_flow(session)
+        if isinstance(result, DevicePollResult.Pending):
+            await asyncio.sleep(result.interval_secs)
+            continue
+        if isinstance(result, DevicePollResult.SlowDown):
+            await asyncio.sleep(result.interval_secs)
+            continue
+        if isinstance(result, DevicePollResult.Success):
+            print("authorized; host should persist tokens (not printed)")
+            if provider_id == "github_copilot":
+                copilot = await exchange_github_copilot_token(result.tokens.access_token())
+                _ = github_copilot_provider(copilot.api_endpoint(), copilot.token())
+                print("constructed github_copilot provider")
+            elif provider_id == "kimi_code":
+                _ = kimi_code_provider(result.tokens.access_token())
+                print("constructed kimi_code provider")
+            return
+        if isinstance(result, DevicePollResult.Denied):
+            raise SystemExit("authorization denied")
+        if isinstance(result, DevicePollResult.Expired):
+            raise SystemExit("device code expired")
+        raise SystemExit(f"unexpected poll result: {result!r}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/crates/goose-sdk/src/bindings.rs
+++ b/crates/goose-sdk/src/bindings.rs
@@ -21,7 +21,11 @@ use goose_providers::{
     databricks_v2::DatabricksV2Provider as GooseDatabricksV2Provider,
     declarative::{DeclarativeProviderConfig, EnvKeyResolver},
     model::ModelConfig,
-    openai::OpenAiProviderBuilder,
+    oauth::{
+        self, DevicePollStatus, OAuthGrant as GooseOAuthGrant,
+        OAuthProviderId as GooseOAuthProviderId,
+    },
+    openai::{OpenAiProviderBuilder, OPEN_AI_VERSIONLESS_BASE_PATH},
     utils::sanitize_unicode_tags,
 };
 use rmcp::model::{
@@ -723,13 +727,13 @@ impl Provider {
         let mut features = vec![Feature::Streaming, Feature::Tools, Feature::JsonSchema];
         if matches!(
             name.as_str(),
-            "openai" | "anthropic" | "databricks" | "databricks_v2" | "groq"
+            "openai" | "anthropic" | "databricks" | "databricks_v2" | "groq" | "github_copilot"
         ) {
             features.push(Feature::Images);
         }
         if matches!(
             name.as_str(),
-            "openai" | "anthropic" | "databricks" | "databricks_v2"
+            "openai" | "anthropic" | "databricks" | "databricks_v2" | "kimi_code"
         ) {
             features.push(Feature::Reasoning);
         }
@@ -844,6 +848,306 @@ pub fn default_compaction_templates() -> CompactionTemplates {
         compaction: templates.compaction,
         summary: templates.summary,
     }
+}
+
+/// OAuth grants gdk knows about. `PkceLoopback` is listed so hosts can branch;
+/// this crate only implements device-code.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, uniffi::Enum)]
+pub enum OAuthGrant {
+    DeviceCode,
+    PkceLoopback,
+}
+
+impl From<GooseOAuthGrant> for OAuthGrant {
+    fn from(grant: GooseOAuthGrant) -> Self {
+        match grant {
+            GooseOAuthGrant::DeviceCode => Self::DeviceCode,
+            GooseOAuthGrant::PkceLoopback => Self::PkceLoopback,
+        }
+    }
+}
+
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct OAuthProviderInfo {
+    pub id: String,
+    pub name: String,
+    pub grants: Vec<OAuthGrant>,
+    pub supports_refresh: bool,
+}
+
+/// Host-driven device-code session. `device_code` is not exported.
+#[derive(uniffi::Object)]
+pub struct DeviceAuthSession {
+    inner: oauth::DeviceAuthSession,
+}
+
+#[uniffi::export]
+impl DeviceAuthSession {
+    pub fn provider_id(&self) -> String {
+        self.inner.provider().as_str().to_string()
+    }
+
+    pub fn user_code(&self) -> String {
+        self.inner.user_code().to_string()
+    }
+
+    pub fn verification_uri(&self) -> String {
+        self.inner.verification_uri().to_string()
+    }
+
+    pub fn interval_secs(&self) -> u64 {
+        self.inner.interval_secs()
+    }
+
+    pub fn expires_at_epoch_secs(&self) -> i64 {
+        self.inner.expires_at().timestamp()
+    }
+}
+
+/// Opaque tokens so generated Kotlin/Python `toString` cannot dump secrets.
+#[derive(uniffi::Object)]
+pub struct OAuthTokens {
+    access_token: String,
+    refresh_token: Option<String>,
+    expires_at_epoch_secs: Option<i64>,
+}
+
+#[uniffi::export]
+impl OAuthTokens {
+    pub fn access_token(&self) -> String {
+        self.access_token.clone()
+    }
+
+    pub fn refresh_token(&self) -> Option<String> {
+        self.refresh_token.clone()
+    }
+
+    pub fn expires_at_epoch_secs(&self) -> Option<i64> {
+        self.expires_at_epoch_secs
+    }
+}
+
+impl std::fmt::Debug for OAuthTokens {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OAuthTokens")
+            .field("access_token", &"[redacted]")
+            .field(
+                "refresh_token",
+                &self.refresh_token.as_ref().map(|_| "[redacted]"),
+            )
+            .field("expires_at_epoch_secs", &self.expires_at_epoch_secs)
+            .finish()
+    }
+}
+
+fn oauth_tokens_from_flow(tokens: oauth::DeviceFlowTokens) -> Arc<OAuthTokens> {
+    Arc::new(OAuthTokens {
+        access_token: tokens.access_token,
+        refresh_token: tokens.refresh_token,
+        expires_at_epoch_secs: tokens.expires_at.map(|t| t.timestamp()),
+    })
+}
+
+/// One poll of the token endpoint. Pending/SlowDown are states, not errors.
+#[derive(uniffi::Enum)]
+pub enum DevicePollResult {
+    Pending { interval_secs: u64 },
+    SlowDown { interval_secs: u64 },
+    Success { tokens: Arc<OAuthTokens> },
+    Denied,
+    Expired,
+}
+
+impl std::fmt::Debug for DevicePollResult {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Pending { interval_secs } => f
+                .debug_struct("Pending")
+                .field("interval_secs", interval_secs)
+                .finish(),
+            Self::SlowDown { interval_secs } => f
+                .debug_struct("SlowDown")
+                .field("interval_secs", interval_secs)
+                .finish(),
+            Self::Success { .. } => f
+                .debug_struct("Success")
+                .field("tokens", &"[redacted]")
+                .finish(),
+            Self::Denied => f.write_str("Denied"),
+            Self::Expired => f.write_str("Expired"),
+        }
+    }
+}
+
+fn parse_oauth_provider(id: &str) -> Result<GooseOAuthProviderId, GooseError> {
+    id.parse().map_err(GooseError::generic)
+}
+
+#[uniffi::export]
+pub fn list_oauth_providers() -> Vec<OAuthProviderInfo> {
+    oauth::list_oauth_providers()
+        .into_iter()
+        .map(|info| OAuthProviderInfo {
+            id: info.id.as_str().to_string(),
+            name: info.name,
+            grants: info.grants.into_iter().map(OAuthGrant::from).collect(),
+            supports_refresh: info.supports_refresh,
+        })
+        .collect()
+}
+
+/// Grants gdk knows about, including `PkceLoopback` which is not implemented here.
+#[uniffi::export]
+pub fn list_oauth_grants() -> Vec<OAuthGrant> {
+    vec![OAuthGrant::DeviceCode, OAuthGrant::PkceLoopback]
+}
+
+/// Start RFC 8628 device-code login. Does not open a browser. The host should
+/// show `verification_uri` + `user_code`, wait `interval_secs`, then poll.
+#[uniffi::export]
+pub async fn start_device_flow(provider_id: String) -> Result<Arc<DeviceAuthSession>, GooseError> {
+    let provider = parse_oauth_provider(&provider_id)?;
+    let session = run_on_runtime(async move { oauth::start_device_flow(provider).await }).await??;
+    Ok(Arc::new(DeviceAuthSession { inner: session }))
+}
+
+/// One token-endpoint round trip. Does not sleep. `Pending` / `SlowDown` are
+/// states, not errors; wait `interval_secs` before calling again.
+#[uniffi::export]
+pub async fn poll_device_flow(
+    session: Arc<DeviceAuthSession>,
+) -> Result<DevicePollResult, GooseError> {
+    let result = run_on_runtime(async move {
+        let status = oauth::poll_device_flow(&session.inner).await?;
+        Ok::<_, anyhow::Error>(match status {
+            DevicePollStatus::Pending => DevicePollResult::Pending {
+                interval_secs: session.inner.interval_secs(),
+            },
+            DevicePollStatus::SlowDown => DevicePollResult::SlowDown {
+                interval_secs: session.inner.interval_secs(),
+            },
+            DevicePollStatus::Success(tokens) => DevicePollResult::Success {
+                tokens: oauth_tokens_from_flow(tokens),
+            },
+            DevicePollStatus::Denied => DevicePollResult::Denied,
+            DevicePollStatus::Expired => DevicePollResult::Expired,
+        })
+    })
+    .await??;
+    Ok(result)
+}
+
+#[derive(uniffi::Object)]
+pub struct CopilotApiToken {
+    token: String,
+    api_endpoint: String,
+    expires_at_epoch_secs: i64,
+}
+
+#[uniffi::export]
+impl CopilotApiToken {
+    pub fn token(&self) -> String {
+        self.token.clone()
+    }
+
+    pub fn api_endpoint(&self) -> String {
+        self.api_endpoint.clone()
+    }
+
+    pub fn expires_at_epoch_secs(&self) -> i64 {
+        self.expires_at_epoch_secs
+    }
+}
+
+impl std::fmt::Debug for CopilotApiToken {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CopilotApiToken")
+            .field("token", &"[redacted]")
+            .field("api_endpoint", &self.api_endpoint)
+            .field("expires_at_epoch_secs", &self.expires_at_epoch_secs)
+            .finish()
+    }
+}
+
+/// GitHub device-code yields a GitHub OAuth token. Exchange it for the Copilot
+/// inference token before constructing an API client.
+#[uniffi::export]
+pub async fn exchange_github_copilot_token(
+    github_token: String,
+) -> Result<Arc<CopilotApiToken>, GooseError> {
+    let token =
+        run_on_runtime(async move { oauth::exchange_github_copilot_token(&github_token).await })
+            .await??;
+    Ok(Arc::new(CopilotApiToken {
+        token: token.token,
+        api_endpoint: token.api_endpoint,
+        expires_at_epoch_secs: token.expires_at.timestamp(),
+    }))
+}
+
+#[uniffi::export]
+pub async fn refresh_oauth_token(
+    provider_id: String,
+    refresh_token: String,
+) -> Result<Arc<OAuthTokens>, GooseError> {
+    let provider = parse_oauth_provider(&provider_id)?;
+    let tokens =
+        run_on_runtime(async move { oauth::refresh_oauth_token(provider, &refresh_token).await })
+            .await??;
+    Ok(oauth_tokens_from_flow(tokens))
+}
+
+/// Build a Copilot inference provider from the exchanged API token
+/// (`exchange_github_copilot_token`).
+#[uniffi::export]
+pub fn github_copilot_provider(
+    api_endpoint: String,
+    token: String,
+) -> Result<Arc<Provider>, GooseError> {
+    oauth::ensure_copilot_api_endpoint(&api_endpoint)?;
+    let mut api_client =
+        ApiClient::new_with_tls(api_endpoint.clone(), AuthMethod::BearerToken(token), None)?;
+    api_client = if api_endpoint.starts_with("https://") {
+        api_client.with_https_only()?
+    } else {
+        api_client.with_loopback_http_only()?
+    };
+    for (key, value) in oauth::github_copilot_headers().iter() {
+        if let Ok(value) = value.to_str() {
+            api_client = api_client.with_header(key.as_str(), value)?;
+        }
+    }
+    // Copilot's API host is versionless (`chat/completions`), unlike api.openai.com.
+    let provider = OpenAiProviderBuilder::new(api_client)
+        .name("github_copilot")
+        .base_path(OPEN_AI_VERSIONLESS_BASE_PATH)
+        .build();
+    Ok(Provider::new(Box::new(provider)))
+}
+
+/// Build a Kimi Code provider from a device-code access token.
+/// Anthropic-compatible inference with Kimi platform headers. Does not persist
+/// tokens or the CLI device-id file.
+#[uniffi::export]
+pub fn kimi_code_provider(access_token: String) -> Result<Arc<Provider>, GooseError> {
+    let mut api_client = ApiClient::new_with_tls(
+        "https://api.kimi.com/coding".to_string(),
+        AuthMethod::BearerToken(access_token),
+        None,
+    )?;
+    api_client = api_client.with_header(
+        "anthropic-version",
+        goose_providers::anthropic::ANTHROPIC_API_VERSION,
+    )?;
+    for (key, value) in oauth::kimi_headers().iter() {
+        if let Ok(value) = value.to_str() {
+            api_client = api_client.with_header(key.as_str(), value)?;
+        }
+    }
+    let provider = AnthropicProviderBuilder::new(api_client)
+        .name("kimi_code")
+        .build();
+    Ok(Provider::new(Box::new(provider)))
 }
 
 #[uniffi::export]
@@ -1182,5 +1486,73 @@ mod tests {
         let result = response.tool_result.unwrap();
         assert_eq!(result.is_error, Some(false));
         assert_eq!(result.content[0].as_text().unwrap().text, "done");
+    }
+
+    #[test]
+    fn github_copilot_provider_rejects_plaintext_remote_endpoint() {
+        let err = match github_copilot_provider(
+            "http://api.example.com".to_string(),
+            "token".to_string(),
+        ) {
+            Ok(_) => panic!("expected plaintext remote endpoint to fail"),
+            Err(err) => err,
+        };
+        assert!(
+            err.to_string().to_ascii_lowercase().contains("https"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn github_copilot_provider_constructs_for_https_endpoint() {
+        github_copilot_provider(
+            "https://api.githubcopilot.com".to_string(),
+            "token".to_string(),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn kimi_code_provider_constructs() {
+        kimi_code_provider("token".to_string()).unwrap();
+    }
+
+    #[test]
+    fn list_oauth_providers_includes_device_code_facades() {
+        let listed = list_oauth_providers();
+        assert!(listed.iter().any(|p| p.id == "github_copilot"));
+        assert!(listed.iter().any(|p| p.id == "kimi_code"));
+        assert!(listed
+            .iter()
+            .all(|p| p.grants.contains(&OAuthGrant::DeviceCode)));
+        assert!(listed
+            .iter()
+            .all(|p| !p.grants.contains(&OAuthGrant::PkceLoopback)));
+        assert!(list_oauth_grants().contains(&OAuthGrant::PkceLoopback));
+    }
+
+    #[test]
+    fn copilot_api_token_debug_redacts_secret() {
+        let token = CopilotApiToken {
+            token: "secret-copilot".to_string(),
+            api_endpoint: "https://api.githubcopilot.com".to_string(),
+            expires_at_epoch_secs: 1,
+        };
+        let rendered = format!("{token:?}");
+        assert!(!rendered.contains("secret-copilot"), "{rendered}");
+    }
+
+    #[test]
+    fn oauth_poll_debug_redacts_tokens() {
+        let result = DevicePollResult::Success {
+            tokens: Arc::new(OAuthTokens {
+                access_token: "secret-access".to_string(),
+                refresh_token: Some("secret-refresh".to_string()),
+                expires_at_epoch_secs: Some(1),
+            }),
+        };
+        let rendered = format!("{result:?}");
+        assert!(!rendered.contains("secret-access"), "{rendered}");
+        assert!(!rendered.contains("secret-refresh"), "{rendered}");
     }
 }

--- a/crates/goose-sdk/src/lib.rs
+++ b/crates/goose-sdk/src/lib.rs
@@ -6,9 +6,10 @@
 //!
 //! With `--features uniffi` the crate additionally compiles as a
 //! `cdylib`/`staticlib` and exposes an in-process API to Python and Kotlin via
-//! [uniffi-rs](https://github.com/mozilla/uniffi-rs). The current uniffi surface
-//! lets callers construct declarative providers from JSON and stream provider
-//! completions.
+//! [uniffi-rs](https://github.com/mozilla/uniffi-rs). The uniffi surface
+//! constructs native providers, streams completions, and runs host-driven
+//! OAuth device-code login (protocol in `goose-providers`; the host owns UI
+//! and token storage).
 
 pub use goose_sdk_types::{custom_notifications, custom_requests};
 

--- a/crates/goose/src/providers/githubcopilot.rs
+++ b/crates/goose/src/providers/githubcopilot.rs
@@ -18,7 +18,7 @@ use serde_json::Value;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::path::PathBuf;
-use std::time::Duration;
+
 use url::{Host, Url};
 
 // Task-local so complete() and stream() can't race on the same provider instance.
@@ -84,7 +84,7 @@ pub const GITHUB_COPILOT_STREAM_MODELS: &[&str] = &[
 const GITHUB_COPILOT_DOC_URL: &str =
     "https://docs.github.com/en/copilot/using-github-copilot/ai-models";
 const DEFAULT_GITHUB_HOST: &str = "github.com";
-const DEFAULT_GITHUB_COPILOT_CLIENT_ID: &str = "Iv1.b507a08c87ecfe98";
+const DEFAULT_GITHUB_COPILOT_CLIENT_ID: &str = goose_providers::oauth::GITHUB_COPILOT_CLIENT_ID;
 
 fn normalize_host(host: &str) -> String {
     let host = host.trim_end_matches('/');
@@ -290,7 +290,10 @@ impl GithubCopilotProvider {
         let copilot_token_url: Option<String> = config.get_param("GITHUB_COPILOT_TOKEN_URL").ok();
         let urls = GithubCopilotUrls::new(&host, copilot_token_url.as_deref());
         let client = Client::builder()
-            .timeout(Duration::from_secs(DEFAULT_PROVIDER_TIMEOUT_SECS))
+            .redirect(reqwest::redirect::Policy::none())
+            .timeout(std::time::Duration::from_secs(
+                DEFAULT_PROVIDER_TIMEOUT_SECS,
+            ))
             .build()?;
         let cache = DiskCache::new(&host);
         let mu = tokio::sync::Mutex::new(RefCell::new(None));

--- a/crates/goose/src/providers/kimicode.rs
+++ b/crates/goose/src/providers/kimicode.rs
@@ -48,7 +48,7 @@ pub const KIMI_CODE_KNOWN_MODELS: &[&str] = &[
 ];
 
 const KIMI_CODE_DOC_URL: &str = "https://www.kimi.com/code/docs/en/";
-const KIMI_CODE_CLIENT_ID: &str = "17e5f671-d194-4dfb-9706-5516cb48c098";
+const KIMI_CODE_CLIENT_ID: &str = goose_providers::oauth::KIMI_CODE_CLIENT_ID;
 const KIMI_AUTH_HOST: &str = "https://auth.kimi.com";
 const KIMI_API_BASE: &str = "https://api.kimi.com/coding";
 const KIMI_MSH_PLATFORM: &str = "kimi_cli";
@@ -174,6 +174,7 @@ impl KimiCodeProvider {
         _tls_config: Option<crate::providers::api_client::TlsConfig>,
     ) -> Result<Self> {
         let client = Client::builder()
+            .redirect(reqwest::redirect::Policy::none())
             .connect_timeout(StdDuration::from_secs(DEFAULT_CONNECT_TIMEOUT_SECS))
             .read_timeout(StdDuration::from_secs(DEFAULT_PROVIDER_TIMEOUT_SECS))
             .build()?;

--- a/crates/goose/src/providers/oauth_device_flow.rs
+++ b/crates/goose/src/providers/oauth_device_flow.rs
@@ -1,15 +1,16 @@
-//! Shared OAuth 2.0 Device Authorization Grant (RFC 8628) helper.
+//! CLI-facing OAuth device-flow helper.
 //!
-//! Used by providers that authenticate via device-code flow (kimicode,
-//! githubcopilot). Handles the authorization request, user-interaction UI,
-//! polling loop with RFC 8628 `authorization_pending` / `slow_down` semantics,
-//! and optional `refresh_token` grant (RFC 6749 §6).
+//! Protocol lives in `goose_providers::oauth`. This module re-exports it and
+//! adds the host UI (clipboard, browser, stderr) used by goose configure.
 
-use anyhow::{anyhow, Context, Result};
-use chrono::{DateTime, Duration, Utc};
-use reqwest::header::HeaderMap;
+pub use goose_providers::oauth::{
+    poll_for_tokens, refresh_device_flow_token, request_device_code, DeviceCodeResponse,
+    DeviceFlowConfig, DeviceFlowTokenRefreshError, DeviceFlowTokens, RequestEncoding,
+    DEFAULT_DEVICE_CODE_LIFETIME_SECS, DEFAULT_POLL_INTERVAL_SECS,
+};
+
+use anyhow::Result;
 use reqwest::Client;
-use serde::{Deserialize, Serialize};
 
 tokio::task_local! {
     /// When set, called instead of the default CLI announce when a device code
@@ -28,169 +29,6 @@ where
     DEVICE_CODE_ANNOUNCE.scope(announce, fut).await
 }
 
-/// Fallback poll interval when the server omits `interval` (RFC 8628 §3.2).
-const DEFAULT_POLL_INTERVAL_SECS: u64 = 5;
-
-/// Fallback device-code window when the server omits `expires_in` (RFC 8628 §3.2).
-const DEFAULT_DEVICE_CODE_LIFETIME_SECS: u64 = 300;
-
-/// Extra seconds added to the poll interval after an RFC 8628 `slow_down`.
-const SLOW_DOWN_BACKOFF_SECS: u64 = 5;
-
-/// How a provider expects the device-authorization and token request bodies to
-/// be encoded. RFC 8628 §3.1 specifies `application/x-www-form-urlencoded`, but
-/// GitHub accepts JSON when `Accept: application/json` is set.
-#[derive(Debug, Clone, Copy)]
-pub enum RequestEncoding {
-    Form,
-    Json,
-}
-
-/// Connection details for a provider's device flow.
-#[derive(Debug, Clone)]
-pub struct DeviceFlowConfig<'a> {
-    /// `device_authorization_endpoint` (RFC 8628 §3.1).
-    /// `None` when only the refresh grant is needed.
-    pub device_auth_url: Option<&'a str>,
-    /// `token_endpoint` used for both device-code polling and refresh grants.
-    pub token_url: &'a str,
-    /// Public OAuth client identifier.
-    pub client_id: &'a str,
-    /// Space-separated scope string, or `None` to omit the parameter.
-    pub scopes: Option<&'a str>,
-    /// Provider-specific headers (user-agent, platform markers, `Accept`, etc.).
-    pub extra_headers: HeaderMap,
-    /// Body encoding for device-auth, polling, and refresh requests.
-    pub encoding: RequestEncoding,
-}
-
-/// Fields returned by `/device_authorization` (RFC 8628 §3.2).
-#[derive(Debug, Clone, Deserialize)]
-pub struct DeviceCodeResponse {
-    pub device_code: String,
-    pub user_code: String,
-    pub verification_uri: String,
-    /// Pre-populated URI with user_code embedded, used when the provider
-    /// supports it (e.g. Kimi). Fall back to `verification_uri` otherwise.
-    pub verification_uri_complete: Option<String>,
-    pub interval: Option<u64>,
-    pub expires_in: Option<u64>,
-}
-
-impl DeviceCodeResponse {
-    /// URI the user should visit. Prefers the `_complete` form when present.
-    pub fn verification_url(&self) -> &str {
-        self.verification_uri_complete
-            .as_deref()
-            .unwrap_or(&self.verification_uri)
-    }
-}
-
-/// Access + optional refresh credentials from a device-code exchange.
-#[derive(Debug, Clone)]
-pub struct DeviceFlowTokens {
-    pub access_token: String,
-    /// Some providers (GitHub Copilot) do not issue a refresh token.
-    pub refresh_token: Option<String>,
-    /// Derived from `expires_in` on the token response. `None` when the server
-    /// omits it (RFC 6749 §5.1 permits that).
-    pub expires_at: Option<DateTime<Utc>>,
-}
-
-#[derive(Debug, thiserror::Error)]
-#[error("token refresh failed ({status}): {body}")]
-pub struct DeviceFlowTokenRefreshError {
-    pub status: reqwest::StatusCode,
-    pub error: Option<String>,
-    body: String,
-}
-
-// ── Public entry points ──────────────────────────────────────────────────────
-
-/// Request a device code from the authorization server.
-pub async fn request_device_code(
-    client: &Client,
-    cfg: &DeviceFlowConfig<'_>,
-) -> Result<DeviceCodeResponse> {
-    #[derive(Serialize)]
-    struct DeviceAuthReq<'a> {
-        client_id: &'a str,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        scope: Option<&'a str>,
-    }
-
-    let body = DeviceAuthReq {
-        client_id: cfg.client_id,
-        scope: cfg.scopes,
-    };
-
-    let url = cfg
-        .device_auth_url
-        .ok_or_else(|| anyhow!("device_auth_url is required for device code request"))?;
-    send_request(client, cfg, url, &body)
-        .await
-        .context("failed to request device authorization")?
-        .error_for_status()
-        .context("device authorization request failed")?
-        .json::<DeviceCodeResponse>()
-        .await
-        .context("failed to parse device authorization response")
-}
-
-/// Poll the token endpoint until the user authorizes (or the device code expires).
-/// Implements RFC 8628 §3.5 — handles `authorization_pending` and `slow_down`.
-pub async fn poll_for_tokens(
-    client: &Client,
-    cfg: &DeviceFlowConfig<'_>,
-    device_code: &str,
-    interval_secs: u64,
-    expires_in_secs: u64,
-) -> Result<DeviceFlowTokens> {
-    #[derive(Serialize)]
-    struct PollReq<'a> {
-        client_id: &'a str,
-        device_code: &'a str,
-        grant_type: &'static str,
-    }
-
-    let req = PollReq {
-        client_id: cfg.client_id,
-        device_code,
-        grant_type: "urn:ietf:params:oauth:grant-type:device_code",
-    };
-
-    let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(expires_in_secs);
-    let mut effective_interval = interval_secs;
-
-    loop {
-        if tokio::time::Instant::now() >= deadline {
-            return Err(anyhow!("timed out waiting for user authorization"));
-        }
-        tokio::time::sleep(tokio::time::Duration::from_secs(effective_interval)).await;
-
-        let response = send_request(client, cfg, cfg.token_url, &req)
-            .await
-            .context("failed to poll for token")?;
-
-        // RFC 8628 §3.5 returns pending/slow_down as 4xx with a JSON error
-        // payload, so don't `error_for_status()` before parsing. If the body
-        // is unparseable AND the status is non-2xx, surface the HTTP status.
-        match parse_token_response(response).await? {
-            TokenPollOutcome::Issued(tokens) => return Ok(tokens),
-            TokenPollOutcome::Pending => {
-                tracing::debug!("authorization pending, continuing to poll");
-            }
-            TokenPollOutcome::SlowDown => {
-                tracing::debug!("slow_down received, increasing poll interval");
-                effective_interval += SLOW_DOWN_BACKOFF_SECS;
-            }
-            TokenPollOutcome::Failed(err) => {
-                return Err(anyhow!("authorization failed: {}", err));
-            }
-        }
-    }
-}
-
 /// High-level flow: request a device code, print user-facing instructions,
 /// open the browser, and poll until tokens are issued.
 pub async fn run_device_flow(
@@ -200,140 +38,10 @@ pub async fn run_device_flow(
     let device = request_device_code(client, cfg).await?;
     announce_user_action(&device);
 
-    let interval = device.interval.unwrap_or(DEFAULT_POLL_INTERVAL_SECS);
-    let expires_in = device
-        .expires_in
-        .unwrap_or(DEFAULT_DEVICE_CODE_LIFETIME_SECS);
+    let interval = device.poll_interval_secs();
+    let expires_in = device.lifetime_secs();
 
     poll_for_tokens(client, cfg, &device.device_code, interval, expires_in).await
-}
-
-/// Exchange a refresh token for a new access token (RFC 6749 §6).
-pub async fn refresh_device_flow_token(
-    client: &Client,
-    cfg: &DeviceFlowConfig<'_>,
-    refresh_token: &str,
-) -> Result<DeviceFlowTokens> {
-    #[derive(Serialize)]
-    struct RefreshReq<'a> {
-        client_id: &'a str,
-        grant_type: &'static str,
-        refresh_token: &'a str,
-    }
-
-    let req = RefreshReq {
-        client_id: cfg.client_id,
-        grant_type: "refresh_token",
-        refresh_token,
-    };
-
-    let response = send_request(client, cfg, cfg.token_url, &req)
-        .await
-        .context("failed to refresh token")?;
-    let status = response.status();
-    let bytes = response
-        .bytes()
-        .await
-        .context("failed to read token refresh response")?;
-    let raw = serde_json::from_slice::<TokenResponseBody>(&bytes);
-
-    if !status.is_success() {
-        return Err(anyhow::Error::new(DeviceFlowTokenRefreshError {
-            status,
-            error: raw.ok().and_then(|body| body.error),
-            body: String::from_utf8_lossy(&bytes).into_owned(),
-        }));
-    }
-
-    let raw = raw.context("failed to parse token refresh response")?;
-
-    let access_token = raw
-        .access_token
-        .ok_or_else(|| anyhow!("refresh response missing access_token"))?;
-    Ok(DeviceFlowTokens {
-        access_token,
-        refresh_token: raw.refresh_token,
-        expires_at: raw
-            .expires_in
-            .map(|secs| Utc::now() + Duration::seconds(secs)),
-    })
-}
-
-// ── Internals ────────────────────────────────────────────────────────────────
-
-#[derive(Debug, Deserialize)]
-struct TokenResponseBody {
-    access_token: Option<String>,
-    refresh_token: Option<String>,
-    expires_in: Option<i64>,
-    error: Option<String>,
-}
-
-enum TokenPollOutcome {
-    Issued(DeviceFlowTokens),
-    Pending,
-    SlowDown,
-    Failed(String),
-}
-
-async fn parse_token_response(response: reqwest::Response) -> Result<TokenPollOutcome> {
-    let status = response.status();
-    let bytes = response
-        .bytes()
-        .await
-        .context("failed to read token poll response")?;
-
-    let body: TokenResponseBody = match serde_json::from_slice(&bytes) {
-        Ok(p) => p,
-        Err(e) => {
-            if !status.is_success() {
-                return Err(anyhow!(
-                    "token poll HTTP {}: {}",
-                    status,
-                    String::from_utf8_lossy(&bytes)
-                ));
-            }
-            return Err(anyhow::Error::new(e).context("failed to parse token poll response"));
-        }
-    };
-
-    if let Some(access_token) = body.access_token {
-        return Ok(TokenPollOutcome::Issued(DeviceFlowTokens {
-            access_token,
-            refresh_token: body.refresh_token,
-            expires_at: body
-                .expires_in
-                .map(|secs| Utc::now() + Duration::seconds(secs)),
-        }));
-    }
-
-    Ok(match body.error.as_deref() {
-        Some("authorization_pending") => TokenPollOutcome::Pending,
-        Some("slow_down") => TokenPollOutcome::SlowDown,
-        Some(err) => TokenPollOutcome::Failed(err.to_string()),
-        None => TokenPollOutcome::Failed(
-            "unexpected token response: no access_token and no error code".to_string(),
-        ),
-    })
-}
-
-async fn send_request<T: Serialize + ?Sized>(
-    client: &Client,
-    cfg: &DeviceFlowConfig<'_>,
-    url: &str,
-    body: &T,
-) -> reqwest::Result<reqwest::Response> {
-    let builder = client
-        .post(url)
-        .timeout(std::time::Duration::from_secs(
-            super::base::DEFAULT_PROVIDER_TIMEOUT_SECS,
-        ))
-        .headers(cfg.extra_headers.clone());
-    let builder = match cfg.encoding {
-        RequestEncoding::Form => builder.form(body),
-        RequestEncoding::Json => builder.json(body),
-    };
-    builder.send().await
 }
 
 fn announce_user_action(device: &DeviceCodeResponse) {
@@ -355,259 +63,61 @@ fn announce_user_action(device: &DeviceCodeResponse) {
         .ok()
         .and_then(|mut cb| cb.set_text(&device.user_code).ok())
         .is_some();
-    if let Err(e) = webbrowser::open(&verify_url) {
-        tracing::warn!("Failed to open browser: {}", e);
-    }
     // stderr keeps stdout clean for CLI workflows parsing provider output.
     let clipboard_hint = if copied { " (copied to clipboard)" } else { "" };
     eprintln!(
         "Please visit {} and enter code {}{}",
         verify_url, device.user_code, clipboard_hint
     );
+    if verification_uri_is_safe(&verify_url) {
+        if let Err(e) = webbrowser::open(&verify_url) {
+            tracing::warn!("Failed to open browser: {}", e);
+        }
+    } else {
+        tracing::warn!(
+            "Refusing to open untrusted verification URI: {}",
+            verify_url
+        );
+    }
+}
+
+fn verification_uri_is_safe(uri: &str) -> bool {
+    let Ok(url) = url::Url::parse(uri) else {
+        return false;
+    };
+    if url.scheme() != "https" {
+        return false;
+    }
+    let Some(host) = url.host_str() else {
+        return false;
+    };
+    let host = host.to_ascii_lowercase();
+    host == "github.com"
+        || host.ends_with(".github.com")
+        || host.ends_with(".ghe.com")
+        || host == "kimi.com"
+        || host.ends_with(".kimi.com")
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use serde_json::json;
-    use wiremock::matchers::{method, path};
-    use wiremock::{Mock, MockServer, ResponseTemplate};
+    use super::verification_uri_is_safe;
 
-    fn make_cfg<'a>(device_auth_url: Option<&'a str>, token_url: &'a str) -> DeviceFlowConfig<'a> {
-        DeviceFlowConfig {
-            device_auth_url,
-            token_url,
-            client_id: "test-client",
-            scopes: None,
-            extra_headers: HeaderMap::new(),
-            encoding: RequestEncoding::Form,
-        }
+    #[test]
+    fn opens_github_and_kimi_https_hosts() {
+        assert!(verification_uri_is_safe("https://github.com/login/device"));
+        assert!(verification_uri_is_safe(
+            "https://auth.kimi.com/activate?user_code=AB"
+        ));
+        assert!(verification_uri_is_safe(
+            "https://my-enterprise.ghe.com/login/device"
+        ));
     }
 
-    #[tokio::test]
-    async fn poll_returns_issued_tokens_when_server_responds_immediately() {
-        let server = MockServer::start().await;
-        Mock::given(method("POST"))
-            .and(path("/token"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-                "access_token": "the_token",
-                "refresh_token": "the_refresh",
-                "expires_in": 1800,
-            })))
-            .mount(&server)
-            .await;
-
-        let token_url = format!("{}/token", server.uri());
-        let cfg = make_cfg(None, &token_url);
-
-        let client = Client::new();
-        let tokens = poll_for_tokens(&client, &cfg, "device-abc", 0, 30)
-            .await
-            .unwrap();
-        assert_eq!(tokens.access_token, "the_token");
-        assert_eq!(tokens.refresh_token.as_deref(), Some("the_refresh"));
-        assert!(tokens.expires_at.is_some());
-    }
-
-    #[tokio::test]
-    async fn poll_handles_authorization_pending_then_success() {
-        let server = MockServer::start().await;
-        Mock::given(method("POST"))
-            .and(path("/token"))
-            .respond_with(ResponseTemplate::new(400).set_body_json(json!({
-                "error": "authorization_pending",
-            })))
-            .up_to_n_times(1)
-            .mount(&server)
-            .await;
-        Mock::given(method("POST"))
-            .and(path("/token"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-                "access_token": "issued",
-                "expires_in": 900,
-            })))
-            .mount(&server)
-            .await;
-
-        let token_url = format!("{}/token", server.uri());
-        let cfg = make_cfg(None, &token_url);
-
-        let client = Client::new();
-        let tokens = poll_for_tokens(&client, &cfg, "device-abc", 0, 30)
-            .await
-            .unwrap();
-        assert_eq!(tokens.access_token, "issued");
-        assert!(tokens.refresh_token.is_none());
-    }
-
-    #[tokio::test]
-    async fn poll_handles_slow_down_then_success() {
-        let server = MockServer::start().await;
-        Mock::given(method("POST"))
-            .and(path("/token"))
-            .respond_with(ResponseTemplate::new(400).set_body_json(json!({
-                "error": "slow_down",
-            })))
-            .up_to_n_times(1)
-            .mount(&server)
-            .await;
-        Mock::given(method("POST"))
-            .and(path("/token"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-                "access_token": "issued",
-                "expires_in": 900,
-            })))
-            .mount(&server)
-            .await;
-
-        let token_url = format!("{}/token", server.uri());
-        let cfg = make_cfg(None, &token_url);
-
-        let client = Client::new();
-        let tokens = poll_for_tokens(&client, &cfg, "device-abc", 0, 30)
-            .await
-            .unwrap();
-        assert_eq!(tokens.access_token, "issued");
-    }
-
-    #[tokio::test]
-    async fn poll_times_out_when_user_never_authorizes() {
-        let server = MockServer::start().await;
-        Mock::given(method("POST"))
-            .and(path("/token"))
-            .respond_with(ResponseTemplate::new(400).set_body_json(json!({
-                "error": "authorization_pending",
-            })))
-            .mount(&server)
-            .await;
-
-        let token_url = format!("{}/token", server.uri());
-        let cfg = make_cfg(None, &token_url);
-
-        let client = Client::new();
-        let err = poll_for_tokens(&client, &cfg, "device-abc", 0, 0)
-            .await
-            .unwrap_err();
-        assert!(err.to_string().contains("timed out"), "got: {}", err);
-    }
-
-    #[tokio::test]
-    async fn poll_surfaces_http_status_on_unparseable_body() {
-        let server = MockServer::start().await;
-        Mock::given(method("POST"))
-            .and(path("/token"))
-            .respond_with(ResponseTemplate::new(502).set_body_string("Bad Gateway"))
-            .mount(&server)
-            .await;
-
-        let token_url = format!("{}/token", server.uri());
-        let cfg = make_cfg(None, &token_url);
-
-        let client = Client::new();
-        let err = poll_for_tokens(&client, &cfg, "device-abc", 0, 5)
-            .await
-            .unwrap_err();
-        let msg = format!("{:#}", err);
-        assert!(msg.contains("502"), "expected status in error: {}", msg);
-        assert!(msg.contains("Bad Gateway"), "expected body: {}", msg);
-    }
-
-    #[tokio::test]
-    async fn poll_surfaces_server_error_message() {
-        let server = MockServer::start().await;
-        Mock::given(method("POST"))
-            .and(path("/token"))
-            .respond_with(ResponseTemplate::new(400).set_body_json(json!({
-                "error": "access_denied",
-            })))
-            .mount(&server)
-            .await;
-
-        let token_url = format!("{}/token", server.uri());
-        let cfg = make_cfg(None, &token_url);
-
-        let client = Client::new();
-        let err = poll_for_tokens(&client, &cfg, "device-abc", 0, 5)
-            .await
-            .unwrap_err();
-        assert!(err.to_string().contains("access_denied"), "got: {}", err);
-    }
-
-    #[tokio::test]
-    async fn request_device_code_parses_complete_response() {
-        let server = MockServer::start().await;
-        Mock::given(method("POST"))
-            .and(path("/device_authorization"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-                "device_code": "dc",
-                "user_code": "UC-1",
-                "verification_uri": "https://example.com/activate",
-                "verification_uri_complete": "https://example.com/activate?user_code=UC-1",
-                "interval": 3,
-                "expires_in": 600,
-            })))
-            .mount(&server)
-            .await;
-
-        let device_url = format!("{}/device_authorization", server.uri());
-        let cfg = make_cfg(Some(&device_url), "");
-
-        let client = Client::new();
-        let resp = request_device_code(&client, &cfg).await.unwrap();
-        assert_eq!(resp.device_code, "dc");
-        assert_eq!(resp.user_code, "UC-1");
-        assert_eq!(
-            resp.verification_url(),
-            "https://example.com/activate?user_code=UC-1"
-        );
-        assert_eq!(resp.interval, Some(3));
-    }
-
-    #[tokio::test]
-    async fn refresh_token_returns_new_credentials() {
-        let server = MockServer::start().await;
-        Mock::given(method("POST"))
-            .and(path("/token"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-                "access_token": "new_access",
-                "refresh_token": "new_refresh",
-                "expires_in": 3600,
-            })))
-            .mount(&server)
-            .await;
-
-        let token_url = format!("{}/token", server.uri());
-        let cfg = make_cfg(None, &token_url);
-
-        let client = Client::new();
-        let tokens = refresh_device_flow_token(&client, &cfg, "old_refresh")
-            .await
-            .unwrap();
-        assert_eq!(tokens.access_token, "new_access");
-        assert_eq!(tokens.refresh_token.as_deref(), Some("new_refresh"));
-    }
-
-    #[tokio::test]
-    async fn refresh_token_allows_server_to_omit_refresh_token() {
-        // RFC 6749 §6: server MAY omit refresh_token; caller should reuse prior.
-        let server = MockServer::start().await;
-        Mock::given(method("POST"))
-            .and(path("/token"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-                "access_token": "new_access",
-                "expires_in": 3600,
-            })))
-            .mount(&server)
-            .await;
-
-        let token_url = format!("{}/token", server.uri());
-        let cfg = make_cfg(None, &token_url);
-
-        let client = Client::new();
-        let tokens = refresh_device_flow_token(&client, &cfg, "old_refresh")
-            .await
-            .unwrap();
-        assert_eq!(tokens.access_token, "new_access");
-        assert!(tokens.refresh_token.is_none());
+    #[test]
+    fn refuses_non_https_and_unknown_hosts() {
+        assert!(!verification_uri_is_safe("http://github.com/login/device"));
+        assert!(!verification_uri_is_safe("https://evil.example/phish"));
+        assert!(!verification_uri_is_safe("file:///etc/passwd"));
     }
 }


### PR DESCRIPTION
# feat: extract device-code OAuth into goose-providers for gdk

Closes #11225
Refs #11377

## Summary

- RFC 8628 device-code protocol now lives in `goose-providers` (request / poll-once / poll-loop / refresh). Hosts own UI and token persistence.
- gdk UniFFI: `list_oauth_providers`, `start_device_flow`, `poll_device_flow`, `refresh_oauth_token`, plus Copilot exchange + constructors.
- Copilot device-code returns a GitHub token; call `exchange_github_copilot_token` then `github_copilot_provider`. Path is versionless `chat/completions`; gpt-5 / o-series still route to `/responses`.
- Kimi: `kimi_code_provider` with platform headers + `anthropic-version`. Device-id is process-local (not the CLI file).
- goose CLI still opens the browser / copies the user code / writes Config. OAuth HTTP clients do not follow redirects.

## Test plan

- [x] `cargo test -p goose-providers --lib oauth`
- [x] `cargo test -p goose-sdk --features uniffi --lib`
- [x] `cargo test -p goose --lib githubcopilot`
- [x] `cargo test -p goose --lib kimicode`
- [x] `cargo clippy -p goose-providers -p goose -p goose-sdk --all-targets --features uniffi -- -D warnings`
- [ ] Optional live: `GOOSE_OAUTH_PROVIDER=github_copilot` + generated UniFFI example (not CI)

## Out of scope (follow-up)

- GHE Copilot host overrides (CLI only)
- Moving full Copilot/Kimi goose providers (Config / Paths / vision headers)
- PKCE/loopback and unified provider auth (#11377)
- MCP OAuth
