### PR TITLE
fix(security): require Developer for doctor

### DIFF
--- a/crates/goose/src/agents/execute_commands.rs
+++ b/crates/goose/src/agents/execute_commands.rs
@@ -635,7 +635,6 @@ mod tests {
             .iter()
             .any(|command| command.name == "status"));
     }
-
     #[tokio::test]
     async fn invalid_rendered_recipe_schema_returns_assistant_response() {
         let agent = Agent::new();
@@ -673,5 +672,26 @@ mod tests {
             .as_concat_text()
             .contains("Recipe /invalid-rendered-schema is not valid"));
         assert!(agent.final_output_tool.lock().await.is_none());
+    }
+    #[tokio::test]
+    async fn doctor_refuses_without_enabling_developer() {
+        let agent = Agent::new();
+
+        let response = agent
+            .execute_command("/doctor", "doctor-disabled-legacy-test")
+            .await
+            .expect("doctor command should succeed")
+            .expect("doctor command should return a message");
+
+        assert_eq!(
+            response.as_concat_text(),
+            crate::doctor::DEVELOPER_EXTENSION_REQUIRED_MESSAGE
+        );
+        assert!(
+            !agent
+                .extension_manager
+                .is_extension_enabled(crate::agents::platform_extensions::developer::EXTENSION_NAME)
+                .await
+        );
     }
 }

--- a/crates/goose/src/agents/state_machine/tests/mod.rs
+++ b/crates/goose/src/agents/state_machine/tests/mod.rs
@@ -31,6 +31,36 @@ async fn bang_shell_requests_the_shell_tool() -> Result<()> {
 }
 
 #[tokio::test]
+async fn doctor_refuses_without_developer_before_inference() -> Result<()> {
+    let (pipeline, api) = test_pipeline().await?;
+    let agent = crate::execution::manager::AgentManager::instance()
+        .await?
+        .get_or_create_agent(pipeline.session_id.clone())
+        .await?;
+    agent
+        .extension_manager
+        .remove_extension(crate::agents::platform_extensions::developer::EXTENSION_NAME)
+        .await?;
+
+    let result = pipeline.run(["/doctor"]).await?;
+
+    result.assert_message(
+        -1,
+        Agent,
+        crate::doctor::DEVELOPER_EXTENSION_REQUIRED_MESSAGE,
+    );
+    assert_eq!(api.call_count(), 0);
+    assert!(
+        !agent
+            .extension_manager
+            .is_extension_enabled(crate::agents::platform_extensions::developer::EXTENSION_NAME)
+            .await
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn max_turns_counts_inference_calls_and_injects_budget() -> Result<()> {
     let (pipeline, api) = test_pipeline().await?;
     api.on("keep going").call(ADD, value(1));

--- a/crates/goose/src/doctor.rs
+++ b/crates/goose/src/doctor.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use crate::agents::platform_extensions::developer;
-use crate::agents::ExtensionConfig;
 use crate::config::Config;
 use crate::conversation::message::Message;
 use crate::providers;
@@ -11,12 +10,20 @@ use crate::session::{
 };
 use goose_providers::errors::ProviderError;
 
+pub(crate) const DEVELOPER_EXTENSION_REQUIRED_MESSAGE: &str = "**Goose Doctor**\n\n\
+`/doctor` requires the Developer extension, but it is disabled for this session.\n\n\
+Enable it for this session and run `/doctor` again:\n\
+- CLI: `/builtin developer`\n\
+- Desktop: select **Developer** in the session extension selector.";
+
 pub async fn run(agent: &crate::agents::Agent, session_id: &str) -> anyhow::Result<Message> {
+    if let Some(message) = require_developer_extension(agent).await {
+        return Ok(message);
+    }
+
     if let Some(msg) = ensure_working_provider(agent, session_id).await? {
         return Ok(msg);
     }
-
-    ensure_developer_extension(agent, session_id).await;
 
     let info = SystemInfo::collect();
     let extensions = agent.list_extensions().await;
@@ -54,6 +61,14 @@ pub async fn run(agent: &crate::agents::Agent, session_id: &str) -> anyhow::Resu
     );
 
     Ok(Message::user().with_text(prompt))
+}
+
+async fn require_developer_extension(agent: &crate::agents::Agent) -> Option<Message> {
+    (!agent
+        .extension_manager
+        .is_extension_enabled(developer::EXTENSION_NAME)
+        .await)
+        .then(|| Message::assistant().with_text(DEVELOPER_EXTENSION_REQUIRED_MESSAGE))
 }
 
 async fn ensure_working_provider(
@@ -113,26 +128,6 @@ async fn ensure_working_provider(
          No working provider found. Run `goose configure` to set one up.",
         preamble,
     ))))
