### PR TITLE
fix(config): scope keyring fallback to config paths

### DIFF
--- a/crates/goose/src/config/base.rs
+++ b/crates/goose/src/config/base.rs
@@ -974,17 +974,18 @@ impl Config {
 
     fn secrets_mutation_lock_paths(&self) -> Result<Vec<PathBuf>, ConfigError> {
         let fallback_lock = secrets_lock_path(&private_file_target_path(self.secrets_file_path())?);
-        let mut lock_paths = match &self.secrets {
+        match &self.secrets {
             #[cfg(feature = "system-keyring")]
-            SecretStorage::Keyring { service, .. } => vec![
-                private_file_target_path(&keyring_lock_path(service))?,
-                fallback_lock,
-            ],
-            SecretStorage::File { .. } => vec![fallback_lock],
-        };
-        lock_paths.sort_unstable();
-        lock_paths.dedup();
-        Ok(lock_paths)
+            SecretStorage::Keyring { service, .. } => {
+                let service_lock = private_file_target_path(&keyring_lock_path(service))?;
+                if service_lock == fallback_lock {
+                    Ok(vec![service_lock])
+                } else {
+                    Ok(vec![service_lock, fallback_lock])
+                }
+            }
+            SecretStorage::File { .. } => Ok(vec![fallback_lock]),
+        }
     }
 
     fn secrets_file_path(&self) -> &Path {
@@ -2382,6 +2383,31 @@ mod tests {
         assert_eq!(first_lock, keyring_lock_path("shared-service"));
         let expected_lock_dir = Paths::os_user_home_dir().join(".goose").join("locks");
         assert_eq!(first_lock.parent(), Some(expected_lock_dir.as_path()));
+    }
+
+    #[cfg(all(feature = "system-keyring", unix))]
+    #[test]
+    #[serial]
+    fn keyring_lock_order_is_independent_of_fallback_parent_aliases() -> Result<(), ConfigError> {
+        use std::os::unix::fs::symlink;
+
+        let directory = TempDir::new().unwrap();
+        let real_parent = directory.path().join("real");
+        let alias_parent = directory.path().join("alias");
+        std::fs::create_dir(&real_parent)?;
+        symlink(&real_parent, &alias_parent)?;
+        let _env = env_lock::lock_env([("GOOSE_DISABLE_KEYRING", None::<&str>)]);
+
+        let direct = Config::new(real_parent.join(CONFIG_YAML_NAME), "shared-service")?;
+        let aliased = Config::new(alias_parent.join(CONFIG_YAML_NAME), "shared-service")?;
+        let direct_locks = direct.secrets_mutation_lock_paths()?;
+        let aliased_locks = aliased.secrets_mutation_lock_paths()?;
+
+        assert_eq!(direct_locks[0], aliased_locks[0]);
+        assert_ne!(direct_locks[1], aliased_locks[1]);
+        assert_eq!(direct_locks[0], keyring_lock_path("shared-service"));
+
+        Ok(())
     }
 
     #[test]

--- a/crates/goose/src/config/base.rs
+++ b/crates/goose/src/config/base.rs
@@ -969,17 +969,21 @@ impl Config {
         }
     }
 
-    fn secrets_mutation_lock_path(&self) -> Result<PathBuf, ConfigError> {
-        match &self.secrets {
+    fn secrets_mutation_lock_paths(&self) -> Result<Vec<PathBuf>, ConfigError> {
+        let fallback_lock = secrets_lock_path(&private_file_target_path(self.secrets_file_path())?);
+        let mut lock_paths = match &self.secrets {
             #[cfg(feature = "system-keyring")]
-            SecretStorage::Keyring { service, .. } => {
-                Ok(private_file_target_path(&keyring_lock_path(service))?)
-            }
-            SecretStorage::File { path } => Ok(secrets_lock_path(&private_file_target_path(path)?)),
-        }
+            SecretStorage::Keyring { service, .. } => vec![
+                private_file_target_path(&keyring_lock_path(service))?,
+                fallback_lock,
+            ],
+            SecretStorage::File { .. } => vec![fallback_lock],
+        };
+        lock_paths.sort_unstable();
+        lock_paths.dedup();
+        Ok(lock_paths)
     }
 
-    #[cfg(feature = "system-keyring")]
     fn secrets_file_path(&self) -> &Path {
         match &self.secrets {
             #[cfg(feature = "system-keyring")]
@@ -988,26 +992,29 @@ impl Config {
         }
     }
 
-    fn lock_secrets_for_mutation(&self) -> Result<std::fs::File, ConfigError> {
-        let lock_path = self.secrets_mutation_lock_path()?;
-        if let Some(parent) = lock_path
-            .parent()
-            .filter(|parent| !parent.as_os_str().is_empty())
-        {
-            std::fs::create_dir_all(parent)
-                .map_err(|e| ConfigError::DirectoryError(e.to_string()))?;
-        }
+    fn lock_secrets_for_mutation(&self) -> Result<Vec<std::fs::File>, ConfigError> {
+        let mut lock_files = Vec::new();
+        for lock_path in self.secrets_mutation_lock_paths()? {
+            if let Some(parent) = lock_path
+                .parent()
+                .filter(|parent| !parent.as_os_str().is_empty())
+            {
+                std::fs::create_dir_all(parent)
+                    .map_err(|e| ConfigError::DirectoryError(e.to_string()))?;
+            }
 
-        let lock_file = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .create(true)
-            .truncate(false)
-            .open(lock_path)?;
-        lock_file
-            .lock_exclusive()
-            .map_err(|e| ConfigError::LockError(e.to_string()))?;
-        Ok(lock_file)
+            let lock_file = OpenOptions::new()
+                .read(true)
+                .write(true)
+                .create(true)
+                .truncate(false)
+                .open(lock_path)?;
+            lock_file
+                .lock_exclusive()
+                .map_err(|e| ConfigError::LockError(e.to_string()))?;
+            lock_files.push(lock_file);
+        }
+        Ok(lock_files)
     }
 
     fn write_all_secrets(&self, values: &HashMap<String, Value>) -> Result<(), ConfigError> {
@@ -1739,8 +1746,8 @@ mod tests {
         let aliased = Config::new_with_file_secrets(&config_path, &secrets_alias)?;
 
         assert_eq!(
-            direct.secrets_mutation_lock_path()?,
-            aliased.secrets_mutation_lock_path()?
+            direct.secrets_mutation_lock_paths()?,
+            aliased.secrets_mutation_lock_paths()?
         );
 
         Ok(())
@@ -2295,9 +2302,19 @@ mod tests {
             )?,
             "keyring-success"
         );
+        let service_lock = private_file_target_path(&keyring_lock_path("custom-service"))?;
+        let fallback_lock = secrets_lock_path(&private_file_target_path(&custom_secrets_path)?);
+        let config_locks = config.secrets_mutation_lock_paths()?;
+        assert!(config_locks.contains(&service_lock));
+        assert!(config_locks.contains(&fallback_lock));
+
+        let file_config = Config::new_with_file_secrets(
+            custom_dir.path().join("file-config.yaml"),
+            &custom_secrets_path,
+        )?;
         assert_eq!(
-            config.secrets_mutation_lock_path()?,
-            private_file_target_path(&keyring_lock_path("custom-service"))?
+            file_config.secrets_mutation_lock_paths()?,
+            vec![fallback_lock]
         );
 
         let second_custom_dir = TempDir::new().unwrap();
@@ -2306,10 +2323,9 @@ mod tests {
             "custom-service",
         )?;
         assert_ne!(config.secrets_file_path(), same_service.secrets_file_path());
-        assert_eq!(
-            config.secrets_mutation_lock_path()?,
-            same_service.secrets_mutation_lock_path()?
-        );
+        assert!(same_service
+            .secrets_mutation_lock_paths()?
+            .contains(&service_lock));
 
         let loaded = config.fallback_to_file_storage()?;
         assert_eq!(

--- a/crates/goose/src/config/base.rs
+++ b/crates/goose/src/config/base.rs
@@ -34,7 +34,7 @@ fn secrets_lock_path(path: &Path) -> PathBuf {
 #[cfg(feature = "system-keyring")]
 fn keyring_lock_path(service: &str) -> PathBuf {
     let service_hash = URL_SAFE_NO_PAD.encode(Sha256::digest(service.as_bytes()));
-    Paths::default_home_dir()
+    Paths::os_user_home_dir()
         .join(".goose")
         .join("locks")
         .join(format!("keyring-{service_hash}.lock"))
@@ -2371,14 +2371,16 @@ mod tests {
         let _env = env_lock::lock_env([
             ("GOOSE_PATH_ROOT", first_root.path().to_str()),
             ("XDG_CONFIG_HOME", first_root.path().to_str()),
+            ("HOME", first_root.path().to_str()),
         ]);
 
         let first_lock = keyring_lock_path("shared-service");
         std::env::set_var("GOOSE_PATH_ROOT", second_root.path());
         std::env::set_var("XDG_CONFIG_HOME", second_root.path());
+        std::env::set_var("HOME", second_root.path());
 
         assert_eq!(first_lock, keyring_lock_path("shared-service"));
-        let expected_lock_dir = Paths::default_home_dir().join(".goose").join("locks");
+        let expected_lock_dir = Paths::os_user_home_dir().join(".goose").join("locks");
         assert_eq!(first_lock.parent(), Some(expected_lock_dir.as_path()));
     }
 

--- a/crates/goose/src/config/base.rs
+++ b/crates/goose/src/config/base.rs
@@ -34,7 +34,10 @@ fn secrets_lock_path(path: &Path) -> PathBuf {
 #[cfg(feature = "system-keyring")]
 fn keyring_lock_path(service: &str) -> PathBuf {
     let service_hash = URL_SAFE_NO_PAD.encode(Sha256::digest(service.as_bytes()));
-    Paths::default_config_dir().join(format!("keyring-{service_hash}.lock"))
+    Paths::default_home_dir()
+        .join(".goose")
+        .join("locks")
+        .join(format!("keyring-{service_hash}.lock"))
 }
 
 #[cfg(feature = "system-keyring")]
@@ -2365,19 +2368,21 @@ mod tests {
     #[cfg(feature = "system-keyring")]
     #[test]
     #[serial]
-    fn keyring_service_lock_is_independent_of_path_root() {
+    fn keyring_service_lock_is_independent_of_config_roots() {
         let first_root = TempDir::new().unwrap();
         let second_root = TempDir::new().unwrap();
-        let _env = env_lock::lock_env([("GOOSE_PATH_ROOT", first_root.path().to_str())]);
+        let _env = env_lock::lock_env([
+            ("GOOSE_PATH_ROOT", first_root.path().to_str()),
+            ("XDG_CONFIG_HOME", first_root.path().to_str()),
+        ]);
 
         let first_lock = keyring_lock_path("shared-service");
         std::env::set_var("GOOSE_PATH_ROOT", second_root.path());
+        std::env::set_var("XDG_CONFIG_HOME", second_root.path());
 
         assert_eq!(first_lock, keyring_lock_path("shared-service"));
-        assert_eq!(
-            first_lock.parent(),
-            Some(Paths::default_config_dir().as_path())
-        );
+        let expected_lock_dir = Paths::default_home_dir().join(".goose").join("locks");
+        assert_eq!(first_lock.parent(), Some(expected_lock_dir.as_path()));
     }
 
     #[test]

--- a/crates/goose/src/config/base.rs
+++ b/crates/goose/src/config/base.rs
@@ -1151,9 +1151,6 @@ impl Config {
     #[cfg(feature = "system-keyring")]
     fn write_secrets_to_file(&self, values: &HashMap<String, Value>) -> Result<(), ConfigError> {
         let fallback_path = self.secrets_file_path();
-        if let Some(parent) = fallback_path.parent() {
-            std::fs::create_dir_all(parent)?;
-        }
         let yaml_value = serde_yaml::to_string(values)?;
         write_secrets_file(fallback_path, &yaml_value)?;
         Ok(())

--- a/crates/goose/src/config/base.rs
+++ b/crates/goose/src/config/base.rs
@@ -32,12 +32,38 @@ fn secrets_lock_path(path: &Path) -> PathBuf {
 }
 
 #[cfg(feature = "system-keyring")]
-fn keyring_lock_path(service: &str) -> PathBuf {
+fn keyring_lock_path(service: &str) -> Result<PathBuf, ConfigError> {
+    keyring_lock_path_with_roots(
+        service,
+        Paths::os_user_home_dir(),
+        Paths::path_root(),
+        env::var_os("HOME").map(PathBuf::from),
+    )
+}
+
+#[cfg(feature = "system-keyring")]
+fn keyring_lock_path_with_roots(
+    service: &str,
+    os_user_home: Option<PathBuf>,
+    path_root: Option<PathBuf>,
+    environment_home: Option<PathBuf>,
+) -> Result<PathBuf, ConfigError> {
     let service_hash = URL_SAFE_NO_PAD.encode(Sha256::digest(service.as_bytes()));
-    Paths::os_user_home_dir()
-        .join(".goose")
-        .join("locks")
-        .join(format!("keyring-{service_hash}.lock"))
+    let lock_directory = os_user_home
+        .map(|home| home.join(".goose").join("locks"))
+        .or_else(|| path_root.map(|root| root.join("state").join("locks")))
+        .or_else(|| {
+            environment_home
+                .filter(|home| home.is_absolute())
+                .map(|home| home.join(".goose").join("locks"))
+        })
+        .ok_or_else(|| {
+            ConfigError::LockError(
+                "unable to determine keyring lock directory: no passwd home, GOOSE_PATH_ROOT, or HOME"
+                    .to_string(),
+            )
+        })?;
+    Ok(lock_directory.join(format!("keyring-{service_hash}.lock")))
 }
 
 #[cfg(feature = "system-keyring")]
@@ -977,7 +1003,7 @@ impl Config {
         match &self.secrets {
             #[cfg(feature = "system-keyring")]
             SecretStorage::Keyring { service, .. } => {
-                let service_lock = private_file_target_path(&keyring_lock_path(service))?;
+                let service_lock = private_file_target_path(&keyring_lock_path(service)?)?;
                 if service_lock == fallback_lock {
                     Ok(vec![service_lock])
                 } else {
@@ -2303,7 +2329,7 @@ mod tests {
             )?,
             "keyring-success"
         );
-        let service_lock = private_file_target_path(&keyring_lock_path("custom-service"))?;
+        let service_lock = private_file_target_path(&keyring_lock_path("custom-service")?)?;
         let fallback_lock = secrets_lock_path(&private_file_target_path(&custom_secrets_path)?);
         let config_locks = config.secrets_mutation_lock_paths()?;
         assert!(config_locks.contains(&service_lock));
@@ -2366,7 +2392,7 @@ mod tests {
     #[cfg(feature = "system-keyring")]
     #[test]
     #[serial]
-    fn keyring_service_lock_is_independent_of_config_roots() {
+    fn keyring_service_lock_is_independent_of_config_roots() -> Result<(), ConfigError> {
         let first_root = TempDir::new().unwrap();
         let second_root = TempDir::new().unwrap();
         let _env = env_lock::lock_env([
@@ -2375,14 +2401,67 @@ mod tests {
             ("HOME", first_root.path().to_str()),
         ]);
 
-        let first_lock = keyring_lock_path("shared-service");
+        let first_lock = keyring_lock_path("shared-service")?;
         std::env::set_var("GOOSE_PATH_ROOT", second_root.path());
         std::env::set_var("XDG_CONFIG_HOME", second_root.path());
         std::env::set_var("HOME", second_root.path());
 
-        assert_eq!(first_lock, keyring_lock_path("shared-service"));
-        let expected_lock_dir = Paths::os_user_home_dir().join(".goose").join("locks");
+        assert_eq!(first_lock, keyring_lock_path("shared-service")?);
+        let expected_lock_dir = Paths::os_user_home_dir()
+            .unwrap()
+            .join(".goose")
+            .join("locks");
         assert_eq!(first_lock.parent(), Some(expected_lock_dir.as_path()));
+        Ok(())
+    }
+
+    #[cfg(feature = "system-keyring")]
+    #[test]
+    fn keyring_service_lock_uses_path_root_without_passwd_home() -> Result<(), ConfigError> {
+        let path_root = TempDir::new().unwrap();
+        let environment_home = TempDir::new().unwrap();
+
+        let lock_path = keyring_lock_path_with_roots(
+            "shared-service",
+            None,
+            Some(path_root.path().to_path_buf()),
+            Some(environment_home.path().to_path_buf()),
+        )?;
+
+        assert_eq!(
+            lock_path.parent(),
+            Some(path_root.path().join("state/locks").as_path())
+        );
+        Ok(())
+    }
+
+    #[cfg(feature = "system-keyring")]
+    #[test]
+    fn keyring_service_lock_uses_home_without_passwd_home_or_path_root() -> Result<(), ConfigError>
+    {
+        let environment_home = TempDir::new().unwrap();
+
+        let lock_path = keyring_lock_path_with_roots(
+            "shared-service",
+            None,
+            None,
+            Some(environment_home.path().to_path_buf()),
+        )?;
+
+        assert_eq!(
+            lock_path.parent(),
+            Some(environment_home.path().join(".goose/locks").as_path())
+        );
+        Ok(())
+    }
+
+    #[cfg(feature = "system-keyring")]
+    #[test]
+    fn keyring_service_lock_errors_without_a_stable_root() {
+        assert!(matches!(
+            keyring_lock_path_with_roots("shared-service", None, None, None),
+            Err(ConfigError::LockError(_))
+        ));
     }
 
     #[cfg(all(feature = "system-keyring", unix))]
@@ -2405,7 +2484,7 @@ mod tests {
 
         assert_eq!(direct_locks[0], aliased_locks[0]);
         assert_ne!(direct_locks[1], aliased_locks[1]);
-        assert_eq!(direct_locks[0], keyring_lock_path("shared-service"));
+        assert_eq!(direct_locks[0], keyring_lock_path("shared-service")?);
 
         Ok(())
     }

--- a/crates/goose/src/config/base.rs
+++ b/crates/goose/src/config/base.rs
@@ -142,6 +142,7 @@ enum SecretStorage {
     #[cfg(feature = "system-keyring")]
     Keyring {
         service: String,
+        fallback_path: PathBuf,
     },
     File {
         path: PathBuf,
@@ -405,6 +406,7 @@ fn secret_storage(config_dir: &Path, keyring_disabled: bool, service: &str) -> S
     } else {
         SecretStorage::Keyring {
             service: service.to_string(),
+            fallback_path: secrets_file_path_in(config_dir),
         }
     }
 }
@@ -923,7 +925,7 @@ impl Config {
     fn load_secrets_from_storage(&self) -> Result<HashMap<String, Value>, ConfigError> {
         match &self.secrets {
             #[cfg(feature = "system-keyring")]
-            SecretStorage::Keyring { service } => {
+            SecretStorage::Keyring { service, .. } => {
                 let result = match Self::read_keyring_password_with_timeout(service) {
                     Ok(content) => Ok(content),
                     // A timed-out read says nothing about whether secrets
@@ -941,7 +943,6 @@ impl Config {
                         self.handle_keyring_fallback_error(&keyring_err, None)
                     }
                 };
-
                 match result {
                     Ok(content) => Ok(serde_json::from_str(&content)?),
                     Err(ConfigError::FallbackToFileStorage) => self.fallback_to_file_storage(),
@@ -959,12 +960,17 @@ impl Config {
     }
 
     fn secrets_mutation_lock_path(&self) -> Result<PathBuf, ConfigError> {
-        let storage_path = match &self.secrets {
+        Ok(secrets_lock_path(&private_file_target_path(
+            self.secrets_file_path(),
+        )?))
+    }
+
+    fn secrets_file_path(&self) -> &Path {
+        match &self.secrets {
             #[cfg(feature = "system-keyring")]
-            SecretStorage::Keyring { .. } => Self::secrets_file_path(),
-            SecretStorage::File { path } => path.clone(),
-        };
-        Ok(secrets_lock_path(&private_file_target_path(&storage_path)?))
+            SecretStorage::Keyring { fallback_path, .. } => fallback_path,
+            SecretStorage::File { path } => path,
+        }
     }
 
     fn lock_secrets_for_mutation(&self) -> Result<std::fs::File, ConfigError> {
@@ -992,7 +998,7 @@ impl Config {
     fn write_all_secrets(&self, values: &HashMap<String, Value>) -> Result<(), ConfigError> {
         match &self.secrets {
             #[cfg(feature = "system-keyring")]
-            SecretStorage::Keyring { service } => {
+            SecretStorage::Keyring { service, .. } => {
                 let json_value = serde_json::to_string(values)?;
                 match self.handle_keyring_operation(
                     |entry| entry.set_password(&json_value),
@@ -1110,26 +1116,21 @@ impl Config {
         }
     }
 
-    /// Get the path to the secrets storage file
-    #[cfg(feature = "system-keyring")]
-    fn secrets_file_path() -> PathBuf {
-        secrets_file_path_in(&Paths::config_dir())
-    }
-
     /// Fall back to file storage when keyring is unavailable
     #[cfg(feature = "system-keyring")]
     fn fallback_to_file_storage(&self) -> Result<HashMap<String, Value>, ConfigError> {
-        let path = Self::secrets_file_path();
-        self.read_secrets_from_file(&path)
+        self.read_secrets_from_file(self.secrets_file_path())
     }
 
     /// Write secrets to file storage (used for fallback)
     #[cfg(feature = "system-keyring")]
     fn write_secrets_to_file(&self, values: &HashMap<String, Value>) -> Result<(), ConfigError> {
-        std::fs::create_dir_all(Paths::config_dir())?;
-        let path = Self::secrets_file_path();
+        let fallback_path = self.secrets_file_path();
+        if let Some(parent) = fallback_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
         let yaml_value = serde_yaml::to_string(values)?;
-        write_secrets_file(&path, &yaml_value)?;
+        write_secrets_file(fallback_path, &yaml_value)?;
         Ok(())
     }
 
@@ -2240,6 +2241,111 @@ mod tests {
         let config_file = NamedTempFile::new().unwrap();
         let secrets_file = NamedTempFile::new().unwrap();
         Config::new_with_file_secrets(config_file.path(), secrets_file.path()).unwrap()
+    }
+
+    #[cfg(feature = "system-keyring")]
+    #[test]
+    #[serial]
+    fn custom_config_keyring_fallback_stays_in_custom_directory() -> Result<(), ConfigError> {
+        let global_root = TempDir::new().unwrap();
+        let custom_dir = TempDir::new().unwrap();
+        let _env = env_lock::lock_env([
+            ("GOOSE_PATH_ROOT", global_root.path().to_str()),
+            ("GOOSE_DISABLE_KEYRING", None),
+        ]);
+
+        let global_secrets_path = Paths::config_dir().join("secrets.yaml");
+        std::fs::create_dir_all(global_secrets_path.parent().unwrap())?;
+        std::fs::write(&global_secrets_path, "GLOBAL_ONLY: global\n")?;
+
+        let custom_secrets_path = custom_dir.path().join("secrets.yaml");
+        std::fs::write(&custom_secrets_path, "CUSTOM_ONLY: custom\n")?;
+        let config = Config::new(custom_dir.path().join(CONFIG_YAML_NAME), "custom-service")?;
+
+        match &config.secrets {
+            SecretStorage::Keyring {
+                service,
+                fallback_path,
+            } => {
+                assert_eq!(service, "custom-service");
+                assert_eq!(fallback_path, &custom_secrets_path);
+            }
+            SecretStorage::File { .. } => panic!("keyring should remain enabled"),
+        }
+        assert_eq!(
+            config.handle_keyring_operation(
+                |_| Ok::<_, keyring::Error>("keyring-success"),
+                "custom-service",
+                None,
+            )?,
+            "keyring-success"
+        );
+        assert_eq!(
+            config.secrets_mutation_lock_path()?,
+            secrets_lock_path(&private_file_target_path(&custom_secrets_path)?)
+        );
+
+        let loaded = config.fallback_to_file_storage()?;
+        assert_eq!(
+            loaded.get("CUSTOM_ONLY"),
+            Some(&Value::String("custom".into()))
+        );
+        assert!(!loaded.contains_key("GLOBAL_ONLY"));
+
+        let updated = HashMap::from([("CUSTOM_ONLY".to_string(), Value::String("updated".into()))]);
+        config.write_secrets_to_file(&updated)?;
+
+        assert_eq!(
+            std::fs::read_to_string(&global_secrets_path)?,
+            "GLOBAL_ONLY: global\n"
+        );
+        assert_eq!(
+            config.read_secrets_from_file(&custom_secrets_path)?,
+            updated
+        );
+
+        let global_config =
+            Config::new(Paths::config_dir().join(CONFIG_YAML_NAME), "global-service")?;
+        match &global_config.secrets {
+            SecretStorage::Keyring {
+                service,
+                fallback_path,
+            } => {
+                assert_eq!(service, "global-service");
+                assert_eq!(fallback_path, &global_secrets_path);
+            }
+            SecretStorage::File { .. } => panic!("keyring should remain enabled"),
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn custom_config_with_disabled_keyring_uses_sibling_secret_file() -> Result<(), ConfigError> {
+        let global_root = TempDir::new().unwrap();
+        let custom_dir = TempDir::new().unwrap();
+        let _env = env_lock::lock_env([
+            ("GOOSE_PATH_ROOT", global_root.path().to_str()),
+            ("GOOSE_DISABLE_KEYRING", Some("1")),
+        ]);
+
+        let custom_secrets_path = custom_dir.path().join("secrets.yaml");
+        let config = Config::new(custom_dir.path().join(CONFIG_YAML_NAME), "unused-service")?;
+        match &config.secrets {
+            SecretStorage::File { path } => assert_eq!(path, &custom_secrets_path),
+            #[cfg(feature = "system-keyring")]
+            SecretStorage::Keyring { .. } => panic!("keyring should be disabled"),
+        }
+
+        config.set_secret("CUSTOM_ONLY", &"custom")?;
+        assert_eq!(
+            config.read_secrets_from_file(&custom_secrets_path)?,
+            HashMap::from([("CUSTOM_ONLY".to_string(), Value::String("custom".into()))])
+        );
+        assert!(!Paths::config_dir().join("secrets.yaml").exists());
+
+        Ok(())
     }
 
     /// Create a test config where `base_content` is a lower-priority layer

--- a/crates/goose/src/config/base.rs
+++ b/crates/goose/src/config/base.rs
@@ -34,7 +34,7 @@ fn secrets_lock_path(path: &Path) -> PathBuf {
 #[cfg(feature = "system-keyring")]
 fn keyring_lock_path(service: &str) -> PathBuf {
     let service_hash = URL_SAFE_NO_PAD.encode(Sha256::digest(service.as_bytes()));
-    Paths::config_dir().join(format!("keyring-{service_hash}.lock"))
+    Paths::default_config_dir().join(format!("keyring-{service_hash}.lock"))
 }
 
 #[cfg(feature = "system-keyring")]
@@ -2360,6 +2360,24 @@ mod tests {
         }
 
         Ok(())
+    }
+
+    #[cfg(feature = "system-keyring")]
+    #[test]
+    #[serial]
+    fn keyring_service_lock_is_independent_of_path_root() {
+        let first_root = TempDir::new().unwrap();
+        let second_root = TempDir::new().unwrap();
+        let _env = env_lock::lock_env([("GOOSE_PATH_ROOT", first_root.path().to_str())]);
+
+        let first_lock = keyring_lock_path("shared-service");
+        std::env::set_var("GOOSE_PATH_ROOT", second_root.path());
+
+        assert_eq!(first_lock, keyring_lock_path("shared-service"));
+        assert_eq!(
+            first_lock.parent(),
+            Some(Paths::default_config_dir().as_path())
+        );
     }
 
     #[test]

--- a/crates/goose/src/config/base.rs
+++ b/crates/goose/src/config/base.rs
@@ -49,21 +49,34 @@ fn keyring_lock_path_with_roots(
     environment_home: Option<PathBuf>,
 ) -> Result<PathBuf, ConfigError> {
     let service_hash = URL_SAFE_NO_PAD.encode(Sha256::digest(service.as_bytes()));
-    let lock_directory = os_user_home
-        .map(|home| home.join(".goose").join("locks"))
-        .or_else(|| path_root.map(|root| root.join("state").join("locks")))
-        .or_else(|| {
-            environment_home
-                .filter(|home| home.is_absolute())
-                .map(|home| home.join(".goose").join("locks"))
-        })
-        .ok_or_else(|| {
-            ConfigError::LockError(
-                "unable to determine keyring lock directory: no passwd home, GOOSE_PATH_ROOT, or HOME"
-                    .to_string(),
-            )
-        })?;
-    Ok(lock_directory.join(format!("keyring-{service_hash}.lock")))
+    let lock_name = format!("keyring-{service_hash}.lock");
+    [
+        os_user_home.map(|home| home.join(".goose").join("locks")),
+        path_root.map(|root| root.join("state").join("locks")),
+        environment_home
+            .filter(|home| home.is_absolute())
+            .map(|home| home.join(".goose").join("locks")),
+    ]
+    .into_iter()
+    .flatten()
+    .find_map(|directory| {
+        let lock_path = private_file_target_path(&directory.join(&lock_name)).ok()?;
+        std::fs::create_dir_all(lock_path.parent()?).ok()?;
+        OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&lock_path)
+            .ok()?;
+        Some(lock_path)
+    })
+    .ok_or_else(|| {
+        ConfigError::LockError(
+            "unable to open a keyring lock under the passwd home, GOOSE_PATH_ROOT, or HOME"
+                .to_string(),
+        )
+    })
 }
 
 #[cfg(feature = "system-keyring")]
@@ -2426,6 +2439,28 @@ mod tests {
             None,
             Some(path_root.path().to_path_buf()),
             Some(environment_home.path().to_path_buf()),
+        )?;
+
+        assert_eq!(
+            lock_path.parent(),
+            Some(path_root.path().join("state/locks").as_path())
+        );
+        Ok(())
+    }
+
+    #[cfg(feature = "system-keyring")]
+    #[test]
+    fn keyring_service_lock_uses_path_root_when_passwd_home_is_unusable() -> Result<(), ConfigError>
+    {
+        let os_user_home = TempDir::new().unwrap();
+        let path_root = TempDir::new().unwrap();
+        std::fs::write(os_user_home.path().join(".goose"), "not a directory")?;
+
+        let lock_path = keyring_lock_path_with_roots(
+            "shared-service",
+            Some(os_user_home.path().to_path_buf()),
+            Some(path_root.path().to_path_buf()),
+            None,
         )?;
 
         assert_eq!(

--- a/crates/goose/src/config/base.rs
+++ b/crates/goose/src/config/base.rs
@@ -1,6 +1,8 @@
 use crate::config::paths::Paths;
 use crate::config::GooseMode;
 use crate::providers::private_file::{private_file_target_path, write_private_file};
+#[cfg(feature = "system-keyring")]
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 use fs2::FileExt;
 use goose_providers::thinking::ThinkingEffort;
 #[cfg(feature = "system-keyring")]
@@ -9,6 +11,8 @@ use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use serde_yaml::Mapping;
+#[cfg(feature = "system-keyring")]
+use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::env;
 use std::fs::OpenOptions;
@@ -25,6 +29,12 @@ fn secrets_lock_path(path: &Path) -> PathBuf {
     let mut lock_path = path.as_os_str().to_os_string();
     lock_path.push(".lock");
     PathBuf::from(lock_path)
+}
+
+#[cfg(feature = "system-keyring")]
+fn keyring_lock_path(service: &str) -> PathBuf {
+    let service_hash = URL_SAFE_NO_PAD.encode(Sha256::digest(service.as_bytes()));
+    Paths::config_dir().join(format!("keyring-{service_hash}.lock"))
 }
 
 #[cfg(feature = "system-keyring")]
@@ -960,11 +970,16 @@ impl Config {
     }
 
     fn secrets_mutation_lock_path(&self) -> Result<PathBuf, ConfigError> {
-        Ok(secrets_lock_path(&private_file_target_path(
-            self.secrets_file_path(),
-        )?))
+        match &self.secrets {
+            #[cfg(feature = "system-keyring")]
+            SecretStorage::Keyring { service, .. } => {
+                Ok(private_file_target_path(&keyring_lock_path(service))?)
+            }
+            SecretStorage::File { path } => Ok(secrets_lock_path(&private_file_target_path(path)?)),
+        }
     }
 
+    #[cfg(feature = "system-keyring")]
     fn secrets_file_path(&self) -> &Path {
         match &self.secrets {
             #[cfg(feature = "system-keyring")]
@@ -2282,7 +2297,18 @@ mod tests {
         );
         assert_eq!(
             config.secrets_mutation_lock_path()?,
-            secrets_lock_path(&private_file_target_path(&custom_secrets_path)?)
+            private_file_target_path(&keyring_lock_path("custom-service"))?
+        );
+
+        let second_custom_dir = TempDir::new().unwrap();
+        let same_service = Config::new(
+            second_custom_dir.path().join(CONFIG_YAML_NAME),
+            "custom-service",
+        )?;
+        assert_ne!(config.secrets_file_path(), same_service.secrets_file_path());
+        assert_eq!(
+            config.secrets_mutation_lock_path()?,
+            same_service.secrets_mutation_lock_path()?
         );
 
         let loaded = config.fallback_to_file_storage()?;

--- a/crates/goose/src/config/paths.rs
+++ b/crates/goose/src/config/paths.rs
@@ -53,8 +53,9 @@ impl Paths {
         Self::get_dir(DirType::Config)
     }
 
-    pub(crate) fn default_config_dir() -> PathBuf {
-        Self::app_strategy().config_dir()
+    #[cfg(feature = "system-keyring")]
+    pub(crate) fn default_home_dir() -> PathBuf {
+        Self::app_strategy().home_dir().to_path_buf()
     }
 
     pub fn data_dir() -> PathBuf {

--- a/crates/goose/src/config/paths.rs
+++ b/crates/goose/src/config/paths.rs
@@ -1,6 +1,56 @@
 use etcetera::{choose_app_strategy, AppStrategy, AppStrategyArgs};
+#[cfg(all(feature = "system-keyring", unix, not(target_os = "redox")))]
+use std::ffi::CStr;
 use std::ffi::OsString;
+#[cfg(all(feature = "system-keyring", unix, not(target_os = "redox")))]
+use std::mem::MaybeUninit;
+#[cfg(all(feature = "system-keyring", unix, not(target_os = "redox")))]
+use std::os::unix::ffi::OsStringExt;
 use std::path::PathBuf;
+#[cfg(all(feature = "system-keyring", unix, not(target_os = "redox")))]
+use std::ptr;
+
+#[cfg(all(feature = "system-keyring", unix, not(target_os = "redox")))]
+fn os_user_home_dir() -> Option<PathBuf> {
+    // SAFETY: sysconf reads a process-global constant and does not dereference pointers.
+    let buffer_size = unsafe { libc::sysconf(libc::_SC_GETPW_R_SIZE_MAX) };
+    let buffer_size = if buffer_size < 0 {
+        512
+    } else {
+        buffer_size as usize
+    };
+    let mut buffer = vec![0_u8; buffer_size];
+    let mut passwd = MaybeUninit::<libc::passwd>::uninit();
+    let mut result = ptr::null_mut();
+
+    // SAFETY: passwd and buffer are valid writable allocations for the duration of the call.
+    let status = unsafe {
+        libc::getpwuid_r(
+            libc::getuid(),
+            passwd.as_mut_ptr(),
+            buffer.as_mut_ptr().cast(),
+            buffer.len(),
+            &mut result,
+        )
+    };
+    if status != 0 || result.is_null() {
+        return None;
+    }
+
+    // SAFETY: a successful getpwuid_r initialized passwd.
+    let passwd = unsafe { passwd.assume_init() };
+    if passwd.pw_dir.is_null() {
+        return None;
+    }
+    // SAFETY: pw_dir is a non-null, null-terminated string owned by passwd's buffer.
+    let bytes = unsafe { CStr::from_ptr(passwd.pw_dir) }.to_bytes();
+    (!bytes.is_empty()).then(|| PathBuf::from(OsString::from_vec(bytes.to_vec())))
+}
+
+#[cfg(all(feature = "system-keyring", any(not(unix), target_os = "redox")))]
+fn os_user_home_dir() -> Option<PathBuf> {
+    dirs::home_dir()
+}
 
 pub struct Paths;
 
@@ -54,8 +104,8 @@ impl Paths {
     }
 
     #[cfg(feature = "system-keyring")]
-    pub(crate) fn default_home_dir() -> PathBuf {
-        Self::app_strategy().home_dir().to_path_buf()
+    pub(crate) fn os_user_home_dir() -> PathBuf {
+        os_user_home_dir().expect("goose requires an OS user home dir")
     }
 
     pub fn data_dir() -> PathBuf {

--- a/crates/goose/src/config/paths.rs
+++ b/crates/goose/src/config/paths.rs
@@ -5,6 +5,18 @@ use std::path::PathBuf;
 pub struct Paths;
 
 impl Paths {
+    fn app_strategy() -> impl AppStrategy {
+        // NOTE: "Block" is kept here for backwards compatibility with existing
+        // user config/data directories (e.g. ~/Library/Application Support/Block/goose/).
+        // Changing this would orphan existing installations.
+        choose_app_strategy(AppStrategyArgs {
+            top_level_domain: "Block".to_string(),
+            author: "Block".to_string(),
+            app_name: "goose".to_string(),
+        })
+        .expect("goose requires a home dir")
+    }
+
     fn get_dir(dir_type: DirType) -> PathBuf {
         if let Some(base) = Self::path_root() {
             match dir_type {
@@ -16,15 +28,7 @@ impl Paths {
                 DirType::AgentsHome => base.join(".agents"),
             }
         } else {
-            // NOTE: "Block" is kept here for backwards compatibility with existing
-            // user config/data directories (e.g. ~/Library/Application Support/Block/goose/).
-            // Changing this would orphan existing installations.
-            let strategy = choose_app_strategy(AppStrategyArgs {
-                top_level_domain: "Block".to_string(),
-                author: "Block".to_string(),
-                app_name: "goose".to_string(),
-            })
-            .expect("goose requires a home dir");
+            let strategy = Self::app_strategy();
 
             match dir_type {
                 DirType::Config => strategy.config_dir(),
@@ -47,6 +51,10 @@ impl Paths {
 
     pub fn config_dir() -> PathBuf {
         Self::get_dir(DirType::Config)
+    }
+
+    pub(crate) fn default_config_dir() -> PathBuf {
+        Self::app_strategy().config_dir()
     }
 
     pub fn data_dir() -> PathBuf {

--- a/crates/goose/src/config/paths.rs
+++ b/crates/goose/src/config/paths.rs
@@ -104,8 +104,8 @@ impl Paths {
     }
 
     #[cfg(feature = "system-keyring")]
-    pub(crate) fn os_user_home_dir() -> PathBuf {
-        os_user_home_dir().expect("goose requires an OS user home dir")
+    pub(crate) fn os_user_home_dir() -> Option<PathBuf> {
+        os_user_home_dir()
     }
 
     pub fn data_dir() -> PathBuf {


### PR DESCRIPTION
## Summary

- keep keyring fallback secret files scoped to each `Config` instance's directory
- preserve default/global paths, disabled-keyring storage, and successful keyring operations
- cover custom fallback reads, writes, and mutation locking without changing global secrets

## Validation

- `cargo test -p goose --lib --features system-keyring config::base::tests` (65 passed)
- `cargo test -p goose --lib custom_config_with_disabled_keyring_uses_sibling_secret_file` (passed)
- `cargo fmt`
- `cargo build`
- `cargo clippy --all-targets -- -D warnings`

*This finding was discovered by [Project Loupe](https://github.com/project-loupe/loupe)*
