### PR TITLE
feat: Restart Command

### DIFF
--- a/crates/goose-cli/src/cli.rs
+++ b/crates/goose-cli/src/cli.rs
@@ -2654,25 +2654,18 @@ async fn handle_default_session() -> Result<()> {
     session.interactive(None).await
 }
 
-fn validate_restart_config(path: &std::path::Path) -> anyhow::Result<()> {
-    if !path.exists() {
-        return Ok(());
-    }
-
-    let contents = std::fs::read_to_string(path)?;
-    serde_yaml::from_str::<serde_yaml::Value>(&contents)?;
-    Ok(())
-}
-
 async fn handle_restart_command() -> anyhow::Result<()> {
     let config_path = std::path::PathBuf::from(Config::global().path());
-    validate_restart_config(&config_path).map_err(|e| {
-        anyhow::anyhow!(
-            "Config validation failed for {}: {}. Fix the file and try again.",
-            config_path.display(),
-            e
-        )
-    })?;
+    if config_path.exists() {
+        let contents = std::fs::read_to_string(&config_path)?;
+        serde_yaml::from_str::<serde_yaml::Mapping>(&contents).map_err(|e| {
+            anyhow::anyhow!(
+                "Config validation failed for {}: {}. Fix the file and try again.",
+                config_path.display(),
+                e
+            )
+        })?;
+    };
 
     let exe = std::env::current_exe()?;
     let args: Vec<_> = std::env::args_os()

--- a/crates/goose-cli/src/cli.rs
+++ b/crates/goose-cli/src/cli.rs
@@ -2668,13 +2668,11 @@ async fn handle_restart_command() -> anyhow::Result<()> {
     };
 
     let exe = std::env::current_exe()?;
-    let args: Vec<_> = std::env::args_os()
-        .skip(1)
-        .filter(|arg| arg != "restart")
-        .collect();
-
+    // `restart` is a leaf subcommand, so the only arg to drop is `restart`
+    // itself. Relaunch as `goose session --resume` to resume the most recent
+    // user session with the updated config instead of starting a fresh one.
     let mut child = std::process::Command::new(exe)
-        .args(args)
+        .args(["session", "--resume"])
         .stdin(std::process::Stdio::inherit())
         .stdout(std::process::Stdio::inherit())
         .stderr(std::process::Stdio::inherit())
@@ -3022,6 +3020,15 @@ mod tests {
             Some(Command::Restart) => {}
             _ => panic!("expected restart command"),
         }
+    }
+
+    #[test]
+    fn restart_command_rejects_extra_args() {
+        // `restart` is a leaf subcommand, so the old args_os().filter("restart")
+        // always produced an empty list and launched a fresh default session.
+        // Locking in arg rejection prevents that bug from regressing.
+        let result = Cli::try_parse_from(["goose", "restart", "--provider", "openai"]);
+        assert!(result.is_err(), "restart must not accept extra arguments");
     }
 
     #[test]