-}
-
-async fn ensure_developer_extension(agent: &crate::agents::Agent, session_id: &str) {
-    if agent
-        .extension_manager
-        .is_extension_enabled(developer::EXTENSION_NAME)
-        .await
-    {
-        return;
-    }
-    let config = ExtensionConfig::Platform {
-        name: developer::EXTENSION_NAME.to_string(),
-        description: "Write and edit files, and execute shell commands".to_string(),
-        display_name: Some("Developer".to_string()),
-        bundled: None,
-        available_tools: vec![],
-    };
-    if let Err(e) = agent.add_extension(config, session_id).await {
-        tracing::warn!("Doctor: failed to load developer extension: {}", e);
-    }
 }
 
 async fn save_and_set(
@@ -270,5 +265,34 @@ fn describe_error(e: &ProviderError) -> String {
             "Provider server error — the service may be temporarily down.".to_string()
         }
         other => format!("{}", other),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agents::ExtensionConfig;
+
+    #[tokio::test]
+    async fn developer_requirement_accepts_enabled_extension() {
+        let agent = crate::agents::Agent::new();
+        agent
+            .extension_manager
+            .add_extension(
+                ExtensionConfig::Platform {
+                    name: developer::EXTENSION_NAME.to_string(),
+                    description: "Developer tools".to_string(),
+                    display_name: Some("Developer".to_string()),
+                    bundled: None,
+                    available_tools: vec![],
+                },
+                None,
+                None,
+                Some("doctor-enabled-test"),
+            )
+            .await
+            .expect("developer extension should load");
+
+        assert!(require_developer_extension(&agent).await.is_none());
     }
 }

--- a/crates/goose/src/doctor.rs
+++ b/crates/goose/src/doctor.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use crate::agents::platform_extensions::developer;
+use crate::agents::ExtensionConfig;
 use crate::config::Config;
 use crate::conversation::message::Message;
 use crate::providers;
@@ -64,11 +65,21 @@ pub async fn run(agent: &crate::agents::Agent, session_id: &str) -> anyhow::Resu
 }
 
 async fn require_developer_extension(agent: &crate::agents::Agent) -> Option<Message> {
-    (!agent
+    let has_developer = agent
         .extension_manager
-        .is_extension_enabled(developer::EXTENSION_NAME)
-        .await)
-        .then(|| Message::assistant().with_text(DEVELOPER_EXTENSION_REQUIRED_MESSAGE))
+        .get_extension_configs()
+        .await
+        .iter()
+        .any(is_developer_platform_config);
+
+    (!has_developer).then(|| Message::assistant().with_text(DEVELOPER_EXTENSION_REQUIRED_MESSAGE))
+}
+
+fn is_developer_platform_config(config: &ExtensionConfig) -> bool {
+    matches!(
+        config,
+        ExtensionConfig::Builtin { .. } | ExtensionConfig::Platform { .. }
+    ) && config.key() == developer::EXTENSION_NAME
 }
 
 async fn ensure_working_provider(
@@ -271,7 +282,6 @@ fn describe_error(e: &ProviderError) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::agents::ExtensionConfig;
 
     #[tokio::test]
     async fn developer_requirement_accepts_enabled_extension() {
@@ -294,5 +304,17 @@ mod tests {
             .expect("developer extension should load");
 
         assert!(require_developer_extension(&agent).await.is_none());
+    }
+
+    #[test]
+    fn custom_extension_named_developer_does_not_satisfy_requirement() {
+        let config = ExtensionConfig::stdio(
+            developer::EXTENSION_NAME,
+            "custom-developer",
+            "Unrelated custom extension",
+            30_u64,
+        );
+
+        assert!(!is_developer_platform_config(&config));
     }
 }


### PR DESCRIPTION
## Summary

- require the real Builtin/Platform Developer extension before running `/doctor`
- explain how to enable Developer for the current CLI or Desktop session
- leave session extension state unchanged when Developer is disabled
- cover the shared behavior through legacy and state-machine command paths

## Verification

- `cargo fmt --all -- --check` — passed
- `cargo test -p goose doctor --lib` — 4 passed
- `cargo test -p goose invalid_rendered_recipe_schema_returns_assistant_response --lib` — 1 passed
- `cargo build -p goose` — passed
- `cargo clippy -p goose --all-targets -- -D warnings` — passed

*This finding was discovered by [Project Loupe](https://github.com/project-loupe/loupe)*

