### PR TITLE
fix(security): scan all shell tool aliases, not just "shell"

### DIFF
--- a/crates/goose/src/security/egress_inspector.rs
+++ b/crates/goose/src/security/egress_inspector.rs
@@ -6,6 +6,7 @@ use std::sync::OnceLock;
 
 use crate::config::GooseMode;
 use crate::conversation::message::{Message, ToolRequest};
+use crate::security::is_shell_tool;
 use crate::tool_inspection::{InspectionAction, InspectionResult, ToolInspector};
 
 pub struct EgressInspector;
@@ -270,15 +271,6 @@ fn detect_direction(command: &str) -> EgressDirection {
     }
 
     EgressDirection::Unknown
-}
-
-fn is_shell_tool(name: &str) -> bool {
-    matches!(
-        name,
-        "shell" | "bash" | "execute_command" | "run_command" | "terminal"
-    ) || name.ends_with("__shell")
-        || name.ends_with("__bash")
-        || name.ends_with("__terminal")
 }
 
 fn is_web_tool(name: &str) -> bool {

--- a/crates/goose/src/security/mod.rs
+++ b/crates/goose/src/security/mod.rs
@@ -14,6 +14,21 @@ use std::env;
 use std::sync::OnceLock;
 use uuid::Uuid;
 
+/// Tools that execute a shell command, and so carry command-injection risk.
+///
+/// Shared by the ML command scanner and the egress inspector: a name only one
+/// of them recognises is a silent coverage gap, since the scanner fails open on
+/// anything it does not match. Extensions namespace their tools, hence the
+/// suffix checks.
+pub(crate) fn is_shell_tool(name: &str) -> bool {
+    matches!(
+        name,
+        "shell" | "bash" | "execute_command" | "run_command" | "terminal"
+    ) || name.ends_with("__shell")
+        || name.ends_with("__bash")
+        || name.ends_with("__terminal")
+}
+
 pub(crate) fn get_override(env_key: &str) -> Option<bool> {
     env::var(env_key).ok().and_then(|v| match v.as_str() {
         "true" => Some(true),
@@ -261,5 +276,33 @@ impl SecurityManager {
 impl Default for SecurityManager {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_shell_tool;
+
+    #[test]
+    fn recognises_shell_aliases_and_namespaced_variants() {
+        for name in [
+            "shell",
+            "bash",
+            "execute_command",
+            "run_command",
+            "terminal",
+            "developer__shell",
+            "developer__bash",
+            "computercontroller__terminal",
+        ] {
+            assert!(is_shell_tool(name), "{name} should be scanned");
+        }
+    }
+
+    #[test]
+    fn ignores_tools_that_do_not_execute_commands() {
+        for name in ["text_editor", "fetch", "shellcheck", "__shellish"] {
+            assert!(!is_shell_tool(name), "{name} should not be scanned");
+        }
     }
 }

--- a/crates/goose/src/security/scanner.rs
+++ b/crates/goose/src/security/scanner.rs
@@ -1,6 +1,7 @@
 use crate::config::Config;
 use crate::conversation::message::Message;
 use crate::security::classification_client::ClassificationClient;
+use crate::security::is_shell_tool;
 use crate::security::patterns::{PatternMatch, PatternMatcher};
 use crate::utils::safe_truncate;
 use anyhow::Result;
@@ -133,7 +134,7 @@ impl PromptInjectionScanner {
         tool_call: &CallToolRequestParams,
         messages: &[Message],
     ) -> Result<ScanResult> {
-        if !is_shell_tool_name(tool_call.name.as_ref()) {
+        if !is_shell_tool(tool_call.name.as_ref()) {
             return Ok(ScanResult {
                 is_malicious: false,
                 confidence: 0.0,
@@ -392,10 +393,6 @@ impl PromptInjectionScanner {
         }
         s
     }
-}
-
-fn is_shell_tool_name(name: &str) -> bool {
-    matches!(name, "shell")
 }
 
 impl Default for PromptInjectionScanner {


### PR DESCRIPTION
## Problem

The ML command-injection scanner gated on an exact match against one string literal:

```rust
fn is_shell_tool_name(name: &str) -> bool {
    matches!(name, "shell")
}
```

Anything else returned `is_malicious: false, scanned: false` — it fails open silently.

Meanwhile `egress_inspector.rs`, in the same module, already recognised a much wider set: `shell`, `bash`, `execute_command`, `run_command`, `terminal`, plus the extension-namespaced `__shell` / `__bash` / `__terminal` forms.

So a tool invoking a shell under any of those names had its commands inspected for egress but **never classified for command injection**. Two lists describing the same concept, drifted apart.

## Change

Move the predicate to `security::is_shell_tool` and use it from both call sites, so the lists cannot diverge again.

- `scanner.rs` — drops the one-literal `is_shell_tool_name`, calls the shared predicate
- `egress_inspector.rs` — drops its local copy, imports the shared one (**no behaviour change**; this was already its list)
- `mod.rs` — hosts the shared predicate plus unit tests covering aliases, namespaced variants, and near-miss negatives (`shellcheck`, `__shellish`)

`session/export_markdown.rs` has a same-named helper that is deliberately untouched — it is a rendering concern with a different list, not a security gate.

## Blast radius

Telemetry over the last 5 days across 286,591 scanned tool calls shows **100% of scanned calls are literally `shell`** — so for deployments that only expose `shell`, nothing changes.

The change matters for deployments exposing a shell under another name, where the classifier is currently not running at all. Those will begin being scanned, so flag volume may rise there; that is the intent, but worth watching after rollout.

## Verification

- `cargo fmt` clean
- New unit tests in `crates/goose/src/security/mod.rs`
- Not compiled locally (local `target/` was cleared); relying on CI for the build and test run — this is why the PR is draft

## Note on process

No linked issue — raising this as maintainer-directed work off the back of a production telemetry review. Happy to file a Ready issue on the board first if it should go through the standard flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)