### PR TITLE
fix(desktop): reject oversized recipe files before reading

### DIFF
--- a/ui/desktop/src/components/recipes/ImportRecipeForm.tsx
+++ b/ui/desktop/src/components/recipes/ImportRecipeForm.tsx
@@ -77,6 +77,8 @@ interface ImportRecipeFormProps {
   onSuccess: () => void;
 }
 
+const MAX_RECIPE_FILE_SIZE_BYTES = 1024 * 1024;
+
 // Define Zod schema for the import form
 const importRecipeSchema = z
   .object({
@@ -91,7 +93,7 @@ const importRecipeSchema = z
       .nullable()
       .refine((file) => {
         if (!file) return true;
-        return file.size <= 1024 * 1024;
+        return file.size <= MAX_RECIPE_FILE_SIZE_BYTES;
       }, 'File is too large, max size is 1MB'),
   })
   .refine((data) => (data.deeplink && data.deeplink.trim()) || data.recipeUploadFile, {
@@ -127,7 +129,11 @@ export default function ImportRecipeForm({ isOpen, onClose, onSuccess }: ImportR
           }
           recipe = parsedRecipe;
         } else {
-          const fileContent = await value.recipeUploadFile!.text();
+          const recipeFile = value.recipeUploadFile!;
+          if (recipeFile.size > MAX_RECIPE_FILE_SIZE_BYTES) {
+            throw new Error('File is too large, max size is 1MB');
+          }
+          const fileContent = await recipeFile.text();
           recipe = await parseRecipeFromFile(fileContent);
         }
 
@@ -190,6 +196,9 @@ export default function ImportRecipeForm({ isOpen, onClose, onSuccess }: ImportR
     importRecipeForm.setFieldValue('recipeUploadFile', file || null);
 
     if (file) {
+      if (file.size > MAX_RECIPE_FILE_SIZE_BYTES) {
+        return;
+      }
       try {
         const fileContent = await file.text();
         await parseRecipeFromFile(fileContent);

--- a/ui/desktop/src/components/recipes/__tests__/ImportRecipeForm.test.tsx
+++ b/ui/desktop/src/components/recipes/__tests__/ImportRecipeForm.test.tsx
@@ -1,0 +1,80 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { IntlTestWrapper } from '../../../i18n/test-utils';
+import ImportRecipeForm from '../ImportRecipeForm';
+
+const recipeMocks = vi.hoisted(() => ({
+  parseDeeplink: vi.fn(),
+  parseRecipeFromFile: vi.fn(),
+}));
+
+vi.mock('../../../recipe', () => recipeMocks);
+vi.mock('../../../recipe/recipe_management', () => ({ saveRecipe: vi.fn() }));
+vi.mock('../../../toasts', () => ({ toastError: vi.fn(), toastSuccess: vi.fn() }));
+
+const MAX_RECIPE_FILE_SIZE_BYTES = 1024 * 1024;
+
+function renderForm() {
+  return render(<ImportRecipeForm isOpen onClose={vi.fn()} onSuccess={vi.fn()} />, {
+    wrapper: IntlTestWrapper,
+  });
+}
+
+function uploadFile(file: File) {
+  fireEvent.change(screen.getByLabelText('Recipe File'), {
+    target: { files: [file] },
+  });
+}
+
+function fileWithText(content: string | ArrayBuffer, name: string, text: string) {
+  const file = new File([content], name);
+  const readText = vi.fn().mockResolvedValue(text);
+  Object.defineProperty(file, 'text', { value: readText });
+  return { file, readText };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  recipeMocks.parseRecipeFromFile.mockResolvedValue({ title: 'Imported recipe' });
+});
+
+describe('ImportRecipeForm file size enforcement', () => {
+  it('rejects an oversized file before reading or parsing it', async () => {
+    const { file, readText } = fileWithText(
+      new ArrayBuffer(MAX_RECIPE_FILE_SIZE_BYTES + 1),
+      'oversized.yaml',
+      'title: oversized'
+    );
+    renderForm();
+
+    uploadFile(file);
+    await act(async () => {});
+
+    expect(readText).not.toHaveBeenCalled();
+    expect(recipeMocks.parseRecipeFromFile).not.toHaveBeenCalled();
+    expect(screen.getByText('File is too large, max size is 1MB')).toBeInTheDocument();
+  });
+
+  it('reads and parses a valid YAML file below the limit', async () => {
+    const content = 'title: Valid recipe';
+    const { file, readText } = fileWithText(content, 'recipe.yaml', content);
+    renderForm();
+
+    uploadFile(file);
+
+    await waitFor(() => expect(recipeMocks.parseRecipeFromFile).toHaveBeenCalledWith(content));
+    expect(readText).toHaveBeenCalledOnce();
+  });
+
+  it('reads and parses a JSON file exactly at the limit', async () => {
+    const content = `{"value":"${'x'.repeat(MAX_RECIPE_FILE_SIZE_BYTES - 12)}"}`;
+    expect(new Blob([content]).size).toBe(MAX_RECIPE_FILE_SIZE_BYTES);
+    const { file, readText } = fileWithText(content, 'recipe.json', content);
+    renderForm();
+
+    uploadFile(file);
+
+    await waitFor(() => expect(recipeMocks.parseRecipeFromFile).toHaveBeenCalledWith(content));
+    expect(readText).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Summary

- enforce the existing 1 MiB recipe-file limit before reading selected files into renderer memory
- retain schema validation and add a second pre-read guard in submission handling
- cover oversized rejection plus valid YAML below and JSON exactly at the limit

## Verification

- `pnpm test:run src/components/recipes/__tests__/ImportRecipeForm.test.tsx`
- `pnpm run typecheck`
- focused ESLint with zero warnings on the changed component and test

*This finding was discovered by [Project Loupe](https://github.com/project-loupe/loupe)*
