### PR TITLE
fix(desktop): bound HTML comment scanning

### DIFF
--- a/ui/desktop/src/utils/htmlSecurity.test.ts
+++ b/ui/desktop/src/utils/htmlSecurity.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { performance } from 'node:perf_hooks';
 import { containsHTML, wrapHTMLInCodeBlock } from '../utils/htmlSecurity';
 
 describe('HTML Security Detection', () => {
@@ -93,6 +94,15 @@ describe('HTML Security Detection', () => {
         expect(containsHTML('<>')).toBe(false);
         expect(containsHTML('< div >')).toBe(false);
       });
+
+      it('rejects unterminated comment prefixes without blocking the renderer', () => {
+        const maliciousContent = '<!--'.repeat(64_000);
+        const startedAt = performance.now();
+
+        expect(containsHTML(maliciousContent)).toBe(false);
+
+        expect(performance.now() - startedAt).toBeLessThan(750);
+      }, 10_000);
     });
   });
 

--- a/ui/desktop/src/utils/htmlSecurity.ts
+++ b/ui/desktop/src/utils/htmlSecurity.ts
@@ -15,8 +15,9 @@ export function containsHTML(str: string): boolean {
   const withoutCodeBlocks = str.replace(/```[\s\S]*?```/g, '').replace(/`[^`]*`/g, '');
 
   // Check for HTML comments first
-  const commentRegex = /<!--[\s\S]*?-->/;
-  const hasComments = commentRegex.test(withoutCodeBlocks);
+  const commentStart = withoutCodeBlocks.indexOf('<!--');
+  const hasComments =
+    commentStart !== -1 && withoutCodeBlocks.indexOf('-->', commentStart + 4) !== -1;
 
   // Only detect potentially dangerous HTML tags that could execute or affect layout
   const dangerousHTMLRegex =


### PR DESCRIPTION
## Summary

- replace the backtracking HTML-comment regex with direct delimiter searches
- preserve existing behavior for complete comments and unterminated prefixes
- cover a 256 KiB repeated-prefix input with a renderer-blocking regression test

## Verification

- fail-before: focused Vitest took about 1.53 seconds and failed the 750 ms work bound
- `pnpm test:run src/utils/htmlSecurity.test.ts` (29 passed)
- `pnpm run typecheck`
- focused ESLint with zero warnings on both changed files
- Prettier and `git diff --check`

*This finding was discovered by [Project Loupe](https://github.com/project-loupe/loupe)*
