### PR TITLE
fix(providers): drive pre-key model lists from the canonical registry

### DIFF
--- a/crates/goose-provider-types/src/base.rs
+++ b/crates/goose-provider-types/src/base.rs
@@ -8,7 +8,10 @@ use std::pin::Pin;
 use tokio::sync::watch;
 
 use crate::{
-    canonical::{catalog::ProviderSetupMetadata, map_to_canonical_model, CanonicalModelRegistry},
+    canonical::{
+        catalog::ProviderSetupMetadata, map_to_canonical_model, provider_wire_name,
+        recommended_models_from_registry, CanonicalModelRegistry,
+    },
     conversation::{
         message::{Message, MessageContentBlock},
         token_usage::{ProviderUsage, Usage},
@@ -359,6 +362,17 @@ pub fn model_info_for_provider_model(provider_name: &str, model_name: &str) -> M
         thinking_preservation_format: None,
         request_params: None,
     }
+}
+
+/// Pre-key picker list from the bundled catalog. No hardcoded fallback.
+pub fn known_models_from_registry(provider: &str) -> Vec<ModelInfo> {
+    recommended_models_from_registry(provider)
+        .into_iter()
+        .map(|name| {
+            let name = provider_wire_name(provider, &name);
+            model_info_for_provider_model(provider, &name)
+        })
+        .collect()
 }
 
 /// Collect all chunks from a MessageStream into a single Message and ProviderUsage

--- a/crates/goose-provider-types/src/base.rs
+++ b/crates/goose-provider-types/src/base.rs
@@ -364,7 +364,6 @@ pub fn model_info_for_provider_model(provider_name: &str, model_name: &str) -> M
     }
 }
 
