### PR TITLE
fix(desktop): preserve external backend TOFU pins

### DIFF
--- a/ui/desktop/src/backendCertificateTrust.test.ts
+++ b/ui/desktop/src/backendCertificateTrust.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest';
+import { BackendCertificateTrustStore } from './backendCertificateTrust';
+
+const HOSTNAME = 'backend.example';
+const CERTIFICATE_A = 'AA:AA';
+const CERTIFICATE_B = 'BB:BB';
+const CERTIFICATE_C = 'CC:CC';
+
+describe('BackendCertificateTrustStore', () => {
+  it('inherits a learned hostname TOFU pin for later registrations', () => {
+    const store = new BackendCertificateTrustStore();
+    const first = store.register(HOSTNAME, null, 'hostname-tofu');
+
+    expect(store.verify(HOSTNAME, CERTIFICATE_A)).toBe(true);
+
+    const second = store.register(HOSTNAME, null, 'hostname-tofu');
+    expect(first.trust.fingerprint).toBe(CERTIFICATE_A);
+    expect(second.trust.fingerprint).toBe(CERTIFICATE_A);
+    expect(store.verify(HOSTNAME, CERTIFICATE_B)).toBe(false);
+  });
+
+  it('binds concurrent hostname TOFU registrations to the same first certificate', () => {
+    const store = new BackendCertificateTrustStore();
+    const first = store.register(HOSTNAME, null, 'hostname-tofu');
+    const second = store.register(HOSTNAME, null, 'hostname-tofu');
+
+    expect(store.verify(HOSTNAME, CERTIFICATE_A)).toBe(true);
+    expect(first.trust.fingerprint).toBe(CERTIFICATE_A);
+    expect(second.trust.fingerprint).toBe(CERTIFICATE_A);
+    expect(store.verify(HOSTNAME, CERTIFICATE_B)).toBe(false);
+  });
+
+  it('binds an unpinned hostname TOFU registration on an exact match', () => {
+    const store = new BackendCertificateTrustStore();
+    store.register(HOSTNAME, CERTIFICATE_A);
+    const tofu = store.register(HOSTNAME, null, 'hostname-tofu');
+
+    expect(store.verify(HOSTNAME, CERTIFICATE_A)).toBe(true);
+    expect(tofu.trust.fingerprint).toBe(CERTIFICATE_A);
+    expect(store.verify(HOSTNAME, CERTIFICATE_B)).toBe(false);
+  });
+
+  it.each(['first', 'second'] as const)(
+    'preserves the hostname TOFU pin when the %s registration is released',
+    (releasedRegistration) => {
+      const store = new BackendCertificateTrustStore();
+      const first = store.register(HOSTNAME, null, 'hostname-tofu');
+      const second = store.register(HOSTNAME, null, 'hostname-tofu');
+      expect(store.verify(HOSTNAME, CERTIFICATE_A)).toBe(true);
+
+      if (releasedRegistration === 'first') {
+        first.release();
+      } else {
+        second.release();
+      }
+
+      expect(store.verify(HOSTNAME, CERTIFICATE_B)).toBe(false);
+      expect(store.verify(HOSTNAME, CERTIFICATE_A)).toBe(true);
+    }
+  );
+
+  it('allows fresh TOFU after the last registration is released', () => {
+    const store = new BackendCertificateTrustStore();
+    const first = store.register(HOSTNAME, null, 'hostname-tofu');
+    const second = store.register(HOSTNAME, null, 'hostname-tofu');
+    expect(store.verify(HOSTNAME, CERTIFICATE_A)).toBe(true);
+
+    first.release();
+    second.release();
+    expect(store.has(HOSTNAME)).toBe(false);
+
+    store.register(HOSTNAME, null, 'hostname-tofu');
+    expect(store.verify(HOSTNAME, CERTIFICATE_B)).toBe(true);
+  });
+
+  it('keeps hostname TOFU pins independent across hosts', () => {
+    const store = new BackendCertificateTrustStore();
+    store.register('one.example', null, 'hostname-tofu');
+    store.register('two.example', null, 'hostname-tofu');
+
+    expect(store.verify('one.example', CERTIFICATE_A)).toBe(true);
+    expect(store.verify('two.example', CERTIFICATE_B)).toBe(true);
+    expect(store.verify('one.example', CERTIFICATE_B)).toBe(false);
+    expect(store.verify('two.example', CERTIFICATE_A)).toBe(false);
+  });
+
+  it('requires an exact match for an explicit certificate pin', () => {
+    const store = new BackendCertificateTrustStore();
+    store.register(HOSTNAME, CERTIFICATE_A);
+
+    expect(store.verify(HOSTNAME, CERTIFICATE_A)).toBe(true);
+    expect(store.verify(HOSTNAME, CERTIFICATE_B)).toBe(false);
+  });
+
+  it('keeps explicit pins from overlapping lease rotations valid', () => {
+    const store = new BackendCertificateTrustStore();
+    store.register(HOSTNAME, CERTIFICATE_A);
+    store.register(HOSTNAME, CERTIFICATE_B);
+
+    expect(store.verify(HOSTNAME, CERTIFICATE_A)).toBe(true);
+    expect(store.verify(HOSTNAME, CERTIFICATE_B)).toBe(true);
+    expect(store.verify(HOSTNAME, CERTIFICATE_C)).toBe(false);
+  });
+
+  it('keeps explicit and hostname TOFU pins independently valid', () => {
+    const store = new BackendCertificateTrustStore();
+    store.register(HOSTNAME, null, 'hostname-tofu');
+    expect(store.verify(HOSTNAME, CERTIFICATE_A)).toBe(true);
+
+    store.register(HOSTNAME, CERTIFICATE_B);
+    const laterTofu = store.register(HOSTNAME, null, 'hostname-tofu');
+
+    expect(laterTofu.trust.fingerprint).toBe(CERTIFICATE_A);
+    expect(store.verify(HOSTNAME, CERTIFICATE_A)).toBe(true);
+    expect(store.verify(HOSTNAME, CERTIFICATE_B)).toBe(true);
+    expect(store.verify(HOSTNAME, CERTIFICATE_C)).toBe(false);
+  });
+
+  it('allows local lease-scoped registrations to learn different certificates', () => {
+    const store = new BackendCertificateTrustStore();
+    const first = store.register('127.0.0.1', null);
+    expect(store.verify('127.0.0.1', CERTIFICATE_A)).toBe(true);
+
+    const second = store.register('127.0.0.1', null);
+    expect(store.verify('127.0.0.1', CERTIFICATE_B)).toBe(true);
+
+    expect(first.trust.fingerprint).toBe(CERTIFICATE_A);
+    expect(second.trust.fingerprint).toBe(CERTIFICATE_B);
+    expect(store.verify('127.0.0.1', CERTIFICATE_A)).toBe(true);
+    expect(store.verify('127.0.0.1', CERTIFICATE_B)).toBe(true);
+  });
+});

