### PR TITLE
fix(openrouter): rewrite $ref token in Gemini tool results

### DIFF
--- a/crates/goose/src/providers/openrouter.rs
+++ b/crates/goose/src/providers/openrouter.rs
@@ -103,6 +103,64 @@ fn is_gemini_model(model_name: &str) -> bool {
     model_name.starts_with("google/")
 }
 
+/// Literal token Google's Gemini backend misreads inside a `function_response`.
+const GEMINI_REF_TOKEN: &str = "$ref";
+const GEMINI_REF_REPLACEMENT: &str = "dollar_ref";
+const GEMINI_REF_NOTE: &str = "[goose compatibility note] In the tool output below, every JSON Schema reference key was rewritten to \"dollar_ref\". The original key is a dollar sign followed by \"ref\", and the referenced values are unchanged.\n\n";
+
+/// Rewrite `$ref` only where it stands as a complete token. Tool output is
+/// usually file contents or command output, so a bare substring replace would
+/// also corrupt legitimate identifiers such as `$refs` or `$refresh_token`.
+fn rewrite_ref_tokens(text: &str) -> Option<String> {
+    let is_identifier_char = |c: char| c.is_ascii_alphanumeric() || c == '_';
+
+    let mut segments = text.split(GEMINI_REF_TOKEN);
+    let mut out = String::with_capacity(text.len());
+    out.push_str(segments.next()?);
+    let mut replaced = false;
+
+    for segment in segments {
+        if segment.starts_with(is_identifier_char) {
+            out.push_str(GEMINI_REF_TOKEN);
+        } else {
+            out.push_str(GEMINI_REF_REPLACEMENT);
+            replaced = true;
+        }
+        out.push_str(segment);
+    }
+
+    replaced.then_some(out)
+}
+
+/// Google rejects OpenAI `role: "tool"` content containing the literal `$ref`
+/// key: it reads the key as Gemini `function_response` metadata and returns
+/// `400 INVALID_ARGUMENT`. Because Goose replays persisted history, one such
+/// tool result breaks every later turn in the session.
+///
+/// Tool output is treated as opaque text; it is not required to parse as JSON.
+fn rewrite_gemini_ref_token_in_tool_content(payload: &mut Value, model_name: &str) {
+    if !is_gemini_model(model_name) {
+        return;
+    }
+
+    let Some(messages) = payload.get_mut("messages").and_then(Value::as_array_mut) else {
+        return;
+    };
+
+    for message in messages {
+        if message.get("role").and_then(Value::as_str) != Some("tool") {
+            continue;
+        }
+        let Some(content) = message.get_mut("content") else {
+            continue;
+        };
+        let Some(rewritten) = content.as_str().and_then(rewrite_ref_tokens) else {
+            continue;
+        };
+        *content = Value::String(format!("{GEMINI_REF_NOTE}{rewritten}"));
+    }
+}
+
 fn parse_openrouter_parameters(raw: Value) -> Result<HashMap<String, Value>> {
     match raw {
         Value::Object(params) => Ok(params.into_iter().collect()),
@@ -297,6 +355,7 @@ impl Provider for OpenRouterProvider {
         if is_gemini_model(&model_config.model_name) {
             openrouter_format::add_reasoning_details_to_request(&mut payload, messages);
         }
+        rewrite_gemini_ref_token_in_tool_content(&mut payload, &model_config.model_name);
         let sent_reasoning_disable =
             openrouter_format::apply_reasoning_config(&mut payload, model_config);
 
@@ -459,5 +518,163 @@ mod tests {
             .stream(&config, "system", &[Message::user().with_text("hi")], &[])
             .await
             .unwrap();
+    }
+
+    fn tool_payload(content: &str) -> Value {
+        json!({
+            "messages": [
+                { "role": "system", "content": "sys $ref" },
+                { "role": "user", "content": "user $ref" },
+                { "role": "assistant", "content": "assistant $ref" },
+                { "role": "tool", "content": content, "tool_call_id": "call_1" }
+            ]
+        })
+    }
+
+    fn tool_content(payload: &Value) -> &str {
+        payload["messages"][3]["content"].as_str().unwrap()
+    }
+
+    #[test]
+    fn gemini_tool_content_ref_key_is_rewritten_and_value_preserved() {
+        let mut payload =
+            tool_payload("{'properties': {'image': {'$ref': '#/components/schemas/Example'}}}");
+
+        rewrite_gemini_ref_token_in_tool_content(&mut payload, "google/gemini-3.7-flash");
+
+        let content = tool_content(&payload);
+        assert!(content.starts_with(GEMINI_REF_NOTE));
+        assert!(content.ends_with(
+            "{'properties': {'image': {'dollar_ref': '#/components/schemas/Example'}}}"
+        ));
+    }
+
+    #[test]
+    fn gemini_tool_content_rewrites_every_occurrence() {
+        let mut payload = tool_payload("{'a': {'$ref': '#/x'}, 'b': {'$ref': '#/y'}}");
+
+        rewrite_gemini_ref_token_in_tool_content(&mut payload, "google/gemini-2.5-pro");
+
+        assert!(tool_content(&payload)
+            .ends_with("{'a': {'dollar_ref': '#/x'}, 'b': {'dollar_ref': '#/y'}}"));
+    }
+
+    #[test]
+    fn identifiers_that_merely_start_with_the_token_are_preserved() {
+        let source = "this.$refs.input; const $refresh_token = 1; $ref_count += $refs.len();";
+        let mut payload = tool_payload(source);
+
+        rewrite_gemini_ref_token_in_tool_content(&mut payload, "google/gemini-3.7-flash");
+
+        assert_eq!(tool_content(&payload), source);
+    }
+
+    #[test]
+    fn token_is_rewritten_when_followed_by_a_non_identifier_char() {
+        for (input, expected) in [
+            ("\"$ref\":", "\"dollar_ref\":"),
+            ("'$ref' =>", "'dollar_ref' =>"),
+            ("trailing $ref", "trailing dollar_ref"),
+            ("$ref.path", "dollar_ref.path"),
+            ("$ref-dash", "dollar_ref-dash"),
+        ] {
+            let mut payload = tool_payload(input);
+            rewrite_gemini_ref_token_in_tool_content(&mut payload, "google/gemini-3.7-flash");
+            assert!(
+                tool_content(&payload).ends_with(expected),
+                "{input} should rewrite to {expected}"
+            );
+        }
+    }
+
+    #[test]
+    fn mixed_content_rewrites_only_the_standalone_token() {
+        let mut payload = tool_payload("$refs and {'$ref': '#/a'} and $refresh");
+
+        rewrite_gemini_ref_token_in_tool_content(&mut payload, "google/gemini-3.7-flash");
+
+        assert!(tool_content(&payload).ends_with("$refs and {'dollar_ref': '#/a'} and $refresh"));
+    }
+
+    #[test]
+    fn gemini_guard_leaves_other_roles_untouched() {
+        let mut payload = tool_payload("{'$ref': '#/a'}");
+
+        rewrite_gemini_ref_token_in_tool_content(&mut payload, "google/gemini-2.5-flash");
+
+        assert_eq!(payload["messages"][0]["content"], json!("sys $ref"));
+        assert_eq!(payload["messages"][1]["content"], json!("user $ref"));
+        assert_eq!(payload["messages"][2]["content"], json!("assistant $ref"));
+    }
+
+    #[test]
+    fn non_google_models_are_untouched() {
+        let original = tool_payload("{'$ref': '#/a'}");
+        let mut payload = original.clone();
+
+        rewrite_gemini_ref_token_in_tool_content(&mut payload, "anthropic/claude-sonnet-4");
+
+        assert_eq!(payload, original);
+    }
+
+    #[test]
+    fn tool_content_without_the_token_is_unchanged() {
+        for content in ["plain tool output", "this.$refs.input only"] {
+            let original = tool_payload(content);
+            let mut payload = original.clone();
+
+            rewrite_gemini_ref_token_in_tool_content(&mut payload, "google/gemini-3.7-flash");
+
+            assert_eq!(payload, original, "{content} should be untouched");
+        }
+    }
+
+    #[test]
+    fn note_is_added_once_per_affected_tool_message_only() {
+        let mut payload = json!({
+            "messages": [
+                { "role": "tool", "content": "{'$ref': '#/a'}", "tool_call_id": "a" },
+                { "role": "tool", "content": "no marker here", "tool_call_id": "b" },
+                { "role": "tool", "content": "{'$ref': '#/c'}", "tool_call_id": "c" }
+            ]
+        });
+
+        rewrite_gemini_ref_token_in_tool_content(&mut payload, "google/gemini-3.7-flash");
+
+        let messages = payload["messages"].as_array().unwrap();
+        for index in [0, 2] {
+            let content = messages[index]["content"].as_str().unwrap();
+            assert!(content.starts_with(GEMINI_REF_NOTE));
+            assert_eq!(content.matches(GEMINI_REF_NOTE).count(), 1);
+        }
+        assert_eq!(messages[1]["content"], json!("no marker here"));
+    }
+
+    #[test]
+    fn payloads_without_string_tool_content_are_untouched() {
+        for original in [
+            json!({}),
+            json!({ "messages": "not an array" }),
+            json!({ "messages": [{ "role": "tool", "tool_call_id": "a" }] }),
+            json!({
+                "messages": [{
+                    "role": "tool",
+                    "content": [{ "type": "text", "text": "$ref" }],
+                    "tool_call_id": "a"
+                }]
+            }),
+        ] {
+            let mut payload = original.clone();
+
+            rewrite_gemini_ref_token_in_tool_content(&mut payload, "google/gemini-3.7-flash");
+
+            assert_eq!(payload, original);
+        }
+    }
+
+    #[test]
+    fn compatibility_note_matches_the_tokens_it_describes() {
+        assert!(GEMINI_REF_NOTE.contains(GEMINI_REF_REPLACEMENT));
+        assert!(!GEMINI_REF_NOTE.contains(GEMINI_REF_TOKEN));
     }
 }


### PR DESCRIPTION
Implements #11260.

## Problem

Google's Gemini backend reads the literal `$ref` key inside an OpenAI `role: "tool"` message as `function_response` metadata and rejects the request:

```text
400 INVALID_ARGUMENT: The referenced name `#/components/schemas/Example`
in function_response.response does not match to a display_name in the
function_response.parts.
```

Because Goose replays persisted session history, a single tool result containing that key makes **every later turn in the session fail deterministically** — the session is permanently bricked.

## Fix

A narrow compatibility guard in `crates/goose/src/providers/openrouter.rs`, applied after `create_request` and before the payload is posted:

- gated to `google/*` models (the existing `is_gemini_model` predicate);
- gated to `role: "tool"` **string** content;
- rewrites `$ref` → `dollar_ref`, preserving the referenced value verbatim;
- prepends a short reconstruction note **only when a replacement actually occurred**;
- treats tool output as opaque text — it is not required to parse as JSON.

### Token matching, not substring replace

The issue asked to replace "every **exact** `$ref` token". This matches the token only where it stands alone — i.e. when the next character is not `[A-Za-z0-9_]`.

A bare `text.replace("$ref", ...)` would have been a data-corruption bug: Goose tool output is overwhelmingly file contents and command output, so it would also mangle `this.$refs.input`, `$refresh_token`, and `$ref_count`. The model would then read corrupted source and could write it back. That case is covered by `identifiers_that_merely_start_with_the_token_are_preserved` and `mixed_content_rewrites_only_the_standalone_token`.

The compatibility note also deliberately avoids containing the literal token, since that would reintroduce the very trigger it explains — asserted by `compatibility_note_matches_the_tokens_it_describes`.

## Verification

Per the issue's verification plan, plus the false-positive cases above. 17 tests in `providers::openrouter`, covering:

- the exact reproduction payload from the issue — key rewritten, `#/components/schemas/Example` value preserved;
- multiple occurrences in one tool result;
- identifiers that merely *start with* the token, left untouched;
- rewrite when followed by each of `"`, `'`, space, `.`, `-`;
- `system` / `user` / `assistant` content untouched;
- non-Google OpenRouter models untouched;
- tool content without the token byte-for-byte unchanged;
- note added exactly once, and only to affected messages, when a payload mixes affected and unaffected tool results;
- missing / non-array `messages`, missing content, and non-string content all no-ops.

**Each new test was verified to fail against the buggy behaviour** by mutating the implementation back and confirming the failure — for the disabled guard, the removed model gate, the always-prepended note, and the naive substring replace.

```
cargo fmt --check                          # clean
cargo clippy --all-targets -- -D warnings  # clean
cargo test -p goose                        # 1950 passed
```

`cargo test -p goose` has 14 pre-existing failures on this machine (rustls `CryptoProvider` init and shared global config state). I confirmed the identical 14 fail on unmodified `origin/main` at `d0fc739a4`; this branch adds 11 passing tests and no new failures.

### Ordering note

`apply_chat_payload_breakpoints` runs earlier in `stream()`, but `CacheSemantics::for_model` only returns `ExplicitBreakpoints` for `openrouter` + `anthropic/*`, so it can never reshape tool content for a `google/*` model. There is no interaction between the two.
