### PR TITLE
fix(security): protect gateway pairing codes

### DIFF
--- a/crates/goose/src/config/base.rs
+++ b/crates/goose/src/config/base.rs
@@ -987,15 +987,16 @@ impl Config {
         Ok(())
     }
 
-    fn mutate_secrets(
+    fn mutate_secrets<T>(
         &self,
-        mutate: impl FnOnce(&mut HashMap<String, Value>),
-    ) -> Result<(), ConfigError> {
+        mutate: impl FnOnce(&mut HashMap<String, Value>) -> Result<T, ConfigError>,
+    ) -> Result<T, ConfigError> {
         let _guard = self.guard.lock().unwrap();
         let _storage_lock = self.lock_secrets_for_mutation()?;
         let mut values = self.load_secrets_from_storage()?;
-        mutate(&mut values);
-        self.write_all_secrets(&values)
+        let result = mutate(&mut values)?;
+        self.write_all_secrets(&values)?;
+        Ok(result)
     }
 
     /// Set a secret value in the system keyring.
@@ -1019,6 +1020,29 @@ impl Config {
         let value = serde_json::to_value(value)?;
         self.mutate_secrets(|values| {
             values.insert(key.to_string(), value);
+            Ok(())
+        })
+    }
+
+    pub fn update_secret<T, V, R>(
+        &self,
+        key: &str,
+        update: impl FnOnce(T) -> (V, R),
+    ) -> Result<R, ConfigError>
+    where
+        T: for<'de> Deserialize<'de> + Default,
+        V: Serialize,
+    {
+        self.mutate_secrets(|values| {
+            let current = values
+                .get(key)
+                .cloned()
+                .map(serde_json::from_value)
+                .transpose()?
+                .unwrap_or_default();
+            let (updated, result) = update(current);
+            values.insert(key.to_string(), serde_json::to_value(updated)?);
+            Ok(result)
         })
     }
 
@@ -1036,6 +1060,7 @@ impl Config {
             for (key, value) in updates {
                 values.insert(key.clone(), value.clone());
             }
+            Ok(())
         })
     }
 
@@ -1052,6 +1077,7 @@ impl Config {
     pub fn delete_secret(&self, key: &str) -> Result<(), ConfigError> {
         self.mutate_secrets(|values| {
             values.remove(key);
+            Ok(())
         })
     }
 
@@ -1065,6 +1091,7 @@ impl Config {
             for key in keys {
                 values.remove(key);
             }
+            Ok(())
         })
     }
 

--- a/crates/goose/src/config/base.rs
+++ b/crates/goose/src/config/base.rs
@@ -136,6 +136,16 @@ enum SecretStorage {
     },
 }
 
+enum SecretMutation<T> {
+    Write(T),
+    Unchanged(T),
+}
+
+pub(crate) enum SecretUpdate<V, R> {
+    Write(V, R),
+    Unchanged(R),
+}
+
 // Global instance
 static GLOBAL_CONFIG: OnceCell<Config> = OnceCell::new();
 
@@ -989,14 +999,18 @@ impl Config {
 
     fn mutate_secrets<T>(
         &self,
-        mutate: impl FnOnce(&mut HashMap<String, Value>) -> Result<T, ConfigError>,
+        mutate: impl FnOnce(&mut HashMap<String, Value>) -> Result<SecretMutation<T>, ConfigError>,
     ) -> Result<T, ConfigError> {
         let _guard = self.guard.lock().unwrap();
         let _storage_lock = self.lock_secrets_for_mutation()?;
         let mut values = self.load_secrets_from_storage()?;
-        let result = mutate(&mut values)?;
-        self.write_all_secrets(&values)?;
-        Ok(result)
+        match mutate(&mut values)? {
+            SecretMutation::Write(result) => {
+                self.write_all_secrets(&values)?;
+                Ok(result)
+            }
+            SecretMutation::Unchanged(result) => Ok(result),
+        }
     }
 
     /// Set a secret value in the system keyring.
@@ -1020,14 +1034,14 @@ impl Config {
         let value = serde_json::to_value(value)?;
         self.mutate_secrets(|values| {
             values.insert(key.to_string(), value);
-            Ok(())
+            Ok(SecretMutation::Write(()))
         })
     }
 
-    pub fn update_secret<T, V, R>(
+    pub(crate) fn update_secret<T, V, R>(
         &self,
         key: &str,
-        update: impl FnOnce(T) -> (V, R),
+        update: impl FnOnce(T) -> SecretUpdate<V, R>,
     ) -> Result<R, ConfigError>
     where
         T: for<'de> Deserialize<'de> + Default,
@@ -1040,9 +1054,13 @@ impl Config {
                 .map(serde_json::from_value)
                 .transpose()?
                 .unwrap_or_default();
-            let (updated, result) = update(current);
-            values.insert(key.to_string(), serde_json::to_value(updated)?);
-            Ok(result)
+            match update(current) {
+                SecretUpdate::Write(updated, result) => {
+                    values.insert(key.to_string(), serde_json::to_value(updated)?);
+                    Ok(SecretMutation::Write(result))
+                }
+                SecretUpdate::Unchanged(result) => Ok(SecretMutation::Unchanged(result)),
+            }
         })
     }
 
@@ -1060,7 +1078,7 @@ impl Config {
             for (key, value) in updates {
                 values.insert(key.clone(), value.clone());
             }
-            Ok(())
+            Ok(SecretMutation::Write(()))
         })
     }
 
@@ -1077,7 +1095,7 @@ impl Config {
     pub fn delete_secret(&self, key: &str) -> Result<(), ConfigError> {
         self.mutate_secrets(|values| {
             values.remove(key);
-            Ok(())
+            Ok(SecretMutation::Write(()))
         })
     }
 
@@ -1091,7 +1109,7 @@ impl Config {
             for key in keys {
                 values.remove(key);
             }
-            Ok(())
+            Ok(SecretMutation::Write(()))
         })
     }
 

--- a/crates/goose/src/config/base.rs
+++ b/crates/goose/src/config/base.rs
@@ -790,6 +790,7 @@ impl Config {
         &self,
         key: &str,
     ) -> Result<T, ConfigError> {
+        let _guard = self.guard.lock().unwrap();
         let values = self.load_write_config()?;
         let value = values
             .get(key)

--- a/crates/goose/src/config/base.rs
+++ b/crates/goose/src/config/base.rs
@@ -786,18 +786,6 @@ impl Config {
         }
     }
 
-    pub(crate) fn get_write_param<T: for<'de> Deserialize<'de>>(
-        &self,
-        key: &str,
-    ) -> Result<T, ConfigError> {
-        let _guard = self.guard.lock().unwrap();
-        let values = self.load_write_config()?;
-        let value = values
-            .get(key)
-            .ok_or_else(|| ConfigError::NotFound(key.to_string()))?;
-        Ok(serde_yaml::from_value(value.clone())?)
-    }
-
     pub(crate) fn get_param_source_values<T: for<'de> Deserialize<'de>>(
         &self,
         key: &str,

--- a/crates/goose/src/config/base.rs
+++ b/crates/goose/src/config/base.rs
@@ -786,6 +786,17 @@ impl Config {
         }
     }
 
+    pub(crate) fn get_write_param<T: for<'de> Deserialize<'de>>(
+        &self,
+        key: &str,
+    ) -> Result<T, ConfigError> {
+        let values = self.load_write_config()?;
+        let value = values
+            .get(key)
+            .ok_or_else(|| ConfigError::NotFound(key.to_string()))?;
+        Ok(serde_yaml::from_value(value.clone())?)
+    }
+
     /// Read-modify-write a configuration value atomically through the write path.
     pub fn update_param<T, V, F>(&self, key: &str, f: F) -> Result<(), ConfigError>
     where

--- a/crates/goose/src/config/base.rs
+++ b/crates/goose/src/config/base.rs
@@ -797,6 +797,38 @@ impl Config {
         Ok(serde_yaml::from_value(value.clone())?)
     }
 
