### PR TITLE
fix(security): sanitize Unicode tags in MCP prompts

### DIFF
--- a/crates/goose-provider-types/src/conversation/message.rs
+++ b/crates/goose-provider-types/src/conversation/message.rs
@@ -706,7 +706,10 @@ impl From<PromptMessage> for Message {
 
         // Convert and add the content
         let content = match prompt_message.content {
-            ContentBlock::Text(text) => MessageContentBlock::Text(text),
+            ContentBlock::Text(mut text) => {
+                text.text = sanitize_unicode_tags(&text.text);
+                MessageContentBlock::Text(text)
+            }
             ContentBlock::Image(image) => MessageContentBlock::Image(image),
             ContentBlock::ResourceLink(_) => MessageContentBlock::text("[Resource link]"),
             ContentBlock::Resource(resource) => {
@@ -1899,6 +1902,27 @@ mod tests {
         } else {
             panic!("Expected MessageContentBlock::Text");
         }
+    }
+
+    #[test]
+    fn test_from_prompt_message_text_preserves_visible_unicode() {
+        let prompt_message = PromptMessage::new(Role::User, ContentBlock::text("Grüße 你好 🪿"));
+
+        let message = Message::from(prompt_message);
+
+        assert_eq!(message.as_concat_text(), "Grüße 你好 🪿");
+    }
+
+    #[test]
+    fn test_from_prompt_message_text_removes_unicode_tags() {
+        let prompt_message = PromptMessage::new(
+            Role::User,
+            ContentBlock::text("visible\u{E0000}\u{E0041}\u{E007F} text"),
+        );
+
+        let message = Message::from(prompt_message);
+
+        assert_eq!(message.as_concat_text(), "visible text");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Sanitize Unicode tag code points from direct MCP prompt text at the shared provider-message conversion boundary.
- Preserve visible Unicode and existing resource-content handling.
- Add regressions for legitimate Unicode and Unicode tags, including both guarded range bounds.

### Testing

- `cargo fmt --all`
- `cargo test -p goose-provider-types test_from_prompt_message_text -- --nocapture` (4 passed)
- `cargo test -p goose-provider-types` (551 unit tests and 8 integration tests passed)
- `cargo build`
- `cargo clippy --all-targets -- -D warnings`

*This finding was discovered by [Project Loupe](https://github.com/project-loupe/loupe)*
