### PR TITLE
fix(security): confine memory file operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5558,6 +5558,7 @@ dependencies = [
  "tracing-appender",
  "tracing-subscriber",
  "umya-spreadsheet",
+ "winapi",
 ]
 
 [[package]]
@@ -6625,19 +6626,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ipconfig"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
-dependencies = [
- "socket2",
- "widestring",
- "windows-registry",
- "windows-result 0.4.1",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "io-extras"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6658,6 +6646,19 @@ name = "io-lifetimes"
 version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f0fb0570afe1fed943c5c3d4102d5358592d8625fda6a0007fdbe65a92fba96"
+
+[[package]]
+name = "ipconfig"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
+dependencies = [
+ "socket2",
+ "widestring",
+ "windows-registry",
+ "windows-result 0.4.1",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "ipnet"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,6 +172,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "ambient-authority"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9d4ee0d472d1cd2e28c97dfa124b3d8d992e10eb0a035f33f5d12e3a177ba3b"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2171,6 +2177,48 @@ dependencies = [
  "ug",
  "ug-cuda",
  "ug-metal",
+]
+
+[[package]]
+name = "cap-fs-ext"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56ff379b70af8e08307a8f65e7040c7301cb4a572538ade16b4984f0da77847f"
+dependencies = [
+ "cap-primitives",
+ "cap-std",
+ "io-lifetimes 3.0.1",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "cap-primitives"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b5f74729fd2f44701d1a8eb47e906cdb3ccd9ec0f02baad85a744b791940b18"
+dependencies = [
+ "ambient-authority",
+ "fs-set-times",
+ "io-extras",
+ "io-lifetimes 3.0.1",
+ "ipnet",
+ "maybe-owned",
+ "rustix 1.1.4",
+ "rustix-linux-procfs",
+ "windows-sys 0.61.2",
+ "winx",
+]
+
+[[package]]
+name = "cap-std"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1ec78e242cfa2cfe276807ac2ecc00315a6c97786977414bcd1c3963b6c91b8"
+dependencies = [
+ "cap-primitives",
+ "io-extras",
+ "io-lifetimes 3.0.1",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -4590,6 +4638,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs-set-times"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
+dependencies = [
+ "io-lifetimes 2.0.4",
+ "rustix 1.1.4",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "fs2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5477,6 +5536,8 @@ version = "1.48.0"
 dependencies = [
  "anyhow",
  "base64 0.23.1",
+ "cap-fs-ext",
+ "cap-std",
  "chrono",
  "docx-rs",
  "etcetera",
@@ -6577,6 +6638,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-extras"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20fd6de4ccfcc187e38bc21cfa543cb5a302cb86a8b114eb7f0bf0dc9f8ac00f"
+dependencies = [
+ "io-lifetimes 3.0.1",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
+
+[[package]]
+name = "io-lifetimes"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0fb0570afe1fed943c5c3d4102d5358592d8625fda6a0007fdbe65a92fba96"
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7432,6 +7515,12 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "maybe-owned"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "md-5"
@@ -10391,6 +10480,16 @@ dependencies = [
  "libc",
  "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustix-linux-procfs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fc84bf7e9aa16c4f2c758f27412dc9841341e16aa682d9c7ac308fe3ee12056"
+dependencies = [
+ "once_cell",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -15031,6 +15130,16 @@ name = "winsafe"
 version = "0.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
+
+[[package]]
+name = "winx"
+version = "0.36.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
+dependencies = [
+ "bitflags 2.13.0",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "wiremock"

--- a/crates/goose-mcp/Cargo.toml
+++ b/crates/goose-mcp/Cargo.toml
@@ -39,3 +39,5 @@ image = { version = "0.24.4", default-features = false, features = ["bmp", "dds"
 umya-spreadsheet = { version = "3", default-features = false }
 shell-words = { workspace = true }
 process-wrap = { version = "9", default-features = false, features = ["std", "process-session"] }
+cap-std = "4.0.3"
+cap-fs-ext = "4.0.3"

--- a/crates/goose-mcp/Cargo.toml
+++ b/crates/goose-mcp/Cargo.toml
@@ -41,3 +41,6 @@ shell-words = { workspace = true }
 process-wrap = { version = "9", default-features = false, features = ["std", "process-session"] }
 cap-std = "4.0.3"
 cap-fs-ext = "4.0.3"
+
+[target.'cfg(target_os = "windows")'.dependencies]
+winapi = { workspace = true, features = ["accctrl", "aclapi", "sddl", "securitybaseapi", "winbase", "winerror"] }

--- a/crates/goose-mcp/src/memory/mod.rs
+++ b/crates/goose-mcp/src/memory/mod.rs
@@ -1,4 +1,6 @@
 use cap_fs_ext::{DirExt, MetadataExt};
+#[cfg(windows)]
+use cap_std::fs::OpenOptionsExt;
 use cap_std::{
     ambient_authority,
     fs::{Dir, OpenOptions},
@@ -108,6 +110,79 @@ fn restrict_memory_temp_file(_file: &fs::File) -> io::Result<()> {
     Ok(())
 }
 
+fn preserve_memory_file_security(source: &fs::File, destination: &fs::File) -> io::Result<()> {
+    destination.set_permissions(source.metadata()?.permissions())?;
+
+    #[cfg(windows)]
+    {
+        use std::os::windows::io::AsRawHandle;
+        use std::ptr;
+        use winapi::shared::minwindef::HLOCAL;
+        use winapi::shared::winerror::ERROR_SUCCESS;
+        use winapi::um::accctrl::SE_FILE_OBJECT;
+        use winapi::um::aclapi::{GetSecurityInfo, SetSecurityInfo};
+        use winapi::um::securitybaseapi::GetSecurityDescriptorControl;
+        use winapi::um::winbase::LocalFree;
+        use winapi::um::winnt::{
+            DACL_SECURITY_INFORMATION, PACL, PROTECTED_DACL_SECURITY_INFORMATION,
+            PSECURITY_DESCRIPTOR, SE_DACL_PROTECTED, UNPROTECTED_DACL_SECURITY_INFORMATION,
+        };
+
+        let mut dacl: PACL = ptr::null_mut();
+        let mut descriptor: PSECURITY_DESCRIPTOR = ptr::null_mut();
+        let status = unsafe {
+            GetSecurityInfo(
+                source.as_raw_handle(),
+                SE_FILE_OBJECT,
+                DACL_SECURITY_INFORMATION,
+                ptr::null_mut(),
+                ptr::null_mut(),
+                &mut dacl,
+                ptr::null_mut(),
+                &mut descriptor,
+            )
+        };
+        if status != ERROR_SUCCESS {
+            return Err(io::Error::from_raw_os_error(status as i32));
+        }
+
+        let mut control = 0;
+        let mut revision = 0;
+        if unsafe { GetSecurityDescriptorControl(descriptor, &mut control, &mut revision) } == 0 {
+            let error = io::Error::last_os_error();
+            unsafe {
+                LocalFree(descriptor as HLOCAL);
+            }
+            return Err(error);
+        }
+
+        let protection = if control & SE_DACL_PROTECTED != 0 {
+            PROTECTED_DACL_SECURITY_INFORMATION
+        } else {
+            UNPROTECTED_DACL_SECURITY_INFORMATION
+        };
+        let status = unsafe {
+            SetSecurityInfo(
+                destination.as_raw_handle(),
+                SE_FILE_OBJECT,
+                DACL_SECURITY_INFORMATION | protection,
+                ptr::null_mut(),
+                ptr::null_mut(),
+                dacl,
+                ptr::null_mut(),
+            )
+        };
+        unsafe {
+            LocalFree(descriptor as HLOCAL);
+        }
+        if status != ERROR_SUCCESS {
+            return Err(io::Error::from_raw_os_error(status as i32));
+        }
+    }
+
+    Ok(())
+}
+
 fn open_memory_file_at(
     directory: &Dir,
     name: &OsStr,
@@ -144,6 +219,12 @@ fn open_memory_file_at(
         }
         MemoryFileOpen::CreateNew => {
             options.write(true).create_new(true);
+            #[cfg(windows)]
+            options.access_mode({
+                use winapi::um::winnt::{GENERIC_READ, GENERIC_WRITE, READ_CONTROL, WRITE_DAC};
+
+                GENERIC_READ | GENERIC_WRITE | READ_CONTROL | WRITE_DAC
+            });
         }
     }
     // Capability-relative resolution confines any swap that lands during open, while the
@@ -424,7 +505,7 @@ impl MemoryServer {
         directory: &Dir,
         file_name: &OsStr,
         content: &[u8],
-        permissions: fs::Permissions,
+        source: &fs::File,
     ) -> io::Result<()> {
         let process_id = std::process::id();
         let (temp_name, mut temp_file) = loop {
@@ -440,7 +521,7 @@ impl MemoryServer {
         let result = (|| {
             restrict_memory_temp_file(&temp_file)?;
             temp_file.write_all(content)?;
-            temp_file.set_permissions(permissions)?;
+            preserve_memory_file_security(source, &temp_file)?;
             temp_file.sync_all()?;
             drop(temp_file);
             directory.rename(Path::new(&temp_name), directory, Path::new(file_name))
@@ -534,7 +615,6 @@ impl MemoryServer {
             Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
             Err(error) => return Err(error),
         };
-        let permissions = file.metadata()?.permissions();
         let mut content = String::new();
         file.read_to_string(&mut content)?;
 
@@ -549,7 +629,7 @@ impl MemoryServer {
             &directory,
             &file_name,
             new_content.join("\n\n").as_bytes(),
-            permissions,
+            &file,
         )
     }
 
@@ -970,6 +1050,198 @@ mod tests {
                 .mode();
             assert_eq!(mode & 0o777, 0o600);
         }
+    }
+
+    #[cfg(windows)]
+    fn set_owner_only_protected_dacl(path: &Path) {
+        use std::os::windows::{fs::OpenOptionsExt, io::AsRawHandle};
+        use std::ptr;
+        use winapi::shared::minwindef::HLOCAL;
+        use winapi::shared::sddl::{
+            ConvertStringSecurityDescriptorToSecurityDescriptorW, SDDL_REVISION_1,
+        };
+        use winapi::shared::winerror::ERROR_SUCCESS;
+        use winapi::um::accctrl::SE_FILE_OBJECT;
+        use winapi::um::aclapi::SetSecurityInfo;
+        use winapi::um::securitybaseapi::GetSecurityDescriptorDacl;
+        use winapi::um::winbase::LocalFree;
+        use winapi::um::winnt::{
+            DACL_SECURITY_INFORMATION, PACL, PROTECTED_DACL_SECURITY_INFORMATION,
+            PSECURITY_DESCRIPTOR, READ_CONTROL, WRITE_DAC,
+        };
+
+        let sddl: Vec<u16> = "D:P(A;;FA;;;OW)\0".encode_utf16().collect();
+        let mut descriptor: PSECURITY_DESCRIPTOR = ptr::null_mut();
+        assert_ne!(
+            unsafe {
+                ConvertStringSecurityDescriptorToSecurityDescriptorW(
+                    sddl.as_ptr(),
+                    SDDL_REVISION_1 as u32,
+                    &mut descriptor,
+                    ptr::null_mut(),
+                )
+            },
+            0
+        );
+
+        let mut dacl: PACL = ptr::null_mut();
+        let mut dacl_present = 0;
+        let mut dacl_defaulted = 0;
+        assert_ne!(
+            unsafe {
+                GetSecurityDescriptorDacl(
+                    descriptor,
+                    &mut dacl_present,
+                    &mut dacl,
+                    &mut dacl_defaulted,
+                )
+            },
+            0
+        );
+        assert_ne!(dacl_present, 0);
+
+        let file = fs::OpenOptions::new()
+            .access_mode(READ_CONTROL | WRITE_DAC)
+            .open(path)
+            .unwrap();
+        let status = unsafe {
+            SetSecurityInfo(
+                file.as_raw_handle(),
+                SE_FILE_OBJECT,
+                DACL_SECURITY_INFORMATION | PROTECTED_DACL_SECURITY_INFORMATION,
+                ptr::null_mut(),
+                ptr::null_mut(),
+                dacl,
+                ptr::null_mut(),
+            )
+        };
+        unsafe {
+            LocalFree(descriptor as HLOCAL);
+        }
+        assert_eq!(status, ERROR_SUCCESS);
+    }
+
+    #[cfg(windows)]
+    fn assert_owner_only_protected_dacl(path: &Path) {
+        use std::ffi::c_void;
+        use std::os::windows::io::AsRawHandle;
+        use std::ptr;
+        use winapi::shared::minwindef::HLOCAL;
+        use winapi::shared::winerror::ERROR_SUCCESS;
+        use winapi::um::accctrl::SE_FILE_OBJECT;
+        use winapi::um::aclapi::GetSecurityInfo;
+        use winapi::um::securitybaseapi::{
+            CreateWellKnownSid, EqualSid, GetAce, GetSecurityDescriptorControl,
+        };
+        use winapi::um::winbase::LocalFree;
+        use winapi::um::winnt::{
+            WinCreatorOwnerRightsSid, ACCESS_ALLOWED_ACE, ACCESS_ALLOWED_ACE_TYPE,
+            DACL_SECURITY_INFORMATION, FILE_ALL_ACCESS, PACL, PSECURITY_DESCRIPTOR, PSID,
+            SECURITY_MAX_SID_SIZE, SE_DACL_PROTECTED,
+        };
+
+        let file = fs::File::open(path).unwrap();
+        let mut dacl: PACL = ptr::null_mut();
+        let mut descriptor: PSECURITY_DESCRIPTOR = ptr::null_mut();
+        let status = unsafe {
+            GetSecurityInfo(
+                file.as_raw_handle(),
+                SE_FILE_OBJECT,
+                DACL_SECURITY_INFORMATION,
+                ptr::null_mut(),
+                ptr::null_mut(),
+                &mut dacl,
+                ptr::null_mut(),
+                &mut descriptor,
+            )
+        };
+        assert_eq!(status, ERROR_SUCCESS);
+
+        let mut control = 0;
+        let mut revision = 0;
+        assert_ne!(
+            unsafe { GetSecurityDescriptorControl(descriptor, &mut control, &mut revision) },
+            0
+        );
+        assert_ne!(control & SE_DACL_PROTECTED, 0);
+        assert!(!dacl.is_null());
+        assert_eq!(unsafe { (*dacl).AceCount }, 1);
+
+        let mut ace: *mut c_void = ptr::null_mut();
+        assert_ne!(unsafe { GetAce(dacl, 0, &mut ace) }, 0);
+        let allowed = ace.cast::<ACCESS_ALLOWED_ACE>();
+        assert_eq!(
+            unsafe { (*allowed).Header.AceType },
+            ACCESS_ALLOWED_ACE_TYPE
+        );
+        assert_eq!(
+            unsafe { (*allowed).Mask } & FILE_ALL_ACCESS,
+            FILE_ALL_ACCESS
+        );
+
+        let mut expected_sid = [0u8; SECURITY_MAX_SID_SIZE];
+        let mut expected_sid_size = expected_sid.len() as u32;
+        assert_ne!(
+            unsafe {
+                CreateWellKnownSid(
+                    WinCreatorOwnerRightsSid,
+                    ptr::null_mut(),
+                    expected_sid.as_mut_ptr().cast(),
+                    &mut expected_sid_size,
+                )
+            },
+            0
+        );
+        let actual_sid = unsafe { &mut (*allowed).SidStart as *mut u32 as PSID };
+        assert_ne!(
+            unsafe { EqualSid(actual_sid, expected_sid.as_mut_ptr().cast()) },
+            0
+        );
+        unsafe {
+            LocalFree(descriptor as HLOCAL);
+        }
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn test_remove_specific_memory_preserves_windows_dacl() {
+        let temp_dir = tempdir().unwrap();
+        let working_dir = temp_dir.path().join("working");
+        let router = MemoryServer {
+            tool_router: ToolRouter::new(),
+            instructions: String::new(),
+            global_memory_dir: temp_dir.path().join("global"),
+        };
+
+        router
+            .remember(
+                "context",
+                "category",
+                "keep",
+                &[],
+                false,
+                Some(&working_dir),
+            )
+            .unwrap();
+        router
+            .remember(
+                "context",
+                "category",
+                "remove",
+                &[],
+                false,
+                Some(&working_dir),
+            )
+            .unwrap();
+
+        let category = working_dir.join(".goose/memory/category.txt");
+        set_owner_only_protected_dacl(&category);
+
+        router
+            .remove_specific_memory_internal("category", "remove", false, Some(&working_dir))
+            .unwrap();
+
+        assert_owner_only_protected_dacl(&category);
     }
 
     #[cfg(unix)]

--- a/crates/goose-mcp/src/memory/mod.rs
+++ b/crates/goose-mcp/src/memory/mod.rs
@@ -1,3 +1,8 @@
+use cap_fs_ext::{DirExt, MetadataExt};
+use cap_std::{
+    ambient_authority,
+    fs::{Dir, OpenOptions},
+};
 use etcetera::{choose_app_strategy, AppStrategy};
 use indoc::formatdoc;
 use rmcp::{
@@ -13,12 +18,146 @@ use rmcp::{
 use serde::{Deserialize, Serialize};
 use std::{
     collections::HashMap,
+    ffi::{OsStr, OsString},
     fs,
     io::{self, Read, Write},
-    path::PathBuf,
+    path::{Path, PathBuf},
+    sync::atomic::{AtomicU64, Ordering},
 };
 
 const WORKING_DIR_HEADER: &str = "agent-working-dir";
+static NEXT_MEMORY_TEMP_FILE: AtomicU64 = AtomicU64::new(0);
+
+enum MemoryFileOpen {
+    Read,
+    AppendOrCreate,
+    CreateNew,
+}
+
+struct MemoryLocation {
+    anchor: PathBuf,
+    components: Vec<OsString>,
+}
+
+impl MemoryLocation {
+    fn open(&self, create: bool) -> io::Result<Option<Dir>> {
+        if create {
+            fs::create_dir_all(&self.anchor)?;
+        }
+
+        let mut directory = match Dir::open_ambient_dir(&self.anchor, ambient_authority()) {
+            Ok(directory) => directory,
+            Err(error) if !create && error.kind() == io::ErrorKind::NotFound => return Ok(None),
+            Err(error) => return Err(error),
+        };
+
+        for component in &self.components {
+            directory = match directory.open_dir_nofollow(component) {
+                Ok(directory) => directory,
+                Err(error) if create && error.kind() == io::ErrorKind::NotFound => {
+                    match directory.create_dir(component) {
+                        Ok(()) => {}
+                        Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {}
+                        Err(error) => return Err(error),
+                    }
+                    directory.open_dir_nofollow(component)?
+                }
+                Err(error) if !create && error.kind() == io::ErrorKind::NotFound => {
+                    return Ok(None)
+                }
+                Err(error) => return Err(error),
+            };
+        }
+
+        Ok(Some(directory))
+    }
+}
+
+fn validate_memory_category(category: &str) -> io::Result<OsString> {
+    if category.is_empty()
+        || category == "*"
+        || category == "."
+        || category == ".."
+        || category.contains('/')
+        || category.contains('\\')
+        || category.contains(':')
+        || is_reserved_windows_category(category)
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "memory category must be a single filename component",
+        ));
+    }
+
+    Ok(OsString::from(format!("{category}.txt")))
+}
+
+fn same_memory_file(left: &cap_std::fs::Metadata, right: &cap_std::fs::Metadata) -> bool {
+    left.dev() == right.dev() && left.ino() == right.ino()
+}
+
+fn open_memory_file_at(
+    directory: &Dir,
+    name: &OsStr,
+    intent: MemoryFileOpen,
+) -> io::Result<fs::File> {
+    let before_open = if !matches!(intent, MemoryFileOpen::CreateNew) {
+        match directory.symlink_metadata(Path::new(name)) {
+            Ok(metadata) if metadata.file_type().is_symlink() => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "memory category must not be a symbolic link",
+                ));
+            }
+            Ok(metadata) => Some(metadata),
+            Err(error)
+                if matches!(intent, MemoryFileOpen::AppendOrCreate)
+                    && error.kind() == io::ErrorKind::NotFound =>
+            {
+                None
+            }
+            Err(error) => return Err(error),
+        }
+    } else {
+        None
+    };
+
+    let mut options = OpenOptions::new();
+    match intent {
+        MemoryFileOpen::Read => {
+            options.read(true);
+        }
+        MemoryFileOpen::AppendOrCreate => {
+            options.append(true).create(true);
+        }
+        MemoryFileOpen::CreateNew => {
+            options.write(true).create_new(true);
+        }
+    }
+    // Capability-relative resolution confines any swap that lands during open, while the
+    // identity checks reject observing a different in-tree file through the race window.
+    let file = directory.open_with(Path::new(name), &options)?;
+    let opened_metadata = file.metadata()?;
+    let current_metadata = directory.symlink_metadata(Path::new(name))?;
+    if current_metadata.file_type().is_symlink()
+        || !same_memory_file(&opened_metadata, &current_metadata)
+        || before_open
+            .as_ref()
+            .is_some_and(|metadata| !same_memory_file(metadata, &opened_metadata))
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "memory category changed while it was being opened",
+        ));
+    }
+    if !opened_metadata.is_file() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "memory category must be a regular file",
+        ));
+    }
+    Ok(file.into_std())
+}
 
 fn is_reserved_windows_category(category: &str) -> bool {
     let basename = category
@@ -181,121 +320,64 @@ impl MemoryServer {
         &self.instructions
     }
 
-    fn get_memory_file(
+    fn memory_location(
         &self,
-        category: &str,
         is_global: bool,
         working_dir: Option<&PathBuf>,
-    ) -> io::Result<PathBuf> {
-        if category.is_empty()
-            || category == "*"
-            || category == "."
-            || category == ".."
-            || category.contains('/')
-            || category.contains('\\')
-            || category.contains(':')
-            || is_reserved_windows_category(category)
-        {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                "memory category must be a single filename component",
-            ));
-        }
-
-        let base_dir = if is_global {
-            self.global_memory_dir.clone()
+    ) -> io::Result<MemoryLocation> {
+        if is_global {
+            let component = self
+                .global_memory_dir
+                .file_name()
+                .ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        "global memory path must name a directory",
+                    )
+                })?
+                .to_os_string();
+            let parent = self
+                .global_memory_dir
+                .parent()
+                .filter(|parent| !parent.as_os_str().is_empty())
+                .map(Path::to_path_buf)
+                .unwrap_or(std::env::current_dir()?);
+            Ok(MemoryLocation {
+                anchor: parent,
+                components: vec![component],
+            })
         } else {
-            let local_base = working_dir
+            let anchor = working_dir
                 .cloned()
-                .or_else(|| std::env::current_dir().ok())
-                .unwrap_or_else(|| PathBuf::from("."));
-            local_base.join(".goose").join("memory")
-        };
-        Ok(base_dir.join(format!("{}.txt", category)))
+                .map(Ok)
+                .unwrap_or_else(std::env::current_dir)?;
+            Ok(MemoryLocation {
+                anchor,
+                components: vec![OsString::from(".goose"), OsString::from("memory")],
+            })
+        }
     }
 
-    pub fn retrieve_all(
+    fn open_memory_directory(
         &self,
         is_global: bool,
         working_dir: Option<&PathBuf>,
-    ) -> io::Result<HashMap<String, Vec<String>>> {
-        let base_dir = if is_global {
-            self.global_memory_dir.clone()
-        } else {
-            let local_base = working_dir
-                .cloned()
-                .or_else(|| std::env::current_dir().ok())
-                .unwrap_or_else(|| PathBuf::from("."));
-            local_base.join(".goose").join("memory")
-        };
-        let mut memories = HashMap::new();
-        if base_dir.exists() {
-            for entry in fs::read_dir(&base_dir)? {
-                let entry = entry?;
-                if entry.file_type()?.is_file() {
-                    let file_name = entry.file_name();
-                    let Some(category) = file_name
-                        .to_str()
-                        .and_then(|name| name.strip_suffix(".txt"))
-                    else {
-                        continue;
-                    };
-                    if self
-                        .get_memory_file(category, is_global, working_dir)
-                        .is_err()
-                    {
-                        continue;
-                    }
-                    let category_memories = self.retrieve(category, is_global, working_dir)?;
-                    memories.insert(
-                        category.to_string(),
-                        category_memories.into_values().flatten().collect(),
-                    );
-                }
-            }
-        }
-        Ok(memories)
+        create: bool,
+    ) -> io::Result<Option<Dir>> {
+        self.memory_location(is_global, working_dir)?.open(create)
     }
 
-    pub fn remember(
+    fn retrieve_from_directory(
         &self,
-        _context: &str,
+        directory: &Dir,
         category: &str,
-        data: &str,
-        tags: &[&str],
-        is_global: bool,
-        working_dir: Option<&PathBuf>,
-    ) -> io::Result<()> {
-        let memory_file_path = self.get_memory_file(category, is_global, working_dir)?;
-
-        if let Some(parent) = memory_file_path.parent() {
-            fs::create_dir_all(parent)?;
-        }
-
-        let mut file = fs::OpenOptions::new()
-            .append(true)
-            .create(true)
-            .open(&memory_file_path)?;
-        if !tags.is_empty() {
-            writeln!(file, "# {}", tags.join(" "))?;
-        }
-        writeln!(file, "{}\n", data)?;
-
-        Ok(())
-    }
-
-    pub fn retrieve(
-        &self,
-        category: &str,
-        is_global: bool,
-        working_dir: Option<&PathBuf>,
     ) -> io::Result<HashMap<String, Vec<String>>> {
-        let memory_file_path = self.get_memory_file(category, is_global, working_dir)?;
-        if !memory_file_path.exists() {
-            return Ok(HashMap::new());
-        }
-
-        let mut file = fs::File::open(memory_file_path)?;
+        let file_name = validate_memory_category(category)?;
+        let mut file = match open_memory_file_at(directory, &file_name, MemoryFileOpen::Read) {
+            Ok(file) => file,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(HashMap::new()),
+            Err(error) => return Err(error),
+        };
         let mut content = String::new();
         file.read_to_string(&mut content)?;
 
@@ -324,6 +406,104 @@ impl MemoryServer {
         Ok(memories)
     }
 
+    fn replace_memory_file(
+        &self,
+        directory: &Dir,
+        file_name: &OsStr,
+        content: &[u8],
+        permissions: fs::Permissions,
+    ) -> io::Result<()> {
+        let process_id = std::process::id();
+        let (temp_name, mut temp_file) = loop {
+            let sequence = NEXT_MEMORY_TEMP_FILE.fetch_add(1, Ordering::Relaxed);
+            let temp_name = OsString::from(format!(".goose-memory-{process_id}-{sequence}.tmp"));
+            match open_memory_file_at(directory, &temp_name, MemoryFileOpen::CreateNew) {
+                Ok(file) => break (temp_name, file),
+                Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
+                Err(error) => return Err(error),
+            }
+        };
+
+        let result = (|| {
+            temp_file.write_all(content)?;
+            temp_file.set_permissions(permissions)?;
+            temp_file.sync_all()?;
+            drop(temp_file);
+            directory.rename(Path::new(&temp_name), directory, Path::new(file_name))
+        })();
+        if result.is_err() {
+            let _ = directory.remove_file_or_symlink(Path::new(&temp_name));
+        }
+        result
+    }
+
+    pub fn retrieve_all(
+        &self,
+        is_global: bool,
+        working_dir: Option<&PathBuf>,
+    ) -> io::Result<HashMap<String, Vec<String>>> {
+        let Some(directory) = self.open_memory_directory(is_global, working_dir, false)? else {
+            return Ok(HashMap::new());
+        };
+        let mut memories = HashMap::new();
+        for entry in directory.entries()? {
+            let entry = entry?;
+            if entry.file_type()?.is_file() {
+                let file_name = entry.file_name();
+                let Some(category) = file_name
+                    .to_str()
+                    .and_then(|name| name.strip_suffix(".txt"))
+                else {
+                    continue;
+                };
+                if validate_memory_category(category).is_err() {
+                    continue;
+                }
+                let category_memories = self.retrieve_from_directory(&directory, category)?;
+                memories.insert(
+                    category.to_string(),
+                    category_memories.into_values().flatten().collect(),
+                );
+            }
+        }
+        Ok(memories)
+    }
+
+    pub fn remember(
+        &self,
+        _context: &str,
+        category: &str,
+        data: &str,
+        tags: &[&str],
+        is_global: bool,
+        working_dir: Option<&PathBuf>,
+    ) -> io::Result<()> {
+        let file_name = validate_memory_category(category)?;
+        let directory = self
+            .open_memory_directory(is_global, working_dir, true)?
+            .expect("creating a memory directory returns an open directory");
+        let mut file = open_memory_file_at(&directory, &file_name, MemoryFileOpen::AppendOrCreate)?;
+        if !tags.is_empty() {
+            writeln!(file, "# {}", tags.join(" "))?;
+        }
+        writeln!(file, "{}\n", data)?;
+
+        Ok(())
+    }
+
+    pub fn retrieve(
+        &self,
+        category: &str,
+        is_global: bool,
+        working_dir: Option<&PathBuf>,
+    ) -> io::Result<HashMap<String, Vec<String>>> {
+        validate_memory_category(category)?;
+        let Some(directory) = self.open_memory_directory(is_global, working_dir, false)? else {
+            return Ok(HashMap::new());
+        };
+        self.retrieve_from_directory(&directory, category)
+    }
+
     pub fn remove_specific_memory_internal(
         &self,
         category: &str,
@@ -331,12 +511,16 @@ impl MemoryServer {
         is_global: bool,
         working_dir: Option<&PathBuf>,
     ) -> io::Result<()> {
-        let memory_file_path = self.get_memory_file(category, is_global, working_dir)?;
-        if !memory_file_path.exists() {
+        let file_name = validate_memory_category(category)?;
+        let Some(directory) = self.open_memory_directory(is_global, working_dir, false)? else {
             return Ok(());
-        }
-
-        let mut file = fs::File::open(&memory_file_path)?;
+        };
+        let mut file = match open_memory_file_at(&directory, &file_name, MemoryFileOpen::Read) {
+            Ok(file) => file,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
+            Err(error) => return Err(error),
+        };
+        let permissions = file.metadata()?.permissions();
         let mut content = String::new();
         file.read_to_string(&mut content)?;
 
@@ -347,9 +531,12 @@ impl MemoryServer {
             .map(|s| s.to_string())
             .collect();
 
-        fs::write(memory_file_path, new_content.join("\n\n"))?;
-
-        Ok(())
+        self.replace_memory_file(
+            &directory,
+            &file_name,
+            new_content.join("\n\n").as_bytes(),
+            permissions,
+        )
     }
 
     pub fn clear_memory(
@@ -358,12 +545,15 @@ impl MemoryServer {
         is_global: bool,
         working_dir: Option<&PathBuf>,
     ) -> io::Result<()> {
-        let memory_file_path = self.get_memory_file(category, is_global, working_dir)?;
-        if memory_file_path.exists() {
-            fs::remove_file(memory_file_path)?;
+        let file_name = validate_memory_category(category)?;
+        let Some(directory) = self.open_memory_directory(is_global, working_dir, false)? else {
+            return Ok(());
+        };
+        match directory.remove_file_or_symlink(Path::new(&file_name)) {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(error),
         }
-
-        Ok(())
     }
 
     pub fn clear_all_global_or_local_memories(
@@ -371,19 +561,10 @@ impl MemoryServer {
         is_global: bool,
         working_dir: Option<&PathBuf>,
     ) -> io::Result<()> {
-        let base_dir = if is_global {
-            self.global_memory_dir.clone()
-        } else {
-            let local_base = working_dir
-                .cloned()
-                .or_else(|| std::env::current_dir().ok())
-                .unwrap_or_else(|| PathBuf::from("."));
-            local_base.join(".goose").join("memory")
+        let Some(directory) = self.open_memory_directory(is_global, working_dir, false)? else {
+            return Ok(());
         };
-        if base_dir.exists() {
-            fs::remove_dir_all(&base_dir)?;
-        }
-        Ok(())
+        directory.remove_open_dir_all()
     }
 
     /// Stores a memory with optional tags in a specified category
@@ -525,6 +706,38 @@ impl ServerHandler for MemoryServer {
 mod tests {
     use super::*;
     use tempfile::tempdir;
+
+    #[cfg(unix)]
+    fn assert_category_operations_reject_link(
+        router: &MemoryServer,
+        working_dir: &PathBuf,
+        outside_file: &Path,
+    ) {
+        assert!(router
+            .retrieve("category", false, Some(working_dir))
+            .is_err());
+        assert!(router
+            .remember(
+                "context",
+                "category",
+                "malicious append",
+                &[],
+                false,
+                Some(working_dir),
+            )
+            .is_err());
+        assert!(
+            router
+                .remove_specific_memory_internal(
+                    "category",
+                    "outside secret",
+                    false,
+                    Some(working_dir),
+                )
+                .is_err()
+        );
+        assert_eq!(fs::read_to_string(outside_file).unwrap(), "outside secret");
+    }
 
     #[test]
     fn test_lazy_directory_creation() {
@@ -719,6 +932,83 @@ mod tests {
             .values()
             .any(|v| v.iter().any(|content| content.contains("keep_this")));
         assert!(has_kept);
+
+        let memory_dir = working_dir.join(".goose/memory");
+        assert_eq!(fs::read_dir(memory_dir).unwrap().count(), 1);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_category_operations_do_not_follow_file_symlinks() {
+        use std::os::unix::fs::symlink;
+
+        let temp_dir = tempdir().unwrap();
+        let working_dir = temp_dir.path().join("working");
+        let memory_dir = working_dir.join(".goose/memory");
+        let outside_file = temp_dir.path().join("outside.txt");
+        fs::create_dir_all(&memory_dir).unwrap();
+        fs::write(&outside_file, "outside secret").unwrap();
+        symlink(&outside_file, memory_dir.join("category.txt")).unwrap();
+
+        let router = MemoryServer {
+            tool_router: ToolRouter::new(),
+            instructions: String::new(),
+            global_memory_dir: temp_dir.path().join("global"),
+        };
+
+        assert_category_operations_reject_link(&router, &working_dir, &outside_file);
+        assert!(fs::symlink_metadata(memory_dir.join("category.txt"))
+            .unwrap()
+            .file_type()
+            .is_symlink());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_category_operations_do_not_follow_memory_directory_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let temp_dir = tempdir().unwrap();
+        let working_dir = temp_dir.path().join("working");
+        let goose_dir = working_dir.join(".goose");
+        let outside_dir = temp_dir.path().join("outside-memory");
+        let outside_file = outside_dir.join("category.txt");
+        fs::create_dir_all(&goose_dir).unwrap();
+        fs::create_dir(&outside_dir).unwrap();
+        fs::write(&outside_file, "outside secret").unwrap();
+        symlink(&outside_dir, goose_dir.join("memory")).unwrap();
+
+        let router = MemoryServer {
+            tool_router: ToolRouter::new(),
+            instructions: String::new(),
+            global_memory_dir: temp_dir.path().join("global"),
+        };
+
+        assert_category_operations_reject_link(&router, &working_dir, &outside_file);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_category_operations_do_not_follow_goose_directory_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let temp_dir = tempdir().unwrap();
+        let working_dir = temp_dir.path().join("working");
+        let outside_dir = temp_dir.path().join("outside-goose");
+        let outside_memory_dir = outside_dir.join("memory");
+        let outside_file = outside_memory_dir.join("category.txt");
+        fs::create_dir(&working_dir).unwrap();
+        fs::create_dir_all(&outside_memory_dir).unwrap();
+        fs::write(&outside_file, "outside secret").unwrap();
+        symlink(&outside_dir, working_dir.join(".goose")).unwrap();
+
+        let router = MemoryServer {
+            tool_router: ToolRouter::new(),
+            instructions: String::new(),
+            global_memory_dir: temp_dir.path().join("global"),
+        };
+
+        assert_category_operations_reject_link(&router, &working_dir, &outside_file);
     }
 
     #[test]

--- a/crates/goose-mcp/src/memory/mod.rs
+++ b/crates/goose-mcp/src/memory/mod.rs
@@ -353,7 +353,8 @@ impl MemoryServer {
                 .parent()
                 .filter(|parent| !parent.as_os_str().is_empty())
                 .map(Path::to_path_buf)
-                .unwrap_or(std::env::current_dir()?);
+                .map(Ok)
+                .unwrap_or_else(std::env::current_dir)?;
             Ok(MemoryLocation {
                 anchor: parent,
                 components: vec![component],

--- a/crates/goose-mcp/src/memory/mod.rs
+++ b/crates/goose-mcp/src/memory/mod.rs
@@ -96,6 +96,18 @@ fn same_memory_file(left: &cap_std::fs::Metadata, right: &cap_std::fs::Metadata)
     left.dev() == right.dev() && left.ino() == right.ino()
 }
 
+#[cfg(unix)]
+fn restrict_memory_temp_file(file: &fs::File) -> io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    file.set_permissions(fs::Permissions::from_mode(0o600))
+}
+
+#[cfg(not(unix))]
+fn restrict_memory_temp_file(_file: &fs::File) -> io::Result<()> {
+    Ok(())
+}
+
 fn open_memory_file_at(
     directory: &Dir,
     name: &OsStr,
@@ -425,6 +437,7 @@ impl MemoryServer {
         };
 
         let result = (|| {
+            restrict_memory_temp_file(&temp_file)?;
             temp_file.write_all(content)?;
             temp_file.set_permissions(permissions)?;
             temp_file.sync_all()?;
@@ -916,6 +929,17 @@ mod tests {
             .unwrap();
         assert_eq!(memories.len(), 1);
 
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+
+            fs::set_permissions(
+                working_dir.join(".goose/memory/category.txt"),
+                fs::Permissions::from_mode(0o600),
+            )
+            .unwrap();
+        }
+
         router
             .remove_specific_memory_internal("category", "remove_this", false, Some(&working_dir))
             .unwrap();
@@ -935,6 +959,16 @@ mod tests {
 
         let memory_dir = working_dir.join(".goose/memory");
         assert_eq!(fs::read_dir(memory_dir).unwrap().count(), 1);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+
+            let mode = fs::metadata(working_dir.join(".goose/memory/category.txt"))
+                .unwrap()
+                .permissions()
+                .mode();
+            assert_eq!(mode & 0o777, 0o600);
+        }
     }
 
     #[cfg(unix)]

--- a/crates/goose-mcp/src/memory/mod.rs
+++ b/crates/goose-mcp/src/memory/mod.rs
@@ -252,6 +252,26 @@ fn open_memory_file_at(
     Ok(file.into_std())
 }
 
+fn create_memory_temp_file_at(
+    directory: &Dir,
+    name: &OsStr,
+    _source: &fs::File,
+) -> io::Result<fs::File> {
+    let file = open_memory_file_at(directory, name, MemoryFileOpen::CreateNew)?;
+    let result = (|| {
+        restrict_memory_temp_file(&file)?;
+        #[cfg(windows)]
+        preserve_memory_file_security(_source, &file)?;
+        Ok(())
+    })();
+    if let Err(error) = result {
+        drop(file);
+        let _ = directory.remove_file_or_symlink(Path::new(name));
+        return Err(error);
+    }
+    Ok(file)
+}
+
 fn is_reserved_windows_category(category: &str) -> bool {
     let basename = category
         .split('.')
@@ -511,7 +531,7 @@ impl MemoryServer {
         let (temp_name, mut temp_file) = loop {
             let sequence = NEXT_MEMORY_TEMP_FILE.fetch_add(1, Ordering::Relaxed);
             let temp_name = OsString::from(format!(".goose-memory-{process_id}-{sequence}.tmp"));
-            match open_memory_file_at(directory, &temp_name, MemoryFileOpen::CreateNew) {
+            match create_memory_temp_file_at(directory, &temp_name, source) {
                 Ok(file) => break (temp_name, file),
                 Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
                 Err(error) => return Err(error),
@@ -519,8 +539,8 @@ impl MemoryServer {
         };
 
         let result = (|| {
-            restrict_memory_temp_file(&temp_file)?;
             temp_file.write_all(content)?;
+            #[cfg(not(windows))]
             preserve_memory_file_security(source, &temp_file)?;
             temp_file.sync_all()?;
             drop(temp_file);
@@ -1200,6 +1220,44 @@ mod tests {
         unsafe {
             LocalFree(descriptor as HLOCAL);
         }
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn test_memory_temp_file_applies_windows_dacl_before_content() {
+        let temp_dir = tempdir().unwrap();
+        let working_dir = temp_dir.path().join("working");
+        let router = MemoryServer {
+            tool_router: ToolRouter::new(),
+            instructions: String::new(),
+            global_memory_dir: temp_dir.path().join("global"),
+        };
+
+        router
+            .remember(
+                "context",
+                "category",
+                "sensitive",
+                &[],
+                false,
+                Some(&working_dir),
+            )
+            .unwrap();
+        let category = working_dir.join(".goose/memory/category.txt");
+        set_owner_only_protected_dacl(&category);
+
+        let directory = router
+            .open_memory_directory(false, Some(&working_dir), false)
+            .unwrap()
+            .unwrap();
+        let source =
+            open_memory_file_at(&directory, OsStr::new("category.txt"), MemoryFileOpen::Read)
+                .unwrap();
+        let temp_name = OsStr::new(".ordering-test.tmp");
+        let temp_file = create_memory_temp_file_at(&directory, temp_name, &source).unwrap();
+
+        assert_eq!(temp_file.metadata().unwrap().len(), 0);
+        assert_owner_only_protected_dacl(&working_dir.join(".goose/memory/.ordering-test.tmp"));
     }
 
     #[cfg(windows)]


### PR DESCRIPTION
## Summary

- anchor memory directory traversal to open directory handles and reject symbolic-link ancestors
- validate file identity before reads and appends so raced path swaps cannot redirect an operation
- rewrite memory categories through a sibling temporary file and handle-relative atomic rename
- keep listing and deletion operations confined to the same directory capability

## Security impact

Memory category operations can no longer follow pre-created file or directory links outside the selected memory store. Capability-relative resolution confines any concurrent path replacement, while pre-open and post-open identity validation rejects changes before file contents are used.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p goose-mcp memory::tests` (12 passed)
- `cargo build`
- `cargo clippy --all-targets -- -D warnings`
- `git diff --check`

*This finding was discovered by [Project Loupe](https://github.com/project-loupe/loupe)*