--- a/ui/desktop/src/backendCertificateTrust.test.ts
+++ b/ui/desktop/src/backendCertificateTrust.test.ts
@@ -30,14 +30,16 @@ describe('BackendCertificateTrustStore', () => {
     expect(store.verify(HOSTNAME, CERTIFICATE_B)).toBe(false);
   });
 
-  it('binds an unpinned hostname TOFU registration on an exact match', () => {
+  it('does not bind hostname TOFU from a lease-scoped exact match', () => {
     const store = new BackendCertificateTrustStore();
     store.register(HOSTNAME, CERTIFICATE_A);
     const tofu = store.register(HOSTNAME, null, 'hostname-tofu');
 
     expect(store.verify(HOSTNAME, CERTIFICATE_A)).toBe(true);
-    expect(tofu.trust.fingerprint).toBe(CERTIFICATE_A);
-    expect(store.verify(HOSTNAME, CERTIFICATE_B)).toBe(false);
+    expect(tofu.trust.fingerprint).toBeNull();
+    expect(store.verify(HOSTNAME, CERTIFICATE_B)).toBe(true);
+    expect(tofu.trust.fingerprint).toBe(CERTIFICATE_B);
+    expect(store.verify(HOSTNAME, CERTIFICATE_C)).toBe(false);
   });
 
   it.each(['first', 'second'] as const)(

--- a/ui/desktop/src/backendCertificateTrust.ts
+++ b/ui/desktop/src/backendCertificateTrust.ts
@@ -68,8 +68,11 @@ export class BackendCertificateTrustStore {
     const unpinnedHostnameTofuTrusts = trusts.filter(
       (trust) => trust.pinScope === 'hostname-tofu' && trust.fingerprint === null
     );
-    if (trusts.some((trust) => trust.fingerprint === normalizedFingerprint)) {
-      this.bindAll(unpinnedHostnameTofuTrusts, normalizedFingerprint);
+    const exactMatches = trusts.filter((trust) => trust.fingerprint === normalizedFingerprint);
+    if (exactMatches.length > 0) {
+      if (exactMatches.some((trust) => trust.pinScope === 'hostname-tofu')) {
+        this.bindAll(unpinnedHostnameTofuTrusts, normalizedFingerprint);
+      }
       return true;
     }
 

--- a/ui/desktop/src/backendCertificateTrust.ts
+++ b/ui/desktop/src/backendCertificateTrust.ts
@@ -1,0 +1,106 @@
+import { Buffer } from 'node:buffer';
+
+export type BackendCertificatePinScope = 'lease' | 'hostname-tofu';
+
+export interface BackendCertificateTrust {
+  hostname: string;
+  fingerprint: string | null;
+  pinScope: BackendCertificatePinScope;
+}
+
+export interface BackendCertificateTrustRegistration {
+  trust: BackendCertificateTrust;
+  release: () => void;
+}
+
+function normalizeHostname(hostname: string): string {
+  return hostname.toLowerCase();
+}
+
+export function normalizeFingerprint(fingerprint: string): string {
+  if (fingerprint.startsWith('sha256/')) {
+    const base64 = fingerprint.slice('sha256/'.length);
+    const buffer = Buffer.from(base64, 'base64');
+    return Array.from(buffer)
+      .map((byte) => byte.toString(16).padStart(2, '0'))
+      .join(':')
+      .toUpperCase();
+  }
+  return fingerprint.toUpperCase();
+}
+
+export class BackendCertificateTrustStore {
+  private readonly trusts = new Set<BackendCertificateTrust>();
+
+  register(
+    hostname: string,
+    fingerprint: string | null,
+    pinScope: BackendCertificatePinScope = 'lease'
+  ): BackendCertificateTrustRegistration {
+    const normalizedHostname = normalizeHostname(hostname);
+    const inheritedFingerprint =
+      pinScope === 'hostname-tofu' && fingerprint === null
+        ? (this.forHostname(normalizedHostname).find(
+            (trust) => trust.pinScope === 'hostname-tofu' && trust.fingerprint !== null
+          )?.fingerprint ?? null)
+        : null;
+    const trust: BackendCertificateTrust = {
+      hostname: normalizedHostname,
+      fingerprint: fingerprint ? normalizeFingerprint(fingerprint) : inheritedFingerprint,
+      pinScope,
+    };
+    this.trusts.add(trust);
+    return {
+      trust,
+      release: () => {
+        this.trusts.delete(trust);
+      },
+    };
+  }
+
+  verify(hostname: string, fingerprint: string): boolean {
+    const normalizedFingerprint = normalizeFingerprint(fingerprint);
+    const trusts = this.forHostname(hostname);
+    if (trusts.length === 0) {
+      return false;
+    }
+
+    const unpinnedHostnameTofuTrusts = trusts.filter(
+      (trust) => trust.pinScope === 'hostname-tofu' && trust.fingerprint === null
+    );
+    if (trusts.some((trust) => trust.fingerprint === normalizedFingerprint)) {
+      this.bindAll(unpinnedHostnameTofuTrusts, normalizedFingerprint);
+      return true;
+    }
+
+    if (unpinnedHostnameTofuTrusts.length > 0) {
+      this.bindAll(unpinnedHostnameTofuTrusts, normalizedFingerprint);
+      return true;
+    }
+
+    const unpinnedLeaseTrust = trusts.find(
+      (trust) => trust.pinScope === 'lease' && trust.fingerprint === null
+    );
+    if (!unpinnedLeaseTrust) {
+      return false;
+    }
+
+    unpinnedLeaseTrust.fingerprint = normalizedFingerprint;
+    return true;
+  }
+
+  has(hostname: string): boolean {
+    return this.forHostname(hostname).length > 0;
+  }
+
+  private forHostname(hostname: string): BackendCertificateTrust[] {
+    const normalizedHostname = normalizeHostname(hostname);
+    return [...this.trusts].filter((trust) => trust.hostname === normalizedHostname);
+  }
+
+  private bindAll(trusts: BackendCertificateTrust[], fingerprint: string): void {
+    for (const trust of trusts) {
+      trust.fingerprint = fingerprint;
+    }
+  }
+}

--- a/ui/desktop/src/gooseServe.test.ts
+++ b/ui/desktop/src/gooseServe.test.ts
@@ -250,7 +250,7 @@ describe('startGooseServe', () => {
     }
   });
 
-  it.skipIf(process.platform === 'win32')('waits for TLS fingerprint after readiness succeeds', async () => {
+  it.skipIf(process.platform === 'win32')('pins the TLS fingerprint before checking readiness', async () => {
     const tempDir = makeTempDir();
     const goosePath = makeExecutable(
       path.join(tempDir, 'goose'),
@@ -264,13 +264,20 @@ describe('startGooseServe', () => {
     );
     vi.stubEnv('GOOSE_BINARY', goosePath);
 
-    const readinessFetch = vi.fn(async () => new Response(null, { status: 200 }));
+    let reportedFingerprint: string | null = null;
+    const readinessFetch = vi.fn(async () => {
+      expect(reportedFingerprint).toBe('11:22:33');
+      return new Response(null, { status: 200 });
+    });
 
     const result = await startGooseServe({
       serverSecret: 'test-secret',
       dir: tempDir,
       tls: true,
       readinessFetch,
+      onCertFingerprint: (fingerprint) => {
+        reportedFingerprint = fingerprint;
+      },
     });
 
     try {

--- a/ui/desktop/src/gooseServe.test.ts
+++ b/ui/desktop/src/gooseServe.test.ts
@@ -256,7 +256,7 @@ describe('startGooseServe', () => {
       path.join(tempDir, 'goose'),
       [
         '#!/usr/bin/env sh',
-        'sleep 0.1',
+        'sleep 5.1',
         'printf "GOOSED_CERT_FINGERPRINT=11:22:33\\n"',
         'while true; do sleep 1; done',
         '',
@@ -286,5 +286,5 @@ describe('startGooseServe', () => {
     } finally {
       await result.cleanup();
     }
-  });
+  }, 10_000);
 });

--- a/ui/desktop/src/gooseServe.test.ts
+++ b/ui/desktop/src/gooseServe.test.ts
@@ -158,6 +158,22 @@ describe('startGooseServe', () => {
     }
   });
 
+  it.skipIf(process.platform === 'win32')('reports TLS spawn failures promptly', async () => {
+    const tempDir = makeTempDir();
+    const goosePath = path.join(tempDir, 'goose');
+    fs.writeFileSync(goosePath, '#!/usr/bin/env sh\n');
+    fs.chmodSync(goosePath, 0o644);
+    vi.stubEnv('GOOSE_BINARY', goosePath);
+
+    await expect(
+      startGooseServe({
+        serverSecret: 'test-secret',
+        dir: tempDir,
+        tls: true,
+      })
+    ).rejects.toThrow('goose serve did not emit TLS certificate fingerprint');
+  }, 2_000);
+
   it.skipIf(process.platform === 'win32')('captures the TLS fingerprint from stdout', async () => {
     const tempDir = makeTempDir();
     const goosePath = makeExecutable(

--- a/ui/desktop/src/gooseServe.ts
+++ b/ui/desktop/src/gooseServe.ts
@@ -38,6 +38,7 @@ export interface StartGooseServeOptions extends FindGooseBinaryOptions {
   logger?: Logger;
   diagnosticsDir?: string;
   readinessFetch?: ReadinessFetch;
+  onCertFingerprint?: (fingerprint: string) => void;
 }
 
 export interface GooseServeResult {
@@ -333,6 +334,7 @@ export const startGooseServe = async ({
   logger = defaultLogger,
   diagnosticsDir,
   readinessFetch = fetch,
+  onCertFingerprint,
 }: StartGooseServeOptions): Promise<GooseServeResult> => {
   const workingDir = dir || process.cwd();
   const startupTrace = createGooseServeStartupDiagnostics(diagnosticsDir, workingDir);
@@ -441,6 +443,7 @@ export const startGooseServe = async ({
     certFingerprint = fingerprint;
     logger.info(`Pinned cert fingerprint: ${certFingerprint}`);
     startupTrace?.record('fingerprint_received', { certFingerprint });
+    onCertFingerprint?.(certFingerprint);
     resolveFingerprint(certFingerprint);
     stopStdoutCollection();
   };
@@ -536,32 +539,11 @@ export const startGooseServe = async ({
     });
   };
 
-  const ready = await waitForGooseServeReady(statusUrl, errorLog, () => exited || spawnFailed, {
-    healthUrl,
-    readinessFetch,
-    onEvent: startupTrace?.record,
-  });
-
   const stopOutputCollection = () => {
     stopStdoutCollection();
     gooseProcess.stderr?.off('data', onStderrData);
     gooseProcess.stderr?.resume();
   };
-
-  if (!ready) {
-    stopOutputCollection();
-    await cleanup();
-    const exitDetails = exited
-      ? ` Process exited with code ${exitCode} and signal ${exitSignal}.`
-      : '';
-    const stderrDetails = errorLog.length ? ` Stderr: ${errorLog.join('\n')}` : '';
-    throw new Error(
-      withStartupDiagnosticsPath(
-        `goose serve did not become ready on ${statusUrl}.${exitDetails}${stderrDetails}`,
-        startupDiagnosticsPath
-      )
-    );
-  }
 
   if (tls) {
     startupTrace?.record('fingerprint_wait_start', { timeoutMs: TLS_FINGERPRINT_TIMEOUT_MS });
@@ -586,6 +568,27 @@ export const startGooseServe = async ({
         )
       );
     }
+  }
+
+  const ready = await waitForGooseServeReady(statusUrl, errorLog, () => exited || spawnFailed, {
+    healthUrl,
+    readinessFetch,
+    onEvent: startupTrace?.record,
+  });
+
+  if (!ready) {
+    stopOutputCollection();
+    await cleanup();
+    const exitDetails = exited
+      ? ` Process exited with code ${exitCode} and signal ${exitSignal}.`
+      : '';
+    const stderrDetails = errorLog.length ? ` Stderr: ${errorLog.join('\n')}` : '';
+    throw new Error(
+      withStartupDiagnosticsPath(
+        `goose serve did not become ready on ${statusUrl}.${exitDetails}${stderrDetails}`,
+        startupDiagnosticsPath
+      )
+    );
   }
 
   stopOutputCollection();

--- a/ui/desktop/src/gooseServe.ts
+++ b/ui/desktop/src/gooseServe.ts
@@ -501,6 +501,7 @@ export const startGooseServe = async ({
     errorLog.push(error.message);
     logger.error(`Failed to start goose serve on port ${port} and dir ${workingDir}`, error);
     startupTrace?.record('spawn_error', { message: error.message, name: error.name });
+    resolveFingerprint(null);
   });
 
   const cleanup = async (): Promise<void> => {

--- a/ui/desktop/src/gooseServe.ts
+++ b/ui/desktop/src/gooseServe.ts
@@ -136,7 +136,7 @@ const appendErrorTail = (target: string[], lines: string[], maxLines = 100): voi
 };
 
 const CERT_FINGERPRINT_PREFIX = 'GOOSED_CERT_FINGERPRINT=';
-const TLS_FINGERPRINT_TIMEOUT_MS = 5000;
+const GOOSE_SERVE_STARTUP_TIMEOUT_MS = 30000;
 
 const fetchStatus = async (
   statusUrl: string,
@@ -180,12 +180,12 @@ const waitForGooseServeReady = async (
   options: {
     healthUrl: string;
     readinessFetch: ReadinessFetch;
+    deadline: number;
+    timeoutMs: number;
     onEvent?: (name: string, details?: Record<string, unknown>) => void;
   }
 ): Promise<boolean> => {
-  const timeout = 30000;
   const interval = 100;
-  const deadline = Date.now() + timeout;
   const probeDetails = {
     transport: statusUrl.startsWith('https:') ? 'https' : 'plain-http',
     method: 'GET',
@@ -196,12 +196,12 @@ const waitForGooseServeReady = async (
   };
   options.onEvent?.('healthcheck_start', {
     ...probeDetails,
-    timeoutMs: timeout,
+    timeoutMs: options.timeoutMs,
     intervalMs: interval,
   });
 
   let attempt = 1;
-  while (Date.now() < deadline) {
+  while (Date.now() < options.deadline) {
     if (shouldStopWaiting()) {
       options.onEvent?.('healthcheck_fatal_error', {
         ...probeDetails,
@@ -232,7 +232,10 @@ const waitForGooseServeReady = async (
     attempt += 1;
   }
 
-  options.onEvent?.('healthcheck_timeout', { ...probeDetails, timeoutMs: timeout });
+  options.onEvent?.('healthcheck_timeout', {
+    ...probeDetails,
+    timeoutMs: options.timeoutMs,
+  });
   return false;
 };
 
@@ -545,9 +548,11 @@ export const startGooseServe = async ({
     gooseProcess.stderr?.resume();
   };
 
+  const startupDeadline = Date.now() + GOOSE_SERVE_STARTUP_TIMEOUT_MS;
   if (tls) {
-    startupTrace?.record('fingerprint_wait_start', { timeoutMs: TLS_FINGERPRINT_TIMEOUT_MS });
-    const fingerprint = await waitForFingerprint(fingerprintReady, TLS_FINGERPRINT_TIMEOUT_MS);
+    const fingerprintTimeoutMs = Math.max(0, startupDeadline - Date.now());
+    startupTrace?.record('fingerprint_wait_start', { timeoutMs: fingerprintTimeoutMs });
+    const fingerprint = await waitForFingerprint(fingerprintReady, fingerprintTimeoutMs);
     if (!fingerprint) {
       stopOutputCollection();
       await cleanup();
@@ -556,7 +561,7 @@ export const startGooseServe = async ({
         : '';
       const stderrDetails = errorLog.length ? ` Stderr: ${errorLog.join('\n')}` : '';
       startupTrace?.record('fingerprint_missing', {
-        timeoutMs: TLS_FINGERPRINT_TIMEOUT_MS,
+        timeoutMs: fingerprintTimeoutMs,
         exited,
         exitCode,
         exitSignal,
@@ -573,6 +578,8 @@ export const startGooseServe = async ({
   const ready = await waitForGooseServeReady(statusUrl, errorLog, () => exited || spawnFailed, {
     healthUrl,
     readinessFetch,
+    deadline: startupDeadline,
+    timeoutMs: GOOSE_SERVE_STARTUP_TIMEOUT_MS,
     onEvent: startupTrace?.record,
   });
 

--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -1146,6 +1146,9 @@ const createChat = async (
         logger: log,
         diagnosticsDir: STARTUP_LOGS_DIR,
         readinessFetch: net.fetch as unknown as typeof globalThis.fetch,
+        onCertFingerprint: (fingerprint) => {
+          localCertificateTrust.trust.fingerprint = normalizeFingerprint(fingerprint);
+        },
       });
       if (!gooseServeResult.certFingerprint) {
         await gooseServeResult.cleanup();

--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -18,7 +18,6 @@ import {
   Tray,
 } from 'electron';
 import { pathToFileURL, format as formatUrl, URLSearchParams } from 'node:url';
-import { Buffer } from 'node:buffer';
 import fs from 'node:fs/promises';
 import fsSync from 'node:fs';
 import started from 'electron-squirrel-startup';
@@ -27,6 +26,11 @@ import os from 'node:os';
 import { execFileSync, spawn, execFile } from 'child_process';
 import 'dotenv/config';
 import { checkBackendStatus } from './backendStatus';
+import {
+  BackendCertificateTrustStore,
+  normalizeFingerprint,
+  type BackendCertificateTrustRegistration,
+} from './backendCertificateTrust';
 import { startGooseServe } from './gooseServe';
 import { getLoginShellPath } from './loginShellPath';
 import { GooseServeLeaseRegistry, type GooseServeLease } from './gooseServeLeaseRegistry';
@@ -311,94 +315,18 @@ async function configureProxy() {
 
 if (started) app.quit();
 
-// Certificate trust for active backend leases. Renderer requests and
-// main-process net.fetch both pin to the exact cert fingerprint. Each backend
-// lease owns a trust record so old windows keep working after settings change.
-interface BackendCertificateTrust {
-  hostname: string;
-  fingerprint: string | null;
-}
-
-interface BackendCertificateTrustRegistration {
-  trust: BackendCertificateTrust;
-  release: () => void;
-}
-
-const trustedBackendCertificates = new Set<BackendCertificateTrust>();
-
-function normalizeHostname(hostname: string): string {
-  return hostname.toLowerCase();
-}
-
-function normalizeFingerprint(fp: string): string {
-  if (fp.startsWith('sha256/')) {
-    const b64 = fp.slice('sha256/'.length);
-    const buf = Buffer.from(b64, 'base64');
-    return Array.from(buf)
-      .map((b) => b.toString(16).padStart(2, '0'))
-      .join(':')
-      .toUpperCase();
-  }
-  return fp.toUpperCase();
-}
-
-function trustBackendCertificate(
-  hostname: string,
-  fingerprint: string | null
-): BackendCertificateTrustRegistration {
-  const trust: BackendCertificateTrust = {
-    hostname: normalizeHostname(hostname),
-    fingerprint: fingerprint ? normalizeFingerprint(fingerprint) : null,
-  };
-  trustedBackendCertificates.add(trust);
-  return {
-    trust,
-    release: () => {
-      trustedBackendCertificates.delete(trust);
-    },
-  };
-}
-
-function getBackendCertificateTrusts(hostname: string): BackendCertificateTrust[] {
-  const normalizedHostname = normalizeHostname(hostname);
-  return [...trustedBackendCertificates].filter((trust) => trust.hostname === normalizedHostname);
-}
-
-function verifyBackendCertificate(hostname: string, fingerprint: string): boolean {
-  const normalizedFingerprint = normalizeFingerprint(fingerprint);
-  const trusts = getBackendCertificateTrusts(hostname);
-  if (trusts.length === 0) {
-    return false;
-  }
-
-  if (trusts.some((trust) => trust.fingerprint === normalizedFingerprint)) {
-    return true;
-  }
-
-  const tofuTrust = trusts.find((trust) => trust.fingerprint === null);
-  if (tofuTrust) {
-    // TOFU: pin the certificate from the first successful handshake.
-    tofuTrust.fingerprint = normalizedFingerprint;
-    return true;
-  }
-
-  return false;
-}
-
-function isTrustedHost(hostname: string): boolean {
-  return getBackendCertificateTrusts(hostname).length > 0;
-}
+const backendCertificateTrust = new BackendCertificateTrustStore();
 
 // Renderer requests: pin to the exact cert once known.
 app.on('certificate-error', (event, _webContents, url, _error, certificate, callback) => {
   const parsed = new URL(url);
-  if (!isTrustedHost(parsed.hostname)) {
+  if (!backendCertificateTrust.has(parsed.hostname)) {
     callback(false);
     return;
   }
 
   event.preventDefault();
-  callback(verifyBackendCertificate(parsed.hostname, certificate.fingerprint));
+  callback(backendCertificateTrust.verify(parsed.hostname, certificate.fingerprint));
 });
 
 app.whenReady().then(() => {
@@ -408,12 +336,12 @@ app.whenReady().then(() => {
 // Main-process net.fetch: pin to the exact cert once known.
 app.whenReady().then(() => {
   session.defaultSession.setCertificateVerifyProc((request, callback) => {
-    if (!isTrustedHost(request.hostname)) {
+    if (!backendCertificateTrust.has(request.hostname)) {
       callback(-3);
       return;
     }
 
-    const match = verifyBackendCertificate(request.hostname, request.certificate.fingerprint);
+    const match = backendCertificateTrust.verify(request.hostname, request.certificate.fingerprint);
     callback(match ? 0 : -2);
   });
 });
@@ -1122,9 +1050,10 @@ const createChat = async (
       const externalBaseUrl = normalizeAcpHttpBaseUrl(externalBackend.url);
       const externalBase = new URL(externalBaseUrl);
       if (externalBase.protocol === 'https:') {
-        externalCertificateTrust = trustBackendCertificate(
+        externalCertificateTrust = backendCertificateTrust.register(
           externalBase.hostname,
-          externalBackend.certFingerprint ?? null
+          externalBackend.certFingerprint ?? null,
+          externalBackend.certFingerprint ? 'lease' : 'hostname-tofu'
         );
       }
 
@@ -1198,7 +1127,7 @@ const createChat = async (
       return;
     }
   } else {
-    const localCertificateTrust = trustBackendCertificate('127.0.0.1', null);
+    const localCertificateTrust = backendCertificateTrust.register('127.0.0.1', null);
 
     const loginShellPath = await getLoginShellPath(log);
 


### PR DESCRIPTION
## Summary

- keep learned TOFU certificate pins coherent across active external-backend windows
- preserve per-window explicit pins and locally spawned backend certificates
- cover concurrent registrations, release ordering, rotations, and host isolation

## Validation

- `pnpm exec vitest run src/backendCertificateTrust.test.ts src/backendStatus.test.ts src/gooseServeLeaseRegistry.test.ts`
- `pnpm run typecheck`
- `pnpm exec eslint src/backendCertificateTrust.ts src/backendCertificateTrust.test.ts src/main.ts`
- `cargo build`
- `cargo clippy --all-targets -- -D warnings`

*This finding was discovered by [Project Loupe](https://github.com/project-loupe/loupe)*
