### PR TITLE
fix(acp): bind MCP app tools to extension owners

### DIFF
--- a/crates/goose-sdk-types/src/custom_requests.rs
+++ b/crates/goose-sdk-types/src/custom_requests.rs
@@ -99,6 +99,7 @@ pub struct ReadResourceResponse {
 #[serde(rename_all = "camelCase")]
 pub struct GooseToolCallRequest {
     pub session_id: String,
+    pub extension_name: String,
     pub name: String,
     #[serde(default)]
     pub arguments: serde_json::Value,

--- a/crates/goose/acp-schema.json
+++ b/crates/goose/acp-schema.json
@@ -561,6 +561,9 @@
         "sessionId": {
           "type": "string"
         },
+        "extensionName": {
+          "type": "string"
+        },
         "name": {
           "type": "string"
         },
@@ -570,6 +573,7 @@
       },
       "required": [
         "sessionId",
+        "extensionName",
         "name"
       ],
       "description": "Call a tool from an extension.",

--- a/crates/goose/src/acp/server/tools.rs
+++ b/crates/goose/src/acp/server/tools.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::agents::extension_manager::get_parameter_names;
+use crate::agents::extension_manager::{get_parameter_names, is_tool_owned_by_extension};
 use crate::agents::reply_parts::is_tool_visible_to_app;
 use crate::config::permission::PermissionLevel;
 use goose_sdk_types::custom_requests::{ToolListItem, ToolPermissionLevel};
@@ -63,9 +63,13 @@ impl GooseAcpAgent {
     ) -> Result<GooseToolCallResponse, agent_client_protocol::Error> {
         let session_id = &req.session_id;
         let agent = self.get_session_agent(&req.session_id).await?;
-        let tools = agent.list_tools(session_id, None).await;
+        let tools = agent
+            .list_tools(session_id, Some(req.extension_name.clone()))
+            .await;
 
-        let Some(tool) = tools.iter().find(|t| *t.name == req.name) else {
+        let Some(tool) = tools.iter().find(|tool| {
+            *tool.name == req.name && is_tool_owned_by_extension(tool, &req.extension_name)
+        }) else {
             return Err(agent_client_protocol::Error::invalid_params().data("tool not found"));
         };
 

--- a/crates/goose/src/acp/server/tools.rs
+++ b/crates/goose/src/acp/server/tools.rs
@@ -116,7 +116,12 @@ impl GooseAcpAgent {
         );
         let tool_result = agent
             .extension_manager
-            .dispatch_tool_call(&ctx, tool_call, CancellationToken::new())
+            .dispatch_app_tool_call(
+                &ctx,
+                tool_call,
+                &req.extension_name,
+                CancellationToken::new(),
+            )
             .await
             .map_err(|e| agent_client_protocol::Error::internal_error().data(e.to_string()))?;
 

--- a/crates/goose/src/agents/extension_manager.rs
+++ b/crates/goose/src/agents/extension_manager.rs
@@ -39,6 +39,7 @@ use crate::agents::extension_malware_check;
 use crate::agents::mcp_client::{
     GooseMcpClientCapabilities, GooseMcpHostInfo, McpClient, McpClientTrait,
 };
+use crate::agents::reply_parts::is_tool_visible_to_app;
 use crate::builtin_extension::get_builtin_extension;
 use crate::config::extensions::name_to_key;
 use crate::config::search_path::SearchPaths;
@@ -2211,10 +2212,22 @@ impl ExtensionManager {
         }
     }
 
+    #[cfg(test)]
     async fn resolve_tool(
         &self,
         session_id: &str,
         tool_name: &str,
+    ) -> Result<ResolvedTool, ErrorData> {
+        self.resolve_tool_with_constraints(session_id, tool_name, None, false)
+            .await
+    }
+
+    async fn resolve_tool_with_constraints(
+        &self,
+        session_id: &str,
+        tool_name: &str,
+        expected_extension_name: Option<&str>,
+        require_app_visibility: bool,
     ) -> Result<ResolvedTool, ErrorData> {
         let tools = self.get_all_tools_cached(session_id).await.map_err(|e| {
             ErrorData::new(
@@ -2237,6 +2250,24 @@ impl ExtensionManager {
                             None,
                         )
                     })?;
+
+                if expected_extension_name
+                    .is_some_and(|expected| name_to_key(expected) != name_to_key(&owner))
+                {
+                    return Err(ErrorData::new(
+                        ErrorCode::RESOURCE_NOT_FOUND,
+                        format!("Tool '{}' not found for extension", tool_name),
+                        None,
+                    ));
+                }
+
+                if require_app_visibility && !is_tool_visible_to_app(tool) {
+                    return Err(ErrorData::new(
+                        ErrorCode::INVALID_PARAMS,
+                        "Tool is not visible to app clients",
+                        None,
+                    ));
+                }
 
                 let actual_tool_name = name
                     .strip_prefix(&format!("{owner}__"))
@@ -2299,8 +2330,44 @@ impl ExtensionManager {
         tool_call: CallToolRequestParams,
         cancellation_token: CancellationToken,
     ) -> std::result::Result<ToolCallResult, ErrorData> {
+        self.dispatch_tool_call_inner(ctx, tool_call, None, false, cancellation_token)
+            .await
+    }
+
+    pub async fn dispatch_app_tool_call(
+        &self,
+        ctx: &super::tool_execution::ToolCallContext,
+        tool_call: CallToolRequestParams,
+        extension_name: &str,
+        cancellation_token: CancellationToken,
+    ) -> std::result::Result<ToolCallResult, ErrorData> {
+        self.dispatch_tool_call_inner(
+            ctx,
+            tool_call,
+            Some(extension_name),
+            true,
+            cancellation_token,
+        )
+        .await
+    }
+
+    async fn dispatch_tool_call_inner(
+        &self,
+        ctx: &super::tool_execution::ToolCallContext,
+        tool_call: CallToolRequestParams,
+        expected_extension_name: Option<&str>,
+        require_app_visibility: bool,
+        cancellation_token: CancellationToken,
+    ) -> std::result::Result<ToolCallResult, ErrorData> {
         let tool_name_str = tool_call.name.to_string();
-        let resolved = self.resolve_tool(&ctx.session_id, &tool_name_str).await?;
+        let resolved = self
+            .resolve_tool_with_constraints(
+                &ctx.session_id,
+                &tool_name_str,
+                expected_extension_name,
+                require_app_visibility,
+            )
+            .await?;
 
         if let Some(extension) = self.extensions.lock().await.get(&resolved.extension_name) {
             if !extension
@@ -3524,6 +3591,60 @@ mod tests {
 
         assert!(is_tool_owned_by_extension(&own_tool, "ext_a"));
         assert!(!is_tool_owned_by_extension(&sibling_tool, "ext_a"));
+    }
+
+    #[tokio::test]
+    async fn app_dispatch_revalidates_owner_after_tools_cache_changes() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let extension_manager =
+            ExtensionManager::new_without_provider(temp_dir.path().to_path_buf());
+        extension_manager
+            .add_mock_extension("ext_a__ext_b".to_string(), Arc::new(MockClient {}))
+            .await;
+
+        let app_tool = |owner: &str| {
+            let mut tool = Tool::new(
+                "ext_a__ext_b__secret".to_string(),
+                "test tool".to_string(),
+                Arc::new(serde_json::Map::new()),
+            );
+            tool.meta = Some(MetaObject(
+                serde_json::json!({
+                    TOOL_EXTENSION_META_KEY: owner,
+                    "ui": { "resourceUri": "ui://test/app" }
+                })
+                .as_object()
+                .unwrap()
+                .clone(),
+            ));
+            tool
+        };
+
+        *extension_manager.tools_cache.lock().await = Some(Arc::new(vec![app_tool("ext_a")]));
+        let initially_visible = extension_manager
+            .get_prefixed_tools("session", Some("ext_a".to_string()))
+            .await
+            .unwrap();
+        assert_eq!(initially_visible.len(), 1);
+
+        // Model tools/list_changed replacing the validated tool with a sibling
+        // owner's colliding flattened name before the actual dispatch.
+        *extension_manager.tools_cache.lock().await =
+            Some(Arc::new(vec![app_tool("ext_a__ext_b")]));
+        let ctx = ToolCallContext::new("session".to_string(), None, None);
+        let result = extension_manager
+            .dispatch_app_tool_call(
+                &ctx,
+                CallToolRequestParams::new("ext_a__ext_b__secret".to_string()),
+                "ext_a",
+                CancellationToken::default(),
+            )
+            .await;
+
+        let Err(error) = result else {
+            panic!("app dispatch accepted a sibling owner's colliding tool name");
+        };
+        assert_eq!(error.code, ErrorCode::RESOURCE_NOT_FOUND);
     }
 
     #[tokio::test]

--- a/crates/goose/src/agents/extension_manager.rs
+++ b/crates/goose/src/agents/extension_manager.rs
@@ -281,6 +281,11 @@ pub fn get_tool_owner(tool: &Tool) -> Option<String> {
         .map(|s| s.to_string())
 }
 
+pub(crate) fn is_tool_owned_by_extension(tool: &Tool, extension_name: &str) -> bool {
+    let expected_owner = name_to_key(extension_name);
+    get_tool_owner(tool).is_some_and(|owner| name_to_key(&owner) == expected_owner)
+}
+
 /// `tools` pairs each advertised public tool name with its owning extension's
 /// key, when known (`None` for tools with no owner metadata, e.g. those
 /// appended outside the extension manager).
@@ -3495,6 +3500,30 @@ mod tests {
 
         assert!(tool_names.iter().any(|n| n.starts_with("ext_a__")));
         assert!(!tool_names.iter().any(|n| n.starts_with("ext_b__")));
+    }
+
+    #[test]
+    fn test_tool_owner_binding_uses_metadata_not_flattened_name() {
+        let tool = |name: &str, owner: &str| {
+            let mut tool = Tool::new(
+                name.to_string(),
+                "test tool".to_string(),
+                Arc::new(serde_json::Map::new()),
+            );
+            tool.meta = Some(MetaObject(
+                serde_json::json!({ TOOL_EXTENSION_META_KEY: owner })
+                    .as_object()
+                    .unwrap()
+                    .clone(),
+            ));
+            tool
+        };
+
+        let own_tool = tool("ext_a__own", "ext_a");
+        let sibling_tool = tool("ext_a__ext_b__secret", "ext_a__ext_b");
+
+        assert!(is_tool_owned_by_extension(&own_tool, "ext_a"));
+        assert!(!is_tool_owned_by_extension(&sibling_tool, "ext_a"));
     }
 
     #[tokio::test]

--- a/crates/goose/tests/acp_custom_requests_test.rs
+++ b/crates/goose/tests/acp_custom_requests_test.rs
@@ -1188,7 +1188,11 @@ async fn call_app_tool(
     send_custom(
         conn.cx(),
         "_goose/unstable/tools/call",
-        serde_json::json!({ "sessionId": session_id, "name": APP_TOOL }),
+        serde_json::json!({
+            "sessionId": session_id,
+            "extensionName": "mcp-fixture",
+            "name": APP_TOOL
+        }),
     )
     .await
 }

--- a/ui/desktop/src/acp/__tests__/mcp-apps.test.ts
+++ b/ui/desktop/src/acp/__tests__/mcp-apps.test.ts
@@ -112,6 +112,7 @@ describe('ACP MCP app helpers', () => {
 
     expect(client.goose.toolsCall_unstable).toHaveBeenCalledWith({
       sessionId: 'session-1',
+      extensionName: 'weather',
       name: 'weather__refresh',
       arguments: { city: 'Amsterdam' },
     });

--- a/ui/desktop/src/acp/mcp-apps.ts
+++ b/ui/desktop/src/acp/mcp-apps.ts
@@ -139,6 +139,7 @@ export async function callMcpAppTool(
   const client = await getAcpClient();
   const response = await client.goose.toolsCall_unstable({
     sessionId,
+    extensionName,
     name: fullToolName,
     arguments: args || {},
   });

--- a/ui/goose-acp-client/src/generated/types.gen.ts
+++ b/ui/goose-acp-client/src/generated/types.gen.ts
@@ -278,6 +278,7 @@ export type SetToolPermissionsResponse_unstable = {
  */
 export type GooseToolCallRequest_unstable = {
     sessionId: string;
+    extensionName: string;
     name: string;
     arguments?: unknown;
 };

--- a/ui/goose-acp-client/src/generated/zod.gen.ts
+++ b/ui/goose-acp-client/src/generated/zod.gen.ts
@@ -179,6 +179,7 @@ export const zSetToolPermissionsResponse_unstable = z.record(z.string(), z.unkno
  */
 export const zGooseToolCallRequest_unstable = z.object({
     sessionId: z.string(),
+    extensionName: z.string(),
     name: z.string(),
     arguments: z.unknown().optional().default(null)
 });


### PR DESCRIPTION
## Summary

- require MCP app tool calls to carry the requesting extension name
- filter candidate tools to that extension and verify authoritative owner metadata before dispatch
- regenerate ACP schema and SDK bindings and cover sibling-name collisions

### Testing

- `cargo fmt --all -- --check`
- focused owner-binding regression
- `cargo test -p goose-sdk-types`
- `cargo build -p goose -p goose-sdk-types`
- `cargo clippy -p goose -p goose-sdk-types --all-targets -- -D warnings`
- SDK generation/build checks
- desktop MCP app tests: 9 passed
- desktop typecheck, ESLint, i18n, scoped Prettier, and diff checks

*This finding was discovered by [Project Loupe](https://github.com/project-loupe/loupe)*
