### PR TITLE
Add Blox run target for the ACP server

### DIFF
--- a/.blox/workstation.yaml
+++ b/.blox/workstation.yaml
@@ -1,0 +1,6 @@
+# The ACP endpoint binds 0.0.0.0, so it requires a secret key; a random one is
+# generated and printed per launch unless GOOSE_SERVER__SECRET_KEY is set.
+run:
+  - name: ACP Server
+    command: 'export GOOSE_SERVER__SECRET_KEY="${GOOSE_SERVER__SECRET_KEY:-$(openssl rand -hex 32)}"; echo "ACP secret key: $GOOSE_SERVER__SECRET_KEY"; exec goose serve --platform desktop --host 0.0.0.0 --port 3284'
+    port: 3284


### PR DESCRIPTION
Adds `.blox/workstation.yaml`