### PR TITLE
fix(recipes): bound sub-recipe secret discovery

### DIFF
--- a/crates/goose-cli/src/recipes/github_recipe.rs
+++ b/crates/goose-cli/src/recipes/github_recipe.rs
@@ -1,20 +1,38 @@
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use console::style;
-use goose::recipe::template_recipe::parse_recipe_content;
 use goose::recipe::RECIPE_FILE_EXTENSIONS;
+use goose::recipe::template_recipe::parse_recipe_content;
 use serde::{Deserialize, Serialize};
 
 use goose::recipe::read_recipe_file_content::RecipeFile;
-use goose::subprocess::{git_command, SubprocessExt};
+use goose::subprocess::{SubprocessExt, git_command};
 use sha2::{Digest, Sha256};
+use std::collections::HashSet;
 use std::env;
 use std::fs;
-use std::io::Read;
+use std::io::{self, Read};
 
 use std::path::{Component, Path, PathBuf};
 use std::process::Command;
 use std::process::Stdio;
 use tar::Archive;
+
+#[derive(Clone, Copy)]
+struct ArchiveLimits {
+    entries: usize,
+    path_bytes: usize,
+    total_path_bytes: usize,
+    inodes: usize,
+    overhead_bytes: usize,
+}
+
+const ARCHIVE_LIMITS: ArchiveLimits = ArchiveLimits {
+    entries: 1024,
+    path_bytes: 4096,
+    total_path_bytes: 1024 * 1024,
+    inodes: 4096,
+    overhead_bytes: 4 * 1024 * 1024,
+};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RecipeInfo {
@@ -80,7 +98,7 @@ fn retrieve_recipe_from_github_with_optional_limit(
                         content,
                         parent_dir: download_dir.clone(),
                         file_path: recipe_file_local_path,
-                    })
+                    });
                 }
                 Err(err) => return Err(err),
             },
@@ -390,16 +408,95 @@ fn get_folder_from_github_with_byte_limit(
     Ok(output_dir)
 }
 
