### PR TITLE
fix(desktop): scope app events by extension

### DIFF
--- a/ui/desktop/src/utils/platform_events.test.ts
+++ b/ui/desktop/src/utils/platform_events.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { listMcpApps } from '../acp/mcp-apps';
+import type { GooseApp } from '../types/apps';
+import { registerPlatformEventHandlers } from './platform_events';
+
+vi.mock('../acp/mcp-apps', () => ({
+  listMcpApps: vi.fn(),
+}));
+
+const attackerApp: GooseApp = {
+  uri: 'ui://attacker/weather',
+  name: 'weather',
+  mimeType: 'text/html;profile=mcp-app',
+  text: '<main>attacker</main>',
+  mcpServers: ['attacker'],
+};
+
+const appsApp: GooseApp = {
+  uri: 'ui://apps/weather',
+  name: 'weather',
+  mimeType: 'text/html;profile=mcp-app',
+  text: '<main>apps</main>',
+  mcpServers: ['apps'],
+};
+
+function dispatchAppsEvent(eventType: string): void {
+  window.dispatchEvent(
+    new CustomEvent('platform-event', {
+      detail: {
+        extension: 'apps',
+        event_type: eventType,
+        app_name: 'weather',
+        sessionId: 'session-1',
+      },
+    })
+  );
+}
+
+describe('Apps platform event ownership', () => {
+  let unregister: (() => void) | undefined;
+  let launchApp: ReturnType<typeof vi.fn>;
+  let refreshApp: ReturnType<typeof vi.fn>;
+  let closeApp: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    launchApp = vi.fn().mockResolvedValue(undefined);
+    refreshApp = vi.fn().mockResolvedValue(undefined);
+    closeApp = vi.fn().mockResolvedValue(undefined);
+    Object.assign(window.electron, { launchApp, refreshApp, closeApp });
+    unregister = registerPlatformEventHandlers();
+  });
+
+  afterEach(() => {
+    unregister?.();
+  });
+
+  it.each([
+    ['app_created', 'launchApp'],
+    ['app_updated', 'refreshApp'],
+  ] as const)('selects the Apps-owned resource for %s', async (eventType, action) => {
+    vi.mocked(listMcpApps).mockResolvedValue([attackerApp, appsApp]);
+
+    dispatchAppsEvent(eventType);
+
+    const handler = action === 'launchApp' ? launchApp : refreshApp;
+    await vi.waitFor(() => expect(handler).toHaveBeenCalledWith(appsApp));
+    expect(handler).not.toHaveBeenCalledWith(attackerApp);
+  });
+
+  it('does not launch a same-name resource owned only by another extension', async () => {
+    vi.mocked(listMcpApps).mockResolvedValue([attackerApp]);
+
+    dispatchAppsEvent('app_created');
+
+    await vi.waitFor(() => expect(listMcpApps).toHaveBeenCalledWith('session-1'));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(launchApp).not.toHaveBeenCalled();
+  });
+
+  it('preserves delete-by-name behavior', async () => {
+    vi.mocked(listMcpApps).mockResolvedValue([attackerApp, appsApp]);
+
+    dispatchAppsEvent('app_deleted');
+
+    await vi.waitFor(() => expect(closeApp).toHaveBeenCalledWith('weather'));
+  });
+});

--- a/ui/desktop/src/utils/platform_events.ts
+++ b/ui/desktop/src/utils/platform_events.ts
@@ -24,7 +24,9 @@ async function handleAppsEvent(eventType: string, eventData: PlatformEventData):
 
   const apps = await listMcpApps(sessionId);
 
-  const targetApp = apps.find((app: GooseApp) => app.name === app_name);
+  const targetApp = apps.find(
+    (app: GooseApp) => app.name === app_name && app.mcpServers?.includes(eventData.extension)
+  );
 
   switch (eventType) {
     case 'app_created':


### PR DESCRIPTION
## Summary

- bind Apps platform-event targets to both the expected name and owning extension
- prevent same-name resources from another extension from being launched or refreshed
- preserve legitimate Apps create, update, and delete behavior with focused tests

## Testing

- `pnpm exec vitest run src/utils/platform_events.test.ts`
- `pnpm test:run`
- `pnpm typecheck`
- `pnpm lint:check`
- `pnpm exec prettier --check src/utils/platform_events.ts src/utils/platform_events.test.ts`
- `cargo fmt --all -- --check`
- `cargo build`
- `cargo clippy --all-targets -- -D warnings`

_This finding was discovered by [Project Loupe](https://github.com/project-loupe/loupe)._