+    pub(crate) fn get_param_source_values<T: for<'de> Deserialize<'de>>(
+        &self,
+        key: &str,
+    ) -> Result<Vec<T>, ConfigError> {
+        let mut source_values = Vec::new();
+        let env_key = key.to_uppercase();
+        if let Some(value) = env::var_os(&env_key) {
+            let value = value.into_string().map_err(|_| {
+                ConfigError::DeserializeError(format!(
+                    "environment variable {env_key} is not valid UTF-8"
+                ))
+            })?;
+            source_values.push(serde_json::from_value(Self::parse_env_value(&value)?)?);
+        }
+
+        for path in &self.config_paths {
+            let content = match std::fs::read_to_string(path) {
+                Ok(content) => content,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(error) => return Err(error.into()),
+            };
+            let mut values = parse_yaml_content(&content)?;
+            crate::config::migrations::run_read_migrations(&mut values);
+            let Some(value) = values.get(key) else {
+                continue;
+            };
+            source_values.push(serde_yaml::from_value(value.clone())?);
+        }
+
+        Ok(source_values)
+    }
+
     /// Read-modify-write a configuration value atomically through the write path.
     pub fn update_param<T, V, F>(&self, key: &str, f: F) -> Result<(), ConfigError>
     where

--- a/crates/goose/src/gateway/pairing.rs
+++ b/crates/goose/src/gateway/pairing.rs
@@ -32,6 +32,8 @@ struct StoredPendingCodes {
     codes: Vec<StoredPendingCode>,
     #[serde(default)]
     legacy_import_complete: bool,
+    #[serde(default)]
+    imported_legacy_codes: Vec<String>,
 }
 
 #[derive(Deserialize)]
