### PR TITLE
fix(hints): enforce one aggregate output budget

### DIFF
--- a/crates/goose/src/agents/prompt_manager.rs
+++ b/crates/goose/src/agents/prompt_manager.rs
@@ -246,13 +246,6 @@ impl PromptManager {
         let changed = self.last_hint_snapshot.as_ref() != Some(&snapshot);
         self.pending_hint_snapshot = changed.then(|| (snapshot.clone(), output_limit));
         self.last_hint_snapshot = Some(snapshot.clone());
-        if snapshot.is_empty() {
-            self.system_prompt_extras.shift_remove("hints");
-        } else {
-            self.system_prompt_extras.shift_remove("hints");
-            self.system_prompt_extras
-                .insert("hints".to_string(), snapshot);
-        }
         changed
     }
 
@@ -475,7 +468,7 @@ mod tests {
 
     #[test]
     #[serial_test::serial]
-    fn load_subdirectory_hints_remains_visible_to_builder() {
+    fn load_subdirectory_hints_is_used_by_the_next_fresh_builder() {
         let config_root = tempfile::tempdir().unwrap();
         let _guard = env_lock::lock_env([
             (
@@ -500,8 +493,48 @@ mod tests {
         manager.record_tool_arguments(&arguments, project.path());
 
         assert!(manager.load_subdirectory_hints(project.path()));
-        assert!(manager.builder().build().contains("NESTED_HINT"));
+        assert!(manager
+            .builder_with_fresh_hints(project.path(), GooseMode::Auto)
+            .build()
+            .contains("NESTED_HINT"));
         assert!(!manager.load_subdirectory_hints(project.path()));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn legacy_hint_refresh_preserves_caller_owned_hints_extra() {
+        let config_root = tempfile::tempdir().unwrap();
+        let _guard = env_lock::lock_env([
+            (
+                "GOOSE_PATH_ROOT",
+                Some(config_root.path().to_str().unwrap()),
+            ),
+            ("CONTEXT_FILE_NAMES", Some(r#"[".goosehints"]"#)),
+        ]);
+        let project = tempfile::tempdir().unwrap();
+        let hints_path = project.path().join(crate::hints::GOOSE_HINTS_FILENAME);
+        let mut manager = PromptManager::new();
+        manager.add_system_prompt_extra("hints".to_string(), "CALLER_HINTS".to_string());
+
+        assert!(manager.load_subdirectory_hints(project.path()));
+        assert!(manager.builder().build().contains("CALLER_HINTS"));
+
+        std::fs::write(&hints_path, "GENERATED_HINTS").unwrap();
+        assert!(manager.load_subdirectory_hints(project.path()));
+        let generated = manager
+            .builder_with_fresh_hints(project.path(), GooseMode::Auto)
+            .build();
+        assert!(generated.contains("GENERATED_HINTS"));
+        assert!(!generated.contains("CALLER_HINTS"));
+        assert!(manager.builder().build().contains("CALLER_HINTS"));
+
+        std::fs::remove_file(hints_path).unwrap();
+        assert!(manager.load_subdirectory_hints(project.path()));
+        let restored = manager
+            .builder_with_fresh_hints(project.path(), GooseMode::Auto)
+            .build();
+        assert!(restored.contains("CALLER_HINTS"));
+        assert!(!restored.contains("GENERATED_HINTS"));
     }
 
     #[test]

--- a/crates/goose/src/agents/prompt_manager.rs
+++ b/crates/goose/src/agents/prompt_manager.rs
@@ -276,15 +276,20 @@ impl PromptManager {
             .system_prompt_extras
             .keys()
             .any(|key| !self.generated_subdirectory_hint_keys.contains(key));
-        let chat_boundary_count = usize::from(goose_mode == GooseMode::Chat);
+        let has_chat_mode = goose_mode == GooseMode::Chat;
+        let chat_boundary_count = usize::from(has_chat_mode);
         let root_only_boundary_count =
             usize::from(has_prompt_parts || has_caller_owned_extra) + chat_boundary_count;
-        let subdirectory_boundary_count = usize::from(has_prompt_parts)
+        let subdirectories_only_boundary_count = usize::from(has_prompt_parts)
+            + usize::from(has_caller_owned_extra)
+            + usize::from(has_chat_mode && !has_prompt_parts);
+        let with_subdirectories_boundary_count = usize::from(has_prompt_parts)
             + usize::from(has_caller_owned_extra)
             + chat_boundary_count;
         HintOutputReservation::new(
             root_only_boundary_count * HINT_EXTRA_SEPARATOR_BYTES,
-            subdirectory_boundary_count * HINT_EXTRA_SEPARATOR_BYTES,
+            subdirectories_only_boundary_count * HINT_EXTRA_SEPARATOR_BYTES,
+            with_subdirectories_boundary_count * HINT_EXTRA_SEPARATOR_BYTES,
         )
     }
 

--- a/crates/goose/src/agents/prompt_manager.rs
+++ b/crates/goose/src/agents/prompt_manager.rs
@@ -8,7 +8,10 @@ use std::collections::HashMap;
 
 use crate::agents::{extension::ExtensionInfo, moim};
 use crate::hints::load_hints::build_gitignore;
-use crate::hints::{get_context_filenames, load_hint_files, SubdirectoryHintTracker};
+use crate::hints::{
+    get_context_filenames, load_hint_files_with_limit, SubdirectoryHintTracker,
+    MAX_HINT_OUTPUT_BYTES,
+};
 use crate::{
     config::{Config, GooseMode},
     prompt_template,
@@ -88,8 +91,32 @@ impl<'a> SystemPromptBuilder<'a, PromptManager> {
     pub fn with_hints(mut self, working_dir: &Path) -> Self {
         let hints_filenames = get_context_filenames();
         let ignore_patterns = build_gitignore(working_dir);
+        let mut subdirectory_hints = self
+            .manager
+            .system_prompt_extras
+            .iter()
+            .filter(|(key, _)| key.starts_with("subdir_hints:"))
+            .map(|(key, value)| (key.as_str(), value.len()))
+            .collect::<HashMap<_, _>>();
+        subdirectory_hints.extend(
+            self.prompt_extras
+                .iter()
+                .filter(|(key, _)| key.starts_with("subdir_hints:"))
+                .map(|(key, value)| (key.as_str(), value.len())),
+        );
+        let remaining_output_bytes = subdirectory_hints
+            .values()
+            .try_fold(MAX_HINT_OUTPUT_BYTES, |remaining, size| {
+                remaining.checked_sub(*size)
+            })
+            .unwrap_or(0);
 
-        let hints = load_hint_files(working_dir, &hints_filenames, &ignore_patterns);
+        let hints = load_hint_files_with_limit(
+            working_dir,
+            &hints_filenames,
+            &ignore_patterns,
+            remaining_output_bytes,
+        );
 
         if !hints.is_empty() {
             self.hints = Some(hints);
@@ -277,6 +304,7 @@ impl PromptManager {
 #[cfg(test)]
 mod tests {
     use insta::assert_snapshot;
+    use std::fs;
 
     use super::*;
 
@@ -333,6 +361,35 @@ mod tests {
 
         assert!(with_contribution.contains("temporary instruction"));
         assert!(!without_contribution.contains("temporary instruction"));
+    }
+
+    #[test]
+    fn root_and_subdirectory_hints_share_one_output_limit() {
+        let project = tempfile::tempdir().unwrap();
+        let nested = project.path().join("nested");
+        fs::create_dir(&nested).unwrap();
+        fs::write(
+            project.path().join(crate::hints::GOOSE_HINTS_FILENAME),
+            format!("{}ROOT_MARKER", "r".repeat(600 * 1024)),
+        )
+        .unwrap();
+        fs::write(
+            nested.join(crate::hints::GOOSE_HINTS_FILENAME),
+            format!("{}NESTED_MARKER", "n".repeat(600 * 1024)),
+        )
+        .unwrap();
+
+        let mut manager = PromptManager::new();
+        let arguments = serde_json::json!({ "path": "nested/file.txt" })
+            .as_object()
+            .cloned();
+        manager.record_tool_arguments(&arguments, project.path());
+        assert!(manager.load_subdirectory_hints(project.path()));
+
+        let prompt = manager.builder().with_hints(project.path()).build();
+
+        assert!(prompt.contains("NESTED_MARKER"));
+        assert!(!prompt.contains("ROOT_MARKER"));
     }
 
     #[test]

--- a/crates/goose/src/agents/prompt_manager.rs
+++ b/crates/goose/src/agents/prompt_manager.rs
@@ -9,7 +9,7 @@ use std::collections::{HashMap, HashSet};
 use crate::agents::{extension::ExtensionInfo, moim};
 #[cfg(test)]
 use crate::hints::load_hints::build_gitignore;
-use crate::hints::load_hints::{HintSnapshot, HINT_EXTRA_SEPARATOR_BYTES};
+use crate::hints::load_hints::{HintOutputReservation, HintSnapshot, HINT_EXTRA_SEPARATOR_BYTES};
 use crate::hints::SubdirectoryHintTracker;
 #[cfg(test)]
 use crate::hints::MAX_HINT_OUTPUT_BYTES;
@@ -267,19 +267,25 @@ impl PromptManager {
         changed
     }
 
-    pub(crate) fn reserved_hint_separator_bytes(
+    pub(crate) fn hint_output_reservation(
         &self,
         has_prompt_parts: bool,
         goose_mode: GooseMode,
-    ) -> usize {
+    ) -> HintOutputReservation {
         let has_caller_owned_extra = self
             .system_prompt_extras
             .keys()
             .any(|key| !self.generated_subdirectory_hint_keys.contains(key));
-        let boundary_count = usize::from(has_prompt_parts)
+        let chat_boundary_count = usize::from(goose_mode == GooseMode::Chat);
+        let root_only_boundary_count =
+            usize::from(has_prompt_parts || has_caller_owned_extra) + chat_boundary_count;
+        let subdirectory_boundary_count = usize::from(has_prompt_parts)
             + usize::from(has_caller_owned_extra)
-            + usize::from(goose_mode == GooseMode::Chat);
-        boundary_count * HINT_EXTRA_SEPARATOR_BYTES
+            + chat_boundary_count;
+        HintOutputReservation::new(
+            root_only_boundary_count * HINT_EXTRA_SEPARATOR_BYTES,
+            subdirectory_boundary_count * HINT_EXTRA_SEPARATOR_BYTES,
+        )
     }
 
     pub fn build_system_prompt(
@@ -288,11 +294,10 @@ impl PromptManager {
         prompt_parts: Vec<(String, String)>,
         goose_mode: GooseMode,
     ) -> String {
-        let reserved_output_bytes =
-            self.reserved_hint_separator_bytes(!prompt_parts.is_empty(), goose_mode);
+        let reservation = self.hint_output_reservation(!prompt_parts.is_empty(), goose_mode);
         let snapshot = self
             .subdirectory_hint_tracker
-            .load_snapshot(working_dir, reserved_output_bytes);
+            .load_snapshot(working_dir, reservation);
         self.build_system_prompt_from_snapshot(prompt_parts, goose_mode, snapshot)
     }
 
@@ -316,10 +321,10 @@ impl PromptManager {
         working_dir: &Path,
         goose_mode: GooseMode,
     ) -> SystemPromptBuilder<'_, PromptManager> {
-        let reserved_output_bytes = self.reserved_hint_separator_bytes(false, goose_mode);
+        let reservation = self.hint_output_reservation(false, goose_mode);
         let snapshot = self
             .subdirectory_hint_tracker
-            .load_snapshot(working_dir, reserved_output_bytes);
+            .load_snapshot(working_dir, reservation);
         self.apply_subdirectory_hints(snapshot.subdirectories);
         self.builder()
             .with_hint_snapshot(snapshot.top_level)
@@ -665,6 +670,46 @@ mod tests {
             .builder_with_fresh_hints(project.path(), GooseMode::Chat)
             .build();
         assert!(!prompt.contains("CALLER_OVERFLOW"));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn legacy_root_hints_share_one_boundary_with_contiguous_prompt_extras() {
+        let config_root = tempfile::tempdir().unwrap();
+        let _guard = env_lock::lock_env([
+            (
+                "GOOSE_PATH_ROOT",
+                Some(config_root.path().to_str().unwrap()),
+            ),
+            ("CONTEXT_FILE_NAMES", Some(r#"[".goosehints"]"#)),
+        ]);
+        let project = tempfile::tempdir().unwrap();
+        let mut manager = PromptManager::new();
+        manager.add_system_prompt_extra("caller".to_string(), "caller instruction".to_string());
+        let reservation = manager.hint_output_reservation(true, GooseMode::Auto);
+        assert_eq!(reservation.root_only, HINT_EXTRA_SEPARATOR_BYTES);
+        assert_eq!(
+            reservation.with_subdirectories,
+            2 * HINT_EXTRA_SEPARATOR_BYTES
+        );
+        write_root_hints_with_output_len(
+            project.path(),
+            MAX_HINT_OUTPUT_BYTES - reservation.root_only,
+            "ROOT_ONLY_BOUNDARY",
+        );
+
+        let prompt = manager.build_system_prompt(
+            project.path(),
+            vec![(
+                "extensions".to_string(),
+                "operation prompt instruction".to_string(),
+            )],
+            GooseMode::Auto,
+        );
+
+        assert!(prompt.contains("caller instruction"));
+        assert!(prompt.contains("operation prompt instruction"));
+        assert!(prompt.contains("ROOT_ONLY_BOUNDARY"));
     }
 
     #[test]

--- a/crates/goose/src/agents/prompt_manager.rs
+++ b/crates/goose/src/agents/prompt_manager.rs
@@ -9,12 +9,12 @@ use std::collections::HashMap;
 use crate::agents::{extension::ExtensionInfo, moim};
 #[cfg(test)]
 use crate::hints::load_hints::build_gitignore;
-use crate::hints::load_hints::HintSnapshot;
+use crate::hints::load_hints::{HintSnapshot, HINT_EXTRA_SEPARATOR_BYTES};
 use crate::hints::SubdirectoryHintTracker;
 #[cfg(test)]
-use crate::hints::{get_context_filenames, load_hint_files};
+use crate::hints::MAX_HINT_OUTPUT_BYTES;
 #[cfg(test)]
-use crate::hints::{HINT_EXTRA_SEPARATOR_BYTES, MAX_HINT_OUTPUT_BYTES};
+use crate::hints::{get_context_filenames, load_hint_files};
 use crate::{
     config::{Config, GooseMode},
     prompt_template,
@@ -27,6 +27,14 @@ pub struct PromptManager {
     system_prompt_extras: IndexMap<String, String>,
     current_date_timestamp: String,
     subdirectory_hint_tracker: SubdirectoryHintTracker,
+}
+
+fn trailing_hint_separator_bytes(goose_mode: GooseMode) -> usize {
+    if goose_mode == GooseMode::Chat {
+        HINT_EXTRA_SEPARATOR_BYTES
+    } else {
+        0
+    }
 }
 
 impl Default for PromptManager {
@@ -261,7 +269,9 @@ impl PromptManager {
         prompt_parts: Vec<(String, String)>,
         goose_mode: GooseMode,
     ) -> String {
-        let snapshot = self.subdirectory_hint_tracker.load_snapshot(working_dir, 0);
+        let snapshot = self
+            .subdirectory_hint_tracker
+            .load_snapshot(working_dir, trailing_hint_separator_bytes(goose_mode));
         self.build_system_prompt_from_snapshot(prompt_parts, goose_mode, snapshot)
     }
 
@@ -283,10 +293,15 @@ impl PromptManager {
     pub fn builder_with_fresh_hints(
         &mut self,
         working_dir: &Path,
+        goose_mode: GooseMode,
     ) -> SystemPromptBuilder<'_, PromptManager> {
-        let snapshot = self.subdirectory_hint_tracker.load_snapshot(working_dir, 0);
+        let snapshot = self
+            .subdirectory_hint_tracker
+            .load_snapshot(working_dir, trailing_hint_separator_bytes(goose_mode));
         self.apply_subdirectory_hints(snapshot.subdirectories);
-        self.builder().with_hint_snapshot(snapshot.top_level)
+        self.builder()
+            .with_hint_snapshot(snapshot.top_level)
+            .with_goose_mode(goose_mode)
     }
 
     /// Override the system prompt with custom text
@@ -325,6 +340,15 @@ mod tests {
     use std::fs;
 
     use super::*;
+
+    const PROJECT_HINTS_HEADER: &str =
+        "### Project Hints\nThese are hints for working on the project in this directory.\n";
+
+    fn write_root_hints_with_output_len(project: &Path, output_len: usize, marker: &str) {
+        let content_len = output_len - PROJECT_HINTS_HEADER.len();
+        let content = format!("{marker}{}", "h".repeat(content_len - marker.len()));
+        fs::write(project.join(crate::hints::GOOSE_HINTS_FILENAME), content).unwrap();
+    }
 
     #[test]
     fn test_build_system_prompt_sanitizes_override() {
@@ -456,8 +480,7 @@ mod tests {
         )
         .unwrap();
         let prompt = manager
-            .builder_with_fresh_hints(project.path())
-            .with_goose_mode(GooseMode::Auto)
+            .builder_with_fresh_hints(project.path(), GooseMode::Auto)
             .build();
         let hints_filenames = get_context_filenames();
         let ignore_patterns = build_gitignore(project.path());
@@ -482,6 +505,39 @@ mod tests {
         );
         assert!(prompt.contains("ROOT_MARKER"));
         assert!(!prompt.contains("NESTED_MARKER"));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn legacy_chat_hints_reserve_trailing_separator_at_exact_limit() {
+        let config_root = tempfile::tempdir().unwrap();
+        let _guard = env_lock::lock_env([
+            (
+                "GOOSE_PATH_ROOT",
+                Some(config_root.path().to_str().unwrap()),
+            ),
+            ("CONTEXT_FILE_NAMES", Some(r#"[".goosehints"]"#)),
+        ]);
+        let project = tempfile::tempdir().unwrap();
+        write_root_hints_with_output_len(
+            project.path(),
+            MAX_HINT_OUTPUT_BYTES - HINT_EXTRA_SEPARATOR_BYTES,
+            "CHAT_BOUNDARY",
+        );
+
+        let mut manager = PromptManager::new();
+        let builder = manager.builder_with_fresh_hints(project.path(), GooseMode::Chat);
+        assert_eq!(
+            builder.hints.as_ref().unwrap().len() + HINT_EXTRA_SEPARATOR_BYTES,
+            MAX_HINT_OUTPUT_BYTES
+        );
+        assert!(builder.build().contains("CHAT_BOUNDARY"));
+
+        write_root_hints_with_output_len(project.path(), MAX_HINT_OUTPUT_BYTES, "CHAT_OVERFLOW");
+        let prompt = manager
+            .builder_with_fresh_hints(project.path(), GooseMode::Chat)
+            .build();
+        assert!(!prompt.contains("CHAT_OVERFLOW"));
     }
 
     #[test]

--- a/crates/goose/src/agents/prompt_manager.rs
+++ b/crates/goose/src/agents/prompt_manager.rs
@@ -245,13 +245,19 @@ impl PromptManager {
         prompt_parts: Vec<(String, String)>,
         goose_mode: GooseMode,
     ) -> String {
-        self.load_subdirectory_hints(working_dir);
-        self.builder()
+        self.builder_with_fresh_hints(working_dir)
             .with_prompt_extras(prompt_parts)
-            .with_hints(working_dir)
             .with_goose_mode(goose_mode)
             .without_extensions()
             .build()
+    }
+
+    pub fn builder_with_fresh_hints(
+        &mut self,
+        working_dir: &Path,
+    ) -> SystemPromptBuilder<'_, PromptManager> {
+        self.load_subdirectory_hints(working_dir);
+        self.builder().with_hints(working_dir)
     }
 
     /// Override the system prompt with custom text
@@ -420,7 +426,10 @@ mod tests {
             format!("{}ROOT_MARKER", "r".repeat(700 * 1024)),
         )
         .unwrap();
-        let prompt = manager.build_system_prompt(project.path(), Vec::new(), GooseMode::Auto);
+        let prompt = manager
+            .builder_with_fresh_hints(project.path())
+            .with_goose_mode(GooseMode::Auto)
+            .build();
         let hints_filenames = get_context_filenames();
         let ignore_patterns = build_gitignore(project.path());
         let top_level_hints = load_hint_files(project.path(), &hints_filenames, &ignore_patterns);

--- a/crates/goose/src/agents/prompt_manager.rs
+++ b/crates/goose/src/agents/prompt_manager.rs
@@ -8,7 +8,9 @@ use std::collections::HashMap;
 
 use crate::agents::{extension::ExtensionInfo, moim};
 use crate::hints::load_hints::build_gitignore;
-use crate::hints::{get_context_filenames, load_hint_files, SubdirectoryHintTracker};
+use crate::hints::{
+    get_context_filenames, load_hint_files, SubdirectoryHintTracker, MAX_HINT_OUTPUT_BYTES,
+};
 use crate::{
     config::{Config, GooseMode},
     prompt_template,
@@ -16,13 +18,15 @@ use crate::{
 };
 use std::path::Path;
 
+const PROMPT_EXTRA_SEPARATOR: &str = "\n\n";
+
 pub struct PromptManager {
     system_prompt_override: Option<String>,
     system_prompt_extras: IndexMap<String, String>,
     current_date_timestamp: String,
     subdirectory_hint_tracker: SubdirectoryHintTracker,
     last_hint_snapshot: Option<String>,
-    pending_hint_snapshot: Option<String>,
+    pending_hint_snapshot: Option<(String, usize)>,
 }
 
 impl Default for PromptManager {
@@ -182,7 +186,7 @@ impl<'a> SystemPromptBuilder<'a, PromptManager> {
             format!(
                 "{}\n\n# Additional Instructions:\n\n{}",
                 base_prompt,
-                sanitized_system_prompt_extras.join("\n\n")
+                sanitized_system_prompt_extras.join(PROMPT_EXTRA_SEPARATOR)
             )
         }
     }
@@ -234,21 +238,52 @@ impl PromptManager {
     }
 
     pub fn load_subdirectory_hints(&mut self, working_dir: &Path) -> bool {
+        let goose_mode = Config::global().get_goose_mode().unwrap_or_default();
+        let output_limit = self.hint_output_limit(&[], goose_mode);
         let snapshot = self
             .subdirectory_hint_tracker
-            .load_prompt_snapshot(working_dir);
+            .load_prompt_snapshot(working_dir, output_limit);
         let changed = self.last_hint_snapshot.as_ref() != Some(&snapshot);
-        self.pending_hint_snapshot = changed.then_some(snapshot);
+        self.pending_hint_snapshot = changed.then(|| (snapshot.clone(), output_limit));
+        self.last_hint_snapshot = Some(snapshot.clone());
+        if snapshot.is_empty() {
+            self.system_prompt_extras.shift_remove("hints");
+        } else {
+            self.system_prompt_extras.shift_remove("hints");
+            self.system_prompt_extras
+                .insert("hints".to_string(), snapshot);
+        }
         changed
     }
 
-    fn take_fresh_hint_snapshot(&mut self, working_dir: &Path) -> String {
-        let snapshot = self.pending_hint_snapshot.take().unwrap_or_else(|| {
-            self.subdirectory_hint_tracker
-                .load_prompt_snapshot(working_dir)
-        });
+    fn take_fresh_hint_snapshot(&mut self, working_dir: &Path, output_limit: usize) -> String {
+        let snapshot = match self.pending_hint_snapshot.take() {
+            Some((snapshot, pending_limit)) if pending_limit == output_limit => snapshot,
+            _ => self
+                .subdirectory_hint_tracker
+                .load_prompt_snapshot(working_dir, output_limit),
+        };
         self.last_hint_snapshot = Some(snapshot.clone());
         snapshot
+    }
+
+    pub(crate) fn hint_output_limit(
+        &self,
+        prompt_parts: &[(String, String)],
+        goose_mode: GooseMode,
+    ) -> usize {
+        let mut extras = self.system_prompt_extras.clone();
+        extras.extend(prompt_parts.iter().cloned());
+        extras.shift_remove("hints");
+        extras.insert("hints".to_string(), String::new());
+        if goose_mode == GooseMode::Chat {
+            extras.insert("chat_mode".to_string(), String::new());
+        }
+
+        let hint_index = extras.get_index_of("hints").unwrap();
+        let adjacent_separators =
+            usize::from(hint_index > 0) + usize::from(hint_index + 1 < extras.len());
+        MAX_HINT_OUTPUT_BYTES.saturating_sub(adjacent_separators * PROMPT_EXTRA_SEPARATOR.len())
     }
 
     pub fn build_system_prompt(
@@ -257,7 +292,8 @@ impl PromptManager {
         prompt_parts: Vec<(String, String)>,
         goose_mode: GooseMode,
     ) -> String {
-        let snapshot = self.take_fresh_hint_snapshot(working_dir);
+        let output_limit = self.hint_output_limit(&prompt_parts, goose_mode);
+        let snapshot = self.take_fresh_hint_snapshot(working_dir, output_limit);
         self.build_system_prompt_from_snapshot(prompt_parts, goose_mode, snapshot)
     }
 
@@ -280,7 +316,8 @@ impl PromptManager {
         working_dir: &Path,
         goose_mode: GooseMode,
     ) -> SystemPromptBuilder<'_, PromptManager> {
-        let snapshot = self.take_fresh_hint_snapshot(working_dir);
+        let output_limit = self.hint_output_limit(&[], goose_mode);
+        let snapshot = self.take_fresh_hint_snapshot(working_dir, output_limit);
         self.builder()
             .with_hint_snapshot(snapshot)
             .with_goose_mode(goose_mode)
@@ -434,6 +471,37 @@ mod tests {
             .build();
         assert!(reread.contains("ROOT_V4"));
         assert!(!reread.contains("ROOT_V3"));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn load_subdirectory_hints_remains_visible_to_builder() {
+        let config_root = tempfile::tempdir().unwrap();
+        let _guard = env_lock::lock_env([
+            (
+                "GOOSE_PATH_ROOT",
+                Some(config_root.path().to_str().unwrap()),
+            ),
+            ("CONTEXT_FILE_NAMES", Some(r#"[".goosehints"]"#)),
+        ]);
+        let project = tempfile::tempdir().unwrap();
+        let nested = project.path().join("nested");
+        std::fs::create_dir(&nested).unwrap();
+        std::fs::write(
+            nested.join(crate::hints::GOOSE_HINTS_FILENAME),
+            "NESTED_HINT",
+        )
+        .unwrap();
+
+        let mut manager = PromptManager::new();
+        let arguments = serde_json::json!({ "path": "nested/file.rs" })
+            .as_object()
+            .cloned();
+        manager.record_tool_arguments(&arguments, project.path());
+
+        assert!(manager.load_subdirectory_hints(project.path()));
+        assert!(manager.builder().build().contains("NESTED_HINT"));
+        assert!(!manager.load_subdirectory_hints(project.path()));
     }
 
     #[test]

--- a/crates/goose/src/agents/prompt_manager.rs
+++ b/crates/goose/src/agents/prompt_manager.rs
@@ -268,25 +268,70 @@ impl PromptManager {
         changed
     }
 
-    pub(crate) fn hint_output_reservation(
+    pub(crate) fn hint_output_reservation<'a>(
         &self,
-        has_prompt_parts: bool,
+        prompt_part_keys: impl IntoIterator<Item = &'a str>,
         goose_mode: GooseMode,
     ) -> HintOutputReservation {
-        let has_caller_owned_extra = self
-            .system_prompt_extras
-            .keys()
-            .any(|key| !self.generated_subdirectory_hint_keys.contains(key));
-        let has_chat_mode = goose_mode == GooseMode::Chat;
-        let chat_boundary_count = usize::from(has_chat_mode);
-        let root_only_boundary_count =
-            usize::from(has_prompt_parts || has_caller_owned_extra) + chat_boundary_count;
-        let subdirectories_only_boundary_count = usize::from(has_prompt_parts)
-            + usize::from(has_caller_owned_extra)
-            + usize::from(has_chat_mode && !has_prompt_parts);
-        let with_subdirectories_boundary_count = usize::from(has_prompt_parts)
-            + usize::from(has_caller_owned_extra)
-            + chat_boundary_count;
+        #[derive(Hash, PartialEq, Eq)]
+        enum ReservationKey {
+            Extra(String),
+            SubdirectoryHints,
+            RootHints,
+        }
+
+        #[derive(Clone, Copy, PartialEq, Eq)]
+        enum ReservationPart {
+            Extra,
+            Hint,
+        }
+
+        let prompt_part_keys = prompt_part_keys.into_iter().collect::<Vec<_>>();
+        let boundary_count = |include_subdirectories: bool, include_root: bool| {
+            let mut parts = IndexMap::new();
+            for key in self
+                .system_prompt_extras
+                .keys()
+                .filter(|key| !self.generated_subdirectory_hint_keys.contains(*key))
+            {
+                parts.insert(ReservationKey::Extra(key.clone()), ReservationPart::Extra);
+            }
+            if include_subdirectories {
+                parts.insert(ReservationKey::SubdirectoryHints, ReservationPart::Hint);
+            }
+            for key in &prompt_part_keys {
+                parts.insert(
+                    ReservationKey::Extra((*key).to_string()),
+                    ReservationPart::Extra,
+                );
+            }
+            if include_root {
+                parts.shift_remove(&ReservationKey::Extra("hints".to_string()));
+                parts.insert(ReservationKey::RootHints, ReservationPart::Hint);
+            }
+            if goose_mode == GooseMode::Chat {
+                parts.insert(
+                    ReservationKey::Extra("chat_mode".to_string()),
+                    ReservationPart::Extra,
+                );
+            }
+
+            let hint_boundaries = parts
+                .values()
+                .copied()
+                .collect::<Vec<_>>()
+                .windows(2)
+                .filter(|pair| pair.contains(&ReservationPart::Hint))
+                .count();
+            // Hint loading already charges separators between generated hint groups.
+            let charged_hint_boundaries =
+                (usize::from(include_subdirectories) + usize::from(include_root)).saturating_sub(1);
+            hint_boundaries.saturating_sub(charged_hint_boundaries)
+        };
+
+        let root_only_boundary_count = boundary_count(false, true);
+        let subdirectories_only_boundary_count = boundary_count(true, false);
+        let with_subdirectories_boundary_count = boundary_count(true, true);
         HintOutputReservation::new(
             root_only_boundary_count * HINT_EXTRA_SEPARATOR_BYTES,
             subdirectories_only_boundary_count * HINT_EXTRA_SEPARATOR_BYTES,
@@ -300,7 +345,8 @@ impl PromptManager {
         prompt_parts: Vec<(String, String)>,
         goose_mode: GooseMode,
     ) -> String {
-        let reservation = self.hint_output_reservation(!prompt_parts.is_empty(), goose_mode);
+        let reservation = self
+            .hint_output_reservation(prompt_parts.iter().map(|(key, _)| key.as_str()), goose_mode);
         let snapshot = self
             .subdirectory_hint_tracker
             .load_snapshot(working_dir, reservation);
@@ -327,7 +373,7 @@ impl PromptManager {
         working_dir: &Path,
         goose_mode: GooseMode,
     ) -> SystemPromptBuilder<'_, PromptManager> {
-        let reservation = self.hint_output_reservation(false, goose_mode);
+        let reservation = self.hint_output_reservation(std::iter::empty(), goose_mode);
         let snapshot = self
             .subdirectory_hint_tracker
             .load_snapshot(working_dir, reservation);
@@ -446,7 +492,7 @@ mod tests {
         manager.add_system_prompt_extra("hints".to_string(), "CALLER_HINTS".to_string());
         manager.add_system_prompt_extra("last".to_string(), "CALLER_LAST".to_string());
 
-        let reservation = manager.hint_output_reservation(false, GooseMode::Auto);
+        let reservation = manager.hint_output_reservation(std::iter::empty(), GooseMode::Auto);
         let hint_content_bytes =
             MAX_HINT_OUTPUT_BYTES - reservation.with_subdirectories - HINT_EXTRA_SEPARATOR_BYTES;
         let root_len = hint_content_bytes / 2;
@@ -751,7 +797,7 @@ mod tests {
         let project = tempfile::tempdir().unwrap();
         let mut manager = PromptManager::new();
         manager.add_system_prompt_extra("caller".to_string(), "caller instruction".to_string());
-        let reservation = manager.hint_output_reservation(true, GooseMode::Auto);
+        let reservation = manager.hint_output_reservation(["extensions"], GooseMode::Auto);
         assert_eq!(reservation.root_only, HINT_EXTRA_SEPARATOR_BYTES);
         assert_eq!(
             reservation.with_subdirectories,

--- a/crates/goose/src/agents/prompt_manager.rs
+++ b/crates/goose/src/agents/prompt_manager.rs
@@ -30,14 +30,6 @@ pub struct PromptManager {
     generated_subdirectory_hint_keys: HashSet<String>,
 }
 
-fn trailing_hint_separator_bytes(goose_mode: GooseMode) -> usize {
-    if goose_mode == GooseMode::Chat {
-        HINT_EXTRA_SEPARATOR_BYTES
-    } else {
-        0
-    }
-}
-
 impl Default for PromptManager {
     fn default() -> Self {
         PromptManager::new()
@@ -275,15 +267,31 @@ impl PromptManager {
         changed
     }
 
+    fn reserved_hint_separator_bytes(
+        &self,
+        has_prompt_parts: bool,
+        goose_mode: GooseMode,
+    ) -> usize {
+        let has_caller_owned_extra = self
+            .system_prompt_extras
+            .keys()
+            .any(|key| !self.generated_subdirectory_hint_keys.contains(key));
+        let boundary_count = usize::from(has_prompt_parts || has_caller_owned_extra)
+            + usize::from(goose_mode == GooseMode::Chat);
+        boundary_count * HINT_EXTRA_SEPARATOR_BYTES
+    }
+
     pub fn build_system_prompt(
         &mut self,
         working_dir: &Path,
         prompt_parts: Vec<(String, String)>,
         goose_mode: GooseMode,
     ) -> String {
+        let reserved_output_bytes =
+            self.reserved_hint_separator_bytes(!prompt_parts.is_empty(), goose_mode);
         let snapshot = self
             .subdirectory_hint_tracker
-            .load_snapshot(working_dir, trailing_hint_separator_bytes(goose_mode));
+            .load_snapshot(working_dir, reserved_output_bytes);
         self.build_system_prompt_from_snapshot(prompt_parts, goose_mode, snapshot)
     }
 
@@ -307,9 +315,10 @@ impl PromptManager {
         working_dir: &Path,
         goose_mode: GooseMode,
     ) -> SystemPromptBuilder<'_, PromptManager> {
+        let reserved_output_bytes = self.reserved_hint_separator_bytes(false, goose_mode);
         let snapshot = self
             .subdirectory_hint_tracker
-            .load_snapshot(working_dir, trailing_hint_separator_bytes(goose_mode));
+            .load_snapshot(working_dir, reserved_output_bytes);
         self.apply_subdirectory_hints(snapshot.subdirectories);
         self.builder()
             .with_hint_snapshot(snapshot.top_level)
@@ -614,6 +623,47 @@ mod tests {
             .builder_with_fresh_hints(project.path(), GooseMode::Chat)
             .build();
         assert!(!prompt.contains("CHAT_OVERFLOW"));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn legacy_chat_hints_reserve_caller_extra_boundary_at_exact_limit() {
+        let config_root = tempfile::tempdir().unwrap();
+        let _guard = env_lock::lock_env([
+            (
+                "GOOSE_PATH_ROOT",
+                Some(config_root.path().to_str().unwrap()),
+            ),
+            ("CONTEXT_FILE_NAMES", Some(r#"[".goosehints"]"#)),
+        ]);
+        let project = tempfile::tempdir().unwrap();
+        let reserved_output_bytes = HINT_EXTRA_SEPARATOR_BYTES * 2;
+        write_root_hints_with_output_len(
+            project.path(),
+            MAX_HINT_OUTPUT_BYTES - reserved_output_bytes,
+            "CALLER_BOUNDARY",
+        );
+
+        let mut manager = PromptManager::new();
+        manager.add_system_prompt_extra("caller".to_string(), "caller instruction".to_string());
+        let builder = manager.builder_with_fresh_hints(project.path(), GooseMode::Chat);
+        assert_eq!(
+            builder.hints.as_ref().unwrap().len() + reserved_output_bytes,
+            MAX_HINT_OUTPUT_BYTES
+        );
+        let prompt = builder.build();
+        assert!(prompt.contains("caller instruction"));
+        assert!(prompt.contains("CALLER_BOUNDARY"));
+
+        write_root_hints_with_output_len(
+            project.path(),
+            MAX_HINT_OUTPUT_BYTES - HINT_EXTRA_SEPARATOR_BYTES,
+            "CALLER_OVERFLOW",
+        );
+        let prompt = manager
+            .builder_with_fresh_hints(project.path(), GooseMode::Chat)
+            .build();
+        assert!(!prompt.contains("CALLER_OVERFLOW"));
     }
 
     #[test]

--- a/crates/goose/src/agents/prompt_manager.rs
+++ b/crates/goose/src/agents/prompt_manager.rs
@@ -8,9 +8,9 @@ use std::collections::HashMap;
 
 use crate::agents::{extension::ExtensionInfo, moim};
 use crate::hints::load_hints::build_gitignore;
-#[cfg(test)]
-use crate::hints::MAX_HINT_OUTPUT_BYTES;
 use crate::hints::{get_context_filenames, load_hint_files, SubdirectoryHintTracker};
+#[cfg(test)]
+use crate::hints::{HINT_EXTRA_SEPARATOR_BYTES, MAX_HINT_OUTPUT_BYTES};
 use crate::{
     config::{Config, GooseMode},
     prompt_template,
@@ -379,8 +379,18 @@ mod tests {
             .filter(|(key, _)| key.starts_with("subdir_hints:"))
             .map(|(_, value)| value.len())
             .sum();
+        let hint_count = usize::from(!top_level_hints.is_empty())
+            + manager
+                .system_prompt_extras
+                .keys()
+                .filter(|key| key.starts_with("subdir_hints:"))
+                .count();
+        let separator_bytes = hint_count.saturating_sub(1) * HINT_EXTRA_SEPARATOR_BYTES;
 
-        assert!(top_level_hints.len() + subdirectory_hint_bytes <= MAX_HINT_OUTPUT_BYTES);
+        assert!(
+            top_level_hints.len() + subdirectory_hint_bytes + separator_bytes
+                <= MAX_HINT_OUTPUT_BYTES
+        );
         assert!(prompt.contains("ROOT_MARKER"));
         assert!(!prompt.contains("NESTED_MARKER"));
     }
@@ -420,8 +430,18 @@ mod tests {
             .filter(|(key, _)| key.starts_with("subdir_hints:"))
             .map(|(_, value)| value.len())
             .sum();
+        let hint_count = usize::from(!top_level_hints.is_empty())
+            + manager
+                .system_prompt_extras
+                .keys()
+                .filter(|key| key.starts_with("subdir_hints:"))
+                .count();
+        let separator_bytes = hint_count.saturating_sub(1) * HINT_EXTRA_SEPARATOR_BYTES;
 
-        assert!(top_level_hints.len() + subdirectory_hint_bytes <= MAX_HINT_OUTPUT_BYTES);
+        assert!(
+            top_level_hints.len() + subdirectory_hint_bytes + separator_bytes
+                <= MAX_HINT_OUTPUT_BYTES
+        );
         assert!(prompt.contains("ROOT_MARKER"));
         assert!(!prompt.contains("NESTED_MARKER"));
     }

--- a/crates/goose/src/agents/prompt_manager.rs
+++ b/crates/goose/src/agents/prompt_manager.rs
@@ -7,8 +7,12 @@ use serde_json::Value;
 use std::collections::HashMap;
 
 use crate::agents::{extension::ExtensionInfo, moim};
+#[cfg(test)]
 use crate::hints::load_hints::build_gitignore;
-use crate::hints::{get_context_filenames, load_hint_files, SubdirectoryHintTracker};
+use crate::hints::load_hints::HintSnapshot;
+use crate::hints::SubdirectoryHintTracker;
+#[cfg(test)]
+use crate::hints::{get_context_filenames, load_hint_files};
 #[cfg(test)]
 use crate::hints::{HINT_EXTRA_SEPARATOR_BYTES, MAX_HINT_OUTPUT_BYTES};
 use crate::{
@@ -87,11 +91,19 @@ impl<'a> SystemPromptBuilder<'a, PromptManager> {
         self
     }
 
+    #[cfg(test)]
     pub fn with_hints(mut self, working_dir: &Path) -> Self {
         let hints_filenames = get_context_filenames();
         let ignore_patterns = build_gitignore(working_dir);
         let hints = load_hint_files(working_dir, &hints_filenames, &ignore_patterns);
 
+        if !hints.is_empty() {
+            self.hints = Some(hints);
+        }
+        self
+    }
+
+    fn with_hint_snapshot(mut self, hints: String) -> Self {
         if !hints.is_empty() {
             self.hints = Some(hints);
         }
@@ -223,6 +235,10 @@ impl PromptManager {
 
     pub fn load_subdirectory_hints(&mut self, working_dir: &Path) -> bool {
         let hints = self.subdirectory_hint_tracker.load_hints(working_dir);
+        self.apply_subdirectory_hints(hints)
+    }
+
+    fn apply_subdirectory_hints(&mut self, hints: Vec<(String, String)>) -> bool {
         let previous_hints: Vec<_> = self
             .system_prompt_extras
             .iter()
@@ -245,7 +261,19 @@ impl PromptManager {
         prompt_parts: Vec<(String, String)>,
         goose_mode: GooseMode,
     ) -> String {
-        self.builder_with_fresh_hints(working_dir)
+        let snapshot = self.subdirectory_hint_tracker.load_snapshot(working_dir, 0);
+        self.build_system_prompt_from_snapshot(prompt_parts, goose_mode, snapshot)
+    }
+
+    pub(crate) fn build_system_prompt_from_snapshot(
+        &mut self,
+        prompt_parts: Vec<(String, String)>,
+        goose_mode: GooseMode,
+        snapshot: HintSnapshot,
+    ) -> String {
+        self.apply_subdirectory_hints(snapshot.subdirectories);
+        self.builder()
+            .with_hint_snapshot(snapshot.top_level)
             .with_prompt_extras(prompt_parts)
             .with_goose_mode(goose_mode)
             .without_extensions()
@@ -256,8 +284,9 @@ impl PromptManager {
         &mut self,
         working_dir: &Path,
     ) -> SystemPromptBuilder<'_, PromptManager> {
-        self.load_subdirectory_hints(working_dir);
-        self.builder().with_hints(working_dir)
+        let snapshot = self.subdirectory_hint_tracker.load_snapshot(working_dir, 0);
+        self.apply_subdirectory_hints(snapshot.subdirectories);
+        self.builder().with_hint_snapshot(snapshot.top_level)
     }
 
     /// Override the system prompt with custom text

--- a/crates/goose/src/agents/prompt_manager.rs
+++ b/crates/goose/src/agents/prompt_manager.rs
@@ -1,4 +1,6 @@
 #[cfg(test)]
+use crate::hints::load_hint_files;
+#[cfg(test)]
 use chrono::DateTime;
 use chrono::Utc;
 use indexmap::IndexMap;
@@ -7,16 +9,14 @@ use serde_json::Value;
 use std::collections::HashMap;
 
 use crate::agents::{extension::ExtensionInfo, moim};
-use crate::hints::load_hints::build_gitignore;
-use crate::hints::{
-    get_context_filenames, load_hint_files, SubdirectoryHintTracker, MAX_HINT_OUTPUT_BYTES,
-};
+use crate::hints::load_hints::{build_gitignore, load_hint_files_with_limit};
+use crate::hints::{get_context_filenames, SubdirectoryHintTracker, MAX_HINT_OUTPUT_BYTES};
 use crate::{
     config::{Config, GooseMode},
     prompt_template,
     utils::sanitize_unicode_tags,
 };
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 const PROMPT_EXTRA_SEPARATOR: &str = "\n\n";
 
@@ -55,6 +55,7 @@ pub struct SystemPromptBuilder<'a, M> {
     prompt_extras: IndexMap<String, String>,
     subagents_enabled: bool,
     hints: Option<String>,
+    hints_working_dir: Option<PathBuf>,
     code_execution_mode: bool,
     include_extensions: bool,
     goose_mode: Option<GooseMode>,
@@ -92,17 +93,13 @@ impl<'a> SystemPromptBuilder<'a, PromptManager> {
     }
 
     pub fn with_hints(mut self, working_dir: &Path) -> Self {
-        let hints_filenames = get_context_filenames();
-        let ignore_patterns = build_gitignore(working_dir);
-        let hints = load_hint_files(working_dir, &hints_filenames, &ignore_patterns);
-
-        if !hints.is_empty() {
-            self.hints = Some(hints);
-        }
+        self.hints = None;
+        self.hints_working_dir = Some(working_dir.to_path_buf());
         self
     }
 
     fn with_hint_snapshot(mut self, hints: String) -> Self {
+        self.hints_working_dir = None;
         if !hints.is_empty() {
             self.hints = Some(hints);
         }
@@ -137,6 +134,26 @@ impl<'a> SystemPromptBuilder<'a, PromptManager> {
             .goose_mode
             .unwrap_or_else(|| Config::global().get_goose_mode().unwrap_or_default());
 
+        let hints = if let Some(working_dir) = self.hints_working_dir.as_deref() {
+            let prompt_parts = self
+                .prompt_extras
+                .iter()
+                .map(|(key, value)| (key.clone(), value.clone()))
+                .collect::<Vec<_>>();
+            let output_limit = self.manager.hint_output_limit(&prompt_parts, goose_mode);
+            let hints_filenames = get_context_filenames();
+            let ignore_patterns = build_gitignore(working_dir);
+            let hints = load_hint_files_with_limit(
+                working_dir,
+                &hints_filenames,
+                &ignore_patterns,
+                output_limit,
+            );
+            (!hints.is_empty()).then_some(hints)
+        } else {
+            self.hints
+        };
+
         let context = SystemPromptContext {
             extensions: sanitized_extensions_info,
             current_date_time: self.manager.current_date_timestamp.clone(),
@@ -162,7 +179,7 @@ impl<'a> SystemPromptBuilder<'a, PromptManager> {
         system_prompt_extras.extend(self.prompt_extras);
 
         // Add hints if provided
-        if let Some(hints) = self.hints {
+        if let Some(hints) = hints {
             system_prompt_extras.shift_remove("hints");
             system_prompt_extras.insert("hints".to_string(), hints);
         }
@@ -333,6 +350,7 @@ impl PromptManager {
             prompt_extras: IndexMap::new(),
             subagents_enabled: false,
             hints: None,
+            hints_working_dir: None,
             code_execution_mode: false,
             include_extensions: true,
             goose_mode: None,
@@ -535,6 +553,84 @@ mod tests {
             .build();
         assert!(restored.contains("CALLER_HINTS"));
         assert!(!restored.contains("GENERATED_HINTS"));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn public_with_hints_uses_the_final_prompt_layout_budget() {
+        let config_root = tempfile::tempdir().unwrap();
+        let _guard = env_lock::lock_env([
+            (
+                "GOOSE_PATH_ROOT",
+                Some(config_root.path().to_str().unwrap()),
+            ),
+            ("CONTEXT_FILE_NAMES", Some(r#"[".goosehints"]"#)),
+        ]);
+        let project = tempfile::tempdir().unwrap();
+        let hints_path = project.path().join(crate::hints::GOOSE_HINTS_FILENAME);
+        const MARKER: &str = "BOUNDARY_MARKER";
+        std::fs::write(&hints_path, MARKER).unwrap();
+        let hints_filenames = vec![crate::hints::GOOSE_HINTS_FILENAME.to_string()];
+        let ignore_patterns = build_gitignore(project.path());
+        let framing_bytes = load_hint_files_with_limit(
+            project.path(),
+            &hints_filenames,
+            &ignore_patterns,
+            MAX_HINT_OUTPUT_BYTES,
+        )
+        .len()
+            - MARKER.len();
+
+        let mut manager = PromptManager::new();
+        manager.add_system_prompt_extra("hints".to_string(), "CALLER_HINTS".to_string());
+        manager.add_system_prompt_extra("caller".to_string(), "CALLER_EXTRA".to_string());
+        let output_limit = manager.hint_output_limit(
+            &[("hints".to_string(), "PROMPT_HINTS".to_string())],
+            GooseMode::Chat,
+        );
+        assert_eq!(output_limit, MAX_HINT_OUTPUT_BYTES - 4);
+        std::fs::write(
+            &hints_path,
+            format!(
+                "{}{}",
+                "x".repeat(output_limit - framing_bytes - MARKER.len()),
+                MARKER
+            ),
+        )
+        .unwrap();
+
+        let exact = manager
+            .builder()
+            .with_hints(project.path())
+            .with_prompt_extras([("hints".to_string(), "PROMPT_HINTS".to_string())])
+            .with_goose_mode(GooseMode::Chat)
+            .build();
+        assert!(exact.contains(MARKER));
+        assert!(exact.contains("CALLER_EXTRA"));
+        assert!(!exact.contains("CALLER_HINTS"));
+        assert!(!exact.contains("PROMPT_HINTS"));
+
+        std::fs::write(
+            &hints_path,
+            format!(
+                "{}{}",
+                "x".repeat(output_limit + 1 - framing_bytes - MARKER.len()),
+                MARKER
+            ),
+        )
+        .unwrap();
+        let oversized = manager
+            .builder()
+            .with_hints(project.path())
+            .with_prompt_extras([("hints".to_string(), "PROMPT_HINTS".to_string())])
+            .with_goose_mode(GooseMode::Chat)
+            .build();
+        assert!(!oversized.contains(MARKER));
+        assert!(oversized.contains("PROMPT_HINTS"));
+
+        let caller_only = manager.builder().build();
+        assert!(caller_only.contains("CALLER_HINTS"));
+        assert!(!caller_only.contains("PROMPT_HINTS"));
     }
 
     #[test]

--- a/crates/goose/src/agents/prompt_manager.rs
+++ b/crates/goose/src/agents/prompt_manager.rs
@@ -222,12 +222,21 @@ impl PromptManager {
     }
 
     pub fn load_subdirectory_hints(&mut self, working_dir: &Path) -> bool {
-        let new_hints = self.subdirectory_hint_tracker.load_new_hints(working_dir);
-        let has_new = !new_hints.is_empty();
-        for (key, content) in new_hints {
+        let hints = self.subdirectory_hint_tracker.load_hints(working_dir);
+        let previous_hints: Vec<_> = self
+            .system_prompt_extras
+            .iter()
+            .filter(|(key, _)| key.starts_with("subdir_hints:"))
+            .map(|(key, value)| (key.clone(), value.clone()))
+            .collect();
+        let changed = previous_hints != hints;
+
+        self.system_prompt_extras
+            .retain(|key, _| !key.starts_with("subdir_hints:"));
+        for (key, content) in hints {
             self.system_prompt_extras.insert(key, content);
         }
-        has_new
+        changed
     }
 
     pub fn build_system_prompt(
@@ -361,6 +370,47 @@ mod tests {
         assert!(!manager.load_subdirectory_hints(project.path()));
 
         let prompt = manager.builder().with_hints(project.path()).build();
+        let hints_filenames = get_context_filenames();
+        let ignore_patterns = build_gitignore(project.path());
+        let top_level_hints = load_hint_files(project.path(), &hints_filenames, &ignore_patterns);
+        let subdirectory_hint_bytes: usize = manager
+            .system_prompt_extras
+            .iter()
+            .filter(|(key, _)| key.starts_with("subdir_hints:"))
+            .map(|(_, value)| value.len())
+            .sum();
+
+        assert!(top_level_hints.len() + subdirectory_hint_bytes <= MAX_HINT_OUTPUT_BYTES);
+        assert!(prompt.contains("ROOT_MARKER"));
+        assert!(!prompt.contains("NESTED_MARKER"));
+    }
+
+    #[test]
+    fn growing_root_hints_reclaims_subdirectory_output_budget() {
+        let project = tempfile::tempdir().unwrap();
+        let nested = project.path().join("nested");
+        fs::create_dir(&nested).unwrap();
+        let root_hints = project.path().join(crate::hints::GOOSE_HINTS_FILENAME);
+        fs::write(&root_hints, "initial root hints").unwrap();
+        fs::write(
+            nested.join(crate::hints::GOOSE_HINTS_FILENAME),
+            format!("{}NESTED_MARKER", "n".repeat(400 * 1024)),
+        )
+        .unwrap();
+
+        let mut manager = PromptManager::new();
+        let arguments = serde_json::json!({ "path": "nested/file.txt" })
+            .as_object()
+            .cloned();
+        manager.record_tool_arguments(&arguments, project.path());
+        assert!(manager.load_subdirectory_hints(project.path()));
+
+        fs::write(
+            &root_hints,
+            format!("{}ROOT_MARKER", "r".repeat(700 * 1024)),
+        )
+        .unwrap();
+        let prompt = manager.build_system_prompt(project.path(), Vec::new(), GooseMode::Auto);
         let hints_filenames = get_context_filenames();
         let ignore_patterns = build_gitignore(project.path());
         let top_level_hints = load_hint_files(project.path(), &hints_filenames, &ignore_patterns);

--- a/crates/goose/src/agents/prompt_manager.rs
+++ b/crates/goose/src/agents/prompt_manager.rs
@@ -4,17 +4,11 @@ use chrono::Utc;
 use indexmap::IndexMap;
 use serde::Serialize;
 use serde_json::Value;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 use crate::agents::{extension::ExtensionInfo, moim};
-#[cfg(test)]
 use crate::hints::load_hints::build_gitignore;
-use crate::hints::load_hints::{HintOutputReservation, HintSnapshot, HINT_EXTRA_SEPARATOR_BYTES};
-use crate::hints::SubdirectoryHintTracker;
-#[cfg(test)]
-use crate::hints::MAX_HINT_OUTPUT_BYTES;
-#[cfg(test)]
-use crate::hints::{get_context_filenames, load_hint_files};
+use crate::hints::{get_context_filenames, load_hint_files, SubdirectoryHintTracker};
 use crate::{
     config::{Config, GooseMode},
     prompt_template,
@@ -27,7 +21,8 @@ pub struct PromptManager {
     system_prompt_extras: IndexMap<String, String>,
     current_date_timestamp: String,
     subdirectory_hint_tracker: SubdirectoryHintTracker,
-    generated_subdirectory_hint_keys: HashSet<String>,
+    last_hint_snapshot: Option<String>,
+    pending_hint_snapshot: Option<String>,
 }
 
 impl Default for PromptManager {
@@ -92,7 +87,6 @@ impl<'a> SystemPromptBuilder<'a, PromptManager> {
         self
     }
 
-    #[cfg(test)]
     pub fn with_hints(mut self, working_dir: &Path) -> Self {
         let hints_filenames = get_context_filenames();
         let ignore_patterns = build_gitignore(working_dir);
@@ -203,7 +197,8 @@ impl PromptManager {
             // Filtering to an hour to balance user time accuracy and multi session prompt cache hits.
             current_date_timestamp: Utc::now().format("%Y-%m-%d %H:00 %:z").to_string(),
             subdirectory_hint_tracker: SubdirectoryHintTracker::new(),
-            generated_subdirectory_hint_keys: HashSet::new(),
+            last_hint_snapshot: None,
+            pending_hint_snapshot: None,
         }
     }
 
@@ -214,19 +209,18 @@ impl PromptManager {
             system_prompt_extras: IndexMap::new(),
             current_date_timestamp: dt.format("%Y-%m-%d %H:%M:%S %:z").to_string(),
             subdirectory_hint_tracker: SubdirectoryHintTracker::new(),
-            generated_subdirectory_hint_keys: HashSet::new(),
+            last_hint_snapshot: None,
+            pending_hint_snapshot: None,
         }
     }
 
     /// Add an additional instruction to the system prompt with a key
     /// Using the same key will replace the previous instruction
     pub fn add_system_prompt_extra(&mut self, key: String, instruction: String) {
-        self.generated_subdirectory_hint_keys.remove(&key);
         self.system_prompt_extras.insert(key, instruction);
     }
 
     pub fn remove_system_prompt_extra(&mut self, key: &str) {
-        self.generated_subdirectory_hint_keys.remove(key);
         self.system_prompt_extras.shift_remove(key);
     }
 
@@ -240,103 +234,19 @@ impl PromptManager {
     }
 
     pub fn load_subdirectory_hints(&mut self, working_dir: &Path) -> bool {
-        let hints = self.subdirectory_hint_tracker.load_hints(working_dir);
-        self.apply_subdirectory_hints(hints)
-    }
-
-    fn apply_subdirectory_hints(&mut self, hints: Vec<(String, String)>) -> bool {
-        let previous_hints: Vec<_> = self
-            .system_prompt_extras
-            .iter()
-            .filter(|(key, _)| self.generated_subdirectory_hint_keys.contains(*key))
-            .map(|(key, value)| (key.clone(), value.clone()))
-            .collect();
-
-        self.system_prompt_extras
-            .retain(|key, _| !self.generated_subdirectory_hint_keys.contains(key));
-        self.generated_subdirectory_hint_keys.clear();
-        let applied_hints: Vec<_> = hints
-            .into_iter()
-            .filter(|(key, _)| !self.system_prompt_extras.contains_key(key))
-            .collect();
-        let changed = previous_hints != applied_hints;
-
-        for (key, content) in applied_hints {
-            self.generated_subdirectory_hint_keys.insert(key.clone());
-            self.system_prompt_extras.insert(key, content);
-        }
+        let snapshot = self.subdirectory_hint_tracker.load_snapshot(working_dir);
+        let changed = self.last_hint_snapshot.as_ref() != Some(&snapshot);
+        self.pending_hint_snapshot = Some(snapshot);
         changed
     }
 
-    pub(crate) fn hint_output_reservation<'a>(
-        &self,
-        prompt_part_keys: impl IntoIterator<Item = &'a str>,
-        goose_mode: GooseMode,
-    ) -> HintOutputReservation {
-        #[derive(Hash, PartialEq, Eq)]
-        enum ReservationKey {
-            Extra(String),
-            SubdirectoryHints,
-            RootHints,
-        }
-
-        #[derive(Clone, Copy, PartialEq, Eq)]
-        enum ReservationPart {
-            Extra,
-            Hint,
-        }
-
-        let prompt_part_keys = prompt_part_keys.into_iter().collect::<Vec<_>>();
-        let boundary_count = |include_subdirectories: bool, include_root: bool| {
-            let mut parts = IndexMap::new();
-            for key in self
-                .system_prompt_extras
-                .keys()
-                .filter(|key| !self.generated_subdirectory_hint_keys.contains(*key))
-            {
-                parts.insert(ReservationKey::Extra(key.clone()), ReservationPart::Extra);
-            }
-            if include_subdirectories {
-                parts.insert(ReservationKey::SubdirectoryHints, ReservationPart::Hint);
-            }
-            for key in &prompt_part_keys {
-                parts.insert(
-                    ReservationKey::Extra((*key).to_string()),
-                    ReservationPart::Extra,
-                );
-            }
-            if include_root {
-                parts.shift_remove(&ReservationKey::Extra("hints".to_string()));
-                parts.insert(ReservationKey::RootHints, ReservationPart::Hint);
-            }
-            if goose_mode == GooseMode::Chat {
-                parts.insert(
-                    ReservationKey::Extra("chat_mode".to_string()),
-                    ReservationPart::Extra,
-                );
-            }
-
-            let hint_boundaries = parts
-                .values()
-                .copied()
-                .collect::<Vec<_>>()
-                .windows(2)
-                .filter(|pair| pair.contains(&ReservationPart::Hint))
-                .count();
-            // Hint loading already charges separators between generated hint groups.
-            let charged_hint_boundaries =
-                (usize::from(include_subdirectories) + usize::from(include_root)).saturating_sub(1);
-            hint_boundaries.saturating_sub(charged_hint_boundaries)
-        };
-
-        let root_only_boundary_count = boundary_count(false, true);
-        let subdirectories_only_boundary_count = boundary_count(true, false);
-        let with_subdirectories_boundary_count = boundary_count(true, true);
-        HintOutputReservation::new(
-            root_only_boundary_count * HINT_EXTRA_SEPARATOR_BYTES,
-            subdirectories_only_boundary_count * HINT_EXTRA_SEPARATOR_BYTES,
-            with_subdirectories_boundary_count * HINT_EXTRA_SEPARATOR_BYTES,
-        )
+    fn take_fresh_hint_snapshot(&mut self, working_dir: &Path) -> String {
+        let snapshot = self
+            .pending_hint_snapshot
+            .take()
+            .unwrap_or_else(|| self.subdirectory_hint_tracker.load_snapshot(working_dir));
+        self.last_hint_snapshot = Some(snapshot.clone());
+        snapshot
     }
 
     pub fn build_system_prompt(
@@ -345,11 +255,7 @@ impl PromptManager {
         prompt_parts: Vec<(String, String)>,
         goose_mode: GooseMode,
     ) -> String {
-        let reservation = self
-            .hint_output_reservation(prompt_parts.iter().map(|(key, _)| key.as_str()), goose_mode);
-        let snapshot = self
-            .subdirectory_hint_tracker
-            .load_snapshot(working_dir, reservation);
+        let snapshot = self.take_fresh_hint_snapshot(working_dir);
         self.build_system_prompt_from_snapshot(prompt_parts, goose_mode, snapshot)
     }
 
@@ -357,11 +263,10 @@ impl PromptManager {
         &mut self,
         prompt_parts: Vec<(String, String)>,
         goose_mode: GooseMode,
-        snapshot: HintSnapshot,
+        snapshot: String,
     ) -> String {
-        self.apply_subdirectory_hints(snapshot.subdirectories);
         self.builder()
-            .with_hint_snapshot(snapshot.top_level)
+            .with_hint_snapshot(snapshot)
             .with_prompt_extras(prompt_parts)
             .with_goose_mode(goose_mode)
             .without_extensions()
@@ -373,13 +278,9 @@ impl PromptManager {
         working_dir: &Path,
         goose_mode: GooseMode,
     ) -> SystemPromptBuilder<'_, PromptManager> {
-        let reservation = self.hint_output_reservation(std::iter::empty(), goose_mode);
-        let snapshot = self
-            .subdirectory_hint_tracker
-            .load_snapshot(working_dir, reservation);
-        self.apply_subdirectory_hints(snapshot.subdirectories);
+        let snapshot = self.take_fresh_hint_snapshot(working_dir);
         self.builder()
-            .with_hint_snapshot(snapshot.top_level)
+            .with_hint_snapshot(snapshot)
             .with_goose_mode(goose_mode)
     }
 
@@ -416,18 +317,8 @@ impl PromptManager {
 #[cfg(test)]
 mod tests {
     use insta::assert_snapshot;
-    use std::fs;
 
     use super::*;
-
-    const PROJECT_HINTS_HEADER: &str =
-        "### Project Hints\nThese are hints for working on the project in this directory.\n";
-
-    fn write_root_hints_with_output_len(project: &Path, output_len: usize, marker: &str) {
-        let content_len = output_len - PROJECT_HINTS_HEADER.len();
-        let content = format!("{marker}{}", "h".repeat(content_len - marker.len()));
-        fs::write(project.join(crate::hints::GOOSE_HINTS_FILENAME), content).unwrap();
-    }
 
     #[test]
     fn test_build_system_prompt_sanitizes_override() {
@@ -485,67 +376,8 @@ mod tests {
     }
 
     #[test]
-    fn caller_hints_key_does_not_fragment_generated_hint_budget() {
-        let mut manager = PromptManager::new();
-        manager.set_system_prompt_override("base prompt".to_string());
-        manager.add_system_prompt_extra("first".to_string(), "CALLER_FIRST".to_string());
-        manager.add_system_prompt_extra("hints".to_string(), "CALLER_HINTS".to_string());
-        manager.add_system_prompt_extra("last".to_string(), "CALLER_LAST".to_string());
-
-        let reservation = manager.hint_output_reservation(std::iter::empty(), GooseMode::Auto);
-        let hint_content_bytes =
-            MAX_HINT_OUTPUT_BYTES - reservation.with_subdirectories - HINT_EXTRA_SEPARATOR_BYTES;
-        let root_len = hint_content_bytes / 2;
-        let subdirectory_len = hint_content_bytes - root_len;
-        let root_hints = format!("ROOT_HINT{}", "r".repeat(root_len - "ROOT_HINT".len()));
-        let subdirectory_hints = format!(
-            "SUBDIRECTORY_HINT{}",
-            "s".repeat(subdirectory_len - "SUBDIRECTORY_HINT".len())
-        );
-        let snapshot = HintSnapshot {
-            top_level: root_hints.clone(),
-            subdirectories: vec![(
-                "subdir_hints:nested".to_string(),
-                subdirectory_hints.clone(),
-            )],
-        };
-
-        assert_eq!(
-            root_hints.len()
-                + subdirectory_hints.len()
-                + HINT_EXTRA_SEPARATOR_BYTES
-                + reservation.with_subdirectories,
-            MAX_HINT_OUTPUT_BYTES
-        );
-
-        let prompt =
-            manager.build_system_prompt_from_snapshot(Vec::new(), GooseMode::Auto, snapshot);
-        let extras = prompt
-            .split_once("# Additional Instructions:\n\n")
-            .unwrap()
-            .1
-            .split("\n\n")
-            .collect::<Vec<_>>();
-        let is_generated_hint =
-            |extra: &str| extra.starts_with("ROOT_HINT") || extra.starts_with("SUBDIRECTORY_HINT");
-        let hint_boundary_count = extras
-            .windows(2)
-            .filter(|pair| is_generated_hint(pair[0]) || is_generated_hint(pair[1]))
-            .count();
-        let actual_hint_output_bytes = root_hints.len()
-            + subdirectory_hints.len()
-            + hint_boundary_count * HINT_EXTRA_SEPARATOR_BYTES;
-
-        assert!(actual_hint_output_bytes <= MAX_HINT_OUTPUT_BYTES);
-        assert_eq!(extras[0], "CALLER_FIRST");
-        assert_eq!(extras[1], "CALLER_LAST");
-        assert_eq!(extras[2], subdirectory_hints);
-        assert_eq!(extras[3], root_hints);
-    }
-
-    #[test]
     #[serial_test::serial]
-    fn hint_refresh_preserves_caller_owned_keys_and_removes_stale_generated_keys() {
+    fn legacy_hint_refresh_hands_the_same_snapshot_to_the_next_build() {
         let config_root = tempfile::tempdir().unwrap();
         let _guard = env_lock::lock_env([
             (
@@ -555,272 +387,43 @@ mod tests {
             ("CONTEXT_FILE_NAMES", Some(r#"[".goosehints"]"#)),
         ]);
         let project = tempfile::tempdir().unwrap();
-        let first = project.path().join("first");
-        let second = project.path().join("second");
-        fs::create_dir(&first).unwrap();
-        fs::create_dir(&second).unwrap();
-        let first_hints = first.join(crate::hints::GOOSE_HINTS_FILENAME);
-        let second_hints = second.join(crate::hints::GOOSE_HINTS_FILENAME);
-        fs::write(&first_hints, "first generated hints").unwrap();
-        fs::write(&second_hints, "second generated hints").unwrap();
-
-        let mut manager = PromptManager::new();
-        manager.add_system_prompt_extra(
-            "subdir_hints:caller".to_string(),
-            "caller namespace content".to_string(),
-        );
-        for path in ["first/file.rs", "second/file.rs"] {
-            let arguments = serde_json::json!({ "path": path }).as_object().cloned();
-            manager.record_tool_arguments(&arguments, project.path());
-        }
-        assert!(manager.load_subdirectory_hints(project.path()));
-
-        let first_key = format!("subdir_hints:{}", first.canonicalize().unwrap().display());
-        let second_key = format!("subdir_hints:{}", second.canonicalize().unwrap().display());
-        assert!(manager
-            .generated_subdirectory_hint_keys
-            .contains(&first_key));
-        assert!(manager
-            .generated_subdirectory_hint_keys
-            .contains(&second_key));
-
-        manager.add_system_prompt_extra(first_key.clone(), "caller override".to_string());
-        fs::remove_file(first_hints).unwrap();
-        fs::remove_file(second_hints).unwrap();
-        assert!(manager.load_subdirectory_hints(project.path()));
-
-        assert_eq!(
-            manager
-                .system_prompt_extras
-                .get("subdir_hints:caller")
-                .map(String::as_str),
-            Some("caller namespace content")
-        );
-        assert_eq!(
-            manager
-                .system_prompt_extras
-                .get(&first_key)
-                .map(String::as_str),
-            Some("caller override")
-        );
-        assert!(!manager.system_prompt_extras.contains_key(&second_key));
-        assert!(manager.generated_subdirectory_hint_keys.is_empty());
-    }
-
-    #[test]
-    fn root_and_subdirectory_hints_share_one_output_limit() {
-        let project = tempfile::tempdir().unwrap();
         let nested = project.path().join("nested");
-        fs::create_dir(&nested).unwrap();
-        fs::write(
-            project.path().join(crate::hints::GOOSE_HINTS_FILENAME),
-            format!("{}ROOT_MARKER", "r".repeat(600 * 1024)),
-        )
-        .unwrap();
-        fs::write(
-            nested.join(crate::hints::GOOSE_HINTS_FILENAME),
-            format!("{}NESTED_MARKER", "n".repeat(600 * 1024)),
-        )
-        .unwrap();
-
-        let mut manager = PromptManager::new();
-        let arguments = serde_json::json!({ "path": "nested/file.txt" })
-            .as_object()
-            .cloned();
-        manager.record_tool_arguments(&arguments, project.path());
-        assert!(!manager.load_subdirectory_hints(project.path()));
-
-        let prompt = manager.builder().with_hints(project.path()).build();
-        let hints_filenames = get_context_filenames();
-        let ignore_patterns = build_gitignore(project.path());
-        let top_level_hints = load_hint_files(project.path(), &hints_filenames, &ignore_patterns);
-        let subdirectory_hint_bytes: usize = manager
-            .system_prompt_extras
-            .iter()
-            .filter(|(key, _)| key.starts_with("subdir_hints:"))
-            .map(|(_, value)| value.len())
-            .sum();
-        let hint_count = usize::from(!top_level_hints.is_empty())
-            + manager
-                .system_prompt_extras
-                .keys()
-                .filter(|key| key.starts_with("subdir_hints:"))
-                .count();
-        let separator_bytes = hint_count.saturating_sub(1) * HINT_EXTRA_SEPARATOR_BYTES;
-
-        assert!(
-            top_level_hints.len() + subdirectory_hint_bytes + separator_bytes
-                <= MAX_HINT_OUTPUT_BYTES
-        );
-        assert!(prompt.contains("ROOT_MARKER"));
-        assert!(!prompt.contains("NESTED_MARKER"));
-    }
-
-    #[test]
-    fn growing_root_hints_reclaims_subdirectory_output_budget() {
-        let project = tempfile::tempdir().unwrap();
-        let nested = project.path().join("nested");
-        fs::create_dir(&nested).unwrap();
+        std::fs::create_dir(&nested).unwrap();
         let root_hints = project.path().join(crate::hints::GOOSE_HINTS_FILENAME);
-        fs::write(&root_hints, "initial root hints").unwrap();
-        fs::write(
+        std::fs::write(&root_hints, "ROOT_V1").unwrap();
+        std::fs::write(
             nested.join(crate::hints::GOOSE_HINTS_FILENAME),
-            format!("{}NESTED_MARKER", "n".repeat(400 * 1024)),
+            format!("{}NESTED_HINT", "n".repeat(400 * 1024)),
         )
         .unwrap();
 
         let mut manager = PromptManager::new();
-        let arguments = serde_json::json!({ "path": "nested/file.txt" })
+        let arguments = serde_json::json!({ "path": "nested/file.rs" })
             .as_object()
             .cloned();
         manager.record_tool_arguments(&arguments, project.path());
-        assert!(manager.load_subdirectory_hints(project.path()));
-
-        fs::write(
-            &root_hints,
-            format!("{}ROOT_MARKER", "r".repeat(700 * 1024)),
-        )
-        .unwrap();
-        let prompt = manager
+        let initial = manager
             .builder_with_fresh_hints(project.path(), GooseMode::Auto)
             .build();
-        let hints_filenames = get_context_filenames();
-        let ignore_patterns = build_gitignore(project.path());
-        let top_level_hints = load_hint_files(project.path(), &hints_filenames, &ignore_patterns);
-        let subdirectory_hint_bytes: usize = manager
-            .system_prompt_extras
-            .iter()
-            .filter(|(key, _)| key.starts_with("subdir_hints:"))
-            .map(|(_, value)| value.len())
-            .sum();
-        let hint_count = usize::from(!top_level_hints.is_empty())
-            + manager
-                .system_prompt_extras
-                .keys()
-                .filter(|key| key.starts_with("subdir_hints:"))
-                .count();
-        let separator_bytes = hint_count.saturating_sub(1) * HINT_EXTRA_SEPARATOR_BYTES;
+        assert!(initial.contains("ROOT_V1"));
+        assert!(initial.contains("NESTED_HINT"));
 
-        assert!(
-            top_level_hints.len() + subdirectory_hint_bytes + separator_bytes
-                <= MAX_HINT_OUTPUT_BYTES
-        );
-        assert!(prompt.contains("ROOT_MARKER"));
-        assert!(!prompt.contains("NESTED_MARKER"));
-    }
-
-    #[test]
-    #[serial_test::serial]
-    fn legacy_chat_hints_reserve_trailing_separator_at_exact_limit() {
-        let config_root = tempfile::tempdir().unwrap();
-        let _guard = env_lock::lock_env([
-            (
-                "GOOSE_PATH_ROOT",
-                Some(config_root.path().to_str().unwrap()),
-            ),
-            ("CONTEXT_FILE_NAMES", Some(r#"[".goosehints"]"#)),
-        ]);
-        let project = tempfile::tempdir().unwrap();
-        write_root_hints_with_output_len(
-            project.path(),
-            MAX_HINT_OUTPUT_BYTES - HINT_EXTRA_SEPARATOR_BYTES,
-            "CHAT_BOUNDARY",
-        );
-
-        let mut manager = PromptManager::new();
-        let builder = manager.builder_with_fresh_hints(project.path(), GooseMode::Chat);
-        assert_eq!(
-            builder.hints.as_ref().unwrap().len() + HINT_EXTRA_SEPARATOR_BYTES,
-            MAX_HINT_OUTPUT_BYTES
-        );
-        assert!(builder.build().contains("CHAT_BOUNDARY"));
-
-        write_root_hints_with_output_len(project.path(), MAX_HINT_OUTPUT_BYTES, "CHAT_OVERFLOW");
-        let prompt = manager
-            .builder_with_fresh_hints(project.path(), GooseMode::Chat)
+        std::fs::write(&root_hints, format!("{}ROOT_V2", "r".repeat(700 * 1024))).unwrap();
+        assert!(manager.load_subdirectory_hints(project.path()));
+        std::fs::write(&root_hints, "ROOT_V3").unwrap();
+        let retained = manager
+            .builder_with_fresh_hints(project.path(), GooseMode::Auto)
             .build();
-        assert!(!prompt.contains("CHAT_OVERFLOW"));
-    }
+        assert!(retained.contains("ROOT_V2"));
+        assert!(!retained.contains("ROOT_V3"));
+        assert!(!retained.contains("NESTED_HINT"));
 
-    #[test]
-    #[serial_test::serial]
-    fn legacy_chat_hints_reserve_caller_extra_boundary_at_exact_limit() {
-        let config_root = tempfile::tempdir().unwrap();
-        let _guard = env_lock::lock_env([
-            (
-                "GOOSE_PATH_ROOT",
-                Some(config_root.path().to_str().unwrap()),
-            ),
-            ("CONTEXT_FILE_NAMES", Some(r#"[".goosehints"]"#)),
-        ]);
-        let project = tempfile::tempdir().unwrap();
-        let reserved_output_bytes = HINT_EXTRA_SEPARATOR_BYTES * 2;
-        write_root_hints_with_output_len(
-            project.path(),
-            MAX_HINT_OUTPUT_BYTES - reserved_output_bytes,
-            "CALLER_BOUNDARY",
-        );
-
-        let mut manager = PromptManager::new();
-        manager.add_system_prompt_extra("caller".to_string(), "caller instruction".to_string());
-        let builder = manager.builder_with_fresh_hints(project.path(), GooseMode::Chat);
-        assert_eq!(
-            builder.hints.as_ref().unwrap().len() + reserved_output_bytes,
-            MAX_HINT_OUTPUT_BYTES
-        );
-        let prompt = builder.build();
-        assert!(prompt.contains("caller instruction"));
-        assert!(prompt.contains("CALLER_BOUNDARY"));
-
-        write_root_hints_with_output_len(
-            project.path(),
-            MAX_HINT_OUTPUT_BYTES - HINT_EXTRA_SEPARATOR_BYTES,
-            "CALLER_OVERFLOW",
-        );
-        let prompt = manager
-            .builder_with_fresh_hints(project.path(), GooseMode::Chat)
+        assert!(manager.load_subdirectory_hints(project.path()));
+        let refreshed = manager
+            .builder_with_fresh_hints(project.path(), GooseMode::Auto)
             .build();
-        assert!(!prompt.contains("CALLER_OVERFLOW"));
-    }
-
-    #[test]
-    #[serial_test::serial]
-    fn legacy_root_hints_share_one_boundary_with_contiguous_prompt_extras() {
-        let config_root = tempfile::tempdir().unwrap();
-        let _guard = env_lock::lock_env([
-            (
-                "GOOSE_PATH_ROOT",
-                Some(config_root.path().to_str().unwrap()),
-            ),
-            ("CONTEXT_FILE_NAMES", Some(r#"[".goosehints"]"#)),
-        ]);
-        let project = tempfile::tempdir().unwrap();
-        let mut manager = PromptManager::new();
-        manager.add_system_prompt_extra("caller".to_string(), "caller instruction".to_string());
-        let reservation = manager.hint_output_reservation(["extensions"], GooseMode::Auto);
-        assert_eq!(reservation.root_only, HINT_EXTRA_SEPARATOR_BYTES);
-        assert_eq!(
-            reservation.with_subdirectories,
-            2 * HINT_EXTRA_SEPARATOR_BYTES
-        );
-        write_root_hints_with_output_len(
-            project.path(),
-            MAX_HINT_OUTPUT_BYTES - reservation.root_only,
-            "ROOT_ONLY_BOUNDARY",
-        );
-
-        let prompt = manager.build_system_prompt(
-            project.path(),
-            vec![(
-                "extensions".to_string(),
-                "operation prompt instruction".to_string(),
-            )],
-            GooseMode::Auto,
-        );
-
-        assert!(prompt.contains("caller instruction"));
-        assert!(prompt.contains("operation prompt instruction"));
-        assert!(prompt.contains("ROOT_ONLY_BOUNDARY"));
+        assert!(refreshed.contains("ROOT_V3"));
+        assert!(refreshed.contains("NESTED_HINT"));
     }
 
     #[test]

--- a/crates/goose/src/agents/prompt_manager.rs
+++ b/crates/goose/src/agents/prompt_manager.rs
@@ -8,10 +8,9 @@ use std::collections::HashMap;
 
 use crate::agents::{extension::ExtensionInfo, moim};
 use crate::hints::load_hints::build_gitignore;
-use crate::hints::{
-    get_context_filenames, load_hint_files_with_limit, SubdirectoryHintTracker,
-    MAX_HINT_OUTPUT_BYTES,
-};
+#[cfg(test)]
+use crate::hints::MAX_HINT_OUTPUT_BYTES;
+use crate::hints::{get_context_filenames, load_hint_files, SubdirectoryHintTracker};
 use crate::{
     config::{Config, GooseMode},
     prompt_template,
@@ -91,32 +90,7 @@ impl<'a> SystemPromptBuilder<'a, PromptManager> {
     pub fn with_hints(mut self, working_dir: &Path) -> Self {
         let hints_filenames = get_context_filenames();
         let ignore_patterns = build_gitignore(working_dir);
-        let mut subdirectory_hints = self
-            .manager
-            .system_prompt_extras
-            .iter()
-            .filter(|(key, _)| key.starts_with("subdir_hints:"))
-            .map(|(key, value)| (key.as_str(), value.len()))
-            .collect::<HashMap<_, _>>();
-        subdirectory_hints.extend(
-            self.prompt_extras
-                .iter()
-                .filter(|(key, _)| key.starts_with("subdir_hints:"))
-                .map(|(key, value)| (key.as_str(), value.len())),
-        );
-        let remaining_output_bytes = subdirectory_hints
-            .values()
-            .try_fold(MAX_HINT_OUTPUT_BYTES, |remaining, size| {
-                remaining.checked_sub(*size)
-            })
-            .unwrap_or(0);
-
-        let hints = load_hint_files_with_limit(
-            working_dir,
-            &hints_filenames,
-            &ignore_patterns,
-            remaining_output_bytes,
-        );
+        let hints = load_hint_files(working_dir, &hints_filenames, &ignore_patterns);
 
         if !hints.is_empty() {
             self.hints = Some(hints);
@@ -384,12 +358,22 @@ mod tests {
             .as_object()
             .cloned();
         manager.record_tool_arguments(&arguments, project.path());
-        assert!(manager.load_subdirectory_hints(project.path()));
+        assert!(!manager.load_subdirectory_hints(project.path()));
 
         let prompt = manager.builder().with_hints(project.path()).build();
+        let hints_filenames = get_context_filenames();
+        let ignore_patterns = build_gitignore(project.path());
+        let top_level_hints = load_hint_files(project.path(), &hints_filenames, &ignore_patterns);
+        let subdirectory_hint_bytes: usize = manager
+            .system_prompt_extras
+            .iter()
+            .filter(|(key, _)| key.starts_with("subdir_hints:"))
+            .map(|(_, value)| value.len())
+            .sum();
 
-        assert!(prompt.contains("NESTED_MARKER"));
-        assert!(!prompt.contains("ROOT_MARKER"));
+        assert!(top_level_hints.len() + subdirectory_hint_bytes <= MAX_HINT_OUTPUT_BYTES);
+        assert!(prompt.contains("ROOT_MARKER"));
+        assert!(!prompt.contains("NESTED_MARKER"));
     }
 
     #[test]

--- a/crates/goose/src/agents/prompt_manager.rs
+++ b/crates/goose/src/agents/prompt_manager.rs
@@ -234,17 +234,19 @@ impl PromptManager {
     }
 
     pub fn load_subdirectory_hints(&mut self, working_dir: &Path) -> bool {
-        let snapshot = self.subdirectory_hint_tracker.load_snapshot(working_dir);
+        let snapshot = self
+            .subdirectory_hint_tracker
+            .load_prompt_snapshot(working_dir);
         let changed = self.last_hint_snapshot.as_ref() != Some(&snapshot);
         self.pending_hint_snapshot = changed.then_some(snapshot);
         changed
     }
 
     fn take_fresh_hint_snapshot(&mut self, working_dir: &Path) -> String {
-        let snapshot = self
-            .pending_hint_snapshot
-            .take()
-            .unwrap_or_else(|| self.subdirectory_hint_tracker.load_snapshot(working_dir));
+        let snapshot = self.pending_hint_snapshot.take().unwrap_or_else(|| {
+            self.subdirectory_hint_tracker
+                .load_prompt_snapshot(working_dir)
+        });
         self.last_hint_snapshot = Some(snapshot.clone());
         snapshot
     }

--- a/crates/goose/src/agents/prompt_manager.rs
+++ b/crates/goose/src/agents/prompt_manager.rs
@@ -165,6 +165,7 @@ impl<'a> SystemPromptBuilder<'a, PromptManager> {
 
         // Add hints if provided
         if let Some(hints) = self.hints {
+            system_prompt_extras.shift_remove("hints");
             system_prompt_extras.insert("hints".to_string(), hints);
         }
 
@@ -435,6 +436,65 @@ mod tests {
 
         assert!(with_contribution.contains("temporary instruction"));
         assert!(!without_contribution.contains("temporary instruction"));
+    }
+
+    #[test]
+    fn caller_hints_key_does_not_fragment_generated_hint_budget() {
+        let mut manager = PromptManager::new();
+        manager.set_system_prompt_override("base prompt".to_string());
+        manager.add_system_prompt_extra("first".to_string(), "CALLER_FIRST".to_string());
+        manager.add_system_prompt_extra("hints".to_string(), "CALLER_HINTS".to_string());
+        manager.add_system_prompt_extra("last".to_string(), "CALLER_LAST".to_string());
+
+        let reservation = manager.hint_output_reservation(false, GooseMode::Auto);
+        let hint_content_bytes =
+            MAX_HINT_OUTPUT_BYTES - reservation.with_subdirectories - HINT_EXTRA_SEPARATOR_BYTES;
+        let root_len = hint_content_bytes / 2;
+        let subdirectory_len = hint_content_bytes - root_len;
+        let root_hints = format!("ROOT_HINT{}", "r".repeat(root_len - "ROOT_HINT".len()));
+        let subdirectory_hints = format!(
+            "SUBDIRECTORY_HINT{}",
+            "s".repeat(subdirectory_len - "SUBDIRECTORY_HINT".len())
+        );
+        let snapshot = HintSnapshot {
+            top_level: root_hints.clone(),
+            subdirectories: vec![(
+                "subdir_hints:nested".to_string(),
+                subdirectory_hints.clone(),
+            )],
+        };
+
+        assert_eq!(
+            root_hints.len()
+                + subdirectory_hints.len()
+                + HINT_EXTRA_SEPARATOR_BYTES
+                + reservation.with_subdirectories,
+            MAX_HINT_OUTPUT_BYTES
+        );
+
+        let prompt =
+            manager.build_system_prompt_from_snapshot(Vec::new(), GooseMode::Auto, snapshot);
+        let extras = prompt
+            .split_once("# Additional Instructions:\n\n")
+            .unwrap()
+            .1
+            .split("\n\n")
+            .collect::<Vec<_>>();
+        let is_generated_hint =
+            |extra: &str| extra.starts_with("ROOT_HINT") || extra.starts_with("SUBDIRECTORY_HINT");
+        let hint_boundary_count = extras
+            .windows(2)
+            .filter(|pair| is_generated_hint(pair[0]) || is_generated_hint(pair[1]))
+            .count();
+        let actual_hint_output_bytes = root_hints.len()
+            + subdirectory_hints.len()
+            + hint_boundary_count * HINT_EXTRA_SEPARATOR_BYTES;
+
+        assert!(actual_hint_output_bytes <= MAX_HINT_OUTPUT_BYTES);
+        assert_eq!(extras[0], "CALLER_FIRST");
+        assert_eq!(extras[1], "CALLER_LAST");
+        assert_eq!(extras[2], subdirectory_hints);
+        assert_eq!(extras[3], root_hints);
     }
 
     #[test]

--- a/crates/goose/src/agents/prompt_manager.rs
+++ b/crates/goose/src/agents/prompt_manager.rs
@@ -7,6 +7,7 @@ use indexmap::IndexMap;
 use serde::Serialize;
 use serde_json::Value;
 use std::collections::HashMap;
+use std::sync::Mutex;
 
 use crate::agents::{extension::ExtensionInfo, moim};
 use crate::hints::load_hints::{build_gitignore, load_hint_files_with_limit};
@@ -24,9 +25,19 @@ pub struct PromptManager {
     system_prompt_override: Option<String>,
     system_prompt_extras: IndexMap<String, String>,
     current_date_timestamp: String,
+    hint_state: Mutex<HintState>,
+}
+
+struct HintState {
     subdirectory_hint_tracker: SubdirectoryHintTracker,
     last_hint_snapshot: Option<String>,
     pending_hint_snapshot: Option<(String, usize)>,
+}
+
+enum HintSource {
+    Snapshot(String),
+    TopLevel(PathBuf),
+    Fresh(PathBuf),
 }
 
 impl Default for PromptManager {
@@ -54,8 +65,7 @@ pub struct SystemPromptBuilder<'a, M> {
     extensions_info: Vec<ExtensionInfo>,
     prompt_extras: IndexMap<String, String>,
     subagents_enabled: bool,
-    hints: Option<String>,
-    hints_working_dir: Option<PathBuf>,
+    hint_source: Option<HintSource>,
     code_execution_mode: bool,
     include_extensions: bool,
     goose_mode: Option<GooseMode>,
@@ -93,16 +103,17 @@ impl<'a> SystemPromptBuilder<'a, PromptManager> {
     }
 
     pub fn with_hints(mut self, working_dir: &Path) -> Self {
-        self.hints = None;
-        self.hints_working_dir = Some(working_dir.to_path_buf());
+        self.hint_source = Some(HintSource::TopLevel(working_dir.to_path_buf()));
         self
     }
 
     fn with_hint_snapshot(mut self, hints: String) -> Self {
-        self.hints_working_dir = None;
-        if !hints.is_empty() {
-            self.hints = Some(hints);
-        }
+        self.hint_source = (!hints.is_empty()).then_some(HintSource::Snapshot(hints));
+        self
+    }
+
+    fn with_fresh_hints(mut self, working_dir: &Path) -> Self {
+        self.hint_source = Some(HintSource::Fresh(working_dir.to_path_buf()));
         self
     }
 
@@ -134,24 +145,32 @@ impl<'a> SystemPromptBuilder<'a, PromptManager> {
             .goose_mode
             .unwrap_or_else(|| Config::global().get_goose_mode().unwrap_or_default());
 
-        let hints = if let Some(working_dir) = self.hints_working_dir.as_deref() {
-            let prompt_parts = self
-                .prompt_extras
-                .iter()
-                .map(|(key, value)| (key.clone(), value.clone()))
-                .collect::<Vec<_>>();
-            let output_limit = self.manager.hint_output_limit(&prompt_parts, goose_mode);
-            let hints_filenames = get_context_filenames();
-            let ignore_patterns = build_gitignore(working_dir);
-            let hints = load_hint_files_with_limit(
-                working_dir,
-                &hints_filenames,
-                &ignore_patterns,
-                output_limit,
-            );
-            (!hints.is_empty()).then_some(hints)
-        } else {
-            self.hints
+        let prompt_parts = self
+            .prompt_extras
+            .iter()
+            .map(|(key, value)| (key.clone(), value.clone()))
+            .collect::<Vec<_>>();
+        let output_limit = self.manager.hint_output_limit(&prompt_parts, goose_mode);
+        let hints = match self.hint_source {
+            Some(HintSource::Snapshot(hints)) => Some(hints),
+            Some(HintSource::TopLevel(working_dir)) => {
+                let hints_filenames = get_context_filenames();
+                let ignore_patterns = build_gitignore(&working_dir);
+                let hints = load_hint_files_with_limit(
+                    &working_dir,
+                    &hints_filenames,
+                    &ignore_patterns,
+                    output_limit,
+                );
+                (!hints.is_empty()).then_some(hints)
+            }
+            Some(HintSource::Fresh(working_dir)) => {
+                let hints = self
+                    .manager
+                    .take_fresh_hint_snapshot(&working_dir, output_limit);
+                (!hints.is_empty()).then_some(hints)
+            }
+            None => None,
         };
 
         let context = SystemPromptContext {
@@ -217,9 +236,11 @@ impl PromptManager {
             // Use the fixed current date time so that prompt cache can be used.
             // Filtering to an hour to balance user time accuracy and multi session prompt cache hits.
             current_date_timestamp: Utc::now().format("%Y-%m-%d %H:00 %:z").to_string(),
-            subdirectory_hint_tracker: SubdirectoryHintTracker::new(),
-            last_hint_snapshot: None,
-            pending_hint_snapshot: None,
+            hint_state: Mutex::new(HintState {
+                subdirectory_hint_tracker: SubdirectoryHintTracker::new(),
+                last_hint_snapshot: None,
+                pending_hint_snapshot: None,
+            }),
         }
     }
 
@@ -229,9 +250,11 @@ impl PromptManager {
             system_prompt_override: None,
             system_prompt_extras: IndexMap::new(),
             current_date_timestamp: dt.format("%Y-%m-%d %H:%M:%S %:z").to_string(),
-            subdirectory_hint_tracker: SubdirectoryHintTracker::new(),
-            last_hint_snapshot: None,
-            pending_hint_snapshot: None,
+            hint_state: Mutex::new(HintState {
+                subdirectory_hint_tracker: SubdirectoryHintTracker::new(),
+                last_hint_snapshot: None,
+                pending_hint_snapshot: None,
+            }),
         }
     }
 
@@ -250,30 +273,38 @@ impl PromptManager {
         arguments: &Option<serde_json::Map<String, serde_json::Value>>,
         working_dir: &Path,
     ) {
-        self.subdirectory_hint_tracker
+        self.hint_state
+            .get_mut()
+            .expect("hint state mutex poisoned")
+            .subdirectory_hint_tracker
             .record_tool_arguments(arguments, working_dir);
     }
 
     pub fn load_subdirectory_hints(&mut self, working_dir: &Path) -> bool {
         let goose_mode = Config::global().get_goose_mode().unwrap_or_default();
         let output_limit = self.hint_output_limit(&[], goose_mode);
-        let snapshot = self
+        let state = self
+            .hint_state
+            .get_mut()
+            .expect("hint state mutex poisoned");
+        let snapshot = state
             .subdirectory_hint_tracker
             .load_prompt_snapshot(working_dir, output_limit);
-        let changed = self.last_hint_snapshot.as_ref() != Some(&snapshot);
-        self.pending_hint_snapshot = changed.then(|| (snapshot.clone(), output_limit));
-        self.last_hint_snapshot = Some(snapshot.clone());
+        let changed = state.last_hint_snapshot.as_ref() != Some(&snapshot);
+        state.pending_hint_snapshot = changed.then(|| (snapshot.clone(), output_limit));
+        state.last_hint_snapshot = Some(snapshot.clone());
         changed
     }
 
-    fn take_fresh_hint_snapshot(&mut self, working_dir: &Path, output_limit: usize) -> String {
-        let snapshot = match self.pending_hint_snapshot.take() {
+    fn take_fresh_hint_snapshot(&self, working_dir: &Path, output_limit: usize) -> String {
+        let mut state = self.hint_state.lock().expect("hint state mutex poisoned");
+        let snapshot = match state.pending_hint_snapshot.take() {
             Some((snapshot, pending_limit)) if pending_limit == output_limit => snapshot,
-            _ => self
+            _ => state
                 .subdirectory_hint_tracker
                 .load_prompt_snapshot(working_dir, output_limit),
         };
-        self.last_hint_snapshot = Some(snapshot.clone());
+        state.last_hint_snapshot = Some(snapshot.clone());
         snapshot
     }
 
@@ -326,10 +357,8 @@ impl PromptManager {
         working_dir: &Path,
         goose_mode: GooseMode,
     ) -> SystemPromptBuilder<'_, PromptManager> {
-        let output_limit = self.hint_output_limit(&[], goose_mode);
-        let snapshot = self.take_fresh_hint_snapshot(working_dir, output_limit);
         self.builder()
-            .with_hint_snapshot(snapshot)
+            .with_fresh_hints(working_dir)
             .with_goose_mode(goose_mode)
     }
 
@@ -349,8 +378,7 @@ impl PromptManager {
             extensions_info: vec![],
             prompt_extras: IndexMap::new(),
             subagents_enabled: false,
-            hints: None,
-            hints_working_dir: None,
+            hint_source: None,
             code_execution_mode: false,
             include_extensions: true,
             goose_mode: None,
@@ -631,6 +659,77 @@ mod tests {
         let caller_only = manager.builder().build();
         assert!(caller_only.contains("CALLER_HINTS"));
         assert!(!caller_only.contains("PROMPT_HINTS"));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn fresh_builder_uses_the_layout_and_files_present_at_build_time() {
+        let config_root = tempfile::tempdir().unwrap();
+        let _guard = env_lock::lock_env([
+            (
+                "GOOSE_PATH_ROOT",
+                Some(config_root.path().to_str().unwrap()),
+            ),
+            ("CONTEXT_FILE_NAMES", Some(r#"[".goosehints"]"#)),
+        ]);
+        let project = tempfile::tempdir().unwrap();
+        let hints_path = project.path().join(crate::hints::GOOSE_HINTS_FILENAME);
+        const MARKER: &str = "BOUNDARY_MARKER";
+        std::fs::write(&hints_path, MARKER).unwrap();
+        let hints_filenames = vec![crate::hints::GOOSE_HINTS_FILENAME.to_string()];
+        let ignore_patterns = build_gitignore(project.path());
+        let framing_bytes = load_hint_files_with_limit(
+            project.path(),
+            &hints_filenames,
+            &ignore_patterns,
+            MAX_HINT_OUTPUT_BYTES,
+        )
+        .len()
+            - MARKER.len();
+
+        let mut manager = PromptManager::new();
+        manager.add_system_prompt_extra("caller".to_string(), "CALLER_EXTRA".to_string());
+        let prompt_parts = [("operation".to_string(), "OPERATION_EXTRA".to_string())];
+        let output_limit = manager.hint_output_limit(&prompt_parts, GooseMode::Chat);
+        assert_eq!(output_limit, MAX_HINT_OUTPUT_BYTES - 4);
+
+        std::fs::write(&hints_path, "STALE_HINTS").unwrap();
+        let builder = manager.builder_with_fresh_hints(project.path(), GooseMode::Auto);
+        std::fs::write(
+            &hints_path,
+            format!(
+                "{}{}",
+                "x".repeat(output_limit - framing_bytes - MARKER.len()),
+                MARKER
+            ),
+        )
+        .unwrap();
+        let exact = builder
+            .with_prompt_extras(prompt_parts.clone())
+            .with_goose_mode(GooseMode::Chat)
+            .build();
+        assert!(exact.contains(MARKER));
+        assert!(!exact.contains("STALE_HINTS"));
+        assert!(exact.contains("CALLER_EXTRA"));
+        assert!(exact.contains("OPERATION_EXTRA"));
+
+        let builder = manager.builder_with_fresh_hints(project.path(), GooseMode::Auto);
+        std::fs::write(
+            &hints_path,
+            format!(
+                "{}{}",
+                "x".repeat(output_limit + 1 - framing_bytes - MARKER.len()),
+                MARKER
+            ),
+        )
+        .unwrap();
+        let oversized = builder
+            .with_prompt_extras(prompt_parts)
+            .with_goose_mode(GooseMode::Chat)
+            .build();
+        assert!(!oversized.contains(MARKER));
+        assert!(oversized.contains("CALLER_EXTRA"));
+        assert!(oversized.contains("OPERATION_EXTRA"));
     }
 
     #[test]

--- a/crates/goose/src/agents/prompt_manager.rs
+++ b/crates/goose/src/agents/prompt_manager.rs
@@ -236,7 +236,7 @@ impl PromptManager {
     pub fn load_subdirectory_hints(&mut self, working_dir: &Path) -> bool {
         let snapshot = self.subdirectory_hint_tracker.load_snapshot(working_dir);
         let changed = self.last_hint_snapshot.as_ref() != Some(&snapshot);
-        self.pending_hint_snapshot = Some(snapshot);
+        self.pending_hint_snapshot = changed.then_some(snapshot);
         changed
     }
 
@@ -424,6 +424,14 @@ mod tests {
             .build();
         assert!(refreshed.contains("ROOT_V3"));
         assert!(refreshed.contains("NESTED_HINT"));
+
+        assert!(!manager.load_subdirectory_hints(project.path()));
+        std::fs::write(&root_hints, "ROOT_V4").unwrap();
+        let reread = manager
+            .builder_with_fresh_hints(project.path(), GooseMode::Auto)
+            .build();
+        assert!(reread.contains("ROOT_V4"));
+        assert!(!reread.contains("ROOT_V3"));
     }
 
     #[test]

--- a/crates/goose/src/agents/prompt_manager.rs
+++ b/crates/goose/src/agents/prompt_manager.rs
@@ -267,7 +267,7 @@ impl PromptManager {
         changed
     }
 
-    fn reserved_hint_separator_bytes(
+    pub(crate) fn reserved_hint_separator_bytes(
         &self,
         has_prompt_parts: bool,
         goose_mode: GooseMode,
@@ -276,7 +276,8 @@ impl PromptManager {
             .system_prompt_extras
             .keys()
             .any(|key| !self.generated_subdirectory_hint_keys.contains(key));
-        let boundary_count = usize::from(has_prompt_parts || has_caller_owned_extra)
+        let boundary_count = usize::from(has_prompt_parts)
+            + usize::from(has_caller_owned_extra)
             + usize::from(goose_mode == GooseMode::Chat);
         boundary_count * HINT_EXTRA_SEPARATOR_BYTES
     }

--- a/crates/goose/src/agents/prompt_manager.rs
+++ b/crates/goose/src/agents/prompt_manager.rs
@@ -4,7 +4,7 @@ use chrono::Utc;
 use indexmap::IndexMap;
 use serde::Serialize;
 use serde_json::Value;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use crate::agents::{extension::ExtensionInfo, moim};
 #[cfg(test)]
@@ -27,6 +27,7 @@ pub struct PromptManager {
     system_prompt_extras: IndexMap<String, String>,
     current_date_timestamp: String,
     subdirectory_hint_tracker: SubdirectoryHintTracker,
+    generated_subdirectory_hint_keys: HashSet<String>,
 }
 
 fn trailing_hint_separator_bytes(goose_mode: GooseMode) -> usize {
@@ -209,6 +210,7 @@ impl PromptManager {
             // Filtering to an hour to balance user time accuracy and multi session prompt cache hits.
             current_date_timestamp: Utc::now().format("%Y-%m-%d %H:00 %:z").to_string(),
             subdirectory_hint_tracker: SubdirectoryHintTracker::new(),
+            generated_subdirectory_hint_keys: HashSet::new(),
         }
     }
 
@@ -219,16 +221,19 @@ impl PromptManager {
             system_prompt_extras: IndexMap::new(),
             current_date_timestamp: dt.format("%Y-%m-%d %H:%M:%S %:z").to_string(),
             subdirectory_hint_tracker: SubdirectoryHintTracker::new(),
+            generated_subdirectory_hint_keys: HashSet::new(),
         }
     }
 
     /// Add an additional instruction to the system prompt with a key
     /// Using the same key will replace the previous instruction
     pub fn add_system_prompt_extra(&mut self, key: String, instruction: String) {
+        self.generated_subdirectory_hint_keys.remove(&key);
         self.system_prompt_extras.insert(key, instruction);
     }
 
     pub fn remove_system_prompt_extra(&mut self, key: &str) {
+        self.generated_subdirectory_hint_keys.remove(key);
         self.system_prompt_extras.shift_remove(key);
     }
 
@@ -250,14 +255,21 @@ impl PromptManager {
         let previous_hints: Vec<_> = self
             .system_prompt_extras
             .iter()
-            .filter(|(key, _)| key.starts_with("subdir_hints:"))
+            .filter(|(key, _)| self.generated_subdirectory_hint_keys.contains(*key))
             .map(|(key, value)| (key.clone(), value.clone()))
             .collect();
-        let changed = previous_hints != hints;
 
         self.system_prompt_extras
-            .retain(|key, _| !key.starts_with("subdir_hints:"));
-        for (key, content) in hints {
+            .retain(|key, _| !self.generated_subdirectory_hint_keys.contains(key));
+        self.generated_subdirectory_hint_keys.clear();
+        let applied_hints: Vec<_> = hints
+            .into_iter()
+            .filter(|(key, _)| !self.system_prompt_extras.contains_key(key))
+            .collect();
+        let changed = previous_hints != applied_hints;
+
+        for (key, content) in applied_hints {
+            self.generated_subdirectory_hint_keys.insert(key.clone());
             self.system_prompt_extras.insert(key, content);
         }
         changed
@@ -403,6 +415,70 @@ mod tests {
 
         assert!(with_contribution.contains("temporary instruction"));
         assert!(!without_contribution.contains("temporary instruction"));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn hint_refresh_preserves_caller_owned_keys_and_removes_stale_generated_keys() {
+        let config_root = tempfile::tempdir().unwrap();
+        let _guard = env_lock::lock_env([
+            (
+                "GOOSE_PATH_ROOT",
+                Some(config_root.path().to_str().unwrap()),
+            ),
+            ("CONTEXT_FILE_NAMES", Some(r#"[".goosehints"]"#)),
+        ]);
+        let project = tempfile::tempdir().unwrap();
+        let first = project.path().join("first");
+        let second = project.path().join("second");
+        fs::create_dir(&first).unwrap();
+        fs::create_dir(&second).unwrap();
+        let first_hints = first.join(crate::hints::GOOSE_HINTS_FILENAME);
+        let second_hints = second.join(crate::hints::GOOSE_HINTS_FILENAME);
+        fs::write(&first_hints, "first generated hints").unwrap();
+        fs::write(&second_hints, "second generated hints").unwrap();
+
+        let mut manager = PromptManager::new();
+        manager.add_system_prompt_extra(
+            "subdir_hints:caller".to_string(),
+            "caller namespace content".to_string(),
+        );
+        for path in ["first/file.rs", "second/file.rs"] {
+            let arguments = serde_json::json!({ "path": path }).as_object().cloned();
+            manager.record_tool_arguments(&arguments, project.path());
+        }
+        assert!(manager.load_subdirectory_hints(project.path()));
+
+        let first_key = format!("subdir_hints:{}", first.canonicalize().unwrap().display());
+        let second_key = format!("subdir_hints:{}", second.canonicalize().unwrap().display());
+        assert!(manager
+            .generated_subdirectory_hint_keys
+            .contains(&first_key));
+        assert!(manager
+            .generated_subdirectory_hint_keys
+            .contains(&second_key));
+
+        manager.add_system_prompt_extra(first_key.clone(), "caller override".to_string());
+        fs::remove_file(first_hints).unwrap();
+        fs::remove_file(second_hints).unwrap();
+        assert!(manager.load_subdirectory_hints(project.path()));
+
+        assert_eq!(
+            manager
+                .system_prompt_extras
+                .get("subdir_hints:caller")
+                .map(String::as_str),
+            Some("caller namespace content")
+        );
+        assert_eq!(
+            manager
+                .system_prompt_extras
+                .get(&first_key)
+                .map(String::as_str),
+            Some("caller override")
+        );
+        assert!(!manager.system_prompt_extras.contains_key(&second_key));
+        assert!(manager.generated_subdirectory_hint_keys.is_empty());
     }
 
     #[test]

--- a/crates/goose/src/agents/prompt_manager.rs
+++ b/crates/goose/src/agents/prompt_manager.rs
@@ -1,43 +1,30 @@
 #[cfg(test)]
-use crate::hints::load_hint_files;
-#[cfg(test)]
 use chrono::DateTime;
 use chrono::Utc;
 use indexmap::IndexMap;
 use serde::Serialize;
 use serde_json::Value;
 use std::collections::HashMap;
-use std::sync::Mutex;
 
 use crate::agents::{extension::ExtensionInfo, moim};
-use crate::hints::load_hints::{build_gitignore, load_hint_files_with_limit};
-use crate::hints::{get_context_filenames, SubdirectoryHintTracker, MAX_HINT_OUTPUT_BYTES};
+use crate::hints::load_hints::build_gitignore;
+use crate::hints::{
+    get_context_filenames, load_hint_files, SubdirectoryHintTracker, MAX_HINT_OUTPUT_BYTES,
+};
 use crate::{
     config::{Config, GooseMode},
     prompt_template,
     utils::sanitize_unicode_tags,
 };
-use std::path::{Path, PathBuf};
-
-const PROMPT_EXTRA_SEPARATOR: &str = "\n\n";
+use std::path::Path;
 
 pub struct PromptManager {
     system_prompt_override: Option<String>,
     system_prompt_extras: IndexMap<String, String>,
     current_date_timestamp: String,
-    hint_state: Mutex<HintState>,
-}
-
-struct HintState {
     subdirectory_hint_tracker: SubdirectoryHintTracker,
     last_hint_snapshot: Option<String>,
-    pending_hint_snapshot: Option<(String, usize)>,
-}
-
-enum HintSource {
-    Snapshot(String),
-    TopLevel(PathBuf),
-    Fresh(PathBuf),
+    pending_hint_snapshot: Option<String>,
 }
 
 impl Default for PromptManager {
@@ -65,7 +52,7 @@ pub struct SystemPromptBuilder<'a, M> {
     extensions_info: Vec<ExtensionInfo>,
     prompt_extras: IndexMap<String, String>,
     subagents_enabled: bool,
-    hint_source: Option<HintSource>,
+    hints: Option<String>,
     code_execution_mode: bool,
     include_extensions: bool,
     goose_mode: Option<GooseMode>,
@@ -103,17 +90,17 @@ impl<'a> SystemPromptBuilder<'a, PromptManager> {
     }
 
     pub fn with_hints(mut self, working_dir: &Path) -> Self {
-        self.hint_source = Some(HintSource::TopLevel(working_dir.to_path_buf()));
+        let hints = load_hint_files(
+            working_dir,
+            &get_context_filenames(),
+            &build_gitignore(working_dir),
+        );
+        self.hints = (!hints.is_empty()).then_some(hints);
         self
     }
 
     fn with_hint_snapshot(mut self, hints: String) -> Self {
-        self.hint_source = (!hints.is_empty()).then_some(HintSource::Snapshot(hints));
-        self
-    }
-
-    fn with_fresh_hints(mut self, working_dir: &Path) -> Self {
-        self.hint_source = Some(HintSource::Fresh(working_dir.to_path_buf()));
+        self.hints = (!hints.is_empty()).then_some(hints);
         self
     }
 
@@ -145,34 +132,6 @@ impl<'a> SystemPromptBuilder<'a, PromptManager> {
             .goose_mode
             .unwrap_or_else(|| Config::global().get_goose_mode().unwrap_or_default());
 
-        let prompt_parts = self
-            .prompt_extras
-            .iter()
-            .map(|(key, value)| (key.clone(), value.clone()))
-            .collect::<Vec<_>>();
-        let output_limit = self.manager.hint_output_limit(&prompt_parts, goose_mode);
-        let hints = match self.hint_source {
-            Some(HintSource::Snapshot(hints)) => Some(hints),
-            Some(HintSource::TopLevel(working_dir)) => {
-                let hints_filenames = get_context_filenames();
-                let ignore_patterns = build_gitignore(&working_dir);
-                let hints = load_hint_files_with_limit(
-                    &working_dir,
-                    &hints_filenames,
-                    &ignore_patterns,
-                    output_limit,
-                );
-                (!hints.is_empty()).then_some(hints)
-            }
-            Some(HintSource::Fresh(working_dir)) => {
-                let hints = self
-                    .manager
-                    .take_fresh_hint_snapshot(&working_dir, output_limit);
-                (!hints.is_empty()).then_some(hints)
-            }
-            None => None,
-        };
-
         let context = SystemPromptContext {
             extensions: sanitized_extensions_info,
             current_date_time: self.manager.current_date_timestamp.clone(),
@@ -197,9 +156,8 @@ impl<'a> SystemPromptBuilder<'a, PromptManager> {
         let mut system_prompt_extras = self.manager.system_prompt_extras.clone();
         system_prompt_extras.extend(self.prompt_extras);
 
-        // Add hints if provided
-        if let Some(hints) = hints {
-            system_prompt_extras.shift_remove("hints");
+        let has_generated_hints = self.hints.is_some();
+        if let Some(hints) = self.hints {
             system_prompt_extras.insert("hints".to_string(), hints);
         }
 
@@ -215,14 +173,20 @@ impl<'a> SystemPromptBuilder<'a, PromptManager> {
             base_prompt
         } else {
             let sanitized_system_prompt_extras: Vec<String> = system_prompt_extras
-                .into_values()
-                .map(|extra| sanitize_unicode_tags(&extra))
+                .into_iter()
+                .map(|(key, extra)| {
+                    let mut extra = sanitize_unicode_tags(&extra);
+                    if has_generated_hints && key == "hints" {
+                        extra.truncate(extra.floor_char_boundary(MAX_HINT_OUTPUT_BYTES));
+                    }
+                    extra
+                })
                 .collect();
 
             format!(
                 "{}\n\n# Additional Instructions:\n\n{}",
                 base_prompt,
-                sanitized_system_prompt_extras.join(PROMPT_EXTRA_SEPARATOR)
+                sanitized_system_prompt_extras.join("\n\n")
             )
         }
     }
@@ -236,11 +200,9 @@ impl PromptManager {
             // Use the fixed current date time so that prompt cache can be used.
             // Filtering to an hour to balance user time accuracy and multi session prompt cache hits.
             current_date_timestamp: Utc::now().format("%Y-%m-%d %H:00 %:z").to_string(),
-            hint_state: Mutex::new(HintState {
-                subdirectory_hint_tracker: SubdirectoryHintTracker::new(),
-                last_hint_snapshot: None,
-                pending_hint_snapshot: None,
-            }),
+            subdirectory_hint_tracker: SubdirectoryHintTracker::new(),
+            last_hint_snapshot: None,
+            pending_hint_snapshot: None,
         }
     }
 
@@ -250,11 +212,9 @@ impl PromptManager {
             system_prompt_override: None,
             system_prompt_extras: IndexMap::new(),
             current_date_timestamp: dt.format("%Y-%m-%d %H:%M:%S %:z").to_string(),
-            hint_state: Mutex::new(HintState {
-                subdirectory_hint_tracker: SubdirectoryHintTracker::new(),
-                last_hint_snapshot: None,
-                pending_hint_snapshot: None,
-            }),
+            subdirectory_hint_tracker: SubdirectoryHintTracker::new(),
+            last_hint_snapshot: None,
+            pending_hint_snapshot: None,
         }
     }
 
@@ -273,58 +233,27 @@ impl PromptManager {
         arguments: &Option<serde_json::Map<String, serde_json::Value>>,
         working_dir: &Path,
     ) {
-        self.hint_state
-            .get_mut()
-            .expect("hint state mutex poisoned")
-            .subdirectory_hint_tracker
+        self.subdirectory_hint_tracker
             .record_tool_arguments(arguments, working_dir);
     }
 
     pub fn load_subdirectory_hints(&mut self, working_dir: &Path) -> bool {
-        let goose_mode = Config::global().get_goose_mode().unwrap_or_default();
-        let output_limit = self.hint_output_limit(&[], goose_mode);
-        let state = self
-            .hint_state
-            .get_mut()
-            .expect("hint state mutex poisoned");
-        let snapshot = state
+        let snapshot = self
             .subdirectory_hint_tracker
-            .load_prompt_snapshot(working_dir, output_limit);
-        let changed = state.last_hint_snapshot.as_ref() != Some(&snapshot);
-        state.pending_hint_snapshot = changed.then(|| (snapshot.clone(), output_limit));
-        state.last_hint_snapshot = Some(snapshot.clone());
+            .load_prompt_snapshot(working_dir, MAX_HINT_OUTPUT_BYTES);
+        let changed = self.last_hint_snapshot.as_ref() != Some(&snapshot);
+        self.pending_hint_snapshot = changed.then(|| snapshot.clone());
+        self.last_hint_snapshot = Some(snapshot);
         changed
     }
 
-    fn take_fresh_hint_snapshot(&self, working_dir: &Path, output_limit: usize) -> String {
-        let mut state = self.hint_state.lock().expect("hint state mutex poisoned");
-        let snapshot = match state.pending_hint_snapshot.take() {
-            Some((snapshot, pending_limit)) if pending_limit == output_limit => snapshot,
-            _ => state
-                .subdirectory_hint_tracker
-                .load_prompt_snapshot(working_dir, output_limit),
-        };
-        state.last_hint_snapshot = Some(snapshot.clone());
+    fn take_fresh_hint_snapshot(&mut self, working_dir: &Path) -> String {
+        let snapshot = self.pending_hint_snapshot.take().unwrap_or_else(|| {
+            self.subdirectory_hint_tracker
+                .load_prompt_snapshot(working_dir, MAX_HINT_OUTPUT_BYTES)
+        });
+        self.last_hint_snapshot = Some(snapshot.clone());
         snapshot
-    }
-
-    pub(crate) fn hint_output_limit(
-        &self,
-        prompt_parts: &[(String, String)],
-        goose_mode: GooseMode,
-    ) -> usize {
-        let mut extras = self.system_prompt_extras.clone();
-        extras.extend(prompt_parts.iter().cloned());
-        extras.shift_remove("hints");
-        extras.insert("hints".to_string(), String::new());
-        if goose_mode == GooseMode::Chat {
-            extras.insert("chat_mode".to_string(), String::new());
-        }
-
-        let hint_index = extras.get_index_of("hints").unwrap();
-        let adjacent_separators =
-            usize::from(hint_index > 0) + usize::from(hint_index + 1 < extras.len());
-        MAX_HINT_OUTPUT_BYTES.saturating_sub(adjacent_separators * PROMPT_EXTRA_SEPARATOR.len())
     }
 
     pub fn build_system_prompt(
@@ -333,8 +262,7 @@ impl PromptManager {
         prompt_parts: Vec<(String, String)>,
         goose_mode: GooseMode,
     ) -> String {
-        let output_limit = self.hint_output_limit(&prompt_parts, goose_mode);
-        let snapshot = self.take_fresh_hint_snapshot(working_dir, output_limit);
+        let snapshot = self.take_fresh_hint_snapshot(working_dir);
         self.build_system_prompt_from_snapshot(prompt_parts, goose_mode, snapshot)
     }
 
@@ -357,8 +285,9 @@ impl PromptManager {
         working_dir: &Path,
         goose_mode: GooseMode,
     ) -> SystemPromptBuilder<'_, PromptManager> {
+        let snapshot = self.take_fresh_hint_snapshot(working_dir);
         self.builder()
-            .with_fresh_hints(working_dir)
+            .with_hint_snapshot(snapshot)
             .with_goose_mode(goose_mode)
     }
 
@@ -378,7 +307,7 @@ impl PromptManager {
             extensions_info: vec![],
             prompt_extras: IndexMap::new(),
             subagents_enabled: false,
-            hint_source: None,
+            hints: None,
             code_execution_mode: false,
             include_extensions: true,
             goose_mode: None,
@@ -584,86 +513,32 @@ mod tests {
     }
 
     #[test]
-    #[serial_test::serial]
-    fn public_with_hints_uses_the_final_prompt_layout_budget() {
-        let config_root = tempfile::tempdir().unwrap();
-        let _guard = env_lock::lock_env([
-            (
-                "GOOSE_PATH_ROOT",
-                Some(config_root.path().to_str().unwrap()),
-            ),
-            ("CONTEXT_FILE_NAMES", Some(r#"[".goosehints"]"#)),
-        ]);
-        let project = tempfile::tempdir().unwrap();
-        let hints_path = project.path().join(crate::hints::GOOSE_HINTS_FILENAME);
-        const MARKER: &str = "BOUNDARY_MARKER";
-        std::fs::write(&hints_path, MARKER).unwrap();
-        let hints_filenames = vec![crate::hints::GOOSE_HINTS_FILENAME.to_string()];
-        let ignore_patterns = build_gitignore(project.path());
-        let framing_bytes = load_hint_files_with_limit(
-            project.path(),
-            &hints_filenames,
-            &ignore_patterns,
-            MAX_HINT_OUTPUT_BYTES,
-        )
-        .len()
-            - MARKER.len();
-
+    fn generated_hint_snapshot_is_sanitized_and_truncated_at_a_utf8_boundary() {
         let mut manager = PromptManager::new();
-        manager.add_system_prompt_extra("hints".to_string(), "CALLER_HINTS".to_string());
-        manager.add_system_prompt_extra("caller".to_string(), "CALLER_EXTRA".to_string());
-        let output_limit = manager.hint_output_limit(
-            &[("hints".to_string(), "PROMPT_HINTS".to_string())],
-            GooseMode::Chat,
-        );
-        assert_eq!(output_limit, MAX_HINT_OUTPUT_BYTES - 4);
-        std::fs::write(
-            &hints_path,
+        manager.set_system_prompt_override("base".to_string());
+        for hints in [
             format!(
                 "{}{}",
-                "x".repeat(output_limit - framing_bytes - MARKER.len()),
-                MARKER
+                "\u{0344}".repeat(MAX_HINT_OUTPUT_BYTES / 2),
+                "\u{E0041}"
             ),
-        )
-        .unwrap();
+            sanitize_unicode_tags(&"\u{00c5}\u{E0041}\u{0323}".repeat(MAX_HINT_OUTPUT_BYTES / 4)),
+        ] {
+            let prompt = manager.builder().with_hint_snapshot(hints).build();
+            let output = prompt
+                .strip_prefix("base\n\n# Additional Instructions:\n\n")
+                .unwrap();
 
-        let exact = manager
-            .builder()
-            .with_hints(project.path())
-            .with_prompt_extras([("hints".to_string(), "PROMPT_HINTS".to_string())])
-            .with_goose_mode(GooseMode::Chat)
-            .build();
-        assert!(exact.contains(MARKER));
-        assert!(exact.contains("CALLER_EXTRA"));
-        assert!(!exact.contains("CALLER_HINTS"));
-        assert!(!exact.contains("PROMPT_HINTS"));
-
-        std::fs::write(
-            &hints_path,
-            format!(
-                "{}{}",
-                "x".repeat(output_limit + 1 - framing_bytes - MARKER.len()),
-                MARKER
-            ),
-        )
-        .unwrap();
-        let oversized = manager
-            .builder()
-            .with_hints(project.path())
-            .with_prompt_extras([("hints".to_string(), "PROMPT_HINTS".to_string())])
-            .with_goose_mode(GooseMode::Chat)
-            .build();
-        assert!(!oversized.contains(MARKER));
-        assert!(oversized.contains("PROMPT_HINTS"));
-
-        let caller_only = manager.builder().build();
-        assert!(caller_only.contains("CALLER_HINTS"));
-        assert!(!caller_only.contains("PROMPT_HINTS"));
+            assert!(output.len() <= MAX_HINT_OUTPUT_BYTES);
+            assert!(output.len() >= MAX_HINT_OUTPUT_BYTES - 3);
+            assert!(!output.contains('\u{E0041}'));
+            assert_eq!(output, sanitize_unicode_tags(output));
+        }
     }
 
     #[test]
     #[serial_test::serial]
-    fn fresh_builder_uses_the_layout_and_files_present_at_build_time() {
+    fn hint_snapshot_budget_is_independent_of_other_prompt_extras() {
         let config_root = tempfile::tempdir().unwrap();
         let _guard = env_lock::lock_env([
             (
@@ -676,60 +551,45 @@ mod tests {
         let hints_path = project.path().join(crate::hints::GOOSE_HINTS_FILENAME);
         const MARKER: &str = "BOUNDARY_MARKER";
         std::fs::write(&hints_path, MARKER).unwrap();
-        let hints_filenames = vec![crate::hints::GOOSE_HINTS_FILENAME.to_string()];
-        let ignore_patterns = build_gitignore(project.path());
-        let framing_bytes = load_hint_files_with_limit(
+        let framing_bytes = load_hint_files(
             project.path(),
-            &hints_filenames,
-            &ignore_patterns,
-            MAX_HINT_OUTPUT_BYTES,
+            &get_context_filenames(),
+            &build_gitignore(project.path()),
         )
         .len()
             - MARKER.len();
+        std::fs::write(
+            &hints_path,
+            format!(
+                "{}{}",
+                "x".repeat(MAX_HINT_OUTPUT_BYTES - framing_bytes - MARKER.len()),
+                MARKER
+            ),
+        )
+        .unwrap();
 
         let mut manager = PromptManager::new();
+        manager.add_system_prompt_extra("hints".to_string(), "CALLER_HINTS".to_string());
         manager.add_system_prompt_extra("caller".to_string(), "CALLER_EXTRA".to_string());
-        let prompt_parts = [("operation".to_string(), "OPERATION_EXTRA".to_string())];
-        let output_limit = manager.hint_output_limit(&prompt_parts, GooseMode::Chat);
-        assert_eq!(output_limit, MAX_HINT_OUTPUT_BYTES - 4);
+        for mode in [GooseMode::Auto, GooseMode::Chat] {
+            let prompt = manager
+                .builder()
+                .with_hints(project.path())
+                .with_prompt_extras([("operation".to_string(), "OPERATION_EXTRA".to_string())])
+                .with_goose_mode(mode)
+                .build();
+            assert!(prompt.contains(MARKER));
+            assert!(prompt.contains("CALLER_EXTRA"));
+            assert!(prompt.contains("OPERATION_EXTRA"));
+            assert!(!prompt.contains("CALLER_HINTS"));
+        }
+        assert!(manager.builder().build().contains("CALLER_HINTS"));
 
-        std::fs::write(&hints_path, "STALE_HINTS").unwrap();
-        let builder = manager.builder_with_fresh_hints(project.path(), GooseMode::Auto);
-        std::fs::write(
-            &hints_path,
-            format!(
-                "{}{}",
-                "x".repeat(output_limit - framing_bytes - MARKER.len()),
-                MARKER
-            ),
-        )
-        .unwrap();
-        let exact = builder
-            .with_prompt_extras(prompt_parts.clone())
-            .with_goose_mode(GooseMode::Chat)
-            .build();
-        assert!(exact.contains(MARKER));
-        assert!(!exact.contains("STALE_HINTS"));
-        assert!(exact.contains("CALLER_EXTRA"));
-        assert!(exact.contains("OPERATION_EXTRA"));
-
-        let builder = manager.builder_with_fresh_hints(project.path(), GooseMode::Auto);
-        std::fs::write(
-            &hints_path,
-            format!(
-                "{}{}",
-                "x".repeat(output_limit + 1 - framing_bytes - MARKER.len()),
-                MARKER
-            ),
-        )
-        .unwrap();
-        let oversized = builder
-            .with_prompt_extras(prompt_parts)
-            .with_goose_mode(GooseMode::Chat)
-            .build();
-        assert!(!oversized.contains(MARKER));
-        assert!(oversized.contains("CALLER_EXTRA"));
-        assert!(oversized.contains("OPERATION_EXTRA"));
+        let builder = manager.builder().with_hints(project.path());
+        std::fs::write(&hints_path, "LATER_CONTENT").unwrap();
+        let captured = builder.build();
+        assert!(captured.contains(MARKER));
+        assert!(!captured.contains("LATER_CONTENT"));
     }
 
     #[test]

--- a/crates/goose/src/agents/prompt_manager.rs
+++ b/crates/goose/src/agents/prompt_manager.rs
@@ -242,9 +242,11 @@ impl PromptManager {
             .subdirectory_hint_tracker
             .load_prompt_snapshot(working_dir, MAX_HINT_OUTPUT_BYTES);
         let changed = self.last_hint_snapshot.as_ref() != Some(&snapshot);
-        self.pending_hint_snapshot = changed.then(|| snapshot.clone());
+        if changed {
+            self.pending_hint_snapshot = Some(snapshot.clone());
+        }
         self.last_hint_snapshot = Some(snapshot);
-        changed
+        self.pending_hint_snapshot.is_some()
     }
 
     fn take_fresh_hint_snapshot(&mut self, working_dir: &Path) -> String {
@@ -473,6 +475,52 @@ mod tests {
             .build()
             .contains("NESTED_HINT"));
         assert!(!manager.load_subdirectory_hints(project.path()));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn unchanged_hint_refresh_preserves_pending_snapshot_until_consumed() {
+        let config_root = tempfile::tempdir().unwrap();
+        let _guard = env_lock::lock_env([
+            (
+                "GOOSE_PATH_ROOT",
+                Some(config_root.path().to_str().unwrap()),
+            ),
+            ("CONTEXT_FILE_NAMES", Some(r#"[".goosehints"]"#)),
+        ]);
+        let project = tempfile::tempdir().unwrap();
+        let root_hints = project.path().join(crate::hints::GOOSE_HINTS_FILENAME);
+        std::fs::write(&root_hints, "ROOT_V1").unwrap();
+        let mut manager = PromptManager::new();
+        assert!(manager
+            .builder_with_fresh_hints(project.path(), GooseMode::Auto)
+            .build()
+            .contains("ROOT_V1"));
+
+        std::fs::write(&root_hints, "ROOT_V2").unwrap();
+        assert!(manager.load_subdirectory_hints(project.path()));
+        assert!(manager.load_subdirectory_hints(project.path()));
+        std::fs::write(&root_hints, "ROOT_V3").unwrap();
+        let staged = manager
+            .builder_with_fresh_hints(project.path(), GooseMode::Auto)
+            .build();
+        assert!(staged.contains("ROOT_V2"));
+        assert!(!staged.contains("ROOT_V3"));
+
+        assert!(manager.load_subdirectory_hints(project.path()));
+        std::fs::write(&root_hints, "ROOT_V4").unwrap();
+        assert!(manager.load_subdirectory_hints(project.path()));
+        let replaced = manager.build_system_prompt(project.path(), Vec::new(), GooseMode::Auto);
+        assert!(replaced.contains("ROOT_V4"));
+        assert!(!replaced.contains("ROOT_V3"));
+        assert!(!manager.load_subdirectory_hints(project.path()));
+
+        std::fs::write(&root_hints, "ROOT_V5").unwrap();
+        let fresh = manager
+            .builder_with_fresh_hints(project.path(), GooseMode::Auto)
+            .build();
+        assert!(fresh.contains("ROOT_V5"));
+        assert!(!fresh.contains("ROOT_V4"));
     }
 
     #[test]

--- a/crates/goose/src/agents/reply_parts.rs
+++ b/crates/goose/src/agents/reply_parts.rs
@@ -225,12 +225,11 @@ impl Agent {
             self.tool_inspection_manager.apply_tool_annotations(&tools);
         }
 
-        let prompt_manager = self.prompt_manager.lock().await;
+        let mut prompt_manager = self.prompt_manager.lock().await;
         let system_prompt = prompt_manager
-            .builder()
+            .builder_with_fresh_hints(working_dir)
             .with_extensions(extensions_info.into_iter())
             .with_code_execution_mode(code_execution_active)
-            .with_hints(working_dir)
             .with_goose_mode(goose_mode)
             .build();
 

--- a/crates/goose/src/agents/reply_parts.rs
+++ b/crates/goose/src/agents/reply_parts.rs
@@ -227,10 +227,9 @@ impl Agent {
 
         let mut prompt_manager = self.prompt_manager.lock().await;
         let system_prompt = prompt_manager
-            .builder_with_fresh_hints(working_dir)
+            .builder_with_fresh_hints(working_dir, goose_mode)
             .with_extensions(extensions_info.into_iter())
             .with_code_execution_mode(code_execution_active)
-            .with_goose_mode(goose_mode)
             .build();
 
         let (tools, toolshim_tools, system_prompt) =

--- a/crates/goose/src/agents/state_machine/inference_preparation.rs
+++ b/crates/goose/src/agents/state_machine/inference_preparation.rs
@@ -39,7 +39,7 @@ fn reconstructed_hint_snapshot_with_hook(
             }
         }
     }
-    hints.load_snapshot_with_hook(working_dir, after_top_level_read)
+    hints.load_prompt_snapshot_with_hook(working_dir, after_top_level_read)
 }
 
 pub struct GooseInferenceRequestPreparer<'a> {
@@ -114,6 +114,7 @@ impl InferenceRequestPreparer<Session> for GooseInferenceRequestPreparer<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::hints::load_hints::PROMPT_HINT_BOUNDARY_BYTES;
     use crate::hints::{GOOSE_HINTS_FILENAME, MAX_HINT_OUTPUT_BYTES};
     use rmcp::model::CallToolRequestParams;
     use std::fs;
@@ -152,6 +153,79 @@ mod tests {
         assert!(prompt.contains("NESTED_MARKER"));
         assert!(!prompt.contains("ROOT_V2"));
         assert!(!prompt.contains("ROOT_V3"));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn prompt_snapshots_reserve_both_adjacent_separators() {
+        let config_root = tempfile::tempdir().unwrap();
+        let _guard = env_lock::lock_env([
+            (
+                "GOOSE_PATH_ROOT",
+                Some(config_root.path().to_str().unwrap()),
+            ),
+            ("CONTEXT_FILE_NAMES", Some(r#"[".goosehints"]"#)),
+        ]);
+        let project = tempfile::tempdir().unwrap();
+        let hints_path = project.path().join(GOOSE_HINTS_FILENAME);
+        const MARKER: &str = "BOUNDARY_MARKER";
+        fs::write(&hints_path, MARKER).unwrap();
+        let framing_bytes = SubdirectoryHintTracker::new()
+            .load_snapshot(project.path())
+            .len()
+            - MARKER.len();
+        let allowed_content_bytes =
+            MAX_HINT_OUTPUT_BYTES - PROMPT_HINT_BOUNDARY_BYTES - framing_bytes;
+        fs::write(
+            &hints_path,
+            format!(
+                "{}{}",
+                "x".repeat(allowed_content_bytes - MARKER.len()),
+                MARKER
+            ),
+        )
+        .unwrap();
+
+        let conversation = Conversation::new_unvalidated(Vec::<Message>::new());
+        let snapshot = reconstructed_hint_snapshot(&conversation, project.path());
+        assert_eq!(
+            snapshot.len() + PROMPT_HINT_BOUNDARY_BYTES,
+            MAX_HINT_OUTPUT_BYTES
+        );
+
+        let timestamp = chrono::DateTime::<chrono::Utc>::from_timestamp(0, 0).unwrap();
+        let mut state_machine = PromptManager::with_timestamp(timestamp);
+        state_machine.set_system_prompt_override("base".to_string());
+        state_machine.add_system_prompt_extra("caller".to_string(), "CALLER".to_string());
+        let state_machine_prompt =
+            state_machine.build_system_prompt_from_snapshot(Vec::new(), GooseMode::Chat, snapshot);
+        assert!(state_machine_prompt.contains(MARKER));
+
+        let mut legacy = PromptManager::with_timestamp(timestamp);
+        legacy.set_system_prompt_override("base".to_string());
+        legacy.add_system_prompt_extra("caller".to_string(), "CALLER".to_string());
+        let legacy_prompt = legacy
+            .builder_with_fresh_hints(project.path(), GooseMode::Chat)
+            .build();
+        assert_eq!(legacy_prompt, state_machine_prompt);
+
+        fs::write(
+            &hints_path,
+            format!(
+                "{}{}",
+                "x".repeat(allowed_content_bytes + 1 - MARKER.len()),
+                MARKER
+            ),
+        )
+        .unwrap();
+        assert!(reconstructed_hint_snapshot(&conversation, project.path()).is_empty());
+        let mut legacy = PromptManager::with_timestamp(timestamp);
+        legacy.set_system_prompt_override("base".to_string());
+        legacy.add_system_prompt_extra("caller".to_string(), "CALLER".to_string());
+        assert!(!legacy
+            .builder_with_fresh_hints(project.path(), GooseMode::Chat)
+            .build()
+            .contains(MARKER));
     }
 
     #[test]

--- a/crates/goose/src/agents/state_machine/inference_preparation.rs
+++ b/crates/goose/src/agents/state_machine/inference_preparation.rs
@@ -4,7 +4,9 @@
 use crate::agents::ExtensionManager;
 use crate::agents::PromptManager;
 use crate::config::GooseMode;
-use crate::hints::load_hints::{HintSnapshot, SubdirectoryHintTracker, HINT_EXTRA_SEPARATOR_BYTES};
+use crate::hints::load_hints::{
+    HintOutputReservation, HintSnapshot, SubdirectoryHintTracker, HINT_EXTRA_SEPARATOR_BYTES,
+};
 use crate::session::Session;
 use crate::tool_inspection::ToolInspectionManager;
 use anyhow::Result;
@@ -20,15 +22,15 @@ use tokio::sync::Mutex;
 pub(super) fn reconstructed_hint_snapshot(
     conversation: &Conversation,
     working_dir: &std::path::Path,
-    reserved_output_bytes: usize,
+    reservation: impl Into<HintOutputReservation>,
 ) -> HintSnapshot {
-    reconstructed_hint_snapshot_with_hook(conversation, working_dir, reserved_output_bytes, || {})
+    reconstructed_hint_snapshot_with_hook(conversation, working_dir, reservation, || {})
 }
 
 fn reconstructed_hint_snapshot_with_hook(
     conversation: &Conversation,
     working_dir: &std::path::Path,
-    reserved_output_bytes: usize,
+    reservation: impl Into<HintOutputReservation>,
     after_top_level_read: impl FnOnce(),
 ) -> HintSnapshot {
     let mut hints = SubdirectoryHintTracker::new();
@@ -41,7 +43,7 @@ fn reconstructed_hint_snapshot_with_hook(
             }
         }
     }
-    hints.load_snapshot_with_hook(working_dir, reserved_output_bytes, after_top_level_read)
+    hints.load_snapshot_with_hook(working_dir, reservation, after_top_level_read)
 }
 
 pub struct GooseInferenceRequestPreparer<'a> {
@@ -79,10 +81,10 @@ impl InferenceRequestPreparer<Session> for GooseInferenceRequestPreparer<'_> {
         let tools =
             crate::agents::reply_parts::prepare_inference_tools(input.tools, code_execution_mode);
         let mut prompt_manager = self.prompt_manager.lock().await;
-        let reserved_output_bytes = prompt_manager
-            .reserved_hint_separator_bytes(!input.prompt_parts.is_empty(), goose_mode);
+        let reservation =
+            prompt_manager.hint_output_reservation(!input.prompt_parts.is_empty(), goose_mode);
         let hint_snapshot =
-            reconstructed_hint_snapshot(conversation, &session.working_dir, reserved_output_bytes);
+            reconstructed_hint_snapshot(conversation, &session.working_dir, reservation);
         let system_prompt = prompt_manager.build_system_prompt_from_snapshot(
             input.prompt_parts,
             goose_mode,
@@ -222,6 +224,63 @@ mod tests {
 
     #[test]
     #[serial_test::serial]
+    fn state_machine_root_hints_share_one_boundary_with_contiguous_prompt_extras() {
+        const PROJECT_HINTS_HEADER: &str =
+            "### Project Hints\nThese are hints for working on the project in this directory.\n";
+
+        let config_root = tempfile::tempdir().unwrap();
+        let _guard = env_lock::lock_env([
+            (
+                "GOOSE_PATH_ROOT",
+                Some(config_root.path().to_str().unwrap()),
+            ),
+            ("CONTEXT_FILE_NAMES", Some(r#"[".goosehints"]"#)),
+        ]);
+        let project = tempfile::tempdir().unwrap();
+        let prompt_parts = vec![(
+            "extensions".to_string(),
+            "operation prompt instruction".to_string(),
+        )];
+        let mut prompt_manager = PromptManager::new();
+        prompt_manager
+            .add_system_prompt_extra("caller".to_string(), "caller instruction".to_string());
+        let reservation = prompt_manager.hint_output_reservation(true, GooseMode::Auto);
+        assert_eq!(reservation.root_only, HINT_EXTRA_SEPARATOR_BYTES);
+        assert_eq!(
+            reservation.with_subdirectories,
+            2 * HINT_EXTRA_SEPARATOR_BYTES
+        );
+
+        let exact_content_len =
+            MAX_HINT_OUTPUT_BYTES - reservation.root_only - PROJECT_HINTS_HEADER.len();
+        fs::write(
+            project.path().join(GOOSE_HINTS_FILENAME),
+            format!(
+                "ROOT_ONLY_BOUNDARY{}",
+                "r".repeat(exact_content_len - "ROOT_ONLY_BOUNDARY".len())
+            ),
+        )
+        .unwrap();
+
+        let snapshot =
+            reconstructed_hint_snapshot(&Conversation::default(), project.path(), reservation);
+        assert!(snapshot.subdirectories.is_empty());
+        assert_eq!(
+            snapshot.top_level.len() + reservation.root_only,
+            MAX_HINT_OUTPUT_BYTES
+        );
+        let prompt = prompt_manager.build_system_prompt_from_snapshot(
+            prompt_parts,
+            GooseMode::Auto,
+            snapshot,
+        );
+        assert!(prompt.contains("caller instruction"));
+        assert!(prompt.contains("operation prompt instruction"));
+        assert!(prompt.contains("ROOT_ONLY_BOUNDARY"));
+    }
+
+    #[test]
+    #[serial_test::serial]
     fn state_machine_hints_reserve_caller_prompt_and_chat_boundaries_at_exact_limit() {
         const PROJECT_HINTS_HEADER: &str =
             "### Project Hints\nThese are hints for working on the project in this directory.\n";
@@ -253,19 +312,23 @@ mod tests {
         let mut prompt_manager = PromptManager::new();
         prompt_manager
             .add_system_prompt_extra("caller".to_string(), "caller instruction".to_string());
+        let auto_reservation = prompt_manager.hint_output_reservation(true, GooseMode::Auto);
+        assert_eq!(auto_reservation.root_only, HINT_EXTRA_SEPARATOR_BYTES);
         assert_eq!(
-            prompt_manager.reserved_hint_separator_bytes(true, GooseMode::Auto),
+            auto_reservation.with_subdirectories,
             2 * HINT_EXTRA_SEPARATOR_BYTES
         );
-        let reserved_output_bytes =
-            prompt_manager.reserved_hint_separator_bytes(true, GooseMode::Chat);
-        assert_eq!(reserved_output_bytes, 3 * HINT_EXTRA_SEPARATOR_BYTES);
+        let reservation = prompt_manager.hint_output_reservation(true, GooseMode::Chat);
+        assert_eq!(reservation.root_only, 2 * HINT_EXTRA_SEPARATOR_BYTES);
+        assert_eq!(
+            reservation.with_subdirectories,
+            3 * HINT_EXTRA_SEPARATOR_BYTES
+        );
 
-        let measured =
-            reconstructed_hint_snapshot(&conversation, project.path(), reserved_output_bytes);
+        let measured = reconstructed_hint_snapshot(&conversation, project.path(), reservation);
         let nested_hint_bytes = measured.subdirectories[0].1.len();
         let root_output_bytes = MAX_HINT_OUTPUT_BYTES
-            - reserved_output_bytes
+            - reservation.with_subdirectories
             - HINT_EXTRA_SEPARATOR_BYTES
             - nested_hint_bytes;
         let root_content_bytes = root_output_bytes - PROJECT_HINTS_HEADER.len();
@@ -278,14 +341,13 @@ mod tests {
         )
         .unwrap();
 
-        let snapshot =
-            reconstructed_hint_snapshot(&conversation, project.path(), reserved_output_bytes);
+        let snapshot = reconstructed_hint_snapshot(&conversation, project.path(), reservation);
         assert_eq!(snapshot.subdirectories.len(), 1);
         assert_eq!(
             snapshot.top_level.len()
                 + snapshot.subdirectories[0].1.len()
                 + HINT_EXTRA_SEPARATOR_BYTES
-                + reserved_output_bytes,
+                + reservation.with_subdirectories,
             MAX_HINT_OUTPUT_BYTES
         );
         let prompt = prompt_manager.build_system_prompt_from_snapshot(
@@ -297,9 +359,11 @@ mod tests {
         assert!(prompt.contains("NESTED_BOUNDARY"));
         assert!(prompt.contains("operation prompt instruction"));
         assert!(prompt.contains("ROOT_BOUNDARY"));
+        let final_reservation = prompt_manager.hint_output_reservation(true, GooseMode::Chat);
+        assert_eq!(final_reservation.root_only, reservation.root_only);
         assert_eq!(
-            prompt_manager.reserved_hint_separator_bytes(true, GooseMode::Chat),
-            reserved_output_bytes
+            final_reservation.with_subdirectories,
+            reservation.with_subdirectories
         );
     }
 }

--- a/crates/goose/src/agents/state_machine/inference_preparation.rs
+++ b/crates/goose/src/agents/state_machine/inference_preparation.rs
@@ -20,13 +20,15 @@ use tokio::sync::Mutex;
 pub(super) fn reconstructed_hint_snapshot(
     conversation: &Conversation,
     working_dir: &std::path::Path,
+    output_limit: usize,
 ) -> String {
-    reconstructed_hint_snapshot_with_hook(conversation, working_dir, || {})
+    reconstructed_hint_snapshot_with_hook(conversation, working_dir, output_limit, || {})
 }
 
 fn reconstructed_hint_snapshot_with_hook(
     conversation: &Conversation,
     working_dir: &std::path::Path,
+    output_limit: usize,
     after_top_level_read: impl FnOnce(),
 ) -> String {
     let mut hints = SubdirectoryHintTracker::new();
@@ -39,7 +41,7 @@ fn reconstructed_hint_snapshot_with_hook(
             }
         }
     }
-    hints.load_prompt_snapshot_with_hook(working_dir, after_top_level_read)
+    hints.load_prompt_snapshot_with_hook(working_dir, output_limit, after_top_level_read)
 }
 
 pub struct GooseInferenceRequestPreparer<'a> {
@@ -76,12 +78,15 @@ impl InferenceRequestPreparer<Session> for GooseInferenceRequestPreparer<'_> {
         }
         let tools =
             crate::agents::reply_parts::prepare_inference_tools(input.tools, code_execution_mode);
-        let hint_snapshot = reconstructed_hint_snapshot(conversation, &session.working_dir);
-        let system_prompt = self
-            .prompt_manager
-            .lock()
-            .await
-            .build_system_prompt_from_snapshot(input.prompt_parts, goose_mode, hint_snapshot);
+        let mut prompt_manager = self.prompt_manager.lock().await;
+        let hint_output_limit = prompt_manager.hint_output_limit(&input.prompt_parts, goose_mode);
+        let hint_snapshot =
+            reconstructed_hint_snapshot(conversation, &session.working_dir, hint_output_limit);
+        let system_prompt = prompt_manager.build_system_prompt_from_snapshot(
+            input.prompt_parts,
+            goose_mode,
+            hint_snapshot,
+        );
         let turn = messages_since_kickoff(conversation)?;
         let turn_start = turn
             .first()
@@ -114,7 +119,6 @@ impl InferenceRequestPreparer<Session> for GooseInferenceRequestPreparer<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::hints::load_hints::PROMPT_HINT_BOUNDARY_BYTES;
     use crate::hints::{GOOSE_HINTS_FILENAME, MAX_HINT_OUTPUT_BYTES};
     use rmcp::model::CallToolRequestParams;
     use std::fs;
@@ -137,9 +141,12 @@ mod tests {
             Ok(CallToolRequestParams::new("read_file").with_arguments(arguments)),
         )]);
 
-        let snapshot = reconstructed_hint_snapshot_with_hook(&conversation, project.path(), || {
-            fs::write(&root_hints, format!("{}ROOT_V2", "v".repeat(700 * 1024))).unwrap()
-        });
+        let snapshot = reconstructed_hint_snapshot_with_hook(
+            &conversation,
+            project.path(),
+            MAX_HINT_OUTPUT_BYTES,
+            || fs::write(&root_hints, format!("{}ROOT_V2", "v".repeat(700 * 1024))).unwrap(),
+        );
         fs::write(&root_hints, "ROOT_V3").unwrap();
 
         let prompt = PromptManager::new().build_system_prompt_from_snapshot(
@@ -157,7 +164,7 @@ mod tests {
 
     #[test]
     #[serial_test::serial]
-    fn prompt_snapshots_reserve_both_adjacent_separators() {
+    fn prompt_snapshots_reserve_only_actual_adjacent_separators() {
         let config_root = tempfile::tempdir().unwrap();
         let _guard = env_lock::lock_env([
             (
@@ -174,8 +181,7 @@ mod tests {
             .load_snapshot(project.path())
             .len()
             - MARKER.len();
-        let allowed_content_bytes =
-            MAX_HINT_OUTPUT_BYTES - PROMPT_HINT_BOUNDARY_BYTES - framing_bytes;
+        let allowed_content_bytes = MAX_HINT_OUTPUT_BYTES - framing_bytes;
         fs::write(
             &hints_path,
             format!(
@@ -187,16 +193,33 @@ mod tests {
         .unwrap();
 
         let conversation = Conversation::new_unvalidated(Vec::<Message>::new());
-        let snapshot = reconstructed_hint_snapshot(&conversation, project.path());
-        assert_eq!(
-            snapshot.len() + PROMPT_HINT_BOUNDARY_BYTES,
-            MAX_HINT_OUTPUT_BYTES
-        );
-
         let timestamp = chrono::DateTime::<chrono::Utc>::from_timestamp(0, 0).unwrap();
+        let mut bare = PromptManager::with_timestamp(timestamp);
+        bare.set_system_prompt_override("base".to_string());
+        let bare_limit = bare.hint_output_limit(&[], GooseMode::Auto);
+        assert_eq!(bare_limit, MAX_HINT_OUTPUT_BYTES);
+        let bare_snapshot = reconstructed_hint_snapshot(&conversation, project.path(), bare_limit);
+        assert_eq!(bare_snapshot.len(), MAX_HINT_OUTPUT_BYTES);
+        assert!(bare
+            .build_system_prompt_from_snapshot(Vec::new(), GooseMode::Auto, bare_snapshot)
+            .contains(MARKER));
+
         let mut state_machine = PromptManager::with_timestamp(timestamp);
         state_machine.set_system_prompt_override("base".to_string());
         state_machine.add_system_prompt_extra("caller".to_string(), "CALLER".to_string());
+        let crowded_limit = state_machine.hint_output_limit(&[], GooseMode::Chat);
+        assert_eq!(crowded_limit, MAX_HINT_OUTPUT_BYTES - 4);
+        fs::write(
+            &hints_path,
+            format!(
+                "{}{}",
+                "x".repeat(crowded_limit - framing_bytes - MARKER.len()),
+                MARKER
+            ),
+        )
+        .unwrap();
+        let snapshot = reconstructed_hint_snapshot(&conversation, project.path(), crowded_limit);
+        assert_eq!(snapshot.len(), crowded_limit);
         let state_machine_prompt =
             state_machine.build_system_prompt_from_snapshot(Vec::new(), GooseMode::Chat, snapshot);
         assert!(state_machine_prompt.contains(MARKER));
@@ -213,12 +236,14 @@ mod tests {
             &hints_path,
             format!(
                 "{}{}",
-                "x".repeat(allowed_content_bytes + 1 - MARKER.len()),
+                "x".repeat(crowded_limit - framing_bytes + 1 - MARKER.len()),
                 MARKER
             ),
         )
         .unwrap();
-        assert!(reconstructed_hint_snapshot(&conversation, project.path()).is_empty());
+        assert!(
+            reconstructed_hint_snapshot(&conversation, project.path(), crowded_limit).is_empty()
+        );
         let mut legacy = PromptManager::with_timestamp(timestamp);
         legacy.set_system_prompt_override("base".to_string());
         legacy.add_system_prompt_extra("caller".to_string(), "CALLER".to_string());
@@ -266,7 +291,8 @@ mod tests {
         state_machine.set_system_prompt_override("base".to_string());
         state_machine.add_system_prompt_extra("caller".to_string(), "CALLER_EXTRA".to_string());
         state_machine.add_system_prompt_extra("hints".to_string(), "CALLER_HINTS".to_string());
-        let snapshot = reconstructed_hint_snapshot(&conversation, project.path());
+        let output_limit = state_machine.hint_output_limit(&[], GooseMode::Auto);
+        let snapshot = reconstructed_hint_snapshot(&conversation, project.path(), output_limit);
         assert!(snapshot.find("ROOT_HINT").unwrap() < snapshot.find("NESTED_HINT").unwrap());
         let state_machine_prompt =
             state_machine.build_system_prompt_from_snapshot(Vec::new(), GooseMode::Auto, snapshot);

--- a/crates/goose/src/agents/state_machine/inference_preparation.rs
+++ b/crates/goose/src/agents/state_machine/inference_preparation.rs
@@ -4,9 +4,9 @@
 use crate::agents::ExtensionManager;
 use crate::agents::PromptManager;
 use crate::config::GooseMode;
-use crate::hints::load_hints::{
-    HintOutputReservation, HintSnapshot, SubdirectoryHintTracker, HINT_EXTRA_SEPARATOR_BYTES,
-};
+#[cfg(test)]
+use crate::hints::load_hints::HINT_EXTRA_SEPARATOR_BYTES;
+use crate::hints::load_hints::{HintOutputReservation, HintSnapshot, SubdirectoryHintTracker};
 use crate::session::Session;
 use crate::tool_inspection::ToolInspectionManager;
 use anyhow::Result;
@@ -281,6 +281,68 @@ mod tests {
 
     #[test]
     #[serial_test::serial]
+    fn state_machine_chat_subdirectory_hints_ignore_nonadjacent_chat_boundary() {
+        let config_root = tempfile::tempdir().unwrap();
+        let _guard = env_lock::lock_env([
+            (
+                "GOOSE_PATH_ROOT",
+                Some(config_root.path().to_str().unwrap()),
+            ),
+            ("CONTEXT_FILE_NAMES", Some(r#"[".goosehints"]"#)),
+        ]);
+        let project = tempfile::tempdir().unwrap();
+        let nested = project.path().join("nested");
+        fs::create_dir(&nested).unwrap();
+        let nested_hints = nested.join(GOOSE_HINTS_FILENAME);
+        let marker = "SUBDIRECTORY_BOUNDARY";
+        fs::write(&nested_hints, marker).unwrap();
+        let arguments = serde_json::json!({ "path": "nested/file.rs" })
+            .as_object()
+            .unwrap()
+            .clone();
+        let conversation = Conversation::new_unvalidated([Message::assistant().with_tool_request(
+            "read-nested",
+            Ok(CallToolRequestParams::new("read_file").with_arguments(arguments)),
+        )]);
+        let mut prompt_manager = PromptManager::new();
+        let reservation = prompt_manager.hint_output_reservation(true, GooseMode::Chat);
+        assert_eq!(reservation.root_only, 2 * HINT_EXTRA_SEPARATOR_BYTES);
+        assert_eq!(reservation.subdirectories_only, HINT_EXTRA_SEPARATOR_BYTES);
+        assert_eq!(
+            reservation.with_subdirectories,
+            2 * HINT_EXTRA_SEPARATOR_BYTES
+        );
+        let measured = reconstructed_hint_snapshot(&conversation, project.path(), reservation);
+        let framing_bytes = measured.subdirectories[0].1.len() - marker.len();
+        let hint_output_bytes = MAX_HINT_OUTPUT_BYTES - HINT_EXTRA_SEPARATOR_BYTES;
+        let content_bytes = hint_output_bytes - framing_bytes;
+        fs::write(
+            nested_hints,
+            format!("{marker}{}", "n".repeat(content_bytes - marker.len())),
+        )
+        .unwrap();
+
+        let snapshot = reconstructed_hint_snapshot(&conversation, project.path(), reservation);
+        assert!(snapshot.top_level.is_empty());
+        assert_eq!(snapshot.subdirectories.len(), 1);
+        assert_eq!(
+            snapshot.subdirectories[0].1.len() + HINT_EXTRA_SEPARATOR_BYTES,
+            MAX_HINT_OUTPUT_BYTES
+        );
+        let prompt = prompt_manager.build_system_prompt_from_snapshot(
+            vec![(
+                "extensions".to_string(),
+                "operation prompt instruction".to_string(),
+            )],
+            GooseMode::Chat,
+            snapshot,
+        );
+        assert!(prompt.contains(marker));
+        assert!(prompt.contains("operation prompt instruction"));
+    }
+
+    #[test]
+    #[serial_test::serial]
     fn state_machine_hints_reserve_caller_prompt_and_chat_boundaries_at_exact_limit() {
         const PROJECT_HINTS_HEADER: &str =
             "### Project Hints\nThese are hints for working on the project in this directory.\n";
@@ -315,11 +377,19 @@ mod tests {
         let auto_reservation = prompt_manager.hint_output_reservation(true, GooseMode::Auto);
         assert_eq!(auto_reservation.root_only, HINT_EXTRA_SEPARATOR_BYTES);
         assert_eq!(
+            auto_reservation.subdirectories_only,
+            2 * HINT_EXTRA_SEPARATOR_BYTES
+        );
+        assert_eq!(
             auto_reservation.with_subdirectories,
             2 * HINT_EXTRA_SEPARATOR_BYTES
         );
         let reservation = prompt_manager.hint_output_reservation(true, GooseMode::Chat);
         assert_eq!(reservation.root_only, 2 * HINT_EXTRA_SEPARATOR_BYTES);
+        assert_eq!(
+            reservation.subdirectories_only,
+            2 * HINT_EXTRA_SEPARATOR_BYTES
+        );
         assert_eq!(
             reservation.with_subdirectories,
             3 * HINT_EXTRA_SEPARATOR_BYTES

--- a/crates/goose/src/agents/state_machine/inference_preparation.rs
+++ b/crates/goose/src/agents/state_machine/inference_preparation.rs
@@ -20,15 +20,15 @@ use tokio::sync::Mutex;
 pub(super) fn reconstructed_hint_snapshot(
     conversation: &Conversation,
     working_dir: &std::path::Path,
-    goose_mode: GooseMode,
+    reserved_output_bytes: usize,
 ) -> HintSnapshot {
-    reconstructed_hint_snapshot_with_hook(conversation, working_dir, goose_mode, || {})
+    reconstructed_hint_snapshot_with_hook(conversation, working_dir, reserved_output_bytes, || {})
 }
 
 fn reconstructed_hint_snapshot_with_hook(
     conversation: &Conversation,
     working_dir: &std::path::Path,
-    goose_mode: GooseMode,
+    reserved_output_bytes: usize,
     after_top_level_read: impl FnOnce(),
 ) -> HintSnapshot {
     let mut hints = SubdirectoryHintTracker::new();
@@ -41,12 +41,6 @@ fn reconstructed_hint_snapshot_with_hook(
             }
         }
     }
-    let reserved_output_bytes = HINT_EXTRA_SEPARATOR_BYTES
-        + if goose_mode == GooseMode::Chat {
-            HINT_EXTRA_SEPARATOR_BYTES
-        } else {
-            0
-        };
     hints.load_snapshot_with_hook(working_dir, reserved_output_bytes, after_top_level_read)
 }
 
@@ -84,13 +78,16 @@ impl InferenceRequestPreparer<Session> for GooseInferenceRequestPreparer<'_> {
         }
         let tools =
             crate::agents::reply_parts::prepare_inference_tools(input.tools, code_execution_mode);
+        let mut prompt_manager = self.prompt_manager.lock().await;
+        let reserved_output_bytes = prompt_manager
+            .reserved_hint_separator_bytes(!input.prompt_parts.is_empty(), goose_mode);
         let hint_snapshot =
-            reconstructed_hint_snapshot(conversation, &session.working_dir, goose_mode);
-        let system_prompt = self
-            .prompt_manager
-            .lock()
-            .await
-            .build_system_prompt_from_snapshot(input.prompt_parts, goose_mode, hint_snapshot);
+            reconstructed_hint_snapshot(conversation, &session.working_dir, reserved_output_bytes);
+        let system_prompt = prompt_manager.build_system_prompt_from_snapshot(
+            input.prompt_parts,
+            goose_mode,
+            hint_snapshot,
+        );
         let turn = messages_since_kickoff(conversation)?;
         let turn_start = turn
             .first()
@@ -145,12 +142,10 @@ mod tests {
             Ok(CallToolRequestParams::new("read_file").with_arguments(arguments)),
         )]);
 
-        let snapshot = reconstructed_hint_snapshot_with_hook(
-            &conversation,
-            project.path(),
-            GooseMode::Auto,
-            || fs::write(&root_hints, format!("{}ROOT_V2", "v".repeat(700 * 1024))).unwrap(),
-        );
+        let snapshot =
+            reconstructed_hint_snapshot_with_hook(&conversation, project.path(), 0, || {
+                fs::write(&root_hints, format!("{}ROOT_V2", "v".repeat(700 * 1024))).unwrap()
+            });
         let hint_bytes = snapshot.top_level.len()
             + snapshot
                 .subdirectories
@@ -202,7 +197,8 @@ mod tests {
         .unwrap();
         let conversation = Conversation::default();
 
-        let snapshot = reconstructed_hint_snapshot(&conversation, project.path(), GooseMode::Chat);
+        let snapshot =
+            reconstructed_hint_snapshot(&conversation, project.path(), reserved_output_bytes);
         assert_eq!(
             snapshot.top_level.len() + reserved_output_bytes,
             MAX_HINT_OUTPUT_BYTES
@@ -219,7 +215,91 @@ mod tests {
             ),
         )
         .unwrap();
-        let snapshot = reconstructed_hint_snapshot(&conversation, project.path(), GooseMode::Chat);
+        let snapshot =
+            reconstructed_hint_snapshot(&conversation, project.path(), reserved_output_bytes);
         assert!(snapshot.top_level.is_empty());
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn state_machine_hints_reserve_caller_prompt_and_chat_boundaries_at_exact_limit() {
+        const PROJECT_HINTS_HEADER: &str =
+            "### Project Hints\nThese are hints for working on the project in this directory.\n";
+
+        let config_root = tempfile::tempdir().unwrap();
+        let _guard = env_lock::lock_env([
+            (
+                "GOOSE_PATH_ROOT",
+                Some(config_root.path().to_str().unwrap()),
+            ),
+            ("CONTEXT_FILE_NAMES", Some(r#"[".goosehints"]"#)),
+        ]);
+        let project = tempfile::tempdir().unwrap();
+        let nested = project.path().join("nested");
+        fs::create_dir(&nested).unwrap();
+        fs::write(nested.join(GOOSE_HINTS_FILENAME), "NESTED_BOUNDARY").unwrap();
+        let arguments = serde_json::json!({ "path": "nested/file.rs" })
+            .as_object()
+            .unwrap()
+            .clone();
+        let conversation = Conversation::new_unvalidated([Message::assistant().with_tool_request(
+            "read-nested",
+            Ok(CallToolRequestParams::new("read_file").with_arguments(arguments)),
+        )]);
+        let prompt_parts = vec![(
+            "extensions".to_string(),
+            "operation prompt instruction".to_string(),
+        )];
+        let mut prompt_manager = PromptManager::new();
+        prompt_manager
+            .add_system_prompt_extra("caller".to_string(), "caller instruction".to_string());
+        assert_eq!(
+            prompt_manager.reserved_hint_separator_bytes(true, GooseMode::Auto),
+            2 * HINT_EXTRA_SEPARATOR_BYTES
+        );
+        let reserved_output_bytes =
+            prompt_manager.reserved_hint_separator_bytes(true, GooseMode::Chat);
+        assert_eq!(reserved_output_bytes, 3 * HINT_EXTRA_SEPARATOR_BYTES);
+
+        let measured =
+            reconstructed_hint_snapshot(&conversation, project.path(), reserved_output_bytes);
+        let nested_hint_bytes = measured.subdirectories[0].1.len();
+        let root_output_bytes = MAX_HINT_OUTPUT_BYTES
+            - reserved_output_bytes
+            - HINT_EXTRA_SEPARATOR_BYTES
+            - nested_hint_bytes;
+        let root_content_bytes = root_output_bytes - PROJECT_HINTS_HEADER.len();
+        fs::write(
+            project.path().join(GOOSE_HINTS_FILENAME),
+            format!(
+                "ROOT_BOUNDARY{}",
+                "r".repeat(root_content_bytes - "ROOT_BOUNDARY".len())
+            ),
+        )
+        .unwrap();
+
+        let snapshot =
+            reconstructed_hint_snapshot(&conversation, project.path(), reserved_output_bytes);
+        assert_eq!(snapshot.subdirectories.len(), 1);
+        assert_eq!(
+            snapshot.top_level.len()
+                + snapshot.subdirectories[0].1.len()
+                + HINT_EXTRA_SEPARATOR_BYTES
+                + reserved_output_bytes,
+            MAX_HINT_OUTPUT_BYTES
+        );
+        let prompt = prompt_manager.build_system_prompt_from_snapshot(
+            prompt_parts,
+            GooseMode::Chat,
+            snapshot,
+        );
+        assert!(prompt.contains("caller instruction"));
+        assert!(prompt.contains("NESTED_BOUNDARY"));
+        assert!(prompt.contains("operation prompt instruction"));
+        assert!(prompt.contains("ROOT_BOUNDARY"));
+        assert_eq!(
+            prompt_manager.reserved_hint_separator_bytes(true, GooseMode::Chat),
+            reserved_output_bytes
+        );
     }
 }

--- a/crates/goose/src/agents/state_machine/inference_preparation.rs
+++ b/crates/goose/src/agents/state_machine/inference_preparation.rs
@@ -81,8 +81,10 @@ impl InferenceRequestPreparer<Session> for GooseInferenceRequestPreparer<'_> {
         let tools =
             crate::agents::reply_parts::prepare_inference_tools(input.tools, code_execution_mode);
         let mut prompt_manager = self.prompt_manager.lock().await;
-        let reservation =
-            prompt_manager.hint_output_reservation(!input.prompt_parts.is_empty(), goose_mode);
+        let reservation = prompt_manager.hint_output_reservation(
+            input.prompt_parts.iter().map(|(key, _)| key.as_str()),
+            goose_mode,
+        );
         let hint_snapshot =
             reconstructed_hint_snapshot(conversation, &session.working_dir, reservation);
         let system_prompt = prompt_manager.build_system_prompt_from_snapshot(
@@ -244,7 +246,10 @@ mod tests {
         let mut prompt_manager = PromptManager::new();
         prompt_manager
             .add_system_prompt_extra("caller".to_string(), "caller instruction".to_string());
-        let reservation = prompt_manager.hint_output_reservation(true, GooseMode::Auto);
+        let reservation = prompt_manager.hint_output_reservation(
+            prompt_parts.iter().map(|(key, _)| key.as_str()),
+            GooseMode::Auto,
+        );
         assert_eq!(reservation.root_only, HINT_EXTRA_SEPARATOR_BYTES);
         assert_eq!(
             reservation.with_subdirectories,
@@ -281,6 +286,91 @@ mod tests {
 
     #[test]
     #[serial_test::serial]
+    fn colliding_prompt_part_uses_final_hint_boundary_count() {
+        let config_root = tempfile::tempdir().unwrap();
+        let _guard = env_lock::lock_env([
+            (
+                "GOOSE_PATH_ROOT",
+                Some(config_root.path().to_str().unwrap()),
+            ),
+            ("CONTEXT_FILE_NAMES", Some(r#"[".goosehints"]"#)),
+        ]);
+        let project = tempfile::tempdir().unwrap();
+        let nested = project.path().join("nested");
+        fs::create_dir(&nested).unwrap();
+        let nested_hints = nested.join(GOOSE_HINTS_FILENAME);
+        let marker = "COLLIDING_EXTENSION_BOUNDARY";
+        fs::write(&nested_hints, marker).unwrap();
+        let arguments = serde_json::json!({ "path": "nested/file.rs" })
+            .as_object()
+            .unwrap()
+            .clone();
+        let conversation = Conversation::new_unvalidated([Message::assistant().with_tool_request(
+            "read-nested",
+            Ok(CallToolRequestParams::new("read_file").with_arguments(arguments)),
+        )]);
+        let prompt_parts = vec![("extensions".to_string(), "operation extensions".to_string())];
+        let mut prompt_manager = PromptManager::new();
+        prompt_manager.add_system_prompt_extra("first".to_string(), "CALLER_FIRST".to_string());
+        prompt_manager
+            .add_system_prompt_extra("extensions".to_string(), "caller extensions".to_string());
+        prompt_manager.add_system_prompt_extra("last".to_string(), "CALLER_LAST".to_string());
+
+        let legacy_reservation =
+            prompt_manager.hint_output_reservation(std::iter::empty(), GooseMode::Auto);
+        let state_machine_reservation = prompt_manager.hint_output_reservation(
+            prompt_parts.iter().map(|(key, _)| key.as_str()),
+            GooseMode::Auto,
+        );
+        let measured =
+            reconstructed_hint_snapshot(&conversation, project.path(), legacy_reservation);
+        let framing_bytes = measured.subdirectories[0].1.len() - marker.len();
+        let hint_output_bytes = MAX_HINT_OUTPUT_BYTES - HINT_EXTRA_SEPARATOR_BYTES;
+        let content_bytes = hint_output_bytes - framing_bytes;
+        fs::write(
+            &nested_hints,
+            format!("{marker}{}", "n".repeat(content_bytes - marker.len())),
+        )
+        .unwrap();
+
+        let legacy_snapshot =
+            reconstructed_hint_snapshot(&conversation, project.path(), legacy_reservation);
+        let state_machine_snapshot =
+            reconstructed_hint_snapshot(&conversation, project.path(), state_machine_reservation);
+
+        assert_eq!(legacy_snapshot.subdirectories.len(), 1);
+        assert_eq!(
+            state_machine_snapshot.subdirectories.len(),
+            1,
+            "a colliding prompt key must not reserve a separator absent from the final prompt"
+        );
+        assert_eq!(
+            state_machine_reservation.root_only,
+            legacy_reservation.root_only
+        );
+        assert_eq!(
+            state_machine_reservation.subdirectories_only,
+            legacy_reservation.subdirectories_only
+        );
+        assert_eq!(
+            state_machine_reservation.with_subdirectories,
+            legacy_reservation.with_subdirectories
+        );
+
+        let prompt = prompt_manager.build_system_prompt_from_snapshot(
+            prompt_parts,
+            GooseMode::Auto,
+            state_machine_snapshot,
+        );
+        let first = prompt.find("CALLER_FIRST").unwrap();
+        let extensions = prompt.find("operation extensions").unwrap();
+        let last = prompt.find("CALLER_LAST").unwrap();
+        let hints = prompt.find(marker).unwrap();
+        assert!(first < extensions && extensions < last && last < hints);
+    }
+
+    #[test]
+    #[serial_test::serial]
     fn state_machine_chat_subdirectory_hints_ignore_nonadjacent_chat_boundary() {
         let config_root = tempfile::tempdir().unwrap();
         let _guard = env_lock::lock_env([
@@ -305,7 +395,7 @@ mod tests {
             Ok(CallToolRequestParams::new("read_file").with_arguments(arguments)),
         )]);
         let mut prompt_manager = PromptManager::new();
-        let reservation = prompt_manager.hint_output_reservation(true, GooseMode::Chat);
+        let reservation = prompt_manager.hint_output_reservation(["extensions"], GooseMode::Chat);
         assert_eq!(reservation.root_only, 2 * HINT_EXTRA_SEPARATOR_BYTES);
         assert_eq!(reservation.subdirectories_only, HINT_EXTRA_SEPARATOR_BYTES);
         assert_eq!(
@@ -374,7 +464,10 @@ mod tests {
         let mut prompt_manager = PromptManager::new();
         prompt_manager
             .add_system_prompt_extra("caller".to_string(), "caller instruction".to_string());
-        let auto_reservation = prompt_manager.hint_output_reservation(true, GooseMode::Auto);
+        let auto_reservation = prompt_manager.hint_output_reservation(
+            prompt_parts.iter().map(|(key, _)| key.as_str()),
+            GooseMode::Auto,
+        );
         assert_eq!(auto_reservation.root_only, HINT_EXTRA_SEPARATOR_BYTES);
         assert_eq!(
             auto_reservation.subdirectories_only,
@@ -384,7 +477,10 @@ mod tests {
             auto_reservation.with_subdirectories,
             2 * HINT_EXTRA_SEPARATOR_BYTES
         );
-        let reservation = prompt_manager.hint_output_reservation(true, GooseMode::Chat);
+        let reservation = prompt_manager.hint_output_reservation(
+            prompt_parts.iter().map(|(key, _)| key.as_str()),
+            GooseMode::Chat,
+        );
         assert_eq!(reservation.root_only, 2 * HINT_EXTRA_SEPARATOR_BYTES);
         assert_eq!(
             reservation.subdirectories_only,
@@ -429,7 +525,8 @@ mod tests {
         assert!(prompt.contains("NESTED_BOUNDARY"));
         assert!(prompt.contains("operation prompt instruction"));
         assert!(prompt.contains("ROOT_BOUNDARY"));
-        let final_reservation = prompt_manager.hint_output_reservation(true, GooseMode::Chat);
+        let final_reservation =
+            prompt_manager.hint_output_reservation(["extensions"], GooseMode::Chat);
         assert_eq!(final_reservation.root_only, reservation.root_only);
         assert_eq!(
             final_reservation.with_subdirectories,

--- a/crates/goose/src/agents/state_machine/inference_preparation.rs
+++ b/crates/goose/src/agents/state_machine/inference_preparation.rs
@@ -20,13 +20,15 @@ use tokio::sync::Mutex;
 pub(super) fn reconstructed_hint_snapshot(
     conversation: &Conversation,
     working_dir: &std::path::Path,
+    goose_mode: GooseMode,
 ) -> HintSnapshot {
-    reconstructed_hint_snapshot_with_hook(conversation, working_dir, || {})
+    reconstructed_hint_snapshot_with_hook(conversation, working_dir, goose_mode, || {})
 }
 
 fn reconstructed_hint_snapshot_with_hook(
     conversation: &Conversation,
     working_dir: &std::path::Path,
+    goose_mode: GooseMode,
     after_top_level_read: impl FnOnce(),
 ) -> HintSnapshot {
     let mut hints = SubdirectoryHintTracker::new();
@@ -39,11 +41,13 @@ fn reconstructed_hint_snapshot_with_hook(
             }
         }
     }
-    hints.load_snapshot_with_hook(
-        working_dir,
-        HINT_EXTRA_SEPARATOR_BYTES,
-        after_top_level_read,
-    )
+    let reserved_output_bytes = HINT_EXTRA_SEPARATOR_BYTES
+        + if goose_mode == GooseMode::Chat {
+            HINT_EXTRA_SEPARATOR_BYTES
+        } else {
+            0
+        };
+    hints.load_snapshot_with_hook(working_dir, reserved_output_bytes, after_top_level_read)
 }
 
 pub struct GooseInferenceRequestPreparer<'a> {
@@ -80,7 +84,8 @@ impl InferenceRequestPreparer<Session> for GooseInferenceRequestPreparer<'_> {
         }
         let tools =
             crate::agents::reply_parts::prepare_inference_tools(input.tools, code_execution_mode);
-        let hint_snapshot = reconstructed_hint_snapshot(conversation, &session.working_dir);
+        let hint_snapshot =
+            reconstructed_hint_snapshot(conversation, &session.working_dir, goose_mode);
         let system_prompt = self
             .prompt_manager
             .lock()
@@ -140,9 +145,12 @@ mod tests {
             Ok(CallToolRequestParams::new("read_file").with_arguments(arguments)),
         )]);
 
-        let snapshot = reconstructed_hint_snapshot_with_hook(&conversation, project.path(), || {
-            fs::write(&root_hints, format!("{}ROOT_V2", "v".repeat(700 * 1024))).unwrap()
-        });
+        let snapshot = reconstructed_hint_snapshot_with_hook(
+            &conversation,
+            project.path(),
+            GooseMode::Auto,
+            || fs::write(&root_hints, format!("{}ROOT_V2", "v".repeat(700 * 1024))).unwrap(),
+        );
         let hint_bytes = snapshot.top_level.len()
             + snapshot
                 .subdirectories
@@ -163,5 +171,55 @@ mod tests {
         assert!(prompt.contains("NESTED_MARKER"));
         assert!(!prompt.contains("ROOT_V2"));
         assert!(!prompt.contains("ROOT_V3"));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn state_machine_chat_hints_reserve_trailing_separator_at_exact_limit() {
+        const PROJECT_HINTS_HEADER: &str =
+            "### Project Hints\nThese are hints for working on the project in this directory.\n";
+
+        let config_root = tempfile::tempdir().unwrap();
+        let _guard = env_lock::lock_env([
+            (
+                "GOOSE_PATH_ROOT",
+                Some(config_root.path().to_str().unwrap()),
+            ),
+            ("CONTEXT_FILE_NAMES", Some(r#"[".goosehints"]"#)),
+        ]);
+        let project = tempfile::tempdir().unwrap();
+        let hints_path = project.path().join(GOOSE_HINTS_FILENAME);
+        let reserved_output_bytes = HINT_EXTRA_SEPARATOR_BYTES * 2;
+        let exact_content_len =
+            MAX_HINT_OUTPUT_BYTES - reserved_output_bytes - PROJECT_HINTS_HEADER.len();
+        fs::write(
+            &hints_path,
+            format!(
+                "CHAT_BOUNDARY{}",
+                "h".repeat(exact_content_len - "CHAT_BOUNDARY".len())
+            ),
+        )
+        .unwrap();
+        let conversation = Conversation::default();
+
+        let snapshot = reconstructed_hint_snapshot(&conversation, project.path(), GooseMode::Chat);
+        assert_eq!(
+            snapshot.top_level.len() + reserved_output_bytes,
+            MAX_HINT_OUTPUT_BYTES
+        );
+        assert!(snapshot.top_level.contains("CHAT_BOUNDARY"));
+
+        let old_boundary_content_len =
+            MAX_HINT_OUTPUT_BYTES - HINT_EXTRA_SEPARATOR_BYTES - PROJECT_HINTS_HEADER.len();
+        fs::write(
+            hints_path,
+            format!(
+                "CHAT_OVERFLOW{}",
+                "h".repeat(old_boundary_content_len - "CHAT_OVERFLOW".len())
+            ),
+        )
+        .unwrap();
+        let snapshot = reconstructed_hint_snapshot(&conversation, project.path(), GooseMode::Chat);
+        assert!(snapshot.top_level.is_empty());
     }
 }

--- a/crates/goose/src/agents/state_machine/inference_preparation.rs
+++ b/crates/goose/src/agents/state_machine/inference_preparation.rs
@@ -4,9 +4,7 @@
 use crate::agents::ExtensionManager;
 use crate::agents::PromptManager;
 use crate::config::GooseMode;
-#[cfg(test)]
-use crate::hints::load_hints::HINT_EXTRA_SEPARATOR_BYTES;
-use crate::hints::load_hints::{HintOutputReservation, HintSnapshot, SubdirectoryHintTracker};
+use crate::hints::load_hints::SubdirectoryHintTracker;
 use crate::session::Session;
 use crate::tool_inspection::ToolInspectionManager;
 use anyhow::Result;
@@ -22,17 +20,15 @@ use tokio::sync::Mutex;
 pub(super) fn reconstructed_hint_snapshot(
     conversation: &Conversation,
     working_dir: &std::path::Path,
-    reservation: impl Into<HintOutputReservation>,
-) -> HintSnapshot {
-    reconstructed_hint_snapshot_with_hook(conversation, working_dir, reservation, || {})
+) -> String {
+    reconstructed_hint_snapshot_with_hook(conversation, working_dir, || {})
 }
 
 fn reconstructed_hint_snapshot_with_hook(
     conversation: &Conversation,
     working_dir: &std::path::Path,
-    reservation: impl Into<HintOutputReservation>,
     after_top_level_read: impl FnOnce(),
-) -> HintSnapshot {
+) -> String {
     let mut hints = SubdirectoryHintTracker::new();
     for message in conversation.messages() {
         for content in &message.content {
@@ -43,7 +39,7 @@ fn reconstructed_hint_snapshot_with_hook(
             }
         }
     }
-    hints.load_snapshot_with_hook(working_dir, reservation, after_top_level_read)
+    hints.load_snapshot_with_hook(working_dir, after_top_level_read)
 }
 
 pub struct GooseInferenceRequestPreparer<'a> {
@@ -80,18 +76,12 @@ impl InferenceRequestPreparer<Session> for GooseInferenceRequestPreparer<'_> {
         }
         let tools =
             crate::agents::reply_parts::prepare_inference_tools(input.tools, code_execution_mode);
-        let mut prompt_manager = self.prompt_manager.lock().await;
-        let reservation = prompt_manager.hint_output_reservation(
-            input.prompt_parts.iter().map(|(key, _)| key.as_str()),
-            goose_mode,
-        );
-        let hint_snapshot =
-            reconstructed_hint_snapshot(conversation, &session.working_dir, reservation);
-        let system_prompt = prompt_manager.build_system_prompt_from_snapshot(
-            input.prompt_parts,
-            goose_mode,
-            hint_snapshot,
-        );
+        let hint_snapshot = reconstructed_hint_snapshot(conversation, &session.working_dir);
+        let system_prompt = self
+            .prompt_manager
+            .lock()
+            .await
+            .build_system_prompt_from_snapshot(input.prompt_parts, goose_mode, hint_snapshot);
         let turn = messages_since_kickoff(conversation)?;
         let turn_start = turn
             .first()
@@ -146,26 +136,18 @@ mod tests {
             Ok(CallToolRequestParams::new("read_file").with_arguments(arguments)),
         )]);
 
-        let snapshot =
-            reconstructed_hint_snapshot_with_hook(&conversation, project.path(), 0, || {
-                fs::write(&root_hints, format!("{}ROOT_V2", "v".repeat(700 * 1024))).unwrap()
-            });
-        let hint_bytes = snapshot.top_level.len()
-            + snapshot
-                .subdirectories
-                .iter()
-                .map(|(_, content)| content.len())
-                .sum::<usize>()
-            + snapshot.subdirectories.len() * HINT_EXTRA_SEPARATOR_BYTES;
+        let snapshot = reconstructed_hint_snapshot_with_hook(&conversation, project.path(), || {
+            fs::write(&root_hints, format!("{}ROOT_V2", "v".repeat(700 * 1024))).unwrap()
+        });
         fs::write(&root_hints, "ROOT_V3").unwrap();
 
         let prompt = PromptManager::new().build_system_prompt_from_snapshot(
             Vec::new(),
             GooseMode::Auto,
-            snapshot,
+            snapshot.clone(),
         );
 
-        assert!(hint_bytes <= MAX_HINT_OUTPUT_BYTES);
+        assert!(snapshot.len() <= MAX_HINT_OUTPUT_BYTES);
         assert!(prompt.contains("ROOT_V1"));
         assert!(prompt.contains("NESTED_MARKER"));
         assert!(!prompt.contains("ROOT_V2"));
@@ -174,119 +156,7 @@ mod tests {
 
     #[test]
     #[serial_test::serial]
-    fn state_machine_chat_hints_reserve_trailing_separator_at_exact_limit() {
-        const PROJECT_HINTS_HEADER: &str =
-            "### Project Hints\nThese are hints for working on the project in this directory.\n";
-
-        let config_root = tempfile::tempdir().unwrap();
-        let _guard = env_lock::lock_env([
-            (
-                "GOOSE_PATH_ROOT",
-                Some(config_root.path().to_str().unwrap()),
-            ),
-            ("CONTEXT_FILE_NAMES", Some(r#"[".goosehints"]"#)),
-        ]);
-        let project = tempfile::tempdir().unwrap();
-        let hints_path = project.path().join(GOOSE_HINTS_FILENAME);
-        let reserved_output_bytes = HINT_EXTRA_SEPARATOR_BYTES * 2;
-        let exact_content_len =
-            MAX_HINT_OUTPUT_BYTES - reserved_output_bytes - PROJECT_HINTS_HEADER.len();
-        fs::write(
-            &hints_path,
-            format!(
-                "CHAT_BOUNDARY{}",
-                "h".repeat(exact_content_len - "CHAT_BOUNDARY".len())
-            ),
-        )
-        .unwrap();
-        let conversation = Conversation::default();
-
-        let snapshot =
-            reconstructed_hint_snapshot(&conversation, project.path(), reserved_output_bytes);
-        assert_eq!(
-            snapshot.top_level.len() + reserved_output_bytes,
-            MAX_HINT_OUTPUT_BYTES
-        );
-        assert!(snapshot.top_level.contains("CHAT_BOUNDARY"));
-
-        let old_boundary_content_len =
-            MAX_HINT_OUTPUT_BYTES - HINT_EXTRA_SEPARATOR_BYTES - PROJECT_HINTS_HEADER.len();
-        fs::write(
-            hints_path,
-            format!(
-                "CHAT_OVERFLOW{}",
-                "h".repeat(old_boundary_content_len - "CHAT_OVERFLOW".len())
-            ),
-        )
-        .unwrap();
-        let snapshot =
-            reconstructed_hint_snapshot(&conversation, project.path(), reserved_output_bytes);
-        assert!(snapshot.top_level.is_empty());
-    }
-
-    #[test]
-    #[serial_test::serial]
-    fn state_machine_root_hints_share_one_boundary_with_contiguous_prompt_extras() {
-        const PROJECT_HINTS_HEADER: &str =
-            "### Project Hints\nThese are hints for working on the project in this directory.\n";
-
-        let config_root = tempfile::tempdir().unwrap();
-        let _guard = env_lock::lock_env([
-            (
-                "GOOSE_PATH_ROOT",
-                Some(config_root.path().to_str().unwrap()),
-            ),
-            ("CONTEXT_FILE_NAMES", Some(r#"[".goosehints"]"#)),
-        ]);
-        let project = tempfile::tempdir().unwrap();
-        let prompt_parts = vec![(
-            "extensions".to_string(),
-            "operation prompt instruction".to_string(),
-        )];
-        let mut prompt_manager = PromptManager::new();
-        prompt_manager
-            .add_system_prompt_extra("caller".to_string(), "caller instruction".to_string());
-        let reservation = prompt_manager.hint_output_reservation(
-            prompt_parts.iter().map(|(key, _)| key.as_str()),
-            GooseMode::Auto,
-        );
-        assert_eq!(reservation.root_only, HINT_EXTRA_SEPARATOR_BYTES);
-        assert_eq!(
-            reservation.with_subdirectories,
-            2 * HINT_EXTRA_SEPARATOR_BYTES
-        );
-
-        let exact_content_len =
-            MAX_HINT_OUTPUT_BYTES - reservation.root_only - PROJECT_HINTS_HEADER.len();
-        fs::write(
-            project.path().join(GOOSE_HINTS_FILENAME),
-            format!(
-                "ROOT_ONLY_BOUNDARY{}",
-                "r".repeat(exact_content_len - "ROOT_ONLY_BOUNDARY".len())
-            ),
-        )
-        .unwrap();
-
-        let snapshot =
-            reconstructed_hint_snapshot(&Conversation::default(), project.path(), reservation);
-        assert!(snapshot.subdirectories.is_empty());
-        assert_eq!(
-            snapshot.top_level.len() + reservation.root_only,
-            MAX_HINT_OUTPUT_BYTES
-        );
-        let prompt = prompt_manager.build_system_prompt_from_snapshot(
-            prompt_parts,
-            GooseMode::Auto,
-            snapshot,
-        );
-        assert!(prompt.contains("caller instruction"));
-        assert!(prompt.contains("operation prompt instruction"));
-        assert!(prompt.contains("ROOT_ONLY_BOUNDARY"));
-    }
-
-    #[test]
-    #[serial_test::serial]
-    fn colliding_prompt_part_uses_final_hint_boundary_count() {
+    fn legacy_and_state_machine_use_the_same_snapshot_without_mutating_caller_extras() {
         let config_root = tempfile::tempdir().unwrap();
         let _guard = env_lock::lock_env([
             (
@@ -298,239 +168,44 @@ mod tests {
         let project = tempfile::tempdir().unwrap();
         let nested = project.path().join("nested");
         fs::create_dir(&nested).unwrap();
-        let nested_hints = nested.join(GOOSE_HINTS_FILENAME);
-        let marker = "COLLIDING_EXTENSION_BOUNDARY";
-        fs::write(&nested_hints, marker).unwrap();
+        fs::write(project.path().join(GOOSE_HINTS_FILENAME), "ROOT_HINT").unwrap();
+        fs::write(nested.join(GOOSE_HINTS_FILENAME), "NESTED_HINT").unwrap();
         let arguments = serde_json::json!({ "path": "nested/file.rs" })
             .as_object()
-            .unwrap()
-            .clone();
+            .cloned();
         let conversation = Conversation::new_unvalidated([Message::assistant().with_tool_request(
             "read-nested",
-            Ok(CallToolRequestParams::new("read_file").with_arguments(arguments)),
+            Ok(CallToolRequestParams::new("read_file").with_arguments(arguments.clone().unwrap())),
         )]);
-        let prompt_parts = vec![("extensions".to_string(), "operation extensions".to_string())];
-        let mut prompt_manager = PromptManager::new();
-        prompt_manager.add_system_prompt_extra("first".to_string(), "CALLER_FIRST".to_string());
-        prompt_manager
-            .add_system_prompt_extra("extensions".to_string(), "caller extensions".to_string());
-        prompt_manager.add_system_prompt_extra("last".to_string(), "CALLER_LAST".to_string());
+        let timestamp = chrono::DateTime::<chrono::Utc>::from_timestamp(0, 0).unwrap();
 
-        let legacy_reservation =
-            prompt_manager.hint_output_reservation(std::iter::empty(), GooseMode::Auto);
-        let state_machine_reservation = prompt_manager.hint_output_reservation(
-            prompt_parts.iter().map(|(key, _)| key.as_str()),
-            GooseMode::Auto,
-        );
-        let measured =
-            reconstructed_hint_snapshot(&conversation, project.path(), legacy_reservation);
-        let framing_bytes = measured.subdirectories[0].1.len() - marker.len();
-        let hint_output_bytes = MAX_HINT_OUTPUT_BYTES - HINT_EXTRA_SEPARATOR_BYTES;
-        let content_bytes = hint_output_bytes - framing_bytes;
-        fs::write(
-            &nested_hints,
-            format!("{marker}{}", "n".repeat(content_bytes - marker.len())),
-        )
-        .unwrap();
+        let mut legacy = PromptManager::with_timestamp(timestamp);
+        legacy.set_system_prompt_override("base".to_string());
+        legacy.add_system_prompt_extra("caller".to_string(), "CALLER_EXTRA".to_string());
+        legacy.add_system_prompt_extra("hints".to_string(), "CALLER_HINTS".to_string());
+        legacy.record_tool_arguments(&arguments, project.path());
+        let legacy_prompt = legacy
+            .builder_with_fresh_hints(project.path(), GooseMode::Auto)
+            .build();
 
-        let legacy_snapshot =
-            reconstructed_hint_snapshot(&conversation, project.path(), legacy_reservation);
-        let state_machine_snapshot =
-            reconstructed_hint_snapshot(&conversation, project.path(), state_machine_reservation);
+        let mut state_machine = PromptManager::with_timestamp(timestamp);
+        state_machine.set_system_prompt_override("base".to_string());
+        state_machine.add_system_prompt_extra("caller".to_string(), "CALLER_EXTRA".to_string());
+        state_machine.add_system_prompt_extra("hints".to_string(), "CALLER_HINTS".to_string());
+        let snapshot = reconstructed_hint_snapshot(&conversation, project.path());
+        assert!(snapshot.find("ROOT_HINT").unwrap() < snapshot.find("NESTED_HINT").unwrap());
+        let state_machine_prompt =
+            state_machine.build_system_prompt_from_snapshot(Vec::new(), GooseMode::Auto, snapshot);
 
-        assert_eq!(legacy_snapshot.subdirectories.len(), 1);
-        assert_eq!(
-            state_machine_snapshot.subdirectories.len(),
-            1,
-            "a colliding prompt key must not reserve a separator absent from the final prompt"
-        );
-        assert_eq!(
-            state_machine_reservation.root_only,
-            legacy_reservation.root_only
-        );
-        assert_eq!(
-            state_machine_reservation.subdirectories_only,
-            legacy_reservation.subdirectories_only
-        );
-        assert_eq!(
-            state_machine_reservation.with_subdirectories,
-            legacy_reservation.with_subdirectories
-        );
-
-        let prompt = prompt_manager.build_system_prompt_from_snapshot(
-            prompt_parts,
-            GooseMode::Auto,
-            state_machine_snapshot,
-        );
-        let first = prompt.find("CALLER_FIRST").unwrap();
-        let extensions = prompt.find("operation extensions").unwrap();
-        let last = prompt.find("CALLER_LAST").unwrap();
-        let hints = prompt.find(marker).unwrap();
-        assert!(first < extensions && extensions < last && last < hints);
-    }
-
-    #[test]
-    #[serial_test::serial]
-    fn state_machine_chat_subdirectory_hints_ignore_nonadjacent_chat_boundary() {
-        let config_root = tempfile::tempdir().unwrap();
-        let _guard = env_lock::lock_env([
-            (
-                "GOOSE_PATH_ROOT",
-                Some(config_root.path().to_str().unwrap()),
-            ),
-            ("CONTEXT_FILE_NAMES", Some(r#"[".goosehints"]"#)),
-        ]);
-        let project = tempfile::tempdir().unwrap();
-        let nested = project.path().join("nested");
-        fs::create_dir(&nested).unwrap();
-        let nested_hints = nested.join(GOOSE_HINTS_FILENAME);
-        let marker = "SUBDIRECTORY_BOUNDARY";
-        fs::write(&nested_hints, marker).unwrap();
-        let arguments = serde_json::json!({ "path": "nested/file.rs" })
-            .as_object()
-            .unwrap()
-            .clone();
-        let conversation = Conversation::new_unvalidated([Message::assistant().with_tool_request(
-            "read-nested",
-            Ok(CallToolRequestParams::new("read_file").with_arguments(arguments)),
-        )]);
-        let mut prompt_manager = PromptManager::new();
-        let reservation = prompt_manager.hint_output_reservation(["extensions"], GooseMode::Chat);
-        assert_eq!(reservation.root_only, 2 * HINT_EXTRA_SEPARATOR_BYTES);
-        assert_eq!(reservation.subdirectories_only, HINT_EXTRA_SEPARATOR_BYTES);
-        assert_eq!(
-            reservation.with_subdirectories,
-            2 * HINT_EXTRA_SEPARATOR_BYTES
-        );
-        let measured = reconstructed_hint_snapshot(&conversation, project.path(), reservation);
-        let framing_bytes = measured.subdirectories[0].1.len() - marker.len();
-        let hint_output_bytes = MAX_HINT_OUTPUT_BYTES - HINT_EXTRA_SEPARATOR_BYTES;
-        let content_bytes = hint_output_bytes - framing_bytes;
-        fs::write(
-            nested_hints,
-            format!("{marker}{}", "n".repeat(content_bytes - marker.len())),
-        )
-        .unwrap();
-
-        let snapshot = reconstructed_hint_snapshot(&conversation, project.path(), reservation);
-        assert!(snapshot.top_level.is_empty());
-        assert_eq!(snapshot.subdirectories.len(), 1);
-        assert_eq!(
-            snapshot.subdirectories[0].1.len() + HINT_EXTRA_SEPARATOR_BYTES,
-            MAX_HINT_OUTPUT_BYTES
-        );
-        let prompt = prompt_manager.build_system_prompt_from_snapshot(
-            vec![(
-                "extensions".to_string(),
-                "operation prompt instruction".to_string(),
-            )],
-            GooseMode::Chat,
-            snapshot,
-        );
-        assert!(prompt.contains(marker));
-        assert!(prompt.contains("operation prompt instruction"));
-    }
-
-    #[test]
-    #[serial_test::serial]
-    fn state_machine_hints_reserve_caller_prompt_and_chat_boundaries_at_exact_limit() {
-        const PROJECT_HINTS_HEADER: &str =
-            "### Project Hints\nThese are hints for working on the project in this directory.\n";
-
-        let config_root = tempfile::tempdir().unwrap();
-        let _guard = env_lock::lock_env([
-            (
-                "GOOSE_PATH_ROOT",
-                Some(config_root.path().to_str().unwrap()),
-            ),
-            ("CONTEXT_FILE_NAMES", Some(r#"[".goosehints"]"#)),
-        ]);
-        let project = tempfile::tempdir().unwrap();
-        let nested = project.path().join("nested");
-        fs::create_dir(&nested).unwrap();
-        fs::write(nested.join(GOOSE_HINTS_FILENAME), "NESTED_BOUNDARY").unwrap();
-        let arguments = serde_json::json!({ "path": "nested/file.rs" })
-            .as_object()
-            .unwrap()
-            .clone();
-        let conversation = Conversation::new_unvalidated([Message::assistant().with_tool_request(
-            "read-nested",
-            Ok(CallToolRequestParams::new("read_file").with_arguments(arguments)),
-        )]);
-        let prompt_parts = vec![(
-            "extensions".to_string(),
-            "operation prompt instruction".to_string(),
-        )];
-        let mut prompt_manager = PromptManager::new();
-        prompt_manager
-            .add_system_prompt_extra("caller".to_string(), "caller instruction".to_string());
-        let auto_reservation = prompt_manager.hint_output_reservation(
-            prompt_parts.iter().map(|(key, _)| key.as_str()),
-            GooseMode::Auto,
-        );
-        assert_eq!(auto_reservation.root_only, HINT_EXTRA_SEPARATOR_BYTES);
-        assert_eq!(
-            auto_reservation.subdirectories_only,
-            2 * HINT_EXTRA_SEPARATOR_BYTES
-        );
-        assert_eq!(
-            auto_reservation.with_subdirectories,
-            2 * HINT_EXTRA_SEPARATOR_BYTES
-        );
-        let reservation = prompt_manager.hint_output_reservation(
-            prompt_parts.iter().map(|(key, _)| key.as_str()),
-            GooseMode::Chat,
-        );
-        assert_eq!(reservation.root_only, 2 * HINT_EXTRA_SEPARATOR_BYTES);
-        assert_eq!(
-            reservation.subdirectories_only,
-            2 * HINT_EXTRA_SEPARATOR_BYTES
-        );
-        assert_eq!(
-            reservation.with_subdirectories,
-            3 * HINT_EXTRA_SEPARATOR_BYTES
-        );
-
-        let measured = reconstructed_hint_snapshot(&conversation, project.path(), reservation);
-        let nested_hint_bytes = measured.subdirectories[0].1.len();
-        let root_output_bytes = MAX_HINT_OUTPUT_BYTES
-            - reservation.with_subdirectories
-            - HINT_EXTRA_SEPARATOR_BYTES
-            - nested_hint_bytes;
-        let root_content_bytes = root_output_bytes - PROJECT_HINTS_HEADER.len();
-        fs::write(
-            project.path().join(GOOSE_HINTS_FILENAME),
-            format!(
-                "ROOT_BOUNDARY{}",
-                "r".repeat(root_content_bytes - "ROOT_BOUNDARY".len())
-            ),
-        )
-        .unwrap();
-
-        let snapshot = reconstructed_hint_snapshot(&conversation, project.path(), reservation);
-        assert_eq!(snapshot.subdirectories.len(), 1);
-        assert_eq!(
-            snapshot.top_level.len()
-                + snapshot.subdirectories[0].1.len()
-                + HINT_EXTRA_SEPARATOR_BYTES
-                + reservation.with_subdirectories,
-            MAX_HINT_OUTPUT_BYTES
-        );
-        let prompt = prompt_manager.build_system_prompt_from_snapshot(
-            prompt_parts,
-            GooseMode::Chat,
-            snapshot,
-        );
-        assert!(prompt.contains("caller instruction"));
-        assert!(prompt.contains("NESTED_BOUNDARY"));
-        assert!(prompt.contains("operation prompt instruction"));
-        assert!(prompt.contains("ROOT_BOUNDARY"));
-        let final_reservation =
-            prompt_manager.hint_output_reservation(["extensions"], GooseMode::Chat);
-        assert_eq!(final_reservation.root_only, reservation.root_only);
-        assert_eq!(
-            final_reservation.with_subdirectories,
-            reservation.with_subdirectories
-        );
+        assert_eq!(legacy_prompt, state_machine_prompt);
+        assert!(state_machine_prompt.contains("CALLER_EXTRA"));
+        assert!(!state_machine_prompt.contains("CALLER_HINTS"));
+        assert_eq!(state_machine_prompt.matches("ROOT_HINT").count(), 1);
+        assert_eq!(state_machine_prompt.matches("NESTED_HINT").count(), 1);
+        let caller_only_prompt = state_machine.builder().build();
+        assert!(caller_only_prompt.contains("CALLER_EXTRA"));
+        assert!(caller_only_prompt.contains("CALLER_HINTS"));
+        assert!(!caller_only_prompt.contains("ROOT_HINT"));
+        assert!(!caller_only_prompt.contains("NESTED_HINT"));
     }
 }

--- a/crates/goose/src/agents/state_machine/inference_preparation.rs
+++ b/crates/goose/src/agents/state_machine/inference_preparation.rs
@@ -4,17 +4,47 @@
 use crate::agents::ExtensionManager;
 use crate::agents::PromptManager;
 use crate::config::GooseMode;
+use crate::hints::load_hints::{HintSnapshot, SubdirectoryHintTracker, HINT_EXTRA_SEPARATOR_BYTES};
 use crate::session::Session;
 use crate::tool_inspection::ToolInspectionManager;
 use anyhow::Result;
 use async_trait::async_trait;
 use goose_agent::inference::{InferenceRequestPreparer, PreparedInferenceRequest};
 use goose_agent::operation::{messages_since_kickoff, InferenceInput};
-use goose_providers::conversation::message::Message;
+use goose_providers::conversation::message::{Message, MessageContent};
 use goose_providers::conversation::Conversation;
 #[cfg(feature = "code-mode")]
 use std::sync::Arc;
 use tokio::sync::Mutex;
+
+pub(super) fn reconstructed_hint_snapshot(
+    conversation: &Conversation,
+    working_dir: &std::path::Path,
+) -> HintSnapshot {
+    reconstructed_hint_snapshot_with_hook(conversation, working_dir, || {})
+}
+
+fn reconstructed_hint_snapshot_with_hook(
+    conversation: &Conversation,
+    working_dir: &std::path::Path,
+    after_top_level_read: impl FnOnce(),
+) -> HintSnapshot {
+    let mut hints = SubdirectoryHintTracker::new();
+    for message in conversation.messages() {
+        for content in &message.content {
+            if let MessageContent::ToolRequest(request) = content {
+                if let Ok(tool_call) = &request.tool_call {
+                    hints.record_tool_arguments(&tool_call.arguments, working_dir);
+                }
+            }
+        }
+    }
+    hints.load_snapshot_with_hook(
+        working_dir,
+        HINT_EXTRA_SEPARATOR_BYTES,
+        after_top_level_read,
+    )
+}
 
 pub struct GooseInferenceRequestPreparer<'a> {
     #[cfg(feature = "code-mode")]
@@ -50,11 +80,12 @@ impl InferenceRequestPreparer<Session> for GooseInferenceRequestPreparer<'_> {
         }
         let tools =
             crate::agents::reply_parts::prepare_inference_tools(input.tools, code_execution_mode);
-        let system_prompt = self.prompt_manager.lock().await.build_system_prompt(
-            &session.working_dir,
-            input.prompt_parts,
-            goose_mode,
-        );
+        let hint_snapshot = reconstructed_hint_snapshot(conversation, &session.working_dir);
+        let system_prompt = self
+            .prompt_manager
+            .lock()
+            .await
+            .build_system_prompt_from_snapshot(input.prompt_parts, goose_mode, hint_snapshot);
         let turn = messages_since_kickoff(conversation)?;
         let turn_start = turn
             .first()
@@ -81,5 +112,56 @@ impl InferenceRequestPreparer<Session> for GooseInferenceRequestPreparer<'_> {
             tools,
             additional_messages,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::hints::{GOOSE_HINTS_FILENAME, MAX_HINT_OUTPUT_BYTES};
+    use rmcp::model::CallToolRequestParams;
+    use std::fs;
+
+    #[test]
+    fn reconstructed_hint_snapshot_is_stable_across_file_growth() {
+        let project = tempfile::tempdir().unwrap();
+        let nested = project.path().join("nested");
+        fs::create_dir(&nested).unwrap();
+        let root_hints = project.path().join(GOOSE_HINTS_FILENAME);
+        fs::write(&root_hints, "ROOT_V1").unwrap();
+        fs::write(nested.join(GOOSE_HINTS_FILENAME), "NESTED_MARKER").unwrap();
+
+        let arguments = serde_json::json!({ "path": "nested/file.rs" })
+            .as_object()
+            .unwrap()
+            .clone();
+        let conversation = Conversation::new_unvalidated([Message::assistant().with_tool_request(
+            "read-nested",
+            Ok(CallToolRequestParams::new("read_file").with_arguments(arguments)),
+        )]);
+
+        let snapshot = reconstructed_hint_snapshot_with_hook(&conversation, project.path(), || {
+            fs::write(&root_hints, format!("{}ROOT_V2", "v".repeat(700 * 1024))).unwrap()
+        });
+        let hint_bytes = snapshot.top_level.len()
+            + snapshot
+                .subdirectories
+                .iter()
+                .map(|(_, content)| content.len())
+                .sum::<usize>()
+            + snapshot.subdirectories.len() * HINT_EXTRA_SEPARATOR_BYTES;
+        fs::write(&root_hints, "ROOT_V3").unwrap();
+
+        let prompt = PromptManager::new().build_system_prompt_from_snapshot(
+            Vec::new(),
+            GooseMode::Auto,
+            snapshot,
+        );
+
+        assert!(hint_bytes <= MAX_HINT_OUTPUT_BYTES);
+        assert!(prompt.contains("ROOT_V1"));
+        assert!(prompt.contains("NESTED_MARKER"));
+        assert!(!prompt.contains("ROOT_V2"));
+        assert!(!prompt.contains("ROOT_V3"));
     }
 }

--- a/crates/goose/src/agents/state_machine/inference_preparation.rs
+++ b/crates/goose/src/agents/state_machine/inference_preparation.rs
@@ -166,6 +166,66 @@ mod tests {
 
     #[test]
     #[serial_test::serial]
+    fn both_loops_drop_project_hints_when_working_directory_disappears() {
+        let config_root = tempfile::tempdir().unwrap();
+        let _guard = env_lock::lock_env([
+            (
+                "GOOSE_PATH_ROOT",
+                Some(config_root.path().to_str().unwrap()),
+            ),
+            ("CONTEXT_FILE_NAMES", Some(r#"[".goosehints"]"#)),
+        ]);
+        fs::create_dir(config_root.path().join("config")).unwrap();
+        fs::write(
+            config_root.path().join("config").join(GOOSE_HINTS_FILENAME),
+            "GLOBAL_HINT",
+        )
+        .unwrap();
+        let temp = tempfile::tempdir().unwrap();
+        let project = temp.path().join("project");
+        fs::create_dir_all(project.join("nested")).unwrap();
+        fs::write(project.join(GOOSE_HINTS_FILENAME), "ROOT_HINT").unwrap();
+        fs::write(
+            project.join("nested").join(GOOSE_HINTS_FILENAME),
+            "NESTED_HINT",
+        )
+        .unwrap();
+        let arguments = serde_json::json!({ "path": "nested/file.rs" })
+            .as_object()
+            .cloned();
+        let conversation = Conversation::new_unvalidated([Message::assistant().with_tool_request(
+            "read-nested",
+            Ok(CallToolRequestParams::new("read_file").with_arguments(arguments.clone().unwrap())),
+        )]);
+        let timestamp = chrono::DateTime::<chrono::Utc>::from_timestamp(0, 0).unwrap();
+        let mut legacy = PromptManager::with_timestamp(timestamp);
+        legacy.set_system_prompt_override("base".to_string());
+        legacy.record_tool_arguments(&arguments, &project);
+        assert!(legacy
+            .builder_with_fresh_hints(&project, GooseMode::Auto)
+            .build()
+            .contains("NESTED_HINT"));
+
+        fs::rename(&project, temp.path().join("moved-project")).unwrap();
+        assert!(legacy.load_subdirectory_hints(&project));
+        let legacy_prompt = legacy
+            .builder_with_fresh_hints(&project, GooseMode::Auto)
+            .build();
+        let mut state_machine = PromptManager::with_timestamp(timestamp);
+        state_machine.set_system_prompt_override("base".to_string());
+        let prompt = state_machine.build_system_prompt_from_snapshot(
+            Vec::new(),
+            GooseMode::Auto,
+            reconstructed_hint_snapshot(&conversation, &project),
+        );
+        assert_eq!(legacy_prompt, prompt);
+        assert!(prompt.contains("GLOBAL_HINT"));
+        assert!(!prompt.contains("ROOT_HINT"));
+        assert!(!prompt.contains("NESTED_HINT"));
+    }
+
+    #[test]
+    #[serial_test::serial]
     fn both_loops_bound_one_snapshot_and_deduplicate_ancestor_hints() {
         let config_root = tempfile::tempdir().unwrap();
         let _guard = env_lock::lock_env([

--- a/crates/goose/src/agents/state_machine/inference_preparation.rs
+++ b/crates/goose/src/agents/state_machine/inference_preparation.rs
@@ -4,7 +4,7 @@
 use crate::agents::ExtensionManager;
 use crate::agents::PromptManager;
 use crate::config::GooseMode;
-use crate::hints::load_hints::SubdirectoryHintTracker;
+use crate::hints::{SubdirectoryHintTracker, MAX_HINT_OUTPUT_BYTES};
 use crate::session::Session;
 use crate::tool_inspection::ToolInspectionManager;
 use anyhow::Result;
@@ -20,15 +20,13 @@ use tokio::sync::Mutex;
 pub(super) fn reconstructed_hint_snapshot(
     conversation: &Conversation,
     working_dir: &std::path::Path,
-    output_limit: usize,
 ) -> String {
-    reconstructed_hint_snapshot_with_hook(conversation, working_dir, output_limit, || {})
+    reconstructed_hint_snapshot_with_hook(conversation, working_dir, || {})
 }
 
 fn reconstructed_hint_snapshot_with_hook(
     conversation: &Conversation,
     working_dir: &std::path::Path,
-    output_limit: usize,
     after_top_level_read: impl FnOnce(),
 ) -> String {
     let mut hints = SubdirectoryHintTracker::new();
@@ -41,7 +39,7 @@ fn reconstructed_hint_snapshot_with_hook(
             }
         }
     }
-    hints.load_prompt_snapshot_with_hook(working_dir, output_limit, after_top_level_read)
+    hints.load_prompt_snapshot_with_hook(working_dir, MAX_HINT_OUTPUT_BYTES, after_top_level_read)
 }
 
 pub struct GooseInferenceRequestPreparer<'a> {
@@ -79,9 +77,7 @@ impl InferenceRequestPreparer<Session> for GooseInferenceRequestPreparer<'_> {
         let tools =
             crate::agents::reply_parts::prepare_inference_tools(input.tools, code_execution_mode);
         let mut prompt_manager = self.prompt_manager.lock().await;
-        let hint_output_limit = prompt_manager.hint_output_limit(&input.prompt_parts, goose_mode);
-        let hint_snapshot =
-            reconstructed_hint_snapshot(conversation, &session.working_dir, hint_output_limit);
+        let hint_snapshot = reconstructed_hint_snapshot(conversation, &session.working_dir);
         let system_prompt = prompt_manager.build_system_prompt_from_snapshot(
             input.prompt_parts,
             goose_mode,
@@ -124,7 +120,16 @@ mod tests {
     use std::fs;
 
     #[test]
+    #[serial_test::serial]
     fn reconstructed_hint_snapshot_is_stable_across_file_growth() {
+        let config_root = tempfile::tempdir().unwrap();
+        let _guard = env_lock::lock_env([
+            (
+                "GOOSE_PATH_ROOT",
+                Some(config_root.path().to_str().unwrap()),
+            ),
+            ("CONTEXT_FILE_NAMES", Some(r#"[".goosehints"]"#)),
+        ]);
         let project = tempfile::tempdir().unwrap();
         let nested = project.path().join("nested");
         fs::create_dir(&nested).unwrap();
@@ -141,12 +146,9 @@ mod tests {
             Ok(CallToolRequestParams::new("read_file").with_arguments(arguments)),
         )]);
 
-        let snapshot = reconstructed_hint_snapshot_with_hook(
-            &conversation,
-            project.path(),
-            MAX_HINT_OUTPUT_BYTES,
-            || fs::write(&root_hints, format!("{}ROOT_V2", "v".repeat(700 * 1024))).unwrap(),
-        );
+        let snapshot = reconstructed_hint_snapshot_with_hook(&conversation, project.path(), || {
+            fs::write(&root_hints, format!("{}ROOT_V2", "v".repeat(700 * 1024))).unwrap()
+        });
         fs::write(&root_hints, "ROOT_V3").unwrap();
 
         let prompt = PromptManager::new().build_system_prompt_from_snapshot(
@@ -164,7 +166,7 @@ mod tests {
 
     #[test]
     #[serial_test::serial]
-    fn prompt_snapshots_reserve_only_actual_adjacent_separators() {
+    fn both_loops_bound_one_snapshot_and_deduplicate_ancestor_hints() {
         let config_root = tempfile::tempdir().unwrap();
         let _guard = env_lock::lock_env([
             (
@@ -174,83 +176,72 @@ mod tests {
             ("CONTEXT_FILE_NAMES", Some(r#"[".goosehints"]"#)),
         ]);
         let project = tempfile::tempdir().unwrap();
-        let hints_path = project.path().join(GOOSE_HINTS_FILENAME);
-        const MARKER: &str = "BOUNDARY_MARKER";
-        fs::write(&hints_path, MARKER).unwrap();
-        let framing_bytes = SubdirectoryHintTracker::new()
-            .load_snapshot(project.path())
-            .len()
-            - MARKER.len();
-        let allowed_content_bytes = MAX_HINT_OUTPUT_BYTES - framing_bytes;
+        fs::create_dir_all(project.path().join("a/b")).unwrap();
+        let root_hints = project.path().join(GOOSE_HINTS_FILENAME);
         fs::write(
-            &hints_path,
-            format!(
-                "{}{}",
-                "x".repeat(allowed_content_bytes - MARKER.len()),
-                MARKER
-            ),
+            &root_hints,
+            format!("ROOT_MARKER{}", "r".repeat(600 * 1024)),
         )
         .unwrap();
-
-        let conversation = Conversation::new_unvalidated(Vec::<Message>::new());
-        let timestamp = chrono::DateTime::<chrono::Utc>::from_timestamp(0, 0).unwrap();
-        let mut bare = PromptManager::with_timestamp(timestamp);
-        bare.set_system_prompt_override("base".to_string());
-        let bare_limit = bare.hint_output_limit(&[], GooseMode::Auto);
-        assert_eq!(bare_limit, MAX_HINT_OUTPUT_BYTES);
-        let bare_snapshot = reconstructed_hint_snapshot(&conversation, project.path(), bare_limit);
-        assert_eq!(bare_snapshot.len(), MAX_HINT_OUTPUT_BYTES);
-        assert!(bare
-            .build_system_prompt_from_snapshot(Vec::new(), GooseMode::Auto, bare_snapshot)
-            .contains(MARKER));
-
-        let mut state_machine = PromptManager::with_timestamp(timestamp);
-        state_machine.set_system_prompt_override("base".to_string());
-        state_machine.add_system_prompt_extra("caller".to_string(), "CALLER".to_string());
-        let crowded_limit = state_machine.hint_output_limit(&[], GooseMode::Chat);
-        assert_eq!(crowded_limit, MAX_HINT_OUTPUT_BYTES - 4);
         fs::write(
-            &hints_path,
-            format!(
-                "{}{}",
-                "x".repeat(crowded_limit - framing_bytes - MARKER.len()),
-                MARKER
-            ),
+            project.path().join("a").join(GOOSE_HINTS_FILENAME),
+            format!("ANCESTOR_MARKER{}", "a".repeat(300 * 1024)),
         )
         .unwrap();
-        let snapshot = reconstructed_hint_snapshot(&conversation, project.path(), crowded_limit);
-        assert_eq!(snapshot.len(), crowded_limit);
-        let state_machine_prompt =
-            state_machine.build_system_prompt_from_snapshot(Vec::new(), GooseMode::Chat, snapshot);
-        assert!(state_machine_prompt.contains(MARKER));
-
-        let mut legacy = PromptManager::with_timestamp(timestamp);
-        legacy.set_system_prompt_override("base".to_string());
-        legacy.add_system_prompt_extra("caller".to_string(), "CALLER".to_string());
-        let legacy_prompt = legacy
-            .builder_with_fresh_hints(project.path(), GooseMode::Chat)
-            .build();
-        assert_eq!(legacy_prompt, state_machine_prompt);
-
         fs::write(
-            &hints_path,
-            format!(
-                "{}{}",
-                "x".repeat(crowded_limit - framing_bytes + 1 - MARKER.len()),
-                MARKER
-            ),
+            project.path().join("a/b").join(GOOSE_HINTS_FILENAME),
+            format!("DESCENDANT_MARKER{}", "b".repeat(300 * 1024)),
         )
         .unwrap();
-        assert!(
-            reconstructed_hint_snapshot(&conversation, project.path(), crowded_limit).is_empty()
+        let arguments = ["a/file.rs", "a/b/file.rs"].map(|path| {
+            serde_json::json!({ "path": path })
+                .as_object()
+                .unwrap()
+                .clone()
+        });
+        let conversation = Conversation::new_unvalidated(
+            arguments
+                .iter()
+                .enumerate()
+                .map(|(index, args)| {
+                    Message::assistant().with_tool_request(
+                        format!("read-{index}"),
+                        Ok(CallToolRequestParams::new("read_file").with_arguments(args.clone())),
+                    )
+                })
+                .collect::<Vec<_>>(),
         );
+        let timestamp = chrono::DateTime::<chrono::Utc>::from_timestamp(0, 0).unwrap();
         let mut legacy = PromptManager::with_timestamp(timestamp);
         legacy.set_system_prompt_override("base".to_string());
-        legacy.add_system_prompt_extra("caller".to_string(), "CALLER".to_string());
-        assert!(!legacy
-            .builder_with_fresh_hints(project.path(), GooseMode::Chat)
-            .build()
-            .contains(MARKER));
+        for args in &arguments {
+            legacy.record_tool_arguments(&Some(args.clone()), project.path());
+        }
+
+        for root in [None, Some("SHORT_ROOT")] {
+            if let Some(content) = root {
+                fs::write(&root_hints, content).unwrap();
+            }
+            let snapshot = reconstructed_hint_snapshot(&conversation, project.path());
+            assert!(snapshot.len() <= MAX_HINT_OUTPUT_BYTES);
+            assert_eq!(snapshot.matches("ANCESTOR_MARKER").count(), 1);
+            assert_eq!(snapshot.contains("DESCENDANT_MARKER"), root.is_some());
+            let mut state_machine = PromptManager::with_timestamp(timestamp);
+            state_machine.set_system_prompt_override("base".to_string());
+            let state_machine_prompt = state_machine.build_system_prompt_from_snapshot(
+                Vec::new(),
+                GooseMode::Auto,
+                snapshot,
+            );
+            let legacy_prompt = legacy
+                .builder_with_fresh_hints(project.path(), GooseMode::Auto)
+                .build();
+            assert_eq!(legacy_prompt, state_machine_prompt);
+            let output = legacy_prompt
+                .strip_prefix("base\n\n# Additional Instructions:\n\n")
+                .unwrap();
+            assert!(output.len() <= MAX_HINT_OUTPUT_BYTES);
+        }
     }
 
     #[test]
@@ -291,8 +282,7 @@ mod tests {
         state_machine.set_system_prompt_override("base".to_string());
         state_machine.add_system_prompt_extra("caller".to_string(), "CALLER_EXTRA".to_string());
         state_machine.add_system_prompt_extra("hints".to_string(), "CALLER_HINTS".to_string());
-        let output_limit = state_machine.hint_output_limit(&[], GooseMode::Auto);
-        let snapshot = reconstructed_hint_snapshot(&conversation, project.path(), output_limit);
+        let snapshot = reconstructed_hint_snapshot(&conversation, project.path());
         assert!(snapshot.find("ROOT_HINT").unwrap() < snapshot.find("NESTED_HINT").unwrap());
         let state_machine_prompt =
             state_machine.build_system_prompt_from_snapshot(Vec::new(), GooseMode::Auto, snapshot);

--- a/crates/goose/src/agents/state_machine/inference_preparation.rs
+++ b/crates/goose/src/agents/state_machine/inference_preparation.rs
@@ -357,5 +357,23 @@ mod tests {
         assert!(caller_only_prompt.contains("CALLER_HINTS"));
         assert!(!caller_only_prompt.contains("ROOT_HINT"));
         assert!(!caller_only_prompt.contains("NESTED_HINT"));
+
+        fs::write(project.path().join(GOOSE_HINTS_FILENAME), "UPDATED_ROOT").unwrap();
+        assert!(legacy.load_subdirectory_hints(project.path()));
+        assert!(legacy.load_subdirectory_hints(project.path()));
+        let legacy_refreshed = legacy
+            .builder_with_fresh_hints(project.path(), GooseMode::Auto)
+            .build();
+        let state_machine_refreshed = state_machine.build_system_prompt_from_snapshot(
+            Vec::new(),
+            GooseMode::Auto,
+            reconstructed_hint_snapshot(&conversation, project.path()),
+        );
+        assert_eq!(legacy_refreshed, state_machine_refreshed);
+        assert!(legacy_refreshed.contains("UPDATED_ROOT"));
+        assert!(!legacy_refreshed.contains("ROOT_HINT"));
+        assert!(legacy_refreshed.contains("NESTED_HINT"));
+        assert!(legacy_refreshed.contains("CALLER_EXTRA"));
+        assert!(!legacy.load_subdirectory_hints(project.path()));
     }
 }

--- a/crates/goose/src/agents/state_machine/ops_toolcalling.rs
+++ b/crates/goose/src/agents/state_machine/ops_toolcalling.rs
@@ -62,7 +62,7 @@ fn reconstructed_subdirectory_hints(
             }
         }
     }
-    hints.load_new_hints(working_dir)
+    hints.load_hints(working_dir)
 }
 
 fn string_argument(input: &serde_json::Value, keys: &[&str]) -> Option<String> {

--- a/crates/goose/src/agents/state_machine/ops_toolcalling.rs
+++ b/crates/goose/src/agents/state_machine/ops_toolcalling.rs
@@ -29,19 +29,6 @@ use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
 use tracing_futures::Instrument;
 
-#[cfg(test)]
-fn reconstructed_subdirectory_hints(
-    conversation: &Conversation,
-    working_dir: &std::path::Path,
-) -> Vec<(String, String)> {
-    super::inference_preparation::reconstructed_hint_snapshot(
-        conversation,
-        working_dir,
-        crate::hints::HINT_EXTRA_SEPARATOR_BYTES,
-    )
-    .subdirectories
-}
-
 #[derive(Clone, Copy)]
 enum ToolCategory {
     Shell,
@@ -1030,11 +1017,6 @@ impl Operation<Session, GooseEffect> for ToolExecutionOperation<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::hints::{
-        build_gitignore, get_context_filenames, load_hint_files, GOOSE_HINTS_FILENAME,
-        HINT_EXTRA_SEPARATOR_BYTES, MAX_HINT_OUTPUT_BYTES,
-    };
-    use std::fs;
 
     #[test]
     fn externally_dispatched_observations_are_not_pending_execution() {
@@ -1085,91 +1067,5 @@ mod tests {
             notification.params,
             Some(serde_json::json!({ "event_type": "app_updated" }))
         );
-    }
-
-    #[test]
-    fn reconstructed_hints_reserve_the_top_level_output_budget() {
-        let project = tempfile::tempdir().unwrap();
-        let nested = project.path().join("nested");
-        fs::create_dir(&nested).unwrap();
-        fs::write(
-            project.path().join(GOOSE_HINTS_FILENAME),
-            format!("{}ROOT_MARKER", "r".repeat(600 * 1024)),
-        )
-        .unwrap();
-        fs::write(
-            nested.join(GOOSE_HINTS_FILENAME),
-            format!("{}NESTED_MARKER", "n".repeat(600 * 1024)),
-        )
-        .unwrap();
-
-        let arguments = serde_json::json!({ "path": "nested/file.rs" })
-            .as_object()
-            .unwrap()
-            .clone();
-        let conversation = Conversation::new_unvalidated([Message::assistant().with_tool_request(
-            "read-nested",
-            Ok(CallToolRequestParams::new("read_file").with_arguments(arguments)),
-        )]);
-
-        let subdirectory_hints = reconstructed_subdirectory_hints(&conversation, project.path());
-        let hints_filenames = get_context_filenames();
-        let ignore_patterns = build_gitignore(project.path());
-        let top_level_hints = load_hint_files(project.path(), &hints_filenames, &ignore_patterns);
-        let subdirectory_hint_bytes: usize = subdirectory_hints
-            .iter()
-            .map(|(_, content)| content.len())
-            .sum();
-        let hint_count = usize::from(!top_level_hints.is_empty()) + subdirectory_hints.len();
-        let separator_bytes = hint_count.saturating_sub(1) * HINT_EXTRA_SEPARATOR_BYTES;
-
-        assert!(
-            top_level_hints.len() + subdirectory_hint_bytes + separator_bytes
-                <= MAX_HINT_OUTPUT_BYTES
-        );
-        assert!(top_level_hints.contains("ROOT_MARKER"));
-        assert!(subdirectory_hints.is_empty());
-    }
-
-    #[test]
-    fn reconstructed_hints_reserve_separators_around_non_hint_extras() {
-        let project = tempfile::tempdir().unwrap();
-        let nested = project.path().join("nested");
-        fs::create_dir(&nested).unwrap();
-        fs::write(project.path().join(GOOSE_HINTS_FILENAME), "root hints").unwrap();
-
-        let arguments = serde_json::json!({ "path": "nested/file.rs" })
-            .as_object()
-            .unwrap()
-            .clone();
-        let conversation = Conversation::new_unvalidated([Message::assistant().with_tool_request(
-            "read-nested",
-            Ok(CallToolRequestParams::new("read_file").with_arguments(arguments)),
-        )]);
-        let hints_filenames = get_context_filenames();
-        let ignore_patterns = build_gitignore(project.path());
-        let top_level_hints = load_hint_files(project.path(), &hints_filenames, &ignore_patterns);
-        let header_bytes = format!(
-            "### Subdirectory Hints ({})\n",
-            nested.canonicalize().unwrap().display()
-        )
-        .len();
-        let nested_content_bytes = MAX_HINT_OUTPUT_BYTES
-            - top_level_hints.len()
-            - 2 * HINT_EXTRA_SEPARATOR_BYTES
-            - header_bytes;
-        let nested_hints = nested.join(GOOSE_HINTS_FILENAME);
-        fs::write(&nested_hints, "n".repeat(nested_content_bytes)).unwrap();
-
-        let subdirectory_hints = reconstructed_subdirectory_hints(&conversation, project.path());
-
-        assert_eq!(subdirectory_hints.len(), 1);
-        assert_eq!(
-            top_level_hints.len() + subdirectory_hints[0].1.len() + 2 * HINT_EXTRA_SEPARATOR_BYTES,
-            MAX_HINT_OUTPUT_BYTES
-        );
-
-        fs::write(&nested_hints, "n".repeat(nested_content_bytes + 1)).unwrap();
-        assert!(reconstructed_subdirectory_hints(&conversation, project.path()).is_empty());
     }
 }

--- a/crates/goose/src/agents/state_machine/ops_toolcalling.rs
+++ b/crates/goose/src/agents/state_machine/ops_toolcalling.rs
@@ -22,14 +22,21 @@ use crate::agents::AgentEvent;
 use crate::config::GooseMode;
 use crate::conversation::message::{ActionRequiredData, Message, MessageContent, ToolRequest};
 use crate::conversation::Conversation;
-use crate::hints::load_hints::{SubdirectoryHintTracker, HINT_EXTRA_SEPARATOR_BYTES};
 use crate::hooks::{HookChainOutcome, HookContext, HookEvent, HookManager};
 use crate::session::{EnabledExtensionsState, ExtensionState, Session};
-use std::path::Path;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
 use tracing_futures::Instrument;
+
+#[cfg(test)]
+fn reconstructed_subdirectory_hints(
+    conversation: &Conversation,
+    working_dir: &std::path::Path,
+) -> Vec<(String, String)> {
+    super::inference_preparation::reconstructed_hint_snapshot(conversation, working_dir)
+        .subdirectories
+}
 
 #[derive(Clone, Copy)]
 enum ToolCategory {
@@ -46,24 +53,6 @@ fn categorize_tool(tool_name: &str) -> ToolCategory {
         "write" | "edit" | "patch" | "write_file" | "edit_file" => ToolCategory::Write,
         _ => ToolCategory::Other,
     }
-}
-
-fn reconstructed_subdirectory_hints(
-    conversation: &Conversation,
-    working_dir: &Path,
-) -> Vec<(String, String)> {
-    let mut hints = SubdirectoryHintTracker::new();
-    for message in conversation.messages() {
-        for content in &message.content {
-            if let MessageContent::ToolRequest(request) = content {
-                if let Ok(tool_call) = &request.tool_call {
-                    hints.record_tool_arguments(&tool_call.arguments, working_dir);
-                }
-            }
-        }
-    }
-    // Root hints are appended after the other state-machine prompt parts.
-    hints.load_hints_with_reservation(working_dir, HINT_EXTRA_SEPARATOR_BYTES)
 }
 
 fn string_argument(input: &serde_json::Value, keys: &[&str]) -> Option<String> {
@@ -792,9 +781,9 @@ impl Operation<Session, GooseEffect> for ToolExecutionOperation<'_> {
     async fn prompt_parts(
         &self,
         session: &Session,
-        conversation: &Conversation,
+        _conversation: &Conversation,
     ) -> Result<Vec<(String, String)>> {
-        let mut prompt_parts = reconstructed_subdirectory_hints(conversation, &session.working_dir);
+        let mut prompt_parts = Vec::new();
 
         #[cfg(feature = "code-mode")]
         if self

--- a/crates/goose/src/agents/state_machine/ops_toolcalling.rs
+++ b/crates/goose/src/agents/state_machine/ops_toolcalling.rs
@@ -34,8 +34,12 @@ fn reconstructed_subdirectory_hints(
     conversation: &Conversation,
     working_dir: &std::path::Path,
 ) -> Vec<(String, String)> {
-    super::inference_preparation::reconstructed_hint_snapshot(conversation, working_dir)
-        .subdirectories
+    super::inference_preparation::reconstructed_hint_snapshot(
+        conversation,
+        working_dir,
+        GooseMode::Auto,
+    )
+    .subdirectories
 }
 
 #[derive(Clone, Copy)]

--- a/crates/goose/src/agents/state_machine/ops_toolcalling.rs
+++ b/crates/goose/src/agents/state_machine/ops_toolcalling.rs
@@ -1038,7 +1038,7 @@ mod tests {
     use super::*;
     use crate::hints::{
         build_gitignore, get_context_filenames, load_hint_files, GOOSE_HINTS_FILENAME,
-        MAX_HINT_OUTPUT_BYTES,
+        HINT_EXTRA_SEPARATOR_BYTES, MAX_HINT_OUTPUT_BYTES,
     };
     use std::fs;
 
@@ -1126,8 +1126,13 @@ mod tests {
             .iter()
             .map(|(_, content)| content.len())
             .sum();
+        let hint_count = usize::from(!top_level_hints.is_empty()) + subdirectory_hints.len();
+        let separator_bytes = hint_count.saturating_sub(1) * HINT_EXTRA_SEPARATOR_BYTES;
 
-        assert!(top_level_hints.len() + subdirectory_hint_bytes <= MAX_HINT_OUTPUT_BYTES);
+        assert!(
+            top_level_hints.len() + subdirectory_hint_bytes + separator_bytes
+                <= MAX_HINT_OUTPUT_BYTES
+        );
         assert!(top_level_hints.contains("ROOT_MARKER"));
         assert!(subdirectory_hints.is_empty());
     }

--- a/crates/goose/src/agents/state_machine/ops_toolcalling.rs
+++ b/crates/goose/src/agents/state_machine/ops_toolcalling.rs
@@ -25,6 +25,7 @@ use crate::conversation::Conversation;
 use crate::hints::load_hints::SubdirectoryHintTracker;
 use crate::hooks::{HookChainOutcome, HookContext, HookEvent, HookManager};
 use crate::session::{EnabledExtensionsState, ExtensionState, Session};
+use std::path::Path;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
@@ -45,6 +46,23 @@ fn categorize_tool(tool_name: &str) -> ToolCategory {
         "write" | "edit" | "patch" | "write_file" | "edit_file" => ToolCategory::Write,
         _ => ToolCategory::Other,
     }
+}
+
+fn reconstructed_subdirectory_hints(
+    conversation: &Conversation,
+    working_dir: &Path,
+) -> Vec<(String, String)> {
+    let mut hints = SubdirectoryHintTracker::new();
+    for message in conversation.messages() {
+        for content in &message.content {
+            if let MessageContent::ToolRequest(request) = content {
+                if let Ok(tool_call) = &request.tool_call {
+                    hints.record_tool_arguments(&tool_call.arguments, working_dir);
+                }
+            }
+        }
+    }
+    hints.load_new_hints(working_dir)
 }
 
 fn string_argument(input: &serde_json::Value, keys: &[&str]) -> Option<String> {
@@ -775,17 +793,7 @@ impl Operation<Session, GooseEffect> for ToolExecutionOperation<'_> {
         session: &Session,
         conversation: &Conversation,
     ) -> Result<Vec<(String, String)>> {
-        let mut hints = SubdirectoryHintTracker::new();
-        for message in conversation.messages() {
-            for content in &message.content {
-                if let MessageContent::ToolRequest(request) = content {
-                    if let Ok(tool_call) = &request.tool_call {
-                        hints.record_tool_arguments(&tool_call.arguments, &session.working_dir);
-                    }
-                }
-            }
-        }
-        let mut prompt_parts = hints.load_new_hints(&session.working_dir);
+        let mut prompt_parts = reconstructed_subdirectory_hints(conversation, &session.working_dir);
 
         #[cfg(feature = "code-mode")]
         if self
@@ -1028,6 +1036,11 @@ impl Operation<Session, GooseEffect> for ToolExecutionOperation<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::hints::{
+        build_gitignore, get_context_filenames, load_hint_files, GOOSE_HINTS_FILENAME,
+        MAX_HINT_OUTPUT_BYTES,
+    };
+    use std::fs;
 
     #[test]
     fn externally_dispatched_observations_are_not_pending_execution() {
@@ -1078,5 +1091,44 @@ mod tests {
             notification.params,
             Some(serde_json::json!({ "event_type": "app_updated" }))
         );
+    }
+
+    #[test]
+    fn reconstructed_hints_reserve_the_top_level_output_budget() {
+        let project = tempfile::tempdir().unwrap();
+        let nested = project.path().join("nested");
+        fs::create_dir(&nested).unwrap();
+        fs::write(
+            project.path().join(GOOSE_HINTS_FILENAME),
+            format!("{}ROOT_MARKER", "r".repeat(600 * 1024)),
+        )
+        .unwrap();
+        fs::write(
+            nested.join(GOOSE_HINTS_FILENAME),
+            format!("{}NESTED_MARKER", "n".repeat(600 * 1024)),
+        )
+        .unwrap();
+
+        let arguments = serde_json::json!({ "path": "nested/file.rs" })
+            .as_object()
+            .unwrap()
+            .clone();
+        let conversation = Conversation::new_unvalidated([Message::assistant().with_tool_request(
+            "read-nested",
+            Ok(CallToolRequestParams::new("read_file").with_arguments(arguments)),
+        )]);
+
+        let subdirectory_hints = reconstructed_subdirectory_hints(&conversation, project.path());
+        let hints_filenames = get_context_filenames();
+        let ignore_patterns = build_gitignore(project.path());
+        let top_level_hints = load_hint_files(project.path(), &hints_filenames, &ignore_patterns);
+        let subdirectory_hint_bytes: usize = subdirectory_hints
+            .iter()
+            .map(|(_, content)| content.len())
+            .sum();
+
+        assert!(top_level_hints.len() + subdirectory_hint_bytes <= MAX_HINT_OUTPUT_BYTES);
+        assert!(top_level_hints.contains("ROOT_MARKER"));
+        assert!(subdirectory_hints.is_empty());
     }
 }

--- a/crates/goose/src/agents/state_machine/ops_toolcalling.rs
+++ b/crates/goose/src/agents/state_machine/ops_toolcalling.rs
@@ -37,7 +37,7 @@ fn reconstructed_subdirectory_hints(
     super::inference_preparation::reconstructed_hint_snapshot(
         conversation,
         working_dir,
-        GooseMode::Auto,
+        crate::hints::HINT_EXTRA_SEPARATOR_BYTES,
     )
     .subdirectories
 }

--- a/crates/goose/src/agents/state_machine/ops_toolcalling.rs
+++ b/crates/goose/src/agents/state_machine/ops_toolcalling.rs
@@ -22,7 +22,7 @@ use crate::agents::AgentEvent;
 use crate::config::GooseMode;
 use crate::conversation::message::{ActionRequiredData, Message, MessageContent, ToolRequest};
 use crate::conversation::Conversation;
-use crate::hints::load_hints::SubdirectoryHintTracker;
+use crate::hints::load_hints::{SubdirectoryHintTracker, HINT_EXTRA_SEPARATOR_BYTES};
 use crate::hooks::{HookChainOutcome, HookContext, HookEvent, HookManager};
 use crate::session::{EnabledExtensionsState, ExtensionState, Session};
 use std::path::Path;
@@ -62,7 +62,8 @@ fn reconstructed_subdirectory_hints(
             }
         }
     }
-    hints.load_hints(working_dir)
+    // Root hints are appended after the other state-machine prompt parts.
+    hints.load_hints_with_reservation(working_dir, HINT_EXTRA_SEPARATOR_BYTES)
 }
 
 fn string_argument(input: &serde_json::Value, keys: &[&str]) -> Option<String> {
@@ -1135,5 +1136,47 @@ mod tests {
         );
         assert!(top_level_hints.contains("ROOT_MARKER"));
         assert!(subdirectory_hints.is_empty());
+    }
+
+    #[test]
+    fn reconstructed_hints_reserve_separators_around_non_hint_extras() {
+        let project = tempfile::tempdir().unwrap();
+        let nested = project.path().join("nested");
+        fs::create_dir(&nested).unwrap();
+        fs::write(project.path().join(GOOSE_HINTS_FILENAME), "root hints").unwrap();
+
+        let arguments = serde_json::json!({ "path": "nested/file.rs" })
+            .as_object()
+            .unwrap()
+            .clone();
+        let conversation = Conversation::new_unvalidated([Message::assistant().with_tool_request(
+            "read-nested",
+            Ok(CallToolRequestParams::new("read_file").with_arguments(arguments)),
+        )]);
+        let hints_filenames = get_context_filenames();
+        let ignore_patterns = build_gitignore(project.path());
+        let top_level_hints = load_hint_files(project.path(), &hints_filenames, &ignore_patterns);
+        let header_bytes = format!(
+            "### Subdirectory Hints ({})\n",
+            nested.canonicalize().unwrap().display()
+        )
+        .len();
+        let nested_content_bytes = MAX_HINT_OUTPUT_BYTES
+            - top_level_hints.len()
+            - 2 * HINT_EXTRA_SEPARATOR_BYTES
+            - header_bytes;
+        let nested_hints = nested.join(GOOSE_HINTS_FILENAME);
+        fs::write(&nested_hints, "n".repeat(nested_content_bytes)).unwrap();
+
+        let subdirectory_hints = reconstructed_subdirectory_hints(&conversation, project.path());
+
+        assert_eq!(subdirectory_hints.len(), 1);
+        assert_eq!(
+            top_level_hints.len() + subdirectory_hints[0].1.len() + 2 * HINT_EXTRA_SEPARATOR_BYTES,
+            MAX_HINT_OUTPUT_BYTES
+        );
+
+        fs::write(&nested_hints, "n".repeat(nested_content_bytes + 1)).unwrap();
+        assert!(reconstructed_subdirectory_hints(&conversation, project.path()).is_empty());
     }
 }

--- a/crates/goose/src/hints/import_files.rs
+++ b/crates/goose/src/hints/import_files.rs
@@ -19,6 +19,18 @@ pub(crate) const MAX_HINT_OUTPUT_BYTES: usize = 1024 * 1024;
 const MAX_GIT_POINTER_BYTES: u64 = 4096;
 const MAX_HINT_INPUT_BYTES: usize = MAX_HINT_OUTPUT_BYTES;
 
+pub(crate) struct HintInputBudget {
+    remaining_bytes: usize,
+}
+
+impl HintInputBudget {
+    pub(crate) fn new() -> Self {
+        Self {
+            remaining_bytes: MAX_HINT_INPUT_BYTES,
+        }
+    }
+}
+
 struct FileReference {
     path: PathBuf,
     start: usize,
@@ -38,10 +50,15 @@ struct ImportBoundary {
 }
 
 impl ExpansionBudget {
+    #[cfg(test)]
     fn new(operations: usize, output_bytes: usize) -> Self {
+        Self::with_input_limit(operations, MAX_HINT_INPUT_BYTES, output_bytes)
+    }
+
+    fn with_input_limit(operations: usize, input_bytes: usize, output_bytes: usize) -> Self {
         Self {
             remaining_operations: operations,
-            remaining_input_bytes: MAX_HINT_INPUT_BYTES,
+            remaining_input_bytes: input_bytes,
             remaining_output_bytes: output_bytes,
             exhausted: false,
         }
@@ -581,15 +598,42 @@ pub(crate) fn read_referenced_files_with_limit(
     ignore_patterns: &Gitignore,
     output_limit: usize,
 ) -> String {
-    let mut budget = ExpansionBudget::new(MAX_REFERENCE_OPERATIONS, output_limit);
-    read_referenced_files_with_budget(
+    let mut input_budget = HintInputBudget::new();
+    read_referenced_files_with_limit_and_input_budget(
+        file_path,
+        import_boundary,
+        visited,
+        depth,
+        ignore_patterns,
+        output_limit,
+        &mut input_budget,
+    )
+}
+
+pub(crate) fn read_referenced_files_with_limit_and_input_budget(
+    file_path: &Path,
+    import_boundary: &Path,
+    visited: &mut HashSet<PathBuf>,
+    depth: usize,
+    ignore_patterns: &Gitignore,
+    output_limit: usize,
+    input_budget: &mut HintInputBudget,
+) -> String {
+    let mut budget = ExpansionBudget::with_input_limit(
+        MAX_REFERENCE_OPERATIONS,
+        input_budget.remaining_bytes,
+        output_limit,
+    );
+    let result = read_referenced_files_with_budget(
         file_path,
         import_boundary,
         visited,
         depth,
         ignore_patterns,
         &mut budget,
-    )
+    );
+    input_budget.remaining_bytes = budget.remaining_input_bytes;
+    result
 }
 
 #[cfg(test)]

--- a/crates/goose/src/hints/import_files.rs
+++ b/crates/goose/src/hints/import_files.rs
@@ -13,7 +13,7 @@ static FILE_REFERENCE_REGEX: Lazy<regex::Regex> = Lazy::new(|| {
 
 const MAX_DEPTH: usize = 3;
 const MAX_REFERENCE_OPERATIONS: usize = 64;
-const MAX_EXPANDED_OUTPUT_BYTES: usize = 1024 * 1024;
+pub(crate) const MAX_HINT_OUTPUT_BYTES: usize = 1024 * 1024;
 const MAX_GIT_POINTER_BYTES: u64 = 4096;
 
 struct FileReference {
@@ -54,7 +54,6 @@ impl ExpansionBudget {
 
     fn reserve_output(&mut self, bytes: usize) -> bool {
         if self.exhausted || bytes > self.remaining_output_bytes {
-            self.exhausted = true;
             return false;
         }
 
@@ -65,13 +64,8 @@ impl ExpansionBudget {
         true
     }
 
-    fn can_fit_output(&mut self, bytes: usize) -> bool {
-        if self.exhausted || bytes > self.remaining_output_bytes {
-            self.exhausted = true;
-            return false;
-        }
-
-        true
+    fn can_fit_output(&self, bytes: usize) -> bool {
+        !self.exhausted && bytes <= self.remaining_output_bytes
     }
 }
 
@@ -335,6 +329,10 @@ fn expanded_output_cost(reference: &Path, content_bytes: usize) -> Option<usize>
     content_bytes.checked_add(wrapper_bytes)
 }
 
+fn replaced_reference_cost(reference: &Path) -> Option<usize> {
+    reference.to_string_lossy().len().checked_add(1)
+}
+
 fn content_between(content: &str, start: usize, end: usize) -> &str {
     content
         .get(start..end)
@@ -381,17 +379,21 @@ fn process_file_reference(
     budget: &mut ExpansionBudget,
 ) -> Option<String> {
     let wrapper_bytes = expanded_output_cost(reference, 0)?;
-    if !budget.can_fit_output(wrapper_bytes) {
+    let replaced_bytes = replaced_reference_cost(reference)?;
+    let wrapper_growth = wrapper_bytes.saturating_sub(replaced_bytes);
+    if !budget.can_fit_output(wrapper_growth) {
         return None;
     }
 
     let file_size = usize::try_from(std::fs::metadata(safe_path).ok()?.len()).ok()?;
     let estimated_output = expanded_output_cost(reference, file_size)?;
-    if !budget.can_fit_output(estimated_output) {
+    let estimated_growth = estimated_output.saturating_sub(replaced_bytes);
+    if !budget.can_fit_output(estimated_growth) {
         return None;
     }
 
-    let max_content_bytes = budget.remaining_output_bytes - wrapper_bytes;
+    let max_replacement_bytes = budget.remaining_output_bytes.checked_add(replaced_bytes)?;
+    let max_content_bytes = max_replacement_bytes.checked_sub(wrapper_bytes)?;
     let read_limit = u64::try_from(max_content_bytes).ok()?.saturating_add(1);
     let mut content = String::new();
     let read_result = std::fs::File::open(safe_path)
@@ -405,7 +407,8 @@ fn process_file_reference(
     }
 
     let output_bytes = expanded_output_cost(reference, content.len())?;
-    if !budget.reserve_output(output_bytes) {
+    let output_growth = output_bytes.saturating_sub(replaced_bytes);
+    if !budget.reserve_output(output_growth) {
         return None;
     }
 
@@ -511,17 +514,48 @@ fn read_referenced_files_with_budget(
             return String::new();
         }
     };
-    let content = match std::fs::read_to_string(&safe_file_path) {
-        Ok(content) => content,
+    let max_content_bytes = budget.remaining_output_bytes;
+    let file_size = match std::fs::metadata(&safe_file_path)
+        .and_then(|metadata| usize::try_from(metadata.len()).map_err(std::io::Error::other))
+    {
+        Ok(file_size) => file_size,
         Err(e) => {
-            tracing::warn!("Could not read file {:?}: {}", safe_file_path, e);
+            tracing::warn!("Could not inspect hint file {:?}: {}", safe_file_path, e);
             return String::new();
         }
     };
+    if file_size > max_content_bytes {
+        tracing::warn!(
+            "Hint file too large: {:?} ({} bytes, remaining limit: {} bytes)",
+            safe_file_path,
+            file_size,
+            max_content_bytes
+        );
+        return String::new();
+    }
+
+    let read_limit = u64::try_from(max_content_bytes)
+        .unwrap_or(u64::MAX)
+        .saturating_add(1);
+    let mut content = String::new();
+    let read_result = std::fs::File::open(&safe_file_path)
+        .and_then(|file| file.take(read_limit).read_to_string(&mut content));
+    if let Err(e) = read_result {
+        tracing::warn!("Could not read hint file {:?}: {}", safe_file_path, e);
+        return String::new();
+    }
+    if content.len() > max_content_bytes || !budget.reserve_output(content.len()) {
+        tracing::warn!(
+            "Hint file too large: {:?} (remaining limit: {} bytes)",
+            safe_file_path,
+            max_content_bytes
+        );
+        return String::new();
+    }
 
     expand_file_content(
         &content,
-        file_path,
+        &safe_file_path,
         &import_boundary,
         visited,
         depth,
@@ -530,14 +564,15 @@ fn read_referenced_files_with_budget(
     )
 }
 
-pub fn read_referenced_files(
+pub(crate) fn read_referenced_files_with_limit(
     file_path: &Path,
     import_boundary: &Path,
     visited: &mut HashSet<PathBuf>,
     depth: usize,
     ignore_patterns: &Gitignore,
+    output_limit: usize,
 ) -> String {
-    let mut budget = ExpansionBudget::new(MAX_REFERENCE_OPERATIONS, MAX_EXPANDED_OUTPUT_BYTES);
+    let mut budget = ExpansionBudget::new(MAX_REFERENCE_OPERATIONS, output_limit);
     read_referenced_files_with_budget(
         file_path,
         import_boundary,
@@ -545,6 +580,24 @@ pub fn read_referenced_files(
         depth,
         ignore_patterns,
         &mut budget,
+    )
+}
+
+#[cfg(test)]
+fn read_referenced_files(
+    file_path: &Path,
+    import_boundary: &Path,
+    visited: &mut HashSet<PathBuf>,
+    depth: usize,
+    ignore_patterns: &Gitignore,
+) -> String {
+    read_referenced_files_with_limit(
+        file_path,
+        import_boundary,
+        visited,
+        depth,
+        ignore_patterns,
+        MAX_HINT_OUTPUT_BYTES,
     )
 }
 
@@ -1099,6 +1152,43 @@ mod tests {
         }
 
         #[test]
+        fn test_top_level_content_is_rejected_over_output_limit() {
+            let temp_dir = tempfile::tempdir().unwrap();
+            let import_boundary = temp_dir.path();
+            let ignore_patterns = create_ignore_patterns(import_boundary);
+            let main_file = create_file(import_boundary, "main.md", &"x".repeat(33));
+
+            let expanded = read_with_budget(
+                &main_file,
+                import_boundary,
+                &ignore_patterns,
+                MAX_REFERENCE_OPERATIONS,
+                32,
+            );
+
+            assert!(expanded.is_empty());
+        }
+
+        #[test]
+        fn test_top_level_content_at_output_limit_is_preserved() {
+            let temp_dir = tempfile::tempdir().unwrap();
+            let import_boundary = temp_dir.path();
+            let ignore_patterns = create_ignore_patterns(import_boundary);
+            let content = "legitimate hint";
+            let main_file = create_file(import_boundary, "main.md", content);
+
+            let expanded = read_with_budget(
+                &main_file,
+                import_boundary,
+                &ignore_patterns,
+                MAX_REFERENCE_OPERATIONS,
+                content.len(),
+            );
+
+            assert_eq!(expanded, content);
+        }
+
+        #[test]
         fn test_reference_operation_budget_preserves_excess_references() {
             let temp_dir = tempfile::tempdir().unwrap();
             let import_boundary = temp_dir.path();
@@ -1155,7 +1245,34 @@ mod tests {
             );
 
             assert!(expanded.contains("@included_8.md"));
-            assert!(expanded.len() <= references.join("\n").len() + 1_048_576);
+            assert!(expanded.len() <= MAX_HINT_OUTPUT_BYTES);
+        }
+
+        #[test]
+        fn test_oversized_reference_does_not_block_later_reference() {
+            let temp_dir = tempfile::tempdir().unwrap();
+            let import_boundary = temp_dir.path();
+            let ignore_patterns = create_ignore_patterns(import_boundary);
+            create_file(import_boundary, "large.md", &"large".repeat(100));
+            let small_content = "small content";
+            create_file(import_boundary, "small.md", small_content);
+            let main_content = "@large.md\n@small.md";
+            let main_file = create_file(import_boundary, "main.md", main_content);
+            let small_growth = expanded_output_cost(Path::new("small.md"), small_content.len())
+                .unwrap()
+                - replaced_reference_cost(Path::new("small.md")).unwrap();
+
+            let expanded = read_with_budget(
+                &main_file,
+                import_boundary,
+                &ignore_patterns,
+                MAX_REFERENCE_OPERATIONS,
+                main_content.len() + small_growth,
+            );
+
+            assert!(expanded.contains("@large.md"));
+            assert!(!expanded.contains("largelarge"));
+            assert!(expanded.contains("small content"));
         }
 
         #[test]
@@ -1175,7 +1292,7 @@ mod tests {
                 import_boundary,
                 &ignore_patterns,
                 2,
-                MAX_EXPANDED_OUTPUT_BYTES,
+                MAX_HINT_OUTPUT_BYTES,
             );
 
             assert_eq!(expanded.matches("shared content").count(), 2);
@@ -1199,7 +1316,7 @@ mod tests {
                 import_boundary,
                 &ignore_patterns,
                 3,
-                MAX_EXPANDED_OUTPUT_BYTES,
+                MAX_HINT_OUTPUT_BYTES,
             );
 
             assert!(expanded.contains("leaf one"));
@@ -1216,31 +1333,35 @@ mod tests {
             let included_content = "included content";
             create_file(import_boundary, "included.md", included_content);
             create_file(import_boundary, "later.md", "later content");
-            let main_file = create_file(import_boundary, "main.md", "@included.md\n@later.md");
+            let main_content = "@included.md\n@later.md";
+            let main_file = create_file(import_boundary, "main.md", main_content);
             let exact_cost =
                 expanded_output_cost(Path::new("included.md"), included_content.len()).unwrap();
+            let replaced_bytes = replaced_reference_cost(Path::new("included.md")).unwrap();
+            let total_limit = main_content.len() + exact_cost - replaced_bytes;
 
             let at_boundary = read_with_budget(
                 &main_file,
                 import_boundary,
                 &ignore_patterns,
                 MAX_REFERENCE_OPERATIONS,
-                exact_cost,
+                total_limit,
             );
             let below_boundary = read_with_budget(
                 &main_file,
                 import_boundary,
                 &ignore_patterns,
                 MAX_REFERENCE_OPERATIONS,
-                exact_cost - 1,
+                total_limit - 1,
             );
 
             assert!(at_boundary.contains("included content"));
             assert!(at_boundary.contains("@later.md"));
             assert!(!at_boundary.contains("later content"));
             assert!(below_boundary.contains("@included.md"));
-            assert!(below_boundary.contains("@later.md"));
             assert!(!below_boundary.contains("included content"));
+            assert!(!below_boundary.contains("@later.md"));
+            assert!(below_boundary.contains("later content"));
         }
 
         #[test]

--- a/crates/goose/src/hints/import_files.rs
+++ b/crates/goose/src/hints/import_files.rs
@@ -590,7 +590,8 @@ fn read_referenced_files_with_budget(
     )
 }
 
-pub(crate) fn read_referenced_files_with_limit(
+#[cfg(test)]
+fn read_referenced_files_with_limit(
     file_path: &Path,
     import_boundary: &Path,
     visited: &mut HashSet<PathBuf>,

--- a/crates/goose/src/hints/import_files.rs
+++ b/crates/goose/src/hints/import_files.rs
@@ -6,6 +6,8 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use crate::utils::sanitize_unicode_tags;
+
 static FILE_REFERENCE_REGEX: Lazy<regex::Regex> = Lazy::new(|| {
     regex::Regex::new(r"(?:^|\s)@([a-zA-Z0-9_\-./]+(?:\.[a-zA-Z0-9]+)+|[A-Z][a-zA-Z0-9_\-]*|[a-zA-Z0-9_\-./]*[./][a-zA-Z0-9_\-./]*)")
         .expect("Invalid file reference regex pattern")
@@ -406,6 +408,7 @@ fn process_file_reference(
         }
     }
 
+    let content = sanitize_unicode_tags(&content);
     let output_bytes = expanded_output_cost(reference, content.len())?;
     let output_growth = output_bytes.saturating_sub(replaced_bytes);
     if !budget.reserve_output(output_growth) {
@@ -544,6 +547,7 @@ fn read_referenced_files_with_budget(
         tracing::warn!("Could not read hint file {:?}: {}", safe_file_path, e);
         return String::new();
     }
+    let content = sanitize_unicode_tags(&content);
     if content.len() > max_content_bytes || !budget.reserve_output(content.len()) {
         tracing::warn!(
             "Hint file too large: {:?} (remaining limit: {} bytes)",
@@ -1189,6 +1193,35 @@ mod tests {
         }
 
         #[test]
+        fn test_top_level_content_budgets_nfc_expansion() {
+            let temp_dir = tempfile::tempdir().unwrap();
+            let import_boundary = temp_dir.path();
+            let ignore_patterns = create_ignore_patterns(import_boundary);
+            let content = "\u{0344}".repeat(2);
+            let normalized = "\u{0308}\u{0301}".repeat(2);
+            let main_file = create_file(import_boundary, "main.md", &content);
+
+            let at_boundary = read_with_budget(
+                &main_file,
+                import_boundary,
+                &ignore_patterns,
+                MAX_REFERENCE_OPERATIONS,
+                normalized.len(),
+            );
+            let below_boundary = read_with_budget(
+                &main_file,
+                import_boundary,
+                &ignore_patterns,
+                MAX_REFERENCE_OPERATIONS,
+                normalized.len() - 1,
+            );
+
+            assert!(content.len() < normalized.len() - 1);
+            assert_eq!(at_boundary, normalized);
+            assert!(below_boundary.is_empty());
+        }
+
+        #[test]
         fn test_reference_operation_budget_preserves_excess_references() {
             let temp_dir = tempfile::tempdir().unwrap();
             let import_boundary = temp_dir.path();
@@ -1362,6 +1395,40 @@ mod tests {
             assert!(!below_boundary.contains("included content"));
             assert!(!below_boundary.contains("@later.md"));
             assert!(below_boundary.contains("later content"));
+        }
+
+        #[test]
+        fn test_reference_content_budgets_nfc_expansion() {
+            let temp_dir = tempfile::tempdir().unwrap();
+            let import_boundary = temp_dir.path();
+            let ignore_patterns = create_ignore_patterns(import_boundary);
+            let included_content = "\u{0344}".repeat(2);
+            let normalized = "\u{0308}\u{0301}".repeat(2);
+            create_file(import_boundary, "included.md", &included_content);
+            let main_content = "@included.md";
+            let main_file = create_file(import_boundary, "main.md", main_content);
+            let exact_limit = main_content.len()
+                + expanded_output_cost(Path::new("included.md"), normalized.len()).unwrap()
+                - replaced_reference_cost(Path::new("included.md")).unwrap();
+
+            let at_boundary = read_with_budget(
+                &main_file,
+                import_boundary,
+                &ignore_patterns,
+                MAX_REFERENCE_OPERATIONS,
+                exact_limit,
+            );
+            let below_boundary = read_with_budget(
+                &main_file,
+                import_boundary,
+                &ignore_patterns,
+                MAX_REFERENCE_OPERATIONS,
+                exact_limit - 1,
+            );
+
+            assert!(at_boundary.contains(&normalized));
+            assert!(!at_boundary.contains("@included.md"));
+            assert_eq!(below_boundary, main_content);
         }
 
         #[test]

--- a/crates/goose/src/hints/import_files.rs
+++ b/crates/goose/src/hints/import_files.rs
@@ -2,7 +2,7 @@ use ignore::gitignore::Gitignore;
 use once_cell::sync::Lazy;
 use std::{
     collections::HashSet,
-    io::Read,
+    io::{self, Read},
     path::{Path, PathBuf},
 };
 
@@ -17,6 +17,7 @@ const MAX_DEPTH: usize = 3;
 const MAX_REFERENCE_OPERATIONS: usize = 64;
 pub(crate) const MAX_HINT_OUTPUT_BYTES: usize = 1024 * 1024;
 const MAX_GIT_POINTER_BYTES: u64 = 4096;
+const MAX_HINT_INPUT_BYTES: usize = MAX_HINT_OUTPUT_BYTES;
 
 struct FileReference {
     path: PathBuf,
@@ -26,6 +27,7 @@ struct FileReference {
 
 struct ExpansionBudget {
     remaining_operations: usize,
+    remaining_input_bytes: usize,
     remaining_output_bytes: usize,
     exhausted: bool,
 }
@@ -39,6 +41,7 @@ impl ExpansionBudget {
     fn new(operations: usize, output_bytes: usize) -> Self {
         Self {
             remaining_operations: operations,
+            remaining_input_bytes: MAX_HINT_INPUT_BYTES,
             remaining_output_bytes: output_bytes,
             exhausted: false,
         }
@@ -63,6 +66,15 @@ impl ExpansionBudget {
         if self.remaining_output_bytes == 0 {
             self.exhausted = true;
         }
+        true
+    }
+
+    fn reserve_input(&mut self, bytes: usize) -> bool {
+        if bytes > self.remaining_input_bytes {
+            return false;
+        }
+
+        self.remaining_input_bytes -= bytes;
         true
     }
 
@@ -341,6 +353,29 @@ fn content_between(content: &str, start: usize, end: usize) -> &str {
         .expect("regex match offsets must be UTF-8 boundaries")
 }
 
+fn read_sanitized_hint_file(path: &Path, max_input_bytes: usize) -> io::Result<(String, usize)> {
+    let file = std::fs::File::open(path)?;
+    if file.metadata()?.len() > max_input_bytes as u64 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("hint input exceeds the {max_input_bytes}-byte remaining limit"),
+        ));
+    }
+
+    let mut content = String::new();
+    file.take((max_input_bytes as u64).saturating_add(1))
+        .read_to_string(&mut content)?;
+    if content.len() > max_input_bytes {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("hint input exceeds the {max_input_bytes}-byte remaining limit"),
+        ));
+    }
+
+    let input_bytes = content.len();
+    Ok((sanitize_unicode_tags(&content), input_bytes))
+}
+
 fn should_process_reference(
     reference: &Path,
     including_file_path: &Path,
@@ -387,28 +422,17 @@ fn process_file_reference(
         return None;
     }
 
-    let file_size = usize::try_from(std::fs::metadata(safe_path).ok()?.len()).ok()?;
-    let estimated_output = expanded_output_cost(reference, file_size)?;
-    let estimated_growth = estimated_output.saturating_sub(replaced_bytes);
-    if !budget.can_fit_output(estimated_growth) {
+    let (content, input_bytes) =
+        match read_sanitized_hint_file(safe_path, budget.remaining_input_bytes) {
+            Ok(content) => content,
+            Err(e) => {
+                tracing::warn!("Could not read file {:?}: {}", safe_path, e);
+                return None;
+            }
+        };
+    if !budget.reserve_input(input_bytes) {
         return None;
     }
-
-    let max_replacement_bytes = budget.remaining_output_bytes.checked_add(replaced_bytes)?;
-    let max_content_bytes = max_replacement_bytes.checked_sub(wrapper_bytes)?;
-    let read_limit = u64::try_from(max_content_bytes).ok()?.saturating_add(1);
-    let mut content = String::new();
-    let read_result = std::fs::File::open(safe_path)
-        .and_then(|file| file.take(read_limit).read_to_string(&mut content));
-    match read_result {
-        Ok(_) => {}
-        Err(e) => {
-            tracing::warn!("Could not read file {:?}: {}", safe_path, e);
-            return None;
-        }
-    }
-
-    let content = sanitize_unicode_tags(&content);
     let output_bytes = expanded_output_cost(reference, content.len())?;
     let output_growth = output_bytes.saturating_sub(replaced_bytes);
     if !budget.reserve_output(output_growth) {
@@ -518,36 +542,17 @@ fn read_referenced_files_with_budget(
         }
     };
     let max_content_bytes = budget.remaining_output_bytes;
-    let file_size = match std::fs::metadata(&safe_file_path)
-        .and_then(|metadata| usize::try_from(metadata.len()).map_err(std::io::Error::other))
-    {
-        Ok(file_size) => file_size,
-        Err(e) => {
-            tracing::warn!("Could not inspect hint file {:?}: {}", safe_file_path, e);
-            return String::new();
-        }
-    };
-    if file_size > max_content_bytes {
-        tracing::warn!(
-            "Hint file too large: {:?} ({} bytes, remaining limit: {} bytes)",
-            safe_file_path,
-            file_size,
-            max_content_bytes
-        );
+    let (content, input_bytes) =
+        match read_sanitized_hint_file(&safe_file_path, budget.remaining_input_bytes) {
+            Ok(content) => content,
+            Err(e) => {
+                tracing::warn!("Could not read hint file {:?}: {}", safe_file_path, e);
+                return String::new();
+            }
+        };
+    if !budget.reserve_input(input_bytes) {
         return String::new();
     }
-
-    let read_limit = u64::try_from(max_content_bytes)
-        .unwrap_or(u64::MAX)
-        .saturating_add(1);
-    let mut content = String::new();
-    let read_result = std::fs::File::open(&safe_file_path)
-        .and_then(|file| file.take(read_limit).read_to_string(&mut content));
-    if let Err(e) = read_result {
-        tracing::warn!("Could not read hint file {:?}: {}", safe_file_path, e);
-        return String::new();
-    }
-    let content = sanitize_unicode_tags(&content);
     if content.len() > max_content_bytes || !budget.reserve_output(content.len()) {
         tracing::warn!(
             "Hint file too large: {:?} (remaining limit: {} bytes)",
@@ -559,7 +564,7 @@ fn read_referenced_files_with_budget(
 
     expand_file_content(
         &content,
-        &safe_file_path,
+        file_path,
         &import_boundary,
         visited,
         depth,
@@ -1219,6 +1224,79 @@ mod tests {
             assert!(content.len() < normalized.len() - 1);
             assert_eq!(at_boundary, normalized);
             assert!(below_boundary.is_empty());
+        }
+
+        #[test]
+        fn test_top_level_budget_uses_sanitized_output_size() {
+            let temp_dir = tempfile::tempdir().unwrap();
+            let import_boundary = temp_dir.path();
+            let ignore_patterns = create_ignore_patterns(import_boundary);
+            let sanitized = "fit";
+            let content = format!("{sanitized}{}", "\u{E0041}".repeat(8));
+            let main_file = create_file(import_boundary, "main.md", &content);
+
+            let expanded = read_with_budget(
+                &main_file,
+                import_boundary,
+                &ignore_patterns,
+                MAX_REFERENCE_OPERATIONS,
+                sanitized.len(),
+            );
+
+            assert!(content.len() > sanitized.len());
+            assert_eq!(expanded, sanitized);
+        }
+
+        #[test]
+        fn test_reference_budget_uses_sanitized_output_size() {
+            let temp_dir = tempfile::tempdir().unwrap();
+            let import_boundary = temp_dir.path();
+            let ignore_patterns = create_ignore_patterns(import_boundary);
+            let reference = Path::new("included.md");
+            let sanitized = "fit";
+            create_file(
+                import_boundary,
+                reference.to_str().unwrap(),
+                &format!("{sanitized}{}", "\u{E0041}".repeat(8)),
+            );
+            let main_content = "@included.md";
+            let main_file = create_file(import_boundary, "main.md", main_content);
+            let output_limit = main_content.len()
+                + expanded_output_cost(reference, sanitized.len()).unwrap()
+                - replaced_reference_cost(reference).unwrap();
+
+            let expanded = read_with_budget(
+                &main_file,
+                import_boundary,
+                &ignore_patterns,
+                MAX_REFERENCE_OPERATIONS,
+                output_limit,
+            );
+
+            assert!(expanded.contains(sanitized));
+            assert!(!expanded.contains(main_content));
+        }
+
+        #[test]
+        fn test_top_level_input_limit_remains_bounded() {
+            let temp_dir = tempfile::tempdir().unwrap();
+            let import_boundary = temp_dir.path();
+            let ignore_patterns = create_ignore_patterns(import_boundary);
+            let main_file = create_file(
+                import_boundary,
+                "main.md",
+                &"x".repeat(MAX_HINT_INPUT_BYTES + 1),
+            );
+
+            let expanded = read_with_budget(
+                &main_file,
+                import_boundary,
+                &ignore_patterns,
+                MAX_REFERENCE_OPERATIONS,
+                MAX_HINT_OUTPUT_BYTES,
+            );
+
+            assert!(expanded.is_empty());
         }
 
         #[test]

--- a/crates/goose/src/hints/import_files.rs
+++ b/crates/goose/src/hints/import_files.rs
@@ -86,15 +86,6 @@ impl ExpansionBudget {
         true
     }
 
-    fn reserve_input(&mut self, bytes: usize) -> bool {
-        if bytes > self.remaining_input_bytes {
-            return false;
-        }
-
-        self.remaining_input_bytes -= bytes;
-        true
-    }
-
     fn can_fit_output(&self, bytes: usize) -> bool {
         !self.exhausted && bytes <= self.remaining_output_bytes
     }
@@ -370,7 +361,8 @@ fn content_between(content: &str, start: usize, end: usize) -> &str {
         .expect("regex match offsets must be UTF-8 boundaries")
 }
 
-fn read_sanitized_hint_file(path: &Path, max_input_bytes: usize) -> io::Result<(String, usize)> {
+fn read_sanitized_hint_file(path: &Path, remaining_input_bytes: &mut usize) -> io::Result<String> {
+    let max_input_bytes = *remaining_input_bytes;
     let file = std::fs::File::open(path)?;
     if file.metadata()?.len() > max_input_bytes as u64 {
         return Err(io::Error::new(
@@ -379,9 +371,12 @@ fn read_sanitized_hint_file(path: &Path, max_input_bytes: usize) -> io::Result<(
         ));
     }
 
-    let mut content = String::new();
-    file.take((max_input_bytes as u64).saturating_add(1))
-        .read_to_string(&mut content)?;
+    let mut content = Vec::new();
+    let read_result = file
+        .take((max_input_bytes as u64).saturating_add(1))
+        .read_to_end(&mut content);
+    *remaining_input_bytes = remaining_input_bytes.saturating_sub(content.len());
+    read_result?;
     if content.len() > max_input_bytes {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
@@ -389,8 +384,9 @@ fn read_sanitized_hint_file(path: &Path, max_input_bytes: usize) -> io::Result<(
         ));
     }
 
-    let input_bytes = content.len();
-    Ok((sanitize_unicode_tags(&content), input_bytes))
+    let content = String::from_utf8(content)
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+    Ok(sanitize_unicode_tags(&content))
 }
 
 fn should_process_reference(
@@ -439,17 +435,13 @@ fn process_file_reference(
         return None;
     }
 
-    let (content, input_bytes) =
-        match read_sanitized_hint_file(safe_path, budget.remaining_input_bytes) {
-            Ok(content) => content,
-            Err(e) => {
-                tracing::warn!("Could not read file {:?}: {}", safe_path, e);
-                return None;
-            }
-        };
-    if !budget.reserve_input(input_bytes) {
-        return None;
-    }
+    let content = match read_sanitized_hint_file(safe_path, &mut budget.remaining_input_bytes) {
+        Ok(content) => content,
+        Err(e) => {
+            tracing::warn!("Could not read file {:?}: {}", safe_path, e);
+            return None;
+        }
+    };
     let output_bytes = expanded_output_cost(reference, content.len())?;
     let output_growth = output_bytes.saturating_sub(replaced_bytes);
     if !budget.reserve_output(output_growth) {
@@ -559,17 +551,14 @@ fn read_referenced_files_with_budget(
         }
     };
     let max_content_bytes = budget.remaining_output_bytes;
-    let (content, input_bytes) =
-        match read_sanitized_hint_file(&safe_file_path, budget.remaining_input_bytes) {
-            Ok(content) => content,
-            Err(e) => {
-                tracing::warn!("Could not read hint file {:?}: {}", safe_file_path, e);
-                return String::new();
-            }
-        };
-    if !budget.reserve_input(input_bytes) {
-        return String::new();
-    }
+    let content = match read_sanitized_hint_file(&safe_file_path, &mut budget.remaining_input_bytes)
+    {
+        Ok(content) => content,
+        Err(e) => {
+            tracing::warn!("Could not read hint file {:?}: {}", safe_file_path, e);
+            return String::new();
+        }
+    };
     if content.len() > max_content_bytes || !budget.reserve_output(content.len()) {
         tracing::warn!(
             "Hint file too large: {:?} (remaining limit: {} bytes)",
@@ -1320,6 +1309,62 @@ mod tests {
 
             assert!(expanded.contains(sanitized));
             assert!(!expanded.contains(main_content));
+        }
+
+        #[test]
+        fn failed_utf8_top_level_reads_charge_the_shared_input_budget() {
+            let project = tempfile::tempdir().unwrap();
+            let invalid = project.path().join("invalid.md");
+            std::fs::write(&invalid, [0xff; 12]).unwrap();
+            let valid = create_file(project.path(), "valid.md", "good");
+            let ignore_patterns = create_ignore_patterns(project.path());
+            let mut input_budget = HintInputBudget {
+                remaining_bytes: 16,
+            };
+
+            for (path, expected, remaining) in
+                [(&invalid, "", 4), (&valid, "good", 0), (&valid, "", 0)]
+            {
+                let output = read_referenced_files_with_limit_and_input_budget(
+                    path,
+                    project.path(),
+                    &mut HashSet::new(),
+                    0,
+                    &ignore_patterns,
+                    MAX_HINT_OUTPUT_BYTES,
+                    &mut input_budget,
+                );
+                assert_eq!(output, expected);
+                assert_eq!(input_budget.remaining_bytes, remaining);
+            }
+        }
+
+        #[test]
+        fn failed_utf8_imports_charge_the_shared_input_budget() {
+            let project = tempfile::tempdir().unwrap();
+            std::fs::write(project.path().join("invalid.md"), [0xff; 8]).unwrap();
+            create_file(project.path(), "valid.md", "VALID");
+            let content = "@invalid.md @valid.md";
+            let main = create_file(project.path(), "main.md", content);
+            let ignore_patterns = create_ignore_patterns(project.path());
+
+            for remaining in [0, 5] {
+                let mut input_budget = HintInputBudget {
+                    remaining_bytes: content.len() + 8 + remaining,
+                };
+                let output = read_referenced_files_with_limit_and_input_budget(
+                    &main,
+                    project.path(),
+                    &mut HashSet::new(),
+                    0,
+                    &ignore_patterns,
+                    MAX_HINT_OUTPUT_BYTES,
+                    &mut input_budget,
+                );
+                assert!(output.contains("@invalid.md"));
+                assert_eq!(output.contains("VALID"), remaining > 0);
+                assert_eq!(input_budget.remaining_bytes, 0);
+            }
         }
 
         #[test]

--- a/crates/goose/src/hints/load_hints.rs
+++ b/crates/goose/src/hints/load_hints.rs
@@ -1128,7 +1128,16 @@ End of hints"#;
     }
 
     #[test]
+    #[serial_test::serial]
     fn tracker_aggregates_output_limit_across_subdirectories() {
+        let config_root = TempDir::new().unwrap();
+        let _guard = env_lock::lock_env([
+            (
+                "GOOSE_PATH_ROOT",
+                Some(config_root.path().to_str().unwrap()),
+            ),
+            ("CONTEXT_FILE_NAMES", Some(r#"[".goosehints"]"#)),
+        ]);
         let temp_dir = TempDir::new().unwrap();
         let project_root = temp_dir.path().to_path_buf();
         for directory in ["first", "second", "third"] {
@@ -1242,9 +1251,18 @@ End of hints"#;
 
     #[cfg(unix)]
     #[test]
+    #[serial_test::serial]
     fn tracker_reserves_hints_from_a_lexical_symlink_working_directory() {
         use std::os::unix::fs::symlink;
 
+        let config_root = TempDir::new().unwrap();
+        let _guard = env_lock::lock_env([
+            (
+                "GOOSE_PATH_ROOT",
+                Some(config_root.path().to_str().unwrap()),
+            ),
+            ("CONTEXT_FILE_NAMES", Some(r#"[".goosehints"]"#)),
+        ]);
         let temp_dir = TempDir::new().unwrap();
         let repository = temp_dir.path().join("repository");
         let target = temp_dir.path().join("target");
@@ -1360,7 +1378,16 @@ End of hints"#;
     }
 
     #[test]
+    #[serial_test::serial]
     fn tracker_retries_directory_after_parent_is_created() {
+        let config_root = TempDir::new().unwrap();
+        let _guard = env_lock::lock_env([
+            (
+                "GOOSE_PATH_ROOT",
+                Some(config_root.path().to_str().unwrap()),
+            ),
+            ("CONTEXT_FILE_NAMES", Some(r#"[".goosehints"]"#)),
+        ]);
         let temp_dir = TempDir::new().unwrap();
         let project_root = temp_dir.path().join("project");
         fs::create_dir_all(&project_root).unwrap();

--- a/crates/goose/src/hints/load_hints.rs
+++ b/crates/goose/src/hints/load_hints.rs
@@ -20,6 +20,27 @@ pub(crate) struct HintSnapshot {
     pub(crate) subdirectories: Vec<(String, String)>,
 }
 
+#[derive(Clone, Copy)]
+pub(crate) struct HintOutputReservation {
+    pub(crate) root_only: usize,
+    pub(crate) with_subdirectories: usize,
+}
+
+impl HintOutputReservation {
+    pub(crate) fn new(root_only: usize, with_subdirectories: usize) -> Self {
+        Self {
+            root_only,
+            with_subdirectories,
+        }
+    }
+}
+
+impl From<usize> for HintOutputReservation {
+    fn from(reserved_output_bytes: usize) -> Self {
+        Self::new(reserved_output_bytes, reserved_output_bytes)
+    }
+}
+
 pub fn get_context_filenames() -> Vec<String> {
     use crate::config::Config;
 
@@ -91,17 +112,18 @@ impl SubdirectoryHintTracker {
     pub(crate) fn load_snapshot(
         &mut self,
         working_dir: &Path,
-        reserved_output_bytes: usize,
+        reservation: impl Into<HintOutputReservation>,
     ) -> HintSnapshot {
-        self.load_snapshot_with_hook(working_dir, reserved_output_bytes, || {})
+        self.load_snapshot_with_hook(working_dir, reservation, || {})
     }
 
     pub(crate) fn load_snapshot_with_hook(
         &mut self,
         working_dir: &Path,
-        reserved_output_bytes: usize,
+        reservation: impl Into<HintOutputReservation>,
         after_top_level_read: impl FnOnce(),
     ) -> HintSnapshot {
+        let reservation = reservation.into();
         let pending = std::mem::take(&mut self.pending_dirs);
         let lexical_working_dir = working_dir;
         let Ok(canonical_working_dir) = working_dir.canonicalize() else {
@@ -126,7 +148,7 @@ impl SubdirectoryHintTracker {
 
         self.hints_filenames = get_context_filenames();
         let ignore_patterns = build_gitignore(lexical_working_dir);
-        let top_level_output_limit = MAX_HINT_OUTPUT_BYTES.saturating_sub(reserved_output_bytes);
+        let top_level_output_limit = MAX_HINT_OUTPUT_BYTES.saturating_sub(reservation.root_only);
         let top_level_hints = load_hint_files_with_limit(
             lexical_working_dir,
             &self.hints_filenames,
@@ -136,16 +158,25 @@ impl SubdirectoryHintTracker {
         after_top_level_read();
         let mut remaining_output_bytes = MAX_HINT_OUTPUT_BYTES
             .saturating_sub(top_level_hints.len())
-            .saturating_sub(reserved_output_bytes);
+            .saturating_sub(reservation.root_only);
         let mut has_hint_output = !top_level_hints.is_empty();
         let mut results = Vec::new();
         for dir in &self.loaded_dirs {
+            let additional_reservation = if results.is_empty() {
+                reservation
+                    .with_subdirectories
+                    .saturating_sub(reservation.root_only)
+            } else {
+                0
+            };
             let separator_bytes = if has_hint_output {
                 HINT_EXTRA_SEPARATOR_BYTES
             } else {
                 0
             };
-            let Some(output_limit) = remaining_output_bytes.checked_sub(separator_bytes) else {
+            let Some(output_limit) =
+                remaining_output_bytes.checked_sub(separator_bytes + additional_reservation)
+            else {
                 continue;
             };
             if let Some(content) = load_hints_from_directory(
@@ -154,7 +185,7 @@ impl SubdirectoryHintTracker {
                 &self.hints_filenames,
                 output_limit,
             ) {
-                remaining_output_bytes -= separator_bytes + content.len();
+                remaining_output_bytes -= separator_bytes + additional_reservation + content.len();
                 has_hint_output = true;
                 let key = format!("subdir_hints:{}", dir.display());
                 results.push((key, content));

--- a/crates/goose/src/hints/load_hints.rs
+++ b/crates/goose/src/hints/load_hints.rs
@@ -12,6 +12,7 @@ pub const AGENTS_MD_FILENAME: &str = "AGENTS.md";
 const GLOBAL_HINTS_HEADER: &str = "\n### Global Hints\nThese are my global goose hints.\n";
 const PROJECT_HINTS_HEADER: &str =
     "### Project Hints\nThese are hints for working on the project in this directory.\n";
+pub(crate) const HINT_EXTRA_SEPARATOR_BYTES: usize = "\n\n".len();
 
 pub fn get_context_filenames() -> Vec<String> {
     use crate::config::Config;
@@ -101,15 +102,22 @@ impl SubdirectoryHintTracker {
             load_hint_files(&working_dir, &self.hints_filenames, &ignore_patterns);
         let mut remaining_output_bytes =
             MAX_HINT_OUTPUT_BYTES.saturating_sub(top_level_hints.len());
+        let mut has_hint_output = !top_level_hints.is_empty();
         let mut results = Vec::new();
         for dir in &self.loaded_dirs {
-            if let Some(content) = load_hints_from_directory(
-                dir,
-                &working_dir,
-                &self.hints_filenames,
-                remaining_output_bytes,
-            ) {
-                remaining_output_bytes -= content.len();
+            let separator_bytes = if has_hint_output {
+                HINT_EXTRA_SEPARATOR_BYTES
+            } else {
+                0
+            };
+            let Some(output_limit) = remaining_output_bytes.checked_sub(separator_bytes) else {
+                continue;
+            };
+            if let Some(content) =
+                load_hints_from_directory(dir, &working_dir, &self.hints_filenames, output_limit)
+            {
+                remaining_output_bytes -= separator_bytes + content.len();
+                has_hint_output = true;
                 let key = format!("subdir_hints:{}", dir.display());
                 results.push((key, content));
             }
@@ -1033,7 +1041,11 @@ End of hints"#;
         }
 
         let hints = tracker.load_hints(&project_root);
-        let output_bytes: usize = hints.iter().map(|(_, content)| content.len()).sum();
+        let output_bytes: usize = hints
+            .iter()
+            .map(|(_, content)| content.len())
+            .sum::<usize>()
+            + hints.len().saturating_sub(1) * HINT_EXTRA_SEPARATOR_BYTES;
         let combined = hints
             .iter()
             .map(|(_, content)| content.as_str())
@@ -1043,6 +1055,53 @@ End of hints"#;
         assert!(combined.contains("A1"));
         assert!(!combined.contains("B2"));
         assert!(combined.contains("third hint"));
+    }
+
+    #[test]
+    fn tracker_charges_separator_between_root_and_subdirectory_hints() {
+        let project_root = tempfile::tempdir().unwrap();
+        let nested = project_root.path().join("nested");
+        fs::create_dir(&nested).unwrap();
+        fs::write(
+            project_root.path().join(GOOSE_HINTS_FILENAME),
+            "r".repeat(MAX_HINT_OUTPUT_BYTES - PROJECT_HINTS_HEADER.len() - 2048),
+        )
+        .unwrap();
+        let hints_filenames = vec![GOOSE_HINTS_FILENAME.to_string()];
+        let ignore_patterns = build_gitignore(project_root.path());
+        let top_level_hints =
+            load_hint_files(project_root.path(), &hints_filenames, &ignore_patterns);
+        let remaining = MAX_HINT_OUTPUT_BYTES - top_level_hints.len();
+        let canonical_nested = nested.canonicalize().unwrap();
+        let subdirectory_header =
+            format!("### Subdirectory Hints ({})\n", canonical_nested.display()).len();
+        let nested_hints = nested.join(GOOSE_HINTS_FILENAME);
+        fs::write(
+            &nested_hints,
+            "n".repeat(remaining - 1 - subdirectory_header),
+        )
+        .unwrap();
+
+        let mut tracker = SubdirectoryHintTracker::new();
+        tracker.hints_filenames = hints_filenames;
+        let args = serde_json::json!({ "path": "nested/file.rs" })
+            .as_object()
+            .unwrap()
+            .clone();
+        tracker.record_tool_arguments(&Some(args), project_root.path());
+        assert!(tracker.load_hints(project_root.path()).is_empty());
+
+        fs::write(
+            nested_hints,
+            "n".repeat(remaining - HINT_EXTRA_SEPARATOR_BYTES - subdirectory_header),
+        )
+        .unwrap();
+        let hints = tracker.load_hints(project_root.path());
+        assert_eq!(hints.len(), 1);
+        assert_eq!(
+            top_level_hints.len() + HINT_EXTRA_SEPARATOR_BYTES + hints[0].1.len(),
+            MAX_HINT_OUTPUT_BYTES
+        );
     }
 
     #[test]

--- a/crates/goose/src/hints/load_hints.rs
+++ b/crates/goose/src/hints/load_hints.rs
@@ -15,6 +15,11 @@ const PROJECT_HINTS_HEADER: &str =
     "### Project Hints\nThese are hints for working on the project in this directory.\n";
 pub(crate) const HINT_EXTRA_SEPARATOR_BYTES: usize = "\n\n".len();
 
+pub(crate) struct HintSnapshot {
+    pub(crate) top_level: String,
+    pub(crate) subdirectories: Vec<(String, String)>,
+}
+
 pub fn get_context_filenames() -> Vec<String> {
     use crate::config::Config;
 
@@ -80,18 +85,30 @@ impl SubdirectoryHintTracker {
     }
 
     pub fn load_hints(&mut self, working_dir: &Path) -> Vec<(String, String)> {
-        self.load_hints_with_reservation(working_dir, 0)
+        self.load_snapshot(working_dir, 0).subdirectories
     }
 
-    pub(crate) fn load_hints_with_reservation(
+    pub(crate) fn load_snapshot(
         &mut self,
         working_dir: &Path,
         reserved_output_bytes: usize,
-    ) -> Vec<(String, String)> {
+    ) -> HintSnapshot {
+        self.load_snapshot_with_hook(working_dir, reserved_output_bytes, || {})
+    }
+
+    pub(crate) fn load_snapshot_with_hook(
+        &mut self,
+        working_dir: &Path,
+        reserved_output_bytes: usize,
+        after_top_level_read: impl FnOnce(),
+    ) -> HintSnapshot {
         let pending = std::mem::take(&mut self.pending_dirs);
         let lexical_working_dir = working_dir;
         let Ok(canonical_working_dir) = working_dir.canonicalize() else {
-            return Vec::new();
+            return HintSnapshot {
+                top_level: String::new(),
+                subdirectories: Vec::new(),
+            };
         };
 
         for dir in pending {
@@ -111,6 +128,7 @@ impl SubdirectoryHintTracker {
         let ignore_patterns = build_gitignore(lexical_working_dir);
         let top_level_hints =
             load_hint_files(lexical_working_dir, &self.hints_filenames, &ignore_patterns);
+        after_top_level_read();
         let mut remaining_output_bytes = MAX_HINT_OUTPUT_BYTES
             .saturating_sub(top_level_hints.len())
             .saturating_sub(reserved_output_bytes);
@@ -137,7 +155,10 @@ impl SubdirectoryHintTracker {
                 results.push((key, content));
             }
         }
-        results
+        HintSnapshot {
+            top_level: top_level_hints,
+            subdirectories: results,
+        }
     }
 
     pub fn load_new_hints(&mut self, working_dir: &Path) -> Vec<(String, String)> {

--- a/crates/goose/src/hints/load_hints.rs
+++ b/crates/goose/src/hints/load_hints.rs
@@ -66,6 +66,7 @@ pub fn get_context_filenames() -> Vec<String> {
 
 pub struct SubdirectoryHintTracker {
     loaded_dirs: Vec<PathBuf>,
+    loaded_dir_set: HashSet<PathBuf>,
     pending_dirs: Vec<PathBuf>,
     hints_filenames: Vec<String>,
     emitted_hint_keys: HashSet<String>,
@@ -81,6 +82,7 @@ impl SubdirectoryHintTracker {
     pub fn new() -> Self {
         Self {
             loaded_dirs: Vec::new(),
+            loaded_dir_set: HashSet::new(),
             pending_dirs: Vec::new(),
             hints_filenames: get_context_filenames(),
             emitted_hint_keys: HashSet::new(),
@@ -162,7 +164,7 @@ impl SubdirectoryHintTracker {
             if !dir.starts_with(&canonical_working_dir) || dir == canonical_working_dir {
                 continue;
             }
-            if self.loaded_dirs.contains(&dir) {
+            if !self.loaded_dir_set.insert(dir.clone()) {
                 continue;
             }
             self.loaded_dirs.push(dir);
@@ -1453,6 +1455,44 @@ End of hints"#;
         assert_eq!(hints.len(), 1);
         assert!(hints[0].1.contains("nested hints"));
         assert_eq!(tracker.loaded_dirs.len(), 1);
+    }
+
+    #[test]
+    fn tracker_preserves_first_seen_order_with_companion_membership_set() {
+        let temp_dir = TempDir::new().unwrap();
+        let project_root = temp_dir.path().to_path_buf();
+        for directory in ["second", "first", "third"] {
+            let path = project_root.join(directory);
+            fs::create_dir(&path).unwrap();
+            fs::write(
+                path.join(GOOSE_HINTS_FILENAME),
+                format!("{directory} hints"),
+            )
+            .unwrap();
+        }
+
+        let mut tracker = SubdirectoryHintTracker::new();
+        for directory in ["second", "first", "third", "second", "first"] {
+            let arguments = serde_json::json!({
+                "path": format!("{directory}/file.rs")
+            })
+            .as_object()
+            .cloned();
+            tracker.record_tool_arguments(&arguments, &project_root);
+        }
+        let hints = tracker.load_hints(&project_root);
+        let expected = ["second", "first", "third"]
+            .map(|directory| project_root.join(directory).canonicalize().unwrap());
+
+        assert_eq!(tracker.loaded_dirs, expected);
+        assert_eq!(tracker.loaded_dir_set.len(), expected.len());
+        assert!(expected
+            .iter()
+            .all(|directory| tracker.loaded_dir_set.contains(directory)));
+        assert_eq!(hints.len(), expected.len());
+        for (hint, directory) in hints.iter().zip(["second", "first", "third"]) {
+            assert!(hint.1.contains(&format!("{directory} hints")));
+        }
     }
 
     #[test]

--- a/crates/goose/src/hints/load_hints.rs
+++ b/crates/goose/src/hints/load_hints.rs
@@ -86,6 +86,7 @@ impl SubdirectoryHintTracker {
         }
     }
 
+    #[cfg(test)]
     pub(crate) fn load_snapshot(&mut self, working_dir: &Path) -> String {
         self.load_snapshot_with_limit_and_hook(working_dir, MAX_HINT_OUTPUT_BYTES, || {})
     }

--- a/crates/goose/src/hints/load_hints.rs
+++ b/crates/goose/src/hints/load_hints.rs
@@ -31,6 +31,7 @@ pub fn get_context_filenames() -> Vec<String> {
 pub struct SubdirectoryHintTracker {
     loaded_dirs: Vec<PathBuf>,
     loaded_dir_set: HashSet<PathBuf>,
+    emitted_dir_set: HashSet<PathBuf>,
     pending_dirs: Vec<PathBuf>,
     hints_filenames: Vec<String>,
 }
@@ -46,6 +47,7 @@ impl SubdirectoryHintTracker {
         Self {
             loaded_dirs: Vec::new(),
             loaded_dir_set: HashSet::new(),
+            emitted_dir_set: HashSet::new(),
             pending_dirs: Vec::new(),
             hints_filenames: get_context_filenames(),
         }
@@ -159,6 +161,7 @@ impl SubdirectoryHintTracker {
         };
 
         let mut results = Vec::new();
+        let mut attempted_dirs = HashSet::new();
         for dir in pending {
             let Ok(dir) = dir.canonicalize() else {
                 continue;
@@ -166,16 +169,19 @@ impl SubdirectoryHintTracker {
             if !dir.starts_with(&canonical_working_dir) || dir == canonical_working_dir {
                 continue;
             }
-            if !self.loaded_dir_set.insert(dir.clone()) {
+            if !attempted_dirs.insert(dir.clone()) || self.emitted_dir_set.contains(&dir) {
                 continue;
             }
-            self.loaded_dirs.push(dir.clone());
+            if self.loaded_dir_set.insert(dir.clone()) {
+                self.loaded_dirs.push(dir.clone());
+            }
             if let Some(content) = load_hints_from_directory(
                 &dir,
                 &canonical_working_dir,
                 &self.hints_filenames,
                 MAX_HINT_OUTPUT_BYTES,
             ) {
+                self.emitted_dir_set.insert(dir.clone());
                 results.push((format!("subdir_hints:{}", dir.display()), content));
             }
         }
@@ -1118,6 +1124,37 @@ End of hints"#;
         assert_eq!(first.len(), 1);
         assert!(first[0].1.contains("nested hints"));
         assert!(tracker.load_new_hints(project_root.path()).is_empty());
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn tracker_load_new_hints_retries_content_that_was_too_large() {
+        let config_root = TempDir::new().unwrap();
+        let _guard = env_lock::lock_env([
+            (
+                "GOOSE_PATH_ROOT",
+                Some(config_root.path().to_str().unwrap()),
+            ),
+            ("CONTEXT_FILE_NAMES", Some(r#"[".goosehints"]"#)),
+        ]);
+        let project_root = TempDir::new().unwrap();
+        let nested = project_root.path().join("nested");
+        fs::create_dir(&nested).unwrap();
+        let hints_path = nested.join(GOOSE_HINTS_FILENAME);
+        fs::write(&hints_path, "x".repeat(MAX_HINT_OUTPUT_BYTES)).unwrap();
+
+        let mut tracker = SubdirectoryHintTracker::new();
+        let arguments = serde_json::json!({ "path": "nested/file.rs" })
+            .as_object()
+            .cloned();
+        tracker.record_tool_arguments(&arguments, project_root.path());
+        assert!(tracker.load_new_hints(project_root.path()).is_empty());
+
+        fs::write(&hints_path, "now admissible").unwrap();
+        tracker.record_tool_arguments(&arguments, project_root.path());
+        let retried = tracker.load_new_hints(project_root.path());
+        assert_eq!(retried.len(), 1);
+        assert!(retried[0].1.contains("now admissible"));
     }
 
     #[test]

--- a/crates/goose/src/hints/load_hints.rs
+++ b/crates/goose/src/hints/load_hints.rs
@@ -80,6 +80,14 @@ impl SubdirectoryHintTracker {
     }
 
     pub fn load_hints(&mut self, working_dir: &Path) -> Vec<(String, String)> {
+        self.load_hints_with_reservation(working_dir, 0)
+    }
+
+    pub(crate) fn load_hints_with_reservation(
+        &mut self,
+        working_dir: &Path,
+        reserved_output_bytes: usize,
+    ) -> Vec<(String, String)> {
         let pending = std::mem::take(&mut self.pending_dirs);
         let lexical_working_dir = working_dir;
         let Ok(canonical_working_dir) = working_dir.canonicalize() else {
@@ -99,11 +107,13 @@ impl SubdirectoryHintTracker {
             self.loaded_dirs.push(dir);
         }
 
+        self.hints_filenames = get_context_filenames();
         let ignore_patterns = build_gitignore(lexical_working_dir);
         let top_level_hints =
             load_hint_files(lexical_working_dir, &self.hints_filenames, &ignore_patterns);
-        let mut remaining_output_bytes =
-            MAX_HINT_OUTPUT_BYTES.saturating_sub(top_level_hints.len());
+        let mut remaining_output_bytes = MAX_HINT_OUTPUT_BYTES
+            .saturating_sub(top_level_hints.len())
+            .saturating_sub(reserved_output_bytes);
         let mut has_hint_output = !top_level_hints.is_empty();
         let mut results = Vec::new();
         for dir in &self.loaded_dirs {
@@ -1021,6 +1031,40 @@ End of hints"#;
     }
 
     #[test]
+    #[serial_test::serial]
+    fn tracker_refreshes_context_filenames_before_reserving_root_hints() {
+        let config_root = TempDir::new().unwrap();
+        let _guard = env_lock::lock_env([
+            (
+                "GOOSE_PATH_ROOT",
+                Some(config_root.path().to_str().unwrap()),
+            ),
+            ("CONTEXT_FILE_NAMES", Some(r#"["old.md"]"#)),
+        ]);
+        let project_root = TempDir::new().unwrap();
+        let nested = project_root.path().join("nested");
+        fs::create_dir(&nested).unwrap();
+        fs::write(nested.join("old.md"), "stale nested hints").unwrap();
+
+        let mut tracker = SubdirectoryHintTracker::new();
+        std::env::set_var("CONTEXT_FILE_NAMES", r#"["new.md"]"#);
+        fs::write(
+            project_root.path().join("new.md"),
+            "r".repeat(MAX_HINT_OUTPUT_BYTES - PROJECT_HINTS_HEADER.len()),
+        )
+        .unwrap();
+        let args = serde_json::json!({ "path": "nested/file.rs" })
+            .as_object()
+            .cloned();
+        tracker.record_tool_arguments(&args, project_root.path());
+
+        let hints = tracker.load_hints(project_root.path());
+
+        assert!(hints.is_empty());
+        assert_eq!(tracker.hints_filenames, ["new.md".to_string()]);
+    }
+
+    #[test]
     fn tracker_aggregates_output_limit_across_subdirectories() {
         let temp_dir = TempDir::new().unwrap();
         let project_root = temp_dir.path().to_path_buf();
@@ -1070,7 +1114,16 @@ End of hints"#;
     }
 
     #[test]
+    #[serial_test::serial]
     fn tracker_charges_separator_between_root_and_subdirectory_hints() {
+        let config_root = TempDir::new().unwrap();
+        let _guard = env_lock::lock_env([
+            (
+                "GOOSE_PATH_ROOT",
+                Some(config_root.path().to_str().unwrap()),
+            ),
+            ("CONTEXT_FILE_NAMES", Some(r#"[".goosehints"]"#)),
+        ]);
         let project_root = tempfile::tempdir().unwrap();
         let nested = project_root.path().join("nested");
         fs::create_dir(&nested).unwrap();
@@ -1095,7 +1148,6 @@ End of hints"#;
         .unwrap();
 
         let mut tracker = SubdirectoryHintTracker::new();
-        tracker.hints_filenames = hints_filenames;
         let args = serde_json::json!({ "path": "nested/file.rs" })
             .as_object()
             .unwrap()

--- a/crates/goose/src/hints/load_hints.rs
+++ b/crates/goose/src/hints/load_hints.rs
@@ -13,43 +13,7 @@ pub const AGENTS_MD_FILENAME: &str = "AGENTS.md";
 const GLOBAL_HINTS_HEADER: &str = "\n### Global Hints\nThese are my global goose hints.\n";
 const PROJECT_HINTS_HEADER: &str =
     "### Project Hints\nThese are hints for working on the project in this directory.\n";
-pub(crate) const HINT_EXTRA_SEPARATOR_BYTES: usize = "\n\n".len();
-
-pub(crate) struct HintSnapshot {
-    pub(crate) top_level: String,
-    pub(crate) subdirectories: Vec<(String, String)>,
-}
-
-#[derive(Clone, Copy)]
-pub(crate) struct HintOutputReservation {
-    pub(crate) root_only: usize,
-    pub(crate) subdirectories_only: usize,
-    pub(crate) with_subdirectories: usize,
-}
-
-impl HintOutputReservation {
-    pub(crate) fn new(
-        root_only: usize,
-        subdirectories_only: usize,
-        with_subdirectories: usize,
-    ) -> Self {
-        Self {
-            root_only,
-            subdirectories_only,
-            with_subdirectories,
-        }
-    }
-}
-
-impl From<usize> for HintOutputReservation {
-    fn from(reserved_output_bytes: usize) -> Self {
-        Self::new(
-            reserved_output_bytes,
-            reserved_output_bytes,
-            reserved_output_bytes,
-        )
-    }
-}
+const HINT_SEPARATOR: &str = "\n\n";
 
 pub fn get_context_filenames() -> Vec<String> {
     use crate::config::Config;
@@ -69,7 +33,6 @@ pub struct SubdirectoryHintTracker {
     loaded_dir_set: HashSet<PathBuf>,
     pending_dirs: Vec<PathBuf>,
     hints_filenames: Vec<String>,
-    emitted_hint_keys: HashSet<String>,
 }
 
 impl Default for SubdirectoryHintTracker {
@@ -85,7 +48,6 @@ impl SubdirectoryHintTracker {
             loaded_dir_set: HashSet::new(),
             pending_dirs: Vec::new(),
             hints_filenames: get_context_filenames(),
-            emitted_hint_keys: HashSet::new(),
         }
     }
 
@@ -119,42 +81,32 @@ impl SubdirectoryHintTracker {
         }
     }
 
-    pub fn load_hints(&mut self, working_dir: &Path) -> Vec<(String, String)> {
-        self.load_snapshot(working_dir, 0).subdirectories
+    pub(crate) fn load_snapshot(&mut self, working_dir: &Path) -> String {
+        self.load_snapshot_with_hook(working_dir, || {})
     }
 
-    pub(crate) fn load_snapshot(
-        &mut self,
-        working_dir: &Path,
-        reservation: impl Into<HintOutputReservation>,
-    ) -> HintSnapshot {
-        self.load_snapshot_with_hook(working_dir, reservation, || {})
+    #[cfg(test)]
+    fn load_hints(&mut self, working_dir: &Path) -> String {
+        self.load_snapshot(working_dir)
     }
 
     pub(crate) fn load_snapshot_with_hook(
         &mut self,
         working_dir: &Path,
-        reservation: impl Into<HintOutputReservation>,
         after_top_level_read: impl FnOnce(),
-    ) -> HintSnapshot {
-        let reservation = reservation.into();
+    ) -> String {
         let pending = std::mem::take(&mut self.pending_dirs);
-        let lexical_working_dir = working_dir;
         self.hints_filenames = get_context_filenames();
-        let ignore_patterns = build_gitignore(lexical_working_dir);
-        let top_level_output_limit = MAX_HINT_OUTPUT_BYTES.saturating_sub(reservation.root_only);
-        let top_level_hints = load_hint_files_with_limit(
-            lexical_working_dir,
+        let ignore_patterns = build_gitignore(working_dir);
+        let mut snapshot = load_hint_files_with_limit(
+            working_dir,
             &self.hints_filenames,
             &ignore_patterns,
-            top_level_output_limit,
+            MAX_HINT_OUTPUT_BYTES,
         );
         after_top_level_read();
         let Ok(canonical_working_dir) = working_dir.canonicalize() else {
-            return HintSnapshot {
-                top_level: top_level_hints,
-                subdirectories: Vec::new(),
-            };
+            return snapshot;
         };
 
         for dir in pending {
@@ -170,32 +122,15 @@ impl SubdirectoryHintTracker {
             self.loaded_dirs.push(dir);
         }
 
-        let has_top_level_hints = !top_level_hints.is_empty();
-        let initial_reservation = if has_top_level_hints {
-            reservation.root_only
-        } else {
-            reservation.subdirectories_only
-        };
-        let mut remaining_output_bytes = MAX_HINT_OUTPUT_BYTES
-            .saturating_sub(top_level_hints.len())
-            .saturating_sub(initial_reservation);
-        let mut has_hint_output = has_top_level_hints;
-        let mut results = Vec::new();
         for dir in &self.loaded_dirs {
-            let additional_reservation = if has_top_level_hints && results.is_empty() {
-                reservation
-                    .with_subdirectories
-                    .saturating_sub(reservation.root_only)
+            let separator = if snapshot.is_empty() {
+                ""
             } else {
-                0
+                HINT_SEPARATOR
             };
-            let separator_bytes = if has_hint_output {
-                HINT_EXTRA_SEPARATOR_BYTES
-            } else {
-                0
-            };
-            let Some(output_limit) =
-                remaining_output_bytes.checked_sub(separator_bytes + additional_reservation)
+            let Some(output_limit) = MAX_HINT_OUTPUT_BYTES
+                .checked_sub(snapshot.len())
+                .and_then(|remaining| remaining.checked_sub(separator.len()))
             else {
                 continue;
             };
@@ -205,23 +140,46 @@ impl SubdirectoryHintTracker {
                 &self.hints_filenames,
                 output_limit,
             ) {
-                remaining_output_bytes -= separator_bytes + additional_reservation + content.len();
-                has_hint_output = true;
-                let key = format!("subdir_hints:{}", dir.display());
-                results.push((key, content));
+                snapshot.push_str(separator);
+                snapshot.push_str(&content);
             }
         }
-        HintSnapshot {
-            top_level: top_level_hints,
-            subdirectories: results,
-        }
+        snapshot
     }
 
     pub fn load_new_hints(&mut self, working_dir: &Path) -> Vec<(String, String)> {
-        self.load_hints(working_dir)
-            .into_iter()
-            .filter(|(key, _)| self.emitted_hint_keys.insert(key.clone()))
-            .collect()
+        let pending = std::mem::take(&mut self.pending_dirs);
+        if pending.is_empty() {
+            return Vec::new();
+        }
+
+        self.hints_filenames = get_context_filenames();
+        let Ok(canonical_working_dir) = working_dir.canonicalize() else {
+            return Vec::new();
+        };
+
+        let mut results = Vec::new();
+        for dir in pending {
+            let Ok(dir) = dir.canonicalize() else {
+                continue;
+            };
+            if !dir.starts_with(&canonical_working_dir) || dir == canonical_working_dir {
+                continue;
+            }
+            if !self.loaded_dir_set.insert(dir.clone()) {
+                continue;
+            }
+            self.loaded_dirs.push(dir.clone());
+            if let Some(content) = load_hints_from_directory(
+                &dir,
+                &canonical_working_dir,
+                &self.hints_filenames,
+                MAX_HINT_OUTPUT_BYTES,
+            ) {
+                results.push((format!("subdir_hints:{}", dir.display()), content));
+            }
+        }
+        results
     }
 }
 
@@ -718,13 +676,10 @@ mod tests {
         .unwrap();
         let missing_working_dir = config_root.path().join("removed-project");
 
-        let snapshot = SubdirectoryHintTracker::new().load_snapshot(&missing_working_dir, 0);
+        let snapshot = SubdirectoryHintTracker::new().load_snapshot(&missing_working_dir);
 
-        assert!(snapshot
-            .top_level
-            .contains("GLOBAL_HINT_AFTER_PROJECT_REMOVAL"));
-        assert!(snapshot.top_level.len() <= MAX_HINT_OUTPUT_BYTES);
-        assert!(snapshot.subdirectories.is_empty());
+        assert!(snapshot.contains("GLOBAL_HINT_AFTER_PROJECT_REMOVAL"));
+        assert!(snapshot.len() <= MAX_HINT_OUTPUT_BYTES);
     }
 
     #[test]
@@ -1133,9 +1088,8 @@ End of hints"#;
             serde_json::from_str(r#"{"path": "nested/foo.rs"}"#).unwrap();
         tracker.record_tool_arguments(&Some(args), &project_root);
         let hints = tracker.load_hints(&project_root);
-        assert_eq!(hints.len(), 1);
-        assert!(hints[0].0.contains("nested"));
-        assert!(hints[0].1.contains("nested subdirectory hints"));
+        assert!(hints.contains("### Subdirectory Hints"));
+        assert!(hints.contains("nested subdirectory hints"));
     }
 
     #[test]
@@ -1168,43 +1122,7 @@ End of hints"#;
 
     #[test]
     #[serial_test::serial]
-    fn tracker_load_new_hints_emits_retained_directory_when_budget_allows() {
-        let config_root = TempDir::new().unwrap();
-        let _guard = env_lock::lock_env([
-            (
-                "GOOSE_PATH_ROOT",
-                Some(config_root.path().to_str().unwrap()),
-            ),
-            ("CONTEXT_FILE_NAMES", Some(r#"[".goosehints"]"#)),
-        ]);
-        let project_root = TempDir::new().unwrap();
-        fs::write(
-            project_root.path().join(GOOSE_HINTS_FILENAME),
-            "r".repeat(MAX_HINT_OUTPUT_BYTES - PROJECT_HINTS_HEADER.len()),
-        )
-        .unwrap();
-        let nested = project_root.path().join("nested");
-        fs::create_dir(&nested).unwrap();
-        fs::write(nested.join(GOOSE_HINTS_FILENAME), "nested hints").unwrap();
-
-        let mut tracker = SubdirectoryHintTracker::new();
-        let arguments = serde_json::json!({ "path": "nested/file.rs" })
-            .as_object()
-            .cloned();
-        tracker.record_tool_arguments(&arguments, project_root.path());
-
-        assert!(tracker.load_new_hints(project_root.path()).is_empty());
-        fs::write(project_root.path().join(GOOSE_HINTS_FILENAME), "root").unwrap();
-
-        let newly_admissible = tracker.load_new_hints(project_root.path());
-        assert_eq!(newly_admissible.len(), 1);
-        assert!(newly_admissible[0].1.contains("nested hints"));
-        assert!(tracker.load_new_hints(project_root.path()).is_empty());
-    }
-
-    #[test]
-    #[serial_test::serial]
-    fn tracker_refreshes_context_filenames_before_reserving_root_hints() {
+    fn tracker_refreshes_context_filenames_before_building_snapshot() {
         let config_root = TempDir::new().unwrap();
         let _guard = env_lock::lock_env([
             (
@@ -1232,45 +1150,9 @@ End of hints"#;
 
         let hints = tracker.load_hints(project_root.path());
 
-        assert!(hints.is_empty());
+        assert_eq!(hints.len(), MAX_HINT_OUTPUT_BYTES);
+        assert!(!hints.contains("stale nested hints"));
         assert_eq!(tracker.hints_filenames, ["new.md".to_string()]);
-    }
-
-    #[test]
-    #[serial_test::serial]
-    fn tracker_applies_reserved_bytes_before_loading_top_level_hints() {
-        let config_root = TempDir::new().unwrap();
-        let _guard = env_lock::lock_env([
-            (
-                "GOOSE_PATH_ROOT",
-                Some(config_root.path().to_str().unwrap()),
-            ),
-            ("CONTEXT_FILE_NAMES", Some(r#"[".goosehints"]"#)),
-        ]);
-        let project_root = TempDir::new().unwrap();
-        let hints_path = project_root.path().join(GOOSE_HINTS_FILENAME);
-        let reserved_output_bytes = HINT_EXTRA_SEPARATOR_BYTES;
-        let content_bytes =
-            MAX_HINT_OUTPUT_BYTES - PROJECT_HINTS_HEADER.len() - reserved_output_bytes;
-        let content = format!(
-            "ROOT_MARKER{}",
-            "r".repeat(content_bytes - "ROOT_MARKER".len())
-        );
-        fs::write(&hints_path, &content).unwrap();
-
-        let mut tracker = SubdirectoryHintTracker::new();
-        let snapshot = tracker.load_snapshot(project_root.path(), reserved_output_bytes);
-
-        assert_eq!(
-            snapshot.top_level.len() + reserved_output_bytes,
-            MAX_HINT_OUTPUT_BYTES
-        );
-        assert!(snapshot.top_level.contains("ROOT_MARKER"));
-
-        fs::write(hints_path, format!("{content}xx")).unwrap();
-        let snapshot = tracker.load_snapshot(project_root.path(), reserved_output_bytes);
-
-        assert!(snapshot.top_level.is_empty());
     }
 
     #[test]
@@ -1315,20 +1197,10 @@ End of hints"#;
         }
 
         let hints = tracker.load_hints(&project_root);
-        let output_bytes: usize = hints
-            .iter()
-            .map(|(_, content)| content.len())
-            .sum::<usize>()
-            + hints.len().saturating_sub(1) * HINT_EXTRA_SEPARATOR_BYTES;
-        let combined = hints
-            .iter()
-            .map(|(_, content)| content.as_str())
-            .collect::<String>();
-
-        assert!(output_bytes <= MAX_HINT_OUTPUT_BYTES);
-        assert!(combined.contains("A1"));
-        assert!(!combined.contains("B2"));
-        assert!(combined.contains("third hint"));
+        assert!(hints.len() <= MAX_HINT_OUTPUT_BYTES);
+        assert!(hints.contains("A1"));
+        assert!(!hints.contains("B2"));
+        assert!(hints.contains("third hint"));
     }
 
     #[test]
@@ -1371,19 +1243,17 @@ End of hints"#;
             .unwrap()
             .clone();
         tracker.record_tool_arguments(&Some(args), project_root.path());
-        assert!(tracker.load_hints(project_root.path()).is_empty());
+        let snapshot = tracker.load_hints(project_root.path());
+        assert_eq!(snapshot, top_level_hints);
 
         fs::write(
             nested_hints,
-            "n".repeat(remaining - HINT_EXTRA_SEPARATOR_BYTES - subdirectory_header),
+            "n".repeat(remaining - HINT_SEPARATOR.len() - subdirectory_header),
         )
         .unwrap();
         let hints = tracker.load_hints(project_root.path());
-        assert_eq!(hints.len(), 1);
-        assert_eq!(
-            top_level_hints.len() + HINT_EXTRA_SEPARATOR_BYTES + hints[0].1.len(),
-            MAX_HINT_OUTPUT_BYTES
-        );
+        assert_eq!(hints.len(), MAX_HINT_OUTPUT_BYTES);
+        assert!(hints.contains(&top_level_hints));
     }
 
     #[test]
@@ -1432,7 +1302,9 @@ End of hints"#;
             .clone();
         tracker.record_tool_arguments(&Some(args), &working_dir);
 
-        assert!(tracker.load_hints(&working_dir).is_empty());
+        let snapshot = tracker.load_hints(&working_dir);
+        assert_eq!(snapshot.len(), MAX_HINT_OUTPUT_BYTES - 1);
+        assert!(!snapshot.contains("nested hint"));
     }
 
     #[test]
@@ -1448,12 +1320,11 @@ End of hints"#;
             serde_json::from_str(r#"{"path": "nested/foo.rs"}"#).unwrap();
         tracker.record_tool_arguments(&Some(args.clone()), &project_root);
         let hints = tracker.load_hints(&project_root);
-        assert_eq!(hints.len(), 1);
+        assert_eq!(hints.matches("nested hints").count(), 1);
 
         tracker.record_tool_arguments(&Some(args), &project_root);
         let hints = tracker.load_hints(&project_root);
-        assert_eq!(hints.len(), 1);
-        assert!(hints[0].1.contains("nested hints"));
+        assert_eq!(hints.matches("nested hints").count(), 1);
         assert_eq!(tracker.loaded_dirs.len(), 1);
     }
 
@@ -1489,10 +1360,10 @@ End of hints"#;
         assert!(expected
             .iter()
             .all(|directory| tracker.loaded_dir_set.contains(directory)));
-        assert_eq!(hints.len(), expected.len());
-        for (hint, directory) in hints.iter().zip(["second", "first", "third"]) {
-            assert!(hint.1.contains(&format!("{directory} hints")));
-        }
+        let second = hints.find("second hints").unwrap();
+        let first = hints.find("first hints").unwrap();
+        let third = hints.find("third hints").unwrap();
+        assert!(second < first && first < third);
     }
 
     #[test]
@@ -1551,13 +1422,18 @@ End of hints"#;
             serde_json::from_str(r#"{"path": "alias/file.rs"}"#).unwrap();
         tracker.record_tool_arguments(&Some(alias_args), &project_root);
         let hints = tracker.load_hints(&project_root);
-        assert_eq!(hints.len(), 1);
-        assert!(hints[0].1.contains("real hints"));
+        assert!(hints.contains("real hints"));
 
         let real_args: serde_json::Map<String, serde_json::Value> =
             serde_json::from_str(r#"{"path": "real/file.rs"}"#).unwrap();
         tracker.record_tool_arguments(&Some(real_args), &project_root);
-        assert_eq!(tracker.load_hints(&project_root).len(), 1);
+        assert_eq!(
+            tracker
+                .load_hints(&project_root)
+                .matches("real hints")
+                .count(),
+            1
+        );
         assert_eq!(tracker.loaded_dirs.len(), 1);
     }
 
@@ -1589,8 +1465,7 @@ End of hints"#;
         tracker.record_tool_arguments(&Some(args), &project_root);
 
         let hints = tracker.load_hints(&project_root);
-        assert_eq!(hints.len(), 1);
-        assert!(hints[0].1.contains("future hints"));
+        assert!(hints.contains("future hints"));
     }
 }
 

--- a/crates/goose/src/hints/load_hints.rs
+++ b/crates/goose/src/hints/load_hints.rs
@@ -14,6 +14,7 @@ const GLOBAL_HINTS_HEADER: &str = "\n### Global Hints\nThese are my global goose
 const PROJECT_HINTS_HEADER: &str =
     "### Project Hints\nThese are hints for working on the project in this directory.\n";
 const HINT_SEPARATOR: &str = "\n\n";
+pub(crate) const PROMPT_HINT_BOUNDARY_BYTES: usize = HINT_SEPARATOR.len() * 2;
 
 pub fn get_context_filenames() -> Vec<String> {
     use crate::config::Config;
@@ -86,7 +87,11 @@ impl SubdirectoryHintTracker {
     }
 
     pub(crate) fn load_snapshot(&mut self, working_dir: &Path) -> String {
-        self.load_snapshot_with_hook(working_dir, || {})
+        self.load_snapshot_with_limit_and_hook(working_dir, MAX_HINT_OUTPUT_BYTES, || {})
+    }
+
+    pub(crate) fn load_prompt_snapshot(&mut self, working_dir: &Path) -> String {
+        self.load_prompt_snapshot_with_hook(working_dir, || {})
     }
 
     #[cfg(test)]
@@ -94,9 +99,22 @@ impl SubdirectoryHintTracker {
         self.load_snapshot(working_dir)
     }
 
-    pub(crate) fn load_snapshot_with_hook(
+    pub(crate) fn load_prompt_snapshot_with_hook(
         &mut self,
         working_dir: &Path,
+        after_top_level_read: impl FnOnce(),
+    ) -> String {
+        self.load_snapshot_with_limit_and_hook(
+            working_dir,
+            MAX_HINT_OUTPUT_BYTES.saturating_sub(PROMPT_HINT_BOUNDARY_BYTES),
+            after_top_level_read,
+        )
+    }
+
+    fn load_snapshot_with_limit_and_hook(
+        &mut self,
+        working_dir: &Path,
+        output_limit: usize,
         after_top_level_read: impl FnOnce(),
     ) -> String {
         let pending = std::mem::take(&mut self.pending_dirs);
@@ -106,7 +124,7 @@ impl SubdirectoryHintTracker {
             working_dir,
             &self.hints_filenames,
             &ignore_patterns,
-            MAX_HINT_OUTPUT_BYTES,
+            output_limit,
         );
         after_top_level_read();
         let Ok(canonical_working_dir) = working_dir.canonicalize() else {
@@ -132,7 +150,7 @@ impl SubdirectoryHintTracker {
             } else {
                 HINT_SEPARATOR
             };
-            let Some(output_limit) = MAX_HINT_OUTPUT_BYTES
+            let Some(directory_output_limit) = output_limit
                 .checked_sub(snapshot.len())
                 .and_then(|remaining| remaining.checked_sub(separator.len()))
             else {
@@ -142,7 +160,7 @@ impl SubdirectoryHintTracker {
                 dir,
                 &canonical_working_dir,
                 &self.hints_filenames,
-                output_limit,
+                directory_output_limit,
             ) {
                 snapshot.push_str(separator);
                 snapshot.push_str(&content);
@@ -1054,8 +1072,7 @@ End of hints"#;
         let args: serde_json::Map<String, serde_json::Value> =
             serde_json::from_str(r#"{"path": "src/main.rs"}"#).unwrap();
         tracker.record_tool_arguments(&Some(args), &wd);
-        let hints = tracker.load_hints(&wd);
-        assert!(hints.is_empty());
+        let _ = tracker.load_hints(&wd);
         assert!(tracker.loaded_dirs.contains(&src.canonicalize().unwrap()));
     }
 
@@ -1069,8 +1086,7 @@ End of hints"#;
         let args: serde_json::Map<String, serde_json::Value> =
             serde_json::from_str(r#"{"command": "cat nested/doc.md"}"#).unwrap();
         tracker.record_tool_arguments(&Some(args), &wd);
-        let hints = tracker.load_hints(&wd);
-        assert!(hints.is_empty());
+        let _ = tracker.load_hints(&wd);
         assert!(tracker
             .loaded_dirs
             .contains(&nested.canonicalize().unwrap()));

--- a/crates/goose/src/hints/load_hints.rs
+++ b/crates/goose/src/hints/load_hints.rs
@@ -14,7 +14,6 @@ const GLOBAL_HINTS_HEADER: &str = "\n### Global Hints\nThese are my global goose
 const PROJECT_HINTS_HEADER: &str =
     "### Project Hints\nThese are hints for working on the project in this directory.\n";
 const HINT_SEPARATOR: &str = "\n\n";
-pub(crate) const PROMPT_HINT_BOUNDARY_BYTES: usize = HINT_SEPARATOR.len() * 2;
 
 pub fn get_context_filenames() -> Vec<String> {
     use crate::config::Config;
@@ -91,8 +90,12 @@ impl SubdirectoryHintTracker {
         self.load_snapshot_with_limit_and_hook(working_dir, MAX_HINT_OUTPUT_BYTES, || {})
     }
 
-    pub(crate) fn load_prompt_snapshot(&mut self, working_dir: &Path) -> String {
-        self.load_prompt_snapshot_with_hook(working_dir, || {})
+    pub(crate) fn load_prompt_snapshot(
+        &mut self,
+        working_dir: &Path,
+        output_limit: usize,
+    ) -> String {
+        self.load_prompt_snapshot_with_hook(working_dir, output_limit, || {})
     }
 
     #[cfg(test)]
@@ -103,13 +106,10 @@ impl SubdirectoryHintTracker {
     pub(crate) fn load_prompt_snapshot_with_hook(
         &mut self,
         working_dir: &Path,
+        output_limit: usize,
         after_top_level_read: impl FnOnce(),
     ) -> String {
-        self.load_snapshot_with_limit_and_hook(
-            working_dir,
-            MAX_HINT_OUTPUT_BYTES.saturating_sub(PROMPT_HINT_BOUNDARY_BYTES),
-            after_top_level_read,
-        )
+        self.load_snapshot_with_limit_and_hook(working_dir, output_limit, after_top_level_read)
     }
 
     fn load_snapshot_with_limit_and_hook(

--- a/crates/goose/src/hints/load_hints.rs
+++ b/crates/goose/src/hints/load_hints.rs
@@ -58,6 +58,7 @@ pub struct SubdirectoryHintTracker {
     loaded_dirs: Vec<PathBuf>,
     pending_dirs: Vec<PathBuf>,
     hints_filenames: Vec<String>,
+    emitted_hint_keys: HashSet<String>,
 }
 
 impl Default for SubdirectoryHintTracker {
@@ -72,6 +73,7 @@ impl SubdirectoryHintTracker {
             loaded_dirs: Vec::new(),
             pending_dirs: Vec::new(),
             hints_filenames: get_context_filenames(),
+            emitted_hint_keys: HashSet::new(),
         }
     }
 
@@ -198,17 +200,9 @@ impl SubdirectoryHintTracker {
     }
 
     pub fn load_new_hints(&mut self, working_dir: &Path) -> Vec<(String, String)> {
-        let first_new_directory = self.loaded_dirs.len();
-        let hints = self.load_hints(working_dir);
-        let new_directories = &self.loaded_dirs[first_new_directory..];
-
-        hints
+        self.load_hints(working_dir)
             .into_iter()
-            .filter(|(key, _)| {
-                new_directories
-                    .iter()
-                    .any(|directory| key == &format!("subdir_hints:{}", directory.display()))
-            })
+            .filter(|(key, _)| self.emitted_hint_keys.insert(key.clone()))
             .collect()
     }
 }
@@ -1123,6 +1117,42 @@ End of hints"#;
         let first = tracker.load_new_hints(project_root.path());
         assert_eq!(first.len(), 1);
         assert!(first[0].1.contains("nested hints"));
+        assert!(tracker.load_new_hints(project_root.path()).is_empty());
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn tracker_load_new_hints_emits_retained_directory_when_budget_allows() {
+        let config_root = TempDir::new().unwrap();
+        let _guard = env_lock::lock_env([
+            (
+                "GOOSE_PATH_ROOT",
+                Some(config_root.path().to_str().unwrap()),
+            ),
+            ("CONTEXT_FILE_NAMES", Some(r#"[".goosehints"]"#)),
+        ]);
+        let project_root = TempDir::new().unwrap();
+        fs::write(
+            project_root.path().join(GOOSE_HINTS_FILENAME),
+            "r".repeat(MAX_HINT_OUTPUT_BYTES - PROJECT_HINTS_HEADER.len()),
+        )
+        .unwrap();
+        let nested = project_root.path().join("nested");
+        fs::create_dir(&nested).unwrap();
+        fs::write(nested.join(GOOSE_HINTS_FILENAME), "nested hints").unwrap();
+
+        let mut tracker = SubdirectoryHintTracker::new();
+        let arguments = serde_json::json!({ "path": "nested/file.rs" })
+            .as_object()
+            .cloned();
+        tracker.record_tool_arguments(&arguments, project_root.path());
+
+        assert!(tracker.load_new_hints(project_root.path()).is_empty());
+        fs::write(project_root.path().join(GOOSE_HINTS_FILENAME), "root").unwrap();
+
+        let newly_admissible = tracker.load_new_hints(project_root.path());
+        assert_eq!(newly_admissible.len(), 1);
+        assert!(newly_admissible[0].1.contains("nested hints"));
         assert!(tracker.load_new_hints(project_root.path()).is_empty());
     }
 

--- a/crates/goose/src/hints/load_hints.rs
+++ b/crates/goose/src/hints/load_hints.rs
@@ -31,6 +31,7 @@ pub struct SubdirectoryHintTracker {
     pending_dirs: Vec<PathBuf>,
     hints_filenames: Vec<String>,
     remaining_output_bytes: usize,
+    output_budget_initialized: bool,
 }
 
 impl Default for SubdirectoryHintTracker {
@@ -46,7 +47,19 @@ impl SubdirectoryHintTracker {
             pending_dirs: Vec::new(),
             hints_filenames: get_context_filenames(),
             remaining_output_bytes: MAX_HINT_OUTPUT_BYTES,
+            output_budget_initialized: false,
         }
+    }
+
+    fn initialize_output_budget(&mut self, working_dir: &Path) {
+        if self.output_budget_initialized {
+            return;
+        }
+
+        let ignore_patterns = build_gitignore(working_dir);
+        let top_level_hints = load_hint_files(working_dir, &self.hints_filenames, &ignore_patterns);
+        self.remaining_output_bytes = MAX_HINT_OUTPUT_BYTES.saturating_sub(top_level_hints.len());
+        self.output_budget_initialized = true;
     }
 
     pub fn record_tool_arguments(
@@ -80,6 +93,7 @@ impl SubdirectoryHintTracker {
     }
 
     pub fn load_new_hints(&mut self, working_dir: &Path) -> Vec<(String, String)> {
+        self.initialize_output_budget(working_dir);
         let pending = std::mem::take(&mut self.pending_dirs);
         if pending.is_empty() {
             return Vec::new();

--- a/crates/goose/src/hints/load_hints.rs
+++ b/crates/goose/src/hints/load_hints.rs
@@ -27,11 +27,9 @@ pub fn get_context_filenames() -> Vec<String> {
 }
 
 pub struct SubdirectoryHintTracker {
-    loaded_dirs: HashSet<PathBuf>,
+    loaded_dirs: Vec<PathBuf>,
     pending_dirs: Vec<PathBuf>,
     hints_filenames: Vec<String>,
-    remaining_output_bytes: usize,
-    output_budget_initialized: bool,
 }
 
 impl Default for SubdirectoryHintTracker {
@@ -43,23 +41,10 @@ impl Default for SubdirectoryHintTracker {
 impl SubdirectoryHintTracker {
     pub fn new() -> Self {
         Self {
-            loaded_dirs: HashSet::new(),
+            loaded_dirs: Vec::new(),
             pending_dirs: Vec::new(),
             hints_filenames: get_context_filenames(),
-            remaining_output_bytes: MAX_HINT_OUTPUT_BYTES,
-            output_budget_initialized: false,
         }
-    }
-
-    fn initialize_output_budget(&mut self, working_dir: &Path) {
-        if self.output_budget_initialized {
-            return;
-        }
-
-        let ignore_patterns = build_gitignore(working_dir);
-        let top_level_hints = load_hint_files(working_dir, &self.hints_filenames, &ignore_patterns);
-        self.remaining_output_bytes = MAX_HINT_OUTPUT_BYTES.saturating_sub(top_level_hints.len());
-        self.output_budget_initialized = true;
     }
 
     pub fn record_tool_arguments(
@@ -92,18 +77,12 @@ impl SubdirectoryHintTracker {
         }
     }
 
-    pub fn load_new_hints(&mut self, working_dir: &Path) -> Vec<(String, String)> {
-        self.initialize_output_budget(working_dir);
+    pub fn load_hints(&mut self, working_dir: &Path) -> Vec<(String, String)> {
         let pending = std::mem::take(&mut self.pending_dirs);
-        if pending.is_empty() {
-            return Vec::new();
-        }
-
         let Ok(working_dir) = working_dir.canonicalize() else {
             return Vec::new();
         };
 
-        let mut results = Vec::new();
         for dir in pending {
             let Ok(dir) = dir.canonicalize() else {
                 continue;
@@ -114,19 +93,32 @@ impl SubdirectoryHintTracker {
             if self.loaded_dirs.contains(&dir) {
                 continue;
             }
+            self.loaded_dirs.push(dir);
+        }
+
+        let ignore_patterns = build_gitignore(&working_dir);
+        let top_level_hints =
+            load_hint_files(&working_dir, &self.hints_filenames, &ignore_patterns);
+        let mut remaining_output_bytes =
+            MAX_HINT_OUTPUT_BYTES.saturating_sub(top_level_hints.len());
+        let mut results = Vec::new();
+        for dir in &self.loaded_dirs {
             if let Some(content) = load_hints_from_directory(
-                &dir,
+                dir,
                 &working_dir,
                 &self.hints_filenames,
-                self.remaining_output_bytes,
+                remaining_output_bytes,
             ) {
-                self.remaining_output_bytes -= content.len();
+                remaining_output_bytes -= content.len();
                 let key = format!("subdir_hints:{}", dir.display());
                 results.push((key, content));
             }
-            self.loaded_dirs.insert(dir);
         }
         results
+    }
+
+    pub fn load_new_hints(&mut self, working_dir: &Path) -> Vec<(String, String)> {
+        self.load_hints(working_dir)
     }
 }
 
@@ -949,7 +941,7 @@ End of hints"#;
         let args: serde_json::Map<String, serde_json::Value> =
             serde_json::from_str(r#"{"path": "src/main.rs"}"#).unwrap();
         tracker.record_tool_arguments(&Some(args), &wd);
-        let hints = tracker.load_new_hints(&wd);
+        let hints = tracker.load_hints(&wd);
         assert!(hints.is_empty());
         assert!(tracker.loaded_dirs.contains(&src.canonicalize().unwrap()));
     }
@@ -964,7 +956,7 @@ End of hints"#;
         let args: serde_json::Map<String, serde_json::Value> =
             serde_json::from_str(r#"{"command": "cat nested/doc.md"}"#).unwrap();
         tracker.record_tool_arguments(&Some(args), &wd);
-        let hints = tracker.load_new_hints(&wd);
+        let hints = tracker.load_hints(&wd);
         assert!(hints.is_empty());
         assert!(tracker
             .loaded_dirs
@@ -981,7 +973,7 @@ End of hints"#;
         let args: serde_json::Map<String, serde_json::Value> =
             serde_json::from_str(r#"{"command": "grep -rn pattern src/lib.rs"}"#).unwrap();
         tracker.record_tool_arguments(&Some(args), &wd);
-        let _ = tracker.load_new_hints(&wd);
+        let _ = tracker.load_hints(&wd);
         assert!(tracker.loaded_dirs.contains(&src.canonicalize().unwrap()));
         assert_eq!(tracker.loaded_dirs.len(), 1);
     }
@@ -1002,7 +994,7 @@ End of hints"#;
         let args: serde_json::Map<String, serde_json::Value> =
             serde_json::from_str(r#"{"path": "nested/foo.rs"}"#).unwrap();
         tracker.record_tool_arguments(&Some(args), &project_root);
-        let hints = tracker.load_new_hints(&project_root);
+        let hints = tracker.load_hints(&project_root);
         assert_eq!(hints.len(), 1);
         assert!(hints[0].0.contains("nested"));
         assert!(hints[0].1.contains("nested subdirectory hints"));
@@ -1040,7 +1032,7 @@ End of hints"#;
             tracker.record_tool_arguments(&Some(args), &project_root);
         }
 
-        let hints = tracker.load_new_hints(&project_root);
+        let hints = tracker.load_hints(&project_root);
         let output_bytes: usize = hints.iter().map(|(_, content)| content.len()).sum();
         let combined = hints
             .iter()
@@ -1065,12 +1057,14 @@ End of hints"#;
         let args: serde_json::Map<String, serde_json::Value> =
             serde_json::from_str(r#"{"path": "nested/foo.rs"}"#).unwrap();
         tracker.record_tool_arguments(&Some(args.clone()), &project_root);
-        let hints = tracker.load_new_hints(&project_root);
+        let hints = tracker.load_hints(&project_root);
         assert_eq!(hints.len(), 1);
 
         tracker.record_tool_arguments(&Some(args), &project_root);
-        let hints = tracker.load_new_hints(&project_root);
-        assert!(hints.is_empty());
+        let hints = tracker.load_hints(&project_root);
+        assert_eq!(hints.len(), 1);
+        assert!(hints[0].1.contains("nested hints"));
+        assert_eq!(tracker.loaded_dirs.len(), 1);
     }
 
     #[test]
@@ -1088,7 +1082,7 @@ End of hints"#;
             serde_json::from_str(r#"{"path": "nested/../../outside/file.rs"}"#).unwrap();
         tracker.record_tool_arguments(&Some(args), &project_root);
 
-        assert!(tracker.load_new_hints(&project_root).is_empty());
+        assert!(tracker.load_hints(&project_root).is_empty());
     }
 
     #[cfg(unix)]
@@ -1109,7 +1103,7 @@ End of hints"#;
             serde_json::from_str(r#"{"path": "alias/file.rs"}"#).unwrap();
         tracker.record_tool_arguments(&Some(args), &project_root);
 
-        assert!(tracker.load_new_hints(&project_root).is_empty());
+        assert!(tracker.load_hints(&project_root).is_empty());
     }
 
     #[cfg(unix)]
@@ -1128,14 +1122,14 @@ End of hints"#;
         let alias_args: serde_json::Map<String, serde_json::Value> =
             serde_json::from_str(r#"{"path": "alias/file.rs"}"#).unwrap();
         tracker.record_tool_arguments(&Some(alias_args), &project_root);
-        let hints = tracker.load_new_hints(&project_root);
+        let hints = tracker.load_hints(&project_root);
         assert_eq!(hints.len(), 1);
         assert!(hints[0].1.contains("real hints"));
 
         let real_args: serde_json::Map<String, serde_json::Value> =
             serde_json::from_str(r#"{"path": "real/file.rs"}"#).unwrap();
         tracker.record_tool_arguments(&Some(real_args), &project_root);
-        assert!(tracker.load_new_hints(&project_root).is_empty());
+        assert_eq!(tracker.load_hints(&project_root).len(), 1);
         assert_eq!(tracker.loaded_dirs.len(), 1);
     }
 
@@ -1149,7 +1143,7 @@ End of hints"#;
         let args: serde_json::Map<String, serde_json::Value> =
             serde_json::from_str(r#"{"path": "future/file.rs"}"#).unwrap();
         tracker.record_tool_arguments(&Some(args.clone()), &project_root);
-        assert!(tracker.load_new_hints(&project_root).is_empty());
+        assert!(tracker.load_hints(&project_root).is_empty());
         assert!(tracker.loaded_dirs.is_empty());
 
         let future = project_root.join("future");
@@ -1157,7 +1151,7 @@ End of hints"#;
         fs::write(future.join(GOOSE_HINTS_FILENAME), "future hints").unwrap();
         tracker.record_tool_arguments(&Some(args), &project_root);
 
-        let hints = tracker.load_new_hints(&project_root);
+        let hints = tracker.load_hints(&project_root);
         assert_eq!(hints.len(), 1);
         assert!(hints[0].1.contains("future hints"));
     }

--- a/crates/goose/src/hints/load_hints.rs
+++ b/crates/goose/src/hints/load_hints.rs
@@ -32,6 +32,7 @@ pub struct SubdirectoryHintTracker {
     loaded_dirs: Vec<PathBuf>,
     loaded_dir_set: HashSet<PathBuf>,
     emitted_dir_set: HashSet<PathBuf>,
+    incremental_output_bytes: usize,
     pending_dirs: Vec<PathBuf>,
     hints_filenames: Vec<String>,
 }
@@ -48,6 +49,7 @@ impl SubdirectoryHintTracker {
             loaded_dirs: Vec::new(),
             loaded_dir_set: HashSet::new(),
             emitted_dir_set: HashSet::new(),
+            incremental_output_bytes: 0,
             pending_dirs: Vec::new(),
             hints_filenames: get_context_filenames(),
         }
@@ -175,12 +177,24 @@ impl SubdirectoryHintTracker {
             if self.loaded_dir_set.insert(dir.clone()) {
                 self.loaded_dirs.push(dir.clone());
             }
+            let separator_len = if self.incremental_output_bytes == 0 {
+                0
+            } else {
+                HINT_SEPARATOR.len()
+            };
+            let Some(output_limit) = MAX_HINT_OUTPUT_BYTES
+                .checked_sub(self.incremental_output_bytes)
+                .and_then(|remaining| remaining.checked_sub(separator_len))
+            else {
+                continue;
+            };
             if let Some(content) = load_hints_from_directory(
                 &dir,
                 &canonical_working_dir,
                 &self.hints_filenames,
-                MAX_HINT_OUTPUT_BYTES,
+                output_limit,
             ) {
+                self.incremental_output_bytes += separator_len + content.len();
                 self.emitted_dir_set.insert(dir.clone());
                 results.push((format!("subdir_hints:{}", dir.display()), content));
             }
@@ -1159,6 +1173,61 @@ End of hints"#;
 
     #[test]
     #[serial_test::serial]
+    fn tracker_load_new_hints_shares_output_budget_across_calls() {
+        let config_root = TempDir::new().unwrap();
+        let _guard = env_lock::lock_env([
+            (
+                "GOOSE_PATH_ROOT",
+                Some(config_root.path().to_str().unwrap()),
+            ),
+            ("CONTEXT_FILE_NAMES", Some(r#"[".goosehints"]"#)),
+        ]);
+        let project_root = TempDir::new().unwrap();
+        let first = project_root.path().join("first");
+        let second = project_root.path().join("second");
+        fs::create_dir(&first).unwrap();
+        fs::create_dir(&second).unwrap();
+        fs::write(first.join(GOOSE_HINTS_FILENAME), "a".repeat(600 * 1024)).unwrap();
+        let second_hints = second.join(GOOSE_HINTS_FILENAME);
+        fs::write(&second_hints, "b".repeat(600 * 1024)).unwrap();
+
+        let mut tracker = SubdirectoryHintTracker::new();
+        let first_arguments = serde_json::json!({ "path": "first/file.rs" })
+            .as_object()
+            .cloned();
+        let second_arguments = serde_json::json!({ "path": "second/file.rs" })
+            .as_object()
+            .cloned();
+        tracker.record_tool_arguments(&first_arguments, project_root.path());
+        tracker.record_tool_arguments(&second_arguments, project_root.path());
+
+        let initial = tracker.load_new_hints(project_root.path());
+        assert_eq!(initial.len(), 1);
+        let first_output_len = initial[0].1.len();
+
+        let second_header_len = subdirectory_hints_header(&second.canonicalize().unwrap()).len();
+        let payload_without_separator =
+            MAX_HINT_OUTPUT_BYTES - first_output_len - second_header_len;
+        fs::write(&second_hints, "b".repeat(payload_without_separator)).unwrap();
+        tracker.record_tool_arguments(&second_arguments, project_root.path());
+        assert!(tracker.load_new_hints(project_root.path()).is_empty());
+
+        fs::write(
+            &second_hints,
+            "b".repeat(payload_without_separator - HINT_SEPARATOR.len()),
+        )
+        .unwrap();
+        tracker.record_tool_arguments(&second_arguments, project_root.path());
+        let retried = tracker.load_new_hints(project_root.path());
+        assert_eq!(retried.len(), 1);
+        assert_eq!(
+            first_output_len + HINT_SEPARATOR.len() + retried[0].1.len(),
+            MAX_HINT_OUTPUT_BYTES
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
     fn tracker_refreshes_context_filenames_before_building_snapshot() {
         let config_root = TempDir::new().unwrap();
         let _guard = env_lock::lock_env([
@@ -1439,7 +1508,8 @@ End of hints"#;
             serde_json::from_str(r#"{"path": "alias/file.rs"}"#).unwrap();
         tracker.record_tool_arguments(&Some(args), &project_root);
 
-        assert!(tracker.load_hints(&project_root).is_empty());
+        let hints = tracker.load_hints(&project_root);
+        assert!(!hints.contains("outside hints"));
     }
 
     #[cfg(unix)]

--- a/crates/goose/src/hints/load_hints.rs
+++ b/crates/goose/src/hints/load_hints.rs
@@ -17,6 +17,20 @@ const PROJECT_HINTS_HEADER: &str =
     "### Project Hints\nThese are hints for working on the project in this directory.\n";
 const HINT_SEPARATOR: &str = "\n\n";
 
+struct HintLoadState {
+    input_budget: HintInputBudget,
+    loaded_hint_files: HashSet<PathBuf>,
+}
+
+impl HintLoadState {
+    fn new() -> Self {
+        Self {
+            input_budget: HintInputBudget::new(),
+            loaded_hint_files: HashSet::new(),
+        }
+    }
+}
+
 pub fn get_context_filenames() -> Vec<String> {
     use crate::config::Config;
 
@@ -121,13 +135,13 @@ impl SubdirectoryHintTracker {
         let pending = std::mem::take(&mut self.pending_dirs);
         self.hints_filenames = get_context_filenames();
         let ignore_patterns = build_gitignore(working_dir);
-        let mut input_budget = HintInputBudget::new();
-        let mut snapshot = load_hint_files_with_limit_and_input_budget(
+        let mut load_state = HintLoadState::new();
+        let mut snapshot = load_hint_files_with_state(
             working_dir,
             &self.hints_filenames,
             &ignore_patterns,
             output_limit,
-            &mut input_budget,
+            &mut load_state,
         );
         after_top_level_read();
         let Ok(canonical_working_dir) = working_dir.canonicalize() else {
@@ -164,7 +178,7 @@ impl SubdirectoryHintTracker {
                 &canonical_working_dir,
                 &self.hints_filenames,
                 directory_output_limit,
-                &mut input_budget,
+                &mut load_state,
             ) {
                 snapshot.push_str(separator);
                 snapshot.push_str(&content);
@@ -178,13 +192,13 @@ impl SubdirectoryHintTracker {
     pub fn load_new_hints(&mut self, working_dir: &Path) -> Vec<(String, String)> {
         let pending = std::mem::take(&mut self.pending_dirs);
         self.hints_filenames = get_context_filenames();
-        let mut input_budget = HintInputBudget::new();
-        let top_level_output_bytes = load_hint_files_with_limit_and_input_budget(
+        let mut load_state = HintLoadState::new();
+        let top_level_output_bytes = load_hint_files_with_state(
             working_dir,
             &self.hints_filenames,
             &build_gitignore(working_dir),
             MAX_HINT_OUTPUT_BYTES,
-            &mut input_budget,
+            &mut load_state,
         )
         .len();
         let Ok(canonical_working_dir) = working_dir.canonicalize() else {
@@ -229,11 +243,11 @@ impl SubdirectoryHintTracker {
                 continue;
             };
             if let Some(content) = load_hints_from_directory(
-                &dir,
+                dir,
                 &canonical_working_dir,
                 &self.hints_filenames,
                 output_limit,
-                &mut input_budget,
+                &mut load_state,
             ) {
                 incremental_output_bytes += incremental_separator_len + content.len();
                 next_emitted_hints.insert(dir.clone(), content);
@@ -271,7 +285,7 @@ fn load_hints_from_directory(
     working_dir: &Path,
     hints_filenames: &[String],
     output_limit: usize,
-    input_budget: &mut HintInputBudget,
+    load_state: &mut HintLoadState,
 ) -> Option<String> {
     if !directory.is_dir() || !directory.is_absolute() {
         return None;
@@ -307,7 +321,7 @@ fn load_hints_from_directory(
                     import_boundary,
                     &gitignore,
                     output_limit,
-                    input_budget,
+                    load_state,
                 ) {
                     has_hints = true;
                 }
@@ -332,8 +346,14 @@ fn append_hint_file(
     import_boundary: &Path,
     ignore_patterns: &Gitignore,
     output_limit: usize,
-    input_budget: &mut HintInputBudget,
+    load_state: &mut HintLoadState,
 ) -> bool {
+    if !load_state
+        .loaded_hint_files
+        .insert(hints_path.to_path_buf())
+    {
+        return false;
+    }
     let Some(used_with_framing) = output.len().checked_add(framing.len()) else {
         return false;
     };
@@ -349,7 +369,7 @@ fn append_hint_file(
         0,
         ignore_patterns,
         available,
-        input_budget,
+        &mut load_state.input_budget,
     );
     if expanded.is_empty() {
         return false;
@@ -436,21 +456,21 @@ pub(crate) fn load_hint_files_with_limit(
     ignore_patterns: &Gitignore,
     output_limit: usize,
 ) -> String {
-    load_hint_files_with_limit_and_input_budget(
+    load_hint_files_with_state(
         cwd,
         hints_filenames,
         ignore_patterns,
         output_limit,
-        &mut HintInputBudget::new(),
+        &mut HintLoadState::new(),
     )
 }
 
-fn load_hint_files_with_limit_and_input_budget(
+fn load_hint_files_with_state(
     cwd: &Path,
     hints_filenames: &[String],
     ignore_patterns: &Gitignore,
     output_limit: usize,
-    input_budget: &mut HintInputBudget,
+    load_state: &mut HintLoadState,
 ) -> String {
     let mut global_hints_paths: Vec<PathBuf> = hints_filenames
         .iter()
@@ -483,7 +503,7 @@ fn load_hint_files_with_limit_and_input_budget(
                 hints_dir,
                 &global_ignore_patterns,
                 output_limit,
-                input_budget,
+                load_state,
             ) {
                 has_global_hints = true;
             }
@@ -513,7 +533,7 @@ fn load_hint_files_with_limit_and_input_budget(
                     import_boundary,
                     ignore_patterns,
                     output_limit,
-                    input_budget,
+                    load_state,
                 ) {
                     has_local_hints = true;
                 }
@@ -593,7 +613,7 @@ mod tests {
 
         let gitignore = create_dummy_gitignore();
         let mut output = String::new();
-        let mut input_budget = HintInputBudget::new();
+        let mut load_state = HintLoadState::new();
         let appended = append_hint_file(
             &mut output,
             "header\n",
@@ -601,7 +621,7 @@ mod tests {
             dir.path(),
             &gitignore,
             64,
-            &mut input_budget,
+            &mut load_state,
         );
 
         assert!(appended);
@@ -1499,6 +1519,102 @@ End of hints"#;
         assert!(hints.contains("A1"));
         assert!(!hints.contains("B2"));
         assert!(hints.contains("third hint"));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn tracker_emits_ancestor_hint_file_once_before_near_budget_descendant() {
+        let config_root = TempDir::new().unwrap();
+        let _guard = env_lock::lock_env([
+            (
+                "GOOSE_PATH_ROOT",
+                Some(config_root.path().to_str().unwrap()),
+            ),
+            ("CONTEXT_FILE_NAMES", Some(r#"[".goosehints"]"#)),
+        ]);
+        let project_root = TempDir::new().unwrap();
+        let ancestor = project_root.path().join("a");
+        let descendant = ancestor.join("b");
+        fs::create_dir_all(&descendant).unwrap();
+
+        const ANCESTOR_MARKER: &str = "ANCESTOR_MARKER";
+        const DESCENDANT_MARKER: &str = "DESCENDANT_MARKER";
+        let ancestor_payload_len = 500 * 1024;
+        fs::write(
+            ancestor.join(GOOSE_HINTS_FILENAME),
+            format!(
+                "{}{}",
+                "a".repeat(ancestor_payload_len - ANCESTOR_MARKER.len()),
+                ANCESTOR_MARKER
+            ),
+        )
+        .unwrap();
+
+        let ancestor_output_len = subdirectory_hints_header(&ancestor.canonicalize().unwrap())
+            .len()
+            + ancestor_payload_len;
+        let descendant_header_len =
+            subdirectory_hints_header(&descendant.canonicalize().unwrap()).len();
+        let descendant_payload_len = MAX_HINT_OUTPUT_BYTES
+            - ancestor_output_len
+            - HINT_SEPARATOR.len()
+            - descendant_header_len;
+        fs::write(
+            descendant.join(GOOSE_HINTS_FILENAME),
+            format!(
+                "{}{}",
+                "b".repeat(descendant_payload_len - DESCENDANT_MARKER.len()),
+                DESCENDANT_MARKER
+            ),
+        )
+        .unwrap();
+
+        let mut tracker = SubdirectoryHintTracker::new();
+        for path in ["a/file.rs", "a/b/file.rs"] {
+            let arguments = serde_json::json!({ "path": path }).as_object().cloned();
+            tracker.record_tool_arguments(&arguments, project_root.path());
+        }
+        let hints = tracker.load_snapshot(project_root.path());
+
+        assert_eq!(hints.len(), MAX_HINT_OUTPUT_BYTES);
+        assert_eq!(hints.matches(ANCESTOR_MARKER).count(), 1);
+        assert!(hints.contains(DESCENDANT_MARKER));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    #[serial_test::serial]
+    fn tracker_preserves_lexical_scope_for_symlinked_hint_files() {
+        use std::os::unix::fs::symlink;
+
+        let config_root = TempDir::new().unwrap();
+        let _guard = env_lock::lock_env([
+            (
+                "GOOSE_PATH_ROOT",
+                Some(config_root.path().to_str().unwrap()),
+            ),
+            ("CONTEXT_FILE_NAMES", Some(r#"[".goosehints"]"#)),
+        ]);
+        let project_root = TempDir::new().unwrap();
+        let first = project_root.path().join("a");
+        let second = project_root.path().join("b");
+        fs::create_dir(&first).unwrap();
+        fs::create_dir(&second).unwrap();
+        fs::write(project_root.path().join("shared-hints"), "@policy.md").unwrap();
+        fs::write(first.join("policy.md"), "FIRST_SCOPED_POLICY").unwrap();
+        fs::write(second.join("policy.md"), "SECOND_SCOPED_POLICY").unwrap();
+        symlink("../shared-hints", first.join(GOOSE_HINTS_FILENAME)).unwrap();
+        symlink("../shared-hints", second.join(GOOSE_HINTS_FILENAME)).unwrap();
+
+        let mut tracker = SubdirectoryHintTracker::new();
+        for path in ["a/file.rs", "b/file.rs"] {
+            let arguments = serde_json::json!({ "path": path }).as_object().cloned();
+            tracker.record_tool_arguments(&arguments, project_root.path());
+        }
+        let hints = tracker.load_snapshot(project_root.path());
+
+        assert!(hints.contains("FIRST_SCOPED_POLICY"));
+        assert!(hints.contains("SECOND_SCOPED_POLICY"));
     }
 
     #[test]

--- a/crates/goose/src/hints/load_hints.rs
+++ b/crates/goose/src/hints/load_hints.rs
@@ -177,6 +177,13 @@ impl SubdirectoryHintTracker {
         }
 
         self.hints_filenames = get_context_filenames();
+        let top_level_output_bytes = load_hint_files_with_limit(
+            working_dir,
+            &self.hints_filenames,
+            &build_gitignore(working_dir),
+            MAX_HINT_OUTPUT_BYTES,
+        )
+        .len();
         let Ok(canonical_working_dir) = working_dir.canonicalize() else {
             return Vec::new();
         };
@@ -196,14 +203,21 @@ impl SubdirectoryHintTracker {
             if self.loaded_dir_set.insert(dir.clone()) {
                 self.loaded_dirs.push(dir.clone());
             }
-            let separator_len = if self.incremental_output_bytes == 0 {
-                0
-            } else {
+            let root_separator_len = if top_level_output_bytes > 0 {
                 HINT_SEPARATOR.len()
+            } else {
+                0
+            };
+            let incremental_separator_len = if self.incremental_output_bytes > 0 {
+                HINT_SEPARATOR.len()
+            } else {
+                0
             };
             let Some(output_limit) = MAX_HINT_OUTPUT_BYTES
-                .checked_sub(self.incremental_output_bytes)
-                .and_then(|remaining| remaining.checked_sub(separator_len))
+                .checked_sub(top_level_output_bytes)
+                .and_then(|remaining| remaining.checked_sub(root_separator_len))
+                .and_then(|remaining| remaining.checked_sub(self.incremental_output_bytes))
+                .and_then(|remaining| remaining.checked_sub(incremental_separator_len))
             else {
                 continue;
             };
@@ -213,7 +227,7 @@ impl SubdirectoryHintTracker {
                 &self.hints_filenames,
                 output_limit,
             ) {
-                self.incremental_output_bytes += separator_len + content.len();
+                self.incremental_output_bytes += incremental_separator_len + content.len();
                 self.emitted_dir_set.insert(dir.clone());
                 results.push((format!("subdir_hints:{}", dir.display()), content));
             }
@@ -1239,6 +1253,59 @@ End of hints"#;
         assert_eq!(retried.len(), 1);
         assert_eq!(
             first_output_len + HINT_SEPARATOR.len() + retried[0].1.len(),
+            MAX_HINT_OUTPUT_BYTES
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn tracker_load_new_hints_includes_top_level_hints_in_output_budget() {
+        let config_root = TempDir::new().unwrap();
+        let _guard = env_lock::lock_env([
+            (
+                "GOOSE_PATH_ROOT",
+                Some(config_root.path().to_str().unwrap()),
+            ),
+            ("CONTEXT_FILE_NAMES", Some(r#"[".goosehints"]"#)),
+        ]);
+        let project_root = TempDir::new().unwrap();
+        let nested = project_root.path().join("nested");
+        fs::create_dir(&nested).unwrap();
+        fs::write(
+            project_root.path().join(GOOSE_HINTS_FILENAME),
+            "r".repeat(600 * 1024),
+        )
+        .unwrap();
+        let nested_hints = nested.join(GOOSE_HINTS_FILENAME);
+        fs::write(&nested_hints, "n".repeat(600 * 1024)).unwrap();
+
+        let mut tracker = SubdirectoryHintTracker::new();
+        let arguments = serde_json::json!({ "path": "nested/file.rs" })
+            .as_object()
+            .cloned();
+        tracker.record_tool_arguments(&arguments, project_root.path());
+        assert!(tracker.load_new_hints(project_root.path()).is_empty());
+
+        let top_level_output_len = load_hint_files(
+            project_root.path(),
+            &[GOOSE_HINTS_FILENAME.to_string()],
+            &build_gitignore(project_root.path()),
+        )
+        .len();
+        let nested_header_len = subdirectory_hints_header(&nested.canonicalize().unwrap()).len();
+        let exact_payload_len =
+            MAX_HINT_OUTPUT_BYTES - top_level_output_len - HINT_SEPARATOR.len() - nested_header_len;
+
+        fs::write(&nested_hints, "n".repeat(exact_payload_len + 1)).unwrap();
+        tracker.record_tool_arguments(&arguments, project_root.path());
+        assert!(tracker.load_new_hints(project_root.path()).is_empty());
+
+        fs::write(&nested_hints, "n".repeat(exact_payload_len)).unwrap();
+        tracker.record_tool_arguments(&arguments, project_root.path());
+        let retried = tracker.load_new_hints(project_root.path());
+        assert_eq!(retried.len(), 1);
+        assert_eq!(
+            top_level_output_len + HINT_SEPARATOR.len() + retried[0].1.len(),
             MAX_HINT_OUTPUT_BYTES
         );
     }

--- a/crates/goose/src/hints/load_hints.rs
+++ b/crates/goose/src/hints/load_hints.rs
@@ -23,13 +23,19 @@ pub(crate) struct HintSnapshot {
 #[derive(Clone, Copy)]
 pub(crate) struct HintOutputReservation {
     pub(crate) root_only: usize,
+    pub(crate) subdirectories_only: usize,
     pub(crate) with_subdirectories: usize,
 }
 
 impl HintOutputReservation {
-    pub(crate) fn new(root_only: usize, with_subdirectories: usize) -> Self {
+    pub(crate) fn new(
+        root_only: usize,
+        subdirectories_only: usize,
+        with_subdirectories: usize,
+    ) -> Self {
         Self {
             root_only,
+            subdirectories_only,
             with_subdirectories,
         }
     }
@@ -37,7 +43,11 @@ impl HintOutputReservation {
 
 impl From<usize> for HintOutputReservation {
     fn from(reserved_output_bytes: usize) -> Self {
-        Self::new(reserved_output_bytes, reserved_output_bytes)
+        Self::new(
+            reserved_output_bytes,
+            reserved_output_bytes,
+            reserved_output_bytes,
+        )
     }
 }
 
@@ -158,13 +168,19 @@ impl SubdirectoryHintTracker {
             top_level_output_limit,
         );
         after_top_level_read();
+        let has_top_level_hints = !top_level_hints.is_empty();
+        let initial_reservation = if has_top_level_hints {
+            reservation.root_only
+        } else {
+            reservation.subdirectories_only
+        };
         let mut remaining_output_bytes = MAX_HINT_OUTPUT_BYTES
             .saturating_sub(top_level_hints.len())
-            .saturating_sub(reservation.root_only);
-        let mut has_hint_output = !top_level_hints.is_empty();
+            .saturating_sub(initial_reservation);
+        let mut has_hint_output = has_top_level_hints;
         let mut results = Vec::new();
         for dir in &self.loaded_dirs {
-            let additional_reservation = if results.is_empty() {
+            let additional_reservation = if has_top_level_hints && results.is_empty() {
                 reservation
                     .with_subdirectories
                     .saturating_sub(reservation.root_only)

--- a/crates/goose/src/hints/load_hints.rs
+++ b/crates/goose/src/hints/load_hints.rs
@@ -126,8 +126,13 @@ impl SubdirectoryHintTracker {
 
         self.hints_filenames = get_context_filenames();
         let ignore_patterns = build_gitignore(lexical_working_dir);
-        let top_level_hints =
-            load_hint_files(lexical_working_dir, &self.hints_filenames, &ignore_patterns);
+        let top_level_output_limit = MAX_HINT_OUTPUT_BYTES.saturating_sub(reserved_output_bytes);
+        let top_level_hints = load_hint_files_with_limit(
+            lexical_working_dir,
+            &self.hints_filenames,
+            &ignore_patterns,
+            top_level_output_limit,
+        );
         after_top_level_read();
         let mut remaining_output_bytes = MAX_HINT_OUTPUT_BYTES
             .saturating_sub(top_level_hints.len())
@@ -1083,6 +1088,43 @@ End of hints"#;
 
         assert!(hints.is_empty());
         assert_eq!(tracker.hints_filenames, ["new.md".to_string()]);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn tracker_applies_reserved_bytes_before_loading_top_level_hints() {
+        let config_root = TempDir::new().unwrap();
+        let _guard = env_lock::lock_env([
+            (
+                "GOOSE_PATH_ROOT",
+                Some(config_root.path().to_str().unwrap()),
+            ),
+            ("CONTEXT_FILE_NAMES", Some(r#"[".goosehints"]"#)),
+        ]);
+        let project_root = TempDir::new().unwrap();
+        let hints_path = project_root.path().join(GOOSE_HINTS_FILENAME);
+        let reserved_output_bytes = HINT_EXTRA_SEPARATOR_BYTES;
+        let content_bytes =
+            MAX_HINT_OUTPUT_BYTES - PROJECT_HINTS_HEADER.len() - reserved_output_bytes;
+        let content = format!(
+            "ROOT_MARKER{}",
+            "r".repeat(content_bytes - "ROOT_MARKER".len())
+        );
+        fs::write(&hints_path, &content).unwrap();
+
+        let mut tracker = SubdirectoryHintTracker::new();
+        let snapshot = tracker.load_snapshot(project_root.path(), reserved_output_bytes);
+
+        assert_eq!(
+            snapshot.top_level.len() + reserved_output_bytes,
+            MAX_HINT_OUTPUT_BYTES
+        );
+        assert!(snapshot.top_level.contains("ROOT_MARKER"));
+
+        fs::write(hints_path, format!("{content}xx")).unwrap();
+        let snapshot = tracker.load_snapshot(project_root.path(), reserved_output_bytes);
+
+        assert!(snapshot.top_level.is_empty());
     }
 
     #[test]

--- a/crates/goose/src/hints/load_hints.rs
+++ b/crates/goose/src/hints/load_hints.rs
@@ -5,7 +5,9 @@ use std::{
 };
 
 use crate::config::paths::Paths;
-use crate::hints::import_files::{read_referenced_files_with_limit, MAX_HINT_OUTPUT_BYTES};
+use crate::hints::import_files::{
+    read_referenced_files_with_limit_and_input_budget, HintInputBudget, MAX_HINT_OUTPUT_BYTES,
+};
 use crate::utils::sanitize_unicode_tags;
 
 pub const GOOSE_HINTS_FILENAME: &str = ".goosehints";
@@ -121,11 +123,13 @@ impl SubdirectoryHintTracker {
         let pending = std::mem::take(&mut self.pending_dirs);
         self.hints_filenames = get_context_filenames();
         let ignore_patterns = build_gitignore(working_dir);
-        let mut snapshot = load_hint_files_with_limit(
+        let mut input_budget = HintInputBudget::new();
+        let mut snapshot = load_hint_files_with_limit_and_input_budget(
             working_dir,
             &self.hints_filenames,
             &ignore_patterns,
             output_limit,
+            &mut input_budget,
         );
         after_top_level_read();
         let Ok(canonical_working_dir) = working_dir.canonicalize() else {
@@ -162,6 +166,7 @@ impl SubdirectoryHintTracker {
                 &canonical_working_dir,
                 &self.hints_filenames,
                 directory_output_limit,
+                &mut input_budget,
             ) {
                 snapshot.push_str(separator);
                 snapshot.push_str(&content);
@@ -177,11 +182,13 @@ impl SubdirectoryHintTracker {
         }
 
         self.hints_filenames = get_context_filenames();
-        let top_level_output_bytes = load_hint_files_with_limit(
+        let mut input_budget = HintInputBudget::new();
+        let top_level_output_bytes = load_hint_files_with_limit_and_input_budget(
             working_dir,
             &self.hints_filenames,
             &build_gitignore(working_dir),
             MAX_HINT_OUTPUT_BYTES,
+            &mut input_budget,
         )
         .len();
         let Ok(canonical_working_dir) = working_dir.canonicalize() else {
@@ -226,6 +233,7 @@ impl SubdirectoryHintTracker {
                 &canonical_working_dir,
                 &self.hints_filenames,
                 output_limit,
+                &mut input_budget,
             ) {
                 self.incremental_output_bytes += incremental_separator_len + content.len();
                 self.emitted_dir_set.insert(dir.clone());
@@ -251,6 +259,7 @@ fn load_hints_from_directory(
     working_dir: &Path,
     hints_filenames: &[String],
     output_limit: usize,
+    input_budget: &mut HintInputBudget,
 ) -> Option<String> {
     if !directory.is_dir() || !directory.is_absolute() {
         return None;
@@ -286,6 +295,7 @@ fn load_hints_from_directory(
                     import_boundary,
                     &gitignore,
                     output_limit,
+                    input_budget,
                 ) {
                     has_hints = true;
                 }
@@ -310,6 +320,7 @@ fn append_hint_file(
     import_boundary: &Path,
     ignore_patterns: &Gitignore,
     output_limit: usize,
+    input_budget: &mut HintInputBudget,
 ) -> bool {
     let Some(used_with_framing) = output.len().checked_add(framing.len()) else {
         return false;
@@ -319,13 +330,14 @@ fn append_hint_file(
     };
 
     let mut visited = HashSet::new();
-    let expanded = read_referenced_files_with_limit(
+    let expanded = read_referenced_files_with_limit_and_input_budget(
         hints_path,
         import_boundary,
         &mut visited,
         0,
         ignore_patterns,
         available,
+        input_budget,
     );
     if expanded.is_empty() {
         return false;
@@ -412,6 +424,22 @@ pub(crate) fn load_hint_files_with_limit(
     ignore_patterns: &Gitignore,
     output_limit: usize,
 ) -> String {
+    load_hint_files_with_limit_and_input_budget(
+        cwd,
+        hints_filenames,
+        ignore_patterns,
+        output_limit,
+        &mut HintInputBudget::new(),
+    )
+}
+
+fn load_hint_files_with_limit_and_input_budget(
+    cwd: &Path,
+    hints_filenames: &[String],
+    ignore_patterns: &Gitignore,
+    output_limit: usize,
+    input_budget: &mut HintInputBudget,
+) -> String {
     let mut global_hints_paths: Vec<PathBuf> = hints_filenames
         .iter()
         .map(|name| Paths::in_config_dir(name))
@@ -443,6 +471,7 @@ pub(crate) fn load_hint_files_with_limit(
                 hints_dir,
                 &global_ignore_patterns,
                 output_limit,
+                input_budget,
             ) {
                 has_global_hints = true;
             }
@@ -472,6 +501,7 @@ pub(crate) fn load_hint_files_with_limit(
                     import_boundary,
                     ignore_patterns,
                     output_limit,
+                    input_budget,
                 ) {
                     has_local_hints = true;
                 }
@@ -551,6 +581,7 @@ mod tests {
 
         let gitignore = create_dummy_gitignore();
         let mut output = String::new();
+        let mut input_budget = HintInputBudget::new();
         let appended = append_hint_file(
             &mut output,
             "header\n",
@@ -558,6 +589,7 @@ mod tests {
             dir.path(),
             &gitignore,
             64,
+            &mut input_budget,
         );
 
         assert!(appended);
@@ -589,6 +621,33 @@ mod tests {
         assert_eq!(hints.matches("A1").count(), 300 * 1024);
         assert!(!hints.contains("B2"));
         assert!(hints.ends_with("third hint"));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn top_level_hint_files_share_one_raw_input_budget() {
+        let config_root = TempDir::new().unwrap();
+        let _guard = env_lock::lock_env([(
+            "GOOSE_PATH_ROOT",
+            Some(config_root.path().to_str().unwrap()),
+        )]);
+        let dir = TempDir::new().unwrap();
+        let tag_only_half_budget = "\u{E0001}".repeat(MAX_HINT_OUTPUT_BYTES / 8);
+        fs::write(dir.path().join("first.md"), &tag_only_half_budget).unwrap();
+        fs::write(dir.path().join("second.md"), &tag_only_half_budget).unwrap();
+        fs::write(dir.path().join("third.md"), "MUST_NOT_BE_READ").unwrap();
+
+        let hints = load_hint_files(
+            dir.path(),
+            &[
+                "first.md".to_string(),
+                "second.md".to_string(),
+                "third.md".to_string(),
+            ],
+            &create_dummy_gitignore(),
+        );
+
+        assert!(!hints.contains("MUST_NOT_BE_READ"));
     }
 
     #[test]

--- a/crates/goose/src/hints/load_hints.rs
+++ b/crates/goose/src/hints/load_hints.rs
@@ -167,7 +167,18 @@ impl SubdirectoryHintTracker {
     }
 
     pub fn load_new_hints(&mut self, working_dir: &Path) -> Vec<(String, String)> {
-        self.load_hints(working_dir)
+        let first_new_directory = self.loaded_dirs.len();
+        let hints = self.load_hints(working_dir);
+        let new_directories = &self.loaded_dirs[first_new_directory..];
+
+        hints
+            .into_iter()
+            .filter(|(key, _)| {
+                new_directories
+                    .iter()
+                    .any(|directory| key == &format!("subdir_hints:{}", directory.display()))
+            })
+            .collect()
     }
 }
 
@@ -1054,6 +1065,34 @@ End of hints"#;
         assert_eq!(hints.len(), 1);
         assert!(hints[0].0.contains("nested"));
         assert!(hints[0].1.contains("nested subdirectory hints"));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn tracker_load_new_hints_remains_incremental() {
+        let config_root = TempDir::new().unwrap();
+        let _guard = env_lock::lock_env([
+            (
+                "GOOSE_PATH_ROOT",
+                Some(config_root.path().to_str().unwrap()),
+            ),
+            ("CONTEXT_FILE_NAMES", Some(r#"[".goosehints"]"#)),
+        ]);
+        let project_root = TempDir::new().unwrap();
+        let nested = project_root.path().join("nested");
+        fs::create_dir(&nested).unwrap();
+        fs::write(nested.join(GOOSE_HINTS_FILENAME), "nested hints").unwrap();
+
+        let mut tracker = SubdirectoryHintTracker::new();
+        let arguments = serde_json::json!({ "path": "nested/file.rs" })
+            .as_object()
+            .cloned();
+        tracker.record_tool_arguments(&arguments, project_root.path());
+
+        let first = tracker.load_new_hints(project_root.path());
+        assert_eq!(first.len(), 1);
+        assert!(first[0].1.contains("nested hints"));
+        assert!(tracker.load_new_hints(project_root.path()).is_empty());
     }
 
     #[test]

--- a/crates/goose/src/hints/load_hints.rs
+++ b/crates/goose/src/hints/load_hints.rs
@@ -5,10 +5,13 @@ use std::{
 };
 
 use crate::config::paths::Paths;
-use crate::hints::import_files::read_referenced_files;
+use crate::hints::import_files::{read_referenced_files_with_limit, MAX_HINT_OUTPUT_BYTES};
 
 pub const GOOSE_HINTS_FILENAME: &str = ".goosehints";
 pub const AGENTS_MD_FILENAME: &str = "AGENTS.md";
+const GLOBAL_HINTS_HEADER: &str = "\n### Global Hints\nThese are my global goose hints.\n";
+const PROJECT_HINTS_HEADER: &str =
+    "### Project Hints\nThese are hints for working on the project in this directory.\n";
 
 pub fn get_context_filenames() -> Vec<String> {
     use crate::config::Config;
@@ -23,11 +26,17 @@ pub fn get_context_filenames() -> Vec<String> {
         })
 }
 
-#[derive(Default)]
 pub struct SubdirectoryHintTracker {
     loaded_dirs: HashSet<PathBuf>,
     pending_dirs: Vec<PathBuf>,
     hints_filenames: Vec<String>,
+    remaining_output_bytes: usize,
+}
+
+impl Default for SubdirectoryHintTracker {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl SubdirectoryHintTracker {
@@ -36,6 +45,7 @@ impl SubdirectoryHintTracker {
             loaded_dirs: HashSet::new(),
             pending_dirs: Vec::new(),
             hints_filenames: get_context_filenames(),
+            remaining_output_bytes: MAX_HINT_OUTPUT_BYTES,
         }
     }
 
@@ -90,9 +100,13 @@ impl SubdirectoryHintTracker {
             if self.loaded_dirs.contains(&dir) {
                 continue;
             }
-            if let Some(content) =
-                load_hints_from_directory(&dir, &working_dir, &self.hints_filenames)
-            {
+            if let Some(content) = load_hints_from_directory(
+                &dir,
+                &working_dir,
+                &self.hints_filenames,
+                self.remaining_output_bytes,
+            ) {
+                self.remaining_output_bytes -= content.len();
                 let key = format!("subdir_hints:{}", dir.display());
                 results.push((key, content));
             }
@@ -116,6 +130,7 @@ fn load_hints_from_directory(
     directory: &Path,
     working_dir: &Path,
     hints_filenames: &[String],
+    output_limit: usize,
 ) -> Option<String> {
     if !directory.is_dir() || !directory.is_absolute() {
         return None;
@@ -136,35 +151,62 @@ fn load_hints_from_directory(
         .collect();
     directories.reverse();
 
-    let mut contents = Vec::new();
+    let header = format!("### Subdirectory Hints ({})\n", directory.display());
+    let mut output = String::new();
+    let mut has_hints = false;
     for dir in &directories {
         for hints_filename in hints_filenames {
             let hints_path = dir.join(hints_filename);
             if hints_path.is_file() {
-                let mut visited = HashSet::new();
-                let expanded = read_referenced_files(
+                let framing = if has_hints { "\n" } else { &header };
+                if append_hint_file(
+                    &mut output,
+                    framing,
                     &hints_path,
                     import_boundary,
-                    &mut visited,
-                    0,
                     &gitignore,
-                );
-                if !expanded.is_empty() {
-                    contents.push(expanded);
+                    output_limit,
+                ) {
+                    has_hints = true;
                 }
             }
         }
     }
 
-    if contents.is_empty() {
-        None
-    } else {
-        Some(format!(
-            "### Subdirectory Hints ({})\n{}",
-            directory.display(),
-            contents.join("\n")
-        ))
+    has_hints.then_some(output)
+}
+
+fn append_hint_file(
+    output: &mut String,
+    framing: &str,
+    hints_path: &Path,
+    import_boundary: &Path,
+    ignore_patterns: &Gitignore,
+    output_limit: usize,
+) -> bool {
+    let Some(used_with_framing) = output.len().checked_add(framing.len()) else {
+        return false;
+    };
+    let Some(available) = output_limit.checked_sub(used_with_framing) else {
+        return false;
+    };
+
+    let mut visited = HashSet::new();
+    let expanded = read_referenced_files_with_limit(
+        hints_path,
+        import_boundary,
+        &mut visited,
+        0,
+        ignore_patterns,
+        available,
+    );
+    if expanded.is_empty() {
+        return false;
     }
+
+    output.push_str(framing);
+    output.push_str(&expanded);
+    true
 }
 
 fn find_git_root(start_dir: &Path) -> Option<&Path> {
@@ -234,9 +276,15 @@ pub fn load_hint_files(
     hints_filenames: &[String],
     ignore_patterns: &Gitignore,
 ) -> String {
-    let mut global_hints_contents = Vec::with_capacity(hints_filenames.len());
-    let mut local_hints_contents = Vec::with_capacity(hints_filenames.len());
+    load_hint_files_with_limit(cwd, hints_filenames, ignore_patterns, MAX_HINT_OUTPUT_BYTES)
+}
 
+pub(crate) fn load_hint_files_with_limit(
+    cwd: &Path,
+    hints_filenames: &[String],
+    ignore_patterns: &Gitignore,
+    output_limit: usize,
+) -> String {
     let mut global_hints_paths: Vec<PathBuf> = hints_filenames
         .iter()
         .map(|name| Paths::in_config_dir(name))
@@ -248,22 +296,28 @@ pub fn load_hint_files(
         global_hints_paths.push(Paths::in_agents_home_dir(AGENTS_MD_FILENAME));
     }
 
+    let mut hints = String::new();
+    let mut has_global_hints = false;
     for global_hints_path in &global_hints_paths {
         if global_hints_path.is_file() {
-            let mut visited = HashSet::new();
             let hints_dir = global_hints_path.parent().unwrap();
             let global_ignore_patterns = GitignoreBuilder::new(hints_dir)
                 .build()
                 .unwrap_or_else(|_| Gitignore::empty());
-            let expanded_content = read_referenced_files(
+            let framing = if has_global_hints {
+                "\n"
+            } else {
+                GLOBAL_HINTS_HEADER
+            };
+            if append_hint_file(
+                &mut hints,
+                framing,
                 global_hints_path,
                 hints_dir,
-                &mut visited,
-                0,
                 &global_ignore_patterns,
-            );
-            if !expanded_content.is_empty() {
-                global_hints_contents.push(expanded_content);
+                output_limit,
+            ) {
+                has_global_hints = true;
             }
         }
     }
@@ -272,39 +326,30 @@ pub fn load_hint_files(
 
     let import_boundary = git_root.unwrap_or(cwd);
 
+    let mut has_local_hints = false;
     for directory in &local_directories {
         for hints_filename in hints_filenames {
             let hints_path = directory.join(hints_filename);
             if hints_path.is_file() {
-                let mut visited = HashSet::new();
-                let expanded_content = read_referenced_files(
+                let framing = if has_local_hints {
+                    "\n"
+                } else if has_global_hints {
+                    "\n\n### Project Hints\nThese are hints for working on the project in this directory.\n"
+                } else {
+                    PROJECT_HINTS_HEADER
+                };
+                if append_hint_file(
+                    &mut hints,
+                    framing,
                     &hints_path,
                     import_boundary,
-                    &mut visited,
-                    0,
                     ignore_patterns,
-                );
-                if !expanded_content.is_empty() {
-                    local_hints_contents.push(expanded_content);
+                    output_limit,
+                ) {
+                    has_local_hints = true;
                 }
             }
         }
-    }
-
-    let mut hints = String::new();
-    if !global_hints_contents.is_empty() {
-        hints.push_str("\n### Global Hints\nThese are my global goose hints.\n");
-        hints.push_str(&global_hints_contents.join("\n"));
-    }
-
-    if !local_hints_contents.is_empty() {
-        if !hints.is_empty() {
-            hints.push_str("\n\n");
-        }
-        hints.push_str(
-            "### Project Hints\nThese are hints for working on the project in this directory.\n",
-        );
-        hints.push_str(&local_hints_contents.join("\n"));
     }
 
     hints
@@ -332,6 +377,91 @@ mod tests {
         let hints = load_hint_files(dir.path(), &[GOOSE_HINTS_FILENAME.to_string()], &gitignore);
 
         assert!(hints.contains("Test hint content"));
+    }
+
+    #[test]
+    fn oversized_top_level_hint_is_rejected_without_partial_instructions() {
+        let dir = TempDir::new().unwrap();
+        let filename = "LOUPE_894_OVERSIZED.md";
+        fs::write(
+            dir.path().join(filename),
+            "x".repeat(MAX_HINT_OUTPUT_BYTES + 1),
+        )
+        .unwrap();
+
+        let gitignore = create_dummy_gitignore();
+        let hints = load_hint_files(dir.path(), &[filename.to_string()], &gitignore);
+
+        assert!(hints.is_empty());
+    }
+
+    #[test]
+    fn top_level_hint_and_framing_fit_exact_output_limit() {
+        let dir = TempDir::new().unwrap();
+        let filename = "LOUPE_894_EXACT.md";
+        let content = "x".repeat(MAX_HINT_OUTPUT_BYTES - PROJECT_HINTS_HEADER.len());
+        fs::write(dir.path().join(filename), &content).unwrap();
+
+        let gitignore = create_dummy_gitignore();
+        let hints = load_hint_files(dir.path(), &[filename.to_string()], &gitignore);
+
+        assert_eq!(hints.len(), MAX_HINT_OUTPUT_BYTES);
+        assert!(hints.starts_with(PROJECT_HINTS_HEADER));
+        assert!(hints.ends_with(&content));
+    }
+
+    #[test]
+    fn reference_expansion_cannot_exceed_aggregate_output_limit() {
+        let dir = TempDir::new().unwrap();
+        let filename = "LOUPE_894_REFERENCE.md";
+        let included = "expanded policy".repeat(16);
+        fs::write(dir.path().join("policy.md"), &included).unwrap();
+        fs::write(
+            dir.path().join(filename),
+            "keep this\n@policy.md\nkeep that",
+        )
+        .unwrap();
+
+        let gitignore = create_dummy_gitignore();
+        let mut output = String::new();
+        let appended = append_hint_file(
+            &mut output,
+            "header\n",
+            &dir.path().join(filename),
+            dir.path(),
+            &gitignore,
+            64,
+        );
+
+        assert!(appended);
+        assert!(output.len() <= 64);
+        assert!(output.contains("@policy.md"));
+        assert!(!output.contains("expanded policy"));
+        assert!(output.ends_with("keep that"));
+    }
+
+    #[test]
+    fn multiple_top_level_hints_share_one_output_limit() {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("first.md"), "A1".repeat(300 * 1024)).unwrap();
+        fs::write(dir.path().join("second.md"), "B2".repeat(300 * 1024)).unwrap();
+        fs::write(dir.path().join("third.md"), "third hint").unwrap();
+
+        let gitignore = create_dummy_gitignore();
+        let hints = load_hint_files(
+            dir.path(),
+            &[
+                "first.md".to_string(),
+                "second.md".to_string(),
+                "third.md".to_string(),
+            ],
+            &gitignore,
+        );
+
+        assert!(hints.len() <= MAX_HINT_OUTPUT_BYTES);
+        assert_eq!(hints.matches("A1").count(), 300 * 1024);
+        assert!(!hints.contains("B2"));
+        assert!(hints.ends_with("third hint"));
     }
 
     #[test]
@@ -363,6 +493,33 @@ mod tests {
 
         assert!(hints.contains("Global Hints"));
         assert!(hints.contains("Global agents home instructions"));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn global_and_local_hints_share_one_output_limit() {
+        let root = TempDir::new().unwrap();
+        let filename = "LOUPE_894_GLOBAL_LOCAL.md";
+        std::env::set_var("GOOSE_PATH_ROOT", root.path());
+        fs::create_dir(root.path().join("config")).unwrap();
+        fs::write(
+            root.path().join("config").join(filename),
+            "G1".repeat(300 * 1024),
+        )
+        .unwrap();
+
+        let project = TempDir::new().unwrap();
+        fs::write(project.path().join(filename), "L2".repeat(300 * 1024)).unwrap();
+        let gitignore = create_dummy_gitignore();
+        let hints = load_hint_files(project.path(), &[filename.to_string()], &gitignore);
+
+        std::env::remove_var("GOOSE_PATH_ROOT");
+
+        assert!(hints.len() <= MAX_HINT_OUTPUT_BYTES);
+        assert!(hints.contains("Global Hints"));
+        assert!(hints.contains("G1"));
+        assert!(!hints.contains("Project Hints"));
+        assert!(!hints.contains("L2"));
     }
 
     #[test]
@@ -835,6 +992,51 @@ End of hints"#;
         assert_eq!(hints.len(), 1);
         assert!(hints[0].0.contains("nested"));
         assert!(hints[0].1.contains("nested subdirectory hints"));
+    }
+
+    #[test]
+    fn tracker_aggregates_output_limit_across_subdirectories() {
+        let temp_dir = TempDir::new().unwrap();
+        let project_root = temp_dir.path().to_path_buf();
+        for directory in ["first", "second", "third"] {
+            fs::create_dir(project_root.join(directory)).unwrap();
+        }
+        fs::write(
+            project_root.join("first").join(GOOSE_HINTS_FILENAME),
+            "A1".repeat(300 * 1024),
+        )
+        .unwrap();
+        fs::write(
+            project_root.join("second").join(GOOSE_HINTS_FILENAME),
+            "B2".repeat(300 * 1024),
+        )
+        .unwrap();
+        fs::write(
+            project_root.join("third").join(GOOSE_HINTS_FILENAME),
+            "third hint",
+        )
+        .unwrap();
+
+        let mut tracker = SubdirectoryHintTracker::new();
+        for directory in ["first", "second", "third"] {
+            let args: serde_json::Map<String, serde_json::Value> = serde_json::from_value(
+                serde_json::json!({ "path": format!("{directory}/file.rs") }),
+            )
+            .unwrap();
+            tracker.record_tool_arguments(&Some(args), &project_root);
+        }
+
+        let hints = tracker.load_new_hints(&project_root);
+        let output_bytes: usize = hints.iter().map(|(_, content)| content.len()).sum();
+        let combined = hints
+            .iter()
+            .map(|(_, content)| content.as_str())
+            .collect::<String>();
+
+        assert!(output_bytes <= MAX_HINT_OUTPUT_BYTES);
+        assert!(combined.contains("A1"));
+        assert!(!combined.contains("B2"));
+        assert!(combined.contains("third hint"));
     }
 
     #[test]

--- a/crates/goose/src/hints/load_hints.rs
+++ b/crates/goose/src/hints/load_hints.rs
@@ -138,9 +138,19 @@ impl SubdirectoryHintTracker {
         let reservation = reservation.into();
         let pending = std::mem::take(&mut self.pending_dirs);
         let lexical_working_dir = working_dir;
+        self.hints_filenames = get_context_filenames();
+        let ignore_patterns = build_gitignore(lexical_working_dir);
+        let top_level_output_limit = MAX_HINT_OUTPUT_BYTES.saturating_sub(reservation.root_only);
+        let top_level_hints = load_hint_files_with_limit(
+            lexical_working_dir,
+            &self.hints_filenames,
+            &ignore_patterns,
+            top_level_output_limit,
+        );
+        after_top_level_read();
         let Ok(canonical_working_dir) = working_dir.canonicalize() else {
             return HintSnapshot {
-                top_level: String::new(),
+                top_level: top_level_hints,
                 subdirectories: Vec::new(),
             };
         };
@@ -158,16 +168,6 @@ impl SubdirectoryHintTracker {
             self.loaded_dirs.push(dir);
         }
 
-        self.hints_filenames = get_context_filenames();
-        let ignore_patterns = build_gitignore(lexical_working_dir);
-        let top_level_output_limit = MAX_HINT_OUTPUT_BYTES.saturating_sub(reservation.root_only);
-        let top_level_hints = load_hint_files_with_limit(
-            lexical_working_dir,
-            &self.hints_filenames,
-            &ignore_patterns,
-            top_level_output_limit,
-        );
-        after_top_level_read();
         let has_top_level_hints = !top_level_hints.is_empty();
         let initial_reservation = if has_top_level_hints {
             reservation.root_only
@@ -695,6 +695,34 @@ mod tests {
         std::env::remove_var("GOOSE_PATH_ROOT");
 
         assert!(!hints.contains("Global agents home instructions"));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn tracker_loads_global_hints_when_working_directory_is_missing() {
+        let config_root = TempDir::new().unwrap();
+        let _guard = env_lock::lock_env([
+            (
+                "GOOSE_PATH_ROOT",
+                Some(config_root.path().to_str().unwrap()),
+            ),
+            ("CONTEXT_FILE_NAMES", Some(r#"[".goosehints"]"#)),
+        ]);
+        fs::create_dir(config_root.path().join("config")).unwrap();
+        fs::write(
+            config_root.path().join("config").join(GOOSE_HINTS_FILENAME),
+            "GLOBAL_HINT_AFTER_PROJECT_REMOVAL",
+        )
+        .unwrap();
+        let missing_working_dir = config_root.path().join("removed-project");
+
+        let snapshot = SubdirectoryHintTracker::new().load_snapshot(&missing_working_dir, 0);
+
+        assert!(snapshot
+            .top_level
+            .contains("GLOBAL_HINT_AFTER_PROJECT_REMOVAL"));
+        assert!(snapshot.top_level.len() <= MAX_HINT_OUTPUT_BYTES);
+        assert!(snapshot.subdirectories.is_empty());
     }
 
     #[test]

--- a/crates/goose/src/hints/load_hints.rs
+++ b/crates/goose/src/hints/load_hints.rs
@@ -1,6 +1,6 @@
 use ignore::gitignore::{Gitignore, GitignoreBuilder};
 use std::{
-    collections::HashSet,
+    collections::{HashMap, HashSet},
     path::{Path, PathBuf},
 };
 
@@ -33,8 +33,7 @@ pub fn get_context_filenames() -> Vec<String> {
 pub struct SubdirectoryHintTracker {
     loaded_dirs: Vec<PathBuf>,
     loaded_dir_set: HashSet<PathBuf>,
-    emitted_dir_set: HashSet<PathBuf>,
-    incremental_output_bytes: usize,
+    emitted_hints: HashMap<PathBuf, String>,
     pending_dirs: Vec<PathBuf>,
     hints_filenames: Vec<String>,
 }
@@ -50,8 +49,7 @@ impl SubdirectoryHintTracker {
         Self {
             loaded_dirs: Vec::new(),
             loaded_dir_set: HashSet::new(),
-            emitted_dir_set: HashSet::new(),
-            incremental_output_bytes: 0,
+            emitted_hints: HashMap::new(),
             pending_dirs: Vec::new(),
             hints_filenames: get_context_filenames(),
         }
@@ -175,12 +173,10 @@ impl SubdirectoryHintTracker {
         snapshot
     }
 
+    /// Returns changed subdirectory extras. An empty value retracts the content previously
+    /// emitted for that key when the current root snapshot no longer leaves room for it.
     pub fn load_new_hints(&mut self, working_dir: &Path) -> Vec<(String, String)> {
         let pending = std::mem::take(&mut self.pending_dirs);
-        if pending.is_empty() {
-            return Vec::new();
-        }
-
         self.hints_filenames = get_context_filenames();
         let mut input_budget = HintInputBudget::new();
         let top_level_output_bytes = load_hint_files_with_limit_and_input_budget(
@@ -195,7 +191,6 @@ impl SubdirectoryHintTracker {
             return Vec::new();
         };
 
-        let mut results = Vec::new();
         let mut attempted_dirs = HashSet::new();
         for dir in pending {
             let Ok(dir) = dir.canonicalize() else {
@@ -204,18 +199,23 @@ impl SubdirectoryHintTracker {
             if !dir.starts_with(&canonical_working_dir) || dir == canonical_working_dir {
                 continue;
             }
-            if !attempted_dirs.insert(dir.clone()) || self.emitted_dir_set.contains(&dir) {
+            if !attempted_dirs.insert(dir.clone()) {
                 continue;
             }
             if self.loaded_dir_set.insert(dir.clone()) {
                 self.loaded_dirs.push(dir.clone());
             }
+        }
+
+        let mut incremental_output_bytes = 0;
+        let mut next_emitted_hints = HashMap::new();
+        for dir in &self.loaded_dirs {
             let root_separator_len = if top_level_output_bytes > 0 {
                 HINT_SEPARATOR.len()
             } else {
                 0
             };
-            let incremental_separator_len = if self.incremental_output_bytes > 0 {
+            let incremental_separator_len = if incremental_output_bytes > 0 {
                 HINT_SEPARATOR.len()
             } else {
                 0
@@ -223,7 +223,7 @@ impl SubdirectoryHintTracker {
             let Some(output_limit) = MAX_HINT_OUTPUT_BYTES
                 .checked_sub(top_level_output_bytes)
                 .and_then(|remaining| remaining.checked_sub(root_separator_len))
-                .and_then(|remaining| remaining.checked_sub(self.incremental_output_bytes))
+                .and_then(|remaining| remaining.checked_sub(incremental_output_bytes))
                 .and_then(|remaining| remaining.checked_sub(incremental_separator_len))
             else {
                 continue;
@@ -235,11 +235,23 @@ impl SubdirectoryHintTracker {
                 output_limit,
                 &mut input_budget,
             ) {
-                self.incremental_output_bytes += incremental_separator_len + content.len();
-                self.emitted_dir_set.insert(dir.clone());
-                results.push((format!("subdir_hints:{}", dir.display()), content));
+                incremental_output_bytes += incremental_separator_len + content.len();
+                next_emitted_hints.insert(dir.clone(), content);
             }
         }
+
+        let mut results = Vec::new();
+        for dir in &self.loaded_dirs {
+            let previous = self.emitted_hints.get(dir);
+            let current = next_emitted_hints.get(dir);
+            if previous != current {
+                results.push((
+                    format!("subdir_hints:{}", dir.display()),
+                    current.cloned().unwrap_or_default(),
+                ));
+            }
+        }
+        self.emitted_hints = next_emitted_hints;
         results
     }
 }
@@ -1367,6 +1379,43 @@ End of hints"#;
             top_level_output_len + HINT_SEPARATOR.len() + retried[0].1.len(),
             MAX_HINT_OUTPUT_BYTES
         );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn tracker_load_new_hints_retracts_emitted_content_when_root_grows() {
+        let config_root = TempDir::new().unwrap();
+        let _guard = env_lock::lock_env([
+            (
+                "GOOSE_PATH_ROOT",
+                Some(config_root.path().to_str().unwrap()),
+            ),
+            ("CONTEXT_FILE_NAMES", Some(r#"[".goosehints"]"#)),
+        ]);
+        let project_root = TempDir::new().unwrap();
+        let nested = project_root.path().join("nested");
+        fs::create_dir(&nested).unwrap();
+        fs::write(nested.join(GOOSE_HINTS_FILENAME), "n".repeat(600 * 1024)).unwrap();
+
+        let mut tracker = SubdirectoryHintTracker::new();
+        let arguments = serde_json::json!({ "path": "nested/file.rs" })
+            .as_object()
+            .cloned();
+        tracker.record_tool_arguments(&arguments, project_root.path());
+        let emitted = tracker.load_new_hints(project_root.path());
+        assert_eq!(emitted.len(), 1);
+        assert!(emitted[0].1.len() > 600 * 1024);
+
+        fs::write(
+            project_root.path().join(GOOSE_HINTS_FILENAME),
+            "r".repeat(600 * 1024),
+        )
+        .unwrap();
+        let updates = tracker.load_new_hints(project_root.path());
+        assert_eq!(updates.len(), 1);
+        assert_eq!(updates[0].0, emitted[0].0);
+        assert!(updates[0].1.is_empty());
+        assert!(tracker.load_new_hints(project_root.path()).is_empty());
     }
 
     #[test]

--- a/crates/goose/src/hints/load_hints.rs
+++ b/crates/goose/src/hints/load_hints.rs
@@ -6,6 +6,7 @@ use std::{
 
 use crate::config::paths::Paths;
 use crate::hints::import_files::{read_referenced_files_with_limit, MAX_HINT_OUTPUT_BYTES};
+use crate::utils::sanitize_unicode_tags;
 
 pub const GOOSE_HINTS_FILENAME: &str = ".goosehints";
 pub const AGENTS_MD_FILENAME: &str = "AGENTS.md";
@@ -165,7 +166,7 @@ fn load_hints_from_directory(
         .collect();
     directories.reverse();
 
-    let header = format!("### Subdirectory Hints ({})\n", directory.display());
+    let header = subdirectory_hints_header(directory);
     let mut output = String::new();
     let mut has_hints = false;
     for dir in &directories {
@@ -188,6 +189,13 @@ fn load_hints_from_directory(
     }
 
     has_hints.then_some(output)
+}
+
+fn subdirectory_hints_header(directory: &Path) -> String {
+    sanitize_unicode_tags(&format!(
+        "### Subdirectory Hints ({})\n",
+        directory.display()
+    ))
 }
 
 fn append_hint_file(
@@ -1102,6 +1110,15 @@ End of hints"#;
             top_level_hints.len() + HINT_EXTRA_SEPARATOR_BYTES + hints[0].1.len(),
             MAX_HINT_OUTPUT_BYTES
         );
+    }
+
+    #[test]
+    fn subdirectory_header_is_normalized_before_budgeting() {
+        let directory = Path::new("nested\u{0344}");
+        let header = subdirectory_hints_header(directory);
+
+        assert_eq!(header, "### Subdirectory Hints (nested\u{0308}\u{0301})\n");
+        assert!(header.len() > format!("### Subdirectory Hints ({})\n", directory.display()).len());
     }
 
     #[test]

--- a/crates/goose/src/hints/load_hints.rs
+++ b/crates/goose/src/hints/load_hints.rs
@@ -81,7 +81,8 @@ impl SubdirectoryHintTracker {
 
     pub fn load_hints(&mut self, working_dir: &Path) -> Vec<(String, String)> {
         let pending = std::mem::take(&mut self.pending_dirs);
-        let Ok(working_dir) = working_dir.canonicalize() else {
+        let lexical_working_dir = working_dir;
+        let Ok(canonical_working_dir) = working_dir.canonicalize() else {
             return Vec::new();
         };
 
@@ -89,7 +90,7 @@ impl SubdirectoryHintTracker {
             let Ok(dir) = dir.canonicalize() else {
                 continue;
             };
-            if !dir.starts_with(&working_dir) || dir == working_dir {
+            if !dir.starts_with(&canonical_working_dir) || dir == canonical_working_dir {
                 continue;
             }
             if self.loaded_dirs.contains(&dir) {
@@ -98,9 +99,9 @@ impl SubdirectoryHintTracker {
             self.loaded_dirs.push(dir);
         }
 
-        let ignore_patterns = build_gitignore(&working_dir);
+        let ignore_patterns = build_gitignore(lexical_working_dir);
         let top_level_hints =
-            load_hint_files(&working_dir, &self.hints_filenames, &ignore_patterns);
+            load_hint_files(lexical_working_dir, &self.hints_filenames, &ignore_patterns);
         let mut remaining_output_bytes =
             MAX_HINT_OUTPUT_BYTES.saturating_sub(top_level_hints.len());
         let mut has_hint_output = !top_level_hints.is_empty();
@@ -114,9 +115,12 @@ impl SubdirectoryHintTracker {
             let Some(output_limit) = remaining_output_bytes.checked_sub(separator_bytes) else {
                 continue;
             };
-            if let Some(content) =
-                load_hints_from_directory(dir, &working_dir, &self.hints_filenames, output_limit)
-            {
+            if let Some(content) = load_hints_from_directory(
+                dir,
+                &canonical_working_dir,
+                &self.hints_filenames,
+                output_limit,
+            ) {
                 remaining_output_bytes -= separator_bytes + content.len();
                 has_hint_output = true;
                 let key = format!("subdir_hints:{}", dir.display());
@@ -1119,6 +1123,37 @@ End of hints"#;
 
         assert_eq!(header, "### Subdirectory Hints (nested\u{0308}\u{0301})\n");
         assert!(header.len() > format!("### Subdirectory Hints ({})\n", directory.display()).len());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn tracker_reserves_hints_from_a_lexical_symlink_working_directory() {
+        use std::os::unix::fs::symlink;
+
+        let temp_dir = TempDir::new().unwrap();
+        let repository = temp_dir.path().join("repository");
+        let target = temp_dir.path().join("target");
+        let nested = target.join("nested");
+        fs::create_dir_all(repository.join(".git")).unwrap();
+        fs::create_dir_all(&nested).unwrap();
+        fs::write(
+            repository.join(GOOSE_HINTS_FILENAME),
+            "r".repeat(MAX_HINT_OUTPUT_BYTES - PROJECT_HINTS_HEADER.len() - 1),
+        )
+        .unwrap();
+        fs::write(nested.join(GOOSE_HINTS_FILENAME), "nested hint").unwrap();
+        let working_dir = repository.join("linked-working-dir");
+        symlink(&target, &working_dir).unwrap();
+
+        let mut tracker = SubdirectoryHintTracker::new();
+        tracker.hints_filenames = vec![GOOSE_HINTS_FILENAME.to_string()];
+        let args = serde_json::json!({ "path": "nested/file.rs" })
+            .as_object()
+            .unwrap()
+            .clone();
+        tracker.record_tool_arguments(&Some(args), &working_dir);
+
+        assert!(tracker.load_hints(&working_dir).is_empty());
     }
 
     #[test]

--- a/crates/goose/src/hints/load_hints.rs
+++ b/crates/goose/src/hints/load_hints.rs
@@ -202,7 +202,15 @@ impl SubdirectoryHintTracker {
         )
         .len();
         let Ok(canonical_working_dir) = working_dir.canonicalize() else {
-            return Vec::new();
+            return self
+                .loaded_dirs
+                .iter()
+                .filter_map(|dir| {
+                    self.emitted_hints
+                        .remove(dir)
+                        .map(|_| (format!("subdir_hints:{}", dir.display()), String::new()))
+                })
+                .collect();
         };
 
         let mut attempted_dirs = HashSet::new();
@@ -1260,6 +1268,49 @@ End of hints"#;
         assert_eq!(first.len(), 1);
         assert!(first[0].1.contains("nested hints"));
         assert!(tracker.load_new_hints(project_root.path()).is_empty());
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn tracker_retracts_emitted_hints_when_working_directory_disappears() {
+        let config_root = TempDir::new().unwrap();
+        let _guard = env_lock::lock_env([
+            (
+                "GOOSE_PATH_ROOT",
+                Some(config_root.path().to_str().unwrap()),
+            ),
+            ("CONTEXT_FILE_NAMES", Some(r#"[".goosehints"]"#)),
+        ]);
+        let temp = TempDir::new().unwrap();
+        let project = temp.path().join("project");
+        let moved = temp.path().join("moved-project");
+        fs::create_dir_all(project.join("nested")).unwrap();
+        fs::write(
+            project.join("nested").join(GOOSE_HINTS_FILENAME),
+            "NESTED_HINT",
+        )
+        .unwrap();
+        let mut tracker = SubdirectoryHintTracker::new();
+        let arguments = serde_json::json!({ "path": "nested/file.rs" })
+            .as_object()
+            .cloned();
+        tracker.record_tool_arguments(&arguments, &project);
+        let first = tracker.load_new_hints(&project);
+        assert_eq!(first.len(), 1);
+        assert!(first[0].1.contains("NESTED_HINT"));
+        assert!(tracker.load_new_hints(&project).is_empty());
+
+        fs::rename(&project, &moved).unwrap();
+        assert_eq!(
+            tracker.load_new_hints(&project),
+            vec![(first[0].0.clone(), String::new())]
+        );
+        assert!(tracker.emitted_hints.is_empty());
+        assert!(tracker.load_new_hints(&project).is_empty());
+
+        fs::rename(&moved, &project).unwrap();
+        assert_eq!(tracker.load_new_hints(&project), first);
+        assert!(tracker.load_new_hints(&project).is_empty());
     }
 
     #[test]

--- a/crates/goose/src/hints/load_hints.rs
+++ b/crates/goose/src/hints/load_hints.rs
@@ -356,10 +356,7 @@ fn append_hint_file(
     output_limit: usize,
     load_state: &mut HintLoadState,
 ) -> bool {
-    if !load_state
-        .loaded_hint_files
-        .insert(hints_path.to_path_buf())
-    {
+    if load_state.loaded_hint_files.contains(hints_path) {
         return false;
     }
     let Some(used_with_framing) = output.len().checked_add(framing.len()) else {
@@ -385,6 +382,9 @@ fn append_hint_file(
 
     output.push_str(framing);
     output.push_str(&expanded);
+    load_state
+        .loaded_hint_files
+        .insert(hints_path.to_path_buf());
     true
 }
 
@@ -1630,6 +1630,98 @@ End of hints"#;
         assert_eq!(hints.len(), MAX_HINT_OUTPUT_BYTES);
         assert_eq!(hints.matches(ANCESTOR_MARKER).count(), 1);
         assert!(hints.contains(DESCENDANT_MARKER));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn tracker_retries_ancestor_hints_with_a_shorter_header() {
+        let config_root = TempDir::new().unwrap();
+        let _guard = env_lock::lock_env([
+            (
+                "GOOSE_PATH_ROOT",
+                Some(config_root.path().to_str().unwrap()),
+            ),
+            ("CONTEXT_FILE_NAMES", Some(r#"[".goosehints"]"#)),
+        ]);
+        let project = TempDir::new().unwrap();
+        let ancestor = project.path().join("a");
+        let descendant = ancestor.join("deep".repeat(30));
+        fs::create_dir_all(&descendant).unwrap();
+        const MARKER: &str = "ANCESTOR_MARKER";
+        fs::write(ancestor.join(GOOSE_HINTS_FILENAME), MARKER).unwrap();
+        let root_hints = project.path().join(GOOSE_HINTS_FILENAME);
+        fs::write(&root_hints, "ROOT").unwrap();
+        let root_framing = load_hint_files(
+            project.path(),
+            &[GOOSE_HINTS_FILENAME.to_string()],
+            &build_gitignore(project.path()),
+        )
+        .len()
+            - "ROOT".len();
+        let ancestor_output =
+            subdirectory_hints_header(&ancestor.canonicalize().unwrap()).len() + MARKER.len();
+        assert!(
+            subdirectory_hints_header(&descendant.canonicalize().unwrap()).len() > ancestor_output
+        );
+        fs::write(
+            &root_hints,
+            "r".repeat(
+                MAX_HINT_OUTPUT_BYTES - root_framing - HINT_SEPARATOR.len() - ancestor_output,
+            ),
+        )
+        .unwrap();
+
+        for incremental in [false, true] {
+            let mut tracker = SubdirectoryHintTracker::new();
+            for directory in [&descendant, &ancestor] {
+                let arguments = serde_json::json!({ "path": directory.join("file.rs") })
+                    .as_object()
+                    .cloned();
+                tracker.record_tool_arguments(&arguments, project.path());
+            }
+            if incremental {
+                let extras = tracker.load_new_hints(project.path());
+                assert_eq!(extras.len(), 1);
+                assert_eq!(
+                    extras[0].0,
+                    format!(
+                        "subdir_hints:{}",
+                        ancestor.canonicalize().unwrap().display()
+                    )
+                );
+                assert_eq!(extras[0].1.len(), ancestor_output);
+                assert_eq!(extras[0].1.matches(MARKER).count(), 1);
+                assert!(tracker.load_new_hints(project.path()).is_empty());
+            } else {
+                let snapshot = tracker.load_snapshot(project.path());
+                assert_eq!(snapshot.len(), MAX_HINT_OUTPUT_BYTES);
+                assert_eq!(snapshot.matches(MARKER).count(), 1);
+            }
+        }
+    }
+
+    #[test]
+    fn retrying_unadmitted_hint_files_still_charges_raw_input() {
+        let project = TempDir::new().unwrap();
+        let malformed = project.path().join("malformed.md");
+        let valid = project.path().join("valid.md");
+        fs::write(&malformed, vec![0xff; MAX_HINT_OUTPUT_BYTES / 2]).unwrap();
+        fs::write(&valid, "VALID_HINT").unwrap();
+        let mut state = HintLoadState::new();
+        let mut output = String::new();
+        for path in [&malformed, &malformed, &valid] {
+            assert!(!append_hint_file(
+                &mut output,
+                "",
+                path,
+                project.path(),
+                &Gitignore::empty(),
+                MAX_HINT_OUTPUT_BYTES,
+                &mut state,
+            ));
+        }
+        assert!(output.is_empty());
+        assert!(state.loaded_hint_files.is_empty());
     }
 
     #[test]

--- a/crates/goose/src/hints/mod.rs
+++ b/crates/goose/src/hints/mod.rs
@@ -3,6 +3,8 @@ pub mod load_hints;
 
 #[cfg(test)]
 pub(crate) use import_files::MAX_HINT_OUTPUT_BYTES;
+#[cfg(test)]
+pub(crate) use load_hints::HINT_EXTRA_SEPARATOR_BYTES;
 pub use load_hints::{
     build_gitignore, get_context_filenames, load_hint_files, SubdirectoryHintTracker,
     AGENTS_MD_FILENAME, GOOSE_HINTS_FILENAME,

--- a/crates/goose/src/hints/mod.rs
+++ b/crates/goose/src/hints/mod.rs
@@ -1,8 +1,8 @@
 mod import_files;
 pub mod load_hints;
 
+#[cfg(test)]
 pub(crate) use import_files::MAX_HINT_OUTPUT_BYTES;
-pub(crate) use load_hints::load_hint_files_with_limit;
 pub use load_hints::{
     build_gitignore, get_context_filenames, load_hint_files, SubdirectoryHintTracker,
     AGENTS_MD_FILENAME, GOOSE_HINTS_FILENAME,

--- a/crates/goose/src/hints/mod.rs
+++ b/crates/goose/src/hints/mod.rs
@@ -1,6 +1,8 @@
 mod import_files;
 pub mod load_hints;
 
+pub(crate) use import_files::MAX_HINT_OUTPUT_BYTES;
+pub(crate) use load_hints::load_hint_files_with_limit;
 pub use load_hints::{
     build_gitignore, get_context_filenames, load_hint_files, SubdirectoryHintTracker,
     AGENTS_MD_FILENAME, GOOSE_HINTS_FILENAME,

--- a/crates/goose/src/hints/mod.rs
+++ b/crates/goose/src/hints/mod.rs
@@ -3,8 +3,6 @@ pub mod load_hints;
 
 #[cfg(test)]
 pub(crate) use import_files::MAX_HINT_OUTPUT_BYTES;
-#[cfg(test)]
-pub(crate) use load_hints::HINT_EXTRA_SEPARATOR_BYTES;
 pub use load_hints::{
     build_gitignore, get_context_filenames, load_hint_files, SubdirectoryHintTracker,
     AGENTS_MD_FILENAME, GOOSE_HINTS_FILENAME,

--- a/crates/goose/src/hints/mod.rs
+++ b/crates/goose/src/hints/mod.rs
@@ -1,7 +1,6 @@
 mod import_files;
 pub mod load_hints;
 
-#[cfg(test)]
 pub(crate) use import_files::MAX_HINT_OUTPUT_BYTES;
 pub use load_hints::{
     build_gitignore, get_context_filenames, load_hint_files, SubdirectoryHintTracker,


### PR DESCRIPTION
Global, project, and discovered subdirectory hints now share one bounded snapshot per inference. This prevents independent sources from exceeding the aggregate budget or repeatedly loading overlapping ancestor files.

Prompt assembly sanitizes the owned snapshot and truncates it at a UTF-8 boundary to 1 MiB. Both agent loops share this path. File/import reads share a raw-input budget, including malformed UTF-8 and failed reads. Caller-owned extras and existing import boundaries are preserved.

The implementation follows the requested simpler prompt handling: no layout reservations, deferred layout-dependent reads, or nested hint-state mutex. Follow-up coverage verifies one-time retractions when a working directory disappears and preservation of staged snapshots until consumption, and retrying ancestor hints after a longer header cannot fit.

Verification:

- Formatting, diff checks, `cargo build -p goose`, and `cargo clippy -p goose --all-targets -- -D warnings` passed.
- 95 focused hint tests passed; the remaining traversal test passed separately with isolated configuration. The combined run exposes ambient global hints after older tests remove `GOOSE_PATH_ROOT`.
- Four inference-preparation tests passed, including both-loop parity; six isolated working-directory tests passed.
- Earlier prompt-manager verification: 19 passed; the platform snapshot passed with its required `code-mode` feature.

*This finding was discovered by [Project Loupe](https://github.com/project-loupe/loupe)*