+struct BoundedArchiveReader<R> {
+    inner: R,
+    remaining: usize,
+}
+
+impl<R: Read> Read for BoundedArchiveReader<R> {
+    fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+        if buffer.is_empty() {
+            return Ok(0);
+        }
+        if self.remaining == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Recipe archive exceeds its metadata limit",
+            ));
+        }
+        let read_limit = buffer.len().min(self.remaining);
+        let read = self.inner.read(&mut buffer[..read_limit])?;
+        self.remaining -= read;
+        Ok(read)
+    }
+}
+
 fn extract_bounded_archive(reader: impl Read, output_dir: &Path, max_bytes: usize) -> Result<()> {
-    let mut archive = Archive::new(reader);
+    extract_bounded_archive_with_limits(reader, output_dir, max_bytes, ARCHIVE_LIMITS)
+}
+
+fn extract_bounded_archive_with_limits(
+    reader: impl Read,
+    output_dir: &Path,
+    max_bytes: usize,
+    limits: ArchiveLimits,
+) -> Result<()> {
+    let archive_bytes = max_bytes
+        .checked_add(limits.overhead_bytes)
+        .ok_or_else(|| anyhow!("Recipe archive byte limit is too large"))?;
+    let mut archive = Archive::new(BoundedArchiveReader {
+        inner: reader,
+        remaining: archive_bytes,
+    });
     let mut extracted_bytes = 0_u64;
+    let mut entry_count = 0;
+    let mut path_bytes = 0_usize;
+    let mut extracted_paths = HashSet::new();
     for entry in archive.entries()? {
         let mut entry = entry?;
+        entry_count += 1;
+        if entry_count > limits.entries {
+            return Err(anyhow!(
+                "Recipe bundle exceeds the {}-entry limit",
+                limits.entries
+            ));
+        }
         extracted_bytes = extracted_bytes
-            .checked_add(entry.header().size()?)
+            .checked_add(entry.size())
             .ok_or_else(|| anyhow!("Recipe bundle size overflowed"))?;
         if extracted_bytes > max_bytes as u64 {
             return Err(anyhow!("Recipe bundle exceeds the {max_bytes}-byte limit"));
+        }
+
+        let entry_path_bytes = entry.path_bytes().len();
+        let link_path_bytes = entry.link_name_bytes().map_or(0, |path| path.len());
+        if entry_path_bytes > limits.path_bytes || link_path_bytes > limits.path_bytes {
+            return Err(anyhow!(
+                "Recipe bundle contains a path exceeding the {}-byte limit",
+                limits.path_bytes
+            ));
+        }
+        path_bytes = path_bytes
+            .checked_add(entry_path_bytes)
+            .and_then(|total| total.checked_add(link_path_bytes))
+            .ok_or_else(|| anyhow!("Recipe bundle path size overflowed"))?;
+        if path_bytes > limits.total_path_bytes {
+            return Err(anyhow!(
+                "Recipe bundle exceeds the {}-byte path limit",
+                limits.total_path_bytes
+            ));
+        }
+
+        let mut extracted_path = PathBuf::new();
+        for component in entry.path()?.components() {
+            extracted_path.push(component);
+            extracted_paths.insert(extracted_path.clone());
+            if extracted_paths.len() > limits.inodes {
+                return Err(anyhow!(
+                    "Recipe bundle exceeds the {}-inode limit",
+                    limits.inodes
+                ));
+            }
         }
         if !entry.unpack_in(output_dir)? {
             return Err(anyhow!("Recipe bundle contains an unsafe path"));
@@ -530,7 +627,7 @@ fn get_github_recipe_info(repo: &str, dir_name: &str, recipe_filename: &str) -> 
 
     if let Some(content_b64) = file_info.get("content").and_then(|c| c.as_str()) {
         // Decode base64 content
-        use base64::{engine::general_purpose, Engine as _};
+        use base64::{Engine as _, engine::general_purpose};
         let content_bytes = general_purpose::STANDARD
             .decode(content_b64.replace('\n', ""))
             .map_err(|e| anyhow!("Failed to decode base64 content: {}", e))?;
@@ -583,6 +680,26 @@ mod tests {
             header.set_cksum();
             archive.append_data(&mut header, path, *content).unwrap();
         }
+        archive.into_inner().unwrap()
+    }
+
+    fn archive_with_extended_metadata(metadata: &[u8]) -> Vec<u8> {
+        let mut archive = tar::Builder::new(Vec::new());
+        let mut metadata_header = tar::Header::new_gnu();
+        metadata_header.set_entry_type(tar::EntryType::XHeader);
+        metadata_header.set_size(metadata.len() as u64);
+        metadata_header.set_mode(0o644);
+        metadata_header.set_cksum();
+        archive
+            .append_data(&mut metadata_header, "metadata", metadata)
+            .unwrap();
+        let mut recipe_header = tar::Header::new_gnu();
+        recipe_header.set_size(0);
+        recipe_header.set_mode(0o644);
+        recipe_header.set_cksum();
+        archive
+            .append_data(&mut recipe_header, "recipe.yaml", &[][..])
+            .unwrap();
         archive.into_inner().unwrap()
     }
 
@@ -648,6 +765,103 @@ mod tests {
             fs::read(output_dir.path().join("nested/grandchild.yaml")).unwrap(),
             grandchild
         );
+    }
+
+    #[test]
+    fn bounded_archive_limits_extended_metadata_reads() {
+        let bytes_read = Rc::new(Cell::new(0));
+        let reader = CountingReader {
+            inner: Cursor::new(archive_with_extended_metadata(&vec![b'x'; 2048])),
+            bytes_read: Rc::clone(&bytes_read),
+        };
+        let output_dir = tempfile::tempdir().unwrap();
+        let limits = ArchiveLimits {
+            overhead_bytes: 1024,
+            ..ARCHIVE_LIMITS
+        };
+
+        assert!(extract_bounded_archive_with_limits(reader, output_dir.path(), 0, limits).is_err());
+        assert_eq!(bytes_read.get(), limits.overhead_bytes);
+        assert!(!output_dir.path().join("recipe.yaml").exists());
+    }
+
+    #[test]
+    fn bounded_archive_limits_entries_before_creating_another_inode() {
+        let output_dir = tempfile::tempdir().unwrap();
+        let limits = ArchiveLimits {
+            entries: 1,
+            ..ARCHIVE_LIMITS
+        };
+
+        let error = extract_bounded_archive_with_limits(
+            Cursor::new(archive_with_files(&[("first", b""), ("second", b"")])),
+            output_dir.path(),
+            0,
+            limits,
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(error.contains("entry limit"));
+        assert!(output_dir.path().join("first").exists());
+        assert!(!output_dir.path().join("second").exists());
+    }
+
+    #[test]
+    fn bounded_archive_limits_individual_and_total_path_bytes() {
+        let output_dir = tempfile::tempdir().unwrap();
+        let individual_path_limits = ArchiveLimits {
+            path_bytes: 3,
+            ..ARCHIVE_LIMITS
+        };
+        let total_path_limits = ArchiveLimits {
+            total_path_bytes: 5,
+            ..ARCHIVE_LIMITS
+        };
+
+        let individual_error = extract_bounded_archive_with_limits(
+            Cursor::new(archive_with_files(&[("long", b"")])),
+            output_dir.path(),
+            0,
+            individual_path_limits,
+        )
+        .unwrap_err()
+        .to_string();
+        let total_error = extract_bounded_archive_with_limits(
+            Cursor::new(archive_with_files(&[("one", b""), ("two", b"")])),
+            output_dir.path(),
+            0,
+            total_path_limits,
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(individual_error.contains("path exceeding"));
+        assert!(total_error.contains("path limit"));
+        assert!(!output_dir.path().join("long").exists());
+        assert!(output_dir.path().join("one").exists());
+        assert!(!output_dir.path().join("two").exists());
+    }
+
+    #[test]
+    fn bounded_archive_limits_paths_that_would_create_too_many_inodes() {
+        let output_dir = tempfile::tempdir().unwrap();
+        let limits = ArchiveLimits {
+            inodes: 2,
+            ..ARCHIVE_LIMITS
+        };
+
+        let error = extract_bounded_archive_with_limits(
+            Cursor::new(archive_with_files(&[("one/two/recipe.yaml", b"")])),
+            output_dir.path(),
+            0,
+            limits,
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(error.contains("inode limit"));
+        assert!(!output_dir.path().join("one").exists());
     }
 
     #[test]

--- a/crates/goose-cli/src/recipes/github_recipe.rs
+++ b/crates/goose-cli/src/recipes/github_recipe.rs
@@ -54,44 +54,56 @@ pub fn retrieve_recipe_from_github(
     recipe_name: &str,
     recipe_repo_full_name: &str,
 ) -> Result<RecipeFile> {
-    Ok(
-        retrieve_recipe_from_github_with_optional_limit(recipe_name, recipe_repo_full_name, None)?
-            .recipe_file,
-    )
+    let mut payload_bytes = None;
+    Ok(retrieve_recipe_from_github_with_optional_limit(
+        recipe_name,
+        recipe_repo_full_name,
+        None,
+        &mut payload_bytes,
+    )?
+    .recipe_file)
+}
+
+pub(crate) struct BoundedRecipeLoad {
+    pub recipe_file: Result<RecipeFile>,
+    pub consumed_bytes: Option<usize>,
 }
 
 pub(crate) fn retrieve_recipe_from_github_with_byte_limit(
     recipe_name: &str,
     recipe_repo_full_name: &str,
     max_bytes: usize,
-) -> Result<(RecipeFile, usize)> {
-    let retrieved = retrieve_recipe_from_github_with_optional_limit(
+) -> BoundedRecipeLoad {
+    let mut consumed_bytes = None;
+    let recipe_file = retrieve_recipe_from_github_with_optional_limit(
         recipe_name,
         recipe_repo_full_name,
         Some(max_bytes),
-    )?;
-    let payload_bytes = retrieved
-        .payload_bytes
-        .ok_or_else(|| anyhow!("Bounded recipe download did not report its payload size"))?;
-    Ok((retrieved.recipe_file, payload_bytes))
+        &mut consumed_bytes,
+    )
+    .map(|retrieved| retrieved.recipe_file);
+    BoundedRecipeLoad {
+        recipe_file,
+        consumed_bytes,
+    }
 }
 
 struct RetrievedRecipe {
     recipe_file: RecipeFile,
-    payload_bytes: Option<usize>,
 }
 
 fn retrieve_recipe_from_github_with_optional_limit(
     recipe_name: &str,
     recipe_repo_full_name: &str,
     max_bytes: Option<usize>,
+    consumed_bytes: &mut Option<usize>,
 ) -> Result<RetrievedRecipe> {
     println!(
         "📦 Looking for recipe \"{}\" in github repo: {}",
         recipe_name, recipe_repo_full_name
     );
     ensure_gh_authenticated()?;
-    let max_attempts = 2;
+    let max_attempts = if max_bytes.is_some() { 1 } else { 2 };
     let mut last_err = None;
 
     for attempt in 1..=max_attempts {
@@ -108,16 +120,17 @@ fn retrieve_recipe_from_github_with_optional_limit(
         match download {
             Ok((download_dir, payload_bytes)) => match read_recipe_file(&download_dir, max_bytes) {
                 Ok((content, recipe_file_local_path)) => {
+                    *consumed_bytes = payload_bytes;
                     return Ok(RetrievedRecipe {
                         recipe_file: RecipeFile {
                             content,
                             parent_dir: download_dir.clone(),
                             file_path: recipe_file_local_path,
                         },
-                        payload_bytes,
                     });
                 }
                 Err(err) => {
+                    *consumed_bytes = payload_bytes;
                     let _ = fs::remove_dir_all(download_dir);
                     return Err(err);
                 }

--- a/crates/goose-cli/src/recipes/github_recipe.rs
+++ b/crates/goose-cli/src/recipes/github_recipe.rs
@@ -54,26 +54,38 @@ pub fn retrieve_recipe_from_github(
     recipe_name: &str,
     recipe_repo_full_name: &str,
 ) -> Result<RecipeFile> {
-    retrieve_recipe_from_github_with_optional_limit(recipe_name, recipe_repo_full_name, None)
+    Ok(
+        retrieve_recipe_from_github_with_optional_limit(recipe_name, recipe_repo_full_name, None)?
+            .recipe_file,
+    )
 }
 
-pub fn retrieve_recipe_from_github_with_byte_limit(
+pub(crate) fn retrieve_recipe_from_github_with_byte_limit(
     recipe_name: &str,
     recipe_repo_full_name: &str,
     max_bytes: usize,
-) -> Result<RecipeFile> {
-    retrieve_recipe_from_github_with_optional_limit(
+) -> Result<(RecipeFile, usize)> {
+    let retrieved = retrieve_recipe_from_github_with_optional_limit(
         recipe_name,
         recipe_repo_full_name,
         Some(max_bytes),
-    )
+    )?;
+    let payload_bytes = retrieved
+        .payload_bytes
+        .ok_or_else(|| anyhow!("Bounded recipe download did not report its payload size"))?;
+    Ok((retrieved.recipe_file, payload_bytes))
+}
+
+struct RetrievedRecipe {
+    recipe_file: RecipeFile,
+    payload_bytes: Option<usize>,
 }
 
 fn retrieve_recipe_from_github_with_optional_limit(
     recipe_name: &str,
     recipe_repo_full_name: &str,
     max_bytes: Option<usize>,
-) -> Result<RecipeFile> {
+) -> Result<RetrievedRecipe> {
     println!(
         "📦 Looking for recipe \"{}\" in github repo: {}",
         recipe_name, recipe_repo_full_name
@@ -88,19 +100,27 @@ fn retrieve_recipe_from_github_with_optional_limit(
                 recipe_name,
                 recipe_repo_full_name,
                 max_bytes,
-            ),
-            None => clone_and_download_recipe(recipe_name, recipe_repo_full_name),
+            )
+            .map(|(download_dir, payload_bytes)| (download_dir, Some(payload_bytes))),
+            None => clone_and_download_recipe(recipe_name, recipe_repo_full_name)
+                .map(|download_dir| (download_dir, None)),
         };
         match download {
-            Ok(download_dir) => match read_recipe_file(&download_dir, max_bytes) {
+            Ok((download_dir, payload_bytes)) => match read_recipe_file(&download_dir, max_bytes) {
                 Ok((content, recipe_file_local_path)) => {
-                    return Ok(RecipeFile {
-                        content,
-                        parent_dir: download_dir.clone(),
-                        file_path: recipe_file_local_path,
+                    return Ok(RetrievedRecipe {
+                        recipe_file: RecipeFile {
+                            content,
+                            parent_dir: download_dir.clone(),
+                            file_path: recipe_file_local_path,
+                        },
+                        payload_bytes,
                     });
                 }
-                Err(err) => return Err(err),
+                Err(err) => {
+                    let _ = fs::remove_dir_all(download_dir);
+                    return Err(err);
+                }
             },
             Err(err) => {
                 last_err = Some(err);
@@ -172,7 +192,7 @@ fn clone_and_download_recipe_with_byte_limit(
     recipe_name: &str,
     recipe_repo_full_name: &str,
     max_bytes: usize,
-) -> Result<PathBuf> {
+) -> Result<(PathBuf, usize)> {
     let local_repo_path = ensure_repo_cloned(recipe_repo_full_name)?;
     fetch_origin(&local_repo_path)?;
     get_folder_from_github_with_byte_limit(
@@ -379,7 +399,7 @@ fn get_folder_from_github_with_byte_limit(
     recipe_name: &str,
     recipe_repo_full_name: &str,
     max_bytes: usize,
-) -> Result<PathBuf> {
+) -> Result<(PathBuf, usize)> {
     let ref_and_path = format!("origin/main:{recipe_name}");
     let output_dir =
         clean_unique_temp_child_path(&env::temp_dir(), recipe_name, recipe_repo_full_name)?;
@@ -399,13 +419,22 @@ fn get_folder_from_github_with_byte_limit(
     if extraction.is_err() {
         let _ = child.kill();
     }
-    let status = child.wait()?;
-    extraction?;
-    if !status.success() {
-        return Err(anyhow!("Failed to archive recipe bundle {recipe_name}"));
+    let status = child.wait();
+    let extraction = match (extraction, status) {
+        (Ok(payload_bytes), Ok(status)) if status.success() => Ok(payload_bytes),
+        (Ok(_), Ok(_)) => Err(anyhow!("Failed to archive recipe bundle {recipe_name}")),
+        (Err(err), _) => Err(err),
+        (_, Err(err)) => Err(err.into()),
+    };
+    if extraction.is_err() {
+        let _ = fs::remove_dir_all(&output_dir);
     }
-    list_files(&output_dir)?;
-    Ok(output_dir)
+    let payload_bytes = extraction?;
+    if let Err(err) = list_files(&output_dir) {
+        let _ = fs::remove_dir_all(&output_dir);
+        return Err(err);
+    }
+    Ok((output_dir, payload_bytes))
 }
 
 struct BoundedArchiveReader<R> {
@@ -431,7 +460,11 @@ impl<R: Read> Read for BoundedArchiveReader<R> {
     }
 }
 
-fn extract_bounded_archive(reader: impl Read, output_dir: &Path, max_bytes: usize) -> Result<()> {
+fn extract_bounded_archive(
+    reader: impl Read,
+    output_dir: &Path,
+    max_bytes: usize,
+) -> Result<usize> {
     extract_bounded_archive_with_limits(reader, output_dir, max_bytes, ARCHIVE_LIMITS)
 }
 
@@ -440,7 +473,7 @@ fn extract_bounded_archive_with_limits(
     output_dir: &Path,
     max_bytes: usize,
     limits: ArchiveLimits,
-) -> Result<()> {
+) -> Result<usize> {
     let archive_bytes = max_bytes
         .checked_add(limits.overhead_bytes)
         .ok_or_else(|| anyhow!("Recipe archive byte limit is too large"))?;
@@ -448,7 +481,7 @@ fn extract_bounded_archive_with_limits(
         inner: reader,
         remaining: archive_bytes,
     });
-    let mut extracted_bytes = 0_u64;
+    let mut extracted_bytes = 0_usize;
     let mut entry_count = 0;
     let mut path_bytes = 0_usize;
     let mut extracted_paths = HashSet::new();
@@ -461,10 +494,12 @@ fn extract_bounded_archive_with_limits(
                 limits.entries
             ));
         }
+        let entry_bytes = usize::try_from(entry.size())
+            .map_err(|_| anyhow!("Recipe bundle entry size overflowed"))?;
         extracted_bytes = extracted_bytes
-            .checked_add(entry.size())
+            .checked_add(entry_bytes)
             .ok_or_else(|| anyhow!("Recipe bundle size overflowed"))?;
-        if extracted_bytes > max_bytes as u64 {
+        if extracted_bytes > max_bytes {
             return Err(anyhow!("Recipe bundle exceeds the {max_bytes}-byte limit"));
         }
 
@@ -502,7 +537,7 @@ fn extract_bounded_archive_with_limits(
             return Err(anyhow!("Recipe bundle contains an unsafe path"));
         }
     }
-    Ok(())
+    Ok(extracted_bytes)
 }
 
 fn list_files(dir: &Path) -> Result<()> {
@@ -747,7 +782,7 @@ mod tests {
         let grandchild = b"title: grandchild";
         let output_dir = tempfile::tempdir().unwrap();
 
-        extract_bounded_archive(
+        let payload_bytes = extract_bounded_archive(
             Cursor::new(archive_with_files(&[
                 ("recipe.yaml", recipe),
                 ("nested/grandchild.yaml", grandchild),
@@ -757,6 +792,7 @@ mod tests {
         )
         .unwrap();
 
+        assert_eq!(payload_bytes, recipe.len() + grandchild.len());
         assert_eq!(
             fs::read(output_dir.path().join("recipe.yaml")).unwrap(),
             recipe

--- a/crates/goose-cli/src/recipes/github_recipe.rs
+++ b/crates/goose-cli/src/recipes/github_recipe.rs
@@ -1,11 +1,11 @@
-use anyhow::{Result, anyhow};
+use anyhow::{anyhow, Result};
 use console::style;
-use goose::recipe::RECIPE_FILE_EXTENSIONS;
 use goose::recipe::template_recipe::parse_recipe_content;
+use goose::recipe::RECIPE_FILE_EXTENSIONS;
 use serde::{Deserialize, Serialize};
 
 use goose::recipe::read_recipe_file_content::RecipeFile;
-use goose::subprocess::{SubprocessExt, git_command};
+use goose::subprocess::{git_command, SubprocessExt};
 use sha2::{Digest, Sha256};
 use std::collections::HashSet;
 use std::env;
@@ -627,7 +627,7 @@ fn get_github_recipe_info(repo: &str, dir_name: &str, recipe_filename: &str) -> 
 
     if let Some(content_b64) = file_info.get("content").and_then(|c| c.as_str()) {
         // Decode base64 content
-        use base64::{Engine as _, engine::general_purpose};
+        use base64::{engine::general_purpose, Engine as _};
         let content_bytes = general_purpose::STANDARD
             .decode(content_b64.replace('\n', ""))
             .map_err(|e| anyhow!("Failed to decode base64 content: {}", e))?;
@@ -871,20 +871,16 @@ mod tests {
         let second = get_local_repo_path(parent, "owner-two/shared").unwrap();
 
         assert_ne!(first, second);
-        assert!(
-            first
-                .file_name()
-                .unwrap()
-                .to_string_lossy()
-                .starts_with("owner-one__shared-")
-        );
-        assert!(
-            second
-                .file_name()
-                .unwrap()
-                .to_string_lossy()
-                .starts_with("owner-two__shared-")
-        );
+        assert!(first
+            .file_name()
+            .unwrap()
+            .to_string_lossy()
+            .starts_with("owner-one__shared-"));
+        assert!(second
+            .file_name()
+            .unwrap()
+            .to_string_lossy()
+            .starts_with("owner-two__shared-"));
     }
 
     #[test]
@@ -894,20 +890,16 @@ mod tests {
         let underscore = get_local_repo_path(parent, "owner/caf_").unwrap();
 
         assert_ne!(unicode, underscore);
-        assert!(
-            unicode
-                .file_name()
-                .unwrap()
-                .to_string_lossy()
-                .starts_with("owner__caf_-")
-        );
-        assert!(
-            underscore
-                .file_name()
-                .unwrap()
-                .to_string_lossy()
-                .starts_with("owner__caf_-")
-        );
+        assert!(unicode
+            .file_name()
+            .unwrap()
+            .to_string_lossy()
+            .starts_with("owner__caf_-"));
+        assert!(underscore
+            .file_name()
+            .unwrap()
+            .to_string_lossy()
+            .starts_with("owner__caf_-"));
     }
 
     #[test]

--- a/crates/goose-cli/src/recipes/github_recipe.rs
+++ b/crates/goose-cli/src/recipes/github_recipe.rs
@@ -8,6 +8,7 @@ use goose::recipe::read_recipe_file_content::RecipeFile;
 use goose::subprocess::{git_command, SubprocessExt};
 use std::env;
 use std::fs;
+use std::io::Read;
 
 use std::path::{Component, Path, PathBuf};
 use std::process::Command;
@@ -34,6 +35,26 @@ pub fn retrieve_recipe_from_github(
     recipe_name: &str,
     recipe_repo_full_name: &str,
 ) -> Result<RecipeFile> {
+    retrieve_recipe_from_github_with_optional_limit(recipe_name, recipe_repo_full_name, None)
+}
+
+pub fn retrieve_recipe_from_github_with_byte_limit(
+    recipe_name: &str,
+    recipe_repo_full_name: &str,
+    max_bytes: usize,
+) -> Result<RecipeFile> {
+    retrieve_recipe_from_github_with_optional_limit(
+        recipe_name,
+        recipe_repo_full_name,
+        Some(max_bytes),
+    )
+}
+
+fn retrieve_recipe_from_github_with_optional_limit(
+    recipe_name: &str,
+    recipe_repo_full_name: &str,
+    max_bytes: Option<usize>,
+) -> Result<RecipeFile> {
     println!(
         "📦 Looking for recipe \"{}\" in github repo: {}",
         recipe_name, recipe_repo_full_name
@@ -43,8 +64,16 @@ pub fn retrieve_recipe_from_github(
     let mut last_err = None;
 
     for attempt in 1..=max_attempts {
-        match clone_and_download_recipe(recipe_name, recipe_repo_full_name) {
-            Ok(download_dir) => match read_recipe_file(&download_dir) {
+        let download = match max_bytes {
+            Some(max_bytes) => clone_and_download_recipe_with_byte_limit(
+                recipe_name,
+                recipe_repo_full_name,
+                max_bytes,
+            ),
+            None => clone_and_download_recipe(recipe_name, recipe_repo_full_name),
+        };
+        match download {
+            Ok(download_dir) => match read_recipe_file(&download_dir, max_bytes) {
                 Ok((content, recipe_file_local_path)) => {
                     return Ok(RecipeFile {
                         content,
@@ -72,11 +101,14 @@ fn clean_cloned_dirs(recipe_repo_full_name: &str) -> anyhow::Result<()> {
     }
     Ok(())
 }
-fn read_recipe_file(download_dir: &Path) -> Result<(String, PathBuf)> {
+fn read_recipe_file(download_dir: &Path, max_bytes: Option<usize>) -> Result<(String, PathBuf)> {
     for ext in RECIPE_FILE_EXTENSIONS {
         let candidate_file_path = download_dir.join(format!("recipe.{}", ext));
         if candidate_file_path.exists() {
-            let content = fs::read_to_string(&candidate_file_path)?;
+            let content = match max_bytes {
+                Some(max_bytes) => read_utf8_with_byte_limit(&candidate_file_path, max_bytes)?,
+                None => fs::read_to_string(&candidate_file_path)?,
+            };
             println!(
                 "⬇️  Retrieved recipe file: {}",
                 candidate_file_path
@@ -95,10 +127,36 @@ fn read_recipe_file(download_dir: &Path) -> Result<(String, PathBuf)> {
     ))
 }
 
+fn read_utf8_with_byte_limit(path: &Path, max_bytes: usize) -> Result<String> {
+    let file = fs::File::open(path)?;
+    if file.metadata()?.len() > max_bytes as u64 {
+        return Err(anyhow!("Recipe file exceeds the {max_bytes}-byte limit"));
+    }
+    let read_size = max_bytes
+        .checked_add(1)
+        .ok_or_else(|| anyhow!("Recipe byte limit is too large"))?;
+    let mut bytes = Vec::new();
+    file.take(read_size as u64).read_to_end(&mut bytes)?;
+    if bytes.len() > max_bytes {
+        return Err(anyhow!("Recipe file exceeds the {max_bytes}-byte limit"));
+    }
+    Ok(String::from_utf8(bytes)?)
+}
+
 fn clone_and_download_recipe(recipe_name: &str, recipe_repo_full_name: &str) -> Result<PathBuf> {
     let local_repo_path = ensure_repo_cloned(recipe_repo_full_name)?;
     fetch_origin(&local_repo_path)?;
     get_folder_from_github(&local_repo_path, recipe_name)
+}
+
+fn clone_and_download_recipe_with_byte_limit(
+    recipe_name: &str,
+    recipe_repo_full_name: &str,
+    max_bytes: usize,
+) -> Result<PathBuf> {
+    let local_repo_path = ensure_repo_cloned(recipe_repo_full_name)?;
+    fetch_origin(&local_repo_path)?;
+    get_recipe_file_from_github(&local_repo_path, recipe_name, max_bytes)
 }
 
 pub fn ensure_gh_authenticated() -> Result<()> {
@@ -254,6 +312,94 @@ fn get_folder_from_github(local_repo_path: &Path, recipe_name: &str) -> Result<P
     Ok(output_dir)
 }
 
+fn get_recipe_file_from_github(
+    local_repo_path: &Path,
+    recipe_name: &str,
+    max_bytes: usize,
+) -> Result<PathBuf> {
+    let output_dir = clean_temp_child_path(&env::temp_dir(), recipe_name)?;
+    fs::create_dir_all(&output_dir)?;
+
+    for ext in RECIPE_FILE_EXTENSIONS {
+        let repository_path = format!("{recipe_name}/recipe.{ext}");
+        let Some(blob_size) = git_object_size(local_repo_path, &repository_path)? else {
+            continue;
+        };
+        if blob_size > max_bytes as u64 {
+            return Err(anyhow!("Recipe file exceeds the {max_bytes}-byte limit"));
+        }
+
+        let output_file = output_dir.join(format!("recipe.{ext}"));
+        extract_recipe_file_archive(local_repo_path, &repository_path, &output_file, max_bytes)?;
+        list_files(&output_dir)?;
+        return Ok(output_dir);
+    }
+
+    Err(anyhow!(
+        "No recipe file found for {recipe_name} (looked for extensions: {:?})",
+        RECIPE_FILE_EXTENSIONS
+    ))
+}
+
+fn git_object_size(local_repo_path: &Path, repository_path: &str) -> Result<Option<u64>> {
+    let object = format!("origin/main:{repository_path}");
+    let output = git_command()
+        .args(["cat-file", "-s", &object])
+        .current_dir(local_repo_path)
+        .set_no_window()
+        .output()?;
+    if !output.status.success() {
+        return Ok(None);
+    }
+    let size = String::from_utf8(output.stdout)?.trim().parse()?;
+    Ok(Some(size))
+}
+
+fn extract_recipe_file_archive(
+    local_repo_path: &Path,
+    repository_path: &str,
+    output_file: &Path,
+    max_bytes: usize,
+) -> Result<()> {
+    let mut child = git_command()
+        .args(["archive", "origin/main", "--", repository_path])
+        .current_dir(local_repo_path)
+        .stdout(Stdio::piped())
+        .set_no_window()
+        .spawn()?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| anyhow!("Failed to capture stdout from git archive"))?;
+    let extraction = extract_bounded_archive_entry(stdout, output_file, max_bytes);
+    if extraction.is_err() {
+        let _ = child.kill();
+    }
+    let status = child.wait()?;
+    extraction?;
+    if !status.success() {
+        return Err(anyhow!("Failed to archive recipe file {repository_path}"));
+    }
+    Ok(())
+}
+
+fn extract_bounded_archive_entry(
+    reader: impl Read,
+    output_file: &Path,
+    max_bytes: usize,
+) -> Result<()> {
+    let mut archive = Archive::new(reader);
+    let mut entries = archive.entries()?;
+    let mut entry = entries
+        .next()
+        .ok_or_else(|| anyhow!("Recipe archive was empty"))??;
+    if entry.header().size()? > max_bytes as u64 {
+        return Err(anyhow!("Recipe file exceeds the {max_bytes}-byte limit"));
+    }
+    entry.unpack(output_file)?;
+    Ok(())
+}
+
 fn list_files(dir: &Path) -> Result<()> {
     println!("{}", style("Files downloaded from github:").bold());
     for entry in fs::read_dir(dir)? {
@@ -402,7 +548,70 @@ fn get_github_recipe_info(repo: &str, dir_name: &str, recipe_filename: &str) -> 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::cell::Cell;
+    use std::io::{Cursor, Read};
     use std::path::Path;
+    use std::rc::Rc;
+
+    struct CountingReader {
+        inner: Cursor<Vec<u8>>,
+        bytes_read: Rc<Cell<usize>>,
+    }
+
+    impl Read for CountingReader {
+        fn read(&mut self, buffer: &mut [u8]) -> std::io::Result<usize> {
+            let count = self.inner.read(buffer)?;
+            self.bytes_read.set(self.bytes_read.get() + count);
+            Ok(count)
+        }
+    }
+
+    fn archive_with_recipe(content: &[u8]) -> Vec<u8> {
+        let mut archive = tar::Builder::new(Vec::new());
+        let mut header = tar::Header::new_gnu();
+        header.set_size(content.len() as u64);
+        header.set_mode(0o644);
+        header.set_cksum();
+        archive
+            .append_data(&mut header, "recipes/example/recipe.yaml", content)
+            .unwrap();
+        archive.into_inner().unwrap()
+    }
+
+    #[test]
+    fn bounded_archive_rejects_from_header_before_reading_recipe_body() {
+        let content = vec![b'x'; 16 * 1024];
+        let bytes_read = Rc::new(Cell::new(0));
+        let reader = CountingReader {
+            inner: Cursor::new(archive_with_recipe(&content)),
+            bytes_read: Rc::clone(&bytes_read),
+        };
+        let output = tempfile::tempdir().unwrap().path().join("recipe.yaml");
+
+        let error = extract_bounded_archive_entry(reader, &output, content.len() - 1)
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("byte limit"));
+        assert!(bytes_read.get() < content.len());
+        assert!(!output.exists());
+    }
+
+    #[test]
+    fn bounded_archive_accepts_a_recipe_at_the_exact_boundary() {
+        let content = b"title: exact boundary";
+        let output_dir = tempfile::tempdir().unwrap();
+        let output = output_dir.path().join("recipe.yaml");
+
+        extract_bounded_archive_entry(
+            Cursor::new(archive_with_recipe(content)),
+            &output,
+            content.len(),
+        )
+        .unwrap();
+
+        assert_eq!(fs::read(output).unwrap(), content);
+    }
 
     #[test]
     fn local_repo_path_includes_owner_to_avoid_collisions() {

--- a/crates/goose-cli/src/recipes/github_recipe.rs
+++ b/crates/goose-cli/src/recipes/github_recipe.rs
@@ -229,6 +229,7 @@ fn temp_child_name(name: &str) -> Result<String> {
     }
 }
 
+#[cfg(test)]
 fn temp_child_path(parent: &Path, name: &str) -> Result<PathBuf> {
     Ok(parent.join(temp_child_name(name)?))
 }
@@ -238,12 +239,17 @@ fn unique_temp_child_path(
     recipe_name: &str,
     recipe_repo_full_name: &str,
 ) -> Result<PathBuf> {
-    let child = temp_child_name(recipe_name)?;
+    hashed_temp_child_path(parent, recipe_name, &[recipe_repo_full_name, recipe_name])
+}
+
+fn hashed_temp_child_path(parent: &Path, name: &str, identity: &[&str]) -> Result<PathBuf> {
+    let child = temp_child_name(name)?;
     let visible_child = child.chars().take(160).collect::<String>();
     let mut hasher = Sha256::new();
-    hasher.update(recipe_repo_full_name.as_bytes());
-    hasher.update([0]);
-    hasher.update(recipe_name.as_bytes());
+    for field in identity {
+        hasher.update((field.len() as u64).to_le_bytes());
+        hasher.update(field.as_bytes());
+    }
     let digest = hasher
         .finalize()
         .iter()
@@ -271,7 +277,11 @@ fn get_local_repo_path(
     let (owner, repo_name) = recipe_repo_full_name
         .split_once('/')
         .ok_or_else(|| anyhow::anyhow!("Invalid repository name format"))?;
-    let local_repo_path = temp_child_path(local_repo_parent_path, &format!("{owner}/{repo_name}"))?;
+    let local_repo_path = hashed_temp_child_path(
+        local_repo_parent_path,
+        &format!("{owner}/{repo_name}"),
+        &[recipe_repo_full_name],
+    )?;
     Ok(local_repo_path)
 }
 
@@ -647,8 +657,43 @@ mod tests {
         let second = get_local_repo_path(parent, "owner-two/shared").unwrap();
 
         assert_ne!(first, second);
-        assert_eq!(first, parent.join("owner-one__shared"));
-        assert_eq!(second, parent.join("owner-two__shared"));
+        assert!(
+            first
+                .file_name()
+                .unwrap()
+                .to_string_lossy()
+                .starts_with("owner-one__shared-")
+        );
+        assert!(
+            second
+                .file_name()
+                .unwrap()
+                .to_string_lossy()
+                .starts_with("owner-two__shared-")
+        );
+    }
+
+    #[test]
+    fn local_repo_paths_distinguish_sanitized_name_collisions() {
+        let parent = Path::new("goose-recipes");
+        let unicode = get_local_repo_path(parent, "owner/café").unwrap();
+        let underscore = get_local_repo_path(parent, "owner/caf_").unwrap();
+
+        assert_ne!(unicode, underscore);
+        assert!(
+            unicode
+                .file_name()
+                .unwrap()
+                .to_string_lossy()
+                .starts_with("owner__caf_-")
+        );
+        assert!(
+            underscore
+                .file_name()
+                .unwrap()
+                .to_string_lossy()
+                .starts_with("owner__caf_-")
+        );
     }
 
     #[test]

--- a/crates/goose-cli/src/recipes/github_recipe.rs
+++ b/crates/goose-cli/src/recipes/github_recipe.rs
@@ -156,7 +156,7 @@ fn clone_and_download_recipe_with_byte_limit(
 ) -> Result<PathBuf> {
     let local_repo_path = ensure_repo_cloned(recipe_repo_full_name)?;
     fetch_origin(&local_repo_path)?;
-    get_recipe_file_from_github(&local_repo_path, recipe_name, max_bytes)
+    get_folder_from_github_with_byte_limit(&local_repo_path, recipe_name, max_bytes)
 }
 
 pub fn ensure_gh_authenticated() -> Result<()> {
@@ -312,57 +312,17 @@ fn get_folder_from_github(local_repo_path: &Path, recipe_name: &str) -> Result<P
     Ok(output_dir)
 }
 
-fn get_recipe_file_from_github(
+fn get_folder_from_github_with_byte_limit(
     local_repo_path: &Path,
     recipe_name: &str,
     max_bytes: usize,
 ) -> Result<PathBuf> {
+    let ref_and_path = format!("origin/main:{recipe_name}");
     let output_dir = clean_temp_child_path(&env::temp_dir(), recipe_name)?;
     fs::create_dir_all(&output_dir)?;
 
-    for ext in RECIPE_FILE_EXTENSIONS {
-        let repository_path = format!("{recipe_name}/recipe.{ext}");
-        let Some(blob_size) = git_object_size(local_repo_path, &repository_path)? else {
-            continue;
-        };
-        if blob_size > max_bytes as u64 {
-            return Err(anyhow!("Recipe file exceeds the {max_bytes}-byte limit"));
-        }
-
-        let output_file = output_dir.join(format!("recipe.{ext}"));
-        extract_recipe_file_archive(local_repo_path, &repository_path, &output_file, max_bytes)?;
-        list_files(&output_dir)?;
-        return Ok(output_dir);
-    }
-
-    Err(anyhow!(
-        "No recipe file found for {recipe_name} (looked for extensions: {:?})",
-        RECIPE_FILE_EXTENSIONS
-    ))
-}
-
-fn git_object_size(local_repo_path: &Path, repository_path: &str) -> Result<Option<u64>> {
-    let object = format!("origin/main:{repository_path}");
-    let output = git_command()
-        .args(["cat-file", "-s", &object])
-        .current_dir(local_repo_path)
-        .set_no_window()
-        .output()?;
-    if !output.status.success() {
-        return Ok(None);
-    }
-    let size = String::from_utf8(output.stdout)?.trim().parse()?;
-    Ok(Some(size))
-}
-
-fn extract_recipe_file_archive(
-    local_repo_path: &Path,
-    repository_path: &str,
-    output_file: &Path,
-    max_bytes: usize,
-) -> Result<()> {
     let mut child = git_command()
-        .args(["archive", "origin/main", "--", repository_path])
+        .args(["archive", &ref_and_path])
         .current_dir(local_repo_path)
         .stdout(Stdio::piped())
         .set_no_window()
@@ -371,32 +331,34 @@ fn extract_recipe_file_archive(
         .stdout
         .take()
         .ok_or_else(|| anyhow!("Failed to capture stdout from git archive"))?;
-    let extraction = extract_bounded_archive_entry(stdout, output_file, max_bytes);
+    let extraction = extract_bounded_archive(stdout, &output_dir, max_bytes);
     if extraction.is_err() {
         let _ = child.kill();
     }
     let status = child.wait()?;
     extraction?;
     if !status.success() {
-        return Err(anyhow!("Failed to archive recipe file {repository_path}"));
+        return Err(anyhow!("Failed to archive recipe bundle {recipe_name}"));
     }
-    Ok(())
+    list_files(&output_dir)?;
+    Ok(output_dir)
 }
 
-fn extract_bounded_archive_entry(
-    reader: impl Read,
-    output_file: &Path,
-    max_bytes: usize,
-) -> Result<()> {
+fn extract_bounded_archive(reader: impl Read, output_dir: &Path, max_bytes: usize) -> Result<()> {
     let mut archive = Archive::new(reader);
-    let mut entries = archive.entries()?;
-    let mut entry = entries
-        .next()
-        .ok_or_else(|| anyhow!("Recipe archive was empty"))??;
-    if entry.header().size()? > max_bytes as u64 {
-        return Err(anyhow!("Recipe file exceeds the {max_bytes}-byte limit"));
+    let mut extracted_bytes = 0_u64;
+    for entry in archive.entries()? {
+        let mut entry = entry?;
+        extracted_bytes = extracted_bytes
+            .checked_add(entry.header().size()?)
+            .ok_or_else(|| anyhow!("Recipe bundle size overflowed"))?;
+        if extracted_bytes > max_bytes as u64 {
+            return Err(anyhow!("Recipe bundle exceeds the {max_bytes}-byte limit"));
+        }
+        if !entry.unpack_in(output_dir)? {
+            return Err(anyhow!("Recipe bundle contains an unsafe path"));
+        }
     }
-    entry.unpack(output_file)?;
     Ok(())
 }
 
@@ -566,15 +528,15 @@ mod tests {
         }
     }
 
-    fn archive_with_recipe(content: &[u8]) -> Vec<u8> {
+    fn archive_with_files(files: &[(&str, &[u8])]) -> Vec<u8> {
         let mut archive = tar::Builder::new(Vec::new());
-        let mut header = tar::Header::new_gnu();
-        header.set_size(content.len() as u64);
-        header.set_mode(0o644);
-        header.set_cksum();
-        archive
-            .append_data(&mut header, "recipes/example/recipe.yaml", content)
-            .unwrap();
+        for (path, content) in files {
+            let mut header = tar::Header::new_gnu();
+            header.set_size(content.len() as u64);
+            header.set_mode(0o644);
+            header.set_cksum();
+            archive.append_data(&mut header, path, *content).unwrap();
+        }
         archive.into_inner().unwrap()
     }
 
@@ -583,12 +545,13 @@ mod tests {
         let content = vec![b'x'; 16 * 1024];
         let bytes_read = Rc::new(Cell::new(0));
         let reader = CountingReader {
-            inner: Cursor::new(archive_with_recipe(&content)),
+            inner: Cursor::new(archive_with_files(&[("recipe.yaml", &content)])),
             bytes_read: Rc::clone(&bytes_read),
         };
-        let output = tempfile::tempdir().unwrap().path().join("recipe.yaml");
+        let output_dir = tempfile::tempdir().unwrap();
+        let output = output_dir.path().join("recipe.yaml");
 
-        let error = extract_bounded_archive_entry(reader, &output, content.len() - 1)
+        let error = extract_bounded_archive(reader, output_dir.path(), content.len() - 1)
             .unwrap_err()
             .to_string();
 
@@ -601,16 +564,44 @@ mod tests {
     fn bounded_archive_accepts_a_recipe_at_the_exact_boundary() {
         let content = b"title: exact boundary";
         let output_dir = tempfile::tempdir().unwrap();
-        let output = output_dir.path().join("recipe.yaml");
 
-        extract_bounded_archive_entry(
-            Cursor::new(archive_with_recipe(content)),
-            &output,
+        extract_bounded_archive(
+            Cursor::new(archive_with_files(&[("recipe.yaml", content)])),
+            output_dir.path(),
             content.len(),
         )
         .unwrap();
 
-        assert_eq!(fs::read(output).unwrap(), content);
+        assert_eq!(
+            fs::read(output_dir.path().join("recipe.yaml")).unwrap(),
+            content
+        );
+    }
+
+    #[test]
+    fn bounded_archive_preserves_sibling_recipe_files() {
+        let recipe = b"sub_recipes:\n  - path: '{{ recipe_dir }}/nested/grandchild.yaml'";
+        let grandchild = b"title: grandchild";
+        let output_dir = tempfile::tempdir().unwrap();
+
+        extract_bounded_archive(
+            Cursor::new(archive_with_files(&[
+                ("recipe.yaml", recipe),
+                ("nested/grandchild.yaml", grandchild),
+            ])),
+            output_dir.path(),
+            recipe.len() + grandchild.len(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            fs::read(output_dir.path().join("recipe.yaml")).unwrap(),
+            recipe
+        );
+        assert_eq!(
+            fs::read(output_dir.path().join("nested/grandchild.yaml")).unwrap(),
+            grandchild
+        );
     }
 
     #[test]

--- a/crates/goose-cli/src/recipes/github_recipe.rs
+++ b/crates/goose-cli/src/recipes/github_recipe.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use goose::recipe::read_recipe_file_content::RecipeFile;
 use goose::subprocess::{git_command, SubprocessExt};
+use sha2::{Digest, Sha256};
 use std::env;
 use std::fs;
 use std::io::Read;
@@ -146,7 +147,7 @@ fn read_utf8_with_byte_limit(path: &Path, max_bytes: usize) -> Result<String> {
 fn clone_and_download_recipe(recipe_name: &str, recipe_repo_full_name: &str) -> Result<PathBuf> {
     let local_repo_path = ensure_repo_cloned(recipe_repo_full_name)?;
     fetch_origin(&local_repo_path)?;
-    get_folder_from_github(&local_repo_path, recipe_name)
+    get_folder_from_github(&local_repo_path, recipe_name, recipe_repo_full_name)
 }
 
 fn clone_and_download_recipe_with_byte_limit(
@@ -156,7 +157,12 @@ fn clone_and_download_recipe_with_byte_limit(
 ) -> Result<PathBuf> {
     let local_repo_path = ensure_repo_cloned(recipe_repo_full_name)?;
     fetch_origin(&local_repo_path)?;
-    get_folder_from_github_with_byte_limit(&local_repo_path, recipe_name, max_bytes)
+    get_folder_from_github_with_byte_limit(
+        &local_repo_path,
+        recipe_name,
+        recipe_repo_full_name,
+        max_bytes,
+    )
 }
 
 pub fn ensure_gh_authenticated() -> Result<()> {
@@ -227,8 +233,31 @@ fn temp_child_path(parent: &Path, name: &str) -> Result<PathBuf> {
     Ok(parent.join(temp_child_name(name)?))
 }
 
-fn clean_temp_child_path(parent: &Path, name: &str) -> Result<PathBuf> {
-    let output_dir = temp_child_path(parent, name)?;
+fn unique_temp_child_path(
+    parent: &Path,
+    recipe_name: &str,
+    recipe_repo_full_name: &str,
+) -> Result<PathBuf> {
+    let child = temp_child_name(recipe_name)?;
+    let visible_child = child.chars().take(160).collect::<String>();
+    let mut hasher = Sha256::new();
+    hasher.update(recipe_repo_full_name.as_bytes());
+    hasher.update([0]);
+    hasher.update(recipe_name.as_bytes());
+    let digest = hasher
+        .finalize()
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    Ok(parent.join(format!("{visible_child}-{digest}")))
+}
+
+fn clean_unique_temp_child_path(
+    parent: &Path,
+    recipe_name: &str,
+    recipe_repo_full_name: &str,
+) -> Result<PathBuf> {
+    let output_dir = unique_temp_child_path(parent, recipe_name, recipe_repo_full_name)?;
     if output_dir.exists() {
         fs::remove_dir_all(&output_dir)?;
     }
@@ -289,9 +318,14 @@ fn fetch_origin(local_repo_path: &Path) -> Result<()> {
     }
 }
 
-fn get_folder_from_github(local_repo_path: &Path, recipe_name: &str) -> Result<PathBuf> {
+fn get_folder_from_github(
+    local_repo_path: &Path,
+    recipe_name: &str,
+    recipe_repo_full_name: &str,
+) -> Result<PathBuf> {
     let ref_and_path = format!("origin/main:{}", recipe_name);
-    let output_dir = clean_temp_child_path(&env::temp_dir(), recipe_name)?;
+    let output_dir =
+        clean_unique_temp_child_path(&env::temp_dir(), recipe_name, recipe_repo_full_name)?;
     fs::create_dir_all(&output_dir)?;
 
     let archive_output = git_command()
@@ -315,10 +349,12 @@ fn get_folder_from_github(local_repo_path: &Path, recipe_name: &str) -> Result<P
 fn get_folder_from_github_with_byte_limit(
     local_repo_path: &Path,
     recipe_name: &str,
+    recipe_repo_full_name: &str,
     max_bytes: usize,
 ) -> Result<PathBuf> {
     let ref_and_path = format!("origin/main:{recipe_name}");
-    let output_dir = clean_temp_child_path(&env::temp_dir(), recipe_name)?;
+    let output_dir =
+        clean_unique_temp_child_path(&env::temp_dir(), recipe_name, recipe_repo_full_name)?;
     fs::create_dir_all(&output_dir)?;
 
     let mut child = git_command()
@@ -661,6 +697,24 @@ mod tests {
     }
 
     #[test]
+    fn unique_temp_child_paths_include_the_complete_request_identity() {
+        let parent = Path::new("goose-recipes");
+
+        assert_ne!(
+            unique_temp_child_path(parent, "a/b", "owner/recipes").unwrap(),
+            unique_temp_child_path(parent, "a__b", "owner/recipes").unwrap()
+        );
+        assert_ne!(
+            unique_temp_child_path(parent, "daily-report", "owner-one/recipes").unwrap(),
+            unique_temp_child_path(parent, "daily-report", "owner-two/recipes").unwrap()
+        );
+        assert_eq!(
+            unique_temp_child_path(parent, "a/b", "owner/recipes").unwrap(),
+            unique_temp_child_path(parent, "a/b", "owner/recipes").unwrap()
+        );
+    }
+
+    #[test]
     fn cleanup_rejects_reserved_components_before_removing_files() {
         let root = tempfile::tempdir().unwrap();
         let parent = root.path().join("recipe-temp");
@@ -682,7 +736,7 @@ mod tests {
             "report.",
             "report...",
         ] {
-            assert!(clean_temp_child_path(&parent, name).is_err());
+            assert!(clean_unique_temp_child_path(&parent, name, "owner/recipes").is_err());
             assert!(parent_sentinel.exists());
             assert!(child_sentinel.exists());
         }
@@ -692,14 +746,14 @@ mod tests {
     fn cleanup_removes_only_the_existing_recipe_child() {
         let root = tempfile::tempdir().unwrap();
         let parent = root.path().join("recipe-temp");
-        let child = parent.join("daily-report");
+        let child = unique_temp_child_path(&parent, "daily-report", "owner/recipes").unwrap();
         fs::create_dir_all(&child).unwrap();
         let parent_sentinel = parent.join("keep");
         fs::write(&parent_sentinel, "keep").unwrap();
         fs::write(child.join("old-recipe.yaml"), "old").unwrap();
 
         assert_eq!(
-            clean_temp_child_path(&parent, "daily-report").unwrap(),
+            clean_unique_temp_child_path(&parent, "daily-report", "owner/recipes").unwrap(),
             child
         );
         assert!(!child.exists());

--- a/crates/goose-cli/src/recipes/github_recipe.rs
+++ b/crates/goose-cli/src/recipes/github_recipe.rs
@@ -428,13 +428,19 @@ fn get_folder_from_github_with_byte_limit(
         .stdout
         .take()
         .ok_or_else(|| anyhow!("Failed to capture stdout from git archive"))?;
-    let extraction = extract_bounded_archive(stdout, &output_dir, max_bytes);
+    let extraction = extract_bounded_archive_with_limits(
+        stdout,
+        &output_dir,
+        max_bytes,
+        max_bytes,
+        ARCHIVE_LIMITS,
+    );
     if extraction.is_err() {
         let _ = child.kill();
     }
     let status = child.wait();
     let extraction = match (extraction, status) {
-        (Ok(payload_bytes), Ok(status)) if status.success() => Ok(payload_bytes),
+        (Ok(consumed_bytes), Ok(status)) if status.success() => Ok(consumed_bytes),
         (Ok(_), Ok(_)) => Err(anyhow!("Failed to archive recipe bundle {recipe_name}")),
         (Err(err), _) => Err(err),
         (_, Err(err)) => Err(err.into()),
@@ -442,12 +448,12 @@ fn get_folder_from_github_with_byte_limit(
     if extraction.is_err() {
         let _ = fs::remove_dir_all(&output_dir);
     }
-    let payload_bytes = extraction?;
+    let consumed_bytes = extraction?;
     if let Err(err) = list_files(&output_dir) {
         let _ = fs::remove_dir_all(&output_dir);
         return Err(err);
     }
-    Ok((output_dir, payload_bytes))
+    Ok((output_dir, consumed_bytes))
 }
 
 struct BoundedArchiveReader<R> {
@@ -463,7 +469,7 @@ impl<R: Read> Read for BoundedArchiveReader<R> {
         if self.remaining == 0 {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
-                "Recipe archive exceeds its metadata limit",
+                "Recipe archive exceeds its byte limit",
             ));
         }
         let read_limit = buffer.len().min(self.remaining);
@@ -473,23 +479,17 @@ impl<R: Read> Read for BoundedArchiveReader<R> {
     }
 }
 
-fn extract_bounded_archive(
-    reader: impl Read,
-    output_dir: &Path,
-    max_bytes: usize,
-) -> Result<usize> {
-    extract_bounded_archive_with_limits(reader, output_dir, max_bytes, ARCHIVE_LIMITS)
-}
-
 fn extract_bounded_archive_with_limits(
     reader: impl Read,
     output_dir: &Path,
-    max_bytes: usize,
+    max_payload_bytes: usize,
+    max_archive_bytes: usize,
     limits: ArchiveLimits,
 ) -> Result<usize> {
-    let archive_bytes = max_bytes
+    let archive_bytes = max_payload_bytes
         .checked_add(limits.overhead_bytes)
-        .ok_or_else(|| anyhow!("Recipe archive byte limit is too large"))?;
+        .ok_or_else(|| anyhow!("Recipe archive byte limit is too large"))?
+        .min(max_archive_bytes);
     let mut archive = Archive::new(BoundedArchiveReader {
         inner: reader,
         remaining: archive_bytes,
@@ -512,8 +512,10 @@ fn extract_bounded_archive_with_limits(
         extracted_bytes = extracted_bytes
             .checked_add(entry_bytes)
             .ok_or_else(|| anyhow!("Recipe bundle size overflowed"))?;
-        if extracted_bytes > max_bytes {
-            return Err(anyhow!("Recipe bundle exceeds the {max_bytes}-byte limit"));
+        if extracted_bytes > max_payload_bytes {
+            return Err(anyhow!(
+                "Recipe bundle exceeds the {max_payload_bytes}-byte limit"
+            ));
         }
 
         let entry_path_bytes = entry.path_bytes().len();
@@ -550,7 +552,7 @@ fn extract_bounded_archive_with_limits(
             return Err(anyhow!("Recipe bundle contains an unsafe path"));
         }
     }
-    Ok(extracted_bytes)
+    Ok(archive_bytes - archive.into_inner().remaining)
 }
 
 fn list_files(dir: &Path) -> Result<()> {
@@ -751,6 +753,20 @@ mod tests {
         archive.into_inner().unwrap()
     }
 
+    fn archive_with_empty_files(count: usize) -> Vec<u8> {
+        let mut archive = tar::Builder::new(Vec::new());
+        for index in 0..count {
+            let mut header = tar::Header::new_gnu();
+            header.set_size(0);
+            header.set_mode(0o644);
+            header.set_cksum();
+            archive
+                .append_data(&mut header, format!("empty-{index}"), &[][..])
+                .unwrap();
+        }
+        archive.into_inner().unwrap()
+    }
+
     #[test]
     fn bounded_archive_rejects_from_header_before_reading_recipe_body() {
         let content = vec![b'x'; 16 * 1024];
@@ -762,9 +778,15 @@ mod tests {
         let output_dir = tempfile::tempdir().unwrap();
         let output = output_dir.path().join("recipe.yaml");
 
-        let error = extract_bounded_archive(reader, output_dir.path(), content.len() - 1)
-            .unwrap_err()
-            .to_string();
+        let error = extract_bounded_archive_with_limits(
+            reader,
+            output_dir.path(),
+            content.len() - 1,
+            usize::MAX,
+            ARCHIVE_LIMITS,
+        )
+        .unwrap_err()
+        .to_string();
 
         assert!(error.contains("byte limit"));
         assert!(bytes_read.get() < content.len());
@@ -776,10 +798,12 @@ mod tests {
         let content = b"title: exact boundary";
         let output_dir = tempfile::tempdir().unwrap();
 
-        extract_bounded_archive(
+        extract_bounded_archive_with_limits(
             Cursor::new(archive_with_files(&[("recipe.yaml", content)])),
             output_dir.path(),
             content.len(),
+            usize::MAX,
+            ARCHIVE_LIMITS,
         )
         .unwrap();
 
@@ -795,17 +819,19 @@ mod tests {
         let grandchild = b"title: grandchild";
         let output_dir = tempfile::tempdir().unwrap();
 
-        let payload_bytes = extract_bounded_archive(
+        let consumed_bytes = extract_bounded_archive_with_limits(
             Cursor::new(archive_with_files(&[
                 ("recipe.yaml", recipe),
                 ("nested/grandchild.yaml", grandchild),
             ])),
             output_dir.path(),
             recipe.len() + grandchild.len(),
+            usize::MAX,
+            ARCHIVE_LIMITS,
         )
         .unwrap();
 
-        assert_eq!(payload_bytes, recipe.len() + grandchild.len());
+        assert!(consumed_bytes > recipe.len() + grandchild.len());
         assert_eq!(
             fs::read(output_dir.path().join("recipe.yaml")).unwrap(),
             recipe
@@ -814,6 +840,33 @@ mod tests {
             fs::read(output_dir.path().join("nested/grandchild.yaml")).unwrap(),
             grandchild
         );
+    }
+
+    #[test]
+    fn zero_byte_archives_share_the_aggregate_stream_budget() {
+        let archive = archive_with_empty_files(128);
+        let root = tempfile::tempdir().unwrap();
+        let mut remaining_bytes = archive.len();
+        let mut extracted_archives = 0;
+
+        for index in 0..3 {
+            let output_dir = root.path().join(index.to_string());
+            fs::create_dir(&output_dir).unwrap();
+            let Ok(consumed_bytes) = extract_bounded_archive_with_limits(
+                Cursor::new(archive.clone()),
+                &output_dir,
+                remaining_bytes,
+                remaining_bytes,
+                ARCHIVE_LIMITS,
+            ) else {
+                break;
+            };
+            remaining_bytes -= consumed_bytes;
+            extracted_archives += 1;
+        }
+
+        assert_eq!(extracted_archives, 1);
+        assert!(remaining_bytes < archive.len());
     }
 
     #[test]
@@ -829,7 +882,14 @@ mod tests {
             ..ARCHIVE_LIMITS
         };
 
-        assert!(extract_bounded_archive_with_limits(reader, output_dir.path(), 0, limits).is_err());
+        assert!(extract_bounded_archive_with_limits(
+            reader,
+            output_dir.path(),
+            0,
+            usize::MAX,
+            limits
+        )
+        .is_err());
         assert_eq!(bytes_read.get(), limits.overhead_bytes);
         assert!(!output_dir.path().join("recipe.yaml").exists());
     }
@@ -846,6 +906,7 @@ mod tests {
             Cursor::new(archive_with_files(&[("first", b""), ("second", b"")])),
             output_dir.path(),
             0,
+            usize::MAX,
             limits,
         )
         .unwrap_err()
@@ -872,6 +933,7 @@ mod tests {
             Cursor::new(archive_with_files(&[("long", b"")])),
             output_dir.path(),
             0,
+            usize::MAX,
             individual_path_limits,
         )
         .unwrap_err()
@@ -880,6 +942,7 @@ mod tests {
             Cursor::new(archive_with_files(&[("one", b""), ("two", b"")])),
             output_dir.path(),
             0,
+            usize::MAX,
             total_path_limits,
         )
         .unwrap_err()
@@ -904,6 +967,7 @@ mod tests {
             Cursor::new(archive_with_files(&[("one/two/recipe.yaml", b"")])),
             output_dir.path(),
             0,
+            usize::MAX,
             limits,
         )
         .unwrap_err()

--- a/crates/goose-cli/src/recipes/search_recipe.rs
+++ b/crates/goose-cli/src/recipes/search_recipe.rs
@@ -11,6 +11,11 @@ use goose::recipe::local_recipes::{
     list_local_recipes, load_local_recipe_file, load_local_recipe_file_with_byte_limit,
 };
 
+pub(crate) struct BoundedRecipeFile {
+    pub recipe_file: RecipeFile,
+    pub consumed_bytes: usize,
+}
+
 pub fn load_recipe_file(recipe_name: &str) -> Result<RecipeFile> {
     load_local_recipe_file(recipe_name).or_else(|e| {
         if let Some(recipe_repo_full_name) = configured_github_recipe_repo() {
@@ -21,8 +26,17 @@ pub fn load_recipe_file(recipe_name: &str) -> Result<RecipeFile> {
     })
 }
 
-pub fn load_recipe_file_with_byte_limit(recipe_name: &str, max_bytes: usize) -> Result<RecipeFile> {
-    let local_result = load_local_recipe_file_with_byte_limit(recipe_name, max_bytes);
+pub(crate) fn load_recipe_file_with_byte_limit(
+    recipe_name: &str,
+    max_bytes: usize,
+) -> Result<BoundedRecipeFile> {
+    let local_result =
+        load_local_recipe_file_with_byte_limit(recipe_name, max_bytes).map(|recipe_file| {
+            BoundedRecipeFile {
+                consumed_bytes: recipe_file.content.len(),
+                recipe_file,
+            }
+        });
     if RECIPE_FILE_EXTENSIONS
         .iter()
         .any(|extension| recipe_name.ends_with(&format!(".{extension}")))
@@ -36,6 +50,10 @@ pub fn load_recipe_file_with_byte_limit(recipe_name: &str, max_bytes: usize) -> 
                 &recipe_repo_full_name,
                 max_bytes,
             )
+            .map(|(recipe_file, consumed_bytes)| BoundedRecipeFile {
+                recipe_file,
+                consumed_bytes,
+            })
         } else {
             Err(error)
         }

--- a/crates/goose-cli/src/recipes/search_recipe.rs
+++ b/crates/goose-cli/src/recipes/search_recipe.rs
@@ -29,9 +29,11 @@ pub(crate) fn load_recipe_file_with_byte_limit(
     let has_recipe_extension = RECIPE_FILE_EXTENSIONS
         .iter()
         .any(|extension| recipe_name.ends_with(&format!(".{extension}")));
-    if has_recipe_extension
-        && fs::metadata(recipe_name).is_ok_and(|metadata| metadata.len() > max_bytes as u64)
-    {
+    let local_file_bytes = has_recipe_extension
+        .then(|| fs::metadata(recipe_name))
+        .and_then(Result::ok)
+        .and_then(|metadata| usize::try_from(metadata.len()).ok());
+    if local_file_bytes.is_some_and(|file_bytes| file_bytes > max_bytes) {
         return BoundedRecipeLoad {
             recipe_file: Err(anyhow::anyhow!(
                 "Recipe file exceeds the {max_bytes}-byte limit"
@@ -47,7 +49,7 @@ pub(crate) fn load_recipe_file_with_byte_limit(
         },
         Err(error) if has_recipe_extension => BoundedRecipeLoad {
             recipe_file: Err(error),
-            consumed_bytes: None,
+            consumed_bytes: Some(local_file_bytes.unwrap_or(0)),
         },
         Err(error) => match configured_github_recipe_repo() {
             Some(recipe_repo_full_name) => retrieve_recipe_from_github_with_byte_limit(

--- a/crates/goose-cli/src/recipes/search_recipe.rs
+++ b/crates/goose-cli/src/recipes/search_recipe.rs
@@ -2,14 +2,14 @@ use anyhow::Result;
 use goose::config::Config;
 use goose::recipe::read_recipe_file_content::RecipeFile;
 use goose::recipe::RECIPE_FILE_EXTENSIONS;
-use std::fs;
 
 use super::github_recipe::{
     list_github_recipes, retrieve_recipe_from_github, retrieve_recipe_from_github_with_byte_limit,
     BoundedRecipeLoad, RecipeInfo, RecipeSource, GOOSE_RECIPE_GITHUB_REPO_CONFIG_KEY,
 };
 use goose::recipe::local_recipes::{
-    list_local_recipes, load_local_recipe_file, load_local_recipe_file_with_byte_limit,
+    list_local_recipes, load_local_recipe_file,
+    load_local_recipe_file_with_byte_limit_and_consumption,
 };
 
 pub fn load_recipe_file(recipe_name: &str) -> Result<RecipeFile> {
@@ -38,37 +38,39 @@ pub(crate) fn load_recipe_file_with_byte_limit_from_repo(
     let has_recipe_extension = RECIPE_FILE_EXTENSIONS
         .iter()
         .any(|extension| recipe_name.ends_with(&format!(".{extension}")));
-    let local_file_bytes = has_recipe_extension
-        .then(|| fs::metadata(recipe_name))
-        .and_then(Result::ok)
-        .and_then(|metadata| usize::try_from(metadata.len()).ok());
-    if local_file_bytes.is_some_and(|file_bytes| file_bytes > max_bytes) {
-        return BoundedRecipeLoad {
-            recipe_file: Err(anyhow::anyhow!(
-                "Recipe file exceeds the {max_bytes}-byte limit"
-            )),
-            consumed_bytes: Some(0),
-        };
-    }
-    let local_result = load_local_recipe_file_with_byte_limit(recipe_name, max_bytes);
-    match local_result {
+    let local_result =
+        load_local_recipe_file_with_byte_limit_and_consumption(recipe_name, max_bytes);
+    let local_consumed_bytes = local_result.consumed_bytes;
+    match local_result.recipe_file {
         Ok(recipe_file) => BoundedRecipeLoad {
-            consumed_bytes: Some(recipe_file.content.len()),
+            consumed_bytes: Some(local_consumed_bytes),
             recipe_file: Ok(recipe_file),
         },
         Err(error) if has_recipe_extension => BoundedRecipeLoad {
             recipe_file: Err(error),
-            consumed_bytes: Some(local_file_bytes.unwrap_or(0)),
+            consumed_bytes: Some(local_consumed_bytes),
         },
         Err(error) => match github_repo {
-            Some(recipe_repo_full_name) => retrieve_recipe_from_github_with_byte_limit(
-                recipe_name,
-                recipe_repo_full_name,
-                max_bytes,
-            ),
+            Some(recipe_repo_full_name) if local_consumed_bytes < max_bytes => {
+                let remote_load = retrieve_recipe_from_github_with_byte_limit(
+                    recipe_name,
+                    recipe_repo_full_name,
+                    max_bytes - local_consumed_bytes,
+                );
+                BoundedRecipeLoad {
+                    recipe_file: remote_load.recipe_file,
+                    consumed_bytes: remote_load
+                        .consumed_bytes
+                        .and_then(|remote_bytes| local_consumed_bytes.checked_add(remote_bytes)),
+                }
+            }
+            Some(_) => BoundedRecipeLoad {
+                recipe_file: Err(error),
+                consumed_bytes: Some(local_consumed_bytes),
+            },
             None => BoundedRecipeLoad {
                 recipe_file: Err(error),
-                consumed_bytes: Some(0),
+                consumed_bytes: Some(local_consumed_bytes),
             },
         },
     }

--- a/crates/goose-cli/src/recipes/search_recipe.rs
+++ b/crates/goose-cli/src/recipes/search_recipe.rs
@@ -1,12 +1,15 @@
 use anyhow::Result;
 use goose::config::Config;
 use goose::recipe::read_recipe_file_content::RecipeFile;
+use goose::recipe::RECIPE_FILE_EXTENSIONS;
 
 use super::github_recipe::{
-    list_github_recipes, retrieve_recipe_from_github, RecipeInfo, RecipeSource,
-    GOOSE_RECIPE_GITHUB_REPO_CONFIG_KEY,
+    list_github_recipes, retrieve_recipe_from_github, retrieve_recipe_from_github_with_byte_limit,
+    RecipeInfo, RecipeSource, GOOSE_RECIPE_GITHUB_REPO_CONFIG_KEY,
 };
-use goose::recipe::local_recipes::{list_local_recipes, load_local_recipe_file};
+use goose::recipe::local_recipes::{
+    list_local_recipes, load_local_recipe_file, load_local_recipe_file_with_byte_limit,
+};
 
 pub fn load_recipe_file(recipe_name: &str) -> Result<RecipeFile> {
     load_local_recipe_file(recipe_name).or_else(|e| {
@@ -14,6 +17,27 @@ pub fn load_recipe_file(recipe_name: &str) -> Result<RecipeFile> {
             retrieve_recipe_from_github(recipe_name, &recipe_repo_full_name)
         } else {
             Err(e)
+        }
+    })
+}
+
+pub fn load_recipe_file_with_byte_limit(recipe_name: &str, max_bytes: usize) -> Result<RecipeFile> {
+    let local_result = load_local_recipe_file_with_byte_limit(recipe_name, max_bytes);
+    if RECIPE_FILE_EXTENSIONS
+        .iter()
+        .any(|extension| recipe_name.ends_with(&format!(".{extension}")))
+    {
+        return local_result;
+    }
+    local_result.or_else(|error| {
+        if let Some(recipe_repo_full_name) = configured_github_recipe_repo() {
+            retrieve_recipe_from_github_with_byte_limit(
+                recipe_name,
+                &recipe_repo_full_name,
+                max_bytes,
+            )
+        } else {
+            Err(error)
         }
     })
 }

--- a/crates/goose-cli/src/recipes/search_recipe.rs
+++ b/crates/goose-cli/src/recipes/search_recipe.rs
@@ -26,6 +26,15 @@ pub(crate) fn load_recipe_file_with_byte_limit(
     recipe_name: &str,
     max_bytes: usize,
 ) -> BoundedRecipeLoad {
+    let github_repo = configured_github_recipe_repo();
+    load_recipe_file_with_byte_limit_from_repo(recipe_name, max_bytes, github_repo.as_deref())
+}
+
+pub(crate) fn load_recipe_file_with_byte_limit_from_repo(
+    recipe_name: &str,
+    max_bytes: usize,
+    github_repo: Option<&str>,
+) -> BoundedRecipeLoad {
     let has_recipe_extension = RECIPE_FILE_EXTENSIONS
         .iter()
         .any(|extension| recipe_name.ends_with(&format!(".{extension}")));
@@ -51,15 +60,15 @@ pub(crate) fn load_recipe_file_with_byte_limit(
             recipe_file: Err(error),
             consumed_bytes: Some(local_file_bytes.unwrap_or(0)),
         },
-        Err(error) => match configured_github_recipe_repo() {
+        Err(error) => match github_repo {
             Some(recipe_repo_full_name) => retrieve_recipe_from_github_with_byte_limit(
                 recipe_name,
-                &recipe_repo_full_name,
+                recipe_repo_full_name,
                 max_bytes,
             ),
             None => BoundedRecipeLoad {
                 recipe_file: Err(error),
-                consumed_bytes: None,
+                consumed_bytes: Some(0),
             },
         },
     }

--- a/crates/goose-cli/src/recipes/search_recipe.rs
+++ b/crates/goose-cli/src/recipes/search_recipe.rs
@@ -2,19 +2,15 @@ use anyhow::Result;
 use goose::config::Config;
 use goose::recipe::read_recipe_file_content::RecipeFile;
 use goose::recipe::RECIPE_FILE_EXTENSIONS;
+use std::fs;
 
 use super::github_recipe::{
     list_github_recipes, retrieve_recipe_from_github, retrieve_recipe_from_github_with_byte_limit,
-    RecipeInfo, RecipeSource, GOOSE_RECIPE_GITHUB_REPO_CONFIG_KEY,
+    BoundedRecipeLoad, RecipeInfo, RecipeSource, GOOSE_RECIPE_GITHUB_REPO_CONFIG_KEY,
 };
 use goose::recipe::local_recipes::{
     list_local_recipes, load_local_recipe_file, load_local_recipe_file_with_byte_limit,
 };
-
-pub(crate) struct BoundedRecipeFile {
-    pub recipe_file: RecipeFile,
-    pub consumed_bytes: usize,
-}
 
 pub fn load_recipe_file(recipe_name: &str) -> Result<RecipeFile> {
     load_local_recipe_file(recipe_name).or_else(|e| {
@@ -29,35 +25,42 @@ pub fn load_recipe_file(recipe_name: &str) -> Result<RecipeFile> {
 pub(crate) fn load_recipe_file_with_byte_limit(
     recipe_name: &str,
     max_bytes: usize,
-) -> Result<BoundedRecipeFile> {
-    let local_result =
-        load_local_recipe_file_with_byte_limit(recipe_name, max_bytes).map(|recipe_file| {
-            BoundedRecipeFile {
-                consumed_bytes: recipe_file.content.len(),
-                recipe_file,
-            }
-        });
-    if RECIPE_FILE_EXTENSIONS
+) -> BoundedRecipeLoad {
+    let has_recipe_extension = RECIPE_FILE_EXTENSIONS
         .iter()
-        .any(|extension| recipe_name.ends_with(&format!(".{extension}")))
+        .any(|extension| recipe_name.ends_with(&format!(".{extension}")));
+    if has_recipe_extension
+        && fs::metadata(recipe_name).is_ok_and(|metadata| metadata.len() > max_bytes as u64)
     {
-        return local_result;
+        return BoundedRecipeLoad {
+            recipe_file: Err(anyhow::anyhow!(
+                "Recipe file exceeds the {max_bytes}-byte limit"
+            )),
+            consumed_bytes: Some(0),
+        };
     }
-    local_result.or_else(|error| {
-        if let Some(recipe_repo_full_name) = configured_github_recipe_repo() {
-            retrieve_recipe_from_github_with_byte_limit(
+    let local_result = load_local_recipe_file_with_byte_limit(recipe_name, max_bytes);
+    match local_result {
+        Ok(recipe_file) => BoundedRecipeLoad {
+            consumed_bytes: Some(recipe_file.content.len()),
+            recipe_file: Ok(recipe_file),
+        },
+        Err(error) if has_recipe_extension => BoundedRecipeLoad {
+            recipe_file: Err(error),
+            consumed_bytes: None,
+        },
+        Err(error) => match configured_github_recipe_repo() {
+            Some(recipe_repo_full_name) => retrieve_recipe_from_github_with_byte_limit(
                 recipe_name,
                 &recipe_repo_full_name,
                 max_bytes,
-            )
-            .map(|(recipe_file, consumed_bytes)| BoundedRecipeFile {
-                recipe_file,
-                consumed_bytes,
-            })
-        } else {
-            Err(error)
-        }
-    })
+            ),
+            None => BoundedRecipeLoad {
+                recipe_file: Err(error),
+                consumed_bytes: None,
+            },
+        },
+    }
 }
 
 fn configured_github_recipe_repo() -> Option<String> {

--- a/crates/goose-cli/src/recipes/secret_discovery.rs
+++ b/crates/goose-cli/src/recipes/secret_discovery.rs
@@ -723,13 +723,22 @@ mod tests {
         let root = recipe_with_secret(
             None,
             vec![
+                sub_recipe("missing-extensionless-local-recipe-for-secret-discovery-test"),
                 sub_recipe(missing_path.to_string_lossy()),
                 sub_recipe(invalid_path.to_string_lossy()),
                 sub_recipe(valid_path.to_string_lossy()),
             ],
         );
 
-        let secrets = discover_recipe_secrets(&root);
+        let secrets = discover_recipe_secrets_with_limits_and_loader(
+            &root,
+            DISCOVERY_LIMITS,
+            |path, max_bytes| {
+                crate::recipes::search_recipe::load_recipe_file_with_byte_limit_from_repo(
+                    path, max_bytes, None,
+                )
+            },
+        );
 
         assert_eq!(
             secrets

--- a/crates/goose-cli/src/recipes/secret_discovery.rs
+++ b/crates/goose-cli/src/recipes/secret_discovery.rs
@@ -2,7 +2,29 @@ use crate::recipes::search_recipe::load_recipe_file;
 use goose::agents::extension::ExtensionConfig;
 use goose::recipe::Recipe;
 use regex::{NoExpand, Regex};
-use std::collections::HashSet;
+use std::{collections::HashSet, path::PathBuf};
+
+const MAX_SUB_RECIPE_DEPTH: usize = 64;
+const MAX_DISCOVERED_RECIPES: usize = 256;
+const MAX_DISCOVERY_LOADED_BYTES: usize = 1024 * 1024;
+
+#[derive(Clone, Copy)]
+struct DiscoveryLimits {
+    max_depth: usize,
+    max_recipes: usize,
+    max_loaded_bytes: usize,
+}
+
+const DISCOVERY_LIMITS: DiscoveryLimits = DiscoveryLimits {
+    max_depth: MAX_SUB_RECIPE_DEPTH,
+    max_recipes: MAX_DISCOVERED_RECIPES,
+    max_loaded_bytes: MAX_DISCOVERY_LOADED_BYTES,
+};
+
+struct PendingRecipe {
+    path: String,
+    depth: usize,
+}
 
 /// Represents a secret requirement discovered from a recipe extension
 #[derive(Debug, Clone, PartialEq)]
@@ -29,7 +51,7 @@ impl SecretRequirement {
 
 /// Discovers all secrets required by MCP extensions in a recipe and its sub-recipes
 ///
-/// This function recursively scans the recipe and all its sub-recipes for extensions
+/// This function scans the recipe and its bounded sub-recipe graph for extensions
 /// and collects their declared env_keys, creating SecretRequirement structs for each
 /// unique environment variable.
 ///
@@ -39,8 +61,7 @@ impl SecretRequirement {
 /// # Returns
 /// A vector of SecretRequirement objects, deduplicated by key name
 pub fn discover_recipe_secrets(recipe: &Recipe) -> Vec<SecretRequirement> {
-    let mut visited_recipes = HashSet::new();
-    discover_recipe_secrets_recursive(recipe, &mut visited_recipes)
+    discover_recipe_secrets_with_limits(recipe, DISCOVERY_LIMITS)
 }
 
 /// Extract secrets from a list of extensions
@@ -81,80 +102,152 @@ fn extract_secrets_from_extensions(
     secrets
 }
 
-/// Internal recursive function (depth-first search) to discover secrets nested in sub-recipes
-/// This is future-proofing for a time when we have more than one-level of sub-recipe nesting
-fn discover_recipe_secrets_recursive(
+fn discover_recipe_secrets_with_limits(
     recipe: &Recipe,
-    visited_recipes: &mut HashSet<String>,
+    limits: DiscoveryLimits,
 ) -> Vec<SecretRequirement> {
     let mut secrets: Vec<SecretRequirement> = Vec::new();
     let mut seen_keys = HashSet::new();
+    let mut seen_requests = HashSet::new();
+    let mut seen_files = HashSet::<PathBuf>::new();
+    let mut loaded_recipes = 0;
+    let mut loaded_bytes: usize = 0;
 
     if let Some(extensions) = &recipe.extensions {
         secrets.extend(extract_secrets_from_extensions(extensions, &mut seen_keys));
     }
 
-    if let Some(sub_recipes) = &recipe.sub_recipes {
-        for sub_recipe in sub_recipes {
-            if visited_recipes.contains(&sub_recipe.path) {
+    let mut pending = Vec::new();
+    push_sub_recipes(&mut pending, recipe, None, 1);
+
+    while let Some(next) = pending.pop() {
+        if next.depth > limits.max_depth || !seen_requests.insert(next.path.clone()) {
+            continue;
+        }
+
+        if let Ok(canonical_path) = std::fs::canonicalize(&next.path) {
+            if seen_files.contains(&canonical_path) {
                 continue;
             }
-            visited_recipes.insert(sub_recipe.path.clone());
+        }
 
-            match load_sub_recipe(&sub_recipe.path) {
-                Ok((loaded_recipe, parent_dir)) => {
-                    let sub_secrets =
-                        discover_sub_recipe_secrets(&loaded_recipe, &parent_dir, visited_recipes);
-                    for sub_secret in sub_secrets {
-                        if seen_keys.insert(sub_secret.key.clone()) {
-                            secrets.push(sub_secret);
-                        }
-                    }
-                }
-                Err(_) => {
-                    continue;
-                }
-            }
+        if loaded_recipes == limits.max_recipes {
+            break;
+        }
+        loaded_recipes += 1;
+
+        let Ok(recipe_file) = load_recipe_file(&next.path) else {
+            continue;
+        };
+        let Some(next_loaded_bytes) = loaded_bytes.checked_add(recipe_file.content.len()) else {
+            break;
+        };
+        if next_loaded_bytes > limits.max_loaded_bytes {
+            break;
+        }
+        loaded_bytes = next_loaded_bytes;
+
+        let file_identity = recipe_file
+            .file_path
+            .canonicalize()
+            .unwrap_or_else(|_| recipe_file.file_path.clone());
+        if !seen_files.insert(file_identity) {
+            continue;
+        }
+
+        let Ok(loaded_recipe) = serde_yaml::from_str::<Recipe>(&recipe_file.content) else {
+            continue;
+        };
+        if let Some(extensions) = &loaded_recipe.extensions {
+            secrets.extend(extract_secrets_from_extensions(extensions, &mut seen_keys));
+        }
+        if next.depth < limits.max_depth {
+            push_sub_recipes(
+                &mut pending,
+                &loaded_recipe,
+                Some(recipe_file.parent_dir.to_string_lossy().as_ref()),
+                next.depth + 1,
+            );
         }
     }
 
     secrets
 }
 
-/// Discovers secrets from a loaded sub-recipe, resolving `{{ recipe_dir }}` in nested
-/// sub-recipe paths so they can be loaded without triggering confusing lookup failures.
-fn discover_sub_recipe_secrets(
+fn push_sub_recipes(
+    pending: &mut Vec<PendingRecipe>,
     recipe: &Recipe,
-    parent_dir: &str,
-    visited_recipes: &mut HashSet<String>,
-) -> Vec<SecretRequirement> {
+    parent_dir: Option<&str>,
+    depth: usize,
+) {
+    let Some(sub_recipes) = &recipe.sub_recipes else {
+        return;
+    };
     let re = Regex::new(r"\{\{\s*recipe_dir\s*\}\}").expect("valid regex");
-    let mut resolved = recipe.clone();
-    if let Some(ref mut sub_recipes) = resolved.sub_recipes {
-        for sr in sub_recipes.iter_mut() {
-            sr.path = re.replace_all(&sr.path, NoExpand(parent_dir)).into_owned();
-        }
+    for sub_recipe in sub_recipes.iter().rev() {
+        let path = match parent_dir {
+            Some(parent_dir) => re
+                .replace_all(&sub_recipe.path, NoExpand(parent_dir))
+                .into_owned(),
+            None => sub_recipe.path.clone(),
+        };
+        pending.push(PendingRecipe { path, depth });
     }
-    discover_recipe_secrets_recursive(&resolved, visited_recipes)
-}
-
-/// Loads a recipe from a file path for sub-recipe secret discovery.
-///
-/// Returns the parsed recipe along with its parent directory path, which is
-/// needed to resolve `{{ recipe_dir }}` in any nested sub-recipe paths.
-fn load_sub_recipe(recipe_path: &str) -> Result<(Recipe, String), Box<dyn std::error::Error>> {
-    let recipe_file = load_recipe_file(recipe_path)?;
-    let recipe: Recipe = serde_yaml::from_str(&recipe_file.content)?;
-    let parent_dir = recipe_file.parent_dir.display().to_string();
-    Ok((recipe, parent_dir))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use goose::agents::extension::{Envs, ExtensionConfig};
-    use goose::recipe::Recipe;
+    use goose::recipe::{Recipe, SubRecipe};
     use std::collections::HashMap;
+
+    fn sub_recipe(path: impl Into<String>) -> SubRecipe {
+        SubRecipe {
+            name: "child".to_string(),
+            path: path.into(),
+            values: None,
+            sequential_when_repeated: false,
+            description: None,
+        }
+    }
+
+    fn recipe_with_secret(secret: Option<&str>, sub_recipes: Vec<SubRecipe>) -> Recipe {
+        Recipe {
+            version: "1.0.0".to_string(),
+            title: "Test Recipe".to_string(),
+            description: "Test recipe".to_string(),
+            instructions: Some("Test instructions".to_string()),
+            prompt: None,
+            extensions: secret.map(|key| {
+                vec![ExtensionConfig::Stdio {
+                    name: format!("{key}-extension"),
+                    cmd: "test".to_string(),
+                    args: vec![],
+                    envs: Envs::new(HashMap::new()),
+                    env_keys: vec![key.to_string()],
+                    timeout: None,
+                    cwd: None,
+                    description: "test".to_string(),
+                    bundled: None,
+                    available_tools: Vec::new(),
+                }]
+            }),
+            settings: None,
+            activities: None,
+            author: None,
+            parameters: None,
+            response: None,
+            sub_recipes: (!sub_recipes.is_empty()).then_some(sub_recipes),
+            retry: None,
+        }
+    }
+
+    fn write_recipe(path: &std::path::Path, recipe: &Recipe) -> usize {
+        let content = serde_yaml::to_string(recipe).unwrap();
+        std::fs::write(path, &content).unwrap();
+        content.len()
+    }
 
     fn create_test_recipe_with_extensions() -> Recipe {
         Recipe {
@@ -365,8 +458,6 @@ mod tests {
 
     #[test]
     fn test_discover_recipe_secrets_with_sub_recipes() {
-        use goose::recipe::SubRecipe;
-
         let recipe = Recipe {
             version: "1.0.0".to_string(),
             title: "Parent Recipe".to_string(),
@@ -409,5 +500,187 @@ mod tests {
 
         let parent_secret = secrets.iter().find(|s| s.key == "PARENT_TOKEN").unwrap();
         assert_eq!(parent_secret.extension_name, "parent-ext");
+    }
+
+    #[test]
+    fn nested_sub_recipe_secrets_preserve_depth_first_order() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let child_path = temp_dir.path().join("child.yaml");
+        let grandchild_path = temp_dir.path().join("grandchild.yaml");
+        write_recipe(
+            &grandchild_path,
+            &recipe_with_secret(Some("GRANDCHILD_TOKEN"), vec![]),
+        );
+        write_recipe(
+            &child_path,
+            &recipe_with_secret(
+                Some("CHILD_TOKEN"),
+                vec![sub_recipe("{{ recipe_dir }}/grandchild.yaml")],
+            ),
+        );
+        let root = recipe_with_secret(
+            Some("ROOT_TOKEN"),
+            vec![sub_recipe(child_path.to_string_lossy())],
+        );
+
+        let keys: Vec<_> = discover_recipe_secrets(&root)
+            .into_iter()
+            .map(|secret| secret.key)
+            .collect();
+
+        assert_eq!(keys, ["ROOT_TOKEN", "CHILD_TOKEN", "GRANDCHILD_TOKEN"]);
+    }
+
+    #[test]
+    fn aliases_and_cycles_do_not_consume_the_recipe_budget() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let child_path = temp_dir.path().join("child.yaml");
+        let sibling_path = temp_dir.path().join("sibling.yaml");
+        write_recipe(
+            &child_path,
+            &recipe_with_secret(
+                Some("CHILD_TOKEN"),
+                vec![sub_recipe("{{ recipe_dir }}/child.yaml")],
+            ),
+        );
+        write_recipe(
+            &sibling_path,
+            &recipe_with_secret(Some("SIBLING_TOKEN"), vec![]),
+        );
+        let alias_path = temp_dir.path().join(".").join("child.yaml");
+        let root = recipe_with_secret(
+            None,
+            vec![
+                sub_recipe(child_path.to_string_lossy()),
+                sub_recipe(alias_path.to_string_lossy()),
+                sub_recipe(sibling_path.to_string_lossy()),
+            ],
+        );
+
+        let keys: Vec<_> = discover_recipe_secrets_with_limits(
+            &root,
+            DiscoveryLimits {
+                max_depth: 8,
+                max_recipes: 2,
+                max_loaded_bytes: MAX_DISCOVERY_LOADED_BYTES,
+            },
+        )
+        .into_iter()
+        .map(|secret| secret.key)
+        .collect();
+
+        assert_eq!(keys, ["CHILD_TOKEN", "SIBLING_TOKEN"]);
+    }
+
+    #[test]
+    fn discovery_enforces_depth_count_and_aggregate_byte_boundaries() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let first_path = temp_dir.path().join("first.yaml");
+        let second_path = temp_dir.path().join("second.yaml");
+        let third_path = temp_dir.path().join("third.yaml");
+        let third_size = write_recipe(
+            &third_path,
+            &recipe_with_secret(Some("THIRD_TOKEN"), vec![]),
+        );
+        let second_size = write_recipe(
+            &second_path,
+            &recipe_with_secret(
+                Some("SECOND_TOKEN"),
+                vec![sub_recipe(third_path.to_string_lossy())],
+            ),
+        );
+        let first_size = write_recipe(
+            &first_path,
+            &recipe_with_secret(
+                Some("FIRST_TOKEN"),
+                vec![sub_recipe(second_path.to_string_lossy())],
+            ),
+        );
+        let root = recipe_with_secret(None, vec![sub_recipe(first_path.to_string_lossy())]);
+
+        let depth_limited = discover_recipe_secrets_with_limits(
+            &root,
+            DiscoveryLimits {
+                max_depth: 2,
+                max_recipes: 3,
+                max_loaded_bytes: first_size + second_size + third_size,
+            },
+        );
+        assert_eq!(
+            depth_limited
+                .iter()
+                .map(|secret| secret.key.as_str())
+                .collect::<Vec<_>>(),
+            ["FIRST_TOKEN", "SECOND_TOKEN"]
+        );
+
+        let count_limited = discover_recipe_secrets_with_limits(
+            &root,
+            DiscoveryLimits {
+                max_depth: 3,
+                max_recipes: 2,
+                max_loaded_bytes: first_size + second_size + third_size,
+            },
+        );
+        assert_eq!(
+            count_limited
+                .iter()
+                .map(|secret| secret.key.as_str())
+                .collect::<Vec<_>>(),
+            ["FIRST_TOKEN", "SECOND_TOKEN"]
+        );
+
+        let exact_bytes = discover_recipe_secrets_with_limits(
+            &root,
+            DiscoveryLimits {
+                max_depth: 3,
+                max_recipes: 3,
+                max_loaded_bytes: first_size + second_size + third_size,
+            },
+        );
+        assert_eq!(exact_bytes.len(), 3);
+
+        let below_boundary = discover_recipe_secrets_with_limits(
+            &root,
+            DiscoveryLimits {
+                max_depth: 3,
+                max_recipes: 3,
+                max_loaded_bytes: first_size + second_size + third_size - 1,
+            },
+        );
+        assert_eq!(below_boundary.len(), 2);
+    }
+
+    #[test]
+    fn very_deep_sub_recipe_chain_is_bounded_without_recursion() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let depth = 2048;
+        for index in 0..depth {
+            let next = (index + 1 < depth).then(|| {
+                sub_recipe(
+                    temp_dir
+                        .path()
+                        .join(format!("{}.yaml", index + 1))
+                        .to_string_lossy(),
+                )
+            });
+            write_recipe(
+                &temp_dir.path().join(format!("{index}.yaml")),
+                &recipe_with_secret(Some(&format!("TOKEN_{index}")), next.into_iter().collect()),
+            );
+        }
+        let root = recipe_with_secret(
+            None,
+            vec![sub_recipe(temp_dir.path().join("0.yaml").to_string_lossy())],
+        );
+
+        let secrets = discover_recipe_secrets(&root);
+
+        assert_eq!(secrets.len(), MAX_SUB_RECIPE_DEPTH);
+        assert_eq!(secrets.first().unwrap().key, "TOKEN_0");
+        assert_eq!(
+            secrets.last().unwrap().key,
+            format!("TOKEN_{}", MAX_SUB_RECIPE_DEPTH - 1)
+        );
     }
 }

--- a/crates/goose-cli/src/recipes/secret_discovery.rs
+++ b/crates/goose-cli/src/recipes/secret_discovery.rs
@@ -1,4 +1,4 @@
-use crate::recipes::search_recipe::load_recipe_file_with_byte_limit;
+use crate::recipes::search_recipe::{load_recipe_file_with_byte_limit, BoundedRecipeFile};
 use goose::agents::extension::ExtensionConfig;
 use goose::recipe::Recipe;
 use regex::{NoExpand, Regex};
@@ -106,6 +106,17 @@ fn discover_recipe_secrets_with_limits(
     recipe: &Recipe,
     limits: DiscoveryLimits,
 ) -> Vec<SecretRequirement> {
+    discover_recipe_secrets_with_limits_and_loader(recipe, limits, load_recipe_file_with_byte_limit)
+}
+
+fn discover_recipe_secrets_with_limits_and_loader<F>(
+    recipe: &Recipe,
+    limits: DiscoveryLimits,
+    mut load_recipe: F,
+) -> Vec<SecretRequirement>
+where
+    F: FnMut(&str, usize) -> anyhow::Result<BoundedRecipeFile>,
+{
     let mut secrets: Vec<SecretRequirement> = Vec::new();
     let mut seen_keys = HashSet::new();
     let mut seen_requests = HashSet::new();
@@ -137,16 +148,21 @@ fn discover_recipe_secrets_with_limits(
         loaded_recipes += 1;
 
         let remaining_bytes = limits.max_loaded_bytes - loaded_bytes;
-        let Ok(recipe_file) = load_recipe_file_with_byte_limit(&next.path, remaining_bytes) else {
+        let Ok(bounded_recipe_file) = load_recipe(&next.path, remaining_bytes) else {
             continue;
         };
-        let Some(next_loaded_bytes) = loaded_bytes.checked_add(recipe_file.content.len()) else {
+        if bounded_recipe_file.consumed_bytes < bounded_recipe_file.recipe_file.content.len() {
+            break;
+        }
+        let Some(next_loaded_bytes) = loaded_bytes.checked_add(bounded_recipe_file.consumed_bytes)
+        else {
             break;
         };
         if next_loaded_bytes > limits.max_loaded_bytes {
             break;
         }
         loaded_bytes = next_loaded_bytes;
+        let recipe_file = bounded_recipe_file.recipe_file;
 
         let file_identity = recipe_file
             .file_path
@@ -687,6 +703,54 @@ mod tests {
                 .map(|secret| secret.key.as_str())
                 .collect::<Vec<_>>(),
             ["SMALL_TOKEN"]
+        );
+    }
+
+    #[test]
+    fn github_bundle_payloads_share_the_aggregate_discovery_budget() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let first_content =
+            serde_yaml::to_string(&recipe_with_secret(Some("FIRST_TOKEN"), vec![])).unwrap();
+        let second_content =
+            serde_yaml::to_string(&recipe_with_secret(Some("SECOND_TOKEN"), vec![])).unwrap();
+        let sibling_payload_bytes = 256;
+        let aggregate_budget = first_content.len() + second_content.len() + sibling_payload_bytes;
+        let contents = HashMap::from([
+            ("first".to_string(), first_content),
+            ("second".to_string(), second_content),
+        ]);
+        let root = recipe_with_secret(None, vec![sub_recipe("first"), sub_recipe("second")]);
+
+        let secrets = discover_recipe_secrets_with_limits_and_loader(
+            &root,
+            DiscoveryLimits {
+                max_depth: 1,
+                max_recipes: 2,
+                max_loaded_bytes: aggregate_budget,
+            },
+            |path, max_bytes| {
+                let content = contents.get(path).unwrap().clone();
+                let consumed_bytes = content.len() + sibling_payload_bytes;
+                if consumed_bytes > max_bytes {
+                    return Err(anyhow::anyhow!("bundle exceeds remaining budget"));
+                }
+                Ok(BoundedRecipeFile {
+                    recipe_file: goose::recipe::read_recipe_file_content::RecipeFile {
+                        content,
+                        parent_dir: temp_dir.path().join(path),
+                        file_path: temp_dir.path().join(format!("{path}.yaml")),
+                    },
+                    consumed_bytes,
+                })
+            },
+        );
+
+        assert_eq!(
+            secrets
+                .iter()
+                .map(|secret| secret.key.as_str())
+                .collect::<Vec<_>>(),
+            ["FIRST_TOKEN"]
         );
     }
 

--- a/crates/goose-cli/src/recipes/secret_discovery.rs
+++ b/crates/goose-cli/src/recipes/secret_discovery.rs
@@ -710,6 +710,37 @@ mod tests {
     }
 
     #[test]
+    fn failed_local_children_do_not_hide_later_sibling_secrets() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let missing_path = temp_dir.path().join("missing.yaml");
+        let invalid_path = temp_dir.path().join("invalid.yaml");
+        let valid_path = temp_dir.path().join("valid.yaml");
+        std::fs::write(&invalid_path, [0xff]).unwrap();
+        write_recipe(
+            &valid_path,
+            &recipe_with_secret(Some("VALID_TOKEN"), vec![]),
+        );
+        let root = recipe_with_secret(
+            None,
+            vec![
+                sub_recipe(missing_path.to_string_lossy()),
+                sub_recipe(invalid_path.to_string_lossy()),
+                sub_recipe(valid_path.to_string_lossy()),
+            ],
+        );
+
+        let secrets = discover_recipe_secrets(&root);
+
+        assert_eq!(
+            secrets
+                .iter()
+                .map(|secret| secret.key.as_str())
+                .collect::<Vec<_>>(),
+            ["VALID_TOKEN"]
+        );
+    }
+
+    #[test]
     fn github_bundle_payloads_share_the_aggregate_discovery_budget() {
         let temp_dir = tempfile::tempdir().unwrap();
         let first_content =

--- a/crates/goose-cli/src/recipes/secret_discovery.rs
+++ b/crates/goose-cli/src/recipes/secret_discovery.rs
@@ -1,4 +1,4 @@
-use crate::recipes::search_recipe::load_recipe_file;
+use crate::recipes::search_recipe::load_recipe_file_with_byte_limit;
 use goose::agents::extension::ExtensionConfig;
 use goose::recipe::Recipe;
 use regex::{NoExpand, Regex};
@@ -136,7 +136,8 @@ fn discover_recipe_secrets_with_limits(
         }
         loaded_recipes += 1;
 
-        let Ok(recipe_file) = load_recipe_file(&next.path) else {
+        let remaining_bytes = limits.max_loaded_bytes - loaded_bytes;
+        let Ok(recipe_file) = load_recipe_file_with_byte_limit(&next.path, remaining_bytes) else {
             continue;
         };
         let Some(next_loaded_bytes) = loaded_bytes.checked_add(recipe_file.content.len()) else {
@@ -649,6 +650,44 @@ mod tests {
             },
         );
         assert_eq!(below_boundary.len(), 2);
+    }
+
+    #[test]
+    fn discovery_rejects_an_oversized_child_before_loading_its_content() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let oversized_path = temp_dir.path().join("oversized.yaml");
+        let small_path = temp_dir.path().join("small.yaml");
+        let small_size = write_recipe(
+            &small_path,
+            &recipe_with_secret(Some("SMALL_TOKEN"), vec![]),
+        );
+        let mut oversized = recipe_with_secret(Some("OVERSIZED_TOKEN"), vec![]);
+        oversized.instructions = Some("x".repeat(small_size));
+        assert!(write_recipe(&oversized_path, &oversized) > small_size);
+        let root = recipe_with_secret(
+            None,
+            vec![
+                sub_recipe(oversized_path.to_string_lossy()),
+                sub_recipe(small_path.to_string_lossy()),
+            ],
+        );
+
+        let secrets = discover_recipe_secrets_with_limits(
+            &root,
+            DiscoveryLimits {
+                max_depth: 1,
+                max_recipes: 2,
+                max_loaded_bytes: small_size,
+            },
+        );
+
+        assert_eq!(
+            secrets
+                .iter()
+                .map(|secret| secret.key.as_str())
+                .collect::<Vec<_>>(),
+            ["SMALL_TOKEN"]
+        );
     }
 
     #[test]

--- a/crates/goose-cli/src/recipes/secret_discovery.rs
+++ b/crates/goose-cli/src/recipes/secret_discovery.rs
@@ -1,4 +1,5 @@
-use crate::recipes::search_recipe::{load_recipe_file_with_byte_limit, BoundedRecipeFile};
+use crate::recipes::github_recipe::BoundedRecipeLoad;
+use crate::recipes::search_recipe::load_recipe_file_with_byte_limit;
 use goose::agents::extension::ExtensionConfig;
 use goose::recipe::Recipe;
 use regex::{NoExpand, Regex};
@@ -115,7 +116,7 @@ fn discover_recipe_secrets_with_limits_and_loader<F>(
     mut load_recipe: F,
 ) -> Vec<SecretRequirement>
 where
-    F: FnMut(&str, usize) -> anyhow::Result<BoundedRecipeFile>,
+    F: FnMut(&str, usize) -> BoundedRecipeLoad,
 {
     let mut secrets: Vec<SecretRequirement> = Vec::new();
     let mut seen_keys = HashSet::new();
@@ -148,21 +149,23 @@ where
         loaded_recipes += 1;
 
         let remaining_bytes = limits.max_loaded_bytes - loaded_bytes;
-        let Ok(bounded_recipe_file) = load_recipe(&next.path, remaining_bytes) else {
-            continue;
-        };
-        if bounded_recipe_file.consumed_bytes < bounded_recipe_file.recipe_file.content.len() {
+        let bounded_load = load_recipe(&next.path, remaining_bytes);
+        let Some(consumed_bytes) = bounded_load.consumed_bytes else {
             break;
-        }
-        let Some(next_loaded_bytes) = loaded_bytes.checked_add(bounded_recipe_file.consumed_bytes)
-        else {
+        };
+        let Some(next_loaded_bytes) = loaded_bytes.checked_add(consumed_bytes) else {
             break;
         };
         if next_loaded_bytes > limits.max_loaded_bytes {
             break;
         }
         loaded_bytes = next_loaded_bytes;
-        let recipe_file = bounded_recipe_file.recipe_file;
+        let Ok(recipe_file) = bounded_load.recipe_file else {
+            continue;
+        };
+        if consumed_bytes < recipe_file.content.len() {
+            break;
+        }
 
         let file_identity = recipe_file
             .file_path
@@ -732,16 +735,19 @@ mod tests {
                 let content = contents.get(path).unwrap().clone();
                 let consumed_bytes = content.len() + sibling_payload_bytes;
                 if consumed_bytes > max_bytes {
-                    return Err(anyhow::anyhow!("bundle exceeds remaining budget"));
+                    return BoundedRecipeLoad {
+                        recipe_file: Err(anyhow::anyhow!("bundle exceeds remaining budget")),
+                        consumed_bytes: None,
+                    };
                 }
-                Ok(BoundedRecipeFile {
-                    recipe_file: goose::recipe::read_recipe_file_content::RecipeFile {
+                BoundedRecipeLoad {
+                    recipe_file: Ok(goose::recipe::read_recipe_file_content::RecipeFile {
                         content,
                         parent_dir: temp_dir.path().join(path),
                         file_path: temp_dir.path().join(format!("{path}.yaml")),
-                    },
-                    consumed_bytes,
-                })
+                    }),
+                    consumed_bytes: Some(consumed_bytes),
+                }
             },
         );
 
@@ -752,6 +758,77 @@ mod tests {
                 .collect::<Vec<_>>(),
             ["FIRST_TOKEN"]
         );
+    }
+
+    #[test]
+    fn failed_github_bundles_are_charged_before_continuing() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let first_content =
+            serde_yaml::to_string(&recipe_with_secret(Some("FIRST_TOKEN"), vec![])).unwrap();
+        let second_content =
+            serde_yaml::to_string(&recipe_with_secret(Some("SECOND_TOKEN"), vec![])).unwrap();
+        let beyond_content =
+            serde_yaml::to_string(&recipe_with_secret(Some("BEYOND_TOKEN"), vec![])).unwrap();
+        let failed_bundle_bytes = 256;
+        let aggregate_budget = failed_bundle_bytes * 2 + first_content.len() + second_content.len();
+        let contents = HashMap::from([
+            ("first".to_string(), first_content),
+            ("second".to_string(), second_content),
+            ("beyond".to_string(), beyond_content),
+        ]);
+        let root = recipe_with_secret(
+            None,
+            vec![
+                sub_recipe("malformed-one"),
+                sub_recipe("first"),
+                sub_recipe("malformed-two"),
+                sub_recipe("second"),
+                sub_recipe("beyond"),
+            ],
+        );
+        let mut requested_limits = Vec::new();
+
+        let secrets = discover_recipe_secrets_with_limits_and_loader(
+            &root,
+            DiscoveryLimits {
+                max_depth: 1,
+                max_recipes: 5,
+                max_loaded_bytes: aggregate_budget,
+            },
+            |path, max_bytes| {
+                requested_limits.push((path.to_string(), max_bytes));
+                if path.starts_with("malformed-") {
+                    return BoundedRecipeLoad {
+                        recipe_file: Err(anyhow::anyhow!("recipe file missing")),
+                        consumed_bytes: Some(failed_bundle_bytes),
+                    };
+                }
+                let content = contents.get(path).unwrap().clone();
+                if content.len() > max_bytes {
+                    return BoundedRecipeLoad {
+                        recipe_file: Err(anyhow::anyhow!("bundle exceeds remaining budget")),
+                        consumed_bytes: None,
+                    };
+                }
+                BoundedRecipeLoad {
+                    consumed_bytes: Some(content.len()),
+                    recipe_file: Ok(goose::recipe::read_recipe_file_content::RecipeFile {
+                        content,
+                        parent_dir: temp_dir.path().join(path),
+                        file_path: temp_dir.path().join(format!("{path}.yaml")),
+                    }),
+                }
+            },
+        );
+
+        assert_eq!(
+            secrets
+                .iter()
+                .map(|secret| secret.key.as_str())
+                .collect::<Vec<_>>(),
+            ["FIRST_TOKEN", "SECOND_TOKEN"]
+        );
+        assert_eq!(requested_limits.last().unwrap(), &("beyond".to_string(), 0));
     }
 
     #[test]

--- a/crates/goose/src/recipe/local_recipes.rs
+++ b/crates/goose/src/recipe/local_recipes.rs
@@ -4,7 +4,9 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use crate::config::paths::Paths;
-use crate::recipe::read_recipe_file_content::{read_recipe_file, RecipeFile};
+use crate::recipe::read_recipe_file_content::{
+    read_recipe_file, read_recipe_file_with_byte_limit, RecipeFile,
+};
 use crate::recipe::Recipe;
 use crate::recipe::RECIPE_FILE_EXTENSIONS;
 
@@ -46,12 +48,28 @@ fn local_recipe_dirs() -> Vec<PathBuf> {
 }
 
 pub fn load_local_recipe_file(recipe_name: &str) -> Result<RecipeFile> {
+    load_local_recipe_file_with_reader(recipe_name, |path| read_recipe_file(path))
+}
+
+pub fn load_local_recipe_file_with_byte_limit(
+    recipe_name: &str,
+    max_bytes: usize,
+) -> Result<RecipeFile> {
+    load_local_recipe_file_with_reader(recipe_name, |path| {
+        read_recipe_file_with_byte_limit(path, max_bytes)
+    })
+}
+
+fn load_local_recipe_file_with_reader(
+    recipe_name: &str,
+    read_file: impl Fn(&Path) -> Result<RecipeFile>,
+) -> Result<RecipeFile> {
     if RECIPE_FILE_EXTENSIONS
         .iter()
         .any(|ext| recipe_name.ends_with(&format!(".{}", ext)))
     {
         let path = PathBuf::from(recipe_name);
-        return read_recipe_file(path);
+        return read_file(&path);
     }
 
     if is_file_path(recipe_name) || is_file_name(recipe_name) {
@@ -63,7 +81,7 @@ pub fn load_local_recipe_file(recipe_name: &str) -> Result<RecipeFile> {
 
     let search_dirs = local_recipe_dirs();
     for dir in &search_dirs {
-        if let Ok(result) = load_recipe_file_from_dir(dir, recipe_name) {
+        if let Ok(result) = load_recipe_file_from_dir(dir, recipe_name, &read_file) {
             return Ok(result);
         }
     }
@@ -103,10 +121,14 @@ fn is_file_name(recipe_name: &str) -> bool {
     Path::new(recipe_name).extension().is_some()
 }
 
-fn load_recipe_file_from_dir(dir: &Path, recipe_name: &str) -> Result<RecipeFile> {
+fn load_recipe_file_from_dir(
+    dir: &Path,
+    recipe_name: &str,
+    read_file: &impl Fn(&Path) -> Result<RecipeFile>,
+) -> Result<RecipeFile> {
     for ext in RECIPE_FILE_EXTENSIONS {
         let recipe_path = dir.join(format!("{}.{}", recipe_name, ext));
-        if let Ok(result) = read_recipe_file(recipe_path) {
+        if let Ok(result) = read_file(&recipe_path) {
             return Ok(result);
         }
     }

--- a/crates/goose/src/recipe/local_recipes.rs
+++ b/crates/goose/src/recipe/local_recipes.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 
 use crate::config::paths::Paths;
 use crate::recipe::read_recipe_file_content::{
-    read_recipe_file, read_recipe_file_with_byte_limit, RecipeFile,
+    expand_tilde_path, read_recipe_file, read_recipe_file_with_byte_limit, RecipeFile,
 };
 use crate::recipe::Recipe;
 use crate::recipe::RECIPE_FILE_EXTENSIONS;
@@ -127,12 +127,13 @@ fn load_local_recipe_file_with_byte_limit_from_dirs(
 }
 
 fn read_bounded_local_candidate(path: &Path, max_bytes: usize) -> BoundedLocalRecipeLoad {
-    let known_bytes = fs::symlink_metadata(path)
+    let path = expand_tilde_path(path);
+    let known_bytes = fs::symlink_metadata(&path)
         .ok()
         .filter(|metadata| metadata.is_file())
         .and_then(|metadata| usize::try_from(metadata.len()).ok())
         .filter(|file_bytes| *file_bytes <= max_bytes);
-    let recipe_file = read_recipe_file_with_byte_limit(path, max_bytes);
+    let recipe_file = read_recipe_file_with_byte_limit(&path, max_bytes);
     let consumed_bytes = match &recipe_file {
         Ok(recipe_file) => recipe_file.content.len(),
         Err(_) => known_bytes.unwrap_or(0),
@@ -287,6 +288,23 @@ fn generate_recipe_filename(title: &str, recipe_library_dir: &Path) -> PathBuf {
     }
 }
 
+pub fn save_recipe_to_file(recipe: Recipe, file_path: Option<PathBuf>) -> anyhow::Result<PathBuf> {
+    let recipe_library_dir = get_recipe_library_dir(true);
+
+    let file_path_value = match file_path {
+        Some(path) => path,
+        None => generate_recipe_filename(&recipe.title, &recipe_library_dir),
+    };
+
+    if let Some(parent) = file_path_value.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let yaml_content = recipe.to_yaml()?;
+    fs::write(&file_path_value, yaml_content)?;
+    Ok(file_path_value)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -317,21 +335,24 @@ mod tests {
         assert_eq!(exhausted.consumed_bytes, invalid_yaml.len());
         assert!(exhausted.recipe_file.is_err());
     }
-}
 
-pub fn save_recipe_to_file(recipe: Recipe, file_path: Option<PathBuf>) -> anyhow::Result<PathBuf> {
-    let recipe_library_dir = get_recipe_library_dir(true);
+    #[cfg(unix)]
+    #[test]
+    fn bounded_tilde_paths_share_read_and_accounting_resolution() {
+        let home = tempfile::tempdir().unwrap();
+        let home_path = home.path().to_string_lossy().into_owned();
+        let _guard = env_lock::lock_env([("HOME", Some(home_path.as_str()))]);
+        let invalid_content = [0xff; 8];
+        fs::write(home.path().join("invalid.yaml"), invalid_content).unwrap();
+        let valid_content = "title: valid";
+        fs::write(home.path().join("valid.yaml"), valid_content).unwrap();
 
-    let file_path_value = match file_path {
-        Some(path) => path,
-        None => generate_recipe_filename(&recipe.title, &recipe_library_dir),
-    };
+        let invalid = read_bounded_local_candidate(Path::new("~/invalid.yaml"), 32);
+        assert!(invalid.recipe_file.is_err());
+        assert_eq!(invalid.consumed_bytes, invalid_content.len());
 
-    if let Some(parent) = file_path_value.parent() {
-        fs::create_dir_all(parent)?;
+        let valid = read_bounded_local_candidate(Path::new("~/valid.yaml"), 32);
+        assert_eq!(valid.consumed_bytes, valid_content.len());
+        assert_eq!(valid.recipe_file.unwrap().content, valid_content);
     }
-
-    let yaml_content = recipe.to_yaml()?;
-    fs::write(&file_path_value, yaml_content)?;
-    Ok(file_path_value)
 }

--- a/crates/goose/src/recipe/local_recipes.rs
+++ b/crates/goose/src/recipe/local_recipes.rs
@@ -60,6 +60,89 @@ pub fn load_local_recipe_file_with_byte_limit(
     })
 }
 
+pub struct BoundedLocalRecipeLoad {
+    pub recipe_file: Result<RecipeFile>,
+    pub consumed_bytes: usize,
+}
+
+pub fn load_local_recipe_file_with_byte_limit_and_consumption(
+    recipe_name: &str,
+    max_bytes: usize,
+) -> BoundedLocalRecipeLoad {
+    load_local_recipe_file_with_byte_limit_from_dirs(recipe_name, max_bytes, &local_recipe_dirs())
+}
+
+fn load_local_recipe_file_with_byte_limit_from_dirs(
+    recipe_name: &str,
+    max_bytes: usize,
+    search_dirs: &[PathBuf],
+) -> BoundedLocalRecipeLoad {
+    if RECIPE_FILE_EXTENSIONS
+        .iter()
+        .any(|ext| recipe_name.ends_with(&format!(".{ext}")))
+    {
+        return read_bounded_local_candidate(Path::new(recipe_name), max_bytes);
+    }
+
+    if is_file_path(recipe_name) || is_file_name(recipe_name) {
+        return BoundedLocalRecipeLoad {
+            recipe_file: Err(anyhow!(
+                "Recipe file {} is not a json or yaml file",
+                recipe_name
+            )),
+            consumed_bytes: 0,
+        };
+    }
+
+    let mut consumed_bytes = 0;
+    for dir in search_dirs {
+        for ext in RECIPE_FILE_EXTENSIONS {
+            let remaining_bytes = max_bytes - consumed_bytes;
+            let recipe_path = dir.join(format!("{recipe_name}.{ext}"));
+            let candidate = read_bounded_local_candidate(&recipe_path, remaining_bytes);
+            consumed_bytes += candidate.consumed_bytes;
+            if candidate.recipe_file.is_ok() {
+                return BoundedLocalRecipeLoad {
+                    recipe_file: candidate.recipe_file,
+                    consumed_bytes,
+                };
+            }
+        }
+    }
+
+    let search_dirs_str = search_dirs
+        .iter()
+        .map(|path| path.display().to_string())
+        .collect::<Vec<_>>()
+        .join(":");
+    BoundedLocalRecipeLoad {
+        recipe_file: Err(anyhow!(
+            "ℹ️  Failed to retrieve {}.yaml or {}.json in {}",
+            recipe_name,
+            recipe_name,
+            search_dirs_str
+        )),
+        consumed_bytes,
+    }
+}
+
+fn read_bounded_local_candidate(path: &Path, max_bytes: usize) -> BoundedLocalRecipeLoad {
+    let known_bytes = fs::symlink_metadata(path)
+        .ok()
+        .filter(|metadata| metadata.is_file())
+        .and_then(|metadata| usize::try_from(metadata.len()).ok())
+        .filter(|file_bytes| *file_bytes <= max_bytes);
+    let recipe_file = read_recipe_file_with_byte_limit(path, max_bytes);
+    let consumed_bytes = match &recipe_file {
+        Ok(recipe_file) => recipe_file.content.len(),
+        Err(_) => known_bytes.unwrap_or(0),
+    };
+    BoundedLocalRecipeLoad {
+        recipe_file,
+        consumed_bytes,
+    }
+}
+
 fn load_local_recipe_file_with_reader(
     recipe_name: &str,
     read_file: impl Fn(&Path) -> Result<RecipeFile>,
@@ -201,6 +284,38 @@ fn generate_recipe_filename(title: &str, recipe_library_dir: &Path) -> PathBuf {
             return candidate;
         }
         counter += 1;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bounded_extensionless_search_charges_failed_candidates() {
+        let directory = tempfile::tempdir().unwrap();
+        let invalid_yaml = [0xff; 8];
+        let valid_json = br#"{"title":"valid"}"#;
+        fs::write(directory.path().join("candidate.yaml"), invalid_yaml).unwrap();
+        fs::write(directory.path().join("candidate.json"), valid_json).unwrap();
+        let budget = invalid_yaml.len() + valid_json.len();
+
+        let loaded = load_local_recipe_file_with_byte_limit_from_dirs(
+            "candidate",
+            budget,
+            &[directory.path().to_path_buf()],
+        );
+
+        assert_eq!(loaded.consumed_bytes, budget);
+        assert_eq!(loaded.recipe_file.unwrap().content.as_bytes(), valid_json);
+
+        let exhausted = load_local_recipe_file_with_byte_limit_from_dirs(
+            "candidate",
+            invalid_yaml.len(),
+            &[directory.path().to_path_buf()],
+        );
+        assert_eq!(exhausted.consumed_bytes, invalid_yaml.len());
+        assert!(exhausted.recipe_file.is_err());
     }
 }
 

--- a/crates/goose/src/recipe/read_recipe_file_content.rs
+++ b/crates/goose/src/recipe/read_recipe_file_content.rs
@@ -27,7 +27,7 @@ fn read_recipe_file_with<P: AsRef<Path>>(
     read_content: impl FnOnce(&Path, &Path) -> std::io::Result<String>,
 ) -> Result<RecipeFile> {
     let raw_path = recipe_path.as_ref();
-    let path = convert_path_with_tilde_expansion(raw_path);
+    let path = expand_tilde_path(raw_path);
     let parent = path
         .parent()
         .filter(|parent| !parent.as_os_str().is_empty())
@@ -53,7 +53,7 @@ fn read_recipe_file_with<P: AsRef<Path>>(
     })
 }
 
-fn convert_path_with_tilde_expansion(path: &Path) -> PathBuf {
+pub(crate) fn expand_tilde_path(path: &Path) -> PathBuf {
     if let Some(path_str) = path.to_str() {
         // Handle exact "~" (Windows only to avoid changing behavior on Unix)
         if cfg!(windows) && path_str == "~" {
@@ -80,7 +80,7 @@ fn convert_path_with_tilde_expansion(path: &Path) -> PathBuf {
 
 pub fn read_parameter_file_content<P: AsRef<Path>>(file_path: P) -> Result<String> {
     let raw_path = file_path.as_ref();
-    let path = convert_path_with_tilde_expansion(raw_path);
+    let path = expand_tilde_path(raw_path);
 
     let content = fs::read_to_string(&path)
         .map_err(|e| anyhow!("Failed to read parameter file {}: {}", path.display(), e))?;

--- a/crates/goose/src/recipe/read_recipe_file_content.rs
+++ b/crates/goose/src/recipe/read_recipe_file_content.rs
@@ -10,6 +10,22 @@ pub struct RecipeFile {
 }
 
 pub fn read_recipe_file<P: AsRef<Path>>(recipe_path: P) -> Result<RecipeFile> {
+    read_recipe_file_with(recipe_path, crate::skills::read_source_file)
+}
+
+pub fn read_recipe_file_with_byte_limit<P: AsRef<Path>>(
+    recipe_path: P,
+    max_bytes: usize,
+) -> Result<RecipeFile> {
+    read_recipe_file_with(recipe_path, |parent_dir, file_name| {
+        crate::skills::read_source_file_with_byte_limit(parent_dir, file_name, max_bytes)
+    })
+}
+
+fn read_recipe_file_with<P: AsRef<Path>>(
+    recipe_path: P,
+    read_content: impl FnOnce(&Path, &Path) -> std::io::Result<String>,
+) -> Result<RecipeFile> {
     let raw_path = recipe_path.as_ref();
     let path = convert_path_with_tilde_expansion(raw_path);
     let parent = path
@@ -26,7 +42,7 @@ pub fn read_recipe_file<P: AsRef<Path>>(recipe_path: P) -> Result<RecipeFile> {
     let file_name = path
         .file_name()
         .ok_or_else(|| anyhow!("Recipe path has no file name: {}", path.display()))?;
-    let content = crate::skills::read_source_file(&parent_dir, Path::new(file_name))
+    let content = read_content(&parent_dir, Path::new(file_name))
         .map_err(|e| anyhow!("Failed to read recipe file {}: {}", path.display(), e))?;
     let file_path = parent_dir.join(file_name);
 
@@ -99,6 +115,22 @@ mod tests {
             .unwrap_err()
             .to_string()
             .contains("Failed to read parameter file"));
+    }
+
+    #[test]
+    fn byte_limited_recipe_read_enforces_the_exact_encoded_boundary() {
+        let temp_dir = TempDir::new().unwrap();
+        let recipe = temp_dir.path().join("recipe.yaml");
+        let content = "title: café";
+        std::fs::write(&recipe, content).unwrap();
+
+        assert_eq!(
+            read_recipe_file_with_byte_limit(&recipe, content.len())
+                .unwrap()
+                .content,
+            content
+        );
+        assert!(read_recipe_file_with_byte_limit(&recipe, content.len() - 1).is_err());
     }
 
     #[cfg(unix)]

--- a/crates/goose/src/skills/mod.rs
+++ b/crates/goose/src/skills/mod.rs
@@ -8,7 +8,9 @@ pub mod client;
 mod supporting_files;
 
 pub use client::{SkillsClient, EXTENSION_NAME};
-pub(crate) use supporting_files::{load_supporting_file, read_source_file};
+pub(crate) use supporting_files::{
+    load_supporting_file, read_source_file, read_source_file_with_byte_limit,
+};
 
 use crate::config::{paths::Paths, Config};
 use crate::plugins::installed_plugin_skill_dirs;

--- a/crates/goose/src/skills/supporting_files.rs
+++ b/crates/goose/src/skills/supporting_files.rs
@@ -69,6 +69,14 @@ pub(crate) fn read_source_file(source_dir: &Path, relative: &Path) -> io::Result
     )
 }
 
+pub(crate) fn read_source_file_with_byte_limit(
+    source_dir: &Path,
+    relative: &Path,
+    max_bytes: usize,
+) -> io::Result<String> {
+    read_confined_file_with_hook(source_dir, relative, ReadLimit::Bytes(max_bytes), |_| {})
+}
+
 fn read_supporting_file_with_hook(
     skill_dir: &Path,
     relative: &Path,


### PR DESCRIPTION
## Summary

- replace recursive sub-recipe secret discovery with a bounded iterative depth-first traversal
- cap traversal at 64 levels, 256 unique load attempts, and 1 MiB of aggregate loaded recipe data
- preserve bundled sibling recipes while bounding GitHub archive extraction
- derive GitHub extraction paths from the complete repository and recipe request identity
- canonicalize local recipe identities so aliases and cycles do not consume the recipe budget
- preserve discovery order and partial-results behavior for unreadable or malformed children

## Verification

- `cargo test -p goose-cli github_recipe --lib`
- `cargo test -p goose-cli secret_discovery --lib`
- `cargo build -p goose-cli`
- `cargo clippy -p goose-cli --all-targets -- -D warnings`
- `cargo fmt --all`
- `git diff --check`

*This finding was discovered by [Project Loupe](https://github.com/project-loupe/loupe)*