-/// Pre-key picker list from the bundled catalog. No hardcoded fallback.
 pub fn known_models_from_registry(provider: &str) -> Vec<ModelInfo> {
     recommended_models_from_registry(provider)
         .into_iter()

--- a/crates/goose-provider-types/src/base.rs
+++ b/crates/goose-provider-types/src/base.rs
@@ -9,8 +9,8 @@ use tokio::sync::watch;
 
 use crate::{
     canonical::{
-        catalog::ProviderSetupMetadata, map_to_canonical_model, provider_wire_name,
-        recommended_models_from_registry, CanonicalModelRegistry,
+        catalog::ProviderSetupMetadata, map_to_canonical_model, recommended_models_from_registry,
+        CanonicalModelRegistry,
     },
     conversation::{
         message::{Message, MessageContentBlock},
@@ -367,10 +367,7 @@ pub fn model_info_for_provider_model(provider_name: &str, model_name: &str) -> M
 pub fn known_models_from_registry(provider: &str) -> Vec<ModelInfo> {
     recommended_models_from_registry(provider)
         .into_iter()
-        .map(|name| {
-            let name = provider_wire_name(provider, &name);
-            model_info_for_provider_model(provider, &name)
-        })
+        .map(|name| model_info_for_provider_model(provider, &name))
         .collect()
 }
 

--- a/crates/goose-provider-types/src/canonical.rs
+++ b/crates/goose-provider-types/src/canonical.rs
@@ -65,6 +65,34 @@ pub fn recommended_models_from_registry(provider: &str) -> Vec<String> {
         .collect()
 }
 
+/// Catalog names use dotted versions (`claude-sonnet-4.5`). Anthropic's API
+/// takes the dashed alias (`claude-sonnet-4-5`). Other providers keep catalog names.
+pub fn provider_wire_name(provider: &str, canonical_name: &str) -> String {
+    if map_provider_name(provider) == "anthropic" {
+        dotted_version_to_dash(canonical_name)
+    } else {
+        canonical_name.to_string()
+    }
+}
+
+fn dotted_version_to_dash(name: &str) -> String {
+    let bytes = name.as_bytes();
+    let mut out = String::with_capacity(name.len());
+    for (i, &b) in bytes.iter().enumerate() {
+        if b == b'.'
+            && i > 0
+            && i + 1 < bytes.len()
+            && bytes[i - 1].is_ascii_digit()
+            && bytes[i + 1].is_ascii_digit()
+        {
+            out.push('-');
+        } else {
+            out.push(b as char);
+        }
+    }
+    out
+}
+
 /// Catalog pricing is not valid for local inference: models served via ollama or a
 /// local runtime are actually free to run, so any catalog price would be misleading.
 ///
@@ -202,5 +230,18 @@ mod tests {
         assert_eq!(canonical.limit.context, 1_048_576);
         assert_eq!(canonical.reasoning, Some(true));
         assert_eq!(canonical.temperature, Some(false));
+    }
+
+    #[test]
+    fn anthropic_wire_name_uses_dashed_versions() {
+        assert_eq!(
+            provider_wire_name("anthropic", "claude-sonnet-4.5"),
+            "claude-sonnet-4-5"
+        );
+        assert_eq!(
+            provider_wire_name("anthropic", "claude-opus-5"),
+            "claude-opus-5"
+        );
+        assert_eq!(provider_wire_name("openai", "gpt-5.2"), "gpt-5.2");
     }
 }

--- a/crates/goose-provider-types/src/canonical.rs
+++ b/crates/goose-provider-types/src/canonical.rs
@@ -46,17 +46,24 @@ pub fn recommended_models_from_registry(provider: &str) -> Vec<String> {
     let mut models_with_dates: Vec<(String, Option<String>)> = all
         .iter()
         .filter(|m| m.modalities.input.contains(&Modality::Text) && m.tool_call)
+        .filter(|m| registry_provider != "openai" || !m.id.contains("realtime"))
         .filter_map(|m| {
             let (_, name) = m.id.split_once('/')?;
-            Some((name.to_string(), m.release_date.clone()))
+            Some((
+                provider_wire_name(provider, &m.id, name),
+                m.release_date.clone(),
+            ))
         })
         .collect();
 
-    models_with_dates.sort_by(|a, b| match (&a.1, &b.1) {
-        (Some(date_a), Some(date_b)) => date_b.cmp(date_a),
-        (Some(_), None) => std::cmp::Ordering::Less,
-        (None, Some(_)) => std::cmp::Ordering::Greater,
-        (None, None) => a.0.cmp(&b.0),
+    models_with_dates.sort_by(|a, b| {
+        let date_order = match (&a.1, &b.1) {
+            (Some(date_a), Some(date_b)) => date_b.cmp(date_a),
+            (Some(_), None) => std::cmp::Ordering::Less,
+            (None, Some(_)) => std::cmp::Ordering::Greater,
+            (None, None) => std::cmp::Ordering::Equal,
+        };
+        date_order.then_with(|| a.0.cmp(&b.0))
     });
 
     models_with_dates
@@ -65,12 +72,24 @@ pub fn recommended_models_from_registry(provider: &str) -> Vec<String> {
         .collect()
 }
 
-pub fn provider_wire_name(provider: &str, canonical_name: &str) -> String {
+pub fn provider_wire_name(provider: &str, canonical_id: &str, canonical_name: &str) -> String {
     if map_provider_name(provider) == "anthropic" {
-        dotted_version_to_dash(canonical_name)
-    } else {
-        canonical_name.to_string()
+        return dotted_version_to_dash(canonical_name);
     }
+
+    static REPORT: once_cell::sync::Lazy<serde_json::Value> = once_cell::sync::Lazy::new(|| {
+        serde_json::from_str(include_str!("canonical/data/canonical_mapping_report.json"))
+            .expect("bundled canonical mapping report must be valid")
+    });
+    REPORT["all_mappings"][provider]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter(|mapping| mapping["canonical_model"].as_str() == Some(canonical_id))
+        .filter_map(|mapping| mapping["provider_model"].as_str())
+        .min_by_key(|name| (!name.ends_with("-latest"), name.len(), *name))
+        .unwrap_or(canonical_name)
+        .to_string()
 }
 
 fn dotted_version_to_dash(name: &str) -> String {
@@ -233,13 +252,24 @@ mod tests {
     #[test]
     fn anthropic_wire_name_uses_dashed_versions() {
         assert_eq!(
-            provider_wire_name("anthropic", "claude-sonnet-4.5"),
+            provider_wire_name(
+                "anthropic",
+                "anthropic/claude-sonnet-4.5",
+                "claude-sonnet-4.5"
+            ),
             "claude-sonnet-4-5"
         );
         assert_eq!(
-            provider_wire_name("anthropic", "claude-opus-5"),
+            provider_wire_name("anthropic", "anthropic/claude-opus-5", "claude-opus-5"),
             "claude-opus-5"
         );
-        assert_eq!(provider_wire_name("openai", "gpt-5.2"), "gpt-5.2");
+        assert_eq!(
+            provider_wire_name("openai", "openai/gpt-5.2", "gpt-5.2"),
+            "gpt-5.2"
+        );
+        assert_eq!(
+            provider_wire_name("openai", "openai/gpt-5.2-chat", "gpt-5.2-chat"),
+            "gpt-5.2-chat-latest"
+        );
     }
 }

--- a/crates/goose-provider-types/src/canonical.rs
+++ b/crates/goose-provider-types/src/canonical.rs
@@ -65,8 +65,6 @@ pub fn recommended_models_from_registry(provider: &str) -> Vec<String> {
         .collect()
 }
 
-/// Catalog names use dotted versions (`claude-sonnet-4.5`). Anthropic's API
-/// takes the dashed alias (`claude-sonnet-4-5`). Other providers keep catalog names.
 pub fn provider_wire_name(provider: &str, canonical_name: &str) -> String {
     if map_provider_name(provider) == "anthropic" {
         dotted_version_to_dash(canonical_name)

--- a/crates/goose-providers/src/anthropic.rs
+++ b/crates/goose-providers/src/anthropic.rs
@@ -14,7 +14,9 @@ use tokio::pin;
 use tokio_util::io::StreamReader;
 
 use super::api_client::ApiClient;
-use super::base::{ConfigKey, MessageStream, ModelInfo, Provider, ProviderMetadata};
+use super::base::{
+    known_models_from_registry, ConfigKey, MessageStream, ModelInfo, Provider, ProviderMetadata,
+};
 use super::formats::anthropic::{
     block_binding_behavior, create_request_for_model, is_thinking_signature_error,
     response_to_streaming_message, AnthropicFormatOptions, PrefixMismatchBehavior,
@@ -27,29 +29,6 @@ use crate::model::ModelConfig;
 use rmcp::model::Tool;
 
 pub const ANTHROPIC_DEFAULT_MODEL: &str = "claude-sonnet-4-5";
-const ANTHROPIC_KNOWN_MODELS: &[&str] = &[
-    "claude-fable-5-1",
-    "claude-opus-5",
-    "claude-sonnet-5",
-    "claude-fable-5",
-    "claude-opus-4-8",
-    "claude-opus-4-7",
-    // Claude 4.6 models
-    "claude-opus-4-6",
-    "claude-sonnet-4-6",
-    // Claude 4.5 models with aliases
-    "claude-sonnet-4-5",
-    "claude-sonnet-4-5-20250929",
-    "claude-haiku-4-5",
-    "claude-haiku-4-5-20251001",
-    "claude-opus-4-5",
-    "claude-opus-4-5-20251101",
-    // Legacy Claude 4.0 models
-    "claude-sonnet-4-0",
-    "claude-sonnet-4-20250514",
-    "claude-opus-4-0",
-    "claude-opus-4-20250514",
-];
 
 const ANTHROPIC_DOC_URL: &str = "https://docs.anthropic.com/en/docs/about-claude/models";
 pub const ANTHROPIC_API_VERSION: &str = "2023-06-01";
@@ -339,17 +318,12 @@ impl AnthropicProvider {
 
 impl ProviderDescriptor for AnthropicProvider {
     fn metadata() -> ProviderMetadata {
-        let models: Vec<ModelInfo> = ANTHROPIC_KNOWN_MODELS
-            .iter()
-            .map(|&model_name| ModelInfo::new(model_name).with_context_limit(200_000))
-            .collect();
-
         ProviderMetadata::with_models(
             ANTHROPIC_PROVIDER_NAME,
             "Anthropic",
             "Claude and other models from Anthropic",
             ANTHROPIC_DEFAULT_MODEL,
-            models,
+            known_models_from_registry(ANTHROPIC_PROVIDER_NAME),
             ANTHROPIC_DOC_URL,
             vec![
                 ConfigKey::new("ANTHROPIC_API_KEY", true, true, None, true),
@@ -859,6 +833,24 @@ mod tests {
         assert_eq!(
             beta_header_value(&client, &ModelConfig::new("claude-opus-5"), &payload).as_deref(),
             Some("context-1m-2025-08-07,thinking-binding-controls-2026-08-01")
+        );
+    }
+
+    #[test]
+    fn metadata_comes_from_the_registry() {
+        let metadata = AnthropicProvider::metadata();
+        let sonnet = metadata
+            .known_models
+            .iter()
+            .find(|model| model.name == "claude-sonnet-4-5")
+            .expect("claude-sonnet-4-5 should come from the catalog");
+        assert_eq!(sonnet.context_limit, Some(1_000_000));
+        assert!(
+            metadata
+                .known_models
+                .iter()
+                .all(|model| !model.name.contains('.')),
+            "Anthropic picker ids must be dashed wire names, not dotted catalog names"
         );
     }
 }

--- a/crates/goose-providers/src/google.rs
+++ b/crates/goose-providers/src/google.rs
@@ -5,7 +5,7 @@ use crate::errors::ProviderError;
 use crate::openai_compatible::{handle_status, map_http_error_to_provider_error, sanitize_url};
 use crate::retry::ProviderRetry;
 
-use crate::base::{ConfigKey, Provider, ProviderMetadata};
+use crate::base::{known_models_from_registry, ConfigKey, Provider, ProviderMetadata};
 use crate::formats::google::{create_request_with_thinking_budget, response_to_streaming_message};
 use crate::model::ModelConfig;
 use crate::request_log::{start_log, LoggerHandleExt};
@@ -24,36 +24,6 @@ use tokio_util::io::StreamReader;
 pub const GOOGLE_PROVIDER_NAME: &str = "google";
 pub const GOOGLE_API_HOST: &str = "https://generativelanguage.googleapis.com";
 pub const GOOGLE_DEFAULT_MODEL: &str = "gemini-2.5-pro";
-pub const GOOGLE_KNOWN_MODELS: &[&str] = &[
-    "gemini-3.6-flash",
-    "gemini-3.5-flash",
-    "gemini-3.5-flash-lite",
-    // Gemini 3 models
-    "gemini-3-pro-preview",
-    "gemini-3-pro-image-preview",
-    // Gemini 2.5 Pro models
-    "gemini-2.5-pro",
-    "gemini-2.5-pro-preview-tts",
-    // Gemini 2.5 Flash models
-    "gemini-2.5-flash",
-    "gemini-2.5-flash-preview-09-2025",
-    "gemini-2.5-flash-image",
-    "gemini-2.5-flash-image-preview",
-    "gemini-2.5-flash-native-audio-preview-09-2025",
-    "gemini-2.5-flash-preview-tts",
-    // Gemini 2.5 Flash-Lite models
-    "gemini-2.5-flash-lite",
-    "gemini-2.5-flash-lite-preview-09-2025",
-    // Gemini 2.0 Flash models
-    "gemini-2.0-flash",
-    "gemini-2.0-flash-001",
-    "gemini-2.0-flash-exp",
-    "gemini-2.0-flash-preview-image-generation",
-    "gemini-2.0-flash-live-001",
-    // Gemini 2.0 Flash-Lite models
-    "gemini-2.0-flash-lite",
-    "gemini-2.0-flash-lite-001",
-];
 
 pub const GOOGLE_DOC_URL: &str = "https://ai.google.dev/gemini-api/docs/models";
 
@@ -115,12 +85,12 @@ impl GoogleProvider {
 
 impl crate::base::ProviderDescriptor for GoogleProvider {
     fn metadata() -> ProviderMetadata {
-        ProviderMetadata::new(
+        ProviderMetadata::with_models(
             GOOGLE_PROVIDER_NAME,
             "Google Gemini (API Key)",
             "Gemini models from Google AI",
             GOOGLE_DEFAULT_MODEL,
-            GOOGLE_KNOWN_MODELS.to_vec(),
+            known_models_from_registry(GOOGLE_PROVIDER_NAME),
             GOOGLE_DOC_URL,
             vec![
                 ConfigKey::new("GOOGLE_API_KEY", true, true, None, true),
@@ -217,5 +187,29 @@ impl Provider for GoogleProvider {
                 yield (message, usage);
             }
         }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::ProviderDescriptor;
+
+    #[test]
+    fn metadata_comes_from_the_registry() {
+        let metadata = GoogleProvider::metadata();
+        assert!(
+            metadata
+                .known_models
+                .iter()
+                .any(|model| model.name == GOOGLE_DEFAULT_MODEL),
+            "default model should be in the catalog-backed picker"
+        );
+        let pro = metadata
+            .known_models
+            .iter()
+            .find(|model| model.name == "gemini-2.5-pro")
+            .unwrap();
+        assert_eq!(pro.context_limit, Some(1_048_576));
     }
 }

--- a/crates/goose-providers/src/openai.rs
+++ b/crates/goose-providers/src/openai.rs
@@ -1,5 +1,5 @@
 use super::api_client::ApiClient;
-use super::base::{ConfigKey, ModelInfo, Provider, ProviderMetadata};
+use super::base::{known_models_from_registry, ConfigKey, ModelInfo, Provider, ProviderMetadata};
 use super::retry::ProviderRetry;
 use crate::api_client::{AuthMethod, TlsConfig};
 use crate::conversation::message::Message;
@@ -58,40 +58,6 @@ impl CachedContextLimit {
     }
 }
 pub const OPEN_AI_DEFAULT_MODEL: &str = "gpt-4o";
-pub const OPEN_AI_KNOWN_MODELS: &[(&str, usize)] = &[
-    ("gpt-4o", 128_000),
-    ("gpt-4o-mini", 128_000),
-    ("gpt-4.1", 1_047_576),
-    ("gpt-4.1-mini", 1_047_576),
-    ("gpt-4.1-nano", 1_047_576),
-    ("o1", 200_000),
-    ("o1-pro", 200_000),
-    ("o3", 200_000),
-    ("o3-mini", 200_000),
-    ("o3-pro", 200_000),
-    ("gpt-3.5-turbo", 16_385),
-    ("gpt-4-turbo", 128_000),
-    ("o4-mini", 200_000),
-    ("gpt-5", 400_000),
-    ("gpt-5-mini", 400_000),
-    ("gpt-5-nano", 400_000),
-    ("gpt-5-pro", 400_000),
-    ("gpt-5.1", 400_000),
-    ("gpt-5.2", 400_000),
-    ("gpt-5.2-pro", 400_000),
-    ("gpt-5.3-codex", 400_000),
-    ("gpt-5.4", 1_050_000),
-    ("gpt-5.4-mini", 400_000),
-    ("gpt-5.4-nano", 400_000),
-    ("gpt-5.4-pro", 1_050_000),
-    ("gpt-5.5", 1_050_000),
-    ("gpt-5.5-pro", 1_050_000),
-    ("gpt-5.6", 1_050_000),
-    ("gpt-5.6-sol", 1_050_000),
-    ("gpt-5.6-terra", 1_050_000),
-    ("gpt-5.6-luna", 1_050_000),
-    ("gpt-6-astra", 1_050_000),
-];
 
 pub const OPEN_AI_DOC_URL: &str = "https://platform.openai.com/docs/models";
 const DEFAULT_TIMEOUT_SECONDS: u64 = 600;
@@ -655,16 +621,12 @@ fn parse_n_ctx_from_models(json: &serde_json::Value, model_name: &str) -> Option
 
 impl ProviderDescriptor for OpenAiProvider {
     fn metadata() -> ProviderMetadata {
-        let models = OPEN_AI_KNOWN_MODELS
-            .iter()
-            .map(|(name, limit)| ModelInfo::new(*name).with_context_limit(*limit))
-            .collect();
         ProviderMetadata::with_models(
             OPEN_AI_PROVIDER_NAME,
             "OpenAI",
             "GPT-4 and other OpenAI models, including OpenAI compatible ones",
             OPEN_AI_DEFAULT_MODEL,
-            models,
+            known_models_from_registry(OPEN_AI_PROVIDER_NAME),
             OPEN_AI_DOC_URL,
             vec![
                 ConfigKey::new("OPENAI_API_KEY", false, true, None, true),
@@ -1907,5 +1869,23 @@ mod tests {
         assert_eq!(payload["stream"], json!(true));
         assert_eq!(payload["stream_options"], json!({"include_usage": true}));
         assert_eq!(payload["messages"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn metadata_comes_from_the_registry() {
+        let metadata = OpenAiProvider::metadata();
+        let gpt_4o = metadata
+            .known_models
+            .iter()
+            .find(|model| model.name == "gpt-4o")
+            .expect("gpt-4o should come from the catalog");
+        assert_eq!(gpt_4o.context_limit, Some(128_000));
+        assert!(
+            metadata
+                .known_models
+                .iter()
+                .any(|model| model.name == "gpt-4"),
+            "registry-only list should include models the old hardcoded list had drifted past"
+        );
     }
 }

--- a/crates/goose/src/providers/xai.rs
+++ b/crates/goose/src/providers/xai.rs
@@ -7,43 +7,13 @@ use futures::future::BoxFuture;
 const XAI_PROVIDER_NAME: &str = "xai";
 pub const XAI_API_HOST: &str = "https://api.x.ai/v1";
 pub const XAI_DEFAULT_MODEL: &str = "grok-4.5";
-pub const XAI_KNOWN_MODELS: &[&str] = &[
-    "grok-4.5",
-    "grok-4.3",
-    "grok-4.20-0309-reasoning",
-    "grok-4.20-0309-non-reasoning",
-    "grok-build-0.1",
-    "grok-code-fast-1",
-    "grok-4-0709",
-    "grok-3",
-    "grok-3-fast",
-    "grok-3-mini",
-    "grok-3-mini-fast",
-    "grok-2-vision-1212",
-    "grok-2-image-1212",
-    "grok-3-latest",
-    "grok-3-fast-latest",
-    "grok-3-mini-latest",
-    "grok-3-mini-fast-latest",
-    "grok-2-vision",
-    "grok-2-vision-latest",
-    "grok-2-image",
-    "grok-2-image-latest",
-    "grok-2",
-    "grok-2-latest",
-];
 
 pub const XAI_DOC_URL: &str = "https://docs.x.ai/docs/overview";
 
 pub struct XaiProvider;
 
 pub fn xai_known_model_info() -> Vec<goose_providers::base::ModelInfo> {
-    XAI_KNOWN_MODELS
-        .iter()
-        .map(|model_name| {
-            goose_providers::base::model_info_for_provider_model(XAI_PROVIDER_NAME, model_name)
-        })
-        .collect()
+    goose_providers::base::known_models_from_registry(XAI_PROVIDER_NAME)
 }
 
 impl goose_providers::base::ProviderDescriptor for XaiProvider {


### PR DESCRIPTION
Fixes #11069

## Summary
The pre-key picker was backed by hand-maintained `KNOWN_MODELS` lists. Those drifted (Anthropic twice in two months; OpenAI missing `gpt-4`). `recommended_models_from_registry()` already existed with zero callers.

This drops the hardcoded lists for Anthropic, OpenAI, Google, and xAI. One helper, no fallback. Anthropic catalog names (`claude-sonnet-4.5`) are mapped to dashed wire ids (`claude-sonnet-4-5`). Context limits come from the catalog instead of a blanket `200_000`.

Providers where the catalog is not the picker keep their lists: Ollama (local), OpenRouter (prefixed ids, 276 rows), Snowflake (empty catalog), Azure Foundry / Databricks (SKU/prefix mismatch), CLI wrappers.

### Testing
- `cargo test -p goose-provider-types --lib anthropic_wire_name`
- `cargo test -p goose-providers --lib metadata_comes_from_the_registry`
- `cargo test -p goose --lib current_xai_models`
- `cargo clippy -p goose-provider-types -p goose-providers --all-targets -- -D warnings`

— *Assisted by Grok · Approved by James Wolfe*
