### PR TITLE
fix(security): preserve local inference message text

### DIFF
--- a/crates/goose-local-inference/src/lib.rs
+++ b/crates/goose-local-inference/src/lib.rs
@@ -481,7 +481,7 @@ fn extract_text_content(msg: &Message) -> String {
     for content in &msg.content {
         match content {
             MessageContent::Text(text) => {
-                let text = strip_info_messages(&text.text);
+                let text = text.text.to_string();
                 if !text.trim().is_empty() {
                     parts.push(text);
                 }
@@ -532,24 +532,6 @@ fn extract_text_content(msg: &Message) -> String {
     }
 
     parts.join("\n")
-}
-
-fn strip_info_messages(text: &str) -> String {
-    let mut remaining = text;
-    let mut output = String::new();
-
-    while let Some((before, after_start)) = remaining.split_once("<info-msg>") {
-        output.push_str(before);
-        if let Some((_, after_end)) = after_start.split_once("</info-msg>") {
-            remaining = after_end;
-        } else {
-            remaining = "";
-            break;
-        }
-    }
-
-    output.push_str(remaining);
-    output.trim().to_string()
 }
 
 /// Build a `ProviderUsage` and write the request log entry.
@@ -946,5 +928,33 @@ mod tests {
                 {"type": "media_marker", "text": "<__media__>"},
             ])
         );
+    }
+
+    #[test]
+    fn preserves_balanced_info_tags_in_text_content() {
+        let message =
+            Message::user().with_text("before <info-msg>executed payload</info-msg> after");
+
+        assert_eq!(
+            extract_text_content(&message),
+            "before <info-msg>executed payload</info-msg> after"
+        );
+    }
+
+    #[test]
+    fn preserves_unterminated_info_tags_in_text_content() {
+        let message = Message::user().with_text("before <info-msg>executed payload");
+
+        assert_eq!(
+            extract_text_content(&message),
+            "before <info-msg>executed payload"
+        );
+    }
+
+    #[test]
+    fn preserves_legitimate_text_content() {
+        let message = Message::user().with_text("ordinary user content");
+
+        assert_eq!(extract_text_content(&message), "ordinary user content");
     }
 }


### PR DESCRIPTION
## Summary

- Preserve literal local-inference message text instead of discarding content that resembles internal information tags.
- Add regression coverage for balanced and unterminated tag-like text and ordinary user content.

## Testing

- `cargo test -p goose-local-inference preserves_`
- `cargo test -p goose-local-inference`
- `cargo build`
- `cargo clippy --all-targets -- -D warnings`

*This finding was discovered by [Project Loupe](https://github.com/project-loupe/loupe)*