@@ -52,6 +54,7 @@ impl StoredPendingCodesValue {
         match self {
             Self::State(state) => state,
             Self::Codes(codes) => StoredPendingCodes {
+                imported_legacy_codes: codes.iter().map(|code| code.code.clone()).collect(),
                 codes,
                 legacy_import_complete: false,
             },
@@ -151,15 +154,26 @@ impl PairingStore {
                 PENDING_CODES_SECRET_KEY,
                 |stored: StoredPendingCodesValue| {
                     let mut state = stored.into_state();
-                    if state.legacy_import_complete {
-                        return SecretUpdate::Unchanged(());
-                    }
+                    let mut changed = !state.legacy_import_complete;
                     for legacy_code in legacy_codes.unwrap_or_default() {
+                        if state
+                            .imported_legacy_codes
+                            .iter()
+                            .any(|code| code == &legacy_code.code)
+                        {
+                            continue;
+                        }
+                        state.imported_legacy_codes.push(legacy_code.code.clone());
                         state.codes.retain(|code| code.code != legacy_code.code);
                         state.codes.push(legacy_code);
+                        changed = true;
                     }
                     state.legacy_import_complete = true;
-                    SecretUpdate::Write(state, ())
+                    if changed {
+                        SecretUpdate::Write(state, ())
+                    } else {
+                        SecretUpdate::Unchanged(())
+                    }
                 },
             )
             .map_err(|error| anyhow::anyhow!("failed to migrate pending codes: {}", error))
@@ -609,6 +623,39 @@ mod tests {
 
         assert_eq!(
             PairingStore::consume_pending_code_in(&config, code, 100).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn new_legacy_code_after_completed_migration_is_imported_once() {
+        let directory = TempDir::new().unwrap();
+        let config = test_config(&directory);
+        PairingStore::store_pending_code_in(&config, "CURRENT-CODE", "telegram", 101).unwrap();
+        assert!(
+            config
+                .get_secret::<StoredPendingCodes>(PENDING_CODES_SECRET_KEY)
+                .unwrap()
+                .legacy_import_complete
+        );
+
+        config
+            .set_param(
+                PENDING_CODES_CONFIG_KEY,
+                [StoredPendingCode {
+                    code: "ROLLBACK-CODE".to_string(),
+                    gateway_type: "slack".to_string(),
+                    expires_at: 101,
+                }],
+            )
+            .unwrap();
+
+        assert_eq!(
+            PairingStore::consume_pending_code_in(&config, "ROLLBACK-CODE", 100).unwrap(),
+            Some("slack".to_string())
+        );
+        assert_eq!(
+            PairingStore::consume_pending_code_in(&config, "ROLLBACK-CODE", 100).unwrap(),
             None
         );
     }

--- a/crates/goose/src/gateway/pairing.rs
+++ b/crates/goose/src/gateway/pairing.rs
@@ -130,6 +130,7 @@ impl PairingStore {
     fn verify_legacy_pending_codes_removed(config: &Config) -> anyhow::Result<()> {
         match config.get_param::<Vec<StoredPendingCode>>(PENDING_CODES_CONFIG_KEY) {
             Err(ConfigError::NotFound(_)) => Ok(()),
+            Ok(codes) if codes.is_empty() => Ok(()),
             Ok(_) => Err(anyhow::anyhow!(
                 "legacy pending codes remain in GATEWAY_PENDING_CODES, the system config, or GOOSE_ADDITIONAL_CONFIG_FILES"
             )),
@@ -429,6 +430,30 @@ mod tests {
         assert_eq!(
             PairingStore::consume_pending_code_in(&config, &legacy_code.code, 100).unwrap(),
             None
+        );
+    }
+
+    #[test]
+    fn empty_non_writable_legacy_source_does_not_disable_pairing() {
+        let directory = TempDir::new().unwrap();
+        let system_config_path = directory.path().join("system.yaml");
+        let user_config_path = directory.path().join("user.yaml");
+        let secrets_path = directory.path().join("secrets.yaml");
+        let system_config =
+            Config::new_with_file_secrets(&system_config_path, &secrets_path).unwrap();
+        system_config
+            .set_param(PENDING_CODES_CONFIG_KEY, Vec::<StoredPendingCode>::new())
+            .unwrap();
+        let config = Config::new_with_config_paths(
+            vec![system_config_path, user_config_path],
+            &secrets_path,
+        )
+        .unwrap();
+
+        PairingStore::store_pending_code_in(&config, "NEW-CODE", "telegram", 101).unwrap();
+        assert_eq!(
+            PairingStore::consume_pending_code_in(&config, "NEW-CODE", 100).unwrap(),
+            Some("telegram".to_string())
         );
     }
 

--- a/crates/goose/src/gateway/pairing.rs
+++ b/crates/goose/src/gateway/pairing.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 use tokio::sync::RwLock;
 
+use crate::config::base::SecretUpdate;
 use crate::config::{Config, ConfigError};
 
 use super::{PairingState, PlatformUser};
@@ -143,14 +144,15 @@ impl PairingStore {
                 PENDING_CODES_SECRET_KEY,
                 |stored: StoredPendingCodesValue| {
                     let mut state = stored.into_state();
-                    if !state.legacy_import_complete {
-                        for legacy_code in legacy_codes.unwrap_or_default() {
-                            state.codes.retain(|code| code.code != legacy_code.code);
-                            state.codes.push(legacy_code);
-                        }
-                        state.legacy_import_complete = true;
+                    if state.legacy_import_complete {
+                        return SecretUpdate::Unchanged(());
                     }
-                    (state, ())
+                    for legacy_code in legacy_codes.unwrap_or_default() {
+                        state.codes.retain(|code| code.code != legacy_code.code);
+                        state.codes.push(legacy_code);
+                    }
+                    state.legacy_import_complete = true;
+                    SecretUpdate::Write(state, ())
                 },
             )
             .map_err(|error| anyhow::anyhow!("failed to migrate pending codes: {}", error))
@@ -174,7 +176,7 @@ impl PairingStore {
                         gateway_type: gateway_type.to_string(),
                         expires_at,
                     });
-                    (state, ())
+                    SecretUpdate::Write(state, ())
                 },
             )
             .map_err(|error| anyhow::anyhow!("failed to save pending codes: {}", error))
@@ -191,14 +193,15 @@ impl PairingStore {
                 PENDING_CODES_SECRET_KEY,
                 |stored: StoredPendingCodesValue| {
                     let mut state = stored.into_state();
-                    let consumed = state
-                        .codes
-                        .iter()
-                        .position(|pending| pending.code == code)
-                        .map(|position| state.codes.remove(position))
+                    let Some(position) =
+                        state.codes.iter().position(|pending| pending.code == code)
+                    else {
+                        return SecretUpdate::Unchanged(None);
+                    };
+                    let consumed = Some(state.codes.remove(position))
                         .filter(|pending| now <= pending.expires_at)
                         .map(|pending| pending.gateway_type);
-                    (state, consumed)
+                    SecretUpdate::Write(state, consumed)
                 },
             )
             .map_err(|error| anyhow::anyhow!("failed to consume pending code: {}", error))
@@ -455,6 +458,62 @@ mod tests {
         assert_eq!(
             PairingStore::consume_pending_code_in(&config, code, 100).unwrap(),
             None
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unmatched_pending_codes_do_not_rewrite_secret_storage() {
+        use std::os::unix::fs::MetadataExt;
+
+        let directory = TempDir::new().unwrap();
+        let config = test_config(&directory);
+        let secrets_path = directory.path().join("secrets.yaml");
+        PairingStore::store_pending_code_in(&config, "VALID-CODE", "telegram", 101).unwrap();
+        PairingStore::store_pending_code_in(&config, "EXPIRED-CODE", "slack", 99).unwrap();
+
+        let initial_inode = std::fs::metadata(&secrets_path).unwrap().ino();
+        assert_eq!(
+            PairingStore::consume_pending_code_in(&config, "ZZZZZZ", 100).unwrap(),
+            None
+        );
+        assert_eq!(
+            PairingStore::consume_pending_code_in(&config, "ZZZZZZ", 100).unwrap(),
+            None
+        );
+        assert_eq!(
+            std::fs::metadata(&secrets_path).unwrap().ino(),
+            initial_inode
+        );
+
+        assert_eq!(
+            PairingStore::consume_pending_code_in(&config, "VALID-CODE", 100).unwrap(),
+            Some("telegram".to_string())
+        );
+        let consumed_inode = std::fs::metadata(&secrets_path).unwrap().ino();
+        assert_ne!(consumed_inode, initial_inode);
+        assert_eq!(
+            PairingStore::consume_pending_code_in(&config, "VALID-CODE", 100).unwrap(),
+            None
+        );
+        assert_eq!(
+            std::fs::metadata(&secrets_path).unwrap().ino(),
+            consumed_inode
+        );
+
+        assert_eq!(
+            PairingStore::consume_pending_code_in(&config, "EXPIRED-CODE", 100).unwrap(),
+            None
+        );
+        let expired_inode = std::fs::metadata(&secrets_path).unwrap().ino();
+        assert_ne!(expired_inode, consumed_inode);
+        assert_eq!(
+            PairingStore::consume_pending_code_in(&config, "EXPIRED-CODE", 98).unwrap(),
+            None
+        );
+        assert_eq!(
+            std::fs::metadata(&secrets_path).unwrap().ino(),
+            expired_inode
         );
     }
 }

--- a/crates/goose/src/gateway/pairing.rs
+++ b/crates/goose/src/gateway/pairing.rs
@@ -3,12 +3,13 @@ use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 use tokio::sync::RwLock;
 
-use crate::config::Config;
+use crate::config::{Config, ConfigError};
 
 use super::{PairingState, PlatformUser};
 
 const PAIRINGS_CONFIG_KEY: &str = "gateway_pairings";
 const PENDING_CODES_CONFIG_KEY: &str = "gateway_pending_codes";
+const PENDING_CODES_SECRET_KEY: &str = "gateway_pending_codes";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct StoredPairing {
@@ -23,6 +24,38 @@ struct StoredPendingCode {
     code: String,
     gateway_type: String,
     expires_at: i64,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct StoredPendingCodes {
+    codes: Vec<StoredPendingCode>,
+    #[serde(default)]
+    legacy_import_complete: bool,
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum StoredPendingCodesValue {
+    State(StoredPendingCodes),
+    Codes(Vec<StoredPendingCode>),
+}
+
+impl Default for StoredPendingCodesValue {
+    fn default() -> Self {
+        Self::State(StoredPendingCodes::default())
+    }
+}
+
+impl StoredPendingCodesValue {
+    fn into_state(self) -> StoredPendingCodes {
+        match self {
+            Self::State(state) => state,
+            Self::Codes(codes) => StoredPendingCodes {
+                codes,
+                legacy_import_complete: false,
+            },
+        }
+    }
 }
 
 pub struct PairingStore {
@@ -69,16 +102,106 @@ impl PairingStore {
             .map_err(|e| anyhow::anyhow!("failed to save gateway pairings: {}", e))
     }
 
-    fn load_pending_codes() -> Vec<StoredPendingCode> {
-        Config::global()
-            .get_param(PENDING_CODES_CONFIG_KEY)
-            .unwrap_or_default()
+    fn migrate_pending_codes(config: &Config) -> anyhow::Result<()> {
+        let legacy_codes = match config.get_param(PENDING_CODES_CONFIG_KEY) {
+            Ok(codes) => Some(codes),
+            Err(ConfigError::NotFound(_)) => None,
+            Err(error) => {
+                return Err(anyhow::anyhow!(
+                    "failed to load legacy pending codes: {}",
+                    error
+                ));
+            }
+        };
+
+        let has_legacy_codes = legacy_codes.is_some();
+        Self::complete_pending_code_migration(config, legacy_codes)?;
+        if !has_legacy_codes {
+            return Ok(());
+        }
+
+        if let Err(delete_error) = config.delete(PENDING_CODES_CONFIG_KEY) {
+            match config.get_param::<Vec<StoredPendingCode>>(PENDING_CODES_CONFIG_KEY) {
+                Err(ConfigError::NotFound(_)) => return Ok(()),
+                _ => {
+                    return Err(anyhow::anyhow!(
+                        "failed to remove legacy pending codes: {}",
+                        delete_error
+                    ));
+                }
+            }
+        }
+        Ok(())
     }
 
-    fn save_pending_codes(codes: &[StoredPendingCode]) -> anyhow::Result<()> {
-        Config::global()
-            .set_param(PENDING_CODES_CONFIG_KEY, codes)
-            .map_err(|e| anyhow::anyhow!("failed to save pending codes: {}", e))
+    fn complete_pending_code_migration(
+        config: &Config,
+        legacy_codes: Option<Vec<StoredPendingCode>>,
+    ) -> anyhow::Result<()> {
+        config
+            .update_secret(
+                PENDING_CODES_SECRET_KEY,
+                |stored: StoredPendingCodesValue| {
+                    let mut state = stored.into_state();
+                    if !state.legacy_import_complete {
+                        for legacy_code in legacy_codes.unwrap_or_default() {
+                            state.codes.retain(|code| code.code != legacy_code.code);
+                            state.codes.push(legacy_code);
+                        }
+                        state.legacy_import_complete = true;
+                    }
+                    (state, ())
+                },
+            )
+            .map_err(|error| anyhow::anyhow!("failed to migrate pending codes: {}", error))
+    }
+
+    fn store_pending_code_in(
+        config: &Config,
+        code: &str,
+        gateway_type: &str,
+        expires_at: i64,
+    ) -> anyhow::Result<()> {
+        Self::migrate_pending_codes(config)?;
+        config
+            .update_secret(
+                PENDING_CODES_SECRET_KEY,
+                |stored: StoredPendingCodesValue| {
+                    let mut state = stored.into_state();
+                    state.codes.retain(|pending| pending.code != code);
+                    state.codes.push(StoredPendingCode {
+                        code: code.to_string(),
+                        gateway_type: gateway_type.to_string(),
+                        expires_at,
+                    });
+                    (state, ())
+                },
+            )
+            .map_err(|error| anyhow::anyhow!("failed to save pending codes: {}", error))
+    }
+
+    fn consume_pending_code_in(
+        config: &Config,
+        code: &str,
+        now: i64,
+    ) -> anyhow::Result<Option<String>> {
+        Self::migrate_pending_codes(config)?;
+        config
+            .update_secret(
+                PENDING_CODES_SECRET_KEY,
+                |stored: StoredPendingCodesValue| {
+                    let mut state = stored.into_state();
+                    let consumed = state
+                        .codes
+                        .iter()
+                        .position(|pending| pending.code == code)
+                        .map(|position| state.codes.remove(position))
+                        .filter(|pending| now <= pending.expires_at)
+                        .map(|pending| pending.gateway_type);
+                    (state, consumed)
+                },
+            )
+            .map_err(|error| anyhow::anyhow!("failed to consume pending code: {}", error))
     }
 
     pub async fn get(&self, user: &PlatformUser) -> anyhow::Result<PairingState> {
@@ -107,32 +230,12 @@ impl PairingStore {
         gateway_type: &str,
         expires_at: i64,
     ) -> anyhow::Result<()> {
-        let mut codes = Self::load_pending_codes();
-        codes.retain(|c| c.code != code);
-        codes.push(StoredPendingCode {
-            code: code.to_string(),
-            gateway_type: gateway_type.to_string(),
-            expires_at,
-        });
-        Self::save_pending_codes(&codes)
+        Self::store_pending_code_in(Config::global(), code, gateway_type, expires_at)
     }
 
     pub async fn consume_pending_code(&self, code: &str) -> anyhow::Result<Option<String>> {
-        let mut codes = Self::load_pending_codes();
-        let pos = codes.iter().position(|c| c.code == code);
-        let Some(pos) = pos else {
-            return Ok(None);
-        };
-
-        let entry = codes.remove(pos);
-        Self::save_pending_codes(&codes)?;
-
         let now = chrono::Utc::now().timestamp();
-        if now > entry.expires_at {
-            return Ok(None);
-        }
-
-        Ok(Some(entry.gateway_type))
+        Self::consume_pending_code_in(Config::global(), code, now)
     }
 
     pub fn generate_code() -> String {
@@ -177,6 +280,16 @@ impl PairingStore {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{Arc, Barrier};
+    use tempfile::TempDir;
+
+    fn test_config(directory: &TempDir) -> Config {
+        Config::new_with_file_secrets(
+            directory.path().join("config.yaml"),
+            directory.path().join("secrets.yaml"),
+        )
+        .unwrap()
+    }
 
     #[test]
     fn test_code_generation() {
@@ -185,5 +298,163 @@ mod tests {
         assert!(code
             .chars()
             .all(|c| "ABCDEFGHJKLMNPQRSTUVWXYZ23456789".contains(c)));
+    }
+
+    #[test]
+    fn pending_codes_are_secret_and_consumed_once() {
+        let directory = TempDir::new().unwrap();
+        let config = test_config(&directory);
+        let code = "SECRET-CODE";
+
+        PairingStore::store_pending_code_in(&config, code, "telegram", 101).unwrap();
+
+        let ordinary_config =
+            std::fs::read_to_string(directory.path().join("config.yaml")).unwrap_or_default();
+        assert!(!ordinary_config.contains(code));
+        assert!(!config
+            .all_values()
+            .unwrap()
+            .contains_key(PENDING_CODES_CONFIG_KEY));
+        assert_eq!(
+            PairingStore::consume_pending_code_in(&config, code, 100).unwrap(),
+            Some("telegram".to_string())
+        );
+        assert_eq!(
+            PairingStore::consume_pending_code_in(&config, code, 100).unwrap(),
+            None
+        );
+
+        PairingStore::store_pending_code_in(&config, code, "telegram", 99).unwrap();
+        assert_eq!(
+            PairingStore::consume_pending_code_in(&config, code, 100).unwrap(),
+            None
+        );
+        assert_eq!(
+            PairingStore::consume_pending_code_in(&config, code, 98).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn pending_code_store_migrates_and_removes_legacy_config() {
+        let directory = TempDir::new().unwrap();
+        let config = test_config(&directory);
+        let legacy_code = "LEGACY-CODE";
+        let new_code = "NEW-CODE";
+        config
+            .set_param(
+                PENDING_CODES_CONFIG_KEY,
+                &[StoredPendingCode {
+                    code: legacy_code.to_string(),
+                    gateway_type: "slack".to_string(),
+                    expires_at: 101,
+                }],
+            )
+            .unwrap();
+
+        PairingStore::store_pending_code_in(&config, new_code, "telegram", 101).unwrap();
+
+        let ordinary_config =
+            std::fs::read_to_string(directory.path().join("config.yaml")).unwrap_or_default();
+        assert!(!ordinary_config.contains(legacy_code));
+        assert!(!ordinary_config.contains(new_code));
+        assert!(!config
+            .all_values()
+            .unwrap()
+            .contains_key(PENDING_CODES_CONFIG_KEY));
+        assert_eq!(
+            PairingStore::consume_pending_code_in(&config, legacy_code, 100).unwrap(),
+            Some("slack".to_string())
+        );
+        assert_eq!(
+            PairingStore::consume_pending_code_in(&config, new_code, 100).unwrap(),
+            Some("telegram".to_string())
+        );
+    }
+
+    #[test]
+    fn pending_code_consumption_is_serialized_across_config_instances() {
+        let directory = TempDir::new().unwrap();
+        let config_path = directory.path().join("config.yaml");
+        let secrets_path = directory.path().join("secrets.yaml");
+        let config = Config::new_with_file_secrets(&config_path, &secrets_path).unwrap();
+        let code = "ONE-TIME-CODE";
+        PairingStore::store_pending_code_in(&config, code, "telegram", 101).unwrap();
+
+        let barrier = Arc::new(Barrier::new(2));
+        let handles: Vec<_> = (0..2)
+            .map(|_| {
+                let config_path = config_path.clone();
+                let secrets_path = secrets_path.clone();
+                let barrier = Arc::clone(&barrier);
+                std::thread::spawn(move || {
+                    let config = Config::new_with_file_secrets(config_path, secrets_path).unwrap();
+                    barrier.wait();
+                    PairingStore::consume_pending_code_in(&config, code, 100).unwrap()
+                })
+            })
+            .collect();
+        let results: Vec<_> = handles
+            .into_iter()
+            .map(|handle| handle.join().unwrap())
+            .collect();
+
+        assert_eq!(results.iter().filter(|result| result.is_some()).count(), 1);
+        assert_eq!(results.iter().filter(|result| result.is_none()).count(), 1);
+    }
+
+    #[test]
+    fn delayed_legacy_migration_cannot_reinsert_consumed_code() {
+        let directory = TempDir::new().unwrap();
+        let config = test_config(&directory);
+        let code = "LEGACY-ONE-TIME-CODE";
+        config
+            .set_param(
+                PENDING_CODES_CONFIG_KEY,
+                &[StoredPendingCode {
+                    code: code.to_string(),
+                    gateway_type: "telegram".to_string(),
+                    expires_at: 101,
+                }],
+            )
+            .unwrap();
+        let stale_snapshot = config.get_param(PENDING_CODES_CONFIG_KEY).unwrap();
+
+        assert_eq!(
+            PairingStore::consume_pending_code_in(&config, code, 100).unwrap(),
+            Some("telegram".to_string())
+        );
+        PairingStore::complete_pending_code_migration(&config, Some(stale_snapshot)).unwrap();
+
+        assert_eq!(
+            PairingStore::consume_pending_code_in(&config, code, 100).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn pending_code_migration_accepts_legacy_secret_vec() {
+        let directory = TempDir::new().unwrap();
+        let config = test_config(&directory);
+        let code = "SECRET-VEC-CODE";
+        config
+            .set_secret(
+                PENDING_CODES_SECRET_KEY,
+                &vec![StoredPendingCode {
+                    code: code.to_string(),
+                    gateway_type: "telegram".to_string(),
+                    expires_at: 101,
+                }],
+            )
+            .unwrap();
+
+        assert_eq!(
+            PairingStore::consume_pending_code_in(&config, code, 100).unwrap(),
+            Some("telegram".to_string())
+        );
+        assert_eq!(
+            PairingStore::consume_pending_code_in(&config, code, 100).unwrap(),
+            None
+        );
     }
 }

--- a/crates/goose/src/gateway/pairing.rs
+++ b/crates/goose/src/gateway/pairing.rs
@@ -115,11 +115,11 @@ impl PairingStore {
             }
         };
 
-        let has_legacy_codes = legacy_codes.is_some();
-        Self::complete_pending_code_migration(config, legacy_codes)?;
-        if !has_legacy_codes {
+        let Some(legacy_codes) = legacy_codes else {
             return Self::verify_legacy_pending_codes_removed(config);
-        }
+        };
+
+        Self::complete_pending_code_migration(config, Some(legacy_codes))?;
 
         config
             .delete(PENDING_CODES_CONFIG_KEY)
@@ -175,6 +175,7 @@ impl PairingStore {
                 PENDING_CODES_SECRET_KEY,
                 |stored: StoredPendingCodesValue| {
                     let mut state = stored.into_state();
+                    state.legacy_import_complete = true;
                     state.codes.retain(|pending| pending.code != code);
                     state.codes.push(StoredPendingCode {
                         code: code.to_string(),
@@ -198,10 +199,16 @@ impl PairingStore {
                 PENDING_CODES_SECRET_KEY,
                 |stored: StoredPendingCodesValue| {
                     let mut state = stored.into_state();
+                    let needs_migration_marker = !state.legacy_import_complete;
+                    state.legacy_import_complete = true;
                     let Some(position) =
                         state.codes.iter().position(|pending| pending.code == code)
                     else {
-                        return SecretUpdate::Unchanged(None);
+                        return if needs_migration_marker {
+                            SecretUpdate::Write(state, None)
+                        } else {
+                            SecretUpdate::Unchanged(None)
+                        };
                     };
                     let consumed = Some(state.codes.remove(position))
                         .filter(|pending| now <= pending.expires_at)
@@ -547,25 +554,41 @@ mod tests {
         let directory = TempDir::new().unwrap();
         let config = test_config(&directory);
         let code = "SECRET-VEC-CODE";
+        let legacy_codes = vec![StoredPendingCode {
+            code: code.to_string(),
+            gateway_type: "telegram".to_string(),
+            expires_at: 101,
+        }];
         config
-            .set_secret(
-                PENDING_CODES_SECRET_KEY,
-                &vec![StoredPendingCode {
-                    code: code.to_string(),
-                    gateway_type: "telegram".to_string(),
-                    expires_at: 101,
-                }],
-            )
+            .set_secret(PENDING_CODES_SECRET_KEY, &legacy_codes)
             .unwrap();
 
         assert_eq!(
             PairingStore::consume_pending_code_in(&config, code, 100).unwrap(),
             Some("telegram".to_string())
         );
+        assert!(
+            config
+                .get_secret::<StoredPendingCodes>(PENDING_CODES_SECRET_KEY)
+                .unwrap()
+                .legacy_import_complete
+        );
+        PairingStore::complete_pending_code_migration(&config, Some(legacy_codes)).unwrap();
         assert_eq!(
             PairingStore::consume_pending_code_in(&config, code, 100).unwrap(),
             None
         );
+    }
+
+    #[test]
+    fn migration_without_legacy_config_does_not_touch_secret_storage() {
+        let directory = TempDir::new().unwrap();
+        let config = test_config(&directory);
+        let secrets_path = directory.path().join("secrets.yaml");
+
+        assert!(!secrets_path.exists());
+        PairingStore::migrate_pending_codes(&config).unwrap();
+        assert!(!secrets_path.exists());
     }
 
     #[cfg(unix)]

--- a/crates/goose/src/gateway/pairing.rs
+++ b/crates/goose/src/gateway/pairing.rs
@@ -128,16 +128,17 @@ impl PairingStore {
     }
 
     fn verify_legacy_pending_codes_removed(config: &Config) -> anyhow::Result<()> {
-        match config.get_param::<Vec<StoredPendingCode>>(PENDING_CODES_CONFIG_KEY) {
-            Err(ConfigError::NotFound(_)) => Ok(()),
-            Ok(codes) if codes.is_empty() => Ok(()),
-            Ok(_) => Err(anyhow::anyhow!(
+        let source_values = config
+            .get_param_source_values::<Vec<StoredPendingCode>>(PENDING_CODES_CONFIG_KEY)
+            .map_err(|error| {
+                anyhow::anyhow!("failed to verify removal of legacy pending codes: {error}")
+            })?;
+        if source_values.iter().all(Vec::is_empty) {
+            Ok(())
+        } else {
+            Err(anyhow::anyhow!(
                 "legacy pending codes remain in GATEWAY_PENDING_CODES, the system config, or GOOSE_ADDITIONAL_CONFIG_FILES"
-            )),
-            Err(error) => Err(anyhow::anyhow!(
-                "failed to verify removal of legacy pending codes: {}",
-                error
-            )),
+            ))
         }
     }
 
@@ -454,6 +455,44 @@ mod tests {
         assert_eq!(
             PairingStore::consume_pending_code_in(&config, "NEW-CODE", 100).unwrap(),
             Some("telegram".to_string())
+        );
+    }
+
+    #[test]
+    fn empty_overlay_cannot_hide_nonempty_legacy_source() {
+        let directory = TempDir::new().unwrap();
+        let system_config_path = directory.path().join("system.yaml");
+        let additional_config_path = directory.path().join("additional.yaml");
+        let user_config_path = directory.path().join("user.yaml");
+        let secrets_path = directory.path().join("secrets.yaml");
+        let system_config =
+            Config::new_with_file_secrets(&system_config_path, &secrets_path).unwrap();
+        system_config
+            .set_param(
+                PENDING_CODES_CONFIG_KEY,
+                [StoredPendingCode {
+                    code: "SYSTEM-CODE".to_string(),
+                    gateway_type: "slack".to_string(),
+                    expires_at: 101,
+                }],
+            )
+            .unwrap();
+        let additional_config =
+            Config::new_with_file_secrets(&additional_config_path, &secrets_path).unwrap();
+        additional_config
+            .set_param(PENDING_CODES_CONFIG_KEY, Vec::<StoredPendingCode>::new())
+            .unwrap();
+        let config = Config::new_with_config_paths(
+            vec![system_config_path, additional_config_path, user_config_path],
+            &secrets_path,
+        )
+        .unwrap();
+
+        assert!(
+            PairingStore::store_pending_code_in(&config, "NEW-CODE", "telegram", 101)
+                .unwrap_err()
+                .to_string()
+                .contains("legacy pending codes remain")
         );
     }
 

--- a/crates/goose/src/gateway/pairing.rs
+++ b/crates/goose/src/gateway/pairing.rs
@@ -107,26 +107,21 @@ impl PairingStore {
     }
 
     fn migrate_pending_codes(config: &Config) -> anyhow::Result<()> {
-        let legacy_codes = match config.get_write_param(PENDING_CODES_CONFIG_KEY) {
-            Ok(codes) => Some(codes),
-            Err(ConfigError::NotFound(_)) => None,
-            Err(error) => {
-                return Err(anyhow::anyhow!(
-                    "failed to load legacy pending codes: {}",
-                    error
-                ));
-            }
-        };
+        let legacy_codes: Option<Vec<StoredPendingCode>> =
+            match config.get_write_param(PENDING_CODES_CONFIG_KEY) {
+                Ok(codes) => Some(codes),
+                Err(ConfigError::NotFound(_)) => None,
+                Err(error) => {
+                    return Err(anyhow::anyhow!(
+                        "failed to load legacy pending codes: {}",
+                        error
+                    ));
+                }
+            };
 
-        let Some(legacy_codes) = legacy_codes else {
-            return Self::verify_legacy_pending_codes_removed(config);
-        };
-
-        Self::complete_pending_code_migration(config, Some(legacy_codes))?;
-
-        config
-            .delete(PENDING_CODES_CONFIG_KEY)
-            .map_err(|error| anyhow::anyhow!("failed to remove legacy pending codes: {}", error))?;
+        if legacy_codes.as_ref().is_some_and(|codes| !codes.is_empty()) {
+            Self::complete_pending_code_migration(config, legacy_codes)?;
+        }
         Self::verify_legacy_pending_codes_removed(config)
     }
 
@@ -140,7 +135,7 @@ impl PairingStore {
             Ok(())
         } else {
             Err(anyhow::anyhow!(
-                "legacy pending codes remain in GATEWAY_PENDING_CODES, the system config, or GOOSE_ADDITIONAL_CONFIG_FILES"
+                "legacy pending codes remain in ordinary configuration; stop older Goose processes, remove GATEWAY_PENDING_CODES and gateway_pending_codes from configured files, then retry"
             ))
         }
     }
@@ -367,7 +362,7 @@ mod tests {
     }
 
     #[test]
-    fn pending_code_store_migrates_and_removes_legacy_config() {
+    fn pending_code_store_imports_legacy_config_and_requires_cleanup() {
         let directory = TempDir::new().unwrap();
         let config = test_config(&directory);
         let legacy_code = "LEGACY-CODE";
@@ -383,6 +378,16 @@ mod tests {
             )
             .unwrap();
 
+        let error =
+            PairingStore::store_pending_code_in(&config, new_code, "telegram", 101).unwrap_err();
+        assert!(error.to_string().contains("stop older Goose processes"));
+
+        let ordinary_config =
+            std::fs::read_to_string(directory.path().join("config.yaml")).unwrap_or_default();
+        assert!(ordinary_config.contains(legacy_code));
+        assert!(!ordinary_config.contains(new_code));
+
+        config.delete(PENDING_CODES_CONFIG_KEY).unwrap();
         PairingStore::store_pending_code_in(&config, new_code, "telegram", 101).unwrap();
 
         let ordinary_config =
@@ -428,9 +433,9 @@ mod tests {
         let error =
             PairingStore::store_pending_code_in(&config, "NEW-CODE", "telegram", 101).unwrap_err();
 
-        assert!(error.to_string().contains(
-            "legacy pending codes remain in GATEWAY_PENDING_CODES, the system config, or GOOSE_ADDITIONAL_CONFIG_FILES"
-        ));
+        assert!(error
+            .to_string()
+            .contains("legacy pending codes remain in ordinary configuration"));
         assert_eq!(
             config
                 .get_param::<Vec<StoredPendingCode>>(PENDING_CODES_CONFIG_KEY)
@@ -553,6 +558,7 @@ mod tests {
         );
 
         std::fs::write(system_config_path, "").unwrap();
+        config.delete(PENDING_CODES_CONFIG_KEY).unwrap();
         assert_eq!(
             PairingStore::consume_pending_code_in(&config, "USER-CODE", 100).unwrap(),
             Some("telegram".to_string())
@@ -613,8 +619,12 @@ mod tests {
                 }],
             )
             .unwrap();
-        let stale_snapshot = config.get_param(PENDING_CODES_CONFIG_KEY).unwrap();
+        let stale_snapshot: Vec<StoredPendingCode> =
+            config.get_param(PENDING_CODES_CONFIG_KEY).unwrap();
 
+        PairingStore::complete_pending_code_migration(&config, Some(stale_snapshot.clone()))
+            .unwrap();
+        config.delete(PENDING_CODES_CONFIG_KEY).unwrap();
         assert_eq!(
             PairingStore::consume_pending_code_in(&config, code, 100).unwrap(),
             Some("telegram".to_string())
@@ -650,6 +660,13 @@ mod tests {
             )
             .unwrap();
 
+        assert!(
+            PairingStore::consume_pending_code_in(&config, "ROLLBACK-CODE", 100)
+                .unwrap_err()
+                .to_string()
+                .contains("stop older Goose processes")
+        );
+        config.delete(PENDING_CODES_CONFIG_KEY).unwrap();
         assert_eq!(
             PairingStore::consume_pending_code_in(&config, "ROLLBACK-CODE", 100).unwrap(),
             Some("slack".to_string())
@@ -657,6 +674,58 @@ mod tests {
         assert_eq!(
             PairingStore::consume_pending_code_in(&config, "ROLLBACK-CODE", 100).unwrap(),
             None
+        );
+    }
+
+    #[test]
+    fn legacy_code_written_during_migration_is_preserved_for_cleanup() {
+        let directory = TempDir::new().unwrap();
+        let config_path = directory.path().join("config.yaml");
+        let secrets_path = directory.path().join("secrets.yaml");
+        let config = Config::new_with_file_secrets(&config_path, &secrets_path).unwrap();
+        let old_process = Config::new_with_file_secrets(&config_path, &secrets_path).unwrap();
+        let first = StoredPendingCode {
+            code: "FIRST-CODE".to_string(),
+            gateway_type: "telegram".to_string(),
+            expires_at: 101,
+        };
+        let second = StoredPendingCode {
+            code: "SECOND-CODE".to_string(),
+            gateway_type: "slack".to_string(),
+            expires_at: 101,
+        };
+        config
+            .set_param(PENDING_CODES_CONFIG_KEY, [&first])
+            .unwrap();
+        let stale_snapshot = config.get_write_param(PENDING_CODES_CONFIG_KEY).unwrap();
+        PairingStore::complete_pending_code_migration(&config, Some(stale_snapshot)).unwrap();
+
+        old_process
+            .set_param(PENDING_CODES_CONFIG_KEY, [&first, &second])
+            .unwrap();
+
+        assert!(PairingStore::migrate_pending_codes(&config)
+            .unwrap_err()
+            .to_string()
+            .contains("stop older Goose processes"));
+        let legacy_codes: Vec<StoredPendingCode> =
+            config.get_write_param(PENDING_CODES_CONFIG_KEY).unwrap();
+        assert_eq!(
+            legacy_codes
+                .iter()
+                .map(|pending| pending.code.as_str())
+                .collect::<Vec<_>>(),
+            ["FIRST-CODE", "SECOND-CODE"]
+        );
+
+        config.delete(PENDING_CODES_CONFIG_KEY).unwrap();
+        assert_eq!(
+            PairingStore::consume_pending_code_in(&config, "FIRST-CODE", 100).unwrap(),
+            Some("telegram".to_string())
+        );
+        assert_eq!(
+            PairingStore::consume_pending_code_in(&config, "SECOND-CODE", 100).unwrap(),
+            Some("slack".to_string())
         );
     }
 

--- a/crates/goose/src/gateway/pairing.rs
+++ b/crates/goose/src/gateway/pairing.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::RwLock;
 
 use crate::config::base::SecretUpdate;
-use crate::config::{Config, ConfigError};
+use crate::config::Config;
 
 use super::{PairingState, PlatformUser};
 
@@ -36,6 +36,19 @@ struct StoredPendingCodes {
     imported_legacy_codes: Vec<String>,
 }
 
+impl StoredPendingCodes {
+    fn revoke_imported_codes(&mut self) -> bool {
+        let previous_len = self.codes.len();
+        self.codes.retain(|pending| {
+            !self
+                .imported_legacy_codes
+                .iter()
+                .any(|code| code == &pending.code)
+        });
+        self.codes.len() != previous_len
+    }
+}
+
 #[derive(Deserialize)]
 #[serde(untagged)]
 enum StoredPendingCodesValue {
@@ -54,9 +67,9 @@ impl StoredPendingCodesValue {
         match self {
             Self::State(state) => state,
             Self::Codes(codes) => StoredPendingCodes {
-                imported_legacy_codes: codes.iter().map(|code| code.code.clone()).collect(),
                 codes,
                 legacy_import_complete: false,
+                imported_legacy_codes: Vec::new(),
             },
         }
     }
@@ -107,42 +120,25 @@ impl PairingStore {
     }
 
     fn migrate_pending_codes(config: &Config) -> anyhow::Result<()> {
-        let legacy_codes: Option<Vec<StoredPendingCode>> =
-            match config.get_write_param(PENDING_CODES_CONFIG_KEY) {
-                Ok(codes) => Some(codes),
-                Err(ConfigError::NotFound(_)) => None,
-                Err(error) => {
-                    return Err(anyhow::anyhow!(
-                        "failed to load legacy pending codes: {}",
-                        error
-                    ));
-                }
-            };
-
-        if legacy_codes.as_ref().is_some_and(|codes| !codes.is_empty()) {
-            Self::complete_pending_code_migration(config, legacy_codes)?;
-        }
-        Self::verify_legacy_pending_codes_removed(config)
-    }
-
-    fn verify_legacy_pending_codes_removed(config: &Config) -> anyhow::Result<()> {
-        let source_values = config
+        let legacy_codes: Vec<_> = config
             .get_param_source_values::<Vec<StoredPendingCode>>(PENDING_CODES_CONFIG_KEY)
-            .map_err(|error| {
-                anyhow::anyhow!("failed to verify removal of legacy pending codes: {error}")
-            })?;
-        if source_values.iter().all(Vec::is_empty) {
-            Ok(())
-        } else {
-            Err(anyhow::anyhow!(
-                "legacy pending codes remain in ordinary configuration; stop older Goose processes, remove GATEWAY_PENDING_CODES and gateway_pending_codes from configured files, then retry"
-            ))
+            .map_err(|error| anyhow::anyhow!("failed to verify legacy pending codes: {error}"))?
+            .into_iter()
+            .flatten()
+            .collect();
+        if legacy_codes.is_empty() {
+            return Ok(());
         }
+
+        Self::revoke_legacy_pending_codes(config, legacy_codes)?;
+        Err(anyhow::anyhow!(
+            "legacy pending codes remain in ordinary configuration and have been revoked; stop older Goose processes, remove GATEWAY_PENDING_CODES and gateway_pending_codes from configured files, then retry and generate a new pairing code"
+        ))
     }
 
-    fn complete_pending_code_migration(
+    fn revoke_legacy_pending_codes(
         config: &Config,
-        legacy_codes: Option<Vec<StoredPendingCode>>,
+        legacy_codes: Vec<StoredPendingCode>,
     ) -> anyhow::Result<()> {
         config
             .update_secret(
@@ -150,7 +146,7 @@ impl PairingStore {
                 |stored: StoredPendingCodesValue| {
                     let mut state = stored.into_state();
                     let mut changed = !state.legacy_import_complete;
-                    for legacy_code in legacy_codes.unwrap_or_default() {
+                    for legacy_code in legacy_codes {
                         if state
                             .imported_legacy_codes
                             .iter()
@@ -158,11 +154,10 @@ impl PairingStore {
                         {
                             continue;
                         }
-                        state.imported_legacy_codes.push(legacy_code.code.clone());
-                        state.codes.retain(|code| code.code != legacy_code.code);
-                        state.codes.push(legacy_code);
+                        state.imported_legacy_codes.push(legacy_code.code);
                         changed = true;
                     }
+                    changed |= state.revoke_imported_codes();
                     state.legacy_import_complete = true;
                     if changed {
                         SecretUpdate::Write(state, ())
@@ -186,6 +181,10 @@ impl PairingStore {
                 PENDING_CODES_SECRET_KEY,
                 |stored: StoredPendingCodesValue| {
                     let mut state = stored.into_state();
+                    state.revoke_imported_codes();
+                    state
+                        .imported_legacy_codes
+                        .retain(|legacy_code| legacy_code != code);
                     state.legacy_import_complete = true;
                     state.codes.retain(|pending| pending.code != code);
                     state.codes.push(StoredPendingCode {
@@ -210,12 +209,13 @@ impl PairingStore {
                 PENDING_CODES_SECRET_KEY,
                 |stored: StoredPendingCodesValue| {
                     let mut state = stored.into_state();
-                    let needs_migration_marker = !state.legacy_import_complete;
+                    let mut needs_write = !state.legacy_import_complete;
                     state.legacy_import_complete = true;
+                    needs_write |= state.revoke_imported_codes();
                     let Some(position) =
                         state.codes.iter().position(|pending| pending.code == code)
                     else {
-                        return if needs_migration_marker {
+                        return if needs_write {
                             SecretUpdate::Write(state, None)
                         } else {
                             SecretUpdate::Unchanged(None)
@@ -362,7 +362,7 @@ mod tests {
     }
 
     #[test]
-    fn pending_code_store_imports_legacy_config_and_requires_cleanup() {
+    fn pending_code_store_revokes_legacy_config_and_requires_cleanup() {
         let directory = TempDir::new().unwrap();
         let config = test_config(&directory);
         let legacy_code = "LEGACY-CODE";
@@ -400,7 +400,7 @@ mod tests {
             .contains_key(PENDING_CODES_CONFIG_KEY));
         assert_eq!(
             PairingStore::consume_pending_code_in(&config, legacy_code, 100).unwrap(),
-            Some("slack".to_string())
+            None
         );
         assert_eq!(
             PairingStore::consume_pending_code_in(&config, new_code, 100).unwrap(),
@@ -516,7 +516,7 @@ mod tests {
     }
 
     #[test]
-    fn pending_code_migration_preserves_shadowed_writable_code() {
+    fn pending_code_migration_revokes_codes_from_every_source() {
         let directory = TempDir::new().unwrap();
         let system_config_path = directory.path().join("system.yaml");
         let user_config_path = directory.path().join("user.yaml");
@@ -561,10 +561,6 @@ mod tests {
         config.delete(PENDING_CODES_CONFIG_KEY).unwrap();
         assert_eq!(
             PairingStore::consume_pending_code_in(&config, "USER-CODE", 100).unwrap(),
-            Some("telegram".to_string())
-        );
-        assert_eq!(
-            PairingStore::consume_pending_code_in(&config, "USER-CODE", 100).unwrap(),
             None
         );
         assert_eq!(
@@ -605,7 +601,7 @@ mod tests {
     }
 
     #[test]
-    fn delayed_legacy_migration_cannot_reinsert_consumed_code() {
+    fn delayed_legacy_migration_cannot_activate_revoked_code() {
         let directory = TempDir::new().unwrap();
         let config = test_config(&directory);
         let code = "LEGACY-ONE-TIME-CODE";
@@ -622,14 +618,13 @@ mod tests {
         let stale_snapshot: Vec<StoredPendingCode> =
             config.get_param(PENDING_CODES_CONFIG_KEY).unwrap();
 
-        PairingStore::complete_pending_code_migration(&config, Some(stale_snapshot.clone()))
-            .unwrap();
+        PairingStore::revoke_legacy_pending_codes(&config, stale_snapshot.clone()).unwrap();
         config.delete(PENDING_CODES_CONFIG_KEY).unwrap();
         assert_eq!(
             PairingStore::consume_pending_code_in(&config, code, 100).unwrap(),
-            Some("telegram".to_string())
+            None
         );
-        PairingStore::complete_pending_code_migration(&config, Some(stale_snapshot)).unwrap();
+        PairingStore::revoke_legacy_pending_codes(&config, stale_snapshot).unwrap();
 
         assert_eq!(
             PairingStore::consume_pending_code_in(&config, code, 100).unwrap(),
@@ -638,7 +633,7 @@ mod tests {
     }
 
     #[test]
-    fn new_legacy_code_after_completed_migration_is_imported_once() {
+    fn new_legacy_code_after_completed_migration_is_revoked() {
         let directory = TempDir::new().unwrap();
         let config = test_config(&directory);
         PairingStore::store_pending_code_in(&config, "CURRENT-CODE", "telegram", 101).unwrap();
@@ -669,16 +664,17 @@ mod tests {
         config.delete(PENDING_CODES_CONFIG_KEY).unwrap();
         assert_eq!(
             PairingStore::consume_pending_code_in(&config, "ROLLBACK-CODE", 100).unwrap(),
-            Some("slack".to_string())
-        );
-        assert_eq!(
-            PairingStore::consume_pending_code_in(&config, "ROLLBACK-CODE", 100).unwrap(),
             None
+        );
+        PairingStore::store_pending_code_in(&config, "FRESH-CODE", "slack", 101).unwrap();
+        assert_eq!(
+            PairingStore::consume_pending_code_in(&config, "FRESH-CODE", 100).unwrap(),
+            Some("slack".to_string())
         );
     }
 
     #[test]
-    fn legacy_code_written_during_migration_is_preserved_for_cleanup() {
+    fn legacy_code_written_during_migration_is_preserved_until_cleanup() {
         let directory = TempDir::new().unwrap();
         let config_path = directory.path().join("config.yaml");
         let secrets_path = directory.path().join("secrets.yaml");
@@ -697,8 +693,8 @@ mod tests {
         config
             .set_param(PENDING_CODES_CONFIG_KEY, [&first])
             .unwrap();
-        let stale_snapshot = config.get_write_param(PENDING_CODES_CONFIG_KEY).unwrap();
-        PairingStore::complete_pending_code_migration(&config, Some(stale_snapshot)).unwrap();
+        let stale_snapshot = config.get_param(PENDING_CODES_CONFIG_KEY).unwrap();
+        PairingStore::revoke_legacy_pending_codes(&config, stale_snapshot).unwrap();
 
         old_process
             .set_param(PENDING_CODES_CONFIG_KEY, [&first, &second])
@@ -709,7 +705,7 @@ mod tests {
             .to_string()
             .contains("stop older Goose processes"));
         let legacy_codes: Vec<StoredPendingCode> =
-            config.get_write_param(PENDING_CODES_CONFIG_KEY).unwrap();
+            config.get_param(PENDING_CODES_CONFIG_KEY).unwrap();
         assert_eq!(
             legacy_codes
                 .iter()
@@ -721,12 +717,80 @@ mod tests {
         config.delete(PENDING_CODES_CONFIG_KEY).unwrap();
         assert_eq!(
             PairingStore::consume_pending_code_in(&config, "FIRST-CODE", 100).unwrap(),
-            Some("telegram".to_string())
+            None
         );
         assert_eq!(
             PairingStore::consume_pending_code_in(&config, "SECOND-CODE", 100).unwrap(),
-            Some("slack".to_string())
+            None
         );
+    }
+
+    #[test]
+    fn legacy_codes_consumed_by_old_writer_cannot_be_reused() {
+        let directory = TempDir::new().unwrap();
+        let config_path = directory.path().join("config.yaml");
+        let secrets_path = directory.path().join("secrets.yaml");
+        let config = Config::new_with_file_secrets(&config_path, &secrets_path).unwrap();
+        let old_process = Config::new_with_file_secrets(&config_path, &secrets_path).unwrap();
+        let first = StoredPendingCode {
+            code: "FIRST-CODE".to_string(),
+            gateway_type: "telegram".to_string(),
+            expires_at: 101,
+        };
+        let second = StoredPendingCode {
+            code: "SECOND-CODE".to_string(),
+            gateway_type: "slack".to_string(),
+            expires_at: 101,
+        };
+        old_process
+            .set_param(PENDING_CODES_CONFIG_KEY, [&first, &second])
+            .unwrap();
+
+        assert!(PairingStore::migrate_pending_codes(&config).is_err());
+        old_process
+            .set_param(PENDING_CODES_CONFIG_KEY, [&second])
+            .unwrap();
+        old_process.delete(PENDING_CODES_CONFIG_KEY).unwrap();
+
+        assert_eq!(
+            PairingStore::consume_pending_code_in(&config, &first.code, 100).unwrap(),
+            None
+        );
+        assert_eq!(
+            PairingStore::consume_pending_code_in(&config, &second.code, 100).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn imported_legacy_codes_already_in_secret_state_are_revoked() {
+        let directory = TempDir::new().unwrap();
+        let config = test_config(&directory);
+        let code = "IMPORTED-CODE";
+        config
+            .set_secret(
+                PENDING_CODES_SECRET_KEY,
+                &StoredPendingCodes {
+                    codes: vec![StoredPendingCode {
+                        code: code.to_string(),
+                        gateway_type: "telegram".to_string(),
+                        expires_at: 101,
+                    }],
+                    legacy_import_complete: true,
+                    imported_legacy_codes: vec![code.to_string()],
+                },
+            )
+            .unwrap();
+
+        assert_eq!(
+            PairingStore::consume_pending_code_in(&config, code, 100).unwrap(),
+            None
+        );
+        assert!(config
+            .get_secret::<StoredPendingCodes>(PENDING_CODES_SECRET_KEY)
+            .unwrap()
+            .codes
+            .is_empty());
     }
 
     #[test]
@@ -753,7 +817,7 @@ mod tests {
                 .unwrap()
                 .legacy_import_complete
         );
-        PairingStore::complete_pending_code_migration(&config, Some(legacy_codes)).unwrap();
+        PairingStore::revoke_legacy_pending_codes(&config, legacy_codes).unwrap();
         assert_eq!(
             PairingStore::consume_pending_code_in(&config, code, 100).unwrap(),
             None

--- a/crates/goose/src/gateway/pairing.rs
+++ b/crates/goose/src/gateway/pairing.rs
@@ -104,7 +104,7 @@ impl PairingStore {
     }
 
     fn migrate_pending_codes(config: &Config) -> anyhow::Result<()> {
-        let legacy_codes = match config.get_param(PENDING_CODES_CONFIG_KEY) {
+        let legacy_codes = match config.get_write_param(PENDING_CODES_CONFIG_KEY) {
             Ok(codes) => Some(codes),
             Err(ConfigError::NotFound(_)) => None,
             Err(error) => {
@@ -118,21 +118,26 @@ impl PairingStore {
         let has_legacy_codes = legacy_codes.is_some();
         Self::complete_pending_code_migration(config, legacy_codes)?;
         if !has_legacy_codes {
-            return Ok(());
+            return Self::verify_legacy_pending_codes_removed(config);
         }
 
-        if let Err(delete_error) = config.delete(PENDING_CODES_CONFIG_KEY) {
-            match config.get_param::<Vec<StoredPendingCode>>(PENDING_CODES_CONFIG_KEY) {
-                Err(ConfigError::NotFound(_)) => return Ok(()),
-                _ => {
-                    return Err(anyhow::anyhow!(
-                        "failed to remove legacy pending codes: {}",
-                        delete_error
-                    ));
-                }
-            }
+        config
+            .delete(PENDING_CODES_CONFIG_KEY)
+            .map_err(|error| anyhow::anyhow!("failed to remove legacy pending codes: {}", error))?;
+        Self::verify_legacy_pending_codes_removed(config)
+    }
+
+    fn verify_legacy_pending_codes_removed(config: &Config) -> anyhow::Result<()> {
+        match config.get_param::<Vec<StoredPendingCode>>(PENDING_CODES_CONFIG_KEY) {
+            Err(ConfigError::NotFound(_)) => Ok(()),
+            Ok(_) => Err(anyhow::anyhow!(
+                "legacy pending codes remain in GATEWAY_PENDING_CODES, the system config, or GOOSE_ADDITIONAL_CONFIG_FILES"
+            )),
+            Err(error) => Err(anyhow::anyhow!(
+                "failed to verify removal of legacy pending codes: {}",
+                error
+            )),
         }
-        Ok(())
     }
 
     fn complete_pending_code_migration(
@@ -372,6 +377,108 @@ mod tests {
         assert_eq!(
             PairingStore::consume_pending_code_in(&config, new_code, 100).unwrap(),
             Some("telegram".to_string())
+        );
+    }
+
+    #[test]
+    fn pending_code_migration_rejects_non_writable_config_sources() {
+        let directory = TempDir::new().unwrap();
+        let system_config_path = directory.path().join("system.yaml");
+        let user_config_path = directory.path().join("user.yaml");
+        let secrets_path = directory.path().join("secrets.yaml");
+        let system_config =
+            Config::new_with_file_secrets(&system_config_path, &secrets_path).unwrap();
+        let legacy_code = StoredPendingCode {
+            code: "SYSTEM-CODE".to_string(),
+            gateway_type: "slack".to_string(),
+            expires_at: 101,
+        };
+        system_config
+            .set_param(PENDING_CODES_CONFIG_KEY, [&legacy_code])
+            .unwrap();
+        let config = Config::new_with_config_paths(
+            vec![system_config_path, user_config_path.clone()],
+            &secrets_path,
+        )
+        .unwrap();
+
+        let error =
+            PairingStore::store_pending_code_in(&config, "NEW-CODE", "telegram", 101).unwrap_err();
+
+        assert!(error.to_string().contains(
+            "legacy pending codes remain in GATEWAY_PENDING_CODES, the system config, or GOOSE_ADDITIONAL_CONFIG_FILES"
+        ));
+        assert_eq!(
+            config
+                .get_param::<Vec<StoredPendingCode>>(PENDING_CODES_CONFIG_KEY)
+                .unwrap()[0]
+                .code,
+            legacy_code.code
+        );
+        let user_config = std::fs::read_to_string(user_config_path).unwrap_or_default();
+        assert!(!user_config.contains(&legacy_code.code));
+
+        std::fs::write(directory.path().join("system.yaml"), "").unwrap();
+        assert_eq!(
+            PairingStore::consume_pending_code_in(&config, &legacy_code.code, 100).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn pending_code_migration_preserves_shadowed_writable_code() {
+        let directory = TempDir::new().unwrap();
+        let system_config_path = directory.path().join("system.yaml");
+        let user_config_path = directory.path().join("user.yaml");
+        let secrets_path = directory.path().join("secrets.yaml");
+        let system_config =
+            Config::new_with_file_secrets(&system_config_path, &secrets_path).unwrap();
+        system_config
+            .set_param(
+                PENDING_CODES_CONFIG_KEY,
+                [StoredPendingCode {
+                    code: "SYSTEM-CODE".to_string(),
+                    gateway_type: "slack".to_string(),
+                    expires_at: 101,
+                }],
+            )
+            .unwrap();
+        let user_config = Config::new_with_file_secrets(&user_config_path, &secrets_path).unwrap();
+        user_config
+            .set_param(
+                PENDING_CODES_CONFIG_KEY,
+                [StoredPendingCode {
+                    code: "USER-CODE".to_string(),
+                    gateway_type: "telegram".to_string(),
+                    expires_at: 101,
+                }],
+            )
+            .unwrap();
+        let config = Config::new_with_config_paths(
+            vec![system_config_path.clone(), user_config_path],
+            &secrets_path,
+        )
+        .unwrap();
+
+        assert!(
+            PairingStore::store_pending_code_in(&config, "NEW-CODE", "telegram", 101)
+                .unwrap_err()
+                .to_string()
+                .contains("legacy pending codes remain")
+        );
+
+        std::fs::write(system_config_path, "").unwrap();
+        assert_eq!(
+            PairingStore::consume_pending_code_in(&config, "USER-CODE", 100).unwrap(),
+            Some("telegram".to_string())
+        );
+        assert_eq!(
+            PairingStore::consume_pending_code_in(&config, "USER-CODE", 100).unwrap(),
+            None
+        );
+        assert_eq!(
+            PairingStore::consume_pending_code_in(&config, "SYSTEM-CODE", 100).unwrap(),
+            None
         );
     }
 


### PR DESCRIPTION
## Summary

- store pending gateway pairing codes in secret storage instead of ordinary configuration
- atomically consume one-time codes across configuration instances
- revoke plaintext legacy codes and fail closed until operators stop old writers and remove legacy configuration

### Testing

- `cargo fmt --all`
- `cargo test -p goose gateway::pairing::tests --lib` (16 passed)
- `cargo build -p goose`
- `cargo clippy -p goose --all-targets -- -D warnings`

*This finding was discovered by [Project Loupe](https://github.com/project-loupe/loupe)*
