### PR TITLE
fix(providers): parse OpenRouter nested cache_write_tokens in usage

### DIFF
--- a/crates/goose-provider-types/src/formats/openai.rs
+++ b/crates/goose-provider-types/src/formats/openai.rs
@@ -882,6 +882,12 @@ pub fn get_usage(usage: &Value) -> Usage {
     let cache_write_input_tokens = usage
         .get("cache_creation_input_tokens")
         .and_then(|v| v.as_i64())
+        .or_else(|| {
+            usage
+                .get("prompt_tokens_details")
+                .and_then(|d| d.get("cache_write_tokens"))
+                .and_then(|v| v.as_i64())
+        })
         .map(|v| v as i32);
 
     let total_tokens = usage


### PR DESCRIPTION
## Summary
Parse OpenRouter's nested `prompt_tokens_details.cache_write_tokens` in the OpenAI-compatible usage parser, which previously read cache writes only from the flat `cache_creation_input_tokens` field. Every cache write through OpenRouter was recorded as zero, hiding the 1.25x-2x write premium from session usage and estimated costs.

### Testing
Wire-verified with live OpenRouter cold/warm calls against `anthropic/claude-haiku-4.5`: writes appear only in the nested field and `prompt_tokens` already includes the cache breakdown (25612 = 25600 written + 12 uncached), so no folding is needed.