### PR TITLE
fix(security): revoke deleted extension permissions

### DIFF
--- a/crates/goose-cli/src/commands/configure.rs
+++ b/crates/goose-cli/src/commands/configure.rs
@@ -1883,7 +1883,7 @@ pub async fn configure_tool_permissions_dialog() -> anyhow::Result<()> {
         _ => unreachable!(),
     };
 
-    permission_manager.update_user_permission(&tool.name, new_permission);
+    permission_manager.update_user_permission(&tool.name, new_permission)?;
 
     cliclack::outro(format!(
         "Updated permission level for tool {} to {}.",

--- a/crates/goose-cli/src/commands/configure.rs
+++ b/crates/goose-cli/src/commands/configure.rs
@@ -1797,6 +1797,7 @@ pub async fn configure_tool_permissions_dialog() -> anyhow::Result<()> {
         .await?;
 
     let permission_manager = PermissionManager::instance();
+    let permission_snapshot = permission_manager.snapshot();
     let selected_tools = agent
         .list_tools(&session.id, Some(selected_extension_name.clone()))
         .await
@@ -1809,7 +1810,7 @@ pub async fn configure_tool_permissions_dialog() -> anyhow::Result<()> {
                     .map(|d| d.as_ref())
                     .unwrap_or_default(),
                 get_parameter_names(&tool),
-                permission_manager.get_user_permission(&tool.name),
+                permission_snapshot.get_user_permission(&tool.name),
             )
         })
         .collect::<Vec<ToolInfo>>();

--- a/crates/goose-cli/src/commands/configure.rs
+++ b/crates/goose-cli/src/commands/configure.rs
@@ -1414,9 +1414,10 @@ pub fn remove_extension_dialog() -> anyhow::Result<()> {
         .interact()?;
 
     for name in selected {
-        remove_extension(&name_to_key(name));
-        PermissionManager::instance().remove_extension(&name_to_key(name));
-        cliclack::outro(format!("Removed {} extension", style(name).green()))?;
+        if remove_extension(&name_to_key(name))? {
+            PermissionManager::instance().remove_extension(&name_to_key(name));
+            cliclack::outro(format!("Removed {} extension", style(name).green()))?;
+        }
     }
 
     print_config_file_saved()?;

--- a/crates/goose-cli/src/commands/configure.rs
+++ b/crates/goose-cli/src/commands/configure.rs
@@ -10,7 +10,7 @@ use goose::config::declarative_providers::{
 };
 use goose::config::extensions::{
     get_all_extension_names, get_all_extensions, get_enabled_extensions, get_extension_by_name,
-    name_to_key, remove_extension, set_extension, set_extension_enabled,
+    name_to_key, remove_extension_with_cleanup, set_extension, set_extension_enabled,
 };
 use goose::config::paths::Paths;
 use goose::config::permission::PermissionLevel;
@@ -1414,8 +1414,10 @@ pub fn remove_extension_dialog() -> anyhow::Result<()> {
         .interact()?;
 
     for name in selected {
-        if remove_extension(&name_to_key(name))? {
-            PermissionManager::instance().remove_extension(&name_to_key(name));
+        let key = name_to_key(name);
+        if remove_extension_with_cleanup(&key, || {
+            PermissionManager::instance().remove_extension(&key)
+        })? {
             cliclack::outro(format!("Removed {} extension", style(name).green()))?;
         }
     }

--- a/crates/goose/src/acp/server/extensions.rs
+++ b/crates/goose/src/acp/server/extensions.rs
@@ -95,6 +95,7 @@ impl GooseAcpAgent {
         req: RemoveConfigExtensionRequest,
     ) -> Result<EmptyResponse, agent_client_protocol::Error> {
         crate::config::extensions::remove_extension(&req.config_key);
+        self.permission_manager().remove_extension(&req.config_key);
         Ok(EmptyResponse {})
     }
 

--- a/crates/goose/src/acp/server/extensions.rs
+++ b/crates/goose/src/acp/server/extensions.rs
@@ -94,13 +94,16 @@ impl GooseAcpAgent {
         &self,
         req: RemoveConfigExtensionRequest,
     ) -> Result<EmptyResponse, agent_client_protocol::Error> {
+        let permission_manager = self.permission_manager();
         let removed =
-            crate::config::extensions::remove_extension(&req.config_key).internal_err()?;
+            crate::config::extensions::remove_extension_with_cleanup(&req.config_key, || {
+                permission_manager.remove_extension(&req.config_key)
+            })
+            .internal_err()?;
         if !removed {
             return Err(agent_client_protocol::Error::invalid_params()
                 .data(format!("Extension '{}' not found", req.config_key)));
         }
-        self.permission_manager().remove_extension(&req.config_key);
         Ok(EmptyResponse {})
     }
 

--- a/crates/goose/src/acp/server/extensions.rs
+++ b/crates/goose/src/acp/server/extensions.rs
@@ -94,7 +94,12 @@ impl GooseAcpAgent {
         &self,
         req: RemoveConfigExtensionRequest,
     ) -> Result<EmptyResponse, agent_client_protocol::Error> {
-        crate::config::extensions::remove_extension(&req.config_key);
+        let removed =
+            crate::config::extensions::remove_extension(&req.config_key).internal_err()?;
+        if !removed {
+            return Err(agent_client_protocol::Error::invalid_params()
+                .data(format!("Extension '{}' not found", req.config_key)));
+        }
         self.permission_manager().remove_extension(&req.config_key);
         Ok(EmptyResponse {})
     }

--- a/crates/goose/src/acp/server/tools.rs
+++ b/crates/goose/src/acp/server/tools.rs
@@ -142,7 +142,11 @@ impl GooseAcpAgent {
                 ToolPermissionLevel::AskBefore => PermissionLevel::AskBefore,
                 ToolPermissionLevel::NeverAllow => PermissionLevel::NeverAllow,
             };
-            permission_manager.update_user_permission(&entry.tool_name, level);
+            permission_manager
+                .update_user_permission(&entry.tool_name, level)
+                .map_err(|error| {
+                    agent_client_protocol::Error::internal_error().data(error.to_string())
+                })?;
         }
         Ok(SetToolPermissionsResponse {})
     }

--- a/crates/goose/src/acp/server/tools.rs
+++ b/crates/goose/src/acp/server/tools.rs
@@ -14,17 +14,18 @@ impl GooseAcpAgent {
         let agent = self.get_session_agent(&req.session_id).await?;
         let goose_mode = agent.goose_mode().await;
         let permission_manager = self.permission_manager();
+        let permission_snapshot = permission_manager.snapshot();
 
         let mut tools: Vec<ToolListItem> = agent
             .list_tools(session_id, req.extension_name)
             .await
             .into_iter()
             .map(|tool| {
-                let permission = permission_manager
+                let permission = permission_snapshot
                     .get_user_permission(&tool.name)
                     .or_else(|| {
                         if goose_mode == GooseMode::SmartApprove {
-                            permission_manager.get_smart_approve_permission(&tool.name)
+                            permission_snapshot.get_smart_approve_permission(&tool.name)
                         } else if goose_mode == GooseMode::Approve {
                             Some(PermissionLevel::AskBefore)
                         } else {

--- a/crates/goose/src/agents/reply_parts.rs
+++ b/crates/goose/src/agents/reply_parts.rs
@@ -211,7 +211,8 @@ impl Agent {
         let goose_mode = *self.current_goose_mode.lock().await;
 
         if goose_mode == GooseMode::SmartApprove {
-            self.tool_inspection_manager.apply_tool_annotations(&tools);
+            self.tool_inspection_manager
+                .apply_tool_annotations(&tools)?;
         }
 
         let prompt_manager = self.prompt_manager.lock().await;
@@ -1214,7 +1215,8 @@ mod tests {
         let session_manager = Arc::new(SessionManager::new(data_path.clone()));
         let permission_manager = Arc::new(PermissionManager::new(data_path));
         permission_manager
-            .update_smart_approve_permission("frontend__write_tool", PermissionLevel::AlwaysAllow);
+            .update_smart_approve_permission("frontend__write_tool", PermissionLevel::AlwaysAllow)
+            .unwrap();
         let agent = Agent::with_config(AgentConfig::new(
             Arc::clone(&session_manager),
             Arc::clone(&permission_manager),

--- a/crates/goose/src/agents/state_machine/inference_preparation.rs
+++ b/crates/goose/src/agents/state_machine/inference_preparation.rs
@@ -47,7 +47,7 @@ impl InferenceRequestPreparer<Session> for GooseInferenceRequestPreparer<'_> {
         let goose_mode = *self.goose_mode.lock().await;
         if goose_mode == GooseMode::SmartApprove {
             self.tool_inspection_manager
-                .apply_tool_annotations(&input.tools);
+                .apply_tool_annotations(&input.tools)?;
         }
         let tools =
             crate::agents::reply_parts::prepare_inference_tools(input.tools, code_execution_mode);

--- a/crates/goose/src/agents/state_machine/ops_tool_approval.rs
+++ b/crates/goose/src/agents/state_machine/ops_tool_approval.rs
@@ -68,11 +68,11 @@ impl Operation<Session, GooseEffect> for ToolApprovalOperation<'_> {
                 {
                     self.tool_inspection_manager
                         .update_permission_manager(&tool_name, PermissionLevel::AlwaysAllow)
-                        .await;
+                        .await?;
                 } else if pending.permission == Permission::AlwaysDeny {
                     self.tool_inspection_manager
                         .update_permission_manager(&tool_name, PermissionLevel::NeverAllow)
-                        .await;
+                        .await?;
                 }
             }
 

--- a/crates/goose/src/agents/state_machine/tests/pipeline.rs
+++ b/crates/goose/src/agents/state_machine/tests/pipeline.rs
@@ -490,7 +490,9 @@ impl TestPipeline {
     }
 
     pub(super) fn set_permission(&self, tool: &str, level: PermissionLevel) {
-        self.permission_manager.update_user_permission(tool, level);
+        self.permission_manager
+            .update_user_permission(tool, level)
+            .unwrap();
     }
 
     pub(super) async fn remove_extension(&self, name: &str) -> Result<()> {

--- a/crates/goose/src/agents/tool_execution.rs
+++ b/crates/goose/src/agents/tool_execution.rs
@@ -218,7 +218,7 @@ impl Agent {
                     if confirmation.permission == Permission::AlwaysAllow {
                         self.tool_inspection_manager
                             .update_permission_manager(&tool_call.name, PermissionLevel::AlwaysAllow)
-                            .await;
+                            .await?;
                     }
                 } else {
                     if let Some(response) = request_to_response_map.get_mut(&request.id) {
@@ -232,7 +232,7 @@ impl Agent {
                     if confirmation.permission == Permission::AlwaysDeny {
                         self.tool_inspection_manager
                             .update_permission_manager(&tool_call.name, PermissionLevel::NeverAllow)
-                            .await;
+                            .await?;
                     }
                 }
             }

--- a/crates/goose/src/config/extensions.rs
+++ b/crates/goose/src/config/extensions.rs
@@ -1,4 +1,4 @@
-use super::base::Config;
+use super::base::{Config, ConfigError};
 use crate::agents::extension::PLATFORM_EXTENSIONS;
 use crate::agents::ExtensionConfig;
 use indexmap::IndexMap;
@@ -101,7 +101,6 @@ fn get_extensions_map() -> IndexMap<String, ExtensionEntry> {
 
 enum ExtensionMutation {
     Upsert(String, Box<ExtensionEntry>),
-    Remove(String),
     Noop,
 }
 
@@ -122,9 +121,6 @@ where
                     serialize_error = Some(err);
                 }
             },
-            ExtensionMutation::Remove(key) => {
-                raw.shift_remove(key.as_str());
-            }
             ExtensionMutation::Noop => {}
         }
 
@@ -168,12 +164,17 @@ fn set_extension_with_config(config: &Config, entry: ExtensionEntry) {
     with_raw_extensions_mapping(config, |_| ExtensionMutation::Upsert(key, Box::new(entry)));
 }
 
-pub fn remove_extension(key: &str) {
-    remove_extension_with_config(Config::global(), key);
+pub fn remove_extension(key: &str) -> Result<bool, ConfigError> {
+    remove_extension_with_config(Config::global(), key)
 }
 
-fn remove_extension_with_config(config: &Config, key: &str) {
-    with_raw_extensions_mapping(config, |_| ExtensionMutation::Remove(key.to_string()));
+fn remove_extension_with_config(config: &Config, key: &str) -> Result<bool, ConfigError> {
+    let mut removed = false;
+    config.update_param::<Mapping, Mapping, _>(EXTENSIONS_CONFIG_KEY, |mut raw| {
+        removed = raw.shift_remove(key).is_some();
+        raw
+    })?;
+    Ok(removed)
 }
 
 /// Returns true when an existing extension was updated, false when the key was missing.
@@ -553,11 +554,35 @@ extensions:
         let before = read_extensions(&config);
         let broken_before = before.get("broken").unwrap().clone();
 
-        remove_extension_with_config(&config, "valid");
+        assert!(remove_extension_with_config(&config, "valid").unwrap());
 
         let extensions = read_extensions(&config);
         assert!(!extensions.contains_key("valid"));
         assert_eq!(extensions.get("broken").unwrap(), &broken_before);
+    }
+
+    #[test]
+    fn test_remove_extension_reports_missing_entry() {
+        let (config, _config_file, _secrets_file) = test_config("extensions: {}\n");
+
+        assert!(!remove_extension_with_config(&config, "missing").unwrap());
+    }
+
+    #[test]
+    fn test_remove_extension_reports_config_failure() {
+        let root = tempfile::tempdir().unwrap();
+        let config_path = root.path().join("config.yaml");
+        let secrets_path = root.path().join("secrets.yaml");
+        std::fs::write(
+            &config_path,
+            "extensions:\n  valid:\n    enabled: true\n    type: builtin\n    name: valid\n",
+        )
+        .unwrap();
+        let config = Config::new_with_file_secrets(&config_path, secrets_path).unwrap();
+        std::fs::remove_file(&config_path).unwrap();
+        std::fs::create_dir(&config_path).unwrap();
+
+        assert!(remove_extension_with_config(&config, "valid").is_err());
     }
 
     #[derive(Clone, Default)]

--- a/crates/goose/src/config/extensions.rs
+++ b/crates/goose/src/config/extensions.rs
@@ -180,13 +180,26 @@ fn remove_extension_with_config_cleanup(
     key: &str,
     cleanup: impl FnOnce() -> anyhow::Result<()>,
 ) -> anyhow::Result<bool> {
-    let raw: Mapping = config.get_param(EXTENSIONS_CONFIG_KEY)?;
-    if !raw.contains_key(serde_yaml::Value::String(key.to_string())) {
-        return Ok(false);
-    }
+    let mut cleanup = Some(cleanup);
+    let mut cleanup_error = None;
+    let mut removed = false;
+    let key = serde_yaml::Value::String(key.to_string());
+    let update_result =
+        config.update_param::<Mapping, Mapping, _>(EXTENSIONS_CONFIG_KEY, |mut raw| {
+            if raw.contains_key(&key) {
+                match cleanup.take().unwrap()() {
+                    Ok(()) => removed = raw.shift_remove(&key).is_some(),
+                    Err(error) => cleanup_error = Some(error),
+                }
+            }
+            raw
+        });
 
-    cleanup()?;
-    Ok(remove_extension_with_config(config, key)?)
+    if let Some(error) = cleanup_error {
+        return Err(error);
+    }
+    update_result?;
+    Ok(removed)
 }
 
 fn remove_extension_with_config(config: &Config, key: &str) -> Result<bool, ConfigError> {
@@ -618,6 +631,37 @@ extensions:
 
         assert!(result.is_err());
         assert!(read_extensions(&config).contains_key("valid"));
+    }
+
+    #[test]
+    fn test_cleanup_only_runs_for_extension_in_writable_layer() {
+        let base_file = NamedTempFile::new().unwrap();
+        let config_file = NamedTempFile::new().unwrap();
+        let secrets_file = NamedTempFile::new().unwrap();
+        std::fs::write(
+            base_file.path(),
+            "extensions:\n  inherited:\n    enabled: true\n    type: builtin\n    name: inherited\n",
+        )
+        .unwrap();
+        let config = Config::new_with_config_paths(
+            vec![
+                base_file.path().to_path_buf(),
+                config_file.path().to_path_buf(),
+            ],
+            secrets_file.path(),
+        )
+        .unwrap();
+        let cleanup_called = std::cell::Cell::new(false);
+
+        let removed = remove_extension_with_config_cleanup(&config, "inherited", || {
+            cleanup_called.set(true);
+            Ok(())
+        })
+        .unwrap();
+
+        assert!(!removed);
+        assert!(!cleanup_called.get());
+        assert!(get_extensions_map_with_config(&config).contains_key("inherited"));
     }
 
     #[derive(Clone, Default)]

--- a/crates/goose/src/config/extensions.rs
+++ b/crates/goose/src/config/extensions.rs
@@ -168,6 +168,27 @@ pub fn remove_extension(key: &str) -> Result<bool, ConfigError> {
     remove_extension_with_config(Config::global(), key)
 }
 
+pub fn remove_extension_with_cleanup(
+    key: &str,
+    cleanup: impl FnOnce() -> anyhow::Result<()>,
+) -> anyhow::Result<bool> {
+    remove_extension_with_config_cleanup(Config::global(), key, cleanup)
+}
+
+fn remove_extension_with_config_cleanup(
+    config: &Config,
+    key: &str,
+    cleanup: impl FnOnce() -> anyhow::Result<()>,
+) -> anyhow::Result<bool> {
+    let raw: Mapping = config.get_param(EXTENSIONS_CONFIG_KEY)?;
+    if !raw.contains_key(serde_yaml::Value::String(key.to_string())) {
+        return Ok(false);
+    }
+
+    cleanup()?;
+    Ok(remove_extension_with_config(config, key)?)
+}
+
 fn remove_extension_with_config(config: &Config, key: &str) -> Result<bool, ConfigError> {
     let mut removed = false;
     config.update_param::<Mapping, Mapping, _>(EXTENSIONS_CONFIG_KEY, |mut raw| {
@@ -583,6 +604,20 @@ extensions:
         std::fs::create_dir(&config_path).unwrap();
 
         assert!(remove_extension_with_config(&config, "valid").is_err());
+    }
+
+    #[test]
+    fn test_cleanup_failure_preserves_extension() {
+        let (config, _config_file, _secrets_file) = test_config(
+            "extensions:\n  valid:\n    enabled: true\n    type: builtin\n    name: valid\n",
+        );
+
+        let result = remove_extension_with_config_cleanup(&config, "valid", || {
+            Err(anyhow::anyhow!("permission cleanup failed"))
+        });
+
+        assert!(result.is_err());
+        assert!(read_extensions(&config).contains_key("valid"));
     }
 
     #[derive(Clone, Default)]

--- a/crates/goose/src/config/permission.rs
+++ b/crates/goose/src/config/permission.rs
@@ -44,19 +44,7 @@ impl PermissionManager {
     pub fn new(config_dir: PathBuf) -> Self {
         let permission_path = config_dir.join(PERMISSION_FILE);
         let permission_map = if permission_path.exists() {
-            let file_contents =
-                fs::read_to_string(&permission_path).expect("Failed to read permission.yaml");
-            serde_yaml::from_str(&file_contents).unwrap_or_else(|e| {
-                tracing::error!(
-                    "Failed to parse {}: {}. Refusing to start with corrupted permission config.",
-                    permission_path.display(),
-                    e,
-                );
-                panic!(
-                    "Corrupted permission config at {}. Fix or remove the file to continue.",
-                    permission_path.display(),
-                );
-            })
+            Self::load_permission_map(&permission_path)
         } else {
             // Consolidate directory creation for re-use in global singleton or ACP.
             fs::create_dir_all(&config_dir).expect("Failed to create config directory");
@@ -66,6 +54,22 @@ impl PermissionManager {
             config_path: permission_path,
             permission_map: RwLock::new(permission_map),
         }
+    }
+
+    fn load_permission_map(config_path: &Path) -> HashMap<String, PermissionConfig> {
+        let file_contents =
+            fs::read_to_string(config_path).expect("Failed to read permission.yaml");
+        serde_yaml::from_str(&file_contents).unwrap_or_else(|error| {
+            tracing::error!(
+                "Failed to parse {}: {}. Refusing to start with corrupted permission config.",
+                config_path.display(),
+                error,
+            );
+            panic!(
+                "Corrupted permission config at {}. Fix or remove the file to continue.",
+                config_path.display(),
+            );
+        })
     }
 
     pub fn instance() -> Arc<PermissionManager> {
@@ -214,6 +218,9 @@ impl PermissionManager {
 
     pub fn remove_extension(&self, extension_name: &str) {
         let mut map = self.permission_map.write().unwrap();
+        if self.config_path.exists() {
+            *map = Self::load_permission_map(&self.config_path);
+        }
         for permission_config in map.values_mut() {
             permission_config
                 .always_allow
@@ -425,6 +432,25 @@ mod tests {
 
         manager.clear_permissions();
         assert!(manager.get_permission_names().is_empty());
+    }
+
+    #[test]
+    fn test_remove_extension_preserves_newer_permissions() {
+        let temp_dir = TempDir::new().unwrap();
+        let deleting_manager = PermissionManager::new(temp_dir.path().to_path_buf());
+        deleting_manager.update_user_permission("git__status", PermissionLevel::AlwaysAllow);
+
+        let newer_manager = PermissionManager::new(temp_dir.path().to_path_buf());
+        newer_manager.update_user_permission("github__status", PermissionLevel::AskBefore);
+
+        deleting_manager.remove_extension("git");
+
+        let persisted_manager = PermissionManager::new(temp_dir.path().to_path_buf());
+        assert_eq!(persisted_manager.get_user_permission("git__status"), None);
+        assert_eq!(
+            persisted_manager.get_user_permission("github__status"),
+            Some(PermissionLevel::AskBefore)
+        );
     }
 
     #[test]

--- a/crates/goose/src/config/permission.rs
+++ b/crates/goose/src/config/permission.rs
@@ -131,6 +131,8 @@ impl PermissionManager {
         let mut map = self.state.permission_map.write().unwrap();
         if self.config_path.exists() {
             *map = Self::try_load_permission_map(&self.config_path)?;
+        } else {
+            map.clear();
         }
         modify(&mut map);
         let yaml_content = serde_yaml::to_string(&*map)?;
@@ -603,6 +605,23 @@ mod tests {
         assert_eq!(
             manager.get_user_permission("git__status"),
             Some(PermissionLevel::NeverAllow)
+        );
+    }
+
+    #[test]
+    fn test_update_does_not_restore_externally_deleted_permissions() {
+        let (manager, temp_dir) = create_test_permission_manager();
+        manager.update_user_permission("git__status", PermissionLevel::AlwaysAllow);
+        fs::remove_file(manager.get_config_path()).unwrap();
+
+        manager.update_user_permission("github__status", PermissionLevel::AskBefore);
+        drop(manager);
+
+        let persisted_manager = PermissionManager::new(temp_dir.path().to_path_buf());
+        assert_eq!(persisted_manager.get_user_permission("git__status"), None);
+        assert_eq!(
+            persisted_manager.get_user_permission("github__status"),
+            Some(PermissionLevel::AskBefore)
         );
     }
 

--- a/crates/goose/src/config/permission.rs
+++ b/crates/goose/src/config/permission.rs
@@ -210,7 +210,7 @@ impl PermissionManager {
         self.config_path.as_path()
     }
 
-    pub fn apply_tool_annotations(&self, tools: &[Tool]) {
+    pub fn apply_tool_annotations(&self, tools: &[Tool]) -> Result<()> {
         let mut write_annotated = Vec::new();
         for tool in tools {
             let Some(anns) = &tool.annotations else {
@@ -224,11 +224,16 @@ impl PermissionManager {
             self.bulk_update_smart_approve_permissions(
                 &write_annotated,
                 PermissionLevel::AskBefore,
-            );
+            )?;
         }
+        Ok(())
     }
 
-    fn bulk_update_smart_approve_permissions(&self, tool_names: &[String], level: PermissionLevel) {
+    fn bulk_update_smart_approve_permissions(
+        &self,
+        tool_names: &[String],
+        level: PermissionLevel,
+    ) -> Result<()> {
         self.modify_permission_map(|map| {
             let permission_config = map.entry(SMART_APPROVE_PERMISSION.to_string()).or_default();
 
@@ -252,7 +257,6 @@ impl PermissionManager {
                 }
             }
         })
-        .expect("Failed to update smart-approve permissions");
     }
 
     /// Helper function to retrieve the permission level for a specific permission category and tool.
@@ -285,17 +289,30 @@ impl PermissionManager {
     }
 
     /// Updates the user permission level for a specific tool.
-    pub fn update_user_permission(&self, principal_name: &str, level: PermissionLevel) {
+    pub fn update_user_permission(
+        &self,
+        principal_name: &str,
+        level: PermissionLevel,
+    ) -> Result<()> {
         self.update_permission(USER_PERMISSION, principal_name, level)
     }
 
     /// Updates the smart approve permission level for a specific tool.
-    pub fn update_smart_approve_permission(&self, principal_name: &str, level: PermissionLevel) {
+    pub fn update_smart_approve_permission(
+        &self,
+        principal_name: &str,
+        level: PermissionLevel,
+    ) -> Result<()> {
         self.update_permission(SMART_APPROVE_PERMISSION, principal_name, level)
     }
 
     /// Helper function to update a permission level for a specific tool in a given permission category.
-    fn update_permission(&self, name: &str, principal_name: &str, level: PermissionLevel) {
+    fn update_permission(
+        &self,
+        name: &str,
+        principal_name: &str,
+        level: PermissionLevel,
+    ) -> Result<()> {
         self.modify_permission_map(|map| {
             // Get or create a new PermissionConfig for the specified category
             let permission_config = map.entry(name.to_string()).or_default();
@@ -322,7 +339,6 @@ impl PermissionManager {
                     .push(principal_name.to_string()),
             }
         })
-        .expect("Failed to update user permissions");
     }
 
     pub fn remove_extension(&self, extension_name: &str) -> Result<()> {
@@ -341,9 +357,8 @@ impl PermissionManager {
         })
     }
 
-    pub fn clear_permissions(&self) {
+    pub fn clear_permissions(&self) -> Result<()> {
         self.modify_permission_map(HashMap::clear)
-            .expect("Failed to clear permissions");
     }
 
     fn belongs_to_extension(principal_name: &str, extension_name: &str) -> bool {
@@ -402,7 +417,9 @@ mod tests {
     #[test]
     fn test_update_user_permission() {
         let (manager, _temp_dir) = create_test_permission_manager();
-        manager.update_user_permission("tool1", PermissionLevel::AlwaysAllow);
+        manager
+            .update_user_permission("tool1", PermissionLevel::AlwaysAllow)
+            .unwrap();
 
         let permission = manager.get_user_permission("tool1");
         assert_eq!(permission, Some(PermissionLevel::AlwaysAllow));
@@ -411,10 +428,25 @@ mod tests {
     #[test]
     fn test_update_smart_approve_permission() {
         let (manager, _temp_dir) = create_test_permission_manager();
-        manager.update_smart_approve_permission("tool2", PermissionLevel::AskBefore);
+        manager
+            .update_smart_approve_permission("tool2", PermissionLevel::AskBefore)
+            .unwrap();
 
         let permission = manager.get_smart_approve_permission("tool2");
         assert_eq!(permission, Some(PermissionLevel::AskBefore));
+    }
+
+    #[test]
+    fn permission_update_returns_error_when_refresh_fails() {
+        let (manager, _temp_dir) = create_test_permission_manager();
+        manager
+            .update_user_permission("tool", PermissionLevel::AlwaysAllow)
+            .unwrap();
+        fs::write(manager.get_config_path(), "{{invalid yaml: [broken").unwrap();
+
+        assert!(manager
+            .update_user_permission("tool", PermissionLevel::NeverAllow)
+            .is_err());
     }
 
     #[test]
@@ -429,9 +461,15 @@ mod tests {
     fn test_permission_levels() {
         let (manager, _temp_dir) = create_test_permission_manager();
 
-        manager.update_user_permission("tool4", PermissionLevel::AlwaysAllow);
-        manager.update_user_permission("tool5", PermissionLevel::AskBefore);
-        manager.update_user_permission("tool6", PermissionLevel::NeverAllow);
+        manager
+            .update_user_permission("tool4", PermissionLevel::AlwaysAllow)
+            .unwrap();
+        manager
+            .update_user_permission("tool5", PermissionLevel::AskBefore)
+            .unwrap();
+        manager
+            .update_user_permission("tool6", PermissionLevel::NeverAllow)
+            .unwrap();
 
         // Check the permission levels
         assert_eq!(
@@ -498,14 +536,18 @@ mod tests {
         let (manager, _temp_dir) = create_test_permission_manager();
 
         // Initially AlwaysAllow
-        manager.update_user_permission("tool7", PermissionLevel::AlwaysAllow);
+        manager
+            .update_user_permission("tool7", PermissionLevel::AlwaysAllow)
+            .unwrap();
         assert_eq!(
             manager.get_user_permission("tool7"),
             Some(PermissionLevel::AlwaysAllow)
         );
 
         // Now change to NeverAllow
-        manager.update_user_permission("tool7", PermissionLevel::NeverAllow);
+        manager
+            .update_user_permission("tool7", PermissionLevel::NeverAllow)
+            .unwrap();
         assert_eq!(
             manager.get_user_permission("tool7"),
             Some(PermissionLevel::NeverAllow)
@@ -522,11 +564,21 @@ mod tests {
     #[test]
     fn test_remove_extension() {
         let (manager, _temp_dir) = create_test_permission_manager();
-        manager.update_user_permission("git__status", PermissionLevel::AlwaysAllow);
-        manager.update_user_permission("git__tool__with__delimiter", PermissionLevel::AskBefore);
-        manager.update_user_permission("github__delete_repo", PermissionLevel::NeverAllow);
-        manager.update_user_permission("gitlab__deploy", PermissionLevel::AskBefore);
-        manager.update_user_permission("__cli__ent____tool", PermissionLevel::NeverAllow);
+        manager
+            .update_user_permission("git__status", PermissionLevel::AlwaysAllow)
+            .unwrap();
+        manager
+            .update_user_permission("git__tool__with__delimiter", PermissionLevel::AskBefore)
+            .unwrap();
+        manager
+            .update_user_permission("github__delete_repo", PermissionLevel::NeverAllow)
+            .unwrap();
+        manager
+            .update_user_permission("gitlab__deploy", PermissionLevel::AskBefore)
+            .unwrap();
+        manager
+            .update_user_permission("__cli__ent____tool", PermissionLevel::NeverAllow)
+            .unwrap();
 
         manager.remove_extension("git").unwrap();
 
@@ -553,7 +605,7 @@ mod tests {
             Some(PermissionLevel::NeverAllow)
         );
 
-        manager.clear_permissions();
+        manager.clear_permissions().unwrap();
         assert!(manager.get_permission_names().is_empty());
     }
 
@@ -561,10 +613,14 @@ mod tests {
     fn test_remove_extension_preserves_newer_permissions() {
         let temp_dir = TempDir::new().unwrap();
         let deleting_manager = PermissionManager::new(temp_dir.path().to_path_buf());
-        deleting_manager.update_user_permission("git__status", PermissionLevel::AlwaysAllow);
+        deleting_manager
+            .update_user_permission("git__status", PermissionLevel::AlwaysAllow)
+            .unwrap();
 
         let newer_manager = PermissionManager::new(temp_dir.path().to_path_buf());
-        newer_manager.update_user_permission("github__status", PermissionLevel::AskBefore);
+        newer_manager
+            .update_user_permission("github__status", PermissionLevel::AskBefore)
+            .unwrap();
 
         deleting_manager.remove_extension("git").unwrap();
 
@@ -580,12 +636,16 @@ mod tests {
     fn test_stale_manager_update_does_not_restore_removed_extension_permissions() {
         let temp_dir = TempDir::new().unwrap();
         let deleting_manager = PermissionManager::new(temp_dir.path().to_path_buf());
-        deleting_manager.update_user_permission("git__status", PermissionLevel::AlwaysAllow);
+        deleting_manager
+            .update_user_permission("git__status", PermissionLevel::AlwaysAllow)
+            .unwrap();
         let stale_manager = PermissionManager::new(temp_dir.path().to_path_buf());
 
         deleting_manager.remove_extension("git").unwrap();
         assert_eq!(stale_manager.get_user_permission("git__status"), None);
-        stale_manager.update_user_permission("github__status", PermissionLevel::AskBefore);
+        stale_manager
+            .update_user_permission("github__status", PermissionLevel::AskBefore)
+            .unwrap();
 
         let persisted_manager = PermissionManager::new(temp_dir.path().to_path_buf());
         assert_eq!(persisted_manager.get_user_permission("git__status"), None);
@@ -610,7 +670,9 @@ mod tests {
         let (completed_tx, completed_rx) = mpsc::channel();
 
         let update = thread::spawn(move || {
-            manager.update_user_permission("github__status", PermissionLevel::AskBefore);
+            manager
+                .update_user_permission("github__status", PermissionLevel::AskBefore)
+                .unwrap();
             completed_tx.send(()).unwrap();
         });
 
@@ -625,7 +687,9 @@ mod tests {
     #[test]
     fn test_reads_refresh_permissions_changed_by_another_process() {
         let (manager, temp_dir) = create_test_permission_manager();
-        manager.update_user_permission("git__status", PermissionLevel::AlwaysAllow);
+        manager
+            .update_user_permission("git__status", PermissionLevel::AlwaysAllow)
+            .unwrap();
         let lock_file = OpenOptions::new()
             .read(true)
             .write(true)
@@ -643,7 +707,9 @@ mod tests {
     #[test]
     fn test_reads_fail_closed_when_permission_refresh_fails() {
         let (manager, _temp_dir) = create_test_permission_manager();
-        manager.update_user_permission("git__status", PermissionLevel::AlwaysAllow);
+        manager
+            .update_user_permission("git__status", PermissionLevel::AlwaysAllow)
+            .unwrap();
         fs::write(manager.get_config_path(), "{{invalid yaml: [broken").unwrap();
 
         assert_eq!(
@@ -655,10 +721,14 @@ mod tests {
     #[test]
     fn test_update_does_not_restore_externally_deleted_permissions() {
         let (manager, temp_dir) = create_test_permission_manager();
-        manager.update_user_permission("git__status", PermissionLevel::AlwaysAllow);
+        manager
+            .update_user_permission("git__status", PermissionLevel::AlwaysAllow)
+            .unwrap();
         fs::remove_file(manager.get_config_path()).unwrap();
 
-        manager.update_user_permission("github__status", PermissionLevel::AskBefore);
+        manager
+            .update_user_permission("github__status", PermissionLevel::AskBefore)
+            .unwrap();
         drop(manager);
 
         let persisted_manager = PermissionManager::new(temp_dir.path().to_path_buf());
@@ -699,7 +769,7 @@ mod tests {
     )]
     fn test_apply_tool_annotations(tools: Vec<Tool>, expect_cache: Option<PermissionLevel>) {
         let (manager, _temp_dir) = create_test_permission_manager();
-        manager.apply_tool_annotations(&tools);
+        manager.apply_tool_annotations(&tools).unwrap();
         assert_eq!(manager.get_smart_approve_permission("tool"), expect_cache);
     }
 }

--- a/crates/goose/src/config/permission.rs
+++ b/crates/goose/src/config/permission.rs
@@ -4,13 +4,15 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, LazyLock, RwLock};
+use std::sync::{Arc, LazyLock, Mutex, RwLock, Weak};
 use tracing;
 
 const PERMISSION_FILE: &str = "permission.yaml";
 
 static PERMISSION_MANAGER: LazyLock<Arc<PermissionManager>> =
     LazyLock::new(|| Arc::new(PermissionManager::new(Paths::config_dir())));
+static PERMISSION_FILE_LOCKS: LazyLock<Mutex<HashMap<PathBuf, Weak<Mutex<()>>>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
 
 /// Enum representing the possible permission levels for a tool.
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
@@ -33,6 +35,7 @@ pub struct PermissionConfig {
 #[derive(Debug)]
 pub struct PermissionManager {
     config_path: PathBuf,
+    file_lock: Arc<Mutex<()>>,
     permission_map: RwLock<HashMap<String, PermissionConfig>>,
 }
 
@@ -43,17 +46,34 @@ const SMART_APPROVE_PERMISSION: &str = "smart_approve";
 impl PermissionManager {
     pub fn new(config_dir: PathBuf) -> Self {
         let permission_path = config_dir.join(PERMISSION_FILE);
-        let permission_map = if permission_path.exists() {
-            Self::load_permission_map(&permission_path)
-        } else {
-            // Consolidate directory creation for re-use in global singleton or ACP.
-            fs::create_dir_all(&config_dir).expect("Failed to create config directory");
-            HashMap::new()
+        let file_lock = Self::shared_file_lock(&permission_path);
+        let permission_map = {
+            let _file_guard = file_lock.lock().unwrap();
+            if permission_path.exists() {
+                Self::load_permission_map(&permission_path)
+            } else {
+                // Consolidate directory creation for re-use in global singleton or ACP.
+                fs::create_dir_all(&config_dir).expect("Failed to create config directory");
+                HashMap::new()
+            }
         };
         PermissionManager {
             config_path: permission_path,
+            file_lock,
             permission_map: RwLock::new(permission_map),
         }
+    }
+
+    fn shared_file_lock(config_path: &Path) -> Arc<Mutex<()>> {
+        let mut locks = PERMISSION_FILE_LOCKS.lock().unwrap();
+        locks.retain(|_, lock| lock.strong_count() > 0);
+        if let Some(lock) = locks.get(config_path).and_then(Weak::upgrade) {
+            return lock;
+        }
+
+        let lock = Arc::new(Mutex::new(()));
+        locks.insert(config_path.to_path_buf(), Arc::downgrade(&lock));
+        lock
     }
 
     fn load_permission_map(config_path: &Path) -> HashMap<String, PermissionConfig> {
@@ -70,6 +90,18 @@ impl PermissionManager {
                 config_path.display(),
             );
         })
+    }
+
+    fn modify_permission_map(&self, modify: impl FnOnce(&mut HashMap<String, PermissionConfig>)) {
+        let _file_guard = self.file_lock.lock().unwrap();
+        let mut map = self.permission_map.write().unwrap();
+        if self.config_path.exists() {
+            *map = Self::load_permission_map(&self.config_path);
+        }
+        modify(&mut map);
+        let yaml_content =
+            serde_yaml::to_string(&*map).expect("Failed to serialize permission config");
+        fs::write(&self.config_path, yaml_content).expect("Failed to write to permission.yaml");
     }
 
     pub fn instance() -> Arc<PermissionManager> {
@@ -120,30 +152,29 @@ impl PermissionManager {
     }
 
     fn bulk_update_smart_approve_permissions(&self, tool_names: &[String], level: PermissionLevel) {
-        let mut map = self.permission_map.write().unwrap();
-        let permission_config = map.entry(SMART_APPROVE_PERMISSION.to_string()).or_default();
+        self.modify_permission_map(|map| {
+            let permission_config = map.entry(SMART_APPROVE_PERMISSION.to_string()).or_default();
 
-        for tool_name in tool_names {
-            // Remove from all lists to avoid duplicates
-            permission_config.always_allow.retain(|p| p != tool_name);
-            permission_config.ask_before.retain(|p| p != tool_name);
-            permission_config.never_allow.retain(|p| p != tool_name);
+            for tool_name in tool_names {
+                // Remove from all lists to avoid duplicates
+                permission_config.always_allow.retain(|p| p != tool_name);
+                permission_config.ask_before.retain(|p| p != tool_name);
+                permission_config.never_allow.retain(|p| p != tool_name);
 
-            // Add to the appropriate list
-            match &level {
-                PermissionLevel::AlwaysAllow => {
-                    permission_config.always_allow.push(tool_name.clone())
-                }
-                PermissionLevel::AskBefore => permission_config.ask_before.push(tool_name.clone()),
-                PermissionLevel::NeverAllow => {
-                    permission_config.never_allow.push(tool_name.clone())
+                // Add to the appropriate list
+                match &level {
+                    PermissionLevel::AlwaysAllow => {
+                        permission_config.always_allow.push(tool_name.clone())
+                    }
+                    PermissionLevel::AskBefore => {
+                        permission_config.ask_before.push(tool_name.clone())
+                    }
+                    PermissionLevel::NeverAllow => {
+                        permission_config.never_allow.push(tool_name.clone())
+                    }
                 }
             }
-        }
-
-        let yaml_content =
-            serde_yaml::to_string(&*map).expect("Failed to serialize permission config");
-        fs::write(&self.config_path, yaml_content).expect("Failed to write to permission.yaml");
+        });
     }
 
     /// Helper function to retrieve the permission level for a specific permission category and tool.
@@ -184,67 +215,52 @@ impl PermissionManager {
 
     /// Helper function to update a permission level for a specific tool in a given permission category.
     fn update_permission(&self, name: &str, principal_name: &str, level: PermissionLevel) {
-        let mut map = self.permission_map.write().unwrap();
-        // Get or create a new PermissionConfig for the specified category
-        let permission_config = map.entry(name.to_string()).or_default();
+        self.modify_permission_map(|map| {
+            // Get or create a new PermissionConfig for the specified category
+            let permission_config = map.entry(name.to_string()).or_default();
 
-        // Remove the principal from all existing lists to avoid duplicates
-        permission_config
-            .always_allow
-            .retain(|p| p != principal_name);
-        permission_config.ask_before.retain(|p| p != principal_name);
-        permission_config
-            .never_allow
-            .retain(|p| p != principal_name);
-
-        // Add the principal to the appropriate list
-        match level {
-            PermissionLevel::AlwaysAllow => permission_config
+            // Remove the principal from all existing lists to avoid duplicates
+            permission_config
                 .always_allow
-                .push(principal_name.to_string()),
-            PermissionLevel::AskBefore => permission_config
-                .ask_before
-                .push(principal_name.to_string()),
-            PermissionLevel::NeverAllow => permission_config
+                .retain(|p| p != principal_name);
+            permission_config.ask_before.retain(|p| p != principal_name);
+            permission_config
                 .never_allow
-                .push(principal_name.to_string()),
-        }
+                .retain(|p| p != principal_name);
 
-        // Serialize the updated permission map and write it back to the config file
-        let yaml_content =
-            serde_yaml::to_string(&*map).expect("Failed to serialize permission config");
-        fs::write(&self.config_path, yaml_content).expect("Failed to write to permission.yaml");
+            // Add the principal to the appropriate list
+            match level {
+                PermissionLevel::AlwaysAllow => permission_config
+                    .always_allow
+                    .push(principal_name.to_string()),
+                PermissionLevel::AskBefore => permission_config
+                    .ask_before
+                    .push(principal_name.to_string()),
+                PermissionLevel::NeverAllow => permission_config
+                    .never_allow
+                    .push(principal_name.to_string()),
+            }
+        });
     }
 
     pub fn remove_extension(&self, extension_name: &str) {
-        let mut map = self.permission_map.write().unwrap();
-        if self.config_path.exists() {
-            *map = Self::load_permission_map(&self.config_path);
-        }
-        for permission_config in map.values_mut() {
-            permission_config
-                .always_allow
-                .retain(|p| !Self::belongs_to_extension(p, extension_name));
-            permission_config
-                .ask_before
-                .retain(|p| !Self::belongs_to_extension(p, extension_name));
-            permission_config
-                .never_allow
-                .retain(|p| !Self::belongs_to_extension(p, extension_name));
-        }
-
-        let yaml_content =
-            serde_yaml::to_string(&*map).expect("Failed to serialize permission config");
-        fs::write(&self.config_path, yaml_content).expect("Failed to write to permission.yaml");
+        self.modify_permission_map(|map| {
+            for permission_config in map.values_mut() {
+                permission_config
+                    .always_allow
+                    .retain(|p| !Self::belongs_to_extension(p, extension_name));
+                permission_config
+                    .ask_before
+                    .retain(|p| !Self::belongs_to_extension(p, extension_name));
+                permission_config
+                    .never_allow
+                    .retain(|p| !Self::belongs_to_extension(p, extension_name));
+            }
+        });
     }
 
     pub fn clear_permissions(&self) {
-        let mut map = self.permission_map.write().unwrap();
-        map.clear();
-
-        let yaml_content =
-            serde_yaml::to_string(&*map).expect("Failed to serialize permission config");
-        fs::write(&self.config_path, yaml_content).expect("Failed to write to permission.yaml");
+        self.modify_permission_map(HashMap::clear);
     }
 
     fn belongs_to_extension(principal_name: &str, extension_name: &str) -> bool {
@@ -444,6 +460,24 @@ mod tests {
         newer_manager.update_user_permission("github__status", PermissionLevel::AskBefore);
 
         deleting_manager.remove_extension("git");
+
+        let persisted_manager = PermissionManager::new(temp_dir.path().to_path_buf());
+        assert_eq!(persisted_manager.get_user_permission("git__status"), None);
+        assert_eq!(
+            persisted_manager.get_user_permission("github__status"),
+            Some(PermissionLevel::AskBefore)
+        );
+    }
+
+    #[test]
+    fn test_stale_manager_update_does_not_restore_removed_extension_permissions() {
+        let temp_dir = TempDir::new().unwrap();
+        let deleting_manager = PermissionManager::new(temp_dir.path().to_path_buf());
+        deleting_manager.update_user_permission("git__status", PermissionLevel::AlwaysAllow);
+        let stale_manager = PermissionManager::new(temp_dir.path().to_path_buf());
+
+        deleting_manager.remove_extension("git");
+        stale_manager.update_user_permission("github__status", PermissionLevel::AskBefore);
 
         let persisted_manager = PermissionManager::new(temp_dir.path().to_path_buf());
         assert_eq!(persisted_manager.get_user_permission("git__status"), None);

--- a/crates/goose/src/config/permission.rs
+++ b/crates/goose/src/config/permission.rs
@@ -139,12 +139,27 @@ impl PermissionManager {
         Ok(())
     }
 
+    fn refresh_permission_map(&self) -> Result<()> {
+        let _process_guard = self.state.file_lock.lock().unwrap();
+        let _file_guard = Self::lock_permission_file(&self.config_path)?;
+        let mut map = self.state.permission_map.write().unwrap();
+        if self.config_path.exists() {
+            *map = Self::try_load_permission_map(&self.config_path)?;
+        } else {
+            map.clear();
+        }
+        Ok(())
+    }
+
     pub fn instance() -> Arc<PermissionManager> {
         Arc::clone(&PERMISSION_MANAGER)
     }
 
     /// Returns a list of all the names (keys) in the permission map.
     pub fn get_permission_names(&self) -> Vec<String> {
+        if self.refresh_permission_map().is_err() {
+            return Vec::new();
+        }
         self.state
             .permission_map
             .read()
@@ -216,6 +231,9 @@ impl PermissionManager {
 
     /// Helper function to retrieve the permission level for a specific permission category and tool.
     fn get_permission(&self, name: &str, principal_name: &str) -> Option<PermissionLevel> {
+        if self.refresh_permission_map().is_err() {
+            return None;
+        }
         let map = self.state.permission_map.read().unwrap();
         // Check if the permission category exists in the map
         if let Some(permission_config) = map.get(name) {
@@ -556,6 +574,24 @@ mod tests {
         FileExt::unlock(&lock_file).unwrap();
         completed_rx.recv_timeout(Duration::from_secs(2)).unwrap();
         update.join().unwrap();
+    }
+
+    #[test]
+    fn test_reads_refresh_permissions_changed_by_another_process() {
+        let (manager, temp_dir) = create_test_permission_manager();
+        manager.update_user_permission("git__status", PermissionLevel::AlwaysAllow);
+        let lock_file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(temp_dir.path().join(PERMISSION_LOCK_FILE))
+            .unwrap();
+        lock_file.lock_exclusive().unwrap();
+        fs::write(manager.get_config_path(), "{}\n").unwrap();
+        FileExt::unlock(&lock_file).unwrap();
+
+        assert_eq!(manager.get_user_permission("git__status"), None);
     }
 
     #[test]

--- a/crates/goose/src/config/permission.rs
+++ b/crates/goose/src/config/permission.rs
@@ -11,7 +11,7 @@ const PERMISSION_FILE: &str = "permission.yaml";
 
 static PERMISSION_MANAGER: LazyLock<Arc<PermissionManager>> =
     LazyLock::new(|| Arc::new(PermissionManager::new(Paths::config_dir())));
-static PERMISSION_FILE_LOCKS: LazyLock<Mutex<HashMap<PathBuf, Weak<Mutex<()>>>>> =
+static PERMISSION_STATES: LazyLock<Mutex<HashMap<PathBuf, Weak<SharedPermissionState>>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 
 /// Enum representing the possible permission levels for a tool.
@@ -31,12 +31,17 @@ pub struct PermissionConfig {
     pub never_allow: Vec<String>,  // List of tools that are never allowed
 }
 
+#[derive(Debug)]
+struct SharedPermissionState {
+    file_lock: Mutex<()>,
+    permission_map: RwLock<HashMap<String, PermissionConfig>>,
+}
+
 /// PermissionManager manages permission configurations for various tools.
 #[derive(Debug)]
 pub struct PermissionManager {
     config_path: PathBuf,
-    file_lock: Arc<Mutex<()>>,
-    permission_map: RwLock<HashMap<String, PermissionConfig>>,
+    state: Arc<SharedPermissionState>,
 }
 
 // Constants representing specific permission categories
@@ -46,34 +51,33 @@ const SMART_APPROVE_PERMISSION: &str = "smart_approve";
 impl PermissionManager {
     pub fn new(config_dir: PathBuf) -> Self {
         let permission_path = config_dir.join(PERMISSION_FILE);
-        let file_lock = Self::shared_file_lock(&permission_path);
-        let permission_map = {
-            let _file_guard = file_lock.lock().unwrap();
-            if permission_path.exists() {
-                Self::load_permission_map(&permission_path)
-            } else {
-                // Consolidate directory creation for re-use in global singleton or ACP.
-                fs::create_dir_all(&config_dir).expect("Failed to create config directory");
-                HashMap::new()
-            }
-        };
+        let state = Self::shared_state(&config_dir, &permission_path);
         PermissionManager {
             config_path: permission_path,
-            file_lock,
-            permission_map: RwLock::new(permission_map),
+            state,
         }
     }
 
-    fn shared_file_lock(config_path: &Path) -> Arc<Mutex<()>> {
-        let mut locks = PERMISSION_FILE_LOCKS.lock().unwrap();
-        locks.retain(|_, lock| lock.strong_count() > 0);
-        if let Some(lock) = locks.get(config_path).and_then(Weak::upgrade) {
-            return lock;
+    fn shared_state(config_dir: &Path, config_path: &Path) -> Arc<SharedPermissionState> {
+        let mut states = PERMISSION_STATES.lock().unwrap();
+        states.retain(|_, state| state.strong_count() > 0);
+        if let Some(state) = states.get(config_path).and_then(Weak::upgrade) {
+            return state;
         }
 
-        let lock = Arc::new(Mutex::new(()));
-        locks.insert(config_path.to_path_buf(), Arc::downgrade(&lock));
-        lock
+        let permission_map = if config_path.exists() {
+            Self::load_permission_map(config_path)
+        } else {
+            // Consolidate directory creation for re-use in global singleton or ACP.
+            fs::create_dir_all(config_dir).expect("Failed to create config directory");
+            HashMap::new()
+        };
+        let state = Arc::new(SharedPermissionState {
+            file_lock: Mutex::new(()),
+            permission_map: RwLock::new(permission_map),
+        });
+        states.insert(config_path.to_path_buf(), Arc::downgrade(&state));
+        state
     }
 
     fn load_permission_map(config_path: &Path) -> HashMap<String, PermissionConfig> {
@@ -93,8 +97,8 @@ impl PermissionManager {
     }
 
     fn modify_permission_map(&self, modify: impl FnOnce(&mut HashMap<String, PermissionConfig>)) {
-        let _file_guard = self.file_lock.lock().unwrap();
-        let mut map = self.permission_map.write().unwrap();
+        let _file_guard = self.state.file_lock.lock().unwrap();
+        let mut map = self.state.permission_map.write().unwrap();
         if self.config_path.exists() {
             *map = Self::load_permission_map(&self.config_path);
         }
@@ -110,7 +114,8 @@ impl PermissionManager {
 
     /// Returns a list of all the names (keys) in the permission map.
     pub fn get_permission_names(&self) -> Vec<String> {
-        self.permission_map
+        self.state
+            .permission_map
             .read()
             .unwrap()
             .keys()
@@ -179,7 +184,7 @@ impl PermissionManager {
 
     /// Helper function to retrieve the permission level for a specific permission category and tool.
     fn get_permission(&self, name: &str, principal_name: &str) -> Option<PermissionLevel> {
-        let map = self.permission_map.read().unwrap();
+        let map = self.state.permission_map.read().unwrap();
         // Check if the permission category exists in the map
         if let Some(permission_config) = map.get(name) {
             // Check the permission levels for the given tool
@@ -405,7 +410,7 @@ mod tests {
         );
 
         // Ensure it's removed from other levels
-        let map = manager.permission_map.read().unwrap();
+        let map = manager.state.permission_map.read().unwrap();
         let config = map.get(USER_PERMISSION).unwrap();
         assert!(!config.always_allow.contains(&"tool7".to_string()));
         assert!(!config.ask_before.contains(&"tool7".to_string()));
@@ -477,6 +482,7 @@ mod tests {
         let stale_manager = PermissionManager::new(temp_dir.path().to_path_buf());
 
         deleting_manager.remove_extension("git");
+        assert_eq!(stale_manager.get_user_permission("git__status"), None);
         stale_manager.update_user_permission("github__status", PermissionLevel::AskBefore);
 
         let persisted_manager = PermissionManager::new(temp_dir.path().to_path_buf());

--- a/crates/goose/src/config/permission.rs
+++ b/crates/goose/src/config/permission.rs
@@ -71,8 +71,6 @@ impl PermissionManager {
         }
 
         let permission_map = if config_path.exists() {
-            let _file_guard = Self::lock_permission_file(config_path)
-                .expect("Failed to lock permission file while loading permissions");
             Self::load_permission_map(config_path)
         } else {
             // Consolidate directory creation for re-use in global singleton or ACP.
@@ -87,7 +85,22 @@ impl PermissionManager {
         state
     }
 
-    fn lock_permission_file(config_path: &Path) -> Result<File> {
+    fn lock_permission_file_for_read(config_path: &Path) -> Result<Option<File>> {
+        let lock_path = config_path.with_file_name(PERMISSION_LOCK_FILE);
+        let lock_file = match OpenOptions::new().read(true).open(&lock_path) {
+            Ok(lock_file) => lock_file,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(error) => {
+                return Err(error)
+                    .with_context(|| format!("Failed to open {}", lock_path.display()));
+            }
+        };
+        FileExt::lock_shared(&lock_file)
+            .with_context(|| format!("Failed to lock {}", lock_path.display()))?;
+        Ok(Some(lock_file))
+    }
+
+    fn lock_permission_file_for_write(config_path: &Path) -> Result<File> {
         let lock_file = OpenOptions::new()
             .read(true)
             .write(true)
@@ -102,7 +115,7 @@ impl PermissionManager {
     }
 
     fn load_permission_map(config_path: &Path) -> HashMap<String, PermissionConfig> {
-        Self::try_load_permission_map(config_path).unwrap_or_else(|error| {
+        Self::read_permission_map(config_path).unwrap_or_else(|error| {
             tracing::error!(
                 "Failed to parse {}: {}. Refusing to start with corrupted permission config.",
                 config_path.display(),
@@ -113,6 +126,21 @@ impl PermissionManager {
                 config_path.display(),
             );
         })
+    }
+
+    fn read_permission_map(config_path: &Path) -> Result<HashMap<String, PermissionConfig>> {
+        let lock_path = config_path.with_file_name(PERMISSION_LOCK_FILE);
+        loop {
+            let file_guard = Self::lock_permission_file_for_read(config_path)?;
+            let result = if config_path.exists() {
+                Self::try_load_permission_map(config_path)
+            } else {
+                Ok(HashMap::new())
+            };
+            if file_guard.is_some() || !lock_path.exists() {
+                return result;
+            }
+        }
     }
 
     fn try_load_permission_map(config_path: &Path) -> Result<HashMap<String, PermissionConfig>> {
@@ -127,7 +155,7 @@ impl PermissionManager {
         modify: impl FnOnce(&mut HashMap<String, PermissionConfig>),
     ) -> Result<()> {
         let _process_guard = self.state.file_lock.lock().unwrap();
-        let _file_guard = Self::lock_permission_file(&self.config_path)?;
+        let _file_guard = Self::lock_permission_file_for_write(&self.config_path)?;
         let mut map = self.state.permission_map.write().unwrap();
         if self.config_path.exists() {
             *map = Self::try_load_permission_map(&self.config_path)?;
@@ -143,13 +171,9 @@ impl PermissionManager {
 
     fn refresh_permission_map(&self) -> Result<()> {
         let _process_guard = self.state.file_lock.lock().unwrap();
-        let _file_guard = Self::lock_permission_file(&self.config_path)?;
+        let refreshed = Self::read_permission_map(&self.config_path)?;
         let mut map = self.state.permission_map.write().unwrap();
-        if self.config_path.exists() {
-            *map = Self::try_load_permission_map(&self.config_path)?;
-        } else {
-            map.clear();
-        }
+        *map = refreshed;
         Ok(())
     }
 
@@ -353,6 +377,26 @@ mod tests {
         let (manager, _temp_dir) = create_test_permission_manager();
 
         assert!(manager.get_permission_names().is_empty());
+    }
+
+    #[test]
+    fn test_permission_reads_do_not_create_lock_file() {
+        let temp_dir = TempDir::new().unwrap();
+        let permission_path = temp_dir.path().join(PERMISSION_FILE);
+        let lock_path = temp_dir.path().join(PERMISSION_LOCK_FILE);
+        fs::write(
+            &permission_path,
+            "user:\n  always_allow:\n    - git__status\n  ask_before: []\n  never_allow: []\n",
+        )
+        .unwrap();
+
+        let manager = PermissionManager::new(temp_dir.path().to_path_buf());
+
+        assert_eq!(
+            manager.get_user_permission("git__status"),
+            Some(PermissionLevel::AlwaysAllow)
+        );
+        assert!(!lock_path.exists());
     }
 
     #[test]

--- a/crates/goose/src/config/permission.rs
+++ b/crates/goose/src/config/permission.rs
@@ -47,6 +47,11 @@ pub struct PermissionManager {
     state: Arc<SharedPermissionState>,
 }
 
+#[derive(Debug, Clone)]
+pub struct PermissionSnapshot {
+    permission_map: Option<HashMap<String, PermissionConfig>>,
+}
+
 // Constants representing specific permission categories
 const USER_PERMISSION: &str = "user";
 const SMART_APPROVE_PERMISSION: &str = "smart_approve";
@@ -181,6 +186,14 @@ impl PermissionManager {
         Arc::clone(&PERMISSION_MANAGER)
     }
 
+    pub fn snapshot(&self) -> PermissionSnapshot {
+        let permission_map = self
+            .refresh_permission_map()
+            .ok()
+            .map(|()| self.state.permission_map.read().unwrap().clone());
+        PermissionSnapshot { permission_map }
+    }
+
     /// Returns a list of all the names (keys) in the permission map.
     pub fn get_permission_names(&self) -> Vec<String> {
         if self.refresh_permission_map().is_err() {
@@ -265,27 +278,7 @@ impl PermissionManager {
             return Some(PermissionLevel::NeverAllow);
         }
         let map = self.state.permission_map.read().unwrap();
-        // Check if the permission category exists in the map
-        if let Some(permission_config) = map.get(name) {
-            // Check the permission levels for the given tool
-            if permission_config
-                .never_allow
-                .contains(&principal_name.to_string())
-            {
-                return Some(PermissionLevel::NeverAllow);
-            } else if permission_config
-                .always_allow
-                .contains(&principal_name.to_string())
-            {
-                return Some(PermissionLevel::AlwaysAllow);
-            } else if permission_config
-                .ask_before
-                .contains(&principal_name.to_string())
-            {
-                return Some(PermissionLevel::AskBefore);
-            }
-        }
-        None // Return None if no matching permission level is found
+        permission_from_map(&map, name, principal_name)
     }
 
     /// Updates the user permission level for a specific tool.
@@ -366,6 +359,53 @@ impl PermissionManager {
             && principal_name
                 .strip_prefix(extension_name)
                 .is_some_and(|suffix| suffix.starts_with("__"))
+    }
+}
+
+impl PermissionSnapshot {
+    pub fn get_user_permission(&self, principal_name: &str) -> Option<PermissionLevel> {
+        self.get_permission(USER_PERMISSION, principal_name)
+    }
+
+    pub fn get_smart_approve_permission(&self, principal_name: &str) -> Option<PermissionLevel> {
+        self.get_permission(SMART_APPROVE_PERMISSION, principal_name)
+    }
+
+    fn get_permission(&self, name: &str, principal_name: &str) -> Option<PermissionLevel> {
+        self.permission_map
+            .as_ref()
+            .map_or(Some(PermissionLevel::NeverAllow), |map| {
+                permission_from_map(map, name, principal_name)
+            })
+    }
+}
+
+fn permission_from_map(
+    map: &HashMap<String, PermissionConfig>,
+    name: &str,
+    principal_name: &str,
+) -> Option<PermissionLevel> {
+    let permission_config = map.get(name)?;
+    if permission_config
+        .never_allow
+        .iter()
+        .any(|permission| permission == principal_name)
+    {
+        Some(PermissionLevel::NeverAllow)
+    } else if permission_config
+        .always_allow
+        .iter()
+        .any(|permission| permission == principal_name)
+    {
+        Some(PermissionLevel::AlwaysAllow)
+    } else if permission_config
+        .ask_before
+        .iter()
+        .any(|permission| permission == principal_name)
+    {
+        Some(PermissionLevel::AskBefore)
+    } else {
+        None
     }
 }
 
@@ -702,6 +742,58 @@ mod tests {
         FileExt::unlock(&lock_file).unwrap();
 
         assert_eq!(manager.get_user_permission("git__status"), None);
+    }
+
+    #[test]
+    fn permission_snapshot_refreshes_once_per_batch() {
+        let (manager, temp_dir) = create_test_permission_manager();
+        manager
+            .update_user_permission("git__status", PermissionLevel::AlwaysAllow)
+            .unwrap();
+        let snapshot = manager.snapshot();
+
+        let lock_file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(temp_dir.path().join(PERMISSION_LOCK_FILE))
+            .unwrap();
+        lock_file.lock_exclusive().unwrap();
+        fs::write(
+            manager.get_config_path(),
+            "user:\n  always_allow: []\n  ask_before: []\n  never_allow:\n    - git__status\n",
+        )
+        .unwrap();
+        FileExt::unlock(&lock_file).unwrap();
+
+        assert_eq!(
+            snapshot.get_user_permission("git__status"),
+            Some(PermissionLevel::AlwaysAllow)
+        );
+        assert_eq!(
+            manager.snapshot().get_user_permission("git__status"),
+            Some(PermissionLevel::NeverAllow)
+        );
+    }
+
+    #[test]
+    fn permission_snapshot_fails_closed_when_refresh_fails() {
+        let (manager, _temp_dir) = create_test_permission_manager();
+        manager
+            .update_user_permission("git__status", PermissionLevel::AlwaysAllow)
+            .unwrap();
+        fs::write(manager.get_config_path(), "{{invalid yaml: [broken").unwrap();
+
+        let snapshot = manager.snapshot();
+        assert_eq!(
+            snapshot.get_user_permission("git__status"),
+            Some(PermissionLevel::NeverAllow)
+        );
+        assert_eq!(
+            snapshot.get_smart_approve_permission("unknown"),
+            Some(PermissionLevel::NeverAllow)
+        );
     }
 
     #[test]

--- a/crates/goose/src/config/permission.rs
+++ b/crates/goose/src/config/permission.rs
@@ -1,4 +1,5 @@
 use crate::config::paths::Paths;
+use anyhow::{Context, Result};
 use fs2::FileExt;
 use rmcp::model::Tool;
 use serde::{Deserialize, Serialize};
@@ -61,14 +62,17 @@ impl PermissionManager {
     }
 
     fn shared_state(config_dir: &Path, config_path: &Path) -> Arc<SharedPermissionState> {
-        let mut states = PERMISSION_STATES.lock().unwrap();
+        let mut states = PERMISSION_STATES
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         states.retain(|_, state| state.strong_count() > 0);
         if let Some(state) = states.get(config_path).and_then(Weak::upgrade) {
             return state;
         }
 
         let permission_map = if config_path.exists() {
-            let _file_guard = Self::lock_permission_file(config_path);
+            let _file_guard = Self::lock_permission_file(config_path)
+                .expect("Failed to lock permission file while loading permissions");
             Self::load_permission_map(config_path)
         } else {
             // Consolidate directory creation for re-use in global singleton or ACP.
@@ -83,24 +87,22 @@ impl PermissionManager {
         state
     }
 
-    fn lock_permission_file(config_path: &Path) -> File {
+    fn lock_permission_file(config_path: &Path) -> Result<File> {
         let lock_file = OpenOptions::new()
             .read(true)
             .write(true)
             .create(true)
             .truncate(false)
             .open(config_path.with_file_name(PERMISSION_LOCK_FILE))
-            .expect("Failed to open permission lock file");
+            .context("Failed to open permission lock file")?;
         lock_file
             .lock_exclusive()
-            .expect("Failed to lock permission file");
-        lock_file
+            .context("Failed to lock permission file")?;
+        Ok(lock_file)
     }
 
     fn load_permission_map(config_path: &Path) -> HashMap<String, PermissionConfig> {
-        let file_contents =
-            fs::read_to_string(config_path).expect("Failed to read permission.yaml");
-        serde_yaml::from_str(&file_contents).unwrap_or_else(|error| {
+        Self::try_load_permission_map(config_path).unwrap_or_else(|error| {
             tracing::error!(
                 "Failed to parse {}: {}. Refusing to start with corrupted permission config.",
                 config_path.display(),
@@ -113,17 +115,28 @@ impl PermissionManager {
         })
     }
 
-    fn modify_permission_map(&self, modify: impl FnOnce(&mut HashMap<String, PermissionConfig>)) {
+    fn try_load_permission_map(config_path: &Path) -> Result<HashMap<String, PermissionConfig>> {
+        let file_contents = fs::read_to_string(config_path)
+            .with_context(|| format!("Failed to read {}", config_path.display()))?;
+        serde_yaml::from_str(&file_contents)
+            .with_context(|| format!("Failed to parse {}", config_path.display()))
+    }
+
+    fn modify_permission_map(
+        &self,
+        modify: impl FnOnce(&mut HashMap<String, PermissionConfig>),
+    ) -> Result<()> {
         let _process_guard = self.state.file_lock.lock().unwrap();
-        let _file_guard = Self::lock_permission_file(&self.config_path);
+        let _file_guard = Self::lock_permission_file(&self.config_path)?;
         let mut map = self.state.permission_map.write().unwrap();
         if self.config_path.exists() {
-            *map = Self::load_permission_map(&self.config_path);
+            *map = Self::try_load_permission_map(&self.config_path)?;
         }
         modify(&mut map);
-        let yaml_content =
-            serde_yaml::to_string(&*map).expect("Failed to serialize permission config");
-        fs::write(&self.config_path, yaml_content).expect("Failed to write to permission.yaml");
+        let yaml_content = serde_yaml::to_string(&*map)?;
+        fs::write(&self.config_path, yaml_content)
+            .with_context(|| format!("Failed to write {}", self.config_path.display()))?;
+        Ok(())
     }
 
     pub fn instance() -> Arc<PermissionManager> {
@@ -197,7 +210,8 @@ impl PermissionManager {
                     }
                 }
             }
-        });
+        })
+        .expect("Failed to update smart-approve permissions");
     }
 
     /// Helper function to retrieve the permission level for a specific permission category and tool.
@@ -263,10 +277,11 @@ impl PermissionManager {
                     .never_allow
                     .push(principal_name.to_string()),
             }
-        });
+        })
+        .expect("Failed to update user permissions");
     }
 
-    pub fn remove_extension(&self, extension_name: &str) {
+    pub fn remove_extension(&self, extension_name: &str) -> Result<()> {
         self.modify_permission_map(|map| {
             for permission_config in map.values_mut() {
                 permission_config
@@ -279,11 +294,12 @@ impl PermissionManager {
                     .never_allow
                     .retain(|p| !Self::belongs_to_extension(p, extension_name));
             }
-        });
+        })
     }
 
     pub fn clear_permissions(&self) {
-        self.modify_permission_map(HashMap::clear);
+        self.modify_permission_map(HashMap::clear)
+            .expect("Failed to clear permissions");
     }
 
     fn belongs_to_extension(principal_name: &str, extension_name: &str) -> bool {
@@ -448,7 +464,7 @@ mod tests {
         manager.update_user_permission("gitlab__deploy", PermissionLevel::AskBefore);
         manager.update_user_permission("__cli__ent____tool", PermissionLevel::NeverAllow);
 
-        manager.remove_extension("git");
+        manager.remove_extension("git").unwrap();
 
         assert_eq!(manager.get_user_permission("git__status"), None);
         assert_eq!(
@@ -464,10 +480,10 @@ mod tests {
             Some(PermissionLevel::AskBefore)
         );
 
-        manager.remove_extension("__cli__ent__");
+        manager.remove_extension("__cli__ent__").unwrap();
         assert_eq!(manager.get_user_permission("__cli__ent____tool"), None);
 
-        manager.remove_extension("");
+        manager.remove_extension("").unwrap();
         assert_eq!(
             manager.get_user_permission("github__delete_repo"),
             Some(PermissionLevel::NeverAllow)
@@ -486,7 +502,7 @@ mod tests {
         let newer_manager = PermissionManager::new(temp_dir.path().to_path_buf());
         newer_manager.update_user_permission("github__status", PermissionLevel::AskBefore);
 
-        deleting_manager.remove_extension("git");
+        deleting_manager.remove_extension("git").unwrap();
 
         let persisted_manager = PermissionManager::new(temp_dir.path().to_path_buf());
         assert_eq!(persisted_manager.get_user_permission("git__status"), None);
@@ -503,7 +519,7 @@ mod tests {
         deleting_manager.update_user_permission("git__status", PermissionLevel::AlwaysAllow);
         let stale_manager = PermissionManager::new(temp_dir.path().to_path_buf());
 
-        deleting_manager.remove_extension("git");
+        deleting_manager.remove_extension("git").unwrap();
         assert_eq!(stale_manager.get_user_permission("git__status"), None);
         stale_manager.update_user_permission("github__status", PermissionLevel::AskBefore);
 

--- a/crates/goose/src/config/permission.rs
+++ b/crates/goose/src/config/permission.rs
@@ -232,7 +232,7 @@ impl PermissionManager {
     /// Helper function to retrieve the permission level for a specific permission category and tool.
     fn get_permission(&self, name: &str, principal_name: &str) -> Option<PermissionLevel> {
         if self.refresh_permission_map().is_err() {
-            return None;
+            return Some(PermissionLevel::NeverAllow);
         }
         let map = self.state.permission_map.read().unwrap();
         // Check if the permission category exists in the map
@@ -592,6 +592,18 @@ mod tests {
         FileExt::unlock(&lock_file).unwrap();
 
         assert_eq!(manager.get_user_permission("git__status"), None);
+    }
+
+    #[test]
+    fn test_reads_fail_closed_when_permission_refresh_fails() {
+        let (manager, _temp_dir) = create_test_permission_manager();
+        manager.update_user_permission("git__status", PermissionLevel::AlwaysAllow);
+        fs::write(manager.get_config_path(), "{{invalid yaml: [broken").unwrap();
+
+        assert_eq!(
+            manager.get_user_permission("git__status"),
+            Some(PermissionLevel::NeverAllow)
+        );
     }
 
     #[test]

--- a/crates/goose/src/config/permission.rs
+++ b/crates/goose/src/config/permission.rs
@@ -1,13 +1,15 @@
 use crate::config::paths::Paths;
+use fs2::FileExt;
 use rmcp::model::Tool;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::fs;
+use std::fs::{self, File, OpenOptions};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, LazyLock, Mutex, RwLock, Weak};
 use tracing;
 
 const PERMISSION_FILE: &str = "permission.yaml";
+const PERMISSION_LOCK_FILE: &str = "permission.lock";
 
 static PERMISSION_MANAGER: LazyLock<Arc<PermissionManager>> =
     LazyLock::new(|| Arc::new(PermissionManager::new(Paths::config_dir())));
@@ -66,6 +68,7 @@ impl PermissionManager {
         }
 
         let permission_map = if config_path.exists() {
+            let _file_guard = Self::lock_permission_file(config_path);
             Self::load_permission_map(config_path)
         } else {
             // Consolidate directory creation for re-use in global singleton or ACP.
@@ -78,6 +81,20 @@ impl PermissionManager {
         });
         states.insert(config_path.to_path_buf(), Arc::downgrade(&state));
         state
+    }
+
+    fn lock_permission_file(config_path: &Path) -> File {
+        let lock_file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(config_path.with_file_name(PERMISSION_LOCK_FILE))
+            .expect("Failed to open permission lock file");
+        lock_file
+            .lock_exclusive()
+            .expect("Failed to lock permission file");
+        lock_file
     }
 
     fn load_permission_map(config_path: &Path) -> HashMap<String, PermissionConfig> {
@@ -97,7 +114,8 @@ impl PermissionManager {
     }
 
     fn modify_permission_map(&self, modify: impl FnOnce(&mut HashMap<String, PermissionConfig>)) {
-        let _file_guard = self.state.file_lock.lock().unwrap();
+        let _process_guard = self.state.file_lock.lock().unwrap();
+        let _file_guard = Self::lock_permission_file(&self.config_path);
         let mut map = self.state.permission_map.write().unwrap();
         if self.config_path.exists() {
             *map = Self::load_permission_map(&self.config_path);
@@ -281,6 +299,10 @@ mod tests {
     use super::*;
     use rmcp::model::ToolAnnotations;
     use rmcp::object;
+    use std::fs::OpenOptions;
+    use std::sync::mpsc;
+    use std::thread;
+    use std::time::Duration;
     use tempfile::TempDir;
 
     // Helper function to create a test instance of PermissionManager with a temp dir
@@ -491,6 +513,33 @@ mod tests {
             persisted_manager.get_user_permission("github__status"),
             Some(PermissionLevel::AskBefore)
         );
+    }
+
+    #[test]
+    fn test_permission_updates_wait_for_process_lock() {
+        let temp_dir = TempDir::new().unwrap();
+        let manager = PermissionManager::new(temp_dir.path().to_path_buf());
+        let lock_file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(temp_dir.path().join(PERMISSION_LOCK_FILE))
+            .unwrap();
+        lock_file.lock_exclusive().unwrap();
+        let (completed_tx, completed_rx) = mpsc::channel();
+
+        let update = thread::spawn(move || {
+            manager.update_user_permission("github__status", PermissionLevel::AskBefore);
+            completed_tx.send(()).unwrap();
+        });
+
+        assert!(completed_rx
+            .recv_timeout(Duration::from_millis(100))
+            .is_err());
+        FileExt::unlock(&lock_file).unwrap();
+        completed_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+        update.join().unwrap();
     }
 
     #[test]

--- a/crates/goose/src/permission/permission_inspector.rs
+++ b/crates/goose/src/permission/permission_inspector.rs
@@ -23,14 +23,15 @@ fn cache_non_readonly_decision(
     permission_manager: &PermissionManager,
     candidate: &ToolRequest,
     is_readonly: bool,
-) {
+) -> Result<()> {
     if is_readonly {
-        return;
+        return Ok(());
     }
     if let Ok(tool_call) = &candidate.tool_call {
         permission_manager
-            .update_smart_approve_permission(&tool_call.name, PermissionLevel::AskBefore);
+            .update_smart_approve_permission(&tool_call.name, PermissionLevel::AskBefore)?;
     }
+    Ok(())
 }
 
 impl PermissionInspector {
@@ -49,7 +50,7 @@ impl PermissionInspector {
 
     // readonly_tools is per-agent to avoid concurrent session clobbering; write-annotated
     // tools are cached globally via PermissionManager.
-    pub fn apply_tool_annotations(&self, tools: &[Tool]) {
+    pub fn apply_tool_annotations(&self, tools: &[Tool]) -> Result<()> {
         let mut readonly_annotated = HashSet::new();
         for tool in tools {
             let Some(anns) = &tool.annotations else {
@@ -60,7 +61,7 @@ impl PermissionInspector {
             }
         }
         *self.readonly_tools.write().unwrap() = readonly_annotated;
-        self.permission_manager.apply_tool_annotations(tools);
+        self.permission_manager.apply_tool_annotations(tools)
     }
 
     pub fn is_readonly_annotated_tool(&self, tool_name: &str) -> bool {
@@ -244,7 +245,7 @@ impl ToolInspector for PermissionInspector {
             for candidate in &llm_detect_candidates {
                 let is_readonly = detected_request_ids.contains(&candidate.id);
 
-                cache_non_readonly_decision(permission_manager, candidate, is_readonly);
+                cache_non_readonly_decision(permission_manager, candidate, is_readonly)?;
 
                 results.push(InspectionResult {
                     tool_request_id: candidate.id.clone(),
@@ -286,10 +287,10 @@ mod tests {
     ) -> (InspectionAction, Option<PermissionLevel>) {
         let pm = Arc::new(PermissionManager::new(tempfile::tempdir().unwrap().keep()));
         if let Some(level) = user_permission {
-            pm.update_user_permission("tool", level);
+            pm.update_user_permission("tool", level).unwrap();
         }
         if let Some(level) = smart_approve_cache {
-            pm.update_smart_approve_permission("tool", level);
+            pm.update_smart_approve_permission("tool", level).unwrap();
         }
         let session_manager = Arc::new(crate::session::SessionManager::new(
             tempfile::tempdir().unwrap().keep(),
@@ -383,10 +384,10 @@ mod tests {
             tool_meta: None,
         };
 
-        cache_non_readonly_decision(&pm, &req, true);
+        cache_non_readonly_decision(&pm, &req, true).unwrap();
         assert_eq!(pm.get_smart_approve_permission("multipurpose"), None);
 
-        cache_non_readonly_decision(&pm, &req, false);
+        cache_non_readonly_decision(&pm, &req, false).unwrap();
         assert_eq!(
             pm.get_smart_approve_permission("multipurpose"),
             Some(PermissionLevel::AskBefore)

--- a/crates/goose/src/permission/permission_inspector.rs
+++ b/crates/goose/src/permission/permission_inspector.rs
@@ -151,6 +151,9 @@ impl ToolInspector for PermissionInspector {
     ) -> Result<Vec<InspectionResult>> {
         let mut results = Vec::new();
         let permission_manager = &self.permission_manager;
+        let permission_snapshot =
+            matches!(goose_mode, GooseMode::Approve | GooseMode::SmartApprove)
+                .then(|| permission_manager.snapshot());
         let mut llm_detect_candidates: Vec<&ToolRequest> = Vec::new();
 
         for request in tool_requests {
@@ -161,8 +164,9 @@ impl ToolInspector for PermissionInspector {
                     GooseMode::Chat => continue,
                     GooseMode::Auto => InspectionAction::Allow,
                     GooseMode::Approve | GooseMode::SmartApprove => {
+                        let permission_snapshot = permission_snapshot.as_ref().unwrap();
                         // 1. Check user-defined permission first
-                        if let Some(level) = permission_manager.get_user_permission(tool_name) {
+                        if let Some(level) = permission_snapshot.get_user_permission(tool_name) {
                             match level {
                                 PermissionLevel::AlwaysAllow => InspectionAction::Allow,
                                 PermissionLevel::NeverAllow => InspectionAction::Deny,
@@ -183,7 +187,7 @@ impl ToolInspector for PermissionInspector {
                         // 4. Defer to LLM detection (SmartApprove, uncached or legacy cached allow)
                         } else if goose_mode == GooseMode::SmartApprove
                             && matches!(
-                                permission_manager.get_smart_approve_permission(tool_name),
+                                permission_snapshot.get_smart_approve_permission(tool_name),
                                 None | Some(PermissionLevel::AlwaysAllow)
                             )
                         {

--- a/crates/goose/src/tool_inspection.rs
+++ b/crates/goose/src/tool_inspection.rs
@@ -130,22 +130,24 @@ impl ToolInspectionManager {
             .and_then(|i| i.as_any().downcast_ref::<PermissionInspector>())
     }
 
-    pub fn apply_tool_annotations(&self, tools: &[rmcp::model::Tool]) {
+    pub fn apply_tool_annotations(&self, tools: &[rmcp::model::Tool]) -> Result<()> {
         if let Some(inspector) = self.get_permission_inspector() {
-            inspector.apply_tool_annotations(tools);
+            inspector.apply_tool_annotations(tools)?;
         }
+        Ok(())
     }
 
     pub async fn update_permission_manager(
         &self,
         tool_name: &str,
         permission_level: crate::config::permission::PermissionLevel,
-    ) {
+    ) -> Result<()> {
         if let Some(inspector) = self.get_permission_inspector() {
             inspector
                 .permission_manager
-                .update_user_permission(tool_name, permission_level);
+                .update_user_permission(tool_name, permission_level)?;
         }
+        Ok(())
     }
 
     pub fn process_inspection_results_with_permission_inspector(

--- a/crates/goose/tests/acp_custom_requests_test.rs
+++ b/crates/goose/tests/acp_custom_requests_test.rs
@@ -249,6 +249,33 @@ fn test_custom_get_extensions() {
         )
         .await;
 
+        let missing_remove_result = send_custom(
+            conn.cx(),
+            "_goose/unstable/config/extensions/remove",
+            serde_json::json!({
+                "configKey": config_key,
+            }),
+        )
+        .await;
+        assert_eq!(
+            missing_remove_result.unwrap_err(),
+            agent_client_protocol::Error::invalid_params()
+                .data(format!("Extension '{config_key}' not found"))
+        );
+        let permissions_after_missing_remove = PermissionManager::new(permission_dir.clone());
+        for (principal, level) in &target_user_permissions {
+            assert_eq!(
+                permissions_after_missing_remove.get_user_permission(principal),
+                Some(level.clone())
+            );
+        }
+        for (principal, level) in &target_smart_approve_permissions {
+            assert_eq!(
+                permissions_after_missing_remove.get_smart_approve_permission(principal),
+                Some(level.clone())
+            );
+        }
+
         let extension = serde_json::json!({
             "type": "mcp",
             "description": "Test stdio",

--- a/crates/goose/tests/acp_custom_requests_test.rs
+++ b/crates/goose/tests/acp_custom_requests_test.rs
@@ -12,6 +12,7 @@ use common_tests::fixtures::{
     TestConnectionConfig,
 };
 use goose::acp::server::AcpProviderFactory;
+use goose::config::{permission::PermissionLevel, PermissionManager};
 use goose::providers::base::{MessageStream, Provider};
 use goose_providers::errors::ProviderError;
 use goose_providers::model::ModelConfig;
@@ -193,31 +194,83 @@ fn test_custom_get_extensions() {
     let config_key = "test-stdio-acp-mutation-flow";
     let _guard = env_lock::lock_env([("EXTENSIONS", None::<&str>)]);
     write_acp_global_config(DEFAULT_ACP_TEST_CONFIG);
+    let permission_root = tempfile::tempdir().unwrap();
+    let permission_dir = permission_root.path().to_path_buf();
+    let target_user_permissions = [
+        (
+            format!("{config_key}__write_file"),
+            PermissionLevel::AlwaysAllow,
+        ),
+        (
+            format!("{config_key}__tool__with__delimiter"),
+            PermissionLevel::AskBefore,
+        ),
+        (
+            format!("{config_key}__delete_file"),
+            PermissionLevel::NeverAllow,
+        ),
+    ];
+    let target_smart_approve_permissions = [
+        (
+            format!("{config_key}__smart_write"),
+            PermissionLevel::AlwaysAllow,
+        ),
+        (
+            format!("{config_key}__smart_prompt"),
+            PermissionLevel::AskBefore,
+        ),
+        (
+            format!("{config_key}__smart_deny"),
+            PermissionLevel::NeverAllow,
+        ),
+    ];
+    let user_sibling = format!("{config_key}-sibling__write_file");
+    let smart_approve_sibling = format!("{config_key}_sibling__read_file");
+    let permission_manager = PermissionManager::new(permission_dir.clone());
+    for (principal, level) in &target_user_permissions {
+        permission_manager.update_user_permission(principal, level.clone());
+    }
+    for (principal, level) in &target_smart_approve_permissions {
+        permission_manager.update_smart_approve_permission(principal, level.clone());
+    }
+    permission_manager.update_user_permission(&user_sibling, PermissionLevel::AlwaysAllow);
+    permission_manager
+        .update_smart_approve_permission(&smart_approve_sibling, PermissionLevel::AskBefore);
 
     run_test(async move {
+        let _permission_root = permission_root;
         let openai = OpenAiFixture::new(vec![], Arc::new(EnforceSessionId::default())).await;
-        let conn = AcpServerConnection::new(TestConnectionConfig::default(), openai).await;
+        let conn = AcpServerConnection::new(
+            TestConnectionConfig {
+                data_root: permission_dir.clone(),
+                ..Default::default()
+            },
+            openai,
+        )
+        .await;
+
+        let extension = serde_json::json!({
+            "type": "mcp",
+            "description": "Test stdio",
+            "envKeys": ["SECRET_TOKEN"],
+            "timeout": 42,
+            "server": {
+                "type": "stdio",
+                "name": config_key,
+                "command": "test-command",
+                "args": ["--flag", "value"],
+                "env": [
+                    { "name": "INLINE_TOKEN", "value": "inline-secret" }
+                ]
+            }
+        });
 
         let add_result = send_custom(
             conn.cx(),
             "_goose/unstable/config/extensions/add",
             serde_json::json!({
                 "enabled": true,
-                "extension": {
-                    "type": "mcp",
-                    "description": "Test stdio",
-                    "envKeys": ["SECRET_TOKEN"],
-                    "timeout": 42,
-                    "server": {
-                        "type": "stdio",
-                        "name": config_key,
-                        "command": "test-command",
-                        "args": ["--flag", "value"],
-                        "env": [
-                            { "name": "INLINE_TOKEN", "value": "inline-secret" }
-                        ]
-                    }
-                }
+                "extension": extension.clone(),
             }),
         )
         .await;
@@ -310,6 +363,73 @@ fn test_custom_get_extensions() {
             list_extension().await.is_none(),
             "removed extension should not be listed"
         );
+
+        let persisted_permissions = PermissionManager::new(permission_dir.clone());
+        for (principal, _) in &target_user_permissions {
+            assert_eq!(
+                persisted_permissions.get_user_permission(principal),
+                None,
+                "removed extension retained user permission for {principal}"
+            );
+        }
+        for (principal, _) in &target_smart_approve_permissions {
+            assert_eq!(
+                persisted_permissions.get_smart_approve_permission(principal),
+                None,
+                "removed extension retained smart-approve permission for {principal}"
+            );
+        }
+        assert_eq!(
+            persisted_permissions.get_user_permission(&user_sibling),
+            Some(PermissionLevel::AlwaysAllow)
+        );
+        assert_eq!(
+            persisted_permissions.get_smart_approve_permission(&smart_approve_sibling),
+            Some(PermissionLevel::AskBefore)
+        );
+
+        let readd_result = send_custom(
+            conn.cx(),
+            "_goose/unstable/config/extensions/add",
+            serde_json::json!({
+                "enabled": true,
+                "extension": extension,
+            }),
+        )
+        .await;
+        assert!(
+            readd_result.is_ok(),
+            "expected same-identity reinstall to succeed, got: {readd_result:?}"
+        );
+        assert!(
+            list_extension().await.is_some(),
+            "reinstalled extension should be listed"
+        );
+
+        let reinstalled_permissions = PermissionManager::new(permission_dir);
+        for (principal, _) in &target_user_permissions {
+            assert_eq!(reinstalled_permissions.get_user_permission(principal), None);
+        }
+        for (principal, _) in &target_smart_approve_permissions {
+            assert_eq!(
+                reinstalled_permissions.get_smart_approve_permission(principal),
+                None
+            );
+        }
+
+        let cleanup_result = send_custom(
+            conn.cx(),
+            "_goose/unstable/config/extensions/remove",
+            serde_json::json!({
+                "configKey": config_key,
+            }),
+        )
+        .await;
+        assert!(
+            cleanup_result.is_ok(),
+            "expected cleanup removal to succeed, got: {cleanup_result:?}"
+        );
+        assert!(list_extension().await.is_none());
     });
 }
 

--- a/crates/goose/tests/acp_custom_requests_test.rs
+++ b/crates/goose/tests/acp_custom_requests_test.rs
@@ -228,14 +228,21 @@ fn test_custom_get_extensions() {
     let smart_approve_sibling = format!("{config_key}_sibling__read_file");
     let permission_manager = PermissionManager::new(permission_dir.clone());
     for (principal, level) in &target_user_permissions {
-        permission_manager.update_user_permission(principal, level.clone());
+        permission_manager
+            .update_user_permission(principal, level.clone())
+            .unwrap();
     }
     for (principal, level) in &target_smart_approve_permissions {
-        permission_manager.update_smart_approve_permission(principal, level.clone());
+        permission_manager
+            .update_smart_approve_permission(principal, level.clone())
+            .unwrap();
     }
-    permission_manager.update_user_permission(&user_sibling, PermissionLevel::AlwaysAllow);
     permission_manager
-        .update_smart_approve_permission(&smart_approve_sibling, PermissionLevel::AskBefore);
+        .update_user_permission(&user_sibling, PermissionLevel::AlwaysAllow)
+        .unwrap();
+    permission_manager
+        .update_smart_approve_permission(&smart_approve_sibling, PermissionLevel::AskBefore)
+        .unwrap();
 
     run_test(async move {
         let _permission_root = permission_root;

--- a/crates/goose/tests/acp_fixtures/provider.rs
+++ b/crates/goose/tests/acp_fixtures/provider.rs
@@ -300,7 +300,7 @@ impl Connection for AcpProviderConnection {
     }
 
     fn reset_permissions(&self) {
-        self.permission_manager.clear_permissions();
+        self.permission_manager.clear_permissions().unwrap();
     }
 }
 

--- a/crates/goose/tests/acp_fixtures/server.rs
+++ b/crates/goose/tests/acp_fixtures/server.rs
@@ -550,7 +550,7 @@ impl Connection for AcpServerConnection {
     }
 
     fn reset_permissions(&self) {
-        self.permission_manager.clear_permissions();
+        self.permission_manager.clear_permissions().unwrap();
     }
 }
 


### PR DESCRIPTION
## Summary

- clear persisted tool permissions when a configured extension is deleted through ACP
- preserve permissions for prefix-sharing extensions and require fresh authorization after reinstall
- keep permission revocation at the lifecycle boundary shared by both agent loops

## Validation

- `cargo test -p goose --test acp_custom_requests_test test_custom_get_extensions -- --exact`
- `cargo test -p goose --test acp_custom_requests_test`
- `cargo test -p goose config::permission::tests --lib`
- `cargo fmt --all -- --check`
- `cargo build`
- `cargo clippy --all-targets -- -D warnings`

*This finding was discovered by [Project Loupe](https://github.com/project-loupe/loupe)*
