### PR TITLE
feat(desktop): sort configured providers to the top of the provider list

### DIFF
--- a/ui/desktop/src/components/settings/providers/ProviderGrid.tsx
+++ b/ui/desktop/src/components/settings/providers/ProviderGrid.tsx
@@ -247,9 +247,10 @@ function ProviderCards({
   const providerCards = useMemo(() => {
     // providers needs to be an array
     const providersArray = Array.isArray(providers) ? providers : [];
-    // Sort providers alphabetically by display name
-    const sortedProviders = [...providersArray].sort((a, b) =>
-      a.metadata.display_name.localeCompare(b.metadata.display_name)
+    const sortedProviders = [...providersArray].sort(
+      (a, b) =>
+        Number(b.is_configured) - Number(a.is_configured) ||
+        a.metadata.display_name.localeCompare(b.metadata.display_name)
     );
     const filteredProviders = query
       ? sortedProviders.filter(


### PR DESCRIPTION
## Summary
The provider grid sorted alphabetically only, so users had to search or scroll to reach the one or two providers they had configured.

Fix: Sort on `is_configured` first, keeping display-name ordering within each group.

### Testing
Existing CI

### Related Issues
#11330

### Screenshots/Demos (for UX changes)
Before:  
<img width="1832" height="1431" alt="Screenshot 2026-08-20 at 12 05 22 PM" src="https://github.com/user-attachments/assets/03eb84e5-3a2a-4acd-bb5e-e2be92172621" />

After:
<img width="1832" height="1431" alt="Screenshot 2026-08-20 at 12 05 12 PM" src="https://github.com/user-attachments/assets/4f4adfc8-b98a-40dc-a514-63fe5c355a27" />
