### PR TITLE
fix(desktop): gate recipe submissions on trust

### DIFF
--- a/ui/desktop/src/acp/__tests__/chatSessionController.test.ts
+++ b/ui/desktop/src/acp/__tests__/chatSessionController.test.ts
@@ -334,7 +334,7 @@ describe('acpChatSessionController.updateMessage', () => {
           onFinish: vi.fn(),
         }
       )
-    ).resolves.toBeUndefined();
+    ).resolves.toBe(false);
 
     expect(acpChatSessionActions.setChatState).not.toHaveBeenCalledWith(
       SESSION_ID,
@@ -398,7 +398,7 @@ describe('acpChatSessionController.updateMessage', () => {
       messages: [existingMessage, permissionMessage],
     };
     resolvePromptCancellation!();
-    await updatePromise;
+    await expect(updatePromise).resolves.toBe(true);
 
     expect(acpTruncateSessionConversation).toHaveBeenCalledWith(
       SESSION_ID,

--- a/ui/desktop/src/acp/chatSessionController.ts
+++ b/ui/desktop/src/acp/chatSessionController.ts
@@ -66,7 +66,7 @@ export interface AcpChatSessionController {
     editType: 'fork' | 'edit',
     retainedImages: ImageData[],
     options: AcpSubmitMessageOptions
-  ): Promise<void>;
+  ): Promise<boolean>;
 }
 
 function createAcpCreditsExhaustedMessage(error: AcpCreditsExhaustedError): Message {
@@ -245,7 +245,7 @@ async function updateMessage(
   editType: 'fork' | 'edit',
   retainedImages: ImageData[],
   options: AcpSubmitMessageOptions
-): Promise<void> {
+): Promise<boolean> {
   assertNoPendingPromptCancellation(sessionId);
 
   const currentSnapshot = options.getCurrentSnapshot();
@@ -260,7 +260,7 @@ async function updateMessage(
 
   if (editType === 'fork') {
     await forkSessionWithEditedMessage(sessionId, message, newContent, retainedImages);
-    return;
+    return true;
   }
 
   const editSnapshot = currentSnapshot ?? storedSnapshot;
@@ -274,7 +274,7 @@ async function updateMessage(
   const canEditInPlace = isIdle || pendingToolPermissionPromptAttemptId != null;
 
   if (!canEditInPlace) {
-    return;
+    return false;
   }
 
   if (pendingToolPermissionPromptAttemptId != null) {
@@ -318,6 +318,7 @@ async function updateMessage(
     acpChatSessionActions.setMessages(sessionId, messagesForUI);
 
     await submitMessage(sessionId, updatedUserMessage, options);
+    return true;
   } catch (error) {
     acpChatSessionActions.setChatState(sessionId, ChatState.Idle);
     throw error;

--- a/ui/desktop/src/components/BaseChat.recipeTrust.test.tsx
+++ b/ui/desktop/src/components/BaseChat.recipeTrust.test.tsx
@@ -141,8 +141,14 @@ vi.mock('./ProgressiveMessageList', () => ({
   ),
 }));
 vi.mock('./ui/RecipeWarningModal', () => ({
-  RecipeWarningModal: ({ isOpen }: { isOpen: boolean }) => (
-    <div data-testid="recipe-warning" data-open={String(isOpen)} />
+  RecipeWarningModal: ({ isOpen, onConfirm }: { isOpen: boolean; onConfirm: () => void }) => (
+    <div data-testid="recipe-warning" data-open={String(isOpen)}>
+      {isOpen && (
+        <button type="button" onClick={onConfirm}>
+          accept recipe
+        </button>
+      )}
+    </div>
   ),
 }));
 vi.mock('./Layout/MainPanelLayout', () => ({
@@ -346,10 +352,11 @@ describe('BaseChat recipe trust gate', () => {
     expect(mocks.updateMessage).toHaveBeenCalledTimes(1);
   });
 
-  it('fails closed and opens the warning modal when the trust lookup fails', async () => {
+  it('fails closed on lookup failure and accepts only the current recipe when persistence fails', async () => {
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
     mocks.hasAcceptedRecipeBefore.mockRejectedValue(new Error('trust lookup failed'));
-    renderBaseChat();
+    mocks.recordRecipeHash.mockRejectedValue(new Error('trust persistence failed'));
+    const { rerender } = renderBaseChat();
 
     await waitFor(() =>
       expect(screen.getByTestId('recipe-warning')).toHaveAttribute('data-open', 'true')
@@ -359,7 +366,40 @@ describe('BaseChat recipe trust gate', () => {
     expect(mocks.submitMessage).not.toHaveBeenCalled();
     expect(mocks.steerMessage).not.toHaveBeenCalled();
     expect(mocks.updateMessage).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'accept recipe' }));
+    await waitFor(() =>
+      expect(screen.getByTestId('chat-input')).toHaveAttribute('data-recipe-accepted', 'true')
+    );
+    invokeAllSubmissionPaths();
+
+    expect(mocks.recordRecipeHash).toHaveBeenCalledWith(mocks.session.recipe);
+    expect(mocks.submitMessage).toHaveBeenCalledTimes(5);
+    expect(mocks.steerMessage).toHaveBeenCalledTimes(1);
+    expect(mocks.updateMessage).toHaveBeenCalledTimes(1);
     expect(consoleError).toHaveBeenCalledWith('Failed to check recipe trust:', expect.any(Error));
+    expect(consoleError).toHaveBeenCalledWith('Failed to persist recipe trust:', expect.any(Error));
+
+    mocks.submitMessage.mockClear();
+    mocks.steerMessage.mockClear();
+    mocks.updateMessage.mockClear();
+    mocks.hasAcceptedRecipeBefore.mockReturnValue(new Promise<boolean>(() => undefined));
+    mocks.session = makeSession({
+      recipe: {
+        title: 'Different recipe',
+        description: 'Runs a different prompt',
+        prompt: 'RUN_DIFFERENT_RECIPE',
+      },
+    });
+    rerender(
+      <BaseChat setChat={vi.fn()} sessionId="sess-1" suppressEmptyState={false} isActiveSession />
+    );
+
+    expect(screen.getByTestId('chat-input')).toHaveAttribute('data-recipe-accepted', 'false');
+    invokeAllSubmissionPaths();
+    expect(mocks.submitMessage).not.toHaveBeenCalled();
+    expect(mocks.steerMessage).not.toHaveBeenCalled();
+    expect(mocks.updateMessage).not.toHaveBeenCalled();
     consoleError.mockRestore();
   });
 

--- a/ui/desktop/src/components/BaseChat.recipeTrust.test.tsx
+++ b/ui/desktop/src/components/BaseChat.recipeTrust.test.tsx
@@ -12,6 +12,7 @@ const mocks = vi.hoisted(() => ({
   submitMessage: vi.fn(),
   steerMessage: vi.fn(),
   updateMessage: vi.fn(),
+  elicitationResponse: vi.fn(),
   hasAcceptedRecipeBefore: vi.fn(),
   recordRecipeHash: vi.fn(),
   autoSubmit: undefined as undefined | ((input: UserInput) => void),
@@ -26,7 +27,7 @@ vi.mock('../hooks/useChatSession', () => ({
     updateSession: vi.fn(),
     handleSubmit: mocks.submitMessage,
     onSteerQueuedMessage: mocks.steerMessage,
-    submitElicitationResponse: vi.fn(),
+    submitElicitationResponse: mocks.elicitationResponse,
     stopStreaming: vi.fn(),
     retrySessionLoad: vi.fn(),
     sessionLoadError: undefined,
@@ -115,6 +116,7 @@ vi.mock('./ProgressiveMessageList', () => ({
   default: ({
     append,
     onMessageUpdate,
+    submitElicitationResponse,
   }: {
     append: (text: string) => void;
     onMessageUpdate?: (
@@ -122,7 +124,11 @@ vi.mock('./ProgressiveMessageList', () => ({
       newContent: string,
       editType: 'fork' | 'edit',
       retainedImages: ImageData[]
-    ) => void;
+    ) => Promise<boolean>;
+    submitElicitationResponse?: (
+      elicitationId: string,
+      userData: Record<string, unknown>
+    ) => Promise<boolean>;
   }) => (
     <>
       <button type="button" onClick={() => append('progressive descendant')}>
@@ -136,6 +142,12 @@ vi.mock('./ProgressiveMessageList', () => ({
         onClick={() => onMessageUpdate?.('message-1', 'edited message', 'edit', [])}
       >
         edit message
+      </button>
+      <button
+        type="button"
+        onClick={() => void submitElicitationResponse?.('elicitation-1', { response: 'approved' })}
+      >
+        submit elicitation
       </button>
     </>
   ),
@@ -214,6 +226,7 @@ function invokeAllSubmissionPaths() {
   fireEvent.click(screen.getByRole('button', { name: 'progressive descendant' }));
   fireEvent.click(screen.getByRole('button', { name: 'mcp ui message' }));
   fireEvent.click(screen.getByRole('button', { name: 'edit message' }));
+  fireEvent.click(screen.getByRole('button', { name: 'submit elicitation' }));
   fireEvent.click(screen.getByRole('button', { name: 'steer queued message' }));
   act(() => mocks.autoSubmit?.({ msg: 'programmatic submit', images: [] }));
 }
@@ -224,6 +237,8 @@ describe('BaseChat recipe trust gate', () => {
     mocks.autoSubmit = undefined;
     mocks.session = makeSession();
     mocks.steerMessage.mockResolvedValue(true);
+    mocks.updateMessage.mockResolvedValue(true);
+    mocks.elicitationResponse.mockResolvedValue(true);
     Object.assign(window.electron, {
       hasAcceptedRecipeBefore: mocks.hasAcceptedRecipeBefore,
       recordRecipeHash: mocks.recordRecipeHash,
@@ -251,6 +266,7 @@ describe('BaseChat recipe trust gate', () => {
     expect(mocks.submitMessage).not.toHaveBeenCalled();
     expect(mocks.steerMessage).not.toHaveBeenCalled();
     expect(mocks.updateMessage).not.toHaveBeenCalled();
+    expect(mocks.elicitationResponse).not.toHaveBeenCalled();
 
     await act(async () => resolveAcceptance?.(false));
     await waitFor(() =>
@@ -267,6 +283,7 @@ describe('BaseChat recipe trust gate', () => {
     expect(mocks.submitMessage).not.toHaveBeenCalled();
     expect(mocks.steerMessage).not.toHaveBeenCalled();
     expect(mocks.updateMessage).not.toHaveBeenCalled();
+    expect(mocks.elicitationResponse).not.toHaveBeenCalled();
   });
 
   it('allows every submission path after trust is affirmatively accepted', async () => {
@@ -287,6 +304,7 @@ describe('BaseChat recipe trust gate', () => {
     expect(mocks.submitMessage).toHaveBeenCalledTimes(5);
     expect(mocks.steerMessage).toHaveBeenCalledTimes(1);
     expect(mocks.updateMessage).toHaveBeenCalledTimes(1);
+    expect(mocks.elicitationResponse).toHaveBeenCalledTimes(1);
   });
 
   it('returns to pending before a different recipe in the same session can submit', async () => {
@@ -320,6 +338,7 @@ describe('BaseChat recipe trust gate', () => {
     expect(mocks.submitMessage).not.toHaveBeenCalled();
     expect(mocks.steerMessage).not.toHaveBeenCalled();
     expect(mocks.updateMessage).not.toHaveBeenCalled();
+    expect(mocks.elicitationResponse).not.toHaveBeenCalled();
   });
 
   it('retains accepted trust for background work while the same recipe session is inactive', async () => {
@@ -350,6 +369,7 @@ describe('BaseChat recipe trust gate', () => {
     expect(mocks.submitMessage).toHaveBeenCalledTimes(5);
     expect(mocks.steerMessage).toHaveBeenCalledTimes(1);
     expect(mocks.updateMessage).toHaveBeenCalledTimes(1);
+    expect(mocks.elicitationResponse).toHaveBeenCalledTimes(1);
   });
 
   it('fails closed on lookup failure and accepts only the current recipe when persistence fails', async () => {
@@ -366,6 +386,7 @@ describe('BaseChat recipe trust gate', () => {
     expect(mocks.submitMessage).not.toHaveBeenCalled();
     expect(mocks.steerMessage).not.toHaveBeenCalled();
     expect(mocks.updateMessage).not.toHaveBeenCalled();
+    expect(mocks.elicitationResponse).not.toHaveBeenCalled();
 
     fireEvent.click(screen.getByRole('button', { name: 'accept recipe' }));
     await waitFor(() =>
@@ -377,12 +398,14 @@ describe('BaseChat recipe trust gate', () => {
     expect(mocks.submitMessage).toHaveBeenCalledTimes(5);
     expect(mocks.steerMessage).toHaveBeenCalledTimes(1);
     expect(mocks.updateMessage).toHaveBeenCalledTimes(1);
+    expect(mocks.elicitationResponse).toHaveBeenCalledTimes(1);
     expect(consoleError).toHaveBeenCalledWith('Failed to check recipe trust:', expect.any(Error));
     expect(consoleError).toHaveBeenCalledWith('Failed to persist recipe trust:', expect.any(Error));
 
     mocks.submitMessage.mockClear();
     mocks.steerMessage.mockClear();
     mocks.updateMessage.mockClear();
+    mocks.elicitationResponse.mockClear();
     mocks.hasAcceptedRecipeBefore.mockReturnValue(new Promise<boolean>(() => undefined));
     mocks.session = makeSession({
       recipe: {
@@ -400,6 +423,7 @@ describe('BaseChat recipe trust gate', () => {
     expect(mocks.submitMessage).not.toHaveBeenCalled();
     expect(mocks.steerMessage).not.toHaveBeenCalled();
     expect(mocks.updateMessage).not.toHaveBeenCalled();
+    expect(mocks.elicitationResponse).not.toHaveBeenCalled();
     consoleError.mockRestore();
   });
 
@@ -418,6 +442,7 @@ describe('BaseChat recipe trust gate', () => {
     expect(mocks.submitMessage).toHaveBeenCalledTimes(5);
     expect(mocks.steerMessage).toHaveBeenCalledTimes(1);
     expect(mocks.updateMessage).toHaveBeenCalledTimes(1);
+    expect(mocks.elicitationResponse).toHaveBeenCalledTimes(1);
   });
 
   it('keeps non-recipe submissions enabled', () => {

--- a/ui/desktop/src/components/BaseChat.recipeTrust.test.tsx
+++ b/ui/desktop/src/components/BaseChat.recipeTrust.test.tsx
@@ -3,7 +3,7 @@ import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { IntlTestWrapper } from '../i18n/test-utils';
-import type { UserInput } from '../types/message';
+import type { ImageData, UserInput } from '../types/message';
 import type { Session } from '../types/session';
 import BaseChat from './BaseChat';
 
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   session: {} as Session,
   submitMessage: vi.fn(),
   steerMessage: vi.fn(),
+  updateMessage: vi.fn(),
   hasAcceptedRecipeBefore: vi.fn(),
   recordRecipeHash: vi.fn(),
   autoSubmit: undefined as undefined | ((input: UserInput) => void),
@@ -33,7 +34,7 @@ vi.mock('../hooks/useChatSession', () => ({
     notifications: [],
     pauseQueueOnStop: false,
     queueProcessingBlocked: false,
-    onMessageUpdate: vi.fn(),
+    onMessageUpdate: mocks.updateMessage,
   }),
 }));
 
@@ -111,13 +112,30 @@ vi.mock('./recipes/RecipeActivities', () => ({
   ),
 }));
 vi.mock('./ProgressiveMessageList', () => ({
-  default: ({ append }: { append: (text: string) => void }) => (
+  default: ({
+    append,
+    onMessageUpdate,
+  }: {
+    append: (text: string) => void;
+    onMessageUpdate?: (
+      messageId: string,
+      newContent: string,
+      editType: 'fork' | 'edit',
+      retainedImages: ImageData[]
+    ) => void;
+  }) => (
     <>
       <button type="button" onClick={() => append('progressive descendant')}>
         progressive descendant
       </button>
       <button type="button" onClick={() => append('mcp ui message')}>
         mcp ui message
+      </button>
+      <button
+        type="button"
+        onClick={() => onMessageUpdate?.('message-1', 'edited message', 'edit', [])}
+      >
+        edit message
       </button>
     </>
   ),
@@ -189,6 +207,7 @@ function invokeAllSubmissionPaths() {
   fireEvent.click(screen.getByRole('button', { name: 'recipe activity' }));
   fireEvent.click(screen.getByRole('button', { name: 'progressive descendant' }));
   fireEvent.click(screen.getByRole('button', { name: 'mcp ui message' }));
+  fireEvent.click(screen.getByRole('button', { name: 'edit message' }));
   fireEvent.click(screen.getByRole('button', { name: 'steer queued message' }));
   act(() => mocks.autoSubmit?.({ msg: 'programmatic submit', images: [] }));
 }
@@ -225,6 +244,7 @@ describe('BaseChat recipe trust gate', () => {
     invokeAllSubmissionPaths();
     expect(mocks.submitMessage).not.toHaveBeenCalled();
     expect(mocks.steerMessage).not.toHaveBeenCalled();
+    expect(mocks.updateMessage).not.toHaveBeenCalled();
 
     await act(async () => resolveAcceptance?.(false));
     await waitFor(() =>
@@ -240,6 +260,7 @@ describe('BaseChat recipe trust gate', () => {
     invokeAllSubmissionPaths();
     expect(mocks.submitMessage).not.toHaveBeenCalled();
     expect(mocks.steerMessage).not.toHaveBeenCalled();
+    expect(mocks.updateMessage).not.toHaveBeenCalled();
   });
 
   it('allows every submission path after trust is affirmatively accepted', async () => {
@@ -259,6 +280,7 @@ describe('BaseChat recipe trust gate', () => {
 
     expect(mocks.submitMessage).toHaveBeenCalledTimes(5);
     expect(mocks.steerMessage).toHaveBeenCalledTimes(1);
+    expect(mocks.updateMessage).toHaveBeenCalledTimes(1);
   });
 
   it('returns to pending before a different recipe in the same session can submit', async () => {
@@ -291,6 +313,7 @@ describe('BaseChat recipe trust gate', () => {
     invokeAllSubmissionPaths();
     expect(mocks.submitMessage).not.toHaveBeenCalled();
     expect(mocks.steerMessage).not.toHaveBeenCalled();
+    expect(mocks.updateMessage).not.toHaveBeenCalled();
   });
 
   it('retains accepted trust for background work while the same recipe session is inactive', async () => {
@@ -320,6 +343,24 @@ describe('BaseChat recipe trust gate', () => {
     invokeAllSubmissionPaths();
     expect(mocks.submitMessage).toHaveBeenCalledTimes(5);
     expect(mocks.steerMessage).toHaveBeenCalledTimes(1);
+    expect(mocks.updateMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails closed and opens the warning modal when the trust lookup fails', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    mocks.hasAcceptedRecipeBefore.mockRejectedValue(new Error('trust lookup failed'));
+    renderBaseChat();
+
+    await waitFor(() =>
+      expect(screen.getByTestId('recipe-warning')).toHaveAttribute('data-open', 'true')
+    );
+    invokeAllSubmissionPaths();
+
+    expect(mocks.submitMessage).not.toHaveBeenCalled();
+    expect(mocks.steerMessage).not.toHaveBeenCalled();
+    expect(mocks.updateMessage).not.toHaveBeenCalled();
+    expect(consoleError).toHaveBeenCalledWith('Failed to check recipe trust:', expect.any(Error));
+    consoleError.mockRestore();
   });
 
   it('keeps scheduled recipe submissions exempt from the interactive trust gate', () => {
@@ -336,6 +377,7 @@ describe('BaseChat recipe trust gate', () => {
     invokeAllSubmissionPaths();
     expect(mocks.submitMessage).toHaveBeenCalledTimes(5);
     expect(mocks.steerMessage).toHaveBeenCalledTimes(1);
+    expect(mocks.updateMessage).toHaveBeenCalledTimes(1);
   });
 
   it('keeps non-recipe submissions enabled', () => {

--- a/ui/desktop/src/components/BaseChat.recipeTrust.test.tsx
+++ b/ui/desktop/src/components/BaseChat.recipeTrust.test.tsx
@@ -388,6 +388,38 @@ describe('BaseChat recipe trust gate', () => {
     expect(mocks.hasAcceptedRecipeBefore).toHaveBeenCalledTimes(1);
   });
 
+  it('finishes an in-flight trust lookup after the same recipe session becomes inactive', async () => {
+    let resolveAcceptance: ((accepted: boolean) => void) | undefined;
+    mocks.hasAcceptedRecipeBefore.mockReturnValue(
+      new Promise<boolean>((resolve) => {
+        resolveAcceptance = resolve;
+      })
+    );
+    const { rerender } = renderBaseChat();
+
+    expect(screen.getByTestId('chat-input')).toHaveAttribute('data-recipe-accepted', 'false');
+    rerender(
+      <BaseChat
+        setChat={vi.fn()}
+        sessionId="sess-1"
+        suppressEmptyState={false}
+        isActiveSession={false}
+      />
+    );
+
+    await act(async () => resolveAcceptance?.(true));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('chat-input')).toHaveAttribute('data-recipe-accepted', 'true')
+    );
+    expect(screen.getByTestId('chat-input')).toHaveAttribute(
+      'data-queue-processing-blocked',
+      'false'
+    );
+    expect(screen.getByTestId('tool-approval')).toHaveAttribute('data-disabled', 'false');
+    expect(mocks.hasAcceptedRecipeBefore).toHaveBeenCalledTimes(1);
+  });
+
   it('fails closed on lookup failure and accepts only the current recipe when persistence fails', async () => {
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
     mocks.hasAcceptedRecipeBefore.mockRejectedValue(new Error('trust lookup failed'));

--- a/ui/desktop/src/components/BaseChat.recipeTrust.test.tsx
+++ b/ui/desktop/src/components/BaseChat.recipeTrust.test.tsx
@@ -16,6 +16,7 @@ const mocks = vi.hoisted(() => ({
   hasAcceptedRecipeBefore: vi.fn(),
   recordRecipeHash: vi.fn(),
   autoSubmit: undefined as undefined | ((input: UserInput) => void),
+  mcpAppendResult: undefined as boolean | Promise<boolean> | undefined,
 }));
 
 vi.mock('../hooks/useChatSession', () => ({
@@ -119,7 +120,7 @@ vi.mock('./ProgressiveMessageList', () => ({
     submitElicitationResponse,
     toolApprovalDisabled,
   }: {
-    append: (text: string) => void;
+    append: (text: string) => boolean | Promise<boolean>;
     onMessageUpdate?: (
       messageId: string,
       newContent: string,
@@ -137,7 +138,12 @@ vi.mock('./ProgressiveMessageList', () => ({
       <button type="button" onClick={() => append('progressive descendant')}>
         progressive descendant
       </button>
-      <button type="button" onClick={() => append('mcp ui message')}>
+      <button
+        type="button"
+        onClick={() => {
+          mocks.mcpAppendResult = append('mcp ui message');
+        }}
+      >
         mcp ui message
       </button>
       <button
@@ -231,17 +237,21 @@ function invokeAllSubmissionPaths() {
   fireEvent.click(screen.getByRole('button', { name: 'edit message' }));
   fireEvent.click(screen.getByRole('button', { name: 'submit elicitation' }));
   fireEvent.click(screen.getByRole('button', { name: 'steer queued message' }));
-  act(() => mocks.autoSubmit?.({ msg: 'programmatic submit', images: [] }));
+  act(() => {
+    void mocks.autoSubmit?.({ msg: 'programmatic submit', images: [] });
+  });
 }
 
 describe('BaseChat recipe trust gate', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.autoSubmit = undefined;
+    mocks.mcpAppendResult = undefined;
     mocks.session = makeSession();
     mocks.steerMessage.mockResolvedValue(true);
     mocks.updateMessage.mockResolvedValue(true);
     mocks.elicitationResponse.mockResolvedValue(true);
+    mocks.submitMessage.mockResolvedValue(true);
     Object.assign(window.electron, {
       hasAcceptedRecipeBefore: mocks.hasAcceptedRecipeBefore,
       recordRecipeHash: mocks.recordRecipeHash,
@@ -284,6 +294,7 @@ describe('BaseChat recipe trust gate', () => {
       'data-queue-processing-blocked',
       'true'
     );
+    await expect(mocks.mcpAppendResult).resolves.toBe(false);
     invokeAllSubmissionPaths();
     expect(mocks.submitMessage).not.toHaveBeenCalled();
     expect(mocks.steerMessage).not.toHaveBeenCalled();
@@ -311,6 +322,21 @@ describe('BaseChat recipe trust gate', () => {
     expect(mocks.steerMessage).toHaveBeenCalledTimes(1);
     expect(mocks.updateMessage).toHaveBeenCalledTimes(1);
     expect(mocks.elicitationResponse).toHaveBeenCalledTimes(1);
+    await expect(mocks.mcpAppendResult).resolves.toBe(true);
+  });
+
+  it('reports when the chat session rejects an MCP App message', async () => {
+    mocks.hasAcceptedRecipeBefore.mockResolvedValue(true);
+    mocks.submitMessage.mockResolvedValue(false);
+    renderBaseChat();
+
+    await waitFor(() =>
+      expect(screen.getByTestId('chat-input')).toHaveAttribute('data-recipe-accepted', 'true')
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'mcp ui message' }));
+
+    await expect(mocks.mcpAppendResult).resolves.toBe(false);
+    expect(mocks.submitMessage).toHaveBeenCalledWith({ msg: 'mcp ui message', images: [] });
   });
 
   it('returns to pending before a different recipe in the same session can submit', async () => {

--- a/ui/desktop/src/components/BaseChat.recipeTrust.test.tsx
+++ b/ui/desktop/src/components/BaseChat.recipeTrust.test.tsx
@@ -1,0 +1,275 @@
+import type { ReactNode } from 'react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { IntlTestWrapper } from '../i18n/test-utils';
+import type { UserInput } from '../types/message';
+import type { Session } from '../types/session';
+import BaseChat from './BaseChat';
+
+const mocks = vi.hoisted(() => ({
+  session: {} as Session,
+  submitMessage: vi.fn(),
+  hasAcceptedRecipeBefore: vi.fn(),
+  recordRecipeHash: vi.fn(),
+  autoSubmit: undefined as undefined | ((input: UserInput) => void),
+}));
+
+vi.mock('../hooks/useChatSession', () => ({
+  useChatSession: () => ({
+    session: mocks.session,
+    messages: [],
+    chatState: 'idle',
+    progressMessage: undefined,
+    updateSession: vi.fn(),
+    handleSubmit: mocks.submitMessage,
+    onSteerQueuedMessage: vi.fn(),
+    submitElicitationResponse: vi.fn(),
+    stopStreaming: vi.fn(),
+    retrySessionLoad: vi.fn(),
+    sessionLoadError: undefined,
+    tokenState: undefined,
+    notifications: [],
+    pauseQueueOnStop: false,
+    queueProcessingBlocked: false,
+    onMessageUpdate: vi.fn(),
+  }),
+}));
+
+vi.mock('../hooks/useAutoSubmit', () => ({
+  useAutoSubmit: ({ handleSubmit }: { handleSubmit: (input: UserInput) => void }) => {
+    mocks.autoSubmit = handleSubmit;
+    return { hasAutoSubmitted: false };
+  },
+}));
+
+vi.mock('../hooks/useFileDrop', () => ({
+  useFileDrop: () => ({
+    droppedFiles: [],
+    setDroppedFiles: vi.fn(),
+    handleDrop: vi.fn(),
+    handleDragOver: vi.fn(),
+  }),
+}));
+vi.mock('../hooks/use-mobile', () => ({ useIsMobile: () => false }));
+vi.mock('../hooks/useNavigation', () => ({ useNavigation: () => vi.fn() }));
+vi.mock('./Layout/NavigationContext', () => ({
+  useNavigationContextSafe: () => ({ isNavExpanded: true }),
+}));
+vi.mock('../acp/sessions', () => ({
+  acpDeleteSession: vi.fn(),
+  acpUpdateWorkingDir: vi.fn(),
+}));
+vi.mock('../recipe', () => ({
+  scanRecipe: vi.fn().mockResolvedValue({ has_security_warnings: false }),
+}));
+vi.mock('../acp/acpConnection', () => ({
+  isAcpRecovering: false,
+  subscribeToAcpRecovery: () => () => undefined,
+}));
+
+vi.mock('./ChatInput', () => ({
+  default: ({
+    handleSubmit,
+    initialValue,
+    recipeAccepted,
+  }: {
+    handleSubmit: (input: UserInput) => void;
+    initialValue?: string;
+    recipeAccepted?: boolean;
+  }) => (
+    <button
+      type="button"
+      data-testid="chat-input"
+      data-initial-value={initialValue ?? ''}
+      data-recipe-accepted={String(recipeAccepted)}
+      onClick={() => handleSubmit({ msg: 'chat input', images: [] })}
+    >
+      chat input
+    </button>
+  ),
+}));
+vi.mock('./recipes/RecipeActivities', () => ({
+  default: ({ append }: { append: (text: string) => void }) => (
+    <button type="button" onClick={() => append('recipe activity')}>
+      recipe activity
+    </button>
+  ),
+}));
+vi.mock('./ProgressiveMessageList', () => ({
+  default: ({ append }: { append: (text: string) => void }) => (
+    <>
+      <button type="button" onClick={() => append('progressive descendant')}>
+        progressive descendant
+      </button>
+      <button type="button" onClick={() => append('mcp ui message')}>
+        mcp ui message
+      </button>
+    </>
+  ),
+}));
+vi.mock('./ui/RecipeWarningModal', () => ({
+  RecipeWarningModal: ({ isOpen }: { isOpen: boolean }) => (
+    <div data-testid="recipe-warning" data-open={String(isOpen)} />
+  ),
+}));
+vi.mock('./Layout/MainPanelLayout', () => ({
+  MainPanelLayout: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+vi.mock('./ChatInputCard', () => ({
+  ChatInputCard: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+vi.mock('./ui/scroll-area', () => ({
+  ScrollArea: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+vi.mock('./conversation/SearchView', () => ({
+  SearchView: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+vi.mock('./LoadingGoose', () => ({ default: () => null }));
+vi.mock('./RecipeHeader', () => ({ RecipeHeader: () => null }));
+vi.mock('./icons', () => ({ Goose: () => null }));
+vi.mock('./GooseSidebar/EnvironmentBadge', () => ({ default: () => null }));
+vi.mock('./SessionActionsHeader', () => ({ default: () => null }));
+
+function makeSession(overrides: Partial<Session> = {}): Session {
+  return {
+    id: 'sess-1',
+    name: 'Recipe session',
+    message_count: 0,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    working_dir: '/tmp',
+    extension_data: {},
+    session_type: 'user',
+    recipe: {
+      title: 'Untrusted recipe',
+      description: 'Runs a prompt',
+      prompt: 'RUN_RECIPE',
+    },
+    ...overrides,
+  } as Session;
+}
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return (
+    <MemoryRouter initialEntries={['/pair?resumeSessionId=sess-1']}>
+      <IntlTestWrapper>{children}</IntlTestWrapper>
+    </MemoryRouter>
+  );
+}
+
+function renderBaseChat() {
+  return render(
+    <BaseChat setChat={vi.fn()} sessionId="sess-1" suppressEmptyState={false} isActiveSession />,
+    { wrapper: Wrapper }
+  );
+}
+
+function invokeAllSubmissionPaths() {
+  fireEvent.click(screen.getByRole('button', { name: 'chat input' }));
+  fireEvent.click(screen.getByRole('button', { name: 'recipe activity' }));
+  fireEvent.click(screen.getByRole('button', { name: 'progressive descendant' }));
+  fireEvent.click(screen.getByRole('button', { name: 'mcp ui message' }));
+  act(() => mocks.autoSubmit?.({ msg: 'programmatic submit', images: [] }));
+}
+
+describe('BaseChat recipe trust gate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.autoSubmit = undefined;
+    mocks.session = makeSession();
+    Object.assign(window.electron, {
+      hasAcceptedRecipeBefore: mocks.hasAcceptedRecipeBefore,
+      recordRecipeHash: mocks.recordRecipeHash,
+    });
+  });
+
+  it('blocks direct, descendant, and programmatic submissions while trust is pending or rejected', async () => {
+    let resolveAcceptance: ((accepted: boolean) => void) | undefined;
+    mocks.hasAcceptedRecipeBefore.mockReturnValue(
+      new Promise<boolean>((resolve) => {
+        resolveAcceptance = resolve;
+      })
+    );
+
+    renderBaseChat();
+
+    expect(screen.getByTestId('chat-input')).toHaveAttribute('data-initial-value', '');
+    expect(screen.getByTestId('chat-input')).toHaveAttribute('data-recipe-accepted', 'false');
+    expect(screen.getByTestId('recipe-warning')).toHaveAttribute('data-open', 'false');
+    invokeAllSubmissionPaths();
+    expect(mocks.submitMessage).not.toHaveBeenCalled();
+
+    await act(async () => resolveAcceptance?.(false));
+    await waitFor(() =>
+      expect(screen.getByTestId('recipe-warning')).toHaveAttribute('data-open', 'true')
+    );
+
+    expect(screen.getByTestId('chat-input')).toHaveAttribute('data-initial-value', '');
+    expect(screen.getByTestId('chat-input')).toHaveAttribute('data-recipe-accepted', 'false');
+    invokeAllSubmissionPaths();
+    expect(mocks.submitMessage).not.toHaveBeenCalled();
+  });
+
+  it('allows every submission path after trust is affirmatively accepted', async () => {
+    mocks.hasAcceptedRecipeBefore.mockResolvedValue(true);
+    renderBaseChat();
+
+    await waitFor(() =>
+      expect(screen.getByTestId('chat-input')).toHaveAttribute('data-recipe-accepted', 'true')
+    );
+    expect(screen.getByTestId('chat-input')).toHaveAttribute('data-initial-value', 'RUN_RECIPE');
+
+    invokeAllSubmissionPaths();
+
+    expect(mocks.submitMessage).toHaveBeenCalledTimes(5);
+  });
+
+  it('returns to pending before a different recipe in the same session can submit', async () => {
+    mocks.hasAcceptedRecipeBefore.mockResolvedValueOnce(true);
+    const { rerender } = renderBaseChat();
+
+    await waitFor(() =>
+      expect(screen.getByTestId('chat-input')).toHaveAttribute('data-recipe-accepted', 'true')
+    );
+
+    mocks.submitMessage.mockClear();
+    mocks.hasAcceptedRecipeBefore.mockReturnValue(new Promise<boolean>(() => undefined));
+    mocks.session = makeSession({
+      recipe: {
+        title: 'Different recipe',
+        description: 'Runs a different prompt',
+        prompt: 'RUN_DIFFERENT_RECIPE',
+      },
+    });
+    rerender(
+      <BaseChat setChat={vi.fn()} sessionId="sess-1" suppressEmptyState={false} isActiveSession />
+    );
+
+    expect(screen.getByTestId('chat-input')).toHaveAttribute('data-recipe-accepted', 'false');
+    expect(screen.getByTestId('chat-input')).toHaveAttribute('data-initial-value', '');
+    invokeAllSubmissionPaths();
+    expect(mocks.submitMessage).not.toHaveBeenCalled();
+  });
+
+  it('keeps scheduled recipe submissions exempt from the interactive trust gate', () => {
+    mocks.session = makeSession({ session_type: 'scheduled' });
+    renderBaseChat();
+
+    expect(mocks.hasAcceptedRecipeBefore).not.toHaveBeenCalled();
+    expect(screen.getByTestId('chat-input')).toHaveAttribute('data-recipe-accepted', 'true');
+    expect(screen.getByTestId('chat-input')).toHaveAttribute('data-initial-value', 'RUN_RECIPE');
+    invokeAllSubmissionPaths();
+    expect(mocks.submitMessage).toHaveBeenCalledTimes(5);
+  });
+
+  it('keeps non-recipe submissions enabled', () => {
+    mocks.session = makeSession({ recipe: null });
+    renderBaseChat();
+
+    expect(screen.getByTestId('chat-input')).toHaveAttribute('data-recipe-accepted', 'true');
+    fireEvent.click(screen.getByRole('button', { name: 'chat input' }));
+    act(() => mocks.autoSubmit?.({ msg: 'programmatic submit', images: [] }));
+    expect(mocks.submitMessage).toHaveBeenCalledTimes(2);
+  });
+});

--- a/ui/desktop/src/components/BaseChat.recipeTrust.test.tsx
+++ b/ui/desktop/src/components/BaseChat.recipeTrust.test.tsx
@@ -10,6 +10,7 @@ import BaseChat from './BaseChat';
 const mocks = vi.hoisted(() => ({
   session: {} as Session,
   submitMessage: vi.fn(),
+  steerMessage: vi.fn(),
   hasAcceptedRecipeBefore: vi.fn(),
   recordRecipeHash: vi.fn(),
   autoSubmit: undefined as undefined | ((input: UserInput) => void),
@@ -23,7 +24,7 @@ vi.mock('../hooks/useChatSession', () => ({
     progressMessage: undefined,
     updateSession: vi.fn(),
     handleSubmit: mocks.submitMessage,
-    onSteerQueuedMessage: vi.fn(),
+    onSteerQueuedMessage: mocks.steerMessage,
     submitElicitationResponse: vi.fn(),
     stopStreaming: vi.fn(),
     retrySessionLoad: vi.fn(),
@@ -71,22 +72,32 @@ vi.mock('../acp/acpConnection', () => ({
 vi.mock('./ChatInput', () => ({
   default: ({
     handleSubmit,
+    onSteerQueuedMessage,
     initialValue,
     recipeAccepted,
   }: {
     handleSubmit: (input: UserInput) => void;
+    onSteerQueuedMessage?: (input: UserInput) => Promise<boolean>;
     initialValue?: string;
     recipeAccepted?: boolean;
   }) => (
-    <button
-      type="button"
-      data-testid="chat-input"
-      data-initial-value={initialValue ?? ''}
-      data-recipe-accepted={String(recipeAccepted)}
-      onClick={() => handleSubmit({ msg: 'chat input', images: [] })}
-    >
-      chat input
-    </button>
+    <>
+      <button
+        type="button"
+        data-testid="chat-input"
+        data-initial-value={initialValue ?? ''}
+        data-recipe-accepted={String(recipeAccepted)}
+        onClick={() => handleSubmit({ msg: 'chat input', images: [] })}
+      >
+        chat input
+      </button>
+      <button
+        type="button"
+        onClick={() => void onSteerQueuedMessage?.({ msg: 'steer queued message', images: [] })}
+      >
+        steer queued message
+      </button>
+    </>
   ),
 }));
 vi.mock('./recipes/RecipeActivities', () => ({
@@ -170,6 +181,7 @@ function invokeAllSubmissionPaths() {
   fireEvent.click(screen.getByRole('button', { name: 'recipe activity' }));
   fireEvent.click(screen.getByRole('button', { name: 'progressive descendant' }));
   fireEvent.click(screen.getByRole('button', { name: 'mcp ui message' }));
+  fireEvent.click(screen.getByRole('button', { name: 'steer queued message' }));
   act(() => mocks.autoSubmit?.({ msg: 'programmatic submit', images: [] }));
 }
 
@@ -178,6 +190,7 @@ describe('BaseChat recipe trust gate', () => {
     vi.clearAllMocks();
     mocks.autoSubmit = undefined;
     mocks.session = makeSession();
+    mocks.steerMessage.mockResolvedValue(true);
     Object.assign(window.electron, {
       hasAcceptedRecipeBefore: mocks.hasAcceptedRecipeBefore,
       recordRecipeHash: mocks.recordRecipeHash,
@@ -199,6 +212,7 @@ describe('BaseChat recipe trust gate', () => {
     expect(screen.getByTestId('recipe-warning')).toHaveAttribute('data-open', 'false');
     invokeAllSubmissionPaths();
     expect(mocks.submitMessage).not.toHaveBeenCalled();
+    expect(mocks.steerMessage).not.toHaveBeenCalled();
 
     await act(async () => resolveAcceptance?.(false));
     await waitFor(() =>
@@ -209,6 +223,7 @@ describe('BaseChat recipe trust gate', () => {
     expect(screen.getByTestId('chat-input')).toHaveAttribute('data-recipe-accepted', 'false');
     invokeAllSubmissionPaths();
     expect(mocks.submitMessage).not.toHaveBeenCalled();
+    expect(mocks.steerMessage).not.toHaveBeenCalled();
   });
 
   it('allows every submission path after trust is affirmatively accepted', async () => {
@@ -223,6 +238,7 @@ describe('BaseChat recipe trust gate', () => {
     invokeAllSubmissionPaths();
 
     expect(mocks.submitMessage).toHaveBeenCalledTimes(5);
+    expect(mocks.steerMessage).toHaveBeenCalledTimes(1);
   });
 
   it('returns to pending before a different recipe in the same session can submit', async () => {
@@ -250,6 +266,7 @@ describe('BaseChat recipe trust gate', () => {
     expect(screen.getByTestId('chat-input')).toHaveAttribute('data-initial-value', '');
     invokeAllSubmissionPaths();
     expect(mocks.submitMessage).not.toHaveBeenCalled();
+    expect(mocks.steerMessage).not.toHaveBeenCalled();
   });
 
   it('keeps scheduled recipe submissions exempt from the interactive trust gate', () => {
@@ -261,6 +278,7 @@ describe('BaseChat recipe trust gate', () => {
     expect(screen.getByTestId('chat-input')).toHaveAttribute('data-initial-value', 'RUN_RECIPE');
     invokeAllSubmissionPaths();
     expect(mocks.submitMessage).toHaveBeenCalledTimes(5);
+    expect(mocks.steerMessage).toHaveBeenCalledTimes(1);
   });
 
   it('keeps non-recipe submissions enabled', () => {
@@ -269,7 +287,9 @@ describe('BaseChat recipe trust gate', () => {
 
     expect(screen.getByTestId('chat-input')).toHaveAttribute('data-recipe-accepted', 'true');
     fireEvent.click(screen.getByRole('button', { name: 'chat input' }));
+    fireEvent.click(screen.getByRole('button', { name: 'steer queued message' }));
     act(() => mocks.autoSubmit?.({ msg: 'programmatic submit', images: [] }));
     expect(mocks.submitMessage).toHaveBeenCalledTimes(2);
+    expect(mocks.steerMessage).toHaveBeenCalledTimes(1);
   });
 });

--- a/ui/desktop/src/components/BaseChat.recipeTrust.test.tsx
+++ b/ui/desktop/src/components/BaseChat.recipeTrust.test.tsx
@@ -107,8 +107,14 @@ vi.mock('./ChatInput', () => ({
   ),
 }));
 vi.mock('./recipes/RecipeActivities', () => ({
-  default: ({ append }: { append: (text: string) => void }) => (
-    <button type="button" onClick={() => append('recipe activity')}>
+  default: ({
+    append,
+    disabled,
+  }: {
+    append: (text: string) => boolean | Promise<boolean>;
+    disabled?: boolean;
+  }) => (
+    <button type="button" disabled={disabled} onClick={() => void append('recipe activity')}>
       recipe activity
     </button>
   ),
@@ -276,6 +282,7 @@ describe('BaseChat recipe trust gate', () => {
     );
     expect(screen.getByTestId('recipe-warning')).toHaveAttribute('data-open', 'false');
     expect(screen.getByTestId('tool-approval')).toHaveAttribute('data-disabled', 'true');
+    expect(screen.getByRole('button', { name: 'recipe activity' })).toBeDisabled();
     invokeAllSubmissionPaths();
     expect(mocks.submitMessage).not.toHaveBeenCalled();
     expect(mocks.steerMessage).not.toHaveBeenCalled();
@@ -290,6 +297,7 @@ describe('BaseChat recipe trust gate', () => {
     expect(screen.getByTestId('chat-input')).toHaveAttribute('data-initial-value', '');
     expect(screen.getByTestId('chat-input')).toHaveAttribute('data-recipe-accepted', 'false');
     expect(screen.getByTestId('tool-approval')).toHaveAttribute('data-disabled', 'true');
+    expect(screen.getByRole('button', { name: 'recipe activity' })).toBeDisabled();
     expect(screen.getByTestId('chat-input')).toHaveAttribute(
       'data-queue-processing-blocked',
       'true'
@@ -315,6 +323,7 @@ describe('BaseChat recipe trust gate', () => {
       'false'
     );
     expect(screen.getByTestId('tool-approval')).toHaveAttribute('data-disabled', 'false');
+    expect(screen.getByRole('button', { name: 'recipe activity' })).toBeEnabled();
 
     invokeAllSubmissionPaths();
 

--- a/ui/desktop/src/components/BaseChat.recipeTrust.test.tsx
+++ b/ui/desktop/src/components/BaseChat.recipeTrust.test.tsx
@@ -378,6 +378,14 @@ describe('BaseChat recipe trust gate', () => {
     expect(mocks.steerMessage).toHaveBeenCalledTimes(1);
     expect(mocks.updateMessage).toHaveBeenCalledTimes(1);
     expect(mocks.elicitationResponse).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <BaseChat setChat={vi.fn()} sessionId="sess-1" suppressEmptyState={false} isActiveSession />
+    );
+
+    expect(screen.getByTestId('chat-input')).toHaveAttribute('data-recipe-accepted', 'true');
+    expect(screen.getByTestId('tool-approval')).toHaveAttribute('data-disabled', 'false');
+    expect(mocks.hasAcceptedRecipeBefore).toHaveBeenCalledTimes(1);
   });
 
   it('fails closed on lookup failure and accepts only the current recipe when persistence fails', async () => {
@@ -409,6 +417,20 @@ describe('BaseChat recipe trust gate', () => {
     expect(mocks.elicitationResponse).toHaveBeenCalledTimes(1);
     expect(consoleError).toHaveBeenCalledWith('Failed to check recipe trust:', expect.any(Error));
     expect(consoleError).toHaveBeenCalledWith('Failed to persist recipe trust:', expect.any(Error));
+
+    rerender(
+      <BaseChat
+        setChat={vi.fn()}
+        sessionId="sess-1"
+        suppressEmptyState={false}
+        isActiveSession={false}
+      />
+    );
+    rerender(
+      <BaseChat setChat={vi.fn()} sessionId="sess-1" suppressEmptyState={false} isActiveSession />
+    );
+    expect(screen.getByTestId('chat-input')).toHaveAttribute('data-recipe-accepted', 'true');
+    expect(mocks.hasAcceptedRecipeBefore).toHaveBeenCalledTimes(1);
 
     mocks.submitMessage.mockClear();
     mocks.steerMessage.mockClear();

--- a/ui/desktop/src/components/BaseChat.recipeTrust.test.tsx
+++ b/ui/desktop/src/components/BaseChat.recipeTrust.test.tsx
@@ -75,11 +75,13 @@ vi.mock('./ChatInput', () => ({
     onSteerQueuedMessage,
     initialValue,
     recipeAccepted,
+    queueProcessingBlocked,
   }: {
     handleSubmit: (input: UserInput) => void;
     onSteerQueuedMessage?: (input: UserInput) => Promise<boolean>;
     initialValue?: string;
     recipeAccepted?: boolean;
+    queueProcessingBlocked?: boolean;
   }) => (
     <>
       <button
@@ -87,6 +89,7 @@ vi.mock('./ChatInput', () => ({
         data-testid="chat-input"
         data-initial-value={initialValue ?? ''}
         data-recipe-accepted={String(recipeAccepted)}
+        data-queue-processing-blocked={String(queueProcessingBlocked)}
         onClick={() => handleSubmit({ msg: 'chat input', images: [] })}
       >
         chat input
@@ -209,6 +212,10 @@ describe('BaseChat recipe trust gate', () => {
 
     expect(screen.getByTestId('chat-input')).toHaveAttribute('data-initial-value', '');
     expect(screen.getByTestId('chat-input')).toHaveAttribute('data-recipe-accepted', 'false');
+    expect(screen.getByTestId('chat-input')).toHaveAttribute(
+      'data-queue-processing-blocked',
+      'true'
+    );
     expect(screen.getByTestId('recipe-warning')).toHaveAttribute('data-open', 'false');
     invokeAllSubmissionPaths();
     expect(mocks.submitMessage).not.toHaveBeenCalled();
@@ -221,6 +228,10 @@ describe('BaseChat recipe trust gate', () => {
 
     expect(screen.getByTestId('chat-input')).toHaveAttribute('data-initial-value', '');
     expect(screen.getByTestId('chat-input')).toHaveAttribute('data-recipe-accepted', 'false');
+    expect(screen.getByTestId('chat-input')).toHaveAttribute(
+      'data-queue-processing-blocked',
+      'true'
+    );
     invokeAllSubmissionPaths();
     expect(mocks.submitMessage).not.toHaveBeenCalled();
     expect(mocks.steerMessage).not.toHaveBeenCalled();
@@ -234,6 +245,10 @@ describe('BaseChat recipe trust gate', () => {
       expect(screen.getByTestId('chat-input')).toHaveAttribute('data-recipe-accepted', 'true')
     );
     expect(screen.getByTestId('chat-input')).toHaveAttribute('data-initial-value', 'RUN_RECIPE');
+    expect(screen.getByTestId('chat-input')).toHaveAttribute(
+      'data-queue-processing-blocked',
+      'false'
+    );
 
     invokeAllSubmissionPaths();
 
@@ -263,6 +278,10 @@ describe('BaseChat recipe trust gate', () => {
     );
 
     expect(screen.getByTestId('chat-input')).toHaveAttribute('data-recipe-accepted', 'false');
+    expect(screen.getByTestId('chat-input')).toHaveAttribute(
+      'data-queue-processing-blocked',
+      'true'
+    );
     expect(screen.getByTestId('chat-input')).toHaveAttribute('data-initial-value', '');
     invokeAllSubmissionPaths();
     expect(mocks.submitMessage).not.toHaveBeenCalled();
@@ -276,6 +295,10 @@ describe('BaseChat recipe trust gate', () => {
     expect(mocks.hasAcceptedRecipeBefore).not.toHaveBeenCalled();
     expect(screen.getByTestId('chat-input')).toHaveAttribute('data-recipe-accepted', 'true');
     expect(screen.getByTestId('chat-input')).toHaveAttribute('data-initial-value', 'RUN_RECIPE');
+    expect(screen.getByTestId('chat-input')).toHaveAttribute(
+      'data-queue-processing-blocked',
+      'false'
+    );
     invokeAllSubmissionPaths();
     expect(mocks.submitMessage).toHaveBeenCalledTimes(5);
     expect(mocks.steerMessage).toHaveBeenCalledTimes(1);
@@ -286,6 +309,10 @@ describe('BaseChat recipe trust gate', () => {
     renderBaseChat();
 
     expect(screen.getByTestId('chat-input')).toHaveAttribute('data-recipe-accepted', 'true');
+    expect(screen.getByTestId('chat-input')).toHaveAttribute(
+      'data-queue-processing-blocked',
+      'false'
+    );
     fireEvent.click(screen.getByRole('button', { name: 'chat input' }));
     fireEvent.click(screen.getByRole('button', { name: 'steer queued message' }));
     act(() => mocks.autoSubmit?.({ msg: 'programmatic submit', images: [] }));

--- a/ui/desktop/src/components/BaseChat.recipeTrust.test.tsx
+++ b/ui/desktop/src/components/BaseChat.recipeTrust.test.tsx
@@ -117,6 +117,7 @@ vi.mock('./ProgressiveMessageList', () => ({
     append,
     onMessageUpdate,
     submitElicitationResponse,
+    toolApprovalDisabled,
   }: {
     append: (text: string) => void;
     onMessageUpdate?: (
@@ -129,8 +130,10 @@ vi.mock('./ProgressiveMessageList', () => ({
       elicitationId: string,
       userData: Record<string, unknown>
     ) => Promise<boolean>;
+    toolApprovalDisabled?: boolean;
   }) => (
     <>
+      <div data-testid="tool-approval" data-disabled={String(toolApprovalDisabled)} />
       <button type="button" onClick={() => append('progressive descendant')}>
         progressive descendant
       </button>
@@ -262,6 +265,7 @@ describe('BaseChat recipe trust gate', () => {
       'true'
     );
     expect(screen.getByTestId('recipe-warning')).toHaveAttribute('data-open', 'false');
+    expect(screen.getByTestId('tool-approval')).toHaveAttribute('data-disabled', 'true');
     invokeAllSubmissionPaths();
     expect(mocks.submitMessage).not.toHaveBeenCalled();
     expect(mocks.steerMessage).not.toHaveBeenCalled();
@@ -275,6 +279,7 @@ describe('BaseChat recipe trust gate', () => {
 
     expect(screen.getByTestId('chat-input')).toHaveAttribute('data-initial-value', '');
     expect(screen.getByTestId('chat-input')).toHaveAttribute('data-recipe-accepted', 'false');
+    expect(screen.getByTestId('tool-approval')).toHaveAttribute('data-disabled', 'true');
     expect(screen.getByTestId('chat-input')).toHaveAttribute(
       'data-queue-processing-blocked',
       'true'
@@ -298,6 +303,7 @@ describe('BaseChat recipe trust gate', () => {
       'data-queue-processing-blocked',
       'false'
     );
+    expect(screen.getByTestId('tool-approval')).toHaveAttribute('data-disabled', 'false');
 
     invokeAllSubmissionPaths();
 
@@ -329,6 +335,7 @@ describe('BaseChat recipe trust gate', () => {
     );
 
     expect(screen.getByTestId('chat-input')).toHaveAttribute('data-recipe-accepted', 'false');
+    expect(screen.getByTestId('tool-approval')).toHaveAttribute('data-disabled', 'true');
     expect(screen.getByTestId('chat-input')).toHaveAttribute(
       'data-queue-processing-blocked',
       'true'
@@ -365,6 +372,7 @@ describe('BaseChat recipe trust gate', () => {
       'data-queue-processing-blocked',
       'false'
     );
+    expect(screen.getByTestId('tool-approval')).toHaveAttribute('data-disabled', 'false');
     invokeAllSubmissionPaths();
     expect(mocks.submitMessage).toHaveBeenCalledTimes(5);
     expect(mocks.steerMessage).toHaveBeenCalledTimes(1);
@@ -438,6 +446,7 @@ describe('BaseChat recipe trust gate', () => {
       'data-queue-processing-blocked',
       'false'
     );
+    expect(screen.getByTestId('tool-approval')).toHaveAttribute('data-disabled', 'false');
     invokeAllSubmissionPaths();
     expect(mocks.submitMessage).toHaveBeenCalledTimes(5);
     expect(mocks.steerMessage).toHaveBeenCalledTimes(1);

--- a/ui/desktop/src/components/BaseChat.recipeTrust.test.tsx
+++ b/ui/desktop/src/components/BaseChat.recipeTrust.test.tsx
@@ -172,9 +172,14 @@ function Wrapper({ children }: { children: ReactNode }) {
   );
 }
 
-function renderBaseChat() {
+function renderBaseChat(isActiveSession = true) {
   return render(
-    <BaseChat setChat={vi.fn()} sessionId="sess-1" suppressEmptyState={false} isActiveSession />,
+    <BaseChat
+      setChat={vi.fn()}
+      sessionId="sess-1"
+      suppressEmptyState={false}
+      isActiveSession={isActiveSession}
+    />,
     { wrapper: Wrapper }
   );
 }
@@ -286,6 +291,35 @@ describe('BaseChat recipe trust gate', () => {
     invokeAllSubmissionPaths();
     expect(mocks.submitMessage).not.toHaveBeenCalled();
     expect(mocks.steerMessage).not.toHaveBeenCalled();
+  });
+
+  it('retains accepted trust for background work while the same recipe session is inactive', async () => {
+    mocks.hasAcceptedRecipeBefore.mockResolvedValue(true);
+    const { rerender } = renderBaseChat();
+
+    await waitFor(() =>
+      expect(screen.getByTestId('chat-input')).toHaveAttribute('data-recipe-accepted', 'true')
+    );
+
+    mocks.submitMessage.mockClear();
+    mocks.steerMessage.mockClear();
+    rerender(
+      <BaseChat
+        setChat={vi.fn()}
+        sessionId="sess-1"
+        suppressEmptyState={false}
+        isActiveSession={false}
+      />
+    );
+
+    expect(screen.getByTestId('chat-input')).toHaveAttribute('data-recipe-accepted', 'true');
+    expect(screen.getByTestId('chat-input')).toHaveAttribute(
+      'data-queue-processing-blocked',
+      'false'
+    );
+    invokeAllSubmissionPaths();
+    expect(mocks.submitMessage).toHaveBeenCalledTimes(5);
+    expect(mocks.steerMessage).toHaveBeenCalledTimes(1);
   });
 
   it('keeps scheduled recipe submissions exempt from the interactive trust gate', () => {

--- a/ui/desktop/src/components/BaseChat.tsx
+++ b/ui/desktop/src/components/BaseChat.tsx
@@ -279,7 +279,6 @@ export default function BaseChat({
   }, [messages]);
 
   useEffect(() => {
-    if (!isActiveSession) return;
     if (
       recipeTrustRef.current?.accepted === true &&
       recipeTrustRef.current.identity === recipeIdentity
@@ -312,7 +311,7 @@ export default function BaseChat({
     return () => {
       cancelled = true;
     };
-  }, [recipe, recipeIdentity, isActiveSession, session?.session_type]);
+  }, [recipe, recipeIdentity, session?.session_type]);
 
   const handleRecipeAccept = async (accept: boolean) => {
     if (recipe && accept) {

--- a/ui/desktop/src/components/BaseChat.tsx
+++ b/ui/desktop/src/components/BaseChat.tsx
@@ -157,6 +157,15 @@ export default function BaseChat({
     },
     [recipeAccepted, submitMessage]
   );
+  const handleSteerQueuedMessage = useCallback(
+    (input: UserInput) => {
+      if (!recipeAccepted || !onSteerQueuedMessage) {
+        return Promise.resolve(false);
+      }
+      return onSteerQueuedMessage(input);
+    },
+    [recipeAccepted, onSteerQueuedMessage]
+  );
 
   const resolvedInitialMessage = useMemo((): UserInput | undefined => {
     if (!initialMessage) return undefined;
@@ -538,7 +547,7 @@ export default function BaseChat({
             handleSubmit={chatInputSubmit}
             chatState={chatState}
             onStop={stopStreaming}
-            onSteerQueuedMessage={onSteerQueuedMessage}
+            onSteerQueuedMessage={handleSteerQueuedMessage}
             pauseQueueOnStop={pauseQueueOnStop}
             queueProcessingBlocked={queueProcessingBlocked || acpRecovering}
             commandHistory={commandHistory}

--- a/ui/desktop/src/components/BaseChat.tsx
+++ b/ui/desktop/src/components/BaseChat.tsx
@@ -90,7 +90,10 @@ export default function BaseChat({
   const chatInputRef = useRef<HTMLTextAreaElement>(null);
   const disableAnimation = location.state?.disableAnimation || false;
   const [hasStartedUsingRecipe, setHasStartedUsingRecipe] = React.useState(false);
-  const [hasNotAcceptedRecipe, setHasNotAcceptedRecipe] = useState<boolean>();
+  const [recipeTrust, setRecipeTrust] = useState<{
+    identity: string;
+    accepted: boolean;
+  }>();
   const [hasRecipeSecurityWarnings, setHasRecipeSecurityWarnings] = useState(false);
   const [acpRecovering, setAcpRecovering] = useState(isAcpRecovering);
   const isMobile = useIsMobile();
@@ -109,7 +112,7 @@ export default function BaseChat({
     chatState,
     progressMessage,
     updateSession,
-    handleSubmit,
+    handleSubmit: submitMessage,
     onSteerQueuedMessage,
     submitElicitationResponse,
     stopStreaming,
@@ -141,6 +144,19 @@ export default function BaseChat({
   );
 
   const recipe = session?.recipe as Recipe | null | undefined;
+  const recipeIdentity = recipe ? JSON.stringify(recipe) : undefined;
+  const acceptedCurrentRecipe =
+    recipeTrust && recipeTrust.identity === recipeIdentity ? recipeTrust.accepted : undefined;
+  const recipeAccepted =
+    session?.session_type === 'scheduled' || !recipe || acceptedCurrentRecipe === true;
+  const handleSubmit = useCallback(
+    (input: UserInput) => {
+      if (recipeAccepted) {
+        submitMessage(input);
+      }
+    },
+    [recipeAccepted, submitMessage]
+  );
 
   const resolvedInitialMessage = useMemo((): UserInput | undefined => {
     if (!initialMessage) return undefined;
@@ -157,10 +173,7 @@ export default function BaseChat({
   // (goose://new-session?prompt=...). Once the conversation has messages, later flows
   // such as forks or resumes should auto-submit normally.
   const suppressInitialAutoSubmit = noAutoSubmit && messages.length === 0;
-  const canAutoSubmit =
-    !acpRecovering &&
-    !suppressInitialAutoSubmit &&
-    (session?.session_type === 'scheduled' || !recipe || hasNotAcceptedRecipe === false);
+  const canAutoSubmit = !acpRecovering && !suppressInitialAutoSubmit && recipeAccepted;
 
   useAutoSubmit({
     sessionId,
@@ -237,23 +250,33 @@ export default function BaseChat({
   }, [messages]);
 
   useEffect(() => {
-    if (!recipe || !isActiveSession || session?.session_type === 'scheduled') return;
+    setRecipeTrust(undefined);
+    setHasRecipeSecurityWarnings(false);
 
-    (async () => {
+    if (!recipe || !recipeIdentity || !isActiveSession || session?.session_type === 'scheduled')
+      return;
+    let cancelled = false;
+
+    void (async () => {
       const accepted = await window.electron.hasAcceptedRecipeBefore(recipe);
-      setHasNotAcceptedRecipe(!accepted);
+      if (cancelled) return;
+      setRecipeTrust({ identity: recipeIdentity, accepted });
 
       if (!accepted) {
         const scanResult = await scanRecipe(recipe);
-        setHasRecipeSecurityWarnings(scanResult.has_security_warnings);
+        if (!cancelled) setHasRecipeSecurityWarnings(scanResult.has_security_warnings);
       }
     })();
-  }, [recipe, isActiveSession, session?.session_type]);
+
+    return () => {
+      cancelled = true;
+    };
+  }, [recipe, recipeIdentity, isActiveSession, session?.session_type]);
 
   const handleRecipeAccept = async (accept: boolean) => {
     if (recipe && accept) {
       await window.electron.recordRecipeHash(recipe);
-      setHasNotAcceptedRecipe(false);
+      if (recipeIdentity) setRecipeTrust({ identity: recipeIdentity, accepted: true });
       return;
     }
 
@@ -519,7 +542,7 @@ export default function BaseChat({
             pauseQueueOnStop={pauseQueueOnStop}
             queueProcessingBlocked={queueProcessingBlocked || acpRecovering}
             commandHistory={commandHistory}
-            initialValue={initialPrompt}
+            initialValue={recipeAccepted ? initialPrompt : ''}
             setView={setView}
             totalTokens={tokenState?.totalTokens ?? session?.usage?.total_tokens ?? undefined}
             contextLimit={tokenState?.contextLimit}
@@ -539,7 +562,7 @@ export default function BaseChat({
             messages={messages}
             disableAnimation={disableAnimation}
             recipe={recipe}
-            recipeAccepted={!hasNotAcceptedRecipe}
+            recipeAccepted={recipeAccepted}
             initialPrompt={initialPrompt}
             sessionModel={sessionModel}
             sessionProvider={sessionProvider}
@@ -554,7 +577,7 @@ export default function BaseChat({
 
       {recipe && isActiveSession && session?.session_type !== 'scheduled' && (
         <RecipeWarningModal
-          isOpen={!!hasNotAcceptedRecipe}
+          isOpen={acceptedCurrentRecipe === false}
           onConfirm={() => handleRecipeAccept(true)}
           onCancel={() => handleRecipeAccept(false)}
           recipeDetails={{

--- a/ui/desktop/src/components/BaseChat.tsx
+++ b/ui/desktop/src/components/BaseChat.tsx
@@ -543,6 +543,7 @@ export default function BaseChat({
                     onRenderingComplete={handleRenderingComplete}
                     onMessageUpdate={handleMessageUpdate}
                     submitElicitationResponse={handleSubmitElicitationResponse}
+                    toolApprovalDisabled={!recipeAccepted}
                   />
                 </SearchView>
 

--- a/ui/desktop/src/components/BaseChat.tsx
+++ b/ui/desktop/src/components/BaseChat.tsx
@@ -531,6 +531,7 @@ export default function BaseChat({
                   activities={Array.isArray(recipe.activities) ? recipe.activities : null}
                   title={recipe.title}
                   parameterValues={session?.user_recipe_values || {}}
+                  disabled={!recipeAccepted}
                 />
               </div>
             )}

--- a/ui/desktop/src/components/BaseChat.tsx
+++ b/ui/desktop/src/components/BaseChat.tsx
@@ -129,11 +129,6 @@ export default function BaseChat({
     sessionId,
     onStreamFinish,
   });
-  const appendToChat = useCallback(
-    (text: string) => handleSubmit({ msg: text, images: [] }),
-    [handleSubmit]
-  );
-
   const handleWorkingDirChange = useCallback(
     async (newDir: string) => {
       if (!session) {
@@ -158,6 +153,10 @@ export default function BaseChat({
       }
     },
     [recipeAccepted, submitMessage]
+  );
+  const appendToChat = useCallback(
+    (text: string) => handleSubmit({ msg: text, images: [] }),
+    [handleSubmit]
   );
   const handleSteerQueuedMessage = useCallback(
     (input: UserInput) => {

--- a/ui/desktop/src/components/BaseChat.tsx
+++ b/ui/desktop/src/components/BaseChat.tsx
@@ -549,7 +549,7 @@ export default function BaseChat({
             onStop={stopStreaming}
             onSteerQueuedMessage={handleSteerQueuedMessage}
             pauseQueueOnStop={pauseQueueOnStop}
-            queueProcessingBlocked={queueProcessingBlocked || acpRecovering}
+            queueProcessingBlocked={queueProcessingBlocked || acpRecovering || !recipeAccepted}
             commandHistory={commandHistory}
             initialValue={recipeAccepted ? initialPrompt : ''}
             setView={setView}

--- a/ui/desktop/src/components/BaseChat.tsx
+++ b/ui/desktop/src/components/BaseChat.tsx
@@ -148,9 +148,8 @@ export default function BaseChat({
     session?.session_type === 'scheduled' || !recipe || acceptedCurrentRecipe === true;
   const handleSubmit = useCallback(
     (input: UserInput) => {
-      if (recipeAccepted) {
-        submitMessage(input);
-      }
+      if (!recipeAccepted) return Promise.resolve(false);
+      return submitMessage(input);
     },
     [recipeAccepted, submitMessage]
   );
@@ -258,7 +257,7 @@ export default function BaseChat({
     if (recipe && input.msg.trim()) {
       setHasStartedUsingRecipe(true);
     }
-    handleSubmit(input);
+    void handleSubmit(input);
   };
 
   const sessionModel = session?.model_config?.model_name ?? null;

--- a/ui/desktop/src/components/BaseChat.tsx
+++ b/ui/desktop/src/components/BaseChat.tsx
@@ -94,6 +94,8 @@ export default function BaseChat({
     identity: string;
     accepted: boolean;
   }>();
+  const recipeTrustRef = useRef(recipeTrust);
+  recipeTrustRef.current = recipeTrust;
   const [hasRecipeSecurityWarnings, setHasRecipeSecurityWarnings] = useState(false);
   const [acpRecovering, setAcpRecovering] = useState(isAcpRecovering);
   const isMobile = useIsMobile();
@@ -279,6 +281,12 @@ export default function BaseChat({
 
   useEffect(() => {
     if (!isActiveSession) return;
+    if (
+      recipeTrustRef.current?.accepted === true &&
+      recipeTrustRef.current.identity === recipeIdentity
+    ) {
+      return;
+    }
 
     setRecipeTrust(undefined);
     setHasRecipeSecurityWarnings(false);

--- a/ui/desktop/src/components/BaseChat.tsx
+++ b/ui/desktop/src/components/BaseChat.tsx
@@ -173,10 +173,17 @@ export default function BaseChat({
       editType: 'fork' | 'edit',
       retainedImages: ImageData[]
     ) => {
-      if (!recipeAccepted) return Promise.resolve();
+      if (!recipeAccepted) return Promise.resolve(false);
       return onMessageUpdate(messageId, newContent, editType, retainedImages);
     },
     [recipeAccepted, onMessageUpdate]
+  );
+  const handleSubmitElicitationResponse = useCallback(
+    (elicitationId: string, userData: Record<string, unknown>) => {
+      if (!recipeAccepted) return Promise.resolve(false);
+      return submitElicitationResponse(elicitationId, userData);
+    },
+    [recipeAccepted, submitElicitationResponse]
   );
 
   const resolvedInitialMessage = useMemo((): UserInput | undefined => {
@@ -535,7 +542,7 @@ export default function BaseChat({
                     isStreamingMessage={chatState !== ChatState.Idle}
                     onRenderingComplete={handleRenderingComplete}
                     onMessageUpdate={handleMessageUpdate}
-                    submitElicitationResponse={submitElicitationResponse}
+                    submitElicitationResponse={handleSubmitElicitationResponse}
                   />
                 </SearchView>
 

--- a/ui/desktop/src/components/BaseChat.tsx
+++ b/ui/desktop/src/components/BaseChat.tsx
@@ -302,8 +302,12 @@ export default function BaseChat({
 
   const handleRecipeAccept = async (accept: boolean) => {
     if (recipe && accept) {
-      await window.electron.recordRecipeHash(recipe);
       if (recipeIdentity) setRecipeTrust({ identity: recipeIdentity, accepted: true });
+      try {
+        await window.electron.recordRecipeHash(recipe);
+      } catch (error) {
+        console.error('Failed to persist recipe trust:', error);
+      }
       return;
     }
 

--- a/ui/desktop/src/components/BaseChat.tsx
+++ b/ui/desktop/src/components/BaseChat.tsx
@@ -166,6 +166,18 @@ export default function BaseChat({
     },
     [recipeAccepted, onSteerQueuedMessage]
   );
+  const handleMessageUpdate = useCallback(
+    (
+      messageId: string,
+      newContent: string,
+      editType: 'fork' | 'edit',
+      retainedImages: ImageData[]
+    ) => {
+      if (!recipeAccepted) return Promise.resolve();
+      return onMessageUpdate(messageId, newContent, editType, retainedImages);
+    },
+    [recipeAccepted, onMessageUpdate]
+  );
 
   const resolvedInitialMessage = useMemo((): UserInput | undefined => {
     if (!initialMessage) return undefined;
@@ -268,7 +280,12 @@ export default function BaseChat({
     let cancelled = false;
 
     void (async () => {
-      const accepted = await window.electron.hasAcceptedRecipeBefore(recipe);
+      let accepted = false;
+      try {
+        accepted = await window.electron.hasAcceptedRecipeBefore(recipe);
+      } catch (error) {
+        console.error('Failed to check recipe trust:', error);
+      }
       if (cancelled) return;
       setRecipeTrust({ identity: recipeIdentity, accepted });
 
@@ -513,7 +530,7 @@ export default function BaseChat({
                     isUserMessage={isUserMessage}
                     isStreamingMessage={chatState !== ChatState.Idle}
                     onRenderingComplete={handleRenderingComplete}
-                    onMessageUpdate={onMessageUpdate}
+                    onMessageUpdate={handleMessageUpdate}
                     submitElicitationResponse={submitElicitationResponse}
                   />
                 </SearchView>

--- a/ui/desktop/src/components/BaseChat.tsx
+++ b/ui/desktop/src/components/BaseChat.tsx
@@ -259,11 +259,12 @@ export default function BaseChat({
   }, [messages]);
 
   useEffect(() => {
+    if (!isActiveSession) return;
+
     setRecipeTrust(undefined);
     setHasRecipeSecurityWarnings(false);
 
-    if (!recipe || !recipeIdentity || !isActiveSession || session?.session_type === 'scheduled')
-      return;
+    if (!recipe || !recipeIdentity || session?.session_type === 'scheduled') return;
     let cancelled = false;
 
     void (async () => {

--- a/ui/desktop/src/components/ChatInput.initialValue.test.tsx
+++ b/ui/desktop/src/components/ChatInput.initialValue.test.tsx
@@ -1,9 +1,13 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
 import { describe, expect, it, vi } from 'vitest';
 import { IntlTestWrapper } from '../i18n/test-utils';
 import { ChatState } from '../types/chatState';
 import ChatInput from './ChatInput';
+
+const mocks = vi.hoisted(() => ({
+  onTranscription: undefined as undefined | ((text: string) => void),
+}));
 
 vi.stubGlobal(
   'ResizeObserver',
@@ -22,14 +26,17 @@ vi.mock('./ModelAndProviderContext', () => ({
   }),
 }));
 vi.mock('../hooks/useAudioRecorder', () => ({
-  useAudioRecorder: () => ({
-    isEnabled: false,
-    dictationProvider: null,
-    isRecording: false,
-    isTranscribing: false,
-    startRecording: vi.fn(),
-    stopRecording: vi.fn(),
-  }),
+  useAudioRecorder: ({ onTranscription }: { onTranscription: (text: string) => void }) => {
+    mocks.onTranscription = onTranscription;
+    return {
+      isEnabled: false,
+      dictationProvider: null,
+      isRecording: false,
+      isTranscribing: false,
+      startRecording: vi.fn(),
+      stopRecording: vi.fn(),
+    };
+  },
 }));
 vi.mock('./bottom_menu/BottomMenuExtensionSelection', () => ({
   BottomMenuExtensionSelection: () => null,
@@ -116,5 +123,30 @@ describe('ChatInput initial value updates', () => {
     );
 
     expect(screen.getByRole('button', { name: 'Remove image' })).toBeInTheDocument();
+  });
+
+  it('preserves dictated text when auto-submit is blocked', () => {
+    vi.useFakeTimers();
+    const handleSubmit = vi.fn();
+    render(
+      <MemoryRouter>
+        <IntlTestWrapper>
+          <ChatInput
+            sessionId="sess-1"
+            handleSubmit={handleSubmit}
+            chatState={ChatState.Idle}
+            setView={vi.fn()}
+            queueProcessingBlocked
+          />
+        </IntlTestWrapper>
+      </MemoryRouter>
+    );
+
+    act(() => mocks.onTranscription?.('Keep this message submit'));
+    act(() => vi.advanceTimersByTime(100));
+
+    expect(screen.getByTestId('chat-input')).toHaveValue('Keep this message');
+    expect(handleSubmit).not.toHaveBeenCalled();
+    vi.useRealTimers();
   });
 });

--- a/ui/desktop/src/components/ChatInput.initialValue.test.tsx
+++ b/ui/desktop/src/components/ChatInput.initialValue.test.tsx
@@ -7,6 +7,7 @@ import ChatInput from './ChatInput';
 
 const mocks = vi.hoisted(() => ({
   onTranscription: undefined as undefined | ((text: string) => void),
+  compactAction: undefined as undefined | (() => void),
 }));
 
 vi.stubGlobal(
@@ -45,7 +46,20 @@ vi.mock('./bottom_menu/DirSwitcher', () => ({ DirSwitcher: () => null }));
 vi.mock('./GitBranchIndicator', () => ({ GitBranchIndicator: () => null }));
 vi.mock('./settings/models/bottom_bar/ModelsBottomBar', () => ({ default: () => null }));
 vi.mock('./bottom_menu/CostTracker', () => ({ CostTracker: () => null }));
-vi.mock('./bottom_menu/ContextWindowIndicator', () => ({ ContextWindowIndicator: () => null }));
+vi.mock('./bottom_menu/ContextWindowIndicator', () => ({
+  ContextWindowIndicator: ({
+    alerts,
+  }: {
+    alerts: Array<{ compactButtonDisabled?: boolean; onCompact?: () => void }>;
+  }) => {
+    mocks.compactAction = alerts[0]?.onCompact;
+    return alerts[0] ? (
+      <button type="button" disabled={alerts[0].compactButtonDisabled}>
+        compact
+      </button>
+    ) : null;
+  },
+}));
 vi.mock('../utils/conversionUtils', () => ({
   compressImageDataUrl: (dataUrl: string) => Promise.resolve(dataUrl),
 }));
@@ -148,5 +162,47 @@ describe('ChatInput initial value updates', () => {
     expect(screen.getByTestId('chat-input')).toHaveValue('Keep this message');
     expect(handleSubmit).not.toHaveBeenCalled();
     vi.useRealTimers();
+  });
+
+  it('disables manual compaction while queue processing is blocked', async () => {
+    const handleSubmit = vi.fn();
+    const { rerender } = render(
+      <MemoryRouter>
+        <IntlTestWrapper>
+          <ChatInput
+            sessionId="sess-1"
+            handleSubmit={handleSubmit}
+            chatState={ChatState.Idle}
+            setView={vi.fn()}
+            totalTokens={100}
+            contextLimit={1000}
+          />
+        </IntlTestWrapper>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole('button', { name: 'compact' })).toBeEnabled();
+    const previouslyEnabledCompactAction = mocks.compactAction;
+
+    rerender(
+      <MemoryRouter>
+        <IntlTestWrapper>
+          <ChatInput
+            sessionId="sess-1"
+            handleSubmit={handleSubmit}
+            chatState={ChatState.Idle}
+            setView={vi.fn()}
+            totalTokens={100}
+            contextLimit={1000}
+            queueProcessingBlocked
+          />
+        </IntlTestWrapper>
+      </MemoryRouter>
+    );
+
+    act(() => previouslyEnabledCompactAction?.());
+
+    expect(await screen.findByRole('button', { name: 'compact' })).toBeDisabled();
+    expect(handleSubmit).not.toHaveBeenCalled();
   });
 });

--- a/ui/desktop/src/components/ChatInput.initialValue.test.tsx
+++ b/ui/desktop/src/components/ChatInput.initialValue.test.tsx
@@ -1,0 +1,120 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { describe, expect, it, vi } from 'vitest';
+import { IntlTestWrapper } from '../i18n/test-utils';
+import { ChatState } from '../types/chatState';
+import ChatInput from './ChatInput';
+
+vi.stubGlobal(
+  'ResizeObserver',
+  class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+);
+
+vi.mock('./ModelAndProviderContext', () => ({
+  useModelAndProvider: () => ({
+    currentModel: null,
+    currentProvider: null,
+    getCurrentModelAndProvider: vi.fn().mockResolvedValue(null),
+  }),
+}));
+vi.mock('../hooks/useAudioRecorder', () => ({
+  useAudioRecorder: () => ({
+    isEnabled: false,
+    dictationProvider: null,
+    isRecording: false,
+    isTranscribing: false,
+    startRecording: vi.fn(),
+    stopRecording: vi.fn(),
+  }),
+}));
+vi.mock('./bottom_menu/BottomMenuExtensionSelection', () => ({
+  BottomMenuExtensionSelection: () => null,
+}));
+vi.mock('./bottom_menu/DirSwitcher', () => ({ DirSwitcher: () => null }));
+vi.mock('./GitBranchIndicator', () => ({ GitBranchIndicator: () => null }));
+vi.mock('./settings/models/bottom_bar/ModelsBottomBar', () => ({ default: () => null }));
+vi.mock('./bottom_menu/CostTracker', () => ({ CostTracker: () => null }));
+vi.mock('./bottom_menu/ContextWindowIndicator', () => ({ ContextWindowIndicator: () => null }));
+vi.mock('../utils/conversionUtils', () => ({
+  compressImageDataUrl: (dataUrl: string) => Promise.resolve(dataUrl),
+}));
+
+describe('ChatInput initial value updates', () => {
+  it('preserves an edited draft when the initial value resolves', () => {
+    const { rerender } = render(
+      <MemoryRouter>
+        <IntlTestWrapper>
+          <ChatInput
+            sessionId="sess-1"
+            handleSubmit={vi.fn()}
+            chatState={ChatState.Idle}
+            setView={vi.fn()}
+            initialValue=""
+          />
+        </IntlTestWrapper>
+      </MemoryRouter>
+    );
+
+    fireEvent.change(screen.getByTestId('chat-input'), { target: { value: 'Keep my draft' } });
+
+    rerender(
+      <MemoryRouter>
+        <IntlTestWrapper>
+          <ChatInput
+            sessionId="sess-1"
+            handleSubmit={vi.fn()}
+            chatState={ChatState.Idle}
+            setView={vi.fn()}
+            initialValue="RUN_RECIPE"
+          />
+        </IntlTestWrapper>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByTestId('chat-input')).toHaveValue('Keep my draft');
+  });
+
+  it('preserves a pasted image when the initial value resolves', async () => {
+    const { rerender } = render(
+      <MemoryRouter>
+        <IntlTestWrapper>
+          <ChatInput
+            sessionId="sess-1"
+            handleSubmit={vi.fn()}
+            chatState={ChatState.Idle}
+            setView={vi.fn()}
+            initialValue=""
+          />
+        </IntlTestWrapper>
+      </MemoryRouter>
+    );
+
+    fireEvent.paste(screen.getByTestId('chat-input'), {
+      clipboardData: {
+        files: [new File(['image'], 'draft.png', { type: 'image/png' })],
+        getData: () => '',
+      },
+    });
+    expect(await screen.findByRole('button', { name: 'Remove image' })).toBeInTheDocument();
+
+    rerender(
+      <MemoryRouter>
+        <IntlTestWrapper>
+          <ChatInput
+            sessionId="sess-1"
+            handleSubmit={vi.fn()}
+            chatState={ChatState.Idle}
+            setView={vi.fn()}
+            initialValue="RUN_RECIPE"
+          />
+        </IntlTestWrapper>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole('button', { name: 'Remove image' })).toBeInTheDocument();
+  });
+});

--- a/ui/desktop/src/components/ChatInput.tsx
+++ b/ui/desktop/src/components/ChatInput.tsx
@@ -498,10 +498,12 @@ export default function ChatInput({
       setDisplayValue(newValue);
       setValue(newValue);
 
-      if (shouldAutoSubmit && newValue.trim()) {
+      if (shouldAutoSubmit && newValue.trim() && !queueProcessingBlocked) {
         trackVoiceDictation('auto_submit');
         setTimeout(() => {
-          performSubmit(newValue);
+          if (!queueProcessingBlockedRef.current) {
+            performSubmit(newValue);
+          }
         }, 100);
       } else {
         textAreaRef.current?.focus();

--- a/ui/desktop/src/components/ChatInput.tsx
+++ b/ui/desktop/src/components/ChatInput.tsx
@@ -682,8 +682,9 @@ export default function ChatInput({
           total: tokenLimit,
         },
         showCompactButton: true,
-        compactButtonDisabled: !totalTokens || isLoading,
+        compactButtonDisabled: !totalTokens || isLoading || queueProcessingBlocked,
         onCompact: () => {
+          if (queueProcessingBlockedRef.current) return;
           window.dispatchEvent(new CustomEvent(AppEvents.HIDE_ALERT_POPOVER));
           handleSubmit({ msg: MANUAL_COMPACT_TRIGGER, images: [] });
         },
@@ -692,7 +693,15 @@ export default function ChatInput({
     }
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [totalTokens, tokenLimit, isTokenLimitLoaded, isLoading, addAlert, clearAlerts]);
+  }, [
+    totalTokens,
+    tokenLimit,
+    isTokenLimitLoaded,
+    isLoading,
+    queueProcessingBlocked,
+    addAlert,
+    clearAlerts,
+  ]);
 
   // Cleanup effect for component unmount - prevent memory leaks
   useEffect(() => {

--- a/ui/desktop/src/components/ChatInput.tsx
+++ b/ui/desktop/src/components/ChatInput.tsx
@@ -231,6 +231,9 @@ export default function ChatInput({
 }: ChatInputProps) {
   const [_value, setValue] = useState(initialValue);
   const [displayValue, setDisplayValue] = useState(initialValue); // For immediate visual feedback
+  const previousInitialValueRef = useRef(initialValue);
+  const displayValueRef = useRef(displayValue);
+  displayValueRef.current = displayValue;
   const [isFocused, setIsFocused] = useState(false);
   const [pastedImages, setPastedImages] = useState<PastedImage[]>([]);
   const [isFilePickerOpen, setIsFilePickerOpen] = useState(false);
@@ -518,20 +521,20 @@ export default function ChatInput({
   const timeoutRefsRef = useRef<Set<ReturnType<typeof setTimeout>>>(new Set());
 
   useEffect(() => {
+    const previousInitialValue = previousInitialValueRef.current;
+    previousInitialValueRef.current = initialValue;
+
+    if (displayValueRef.current !== previousInitialValue) return;
+
     setValue(initialValue);
     setDisplayValue(initialValue);
-    setPastedImages([]);
     setHistoryIndex(-1);
     setIsInGlobalHistory(false);
     setHasUserTyped(false);
   }, [initialValue]);
 
-  // Handle recipe prompt updates
   useEffect(() => {
-    // If recipe is accepted and we have an initial prompt, and no messages yet, and we haven't set it before
     if (recipeAccepted && initialPrompt && messages.length === 0) {
-      setDisplayValue(initialPrompt);
-      setValue(initialPrompt);
       setTimeout(() => {
         textAreaRef.current?.focus();
       }, 0);

--- a/ui/desktop/src/components/ElicitationRequest.test.tsx
+++ b/ui/desktop/src/components/ElicitationRequest.test.tsx
@@ -18,17 +18,36 @@ const actionRequiredContent = {
   },
 } as ActionRequired & { type: 'actionRequired' };
 
+const schemaActionRequiredContent = {
+  type: 'actionRequired',
+  data: {
+    actionType: 'elicitation',
+    id: 'elicitation-1',
+    message: 'Need more information',
+    requested_schema: {
+      type: 'object',
+      properties: {
+        project: { type: 'string' },
+      },
+      required: ['project'],
+    },
+  },
+} as ActionRequired & { type: 'actionRequired' };
+
 type SubmitElicitationResponse = (
   elicitationId: string,
   userData: Record<string, unknown>
 ) => Promise<boolean>;
 
-function renderElicitationRequest(onSubmit: SubmitElicitationResponse) {
+function renderElicitationRequest(
+  onSubmit: SubmitElicitationResponse,
+  content = actionRequiredContent
+) {
   return render(
     <ElicitationRequest
       isCancelledMessage={false}
       isClicked={false}
-      actionRequiredContent={actionRequiredContent}
+      actionRequiredContent={content}
       onSubmit={onSubmit}
     />,
     { wrapper: IntlTestWrapper }
@@ -47,7 +66,7 @@ describe('ElicitationRequest', () => {
     expect(await screen.findByText('Information submitted')).toBeInTheDocument();
   });
 
-  it('shows submitted state while the response is pending', async () => {
+  it('keeps the request visible and disabled while the response is pending', async () => {
     let resolveSubmission: (value: boolean) => void = () => {};
     const submission = new Promise<boolean>((resolve) => {
       resolveSubmission = resolve;
@@ -58,7 +77,8 @@ describe('ElicitationRequest', () => {
 
     await userEvent.click(screen.getByRole('button', { name: 'Accept' }));
 
-    expect(screen.getByText('Information submitted')).toBeInTheDocument();
+    expect(screen.queryByText('Information submitted')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Accept' })).toBeDisabled();
 
     await act(async () => {
       resolveSubmission(true);
@@ -78,5 +98,19 @@ describe('ElicitationRequest', () => {
     );
     expect(screen.queryByText('Information submitted')).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Accept' })).toBeEnabled();
+  });
+
+  it('preserves schema values when submission is rejected', async () => {
+    const onSubmit = vi.fn<SubmitElicitationResponse>().mockResolvedValue(false);
+
+    renderElicitationRequest(onSubmit, schemaActionRequiredContent);
+
+    const projectInput = screen.getByRole('textbox', { name: /project/ });
+    await userEvent.type(projectInput, 'goose');
+    await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+    expect(await screen.findByRole('alert')).toBeInTheDocument();
+    expect(projectInput).toHaveValue('goose');
+    expect(onSubmit).toHaveBeenCalledWith('elicitation-1', { project: 'goose' });
   });
 });

--- a/ui/desktop/src/components/ElicitationRequest.tsx
+++ b/ui/desktop/src/components/ElicitationRequest.tsx
@@ -101,18 +101,17 @@ export default function ElicitationRequest({
   const hasSchemaFields = Boolean(schema.properties && Object.keys(schema.properties).length > 0);
 
   const submitResponse = async (formData: Record<string, unknown>) => {
-    setSubmitted(true);
     setIsSubmitting(true);
     setSubmitError(undefined);
     try {
       const didSubmit = await onSubmit(elicitationId, formData);
-      if (!didSubmit) {
-        setSubmitted(false);
+      if (didSubmit) {
+        setSubmitted(true);
+      } else {
         setSubmitError(intl.formatMessage(i18n.submitError));
       }
     } catch (error) {
       console.error('Error submitting elicitation response:', error);
-      setSubmitted(false);
       setSubmitError(intl.formatMessage(i18n.submitError));
     } finally {
       setIsSubmitting(false);

--- a/ui/desktop/src/components/GooseMessage.tsx
+++ b/ui/desktop/src/components/GooseMessage.tsx
@@ -35,7 +35,7 @@ interface GooseMessageProps {
   toolStates: readonly ToolRenderState[];
   toolNotifications: readonly (NotificationEvent[] | undefined)[];
   toolConfirmationShownInline: boolean;
-  append: (value: string) => void;
+  append: (value: string) => boolean | Promise<boolean>;
   isStreaming: boolean;
   submitElicitationResponse?: (
     elicitationId: string,

--- a/ui/desktop/src/components/GooseMessage.tsx
+++ b/ui/desktop/src/components/GooseMessage.tsx
@@ -41,6 +41,7 @@ interface GooseMessageProps {
     elicitationId: string,
     userData: Record<string, unknown>
   ) => Promise<boolean>;
+  toolApprovalDisabled?: boolean;
 }
 
 function GooseMessage({
@@ -53,6 +54,7 @@ function GooseMessage({
   append,
   isStreaming,
   submitElicitationResponse,
+  toolApprovalDisabled = false,
 }: GooseMessageProps) {
   const contentRef = useRef<HTMLDivElement | null>(null);
 
@@ -168,6 +170,7 @@ function GooseMessage({
                         append={append}
                         confirmationContent={toolState.confirmation}
                         isApprovalClicked={isApprovalClicked}
+                        toolApprovalDisabled={toolApprovalDisabled}
                       />
                     </div>
                   );
@@ -205,6 +208,7 @@ function GooseMessage({
             sessionId={sessionId}
             isClicked={false}
             actionRequiredContent={toolConfirmationContent}
+            disabled={toolApprovalDisabled}
           />
         )}
 

--- a/ui/desktop/src/components/McpApps/McpAppRenderer.security.test.tsx
+++ b/ui/desktop/src/components/McpApps/McpAppRenderer.security.test.tsx
@@ -3,17 +3,20 @@ import { useLayoutEffect } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   appendMcpAppMessage,
-  assertMcpAppMessageAllowed,
-  assertMcpAppToolCallAllowed,
+  assertMcpAppHostActionAllowed,
   GooseAppFrame,
 } from './McpAppRenderer';
 
 interface MockBridge {
   oncalltool?: (params: { name: string; arguments?: Record<string, unknown> }) => Promise<unknown>;
   onmessage?: (params: { content: Array<{ type: string; text?: string }> }) => Promise<unknown>;
+  onopenlink?: (params: { url: string }) => Promise<unknown>;
+  onreadresource?: (params: { uri: string }) => Promise<unknown>;
+  fallbackRequestHandler?: (request: { method: string }, extra: unknown) => Promise<unknown>;
 }
 
 const bridgeInstances = vi.hoisted(() => [] as MockBridge[]);
+const disabledError = new Error('MCP App host actions are disabled until the recipe is trusted');
 
 vi.mock('@mcp-ui/client', () => ({
   AppBridge: class {
@@ -26,34 +29,69 @@ vi.mock('@mcp-ui/client', () => ({
   PostMessageTransport: class {},
 }));
 
-describe('MCP App tool-call gating', () => {
+describe('MCP App host-action gating', () => {
   beforeEach(() => {
     bridgeInstances.length = 0;
   });
 
-  it('rejects tool calls while recipe trust is unresolved', () => {
-    expect(() => assertMcpAppToolCallAllowed(true)).toThrow(
-      'MCP App tool calls are disabled until the recipe is trusted'
-    );
+  it('rejects host actions while recipe trust is unresolved', () => {
+    expect(() => assertMcpAppHostActionAllowed(true)).toThrow(disabledError);
+    expect(() => assertMcpAppHostActionAllowed(false)).not.toThrow();
   });
 
-  it('allows tool calls after recipe trust resolves', () => {
-    expect(() => assertMcpAppToolCallAllowed(false)).not.toThrow();
-  });
-
-  it('blocks a bridge call in the same commit that trust is revoked', () => {
+  it('blocks every privileged bridge handler while recipe trust is unresolved', () => {
+    const onMessage = vi.fn().mockResolvedValue({});
+    const onOpenLink = vi.fn().mockResolvedValue({ status: 'success' });
     const onCallTool = vi.fn().mockResolvedValue({ content: [] });
+    const onReadResource = vi.fn().mockResolvedValue({ contents: [] });
+    const onFallbackRequest = vi.fn().mockResolvedValue({});
+
+    render(
+      <GooseAppFrame
+        html=""
+        sandbox={{ url: new URL('about:blank') }}
+        hostContext={{}}
+        onMessage={onMessage}
+        onOpenLink={onOpenLink}
+        onCallTool={onCallTool}
+        onReadResource={onReadResource}
+        onLoggingMessage={() => {}}
+        onFallbackRequest={onFallbackRequest}
+        hostActionsDisabled
+      />
+    );
+
+    const bridge = bridgeInstances[0];
+    expect(bridgeInstances).toHaveLength(1);
+    expect(() => bridge.onmessage?.({ content: [{ type: 'text', text: 'draft' }] })).toThrow(
+      disabledError
+    );
+    expect(() => bridge.onopenlink?.({ url: 'https://example.com' })).toThrow(disabledError);
+    expect(() => bridge.oncalltool?.({ name: 'delete_everything' })).toThrow(disabledError);
+    expect(() => bridge.onreadresource?.({ uri: 'file:///secret' })).toThrow(disabledError);
+    expect(() => bridge.fallbackRequestHandler?.({ method: 'custom/action' }, {})).toThrow(
+      disabledError
+    );
+    expect(onMessage).not.toHaveBeenCalled();
+    expect(onOpenLink).not.toHaveBeenCalled();
+    expect(onCallTool).not.toHaveBeenCalled();
+    expect(onReadResource).not.toHaveBeenCalled();
+    expect(onFallbackRequest).not.toHaveBeenCalled();
+  });
+
+  it('blocks a bridge action in the same commit that trust is revoked', () => {
+    const onOpenLink = vi.fn().mockResolvedValue({ status: 'success' });
     let transitionError: unknown;
 
-    function Harness({ toolCallDisabled }: { toolCallDisabled: boolean }) {
+    function Harness({ hostActionsDisabled }: { hostActionsDisabled: boolean }) {
       useLayoutEffect(() => {
-        if (!toolCallDisabled) return;
+        if (!hostActionsDisabled) return;
         try {
-          void bridgeInstances[0]?.oncalltool?.({ name: 'delete_everything' });
+          void bridgeInstances[0]?.onopenlink?.({ url: 'https://example.com' });
         } catch (error) {
           transitionError = error;
         }
-      }, [toolCallDisabled]);
+      }, [hostActionsDisabled]);
 
       return (
         <GooseAppFrame
@@ -61,84 +99,25 @@ describe('MCP App tool-call gating', () => {
           sandbox={{ url: new URL('about:blank') }}
           hostContext={{}}
           onMessage={async () => ({})}
-          onOpenLink={async () => ({ status: 'success' })}
-          onCallTool={onCallTool}
+          onOpenLink={onOpenLink}
+          onCallTool={async () => ({ content: [] })}
           onReadResource={async () => ({ contents: [] })}
           onLoggingMessage={() => {}}
           onFallbackRequest={async () => ({})}
-          toolCallDisabled={toolCallDisabled}
-          messageDisabled={false}
+          hostActionsDisabled={hostActionsDisabled}
         />
       );
     }
 
-    const { rerender } = render(<Harness toolCallDisabled={false} />);
+    const { rerender } = render(<Harness hostActionsDisabled={false} />);
+    rerender(<Harness hostActionsDisabled />);
 
-    expect(bridgeInstances).toHaveLength(1);
-    rerender(<Harness toolCallDisabled />);
-
-    expect(transitionError).toEqual(
-      new Error('MCP App tool calls are disabled until the recipe is trusted')
-    );
-    expect(onCallTool).not.toHaveBeenCalled();
+    expect(transitionError).toEqual(disabledError);
+    expect(onOpenLink).not.toHaveBeenCalled();
   });
 });
 
-describe('MCP App message gating', () => {
-  beforeEach(() => {
-    bridgeInstances.length = 0;
-  });
-
-  it('blocks a bridge message in the same commit that trust is revoked', () => {
-    const onMessage = vi.fn().mockResolvedValue({});
-    let transitionError: unknown;
-
-    function Harness({ messageDisabled }: { messageDisabled: boolean }) {
-      useLayoutEffect(() => {
-        if (!messageDisabled) return;
-        try {
-          void bridgeInstances[0]?.onmessage?.({
-            content: [{ type: 'text', text: 'keep this draft' }],
-          });
-        } catch (error) {
-          transitionError = error;
-        }
-      }, [messageDisabled]);
-
-      return (
-        <GooseAppFrame
-          html=""
-          sandbox={{ url: new URL('about:blank') }}
-          hostContext={{}}
-          onMessage={onMessage}
-          onOpenLink={async () => ({ status: 'success' })}
-          onCallTool={vi.fn()}
-          onReadResource={async () => ({ contents: [] })}
-          onLoggingMessage={() => {}}
-          onFallbackRequest={async () => ({})}
-          toolCallDisabled={false}
-          messageDisabled={messageDisabled}
-        />
-      );
-    }
-
-    const { rerender } = render(<Harness messageDisabled={false} />);
-
-    expect(bridgeInstances).toHaveLength(1);
-    rerender(<Harness messageDisabled />);
-
-    expect(transitionError).toEqual(
-      new Error('MCP App messages are disabled until the recipe is trusted')
-    );
-    expect(onMessage).not.toHaveBeenCalled();
-  });
-
-  it('rejects messages while recipe trust is unresolved', () => {
-    expect(() => assertMcpAppMessageAllowed(true)).toThrow(
-      'MCP App messages are disabled until the recipe is trusted'
-    );
-  });
-
+describe('MCP App message delivery', () => {
   it('reports when the host rejects a message', async () => {
     const append = vi.fn().mockReturnValue(false);
 

--- a/ui/desktop/src/components/McpApps/McpAppRenderer.security.test.tsx
+++ b/ui/desktop/src/components/McpApps/McpAppRenderer.security.test.tsx
@@ -1,10 +1,16 @@
 import { render } from '@testing-library/react';
 import { useLayoutEffect } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { assertMcpAppToolCallAllowed, GooseAppFrame } from './McpAppRenderer';
+import {
+  appendMcpAppMessage,
+  assertMcpAppMessageAllowed,
+  assertMcpAppToolCallAllowed,
+  GooseAppFrame,
+} from './McpAppRenderer';
 
 interface MockBridge {
   oncalltool?: (params: { name: string; arguments?: Record<string, unknown> }) => Promise<unknown>;
+  onmessage?: (params: { content: Array<{ type: string; text?: string }> }) => Promise<unknown>;
 }
 
 const bridgeInstances = vi.hoisted(() => [] as MockBridge[]);
@@ -61,6 +67,7 @@ describe('MCP App tool-call gating', () => {
           onLoggingMessage={() => {}}
           onFallbackRequest={async () => ({})}
           toolCallDisabled={toolCallDisabled}
+          messageDisabled={false}
         />
       );
     }
@@ -74,5 +81,79 @@ describe('MCP App tool-call gating', () => {
       new Error('MCP App tool calls are disabled until the recipe is trusted')
     );
     expect(onCallTool).not.toHaveBeenCalled();
+  });
+});
+
+describe('MCP App message gating', () => {
+  beforeEach(() => {
+    bridgeInstances.length = 0;
+  });
+
+  it('blocks a bridge message in the same commit that trust is revoked', () => {
+    const onMessage = vi.fn().mockResolvedValue({});
+    let transitionError: unknown;
+
+    function Harness({ messageDisabled }: { messageDisabled: boolean }) {
+      useLayoutEffect(() => {
+        if (!messageDisabled) return;
+        try {
+          void bridgeInstances[0]?.onmessage?.({
+            content: [{ type: 'text', text: 'keep this draft' }],
+          });
+        } catch (error) {
+          transitionError = error;
+        }
+      }, [messageDisabled]);
+
+      return (
+        <GooseAppFrame
+          html=""
+          sandbox={{ url: new URL('about:blank') }}
+          hostContext={{}}
+          onMessage={onMessage}
+          onOpenLink={async () => ({ status: 'success' })}
+          onCallTool={vi.fn()}
+          onReadResource={async () => ({ contents: [] })}
+          onLoggingMessage={() => {}}
+          onFallbackRequest={async () => ({})}
+          toolCallDisabled={false}
+          messageDisabled={messageDisabled}
+        />
+      );
+    }
+
+    const { rerender } = render(<Harness messageDisabled={false} />);
+
+    expect(bridgeInstances).toHaveLength(1);
+    rerender(<Harness messageDisabled />);
+
+    expect(transitionError).toEqual(
+      new Error('MCP App messages are disabled until the recipe is trusted')
+    );
+    expect(onMessage).not.toHaveBeenCalled();
+  });
+
+  it('rejects messages while recipe trust is unresolved', () => {
+    expect(() => assertMcpAppMessageAllowed(true)).toThrow(
+      'MCP App messages are disabled until the recipe is trusted'
+    );
+  });
+
+  it('reports when the host rejects a message', async () => {
+    const append = vi.fn().mockReturnValue(false);
+
+    await expect(
+      appendMcpAppMessage(append, [{ type: 'text', text: 'keep this draft' }])
+    ).rejects.toThrow('MCP App message was not submitted');
+    expect(append).toHaveBeenCalledWith('keep this draft');
+  });
+
+  it('reports success only after the host accepts a message', async () => {
+    const append = vi.fn().mockResolvedValue(true);
+
+    await expect(
+      appendMcpAppMessage(append, [{ type: 'text', text: 'send this draft' }])
+    ).resolves.toBeUndefined();
+    expect(append).toHaveBeenCalledWith('send this draft');
   });
 });

--- a/ui/desktop/src/components/McpApps/McpAppRenderer.security.test.tsx
+++ b/ui/desktop/src/components/McpApps/McpAppRenderer.security.test.tsx
@@ -1,7 +1,8 @@
-import { render } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import { useLayoutEffect } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import {
+import { IntlTestWrapper } from '../../i18n/test-utils';
+import McpAppRenderer, {
   appendMcpAppMessage,
   assertMcpAppHostActionAllowed,
   GooseAppFrame,
@@ -16,6 +17,12 @@ interface MockBridge {
 }
 
 const bridgeInstances = vi.hoisted(() => [] as MockBridge[]);
+const rendererMocks = vi.hoisted(() => ({
+  readMcpAppResource: vi.fn(),
+  getCachedTools: vi.fn(),
+  getAcpUrl: vi.fn(),
+  getSecretKey: vi.fn(),
+}));
 const disabledError = new Error('MCP App host actions are disabled until the recipe is trusted');
 
 vi.mock('@mcp-ui/client', () => ({
@@ -29,9 +36,72 @@ vi.mock('@mcp-ui/client', () => ({
   PostMessageTransport: class {},
 }));
 
+vi.mock('../../acp/mcp-apps', () => ({
+  callMcpAppTool: vi.fn(),
+  readMcpAppResource: rendererMocks.readMcpAppResource,
+}));
+
+vi.mock('./toolsCache', () => ({
+  getCachedTools: rendererMocks.getCachedTools,
+}));
+
+vi.mock('../../contexts/ThemeContext', () => ({
+  useTheme: () => ({ resolvedTheme: 'light', mcpHostStyles: {} }),
+}));
+
+vi.mock('./useDisplayMode', () => ({
+  AVAILABLE_DISPLAY_MODES: ['inline'],
+  PIP_WIDTH: 400,
+  PIP_HEIGHT: 600,
+  PIP_MARGIN_RIGHT: 24,
+  PIP_MARGIN_BOTTOM: 24,
+  useDisplayMode: () => ({
+    activeDisplayMode: 'inline',
+    effectiveDisplayModes: ['inline'],
+    isStandalone: false,
+    isFullscreen: false,
+    isPip: false,
+    isFillsViewport: false,
+    isInline: true,
+    appSupportsFullscreen: false,
+    appSupportsPip: false,
+    appTitle: undefined,
+    changeDisplayMode: vi.fn(),
+    inlineHeight: 200,
+    pipPosition: { x: 0, y: 0 },
+    pipHandlers: {},
+    fullscreenCloseRef: { current: null },
+  }),
+}));
+
+vi.mock('../FlyingBird', () => ({ default: () => null }));
+
+vi.stubGlobal('matchMedia', vi.fn(() => ({ matches: false })));
+vi.stubGlobal(
+  'ResizeObserver',
+  class {
+    observe() {}
+    disconnect() {}
+  }
+);
+
 describe('MCP App host-action gating', () => {
   beforeEach(() => {
     bridgeInstances.length = 0;
+    vi.clearAllMocks();
+    rendererMocks.getCachedTools.mockResolvedValue(null);
+    rendererMocks.getAcpUrl.mockResolvedValue('ws://127.0.0.1:3000');
+    rendererMocks.getSecretKey.mockResolvedValue('secret');
+    rendererMocks.readMcpAppResource.mockResolvedValue({
+      uri: 'ui://recipe/app',
+      text: '<html><body>app</body></html>',
+      mimeType: 'text/html',
+      _meta: {},
+    });
+    Object.assign(window.electron, {
+      getAcpUrl: rendererMocks.getAcpUrl,
+      getSecretKey: rendererMocks.getSecretKey,
+    });
   });
 
   it('rejects host actions while recipe trust is unresolved', () => {
@@ -114,6 +184,134 @@ describe('MCP App host-action gating', () => {
 
     expect(transitionError).toEqual(disabledError);
     expect(onOpenLink).not.toHaveBeenCalled();
+  });
+
+  it('defers app loading and removes the iframe whenever recipe trust is blocked', async () => {
+    const props = {
+      resourceUri: 'ui://recipe/app',
+      extensionName: 'recipe-extension',
+      toolName: 'render-app',
+      sessionId: 'session-1',
+      cachedHtml: '<html><body>cached app</body></html>',
+    };
+    const { rerender } = render(<McpAppRenderer {...props} hostActionsDisabled />, {
+      wrapper: IntlTestWrapper,
+    });
+
+    expect(screen.getByTestId('mcp-app-trust-placeholder')).toBeInTheDocument();
+    expect(rendererMocks.readMcpAppResource).not.toHaveBeenCalled();
+    expect(rendererMocks.getCachedTools).not.toHaveBeenCalled();
+    expect(rendererMocks.getAcpUrl).not.toHaveBeenCalled();
+    expect(bridgeInstances).toHaveLength(0);
+    expect(document.querySelector('iframe')).not.toBeInTheDocument();
+
+    rerender(<McpAppRenderer {...props} hostActionsDisabled={false} />);
+
+    await waitFor(() => expect(rendererMocks.readMcpAppResource).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(rendererMocks.getCachedTools).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(rendererMocks.getAcpUrl).toHaveBeenCalled());
+    await waitFor(() => expect(bridgeInstances).toHaveLength(1));
+    expect(document.querySelector('iframe')).toBeInTheDocument();
+    const trustedBridge = bridgeInstances[0];
+
+    rerender(<McpAppRenderer {...props} hostActionsDisabled />);
+
+    expect(screen.getByTestId('mcp-app-trust-placeholder')).toBeInTheDocument();
+    expect(document.querySelector('iframe')).not.toBeInTheDocument();
+    expect(() => trustedBridge.onopenlink?.({ url: 'https://example.com' })).toThrow(disabledError);
+  });
+
+  it('abandons an in-flight sandbox lookup when recipe trust is revoked', async () => {
+    let resolveAcpUrl: ((url: string) => void) | undefined;
+    rendererMocks.getAcpUrl.mockReturnValueOnce(
+      new Promise<string>((resolve) => {
+        resolveAcpUrl = resolve;
+      })
+    );
+    const props = {
+      resourceUri: 'ui://recipe/app',
+      extensionName: 'recipe-extension',
+      cachedHtml: '<html><body>cached app</body></html>',
+    };
+    function Harness({ hostActionsDisabled }: { hostActionsDisabled: boolean }) {
+      useLayoutEffect(() => {
+        if (hostActionsDisabled) {
+          resolveAcpUrl?.('ws://127.0.0.1:3000');
+        }
+      }, [hostActionsDisabled]);
+
+      return <McpAppRenderer {...props} hostActionsDisabled={hostActionsDisabled} />;
+    }
+    const { rerender } = render(<Harness hostActionsDisabled={false} />, {
+      wrapper: IntlTestWrapper,
+    });
+
+    await waitFor(() => expect(rendererMocks.getAcpUrl).toHaveBeenCalledTimes(1));
+    rerender(<Harness hostActionsDisabled />);
+
+    await waitFor(() => expect(rendererMocks.getSecretKey).not.toHaveBeenCalled());
+    expect(bridgeInstances).toHaveLength(0);
+    expect(screen.getByTestId('mcp-app-trust-placeholder')).toBeInTheDocument();
+  });
+
+  it('does not cache tool or resource results that settle during trust revocation', async () => {
+    let resolveTools: ((tools: Array<{ name: string; inputSchema: { type: string } }>) => void) |
+      undefined;
+    let resolveResource:
+      | ((resource: { uri: string; text: string; mimeType: string; _meta: object }) => void)
+      | undefined;
+    rendererMocks.getCachedTools
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveTools = resolve;
+        })
+      )
+      .mockReturnValueOnce(new Promise(() => undefined));
+    rendererMocks.readMcpAppResource
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveResource = resolve;
+        })
+      )
+      .mockReturnValueOnce(new Promise(() => undefined));
+    const props = {
+      resourceUri: 'ui://recipe/app',
+      extensionName: 'recipe-extension',
+      toolName: 'render-app',
+      sessionId: 'session-1',
+    };
+    function Harness({ hostActionsDisabled }: { hostActionsDisabled: boolean }) {
+      useLayoutEffect(() => {
+        if (!hostActionsDisabled) return;
+        resolveTools?.([
+          {
+            name: 'recipe-extension__render-app',
+            inputSchema: { type: 'object' },
+          },
+        ]);
+        resolveResource?.({
+          uri: 'ui://recipe/app',
+          text: '<html><body>app</body></html>',
+          mimeType: 'text/html',
+          _meta: {},
+        });
+      }, [hostActionsDisabled]);
+
+      return <McpAppRenderer {...props} hostActionsDisabled={hostActionsDisabled} />;
+    }
+    const { rerender } = render(<Harness hostActionsDisabled={false} />, {
+      wrapper: IntlTestWrapper,
+    });
+
+    await waitFor(() => expect(rendererMocks.getCachedTools).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(rendererMocks.readMcpAppResource).toHaveBeenCalledTimes(1));
+    rerender(<Harness hostActionsDisabled />);
+    await act(async () => undefined);
+    rerender(<Harness hostActionsDisabled={false} />);
+
+    await waitFor(() => expect(rendererMocks.getCachedTools).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(rendererMocks.readMcpAppResource).toHaveBeenCalledTimes(2));
+    expect(bridgeInstances).toHaveLength(0);
   });
 });
 

--- a/ui/desktop/src/components/McpApps/McpAppRenderer.security.test.tsx
+++ b/ui/desktop/src/components/McpApps/McpAppRenderer.security.test.tsx
@@ -1,0 +1,78 @@
+import { render } from '@testing-library/react';
+import { useLayoutEffect } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { assertMcpAppToolCallAllowed, GooseAppFrame } from './McpAppRenderer';
+
+interface MockBridge {
+  oncalltool?: (params: { name: string; arguments?: Record<string, unknown> }) => Promise<unknown>;
+}
+
+const bridgeInstances = vi.hoisted(() => [] as MockBridge[]);
+
+vi.mock('@mcp-ui/client', () => ({
+  AppBridge: class {
+    constructor() {
+      bridgeInstances.push(this as MockBridge);
+    }
+
+    close() {}
+  },
+  PostMessageTransport: class {},
+}));
+
+describe('MCP App tool-call gating', () => {
+  beforeEach(() => {
+    bridgeInstances.length = 0;
+  });
+
+  it('rejects tool calls while recipe trust is unresolved', () => {
+    expect(() => assertMcpAppToolCallAllowed(true)).toThrow(
+      'MCP App tool calls are disabled until the recipe is trusted'
+    );
+  });
+
+  it('allows tool calls after recipe trust resolves', () => {
+    expect(() => assertMcpAppToolCallAllowed(false)).not.toThrow();
+  });
+
+  it('blocks a bridge call in the same commit that trust is revoked', () => {
+    const onCallTool = vi.fn().mockResolvedValue({ content: [] });
+    let transitionError: unknown;
+
+    function Harness({ toolCallDisabled }: { toolCallDisabled: boolean }) {
+      useLayoutEffect(() => {
+        if (!toolCallDisabled) return;
+        try {
+          void bridgeInstances[0]?.oncalltool?.({ name: 'delete_everything' });
+        } catch (error) {
+          transitionError = error;
+        }
+      }, [toolCallDisabled]);
+
+      return (
+        <GooseAppFrame
+          html=""
+          sandbox={{ url: new URL('about:blank') }}
+          hostContext={{}}
+          onMessage={async () => ({})}
+          onOpenLink={async () => ({ status: 'success' })}
+          onCallTool={onCallTool}
+          onReadResource={async () => ({ contents: [] })}
+          onLoggingMessage={() => {}}
+          onFallbackRequest={async () => ({})}
+          toolCallDisabled={toolCallDisabled}
+        />
+      );
+    }
+
+    const { rerender } = render(<Harness toolCallDisabled={false} />);
+
+    expect(bridgeInstances).toHaveLength(1);
+    rerender(<Harness toolCallDisabled />);
+
+    expect(transitionError).toEqual(
+      new Error('MCP App tool calls are disabled until the recipe is trusted')
+    );
+    expect(onCallTool).not.toHaveBeenCalled();
+  });
+});

--- a/ui/desktop/src/components/McpApps/McpAppRenderer.tsx
+++ b/ui/desktop/src/components/McpApps/McpAppRenderer.tsx
@@ -32,7 +32,15 @@ import type {
 } from '@modelcontextprotocol/ext-apps/app-bridge';
 import type { CallToolResult, JSONRPCRequest, Tool } from '@modelcontextprotocol/sdk/types.js';
 import { GripHorizontal, Maximize2, PictureInPicture2, X } from 'lucide-react';
-import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useReducer,
+  useRef,
+  useState,
+} from 'react';
 import { callMcpAppTool, readMcpAppResource } from '../../acp/mcp-apps';
 import { httpBaseFromAcpWebSocketUrl, isLoopbackAcpWebSocketUrl } from '../../acp/url';
 import { getCachedTools } from './toolsCache';
@@ -211,6 +219,13 @@ interface McpAppRendererProps {
   displayMode?: GooseDisplayMode;
   cachedHtml?: string;
   onDisplayModeChange?: OnDisplayModeChange;
+  toolCallDisabled?: boolean;
+}
+
+export function assertMcpAppToolCallAllowed(toolCallDisabled: boolean): void {
+  if (toolCallDisabled) {
+    throw new Error('MCP App tool calls are disabled until the recipe is trusted');
+  }
 }
 
 interface ResourceMeta {
@@ -257,11 +272,12 @@ interface GooseAppFrameProps {
   onSizeChanged?: (params: McpUiSizeChangedNotification['params']) => void;
   onInitialized?: (appInfo: AppInfo) => void;
   onError?: (error: Error) => void;
+  toolCallDisabled: boolean;
 }
 
 const SANDBOX_PROXY_READY_METHOD = 'ui/notifications/sandbox-proxy-ready';
 
-function GooseAppFrame({
+export function GooseAppFrame({
   html,
   sandbox,
   hostContext,
@@ -278,6 +294,7 @@ function GooseAppFrame({
   onSizeChanged,
   onInitialized,
   onError,
+  toolCallDisabled,
 }: GooseAppFrameProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
@@ -294,6 +311,7 @@ function GooseAppFrame({
   const onSizeChangedRef = useRef(onSizeChanged);
   const onInitializedRef = useRef(onInitialized);
   const onErrorRef = useRef(onError);
+  const toolCallDisabledRef = useRef(toolCallDisabled);
 
   useEffect(() => {
     hostContextRef.current = hostContext;
@@ -307,6 +325,10 @@ function GooseAppFrame({
     onInitializedRef.current = onInitialized;
     onErrorRef.current = onError;
   });
+
+  useLayoutEffect(() => {
+    toolCallDisabledRef.current = toolCallDisabled;
+  }, [toolCallDisabled]);
 
   useEffect(() => {
     const container = containerRef.current;
@@ -328,7 +350,10 @@ function GooseAppFrame({
     bridge.onmessage = (params) => onMessageRef.current(params);
     bridge.onopenlink = (params) => onOpenLinkRef.current(params);
     bridge.onloggingmessage = (params) => onLoggingMessageRef.current(params);
-    bridge.oncalltool = (params) => onCallToolRef.current(params);
+    bridge.oncalltool = (params) => {
+      assertMcpAppToolCallAllowed(toolCallDisabledRef.current);
+      return onCallToolRef.current(params);
+    };
     bridge.onreadresource = (params) => onReadResourceRef.current(params);
     (bridge as FallbackRequestHandler).fallbackRequestHandler = (request, extra) =>
       onFallbackRequestRef.current(request, extra);
@@ -559,6 +584,7 @@ export default function McpAppRenderer({
   displayMode = 'inline',
   cachedHtml,
   onDisplayModeChange,
+  toolCallDisabled = false,
 }: McpAppRendererProps) {
   const intl = useIntl();
   const containerRef = useRef<HTMLDivElement>(null);
@@ -818,12 +844,13 @@ export default function McpAppRenderer({
       name: string;
       arguments?: Record<string, unknown>;
     }): Promise<CallToolResult> => {
+      assertMcpAppToolCallAllowed(toolCallDisabled);
       if (!sessionId) {
         throw new Error('Session not initialized for MCP request');
       }
       return callMcpAppTool(sessionId, extensionName, name, args);
     },
-    [sessionId, extensionName]
+    [sessionId, extensionName, toolCallDisabled]
   );
 
   const handleReadResource = useCallback(
@@ -1022,6 +1049,7 @@ export default function McpAppRenderer({
         onFallbackRequest={handleFallbackRequest}
         onSizeChanged={handleSizeChanged}
         onError={handleError}
+        toolCallDisabled={toolCallDisabled}
       />
     );
   };

--- a/ui/desktop/src/components/McpApps/McpAppRenderer.tsx
+++ b/ui/desktop/src/components/McpApps/McpAppRenderer.tsx
@@ -219,19 +219,12 @@ interface McpAppRendererProps {
   displayMode?: GooseDisplayMode;
   cachedHtml?: string;
   onDisplayModeChange?: OnDisplayModeChange;
-  toolCallDisabled?: boolean;
-  messageDisabled?: boolean;
+  hostActionsDisabled?: boolean;
 }
 
-export function assertMcpAppToolCallAllowed(toolCallDisabled: boolean): void {
-  if (toolCallDisabled) {
-    throw new Error('MCP App tool calls are disabled until the recipe is trusted');
-  }
-}
-
-export function assertMcpAppMessageAllowed(messageDisabled: boolean): void {
-  if (messageDisabled) {
-    throw new Error('MCP App messages are disabled until the recipe is trusted');
+export function assertMcpAppHostActionAllowed(hostActionsDisabled: boolean): void {
+  if (hostActionsDisabled) {
+    throw new Error('MCP App host actions are disabled until the recipe is trusted');
   }
 }
 
@@ -298,8 +291,7 @@ interface GooseAppFrameProps {
   onSizeChanged?: (params: McpUiSizeChangedNotification['params']) => void;
   onInitialized?: (appInfo: AppInfo) => void;
   onError?: (error: Error) => void;
-  toolCallDisabled: boolean;
-  messageDisabled: boolean;
+  hostActionsDisabled: boolean;
 }
 
 const SANDBOX_PROXY_READY_METHOD = 'ui/notifications/sandbox-proxy-ready';
@@ -321,8 +313,7 @@ export function GooseAppFrame({
   onSizeChanged,
   onInitialized,
   onError,
-  toolCallDisabled,
-  messageDisabled,
+  hostActionsDisabled,
 }: GooseAppFrameProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
@@ -339,8 +330,7 @@ export function GooseAppFrame({
   const onSizeChangedRef = useRef(onSizeChanged);
   const onInitializedRef = useRef(onInitialized);
   const onErrorRef = useRef(onError);
-  const toolCallDisabledRef = useRef(toolCallDisabled);
-  const messageDisabledRef = useRef(messageDisabled);
+  const hostActionsDisabledRef = useRef(hostActionsDisabled);
 
   useEffect(() => {
     hostContextRef.current = hostContext;
@@ -356,9 +346,8 @@ export function GooseAppFrame({
   });
 
   useLayoutEffect(() => {
-    toolCallDisabledRef.current = toolCallDisabled;
-    messageDisabledRef.current = messageDisabled;
-  }, [messageDisabled, toolCallDisabled]);
+    hostActionsDisabledRef.current = hostActionsDisabled;
+  }, [hostActionsDisabled]);
 
   useEffect(() => {
     const container = containerRef.current;
@@ -378,18 +367,26 @@ export function GooseAppFrame({
       hostContext: hostContextRef.current,
     });
     bridge.onmessage = (params) => {
-      assertMcpAppMessageAllowed(messageDisabledRef.current);
+      assertMcpAppHostActionAllowed(hostActionsDisabledRef.current);
       return onMessageRef.current(params);
     };
-    bridge.onopenlink = (params) => onOpenLinkRef.current(params);
+    bridge.onopenlink = (params) => {
+      assertMcpAppHostActionAllowed(hostActionsDisabledRef.current);
+      return onOpenLinkRef.current(params);
+    };
     bridge.onloggingmessage = (params) => onLoggingMessageRef.current(params);
     bridge.oncalltool = (params) => {
-      assertMcpAppToolCallAllowed(toolCallDisabledRef.current);
+      assertMcpAppHostActionAllowed(hostActionsDisabledRef.current);
       return onCallToolRef.current(params);
     };
-    bridge.onreadresource = (params) => onReadResourceRef.current(params);
-    (bridge as FallbackRequestHandler).fallbackRequestHandler = (request, extra) =>
-      onFallbackRequestRef.current(request, extra);
+    bridge.onreadresource = (params) => {
+      assertMcpAppHostActionAllowed(hostActionsDisabledRef.current);
+      return onReadResourceRef.current(params);
+    };
+    (bridge as FallbackRequestHandler).fallbackRequestHandler = (request, extra) => {
+      assertMcpAppHostActionAllowed(hostActionsDisabledRef.current);
+      return onFallbackRequestRef.current(request, extra);
+    };
 
     const iframe = document.createElement('iframe');
     iframe.style.width = '100%';
@@ -617,8 +614,7 @@ export default function McpAppRenderer({
   displayMode = 'inline',
   cachedHtml,
   onDisplayModeChange,
-  toolCallDisabled = false,
-  messageDisabled = false,
+  hostActionsDisabled = false,
 }: McpAppRendererProps) {
   const intl = useIntl();
   const containerRef = useRef<HTMLDivElement>(null);
@@ -838,6 +834,7 @@ export default function McpAppRenderer({
 
   const handleOpenLink = useCallback(
     async ({ url }: { url: string }) => {
+      assertMcpAppHostActionAllowed(hostActionsDisabled);
       const result = await window.electron.openExternal(url);
       if (result === 'opened') {
         return { status: 'success' as const };
@@ -848,16 +845,17 @@ export default function McpAppRenderer({
         message: result === 'cancelled' ? 'User cancelled' : intl.formatMessage(i18n.invalidUrl),
       };
     },
-    [intl]
+    [hostActionsDisabled, intl]
   );
 
   const handleMessage = useCallback(
     async ({ content }: { content: Array<{ type: string; text?: string }> }) => {
+      assertMcpAppHostActionAllowed(hostActionsDisabled);
       await appendMcpAppMessage(append, content);
       window.dispatchEvent(new CustomEvent(AppEvents.SCROLL_CHAT_TO_BOTTOM));
       return {};
     },
-    [append]
+    [append, hostActionsDisabled]
   );
 
   const handleCallTool = useCallback(
@@ -868,17 +866,18 @@ export default function McpAppRenderer({
       name: string;
       arguments?: Record<string, unknown>;
     }): Promise<CallToolResult> => {
-      assertMcpAppToolCallAllowed(toolCallDisabled);
+      assertMcpAppHostActionAllowed(hostActionsDisabled);
       if (!sessionId) {
         throw new Error('Session not initialized for MCP request');
       }
       return callMcpAppTool(sessionId, extensionName, name, args);
     },
-    [sessionId, extensionName, toolCallDisabled]
+    [sessionId, extensionName, hostActionsDisabled]
   );
 
   const handleReadResource = useCallback(
     async ({ uri }: { uri: string }) => {
+      assertMcpAppHostActionAllowed(hostActionsDisabled);
       if (!sessionId) {
         throw new Error('Session not initialized for MCP request');
       }
@@ -890,7 +889,7 @@ export default function McpAppRenderer({
         contents: [{ uri: data.uri || uri, text: data.text, mimeType: data.mimeType || undefined }],
       };
     },
-    [sessionId, extensionName]
+    [sessionId, extensionName, hostActionsDisabled]
   );
 
   const handleLoggingMessage = useCallback(
@@ -944,12 +943,13 @@ export default function McpAppRenderer({
 
   const handleFallbackRequest = useCallback(
     async (request: JSONRPCRequest, _extra: RequestHandlerExtra) => {
+      assertMcpAppHostActionAllowed(hostActionsDisabled);
       return {
         status: 'error' as const,
         message: `Unhandled JSON-RPC method: ${request.method ?? '<unknown>'}`,
       };
     },
-    []
+    [hostActionsDisabled]
   );
 
   const handleError = useCallback((err: Error) => {
@@ -1073,8 +1073,7 @@ export default function McpAppRenderer({
         onFallbackRequest={handleFallbackRequest}
         onSizeChanged={handleSizeChanged}
         onError={handleError}
-        toolCallDisabled={toolCallDisabled}
-        messageDisabled={messageDisabled}
+        hostActionsDisabled={hostActionsDisabled}
       />
     );
   };

--- a/ui/desktop/src/components/McpApps/McpAppRenderer.tsx
+++ b/ui/desktop/src/components/McpApps/McpAppRenderer.tsx
@@ -40,6 +40,7 @@ import {
   useReducer,
   useRef,
   useState,
+  type RefObject,
 } from 'react';
 import { callMcpAppTool, readMcpAppResource } from '../../acp/mcp-apps';
 import { httpBaseFromAcpWebSocketUrl, isLoopbackAcpWebSocketUrl } from '../../acp/url';
@@ -120,6 +121,15 @@ const DEFAULT_IFRAME_HEIGHT = 200;
 const FULLSCREEN_HEADER_HEIGHT = 48;
 const DEFAULT_SANDBOX_PERMISSIONS = 'allow-scripts allow-same-origin allow-forms';
 
+interface CancellationSignal {
+  readonly aborted: boolean;
+}
+
+interface CancellationController {
+  readonly signal: CancellationSignal;
+  abort(): void;
+}
+
 const DISPLAY_MODE_LAYOUTS: Record<GooseDisplayMode, DimensionLayout> = {
   inline: { width: 'fixed', height: 'unbounded' },
   fullscreen: { width: 'fixed', height: 'fixed' },
@@ -167,10 +177,15 @@ function getContainerDimensions(
   return { ...widthDimension, ...heightDimension };
 }
 
-async function fetchMcpAppProxyUrl(csp: McpUiResourceCsp | null): Promise<string | null> {
+async function fetchMcpAppProxyUrl(
+  csp: McpUiResourceCsp | null,
+  signal?: CancellationSignal
+): Promise<string | null> {
   try {
     const acpUrl = await window.electron.getAcpUrl();
+    if (signal?.aborted) return null;
     const secretKey = await window.electron.getSecretKey();
+    if (signal?.aborted) return null;
 
     if (!acpUrl || !secretKey) {
       console.error('[McpAppRenderer] Failed to get ACP URL or secret key');
@@ -292,6 +307,7 @@ interface GooseAppFrameProps {
   onInitialized?: (appInfo: AppInfo) => void;
   onError?: (error: Error) => void;
   hostActionsDisabled: boolean;
+  hostActionsDisabledRef?: RefObject<boolean>;
 }
 
 const SANDBOX_PROXY_READY_METHOD = 'ui/notifications/sandbox-proxy-ready';
@@ -314,6 +330,7 @@ export function GooseAppFrame({
   onInitialized,
   onError,
   hostActionsDisabled,
+  hostActionsDisabledRef,
 }: GooseAppFrameProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
@@ -330,7 +347,8 @@ export function GooseAppFrame({
   const onSizeChangedRef = useRef(onSizeChanged);
   const onInitializedRef = useRef(onInitialized);
   const onErrorRef = useRef(onError);
-  const hostActionsDisabledRef = useRef(hostActionsDisabled);
+  const localHostActionsDisabledRef = useRef(hostActionsDisabled);
+  const activeHostActionsDisabledRef = hostActionsDisabledRef ?? localHostActionsDisabledRef;
 
   useEffect(() => {
     hostContextRef.current = hostContext;
@@ -346,7 +364,7 @@ export function GooseAppFrame({
   });
 
   useLayoutEffect(() => {
-    hostActionsDisabledRef.current = hostActionsDisabled;
+    localHostActionsDisabledRef.current = hostActionsDisabled;
   }, [hostActionsDisabled]);
 
   useEffect(() => {
@@ -367,24 +385,24 @@ export function GooseAppFrame({
       hostContext: hostContextRef.current,
     });
     bridge.onmessage = (params) => {
-      assertMcpAppHostActionAllowed(hostActionsDisabledRef.current);
+      assertMcpAppHostActionAllowed(activeHostActionsDisabledRef.current);
       return onMessageRef.current(params);
     };
     bridge.onopenlink = (params) => {
-      assertMcpAppHostActionAllowed(hostActionsDisabledRef.current);
+      assertMcpAppHostActionAllowed(activeHostActionsDisabledRef.current);
       return onOpenLinkRef.current(params);
     };
     bridge.onloggingmessage = (params) => onLoggingMessageRef.current(params);
     bridge.oncalltool = (params) => {
-      assertMcpAppHostActionAllowed(hostActionsDisabledRef.current);
+      assertMcpAppHostActionAllowed(activeHostActionsDisabledRef.current);
       return onCallToolRef.current(params);
     };
     bridge.onreadresource = (params) => {
-      assertMcpAppHostActionAllowed(hostActionsDisabledRef.current);
+      assertMcpAppHostActionAllowed(activeHostActionsDisabledRef.current);
       return onReadResourceRef.current(params);
     };
     (bridge as FallbackRequestHandler).fallbackRequestHandler = (request, extra) => {
-      assertMcpAppHostActionAllowed(hostActionsDisabledRef.current);
+      assertMcpAppHostActionAllowed(activeHostActionsDisabledRef.current);
       return onFallbackRequestRef.current(request, extra);
     };
 
@@ -476,7 +494,7 @@ export function GooseAppFrame({
       bridge.close();
       iframe.remove();
     };
-  }, [sandbox.permissions, sandbox.url.href]);
+  }, [sandbox.permissions, sandbox.url.href, activeHostActionsDisabledRef]);
 
   useEffect(() => {
     const bridge = bridgeRef.current;
@@ -619,6 +637,16 @@ export default function McpAppRenderer({
   const intl = useIntl();
   const containerRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
+  const hostActionsDisabledRef = useRef(hostActionsDisabled);
+  const proxyAbortControllerRef = useRef<CancellationController | null>(null);
+
+  useLayoutEffect(() => {
+    hostActionsDisabledRef.current = hostActionsDisabled;
+    if (hostActionsDisabled) {
+      proxyAbortControllerRef.current?.abort();
+      proxyAbortControllerRef.current = null;
+    }
+  }, [hostActionsDisabled]);
 
   const dm = useDisplayMode({ displayMode, onDisplayModeChange, containerRef });
   const {
@@ -649,7 +677,7 @@ export default function McpAppRenderer({
   const [mcpTool, setMcpTool] = useState<Tool | null>(null);
   const toolDefRef = useRef<Tool | null>(null);
   useEffect(() => {
-    if (!sessionId || !toolName || toolDefRef.current) {
+    if (hostActionsDisabled || !sessionId || !toolName || toolDefRef.current) {
       if (toolDefRef.current) setMcpTool(toolDefRef.current);
       return;
     }
@@ -657,7 +685,7 @@ export default function McpAppRenderer({
     let cancelled = false;
     (async () => {
       const tools = await getCachedTools(sessionId, extensionName || undefined);
-      if (cancelled || !tools) return;
+      if (cancelled || hostActionsDisabledRef.current || !tools) return;
 
       const prefixedName = extensionName ? `${extensionName}__${toolName}` : toolName;
       const match = tools.find((t) => t.name === prefixedName);
@@ -675,7 +703,7 @@ export default function McpAppRenderer({
     return () => {
       cancelled = true;
     };
-  }, [sessionId, toolName, extensionName]);
+  }, [sessionId, toolName, extensionName, hostActionsDisabled]);
 
   // Survive StrictMode remounts — replay cached results instead of re-fetching,
   // which prevents the iframe from being torn down and recreated (visible flicker).
@@ -724,7 +752,7 @@ export default function McpAppRenderer({
   // finished loading yet, causing a transient 500). Cached HTML skips retries since
   // the app can render immediately with the cached version.
   useEffect(() => {
-    if (!sessionId) return;
+    if (hostActionsDisabled || !sessionId) return;
 
     // On StrictMode remount, replay the cached result instead of re-fetching.
     if (fetchedDataRef.current) {
@@ -741,12 +769,12 @@ export default function McpAppRenderer({
       dispatch({ type: 'FETCH_RESOURCE' });
 
       for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
-        if (cancelled) return;
+        if (cancelled || hostActionsDisabledRef.current) return;
 
         try {
           const content = await readMcpAppResource(sessionId, extensionName, resourceUri);
 
-          if (cancelled) return;
+          if (cancelled || hostActionsDisabledRef.current) return;
 
           if (content) {
             const rawMeta = content._meta as
@@ -775,7 +803,7 @@ export default function McpAppRenderer({
             return;
           }
         } catch (err) {
-          if (cancelled) return;
+          if (cancelled || hostActionsDisabledRef.current) return;
 
           const isLastAttempt = attempt === MAX_RETRIES;
 
@@ -807,14 +835,14 @@ export default function McpAppRenderer({
     return () => {
       cancelled = true;
     };
-  }, [resourceUri, extensionName, sessionId, cachedHtml, intl]);
+  }, [resourceUri, extensionName, sessionId, cachedHtml, intl, hostActionsDisabled]);
 
   // Create the sandbox proxy URL once we have HTML and metadata.
   // On StrictMode remount, reuse the cached URL to avoid recreating the proxy
   // (which would destroy iframe state and cause a visible flicker).
   const pendingCsp = state.status === 'loading_sandbox' ? state.meta.csp : null;
   useEffect(() => {
-    if (state.status !== 'loading_sandbox') return;
+    if (hostActionsDisabled || state.status !== 'loading_sandbox') return;
 
     if (sandboxUrlRef.current) {
       const { url, csp } = sandboxUrlRef.current;
@@ -822,7 +850,11 @@ export default function McpAppRenderer({
       return;
     }
 
-    fetchMcpAppProxyUrl(pendingCsp).then((url) => {
+    const controller = new AbortController();
+    proxyAbortControllerRef.current = controller;
+
+    fetchMcpAppProxyUrl(pendingCsp, controller.signal).then((url) => {
+      if (controller.signal.aborted) return;
       if (url) {
         sandboxUrlRef.current = { url, csp: pendingCsp };
         dispatch({ type: 'SANDBOX_READY', sandboxUrl: url, sandboxCsp: pendingCsp });
@@ -830,7 +862,14 @@ export default function McpAppRenderer({
         dispatch({ type: 'SANDBOX_FAILED', message: intl.formatMessage(i18n.failedToInitSandbox) });
       }
     });
-  }, [state.status, pendingCsp, intl]);
+
+    return () => {
+      controller.abort();
+      if (proxyAbortControllerRef.current === controller) {
+        proxyAbortControllerRef.current = null;
+      }
+    };
+  }, [state.status, pendingCsp, intl, hostActionsDisabled]);
 
   const handleOpenLink = useCallback(
     async ({ url }: { url: string }) => {
@@ -1074,6 +1113,7 @@ export default function McpAppRenderer({
         onSizeChanged={handleSizeChanged}
         onError={handleError}
         hostActionsDisabled={hostActionsDisabled}
+        hostActionsDisabledRef={hostActionsDisabledRef}
       />
     );
   };
@@ -1178,8 +1218,19 @@ export default function McpAppRenderer({
     );
   };
 
-  // Single stable container — CSS switches between inline/fullscreen/pip positioning.
-  // The iframe is never unmounted, preserving app state across mode changes.
+  if (hostActionsDisabled) {
+    return (
+      <div
+        data-testid="mcp-app-trust-placeholder"
+        className="relative mt-6 mb-2 flex w-full items-center justify-center overflow-hidden rounded bg-black/[0.03] dark:bg-white/[0.03]"
+        style={{ height: `${DEFAULT_IFRAME_HEIGHT}px` }}
+      >
+        <FlyingBird className="scale-200 opacity-30" cycleInterval={120} />
+      </div>
+    );
+  }
+
+  // While trusted, CSS switches the stable iframe between inline/fullscreen/pip positioning.
   const containerClasses = cn(
     'mcp-app-container bg-background-primary [&_iframe]:!w-full',
     isFillsViewport && 'fixed inset-0 z-[1000] overflow-hidden [&_iframe]:!h-full',

--- a/ui/desktop/src/components/McpApps/McpAppRenderer.tsx
+++ b/ui/desktop/src/components/McpApps/McpAppRenderer.tsx
@@ -215,16 +215,42 @@ interface McpAppRendererProps {
   toolInputPartial?: McpAppToolInputPartial;
   toolResult?: CallToolResult;
   toolCancelled?: McpAppToolCancelled;
-  append?: (text: string) => void;
+  append?: (text: string) => boolean | Promise<boolean>;
   displayMode?: GooseDisplayMode;
   cachedHtml?: string;
   onDisplayModeChange?: OnDisplayModeChange;
   toolCallDisabled?: boolean;
+  messageDisabled?: boolean;
 }
 
 export function assertMcpAppToolCallAllowed(toolCallDisabled: boolean): void {
   if (toolCallDisabled) {
     throw new Error('MCP App tool calls are disabled until the recipe is trusted');
+  }
+}
+
+export function assertMcpAppMessageAllowed(messageDisabled: boolean): void {
+  if (messageDisabled) {
+    throw new Error('MCP App messages are disabled until the recipe is trusted');
+  }
+}
+
+export async function appendMcpAppMessage(
+  append: McpAppRendererProps['append'],
+  content: Array<{ type: string; text?: string }>
+): Promise<void> {
+  if (!append) {
+    throw new Error('Message handler not available in this context');
+  }
+  if (!Array.isArray(content)) {
+    throw new Error('Invalid message format: content must be an array of ContentBlock');
+  }
+  const textContent = content.find((block) => block.type === 'text');
+  if (!textContent?.text) {
+    throw new Error('Invalid message format: content must contain a text block');
+  }
+  if (!(await append(textContent.text))) {
+    throw new Error('MCP App message was not submitted');
   }
 }
 
@@ -273,6 +299,7 @@ interface GooseAppFrameProps {
   onInitialized?: (appInfo: AppInfo) => void;
   onError?: (error: Error) => void;
   toolCallDisabled: boolean;
+  messageDisabled: boolean;
 }
 
 const SANDBOX_PROXY_READY_METHOD = 'ui/notifications/sandbox-proxy-ready';
@@ -295,6 +322,7 @@ export function GooseAppFrame({
   onInitialized,
   onError,
   toolCallDisabled,
+  messageDisabled,
 }: GooseAppFrameProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
@@ -312,6 +340,7 @@ export function GooseAppFrame({
   const onInitializedRef = useRef(onInitialized);
   const onErrorRef = useRef(onError);
   const toolCallDisabledRef = useRef(toolCallDisabled);
+  const messageDisabledRef = useRef(messageDisabled);
 
   useEffect(() => {
     hostContextRef.current = hostContext;
@@ -328,7 +357,8 @@ export function GooseAppFrame({
 
   useLayoutEffect(() => {
     toolCallDisabledRef.current = toolCallDisabled;
-  }, [toolCallDisabled]);
+    messageDisabledRef.current = messageDisabled;
+  }, [messageDisabled, toolCallDisabled]);
 
   useEffect(() => {
     const container = containerRef.current;
@@ -347,7 +377,10 @@ export function GooseAppFrame({
     const bridge = new AppBridge(null, { name: 'MCP-UI Host', version: '1.0.0' }, capabilities, {
       hostContext: hostContextRef.current,
     });
-    bridge.onmessage = (params) => onMessageRef.current(params);
+    bridge.onmessage = (params) => {
+      assertMcpAppMessageAllowed(messageDisabledRef.current);
+      return onMessageRef.current(params);
+    };
     bridge.onopenlink = (params) => onOpenLinkRef.current(params);
     bridge.onloggingmessage = (params) => onLoggingMessageRef.current(params);
     bridge.oncalltool = (params) => {
@@ -585,6 +618,7 @@ export default function McpAppRenderer({
   cachedHtml,
   onDisplayModeChange,
   toolCallDisabled = false,
+  messageDisabled = false,
 }: McpAppRendererProps) {
   const intl = useIntl();
   const containerRef = useRef<HTMLDivElement>(null);
@@ -819,17 +853,7 @@ export default function McpAppRenderer({
 
   const handleMessage = useCallback(
     async ({ content }: { content: Array<{ type: string; text?: string }> }) => {
-      if (!append) {
-        throw new Error('Message handler not available in this context');
-      }
-      if (!Array.isArray(content)) {
-        throw new Error('Invalid message format: content must be an array of ContentBlock');
-      }
-      const textContent = content.find((block) => block.type === 'text');
-      if (!textContent || !textContent.text) {
-        throw new Error('Invalid message format: content must contain a text block');
-      }
-      append(textContent.text);
+      await appendMcpAppMessage(append, content);
       window.dispatchEvent(new CustomEvent(AppEvents.SCROLL_CHAT_TO_BOTTOM));
       return {};
     },
@@ -1050,6 +1074,7 @@ export default function McpAppRenderer({
         onSizeChanged={handleSizeChanged}
         onError={handleError}
         toolCallDisabled={toolCallDisabled}
+        messageDisabled={messageDisabled}
       />
     );
   };

--- a/ui/desktop/src/components/ProgressiveMessageList.tsx
+++ b/ui/desktop/src/components/ProgressiveMessageList.tsx
@@ -71,7 +71,7 @@ interface MessageRowProps {
     newContent: string,
     editType: 'fork' | 'edit',
     retainedImages: ImageData[]
-  ) => void;
+  ) => Promise<boolean>;
   rowContext: MessageRowContext;
   sessionId: string;
   submitElicitationResponse?: (
@@ -163,7 +163,7 @@ interface ProgressiveMessageListProps {
     newContent: string,
     editType: 'fork' | 'edit',
     retainedImages: ImageData[]
-  ) => void;
+  ) => Promise<boolean>;
   onRenderingComplete?: () => void;
   submitElicitationResponse?: (
     elicitationId: string,

--- a/ui/desktop/src/components/ProgressiveMessageList.tsx
+++ b/ui/desktop/src/components/ProgressiveMessageList.tsx
@@ -37,7 +37,7 @@ const i18n = defineMessages({
 });
 
 const emptyToolCallNotifications = new Map<string, NotificationEvent[]>();
-const emptyAppend = () => {};
+const emptyAppend = () => false;
 
 function getResolvedModel(message: Message): string | null {
   if (message.role !== 'assistant' || !message.metadata.userVisible) return null;
@@ -60,7 +60,7 @@ function renderSystemNotification(notification: SystemNotificationContent) {
 }
 
 interface MessageRowProps {
-  append: (value: string) => void;
+  append: (value: string) => boolean | Promise<boolean>;
   index: number;
   isStreaming: boolean;
   isUser: boolean;
@@ -154,7 +154,7 @@ interface ProgressiveMessageListProps {
   messages: Message[];
   sessionId: string;
   toolCallNotifications?: Map<string, NotificationEvent[]>;
-  append?: (value: string) => void;
+  append?: (value: string) => boolean | Promise<boolean>;
   isUserMessage: (message: Message) => boolean;
   batchSize?: number;
   batchDelay?: number;

--- a/ui/desktop/src/components/ProgressiveMessageList.tsx
+++ b/ui/desktop/src/components/ProgressiveMessageList.tsx
@@ -78,6 +78,7 @@ interface MessageRowProps {
     elicitationId: string,
     userData: Record<string, unknown>
   ) => Promise<boolean>;
+  toolApprovalDisabled: boolean;
   toolNotifications: readonly (NotificationEvent[] | undefined)[];
 }
 
@@ -92,6 +93,7 @@ function MessageRowComponent({
   rowContext,
   sessionId,
   submitElicitationResponse,
+  toolApprovalDisabled,
   toolNotifications,
 }: MessageRowProps) {
   const notification = getSystemNotification(message);
@@ -138,6 +140,7 @@ function MessageRowComponent({
             append={append}
             isStreaming={isStreaming}
             submitElicitationResponse={submitElicitationResponse}
+            toolApprovalDisabled={toolApprovalDisabled}
           />
         )}
       </div>
@@ -169,6 +172,7 @@ interface ProgressiveMessageListProps {
     elicitationId: string,
     userData: Record<string, unknown>
   ) => Promise<boolean>;
+  toolApprovalDisabled?: boolean;
 }
 
 export default function ProgressiveMessageList({
@@ -185,6 +189,7 @@ export default function ProgressiveMessageList({
   onMessageUpdate,
   onRenderingComplete,
   submitElicitationResponse,
+  toolApprovalDisabled = false,
 }: ProgressiveMessageListProps) {
   const intl = useIntl();
   const [renderedCount, setRenderedCount] = useState(() =>
@@ -283,6 +288,7 @@ export default function ProgressiveMessageList({
           rowContext={rowContext}
           sessionId={sessionId}
           submitElicitationResponse={submitElicitationResponse}
+          toolApprovalDisabled={toolApprovalDisabled}
           toolNotifications={toolNotifications}
         />
       );

--- a/ui/desktop/src/components/ToolApprovalButtons.test.tsx
+++ b/ui/desktop/src/components/ToolApprovalButtons.test.tsx
@@ -69,6 +69,26 @@ describe('ToolApprovalButtons', () => {
     expect(screen.queryByText('developer__shell - Allowed once')).not.toBeInTheDocument();
   });
 
+  it('does not resolve an ACP request while approvals are disabled', async () => {
+    renderWithIntl(
+      <ToolApprovalButtons
+        disabled
+        data={{
+          id: 'tool-call-blocked',
+          generation: 'permission-generation-blocked',
+          toolName: 'developer__shell',
+          sessionId: 'session-1',
+        }}
+      />
+    );
+
+    const allowButton = screen.getByRole('button', { name: 'Allow Once' });
+    expect(allowButton).toBeDisabled();
+    await userEvent.click(allowButton);
+
+    expect(resolveAcpPermissionRequestMock).not.toHaveBeenCalled();
+  });
+
   it('resets the displayed decision for a new permission generation', async () => {
     resolveAcpPermissionRequestMock.mockReturnValue(true);
     const { rerender } = renderWithIntl(

--- a/ui/desktop/src/components/ToolApprovalButtons.tsx
+++ b/ui/desktop/src/components/ToolApprovalButtons.tsx
@@ -60,7 +60,13 @@ export interface ToolApprovalData {
   isClicked?: boolean;
 }
 
-export default function ToolApprovalButtons({ data }: { data: ToolApprovalData }) {
+export default function ToolApprovalButtons({
+  data,
+  disabled = false,
+}: {
+  data: ToolApprovalData;
+  disabled?: boolean;
+}) {
   const intl = useIntl();
   const { generation, id, toolName, prompt, sessionId, isClicked: initialIsClicked } = data;
   const approvalStateKey = generation ?? id;
@@ -93,6 +99,8 @@ export default function ToolApprovalButtons({ data }: { data: ToolApprovalData }
   }, [approvalStateKey, decision, isClicked]);
 
   const handleAction = async (action: Permission) => {
+    if (disabled) return;
+
     try {
       if (resolveAcpPermissionRequest(sessionId, id, generation, action)) {
         setResolvedDecision(action);
@@ -125,6 +133,7 @@ export default function ToolApprovalButtons({ data }: { data: ToolApprovalData }
         <Button
           className="rounded-full"
           variant="secondary"
+          disabled={disabled}
           onClick={() => handleAction('allow_once')}
         >
           {intl.formatMessage(i18n.allowOnce)}
@@ -133,12 +142,18 @@ export default function ToolApprovalButtons({ data }: { data: ToolApprovalData }
           <Button
             className="rounded-full"
             variant="secondary"
+            disabled={disabled}
             onClick={() => handleAction('always_allow')}
           >
             {intl.formatMessage(i18n.alwaysAllow)}
           </Button>
         )}
-        <Button className="rounded-full" variant="outline" onClick={() => handleAction('deny_once')}>
+        <Button
+          className="rounded-full"
+          variant="outline"
+          disabled={disabled}
+          onClick={() => handleAction('deny_once')}
+        >
           {intl.formatMessage(i18n.deny)}
         </Button>
       </div>

--- a/ui/desktop/src/components/ToolCallConfirmation.tsx
+++ b/ui/desktop/src/components/ToolCallConfirmation.tsx
@@ -27,12 +27,14 @@ interface ToolConfirmationProps {
   sessionId: string;
   isClicked: boolean;
   actionRequiredContent: ActionRequired & { type: 'actionRequired' };
+  disabled?: boolean;
 }
 
 export default function ToolConfirmation({
   sessionId,
   isClicked,
   actionRequiredContent,
+  disabled = false,
 }: ToolConfirmationProps) {
   const intl = useIntl();
   const data = actionRequiredContent.data as ToolConfirmationData;
@@ -50,6 +52,7 @@ export default function ToolConfirmation({
         {prompt && <div className="py-2 text-sm text-amber-600 dark:text-amber-400">{prompt}</div>}
         <ToolCallArguments args={toolArguments as Record<string, ToolCallArgumentValue>} />
         <ToolApprovalButtons
+          disabled={disabled}
           data={{ generation, id, toolName, prompt: prompt ?? undefined, sessionId, isClicked }}
         />
       </div>

--- a/ui/desktop/src/components/ToolCallWithResponse.test.tsx
+++ b/ui/desktop/src/components/ToolCallWithResponse.test.tsx
@@ -16,6 +16,12 @@ vi.mock('../acp/permissionRequests', () => ({
   resolveAcpPermissionRequest: vi.fn(),
 }));
 
+vi.mock('./McpApps/McpAppRenderer', () => ({
+  default: ({ toolCallDisabled }: { toolCallDisabled?: boolean }) => (
+    <div data-testid="mcp-app" data-tool-call-disabled={String(toolCallDisabled)} />
+  ),
+}));
+
 const toolRequest: ToolRequestMessageContent = {
   type: 'toolRequest',
   id: 'tool-1',
@@ -86,6 +92,39 @@ function renderToolCall(response?: ToolResponseMessageContent) {
 describe('ToolCallWithResponse live output', () => {
   beforeEach(() => {
     vi.mocked(window.electron.getSetting).mockResolvedValue('detailed');
+  });
+
+  it('disables MCP App tool calls while recipe trust is unresolved', () => {
+    const appResponse: ToolResponseMessageContent = {
+      ...toolResponse,
+      toolResult: {
+        status: 'success',
+        value: {
+          content: [],
+          isError: false,
+          _meta: {
+            ui: { resourceUri: 'ui://developer/render' },
+            extensionName: 'developer',
+            toolName: 'shell',
+            toolNameIsActual: true,
+          },
+        },
+      },
+    };
+
+    render(
+      <ToolCallWithResponse
+        sessionId="session-1"
+        isCancelledMessage={false}
+        toolRequest={toolRequest}
+        toolResponse={appResponse}
+        isPendingApproval={false}
+        toolApprovalDisabled
+      />,
+      { wrapper: IntlTestWrapper }
+    );
+
+    expect(screen.getByTestId('mcp-app')).toHaveAttribute('data-tool-call-disabled', 'true');
   });
 
   it('renders raw live output while running and replaces it with the final result', async () => {

--- a/ui/desktop/src/components/ToolCallWithResponse.test.tsx
+++ b/ui/desktop/src/components/ToolCallWithResponse.test.tsx
@@ -17,8 +17,8 @@ vi.mock('../acp/permissionRequests', () => ({
 }));
 
 vi.mock('./McpApps/McpAppRenderer', () => ({
-  default: ({ toolCallDisabled }: { toolCallDisabled?: boolean }) => (
-    <div data-testid="mcp-app" data-tool-call-disabled={String(toolCallDisabled)} />
+  default: ({ hostActionsDisabled }: { hostActionsDisabled?: boolean }) => (
+    <div data-testid="mcp-app" data-host-actions-disabled={String(hostActionsDisabled)} />
   ),
 }));
 
@@ -94,7 +94,7 @@ describe('ToolCallWithResponse live output', () => {
     vi.mocked(window.electron.getSetting).mockResolvedValue('detailed');
   });
 
-  it('disables MCP App tool calls while recipe trust is unresolved', () => {
+  it('disables MCP App host actions while recipe trust is unresolved', () => {
     const appResponse: ToolResponseMessageContent = {
       ...toolResponse,
       toolResult: {
@@ -124,7 +124,7 @@ describe('ToolCallWithResponse live output', () => {
       { wrapper: IntlTestWrapper }
     );
 
-    expect(screen.getByTestId('mcp-app')).toHaveAttribute('data-tool-call-disabled', 'true');
+    expect(screen.getByTestId('mcp-app')).toHaveAttribute('data-host-actions-disabled', 'true');
   });
 
   it('renders raw live output while running and replaces it with the final result', async () => {

--- a/ui/desktop/src/components/ToolCallWithResponse.tsx
+++ b/ui/desktop/src/components/ToolCallWithResponse.tsx
@@ -111,6 +111,7 @@ interface ToolCallWithResponseProps {
   append?: (value: string) => void;
   confirmationContent?: ToolConfirmationData;
   isApprovalClicked?: boolean;
+  toolApprovalDisabled?: boolean;
 }
 
 function getSubagentSessionId(
@@ -236,6 +237,7 @@ export default function ToolCallWithResponse({
   append,
   confirmationContent,
   isApprovalClicked,
+  toolApprovalDisabled = false,
 }: ToolCallWithResponseProps) {
   // Handle both the wrapped ToolResult format and the unwrapped format
   // The server serializes ToolResult<T> as { status: "success", value: T } or { status: "error", error: string }
@@ -283,6 +285,7 @@ export default function ToolCallWithResponse({
             )}
             <div className="px-4 pb-2">
               <ToolApprovalButtons
+                disabled={toolApprovalDisabled}
                 data={{
                   generation: confirmationContent.generation,
                   id: confirmationContent.id,

--- a/ui/desktop/src/components/ToolCallWithResponse.tsx
+++ b/ui/desktop/src/components/ToolCallWithResponse.tsx
@@ -108,7 +108,7 @@ interface ToolCallWithResponseProps {
   notifications?: NotificationEvent[];
   isStreamingMessage?: boolean;
   isPendingApproval: boolean;
-  append?: (value: string) => void;
+  append?: (value: string) => boolean | Promise<boolean>;
   confirmationContent?: ToolConfirmationData;
   isApprovalClicked?: boolean;
   toolApprovalDisabled?: boolean;
@@ -156,7 +156,7 @@ interface McpAppWrapperProps {
   toolRequest: ToolRequestMessageContent;
   toolResponse?: ToolResponseMessageContent;
   sessionId: string;
-  append?: (value: string) => void;
+  append?: (value: string) => boolean | Promise<boolean>;
   toolCallDisabled: boolean;
 }
 
@@ -224,6 +224,7 @@ function McpAppWrapper({
         sessionId={sessionId}
         append={append}
         toolCallDisabled={toolCallDisabled}
+        messageDisabled={toolCallDisabled}
       />
     </div>
   );

--- a/ui/desktop/src/components/ToolCallWithResponse.tsx
+++ b/ui/desktop/src/components/ToolCallWithResponse.tsx
@@ -157,7 +157,7 @@ interface McpAppWrapperProps {
   toolResponse?: ToolResponseMessageContent;
   sessionId: string;
   append?: (value: string) => boolean | Promise<boolean>;
-  toolCallDisabled: boolean;
+  hostActionsDisabled: boolean;
 }
 
 export function resolveMcpAppMetadata(
@@ -186,7 +186,7 @@ function McpAppWrapper({
   toolResponse,
   sessionId,
   append,
-  toolCallDisabled,
+  hostActionsDisabled,
 }: McpAppWrapperProps): React.ReactNode {
   const requestWithMeta = toolRequest as ToolRequestWithMeta;
   const resultWithMeta = toolResponse?.toolResult as ToolResultWithMeta | undefined;
@@ -223,8 +223,7 @@ function McpAppWrapper({
         toolName={toolName}
         sessionId={sessionId}
         append={append}
-        toolCallDisabled={toolCallDisabled}
-        messageDisabled={toolCallDisabled}
+        hostActionsDisabled={hostActionsDisabled}
       />
     </div>
   );
@@ -311,7 +310,7 @@ export default function ToolCallWithResponse({
           toolResponse={toolResponse}
           sessionId={sessionId}
           append={append}
-          toolCallDisabled={toolApprovalDisabled}
+          hostActionsDisabled={toolApprovalDisabled}
         />
       )}
     </>

--- a/ui/desktop/src/components/ToolCallWithResponse.tsx
+++ b/ui/desktop/src/components/ToolCallWithResponse.tsx
@@ -157,6 +157,7 @@ interface McpAppWrapperProps {
   toolResponse?: ToolResponseMessageContent;
   sessionId: string;
   append?: (value: string) => void;
+  toolCallDisabled: boolean;
 }
 
 export function resolveMcpAppMetadata(
@@ -185,6 +186,7 @@ function McpAppWrapper({
   toolResponse,
   sessionId,
   append,
+  toolCallDisabled,
 }: McpAppWrapperProps): React.ReactNode {
   const requestWithMeta = toolRequest as ToolRequestWithMeta;
   const resultWithMeta = toolResponse?.toolResult as ToolResultWithMeta | undefined;
@@ -221,6 +223,7 @@ function McpAppWrapper({
         toolName={toolName}
         sessionId={sessionId}
         append={append}
+        toolCallDisabled={toolCallDisabled}
       />
     </div>
   );
@@ -307,6 +310,7 @@ export default function ToolCallWithResponse({
           toolResponse={toolResponse}
           sessionId={sessionId}
           append={append}
+          toolCallDisabled={toolApprovalDisabled}
         />
       )}
     </>

--- a/ui/desktop/src/components/UserMessage.editing.test.tsx
+++ b/ui/desktop/src/components/UserMessage.editing.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { IntlTestWrapper } from '../i18n/test-utils';
 import type { Message } from '../types/message';
@@ -15,7 +15,12 @@ const message: Message = {
 describe('UserMessage editing', () => {
   it('keeps the editor and draft open when an update is rejected', async () => {
     Object.assign(window.electron, { logInfo: vi.fn() });
-    const onMessageUpdate = vi.fn().mockResolvedValue(false);
+    let resolveUpdate: ((updated: boolean) => void) | undefined;
+    const onMessageUpdate = vi.fn().mockReturnValue(
+      new Promise<boolean>((resolve) => {
+        resolveUpdate = resolve;
+      })
+    );
 
     render(<UserMessage message={message} onMessageUpdate={onMessageUpdate} />, {
       wrapper: IntlTestWrapper,
@@ -25,9 +30,14 @@ describe('UserMessage editing', () => {
     fireEvent.change(screen.getByRole('textbox', { name: 'Edit message content' }), {
       target: { value: 'Keep this edited draft' },
     });
-    fireEvent.click(screen.getByRole('button', { name: 'Edit message in place' }));
+    const saveButton = screen.getByRole('button', { name: 'Edit message in place' });
+    fireEvent.click(saveButton);
+    fireEvent.click(saveButton);
 
-    await waitFor(() => expect(onMessageUpdate).toHaveBeenCalledTimes(1));
+    expect(onMessageUpdate).toHaveBeenCalledTimes(1);
+    expect(saveButton).toBeDisabled();
+    await act(async () => resolveUpdate?.(false));
+    await waitFor(() => expect(saveButton).toBeEnabled());
     expect(screen.getByRole('textbox', { name: 'Edit message content' })).toHaveValue(
       'Keep this edited draft'
     );

--- a/ui/desktop/src/components/UserMessage.editing.test.tsx
+++ b/ui/desktop/src/components/UserMessage.editing.test.tsx
@@ -12,6 +12,11 @@ const message: Message = {
   metadata: { agentVisible: true, userVisible: true },
 };
 
+const messageWithImage: Message = {
+  ...message,
+  content: [...message.content, { type: 'image', data: 'base64-image', mimeType: 'image/png' }],
+};
+
 describe('UserMessage editing', () => {
   it('keeps the editor and draft open when an update is rejected', async () => {
     Object.assign(window.electron, { logInfo: vi.fn() });
@@ -22,7 +27,7 @@ describe('UserMessage editing', () => {
       })
     );
 
-    render(<UserMessage message={message} onMessageUpdate={onMessageUpdate} />, {
+    render(<UserMessage message={messageWithImage} onMessageUpdate={onMessageUpdate} />, {
       wrapper: IntlTestWrapper,
     });
 
@@ -36,11 +41,21 @@ describe('UserMessage editing', () => {
 
     expect(onMessageUpdate).toHaveBeenCalledTimes(1);
     expect(saveButton).toBeDisabled();
+    const textarea = screen.getByRole('textbox', { name: 'Edit message content' });
+    const cancelButton = screen.getByRole('button', { name: 'Cancel editing' });
+    const removeImageButton = screen.getByRole('button', { name: 'Remove image from message' });
+    expect(textarea).toBeDisabled();
+    expect(cancelButton).toBeDisabled();
+    expect(removeImageButton).toBeDisabled();
+    fireEvent.change(textarea, { target: { value: 'Discard this later change' } });
+    fireEvent.keyDown(textarea, { key: 'Escape' });
+    expect(textarea).toHaveValue('Keep this edited draft');
     await act(async () => resolveUpdate?.(false));
     await waitFor(() => expect(saveButton).toBeEnabled());
-    expect(screen.getByRole('textbox', { name: 'Edit message content' })).toHaveValue(
-      'Keep this edited draft'
-    );
+    expect(textarea).toBeEnabled();
+    expect(cancelButton).toBeEnabled();
+    expect(removeImageButton).toBeEnabled();
+    expect(textarea).toHaveValue('Keep this edited draft');
   });
 
   it('closes the editor when an update succeeds', async () => {

--- a/ui/desktop/src/components/UserMessage.editing.test.tsx
+++ b/ui/desktop/src/components/UserMessage.editing.test.tsx
@@ -1,0 +1,55 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { IntlTestWrapper } from '../i18n/test-utils';
+import type { Message } from '../types/message';
+import UserMessage from './UserMessage';
+
+const message: Message = {
+  id: 'message-1',
+  role: 'user',
+  content: [{ type: 'text', text: 'Original message' }],
+  created: 0,
+  metadata: { agentVisible: true, userVisible: true },
+};
+
+describe('UserMessage editing', () => {
+  it('keeps the editor and draft open when an update is rejected', async () => {
+    Object.assign(window.electron, { logInfo: vi.fn() });
+    const onMessageUpdate = vi.fn().mockResolvedValue(false);
+
+    render(<UserMessage message={message} onMessageUpdate={onMessageUpdate} />, {
+      wrapper: IntlTestWrapper,
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /Edit message:/ }));
+    fireEvent.change(screen.getByRole('textbox', { name: 'Edit message content' }), {
+      target: { value: 'Keep this edited draft' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Edit message in place' }));
+
+    await waitFor(() => expect(onMessageUpdate).toHaveBeenCalledTimes(1));
+    expect(screen.getByRole('textbox', { name: 'Edit message content' })).toHaveValue(
+      'Keep this edited draft'
+    );
+  });
+
+  it('closes the editor when an update succeeds', async () => {
+    Object.assign(window.electron, { logInfo: vi.fn() });
+    const onMessageUpdate = vi.fn().mockResolvedValue(true);
+    render(<UserMessage message={message} onMessageUpdate={onMessageUpdate} />, {
+      wrapper: IntlTestWrapper,
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /Edit message:/ }));
+    fireEvent.change(screen.getByRole('textbox', { name: 'Edit message content' }), {
+      target: { value: 'Apply this edited draft' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Edit message in place' }));
+
+    await waitFor(() =>
+      expect(
+        screen.queryByRole('textbox', { name: 'Edit message content' })
+      ).not.toBeInTheDocument()
+    );
+  });
+});

--- a/ui/desktop/src/components/UserMessage.tsx
+++ b/ui/desktop/src/components/UserMessage.tsx
@@ -101,6 +101,8 @@ function UserMessage({ message, onMessageUpdate }: UserMessageProps) {
   const contentRef = useRef<HTMLDivElement | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const [isEditing, setIsEditing] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const isSavingRef = useRef(false);
   const [editContent, setEditContent] = useState('');
   const [error, setError] = useState<string | null>(null);
 
@@ -163,6 +165,8 @@ function UserMessage({ message, onMessageUpdate }: UserMessageProps) {
 
   const handleSave = useCallback(
     async (editType: 'fork' | 'edit') => {
+      if (isSavingRef.current) return;
+
       const retainedImages = messageImages.filter((_, index) => !removedImageIndices.has(index));
 
       if (editContent.trim().length === 0 && retainedImages.length === 0) {
@@ -180,7 +184,15 @@ function UserMessage({ message, onMessageUpdate }: UserMessageProps) {
       }
 
       if (onMessageUpdate && message.id) {
-        const updated = await onMessageUpdate(message.id, editContent, editType, retainedImages);
+        isSavingRef.current = true;
+        setIsSaving(true);
+        let updated: boolean;
+        try {
+          updated = await onMessageUpdate(message.id, editContent, editType, retainedImages);
+        } finally {
+          isSavingRef.current = false;
+          setIsSaving(false);
+        }
         if (!updated) return;
       }
       setIsEditing(false);
@@ -303,6 +315,7 @@ function UserMessage({ message, onMessageUpdate }: UserMessageProps) {
                 </Button>
                 <Button
                   onClick={() => void handleSave('edit')}
+                  disabled={isSaving}
                   variant="secondary"
                   aria-label={intl.formatMessage(i18n.editInPlaceAriaLabel)}
                   title={intl.formatMessage(i18n.editInPlaceTitle)}
@@ -311,6 +324,7 @@ function UserMessage({ message, onMessageUpdate }: UserMessageProps) {
                 </Button>
                 <Button
                   onClick={() => void handleSave('fork')}
+                  disabled={isSaving}
                   aria-label={intl.formatMessage(i18n.forkSessionAriaLabel)}
                   title={intl.formatMessage(i18n.forkSessionTitle)}
                 >

--- a/ui/desktop/src/components/UserMessage.tsx
+++ b/ui/desktop/src/components/UserMessage.tsx
@@ -127,6 +127,8 @@ function UserMessage({ message, onMessageUpdate }: UserMessageProps) {
   }, [textContent]);
 
   const handleRemoveImage = useCallback((index: number) => {
+    if (isSavingRef.current) return;
+
     setRemovedImageIndices((prev) => {
       const next = new Set(prev);
       next.add(index);
@@ -157,6 +159,8 @@ function UserMessage({ message, onMessageUpdate }: UserMessageProps) {
   }, [isEditing, initializeEditMode, message.id]);
 
   const handleContentChange = useCallback((e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    if (isSavingRef.current) return;
+
     const newContent = e.target.value;
     setEditContent(newContent);
     setError(null);
@@ -209,6 +213,8 @@ function UserMessage({ message, onMessageUpdate }: UserMessageProps) {
   );
 
   const handleCancel = useCallback(() => {
+    if (isSavingRef.current) return;
+
     window.electron.logInfo('Cancel clicked - reverting to original content');
     setIsEditing(false);
     setEditContent(textContent);
@@ -263,6 +269,7 @@ function UserMessage({ message, onMessageUpdate }: UserMessageProps) {
               placeholder={intl.formatMessage(i18n.editPlaceholder)}
               aria-label={intl.formatMessage(i18n.editAriaLabel)}
               aria-describedby={error ? `error-${message.id}` : undefined}
+              disabled={isSaving}
             />
             {messageImages.length > 0 && (
               <div className="mt-3">
@@ -278,6 +285,7 @@ function UserMessage({ message, onMessageUpdate }: UserMessageProps) {
                         <ImagePreview src={dataUrl} />
                         <button
                           onClick={() => handleRemoveImage(index)}
+                          disabled={isSaving}
                           className="absolute -top-1.5 -right-1.5 bg-text-primary text-background-primary rounded-full p-0.5 transition-opacity hover:cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
                           aria-label={intl.formatMessage(i18n.removeImageFromEdit)}
                         >
@@ -308,6 +316,7 @@ function UserMessage({ message, onMessageUpdate }: UserMessageProps) {
               <div className="flex gap-3">
                 <Button
                   onClick={handleCancel}
+                  disabled={isSaving}
                   variant="ghost"
                   aria-label={intl.formatMessage(i18n.cancelAriaLabel)}
                 >

--- a/ui/desktop/src/components/UserMessage.tsx
+++ b/ui/desktop/src/components/UserMessage.tsx
@@ -93,7 +93,7 @@ interface UserMessageProps {
     newContent: string,
     editType: 'fork' | 'edit',
     retainedImages: ImageData[]
-  ) => void;
+  ) => Promise<boolean>;
 }
 
 function UserMessage({ message, onMessageUpdate }: UserMessageProps) {
@@ -162,7 +162,7 @@ function UserMessage({ message, onMessageUpdate }: UserMessageProps) {
   }, []);
 
   const handleSave = useCallback(
-    (editType: 'fork' | 'edit') => {
+    async (editType: 'fork' | 'edit') => {
       const retainedImages = messageImages.filter((_, index) => !removedImageIndices.has(index));
 
       if (editContent.trim().length === 0 && retainedImages.length === 0) {
@@ -170,19 +170,20 @@ function UserMessage({ message, onMessageUpdate }: UserMessageProps) {
         return;
       }
 
-      setIsEditing(false);
-
       if (
         editType === 'edit' &&
         editContent.trim() === textContent.trim() &&
         retainedImages.length === messageImages.length
       ) {
+        setIsEditing(false);
         return;
       }
 
       if (onMessageUpdate && message.id) {
-        onMessageUpdate(message.id, editContent, editType, retainedImages);
+        const updated = await onMessageUpdate(message.id, editContent, editType, retainedImages);
+        if (!updated) return;
       }
+      setIsEditing(false);
     },
     [
       editContent,
@@ -214,7 +215,7 @@ function UserMessage({ message, onMessageUpdate }: UserMessageProps) {
       } else if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
         e.preventDefault();
         window.electron.logInfo('Cmd+Enter detected, calling handleSave');
-        handleSave('fork');
+        void handleSave('fork');
       }
     },
     [handleCancel, handleSave]
@@ -301,7 +302,7 @@ function UserMessage({ message, onMessageUpdate }: UserMessageProps) {
                   {intl.formatMessage(i18n.cancel)}
                 </Button>
                 <Button
-                  onClick={() => handleSave('edit')}
+                  onClick={() => void handleSave('edit')}
                   variant="secondary"
                   aria-label={intl.formatMessage(i18n.editInPlaceAriaLabel)}
                   title={intl.formatMessage(i18n.editInPlaceTitle)}
@@ -309,7 +310,7 @@ function UserMessage({ message, onMessageUpdate }: UserMessageProps) {
                   {intl.formatMessage(i18n.editInPlace)}
                 </Button>
                 <Button
-                  onClick={() => handleSave('fork')}
+                  onClick={() => void handleSave('fork')}
                   aria-label={intl.formatMessage(i18n.forkSessionAriaLabel)}
                   title={intl.formatMessage(i18n.forkSessionTitle)}
                 >

--- a/ui/desktop/src/components/recipes/RecipeActivities.test.tsx
+++ b/ui/desktop/src/components/recipes/RecipeActivities.test.tsx
@@ -1,0 +1,23 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import RecipeActivities from './RecipeActivities';
+
+describe('RecipeActivities', () => {
+  it('disables activity submissions while recipe trust is unresolved', () => {
+    const append = vi.fn();
+    render(<RecipeActivities append={append} activities={['Run analysis']} disabled />);
+
+    const activity = screen.getByRole('button', { name: 'Run analysis' });
+    expect(activity).toBeDisabled();
+    fireEvent.click(activity);
+    expect(append).not.toHaveBeenCalled();
+  });
+
+  it('submits activities after recipe trust resolves', () => {
+    const append = vi.fn().mockResolvedValue(true);
+    render(<RecipeActivities append={append} activities={['Run analysis']} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Run analysis' }));
+    expect(append).toHaveBeenCalledWith('Run analysis');
+  });
+});

--- a/ui/desktop/src/components/recipes/RecipeActivities.tsx
+++ b/ui/desktop/src/components/recipes/RecipeActivities.tsx
@@ -1,19 +1,20 @@
-import { Card } from '../ui/card';
 import GooseLogo from '../GooseLogo';
 import MarkdownContent from '../MarkdownContent';
 import { substituteParameters } from '../../utils/parameterSubstitution';
 
 interface RecipeActivitiesProps {
-  append: (text: string) => void;
+  append: (text: string) => boolean | Promise<boolean>;
   activities: string[] | null;
   title?: string;
   parameterValues?: Record<string, string>;
+  disabled?: boolean;
 }
 
 export default function RecipeActivities({
   append,
   activities,
   parameterValues = {},
+  disabled = false,
 }: RecipeActivitiesProps) {
   const pills = activities || [];
 
@@ -52,16 +53,18 @@ export default function RecipeActivities({
           {remainingPills.map((content, index) => {
             const substitutedContent = substituteParameters(content, parameterValues);
             return (
-              <Card
+              <button
                 key={index}
-                onClick={() => append(substitutedContent)}
+                type="button"
+                disabled={disabled}
+                onClick={() => void append(substitutedContent)}
                 title={substitutedContent.length > 60 ? substitutedContent : undefined}
-                className="cursor-pointer px-3 py-1.5 text-sm hover:bg-background-secondary transition-colors"
+                className="bg-background-primary text-text-primary rounded-xl border shadow-sm cursor-pointer px-3 py-1.5 text-sm text-left hover:bg-background-secondary transition-colors disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-background-primary"
               >
                 {substitutedContent.length > 60
                   ? substitutedContent.slice(0, 60) + '...'
                   : substitutedContent}
-              </Card>
+              </button>
             );
           })}
         </div>

--- a/ui/desktop/src/hooks/useChatSession.acceptance.test.tsx
+++ b/ui/desktop/src/hooks/useChatSession.acceptance.test.tsx
@@ -106,4 +106,36 @@ describe('useChatSession submission acceptance', () => {
     expect(accepted).toBe(true);
     expect(mocks.submitMessage).toHaveBeenCalledTimes(1);
   });
+
+  it('rejects a rapid second message when the live store shows the first prompt', async () => {
+    mocks.submitMessage.mockImplementationOnce(() => {
+      mocks.snapshot = {
+        ...mocks.snapshot!,
+        activePromptAttemptId: 'prompt-1',
+        chatState: ChatState.Streaming,
+      };
+      return new Promise<void>(() => undefined);
+    });
+    const { result } = renderHook(
+      () =>
+        useChatSession({
+          sessionId: 'session-1',
+          onStreamFinish: vi.fn(),
+          onSessionLoaded: vi.fn(),
+        }),
+      { wrapper: Wrapper }
+    );
+
+    let firstAccepted = false;
+    let secondAccepted = true;
+    await act(async () => {
+      firstAccepted = await result.current.handleSubmit({ msg: 'first', images: [] });
+      secondAccepted = await result.current.handleSubmit({ msg: 'second', images: [] });
+    });
+
+    expect(firstAccepted).toBe(true);
+    expect(secondAccepted).toBe(false);
+    expect(mocks.submitMessage).toHaveBeenCalledTimes(1);
+    expect(mocks.setMessages).toHaveBeenCalledTimes(1);
+  });
 });

--- a/ui/desktop/src/hooks/useChatSession.acceptance.test.tsx
+++ b/ui/desktop/src/hooks/useChatSession.acceptance.test.tsx
@@ -1,0 +1,109 @@
+import type { ReactNode } from 'react';
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AcpChatSessionSnapshot } from '../acp/chatSessionStore';
+import { IntlTestWrapper } from '../i18n/test-utils';
+import { ChatState } from '../types/chatState';
+import { useChatSession } from './useChatSession';
+
+const mocks = vi.hoisted(() => ({
+  snapshot: undefined as AcpChatSessionSnapshot | undefined,
+  loadSession: vi.fn(),
+  submitMessage: vi.fn(),
+  setMessages: vi.fn(),
+}));
+
+vi.mock('../acp/chatSessionController', () => ({
+  acpChatSessionController: {
+    loadSession: mocks.loadSession,
+    submitMessage: mocks.submitMessage,
+    stop: vi.fn(),
+    updateMessage: vi.fn(),
+  },
+}));
+
+vi.mock('../acp/chatSessionStore', () => ({
+  acpChatSessionActions: {
+    setMessages: mocks.setMessages,
+    setSessionMetadata: vi.fn(),
+  },
+  acpChatSessionStore: {
+    getSnapshot: () => mocks.snapshot,
+  },
+  useAcpChatSessionSnapshot: () => mocks.snapshot,
+}));
+
+vi.mock('../acp/acpConnection', () => ({
+  isAcpRecovering: () => false,
+}));
+
+vi.mock('../acp/elicitationRequests', () => ({
+  resolveAcpElicitationRequest: vi.fn(),
+}));
+
+vi.mock('../acp/prompt', () => ({
+  acpSteerSession: vi.fn(),
+}));
+
+vi.mock('../toasts', () => ({
+  toastError: vi.fn(),
+}));
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return <IntlTestWrapper>{children}</IntlTestWrapper>;
+}
+
+describe('useChatSession submission acceptance', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.snapshot = {
+      session: {
+        id: 'session-1',
+        name: 'Test session',
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+        working_dir: '/tmp',
+        extension_data: {},
+        message_count: 0,
+      },
+      messages: [],
+      tokenState: {
+        inputTokens: 0,
+        outputTokens: 0,
+        totalTokens: 0,
+        accumulatedInputTokens: 0,
+        accumulatedOutputTokens: 0,
+        accumulatedTotalTokens: 0,
+      },
+      notifications: [],
+      progressMessage: undefined,
+      chatState: ChatState.Idle,
+      sessionLoadError: undefined,
+      activePromptAttemptId: null,
+      activeRunId: null,
+      pendingCancelPromptAttemptId: null,
+    } as AcpChatSessionSnapshot;
+    mocks.loadSession.mockResolvedValue(undefined);
+  });
+
+  it('acknowledges an accepted message before the agent run completes', async () => {
+    mocks.submitMessage.mockReturnValue(new Promise<void>(() => undefined));
+    const { result } = renderHook(
+      () =>
+        useChatSession({
+          sessionId: 'session-1',
+          onStreamFinish: vi.fn(),
+          onSessionLoaded: vi.fn(),
+        }),
+      { wrapper: Wrapper }
+    );
+
+    let accepted = false;
+    await act(async () => {
+      accepted = await result.current.handleSubmit({ msg: 'from MCP App', images: [] });
+    });
+
+    expect(accepted).toBe(true);
+    expect(mocks.submitMessage).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ui/desktop/src/hooks/useChatSession.submit.test.ts
+++ b/ui/desktop/src/hooks/useChatSession.submit.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import type { AcpChatSessionSnapshot } from '../acp/chatSessionStore';
+import { ChatState } from '../types/chatState';
+import type { UserInput } from '../types/message';
+import { isChatSubmissionAllowed } from './useChatSession';
+
+const input: UserInput = { msg: 'hello', images: [] };
+
+function snapshot(overrides: Partial<AcpChatSessionSnapshot> = {}): AcpChatSessionSnapshot {
+  return {
+    session: { id: 'session-1' },
+    messages: [],
+    tokenState: {
+      inputTokens: 0,
+      outputTokens: 0,
+      totalTokens: 0,
+      accumulatedInputTokens: 0,
+      accumulatedOutputTokens: 0,
+      accumulatedTotalTokens: 0,
+    },
+    notifications: [],
+    progressMessage: undefined,
+    chatState: ChatState.Idle,
+    sessionLoadError: undefined,
+    activePromptAttemptId: null,
+    activeRunId: null,
+    pendingCancelPromptAttemptId: null,
+    ...overrides,
+  } as AcpChatSessionSnapshot;
+}
+
+describe('isChatSubmissionAllowed', () => {
+  it.each([
+    ChatState.LoadingConversation,
+    ChatState.Streaming,
+    ChatState.Thinking,
+    ChatState.WaitingForUserInput,
+    ChatState.Compacting,
+    ChatState.RestartingAgent,
+  ])('rejects submissions while the chat state is %s', (chatState) => {
+    expect(isChatSubmissionAllowed(false, snapshot({ chatState }), input)).toBe(false);
+  });
+
+  it('rejects submissions while recovering or a prompt is active or cancelling', () => {
+    expect(isChatSubmissionAllowed(true, snapshot(), input)).toBe(false);
+    expect(
+      isChatSubmissionAllowed(false, snapshot({ activePromptAttemptId: 'prompt-1' }), input)
+    ).toBe(false);
+    expect(
+      isChatSubmissionAllowed(false, snapshot({ pendingCancelPromptAttemptId: 'prompt-1' }), input)
+    ).toBe(false);
+  });
+
+  it('rejects missing sessions and empty new conversations', () => {
+    expect(isChatSubmissionAllowed(false, snapshot({ session: undefined }), input)).toBe(false);
+    expect(isChatSubmissionAllowed(false, snapshot(), { msg: '', images: [] })).toBe(false);
+  });
+
+  it('allows idle new messages and continuation of existing conversations', () => {
+    expect(isChatSubmissionAllowed(false, snapshot(), input)).toBe(true);
+    expect(
+      isChatSubmissionAllowed(false, snapshot({ messages: [{}] as never[] }), {
+        msg: '',
+        images: [],
+      })
+    ).toBe(true);
+  });
+});

--- a/ui/desktop/src/hooks/useChatSession.ts
+++ b/ui/desktop/src/hooks/useChatSession.ts
@@ -21,6 +21,7 @@ import { acpChatSessionController } from '../acp/chatSessionController';
 import {
   acpChatSessionActions,
   acpChatSessionStore,
+  type AcpChatSessionSnapshot,
   useAcpChatSessionSnapshot,
 } from '../acp/chatSessionStore';
 import { acpSteerSession } from '../acp/prompt';
@@ -41,6 +42,24 @@ function isClearCommand(message: string): boolean {
 
 function isSlashCommand(message: string): boolean {
   return message.trim().startsWith('/');
+}
+
+export function isChatSubmissionAllowed(
+  recovering: boolean,
+  snapshot: AcpChatSessionSnapshot | undefined,
+  input: UserInput
+): boolean {
+  if (
+    recovering ||
+    !snapshot?.session ||
+    snapshot.chatState !== ChatState.Idle ||
+    snapshot.activePromptAttemptId !== null ||
+    snapshot.pendingCancelPromptAttemptId !== null
+  ) {
+    return false;
+  }
+
+  return input.msg.trim().length > 0 || input.images.length > 0 || snapshot.messages.length > 0;
 }
 
 const i18n = defineMessages({
@@ -158,32 +177,17 @@ export function useChatSession({
 
   const handleSubmit = useCallback(
     async (input: UserInput) => {
-      if (isAcpRecovering()) {
-        return;
-      }
-
       const { msg: userMessage, images } = input;
       const currentSnapshot = getCurrentSnapshot();
 
-      if (
-        !currentSnapshot?.session ||
-        currentSnapshot.chatState === ChatState.LoadingConversation ||
-        currentSnapshot.chatState === ChatState.Streaming ||
-        currentSnapshot.chatState === ChatState.Thinking ||
-        currentSnapshot.chatState === ChatState.Compacting ||
-        currentSnapshot.pendingCancelPromptAttemptId !== null
-      ) {
-        return;
+      if (!currentSnapshot || !isChatSubmissionAllowed(isAcpRecovering(), currentSnapshot, input)) {
+        return false;
       }
 
       const currentMessages = currentSnapshot.messages;
       const hasExistingMessages = currentMessages.length > 0;
       const hasNewMessage = userMessage.trim().length > 0 || images.length > 0;
       const clearsConversation = hasNewMessage && isClearCommand(userMessage);
-
-      if (!hasNewMessage && !hasExistingMessages) {
-        return;
-      }
 
       // Emit session-created event for first message in a new session
       if (!hasExistingMessages && hasNewMessage) {
@@ -204,6 +208,7 @@ export function useChatSession({
       }
 
       await submitToAcpSession(sessionId, newMessage);
+      return true;
     },
     [getCurrentSnapshot, sessionId, submitToAcpSession]
   );

--- a/ui/desktop/src/hooks/useChatSession.ts
+++ b/ui/desktop/src/hooks/useChatSession.ts
@@ -294,7 +294,7 @@ export function useChatSession({
       retainedImages: ImageData[]
     ) => {
       try {
-        await acpChatSessionController.updateMessage(
+        return await acpChatSessionController.updateMessage(
           sessionId,
           messageId,
           newContent,
@@ -305,7 +305,6 @@ export function useChatSession({
             onFinish,
           }
         );
-        return true;
       } catch (error) {
         const errorMsg = errorMessage(error);
         console.error('Failed to edit message:', error);

--- a/ui/desktop/src/hooks/useChatSession.ts
+++ b/ui/desktop/src/hooks/useChatSession.ts
@@ -305,6 +305,7 @@ export function useChatSession({
             onFinish,
           }
         );
+        return true;
       } catch (error) {
         const errorMsg = errorMessage(error);
         console.error('Failed to edit message:', error);
@@ -312,6 +313,7 @@ export function useChatSession({
           title: 'Failed to edit message',
           msg: errorMsg,
         });
+        return false;
       }
     },
     [getCurrentSnapshot, onFinish, sessionId]

--- a/ui/desktop/src/hooks/useChatSession.ts
+++ b/ui/desktop/src/hooks/useChatSession.ts
@@ -178,7 +178,7 @@ export function useChatSession({
   const handleSubmit = useCallback(
     async (input: UserInput) => {
       const { msg: userMessage, images } = input;
-      const currentSnapshot = getCurrentSnapshot();
+      const currentSnapshot = acpChatSessionStore.getSnapshot(sessionId) ?? getCurrentSnapshot();
 
       if (!currentSnapshot || !isChatSubmissionAllowed(isAcpRecovering(), currentSnapshot, input)) {
         return false;

--- a/ui/desktop/src/hooks/useChatSession.ts
+++ b/ui/desktop/src/hooks/useChatSession.ts
@@ -207,7 +207,7 @@ export function useChatSession({
         acpChatSessionActions.setMessages(sessionId, messagesForStore);
       }
 
-      await submitToAcpSession(sessionId, newMessage);
+      void submitToAcpSession(sessionId, newMessage);
       return true;
     },
     [getCurrentSnapshot, sessionId, submitToAcpSession]

--- a/ui/desktop/src/hooks/useChatSessionTypes.ts
+++ b/ui/desktop/src/hooks/useChatSessionTypes.ts
@@ -33,5 +33,5 @@ export interface UseChatSessionResult {
     newContent: string,
     editType: 'fork' | 'edit',
     retainedImages: ImageData[]
-  ) => Promise<void>;
+  ) => Promise<boolean>;
 }

--- a/ui/desktop/src/hooks/useChatSessionTypes.ts
+++ b/ui/desktop/src/hooks/useChatSessionTypes.ts
@@ -15,7 +15,7 @@ export interface UseChatSessionResult {
   chatState: ChatState;
   progressMessage?: string;
   updateSession: (updater: (session: Session) => Session) => void;
-  handleSubmit: (input: UserInput) => Promise<void>;
+  handleSubmit: (input: UserInput) => Promise<boolean>;
   onSteerQueuedMessage?: (input: UserInput) => Promise<boolean>;
   submitElicitationResponse: (
     elicitationId: string,


### PR DESCRIPTION
## Summary

- route every recipe chat submission through one fail-closed trust gate
- bind trust decisions to the exact recipe content and withhold initial prompts until acceptance
- cover direct, descendant, MCP App, and programmatic submission paths while preserving scheduled and non-recipe behavior

## Validation

- `pnpm --dir ui/desktop test:run` (77 test files, 713 tests passed)
- `pnpm --dir ui/desktop run lint:check`
- `cargo build`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`

*This finding was discovered by [Project Loupe](https://github.com/project-loupe/loupe)*