--- a/crates/goose-cli/src/cli.rs
+++ b/crates/goose-cli/src/cli.rs
@@ -816,6 +816,10 @@ enum Command {
     #[command(about = "Check that your Goose setup is working")]
     Doctor {},
 
+    /// Restart Goose with the current configuration
+    #[command(about = "Restart Goose with the current configuration")]
+    Restart,
+
     /// Manage system prompts and behaviors
     #[command(about = "Run one of the mcp servers bundled with goose")]
     Mcp {
@@ -1374,6 +1378,7 @@ fn get_command_name(command: &Option<Command>) -> &'static str {
     match command {
         Some(Command::Configure {}) => "configure",
         Some(Command::Doctor {}) => "doctor",
+        Some(Command::Restart) => "restart",
         Some(Command::Info { .. }) => "info",
         Some(Command::Mcp { .. }) => "mcp",
         Some(Command::Acp { .. }) => "acp",
@@ -2649,6 +2654,43 @@ async fn handle_default_session() -> Result<()> {
     session.interactive(None).await
 }
 
+fn validate_restart_config(path: &std::path::Path) -> anyhow::Result<()> {
+    if !path.exists() {
+        return Ok(());
+    }
+
+    let contents = std::fs::read_to_string(path)?;
+    serde_yaml::from_str::<serde_yaml::Value>(&contents)?;
+    Ok(())
+}
+
+async fn handle_restart_command() -> anyhow::Result<()> {
+    let config_path = std::path::PathBuf::from(Config::global().path());
+    validate_restart_config(&config_path).map_err(|e| {
+        anyhow::anyhow!(
+            "Config validation failed for {}: {}. Fix the file and try again.",
+            config_path.display(),
+            e
+        )
+    })?;
+
+    let exe = std::env::current_exe()?;
+    let args: Vec<_> = std::env::args_os()
+        .skip(1)
+        .filter(|arg| arg != "restart")
+        .collect();
+
+    let mut child = std::process::Command::new(exe)
+        .args(args)
+        .stdin(std::process::Stdio::inherit())
+        .stdout(std::process::Stdio::inherit())
+        .stderr(std::process::Stdio::inherit())
+        .spawn()?;
+
+    let _ = child.wait();
+    std::process::exit(0);
+}
+
 pub async fn cli() -> anyhow::Result<()> {
     register_builtin_extensions(goose_mcp::BUILTIN_EXTENSIONS.clone());
 
@@ -2669,6 +2711,7 @@ pub async fn cli() -> anyhow::Result<()> {
         }
         Some(Command::Configure {}) => handle_configure().await,
         Some(Command::Doctor {}) => crate::commands::doctor::handle_doctor().await,
+        Some(Command::Restart) => handle_restart_command().await,
         Some(Command::Info { verbose, check }) => handle_info(verbose, check).await,
         Some(Command::Mcp { server }) => handle_mcp_command(server).await,
         Some(Command::Acp {
@@ -2975,6 +3018,16 @@ mod tests {
                 );
             }
             _ => panic!("expected serve command"),
+        }
+    }
+
+    #[test]
+    fn restart_command_parses() {
+        let cli = Cli::try_parse_from(["goose", "restart"]).expect("parse failed");
+
+        match cli.command {
+            Some(Command::Restart) => {}
+            _ => panic!("expected restart command"),
         }
     }
 

--- a/documentation/docs/guides/desktop-navigation.md
+++ b/documentation/docs/guides/desktop-navigation.md
@@ -73,3 +73,17 @@ Show or hide the sidebar without opening Settings:
 - **Keyboard shortcut:** The shortcut is shown next to the menu item and can be customized in `Settings` > `Keyboard`
 
 The sidebar's open/closed state is remembered across sessions.
+
+---
+
+## File Menu
+
+The File menu in goose Desktop provides application-level actions.
+
+### Restart Goose
+
+Restart the goose Desktop application to apply configuration changes without manually quitting and reopening.
+
+- **Menu bar:** Go to **File → Restart Goose**
+
+This is useful when you've modified your `config.yaml` file and want to apply the changes immediately.

--- a/documentation/docs/guides/desktop-navigation.md
+++ b/documentation/docs/guides/desktop-navigation.md
@@ -80,10 +80,10 @@ The sidebar's open/closed state is remembered across sessions.
 
 The File menu in goose Desktop provides application-level actions.
 
-### Restart Goose
+### Restart goose
 
 Restart the goose Desktop application to apply configuration changes without manually quitting and reopening.
 
-- **Menu bar:** Go to **File → Restart Goose**
+- **Menu bar:** Go to **File → Restart goose**
 
 This is useful when you've modified your `config.yaml` file and want to apply the changes immediately.

--- a/documentation/docs/guides/goose-cli-commands.md
+++ b/documentation/docs/guides/goose-cli-commands.md
@@ -64,6 +64,16 @@ goose info
 
 ---
 
+#### restart
+Restart goose with the current configuration. This validates your config file and relaunches goose with the same arguments, providing a supported flow for applying configuration changes without manually stopping and starting goose.
+
+**Usage:**
+```bash
+goose restart
+```
+
+---
+
 #### version
 Check the current goose version you have installed.
 

--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -106,6 +106,7 @@ const MENU_TRANSLATIONS_ZH_CN: Record<string, string> = {
   'Recent Directories': '最近的目录',
   'Focus Goose Window': '聚焦 Goose 窗口',
   'Quick Launcher': '快速启动器',
+  'Restart Goose': '重新启动 Goose',
   'Always on Top': '窗口置顶',
   'Toggle Navigation': '切换导航',
   'About Goose': '关于 Goose',
@@ -2709,6 +2710,16 @@ async function appMain() {
         })
       );
     }
+
+    fileMenu.submenu.append(
+      new MenuItem({
+        label: menuT('Restart Goose'),
+        click() {
+          app.relaunch();
+          app.exit(0);
+        },
+      })
+    );
   }
 
   if (menu) {


### PR DESCRIPTION
## Summary

Hi, this is my first time contributing. Please let me know if there are any issues. Would love to help and learn.

Implements the missing restart sub command as brought up in #10190 validating config file and relaunches goose.

* Restart is added to command enum
* Added validate_restart_config() to catch yaml issues & uses existing config file analysis system
* Implemented handle_restart_command() to spawn new process

Added desktop restart goose option to file menu
* Utilizes Electron's app.relaunch() + app.exit(0) to restart the desktop app

Chinese Translation for menu item was done by Google Translate. Should be correct but please verify.

Documented restart functionality in goose-cli-commands.md
Added file menu restart documentation to desktop-navigation.md

### Testing
<!-- How have this change been tested? Unit/integration tests? Manual testing? -->
* Added unit tests for command parsing to verify existence of command
* Manual testing to see new PID was spawned

### Related Issues
Relates to #10190 
Discussion: n/a


### Screenshots/Demos (for UX changes)
Before:  
Same thing but without Restart Goose
After:   
<img width="1096" height="724" alt="image" src="https://github.com/user-attachments/assets/4cfa3d94-ef6c-4b5f-b50b-e30ebd8106bd" />