### PR TITLE
fix(security): escape OAuth callback content

### DIFF
--- a/crates/goose/src/config/signup_openrouter/server.rs
+++ b/crates/goose/src/config/signup_openrouter/server.rs
@@ -54,8 +54,8 @@ async fn handle_callback(
             .contents_utf8()
             .expect("error.html is not valid UTF-8");
 
-        env.add_template("error", template_content).unwrap();
-        let tmpl = env.get_template("error").unwrap();
+        env.add_template("error.html", template_content).unwrap();
+        let tmpl = env.get_template("error.html").unwrap();
         let rendered = tmpl.render(context! { error => error }).unwrap();
 
         return (StatusCode::BAD_REQUEST, Html(rendered));
@@ -83,4 +83,44 @@ async fn handle_callback(
         .expect("invalid.html is not valid UTF-8");
 
     (StatusCode::BAD_REQUEST, Html(invalid_html.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::to_bytes;
+
+    async fn error_response(error: &str) -> (StatusCode, String) {
+        let state = std::sync::Arc::new(tokio::sync::Mutex::new(None));
+        let response = handle_callback(
+            Query(CallbackQuery {
+                code: None,
+                error: Some(error.to_string()),
+            }),
+            axum::extract::State(state),
+        )
+        .await
+        .into_response();
+        let status = response.status();
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        (status, String::from_utf8(body.to_vec()).unwrap())
+    }
+
+    #[tokio::test]
+    async fn error_response_escapes_html() {
+        let payload = r#"<script>alert("xss")</script>&"#;
+        let (status, body) = error_response(payload).await;
+
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert!(!body.contains(payload));
+        assert!(body.contains("&lt;script&gt;"));
+        assert!(body.contains("&amp;"));
+    }
+
+    #[tokio::test]
+    async fn error_response_preserves_plain_text() {
+        let (_, body) = error_response("authorization denied").await;
+
+        assert!(body.contains("authorization denied"));
+    }
 }

--- a/crates/goose/src/config/signup_tetrate/server.rs
+++ b/crates/goose/src/config/signup_tetrate/server.rs
@@ -51,8 +51,8 @@ async fn handle_callback(
             .contents_utf8()
             .expect("error.html is not valid UTF-8");
 
-        env.add_template("error", template_content).unwrap();
-        let tmpl = env.get_template("error").unwrap();
+        env.add_template("error.html", template_content).unwrap();
+        let tmpl = env.get_template("error.html").unwrap();
         let rendered = tmpl.render(context! { error => error }).unwrap();
 
         return (StatusCode::BAD_REQUEST, Html(rendered));
@@ -80,4 +80,44 @@ async fn handle_callback(
         .expect("invalid.html is not valid UTF-8");
 
     (StatusCode::BAD_REQUEST, Html(invalid_html.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::to_bytes;
+
+    async fn error_response(error: &str) -> (StatusCode, String) {
+        let state = std::sync::Arc::new(tokio::sync::Mutex::new(None));
+        let response = handle_callback(
+            Query(CallbackQuery {
+                code: None,
+                error: Some(error.to_string()),
+            }),
+            axum::extract::State(state),
+        )
+        .await
+        .into_response();
+        let status = response.status();
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        (status, String::from_utf8(body.to_vec()).unwrap())
+    }
+
+    #[tokio::test]
+    async fn error_response_escapes_html() {
+        let payload = r#"<script>alert("xss")</script>&"#;
+        let (status, body) = error_response(payload).await;
+
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert!(!body.contains(payload));
+        assert!(body.contains("&lt;script&gt;"));
+        assert!(body.contains("&amp;"));
+    }
+
+    #[tokio::test]
+    async fn error_response_preserves_plain_text() {
+        let (_, body) = error_response("authorization denied").await;
+
+        assert!(body.contains("authorization denied"));
+    }
 }

--- a/crates/goose/src/oauth/mod.rs
+++ b/crates/goose/src/oauth/mod.rs
@@ -6,7 +6,7 @@ use axum::extract::{Query, State};
 use axum::response::Html;
 use axum::routing::get;
 use axum::Router;
-use minijinja::render;
+use minijinja::{context, Environment};
 use oauth2::{Scope, TokenResponse};
 use rmcp::transport::auth::{
     AuthError, AuthorizationRequest, CredentialStore, OAuthClientConfig, OAuthState,
@@ -60,6 +60,16 @@ fn resolve_oauth_callback_timeout(value: Option<&str>) -> Duration {
 fn oauth_callback_timeout() -> Duration {
     let timeout = std::env::var(OAUTH_CALLBACK_TIMEOUT_ENV).ok();
     resolve_oauth_callback_timeout(timeout.as_deref())
+}
+
+fn render_oauth_callback(name: &str) -> String {
+    Environment::new()
+        .render_named_str(
+            "oauth_callback.html",
+            CALLBACK_TEMPLATE,
+            context! { name => name },
+        )
+        .expect("failed to render OAuth callback")
 }
 
 fn announce_authorization_url(name: &str, authorization_url: &str) {
@@ -380,7 +390,7 @@ pub async fn oauth_flow_with_challenge(
     let app_state = AppState {
         callback_receiver: Arc::new(Mutex::new(Some(callback_sender))),
     };
-    let rendered = render!(CALLBACK_TEMPLATE, name => name);
+    let rendered = render_oauth_callback(name);
     let handler = move |Query(params): Query<CallbackParams>, State(state): State<AppState>| {
         let rendered = rendered.clone();
         async move {
@@ -510,6 +520,24 @@ mod tests {
             resolve_oauth_callback_timeout(Some("42")),
             Duration::from_secs(42)
         );
+    }
+
+    #[test]
+    fn oauth_callback_escapes_extension_name() {
+        let payload = r#"<script>alert("xss")</script>&"#;
+        let rendered = render_oauth_callback(payload);
+
+        assert!(!rendered.contains(payload));
+        assert!(rendered.contains("&lt;script&gt;"));
+        assert!(rendered.contains("&amp;"));
+    }
+
+    #[test]
+    fn oauth_callback_preserves_plain_extension_name() {
+        let rendered = render_oauth_callback("Example MCP");
+
+        assert!(rendered.contains("Example MCP OAuth Success"));
+        assert!(rendered.contains(">Example MCP</span>"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Render OAuth callback templates under HTML template names so MiniJinja applies automatic escaping.
- Cover OpenRouter, Tetrate, and MCP callback pages with hostile-markup and plain-text regressions.

## Validation

- `cargo test -p goose --lib config::signup_openrouter`
- `cargo test -p goose --lib config::signup_tetrate`
- `cargo test -p goose --lib oauth::tests`
- `cargo fmt`
- `cargo build`
- `cargo clippy --all-targets -- -D warnings`

*This finding was discovered by [Project Loupe](https://github.com/project-loupe/loupe)*
