### PR TITLE
fix(security): anchor execute shell extraction

### DIFF
--- a/crates/goose/src/providers/toolshim.rs
+++ b/crates/goose/src/providers/toolshim.rs
@@ -377,6 +377,20 @@ fn parse_tokenized_tool_calls_with_status(content: &str, tools: &[Tool]) -> Toke
 
         // Find the end of this tool call first
         let Some(call_end_offset) = after_begin.find(TOOL_CALL_END) else {
+            let name_end = after_begin
+                .find(TOOL_CALL_ARGUMENT_BEGIN)
+                .or_else(|| after_begin.find('{'))
+                .unwrap_or(after_begin.len());
+            let raw_tool_name = after_begin[..name_end]
+                .split_whitespace()
+                .next()
+                .unwrap_or_default();
+            let alias = normalized_tool_alias(raw_tool_name);
+            if resolve_tool_name(raw_tool_name, tools).is_none()
+                && matches!(alias.as_str(), "execute" | "execute_code")
+            {
+                rejected_execute = true;
+            }
             break;
         };
         let call_body = &after_begin[..call_end_offset];
@@ -1426,6 +1440,7 @@ mod tests {
             "<|tool_calls_section_begin|> <|tool_call_begin|> functions.execute:0 <|tool_call_argument_begin|> {\"code\":\"Developer.shell({ command: getCommand() });\"} <|tool_call_end|> <|tool_calls_section_end|>",
             "<|tool_calls_section_begin|> <|tool_call_begin|> functions.execute:0 <|tool_call_argument_begin|> {\"code\": <|tool_call_end|> <|tool_calls_section_end|>",
             "<|tool_calls_section_begin|> <|tool_call_begin|> functions.execute:0 <|tool_call_end|> <|tool_calls_section_end|>",
+            "<|tool_calls_section_begin|> <|tool_call_begin|> functions.execute:0 <|tool_call_argument_begin|> {\"code\":\"Developer.shell({ command: 'pwd' });\"}",
         ];
 
         for content in rejected {

--- a/crates/goose/src/providers/toolshim.rs
+++ b/crates/goose/src/providers/toolshim.rs
@@ -34,8 +34,8 @@
 use super::local_inference::LOCAL_LLM_MODEL_CONFIG_KEY;
 use super::ollama::OLLAMA_DEFAULT_PORT;
 use super::ollama::OLLAMA_HOST;
-use crate::conversation::message::{Message, MessageContent};
 use crate::conversation::Conversation;
+use crate::conversation::message::{Message, MessageContent};
 use crate::model_config::model_config_from_user_config;
 use crate::providers::base::DEFAULT_PROVIDER_TIMEOUT_SECS;
 use anyhow::Result;
@@ -44,8 +44,8 @@ use goose_providers::errors::ProviderError;
 use goose_providers::formats::openai::create_request;
 use goose_providers::images::ImageFormat;
 use reqwest::Client;
-use rmcp::model::{object, CallToolRequestParams, ContentBlock, Tool};
-use serde_json::{json, Value};
+use rmcp::model::{CallToolRequestParams, ContentBlock, Tool, object};
+use serde_json::{Value, json};
 use std::time::Duration;
 use uuid::Uuid;
 
@@ -450,19 +450,21 @@ fn parse_tokenized_tool_calls_with_status(content: &str, tools: &[Tool]) -> Toke
         let is_execute_compatibility = contains_unresolved_execute_alias(raw_tool_name, tools);
 
         if let Some(arguments_value) = parse_json_value_tolerant(raw_args) {
-            if let Some(tool_name) = resolved_tool_name {
+            if is_execute_compatibility {
+                if let Some(shell_call) =
+                    maybe_convert_execute_to_shell_tool_call(raw_tool_name, &arguments_value, tools)
+                {
+                    calls.push(shell_call);
+                } else {
+                    rejected_execute = true;
+                }
+            } else if let Some(tool_name) = resolved_tool_name {
                 if arguments_value.is_object() {
                     calls.push(
                         CallToolRequestParams::new(tool_name)
                             .with_arguments(object(arguments_value.clone())),
                     );
                 }
-            } else if let Some(shell_call) =
-                maybe_convert_execute_to_shell_tool_call(raw_tool_name, &arguments_value, tools)
-            {
-                calls.push(shell_call);
-            } else if is_execute_compatibility {
-                rejected_execute = true;
             }
         } else if is_execute_compatibility
             || malformed_arguments_contain_unresolved_execute_alias(raw_args, tools)
@@ -1449,10 +1451,12 @@ mod tests {
             .await
             .unwrap();
 
-        assert!(augmented
-            .content
-            .iter()
-            .any(|c| matches!(c, MessageContent::ToolRequest(_))));
+        assert!(
+            augmented
+                .content
+                .iter()
+                .any(|c| matches!(c, MessageContent::ToolRequest(_)))
+        );
         assert!(!augmented.as_concat_text().contains("<|tool_call_begin|>"));
     }
 
@@ -1490,6 +1494,24 @@ mod tests {
 
             assert!(augmented.content.is_empty());
         }
+    }
+
+    #[tokio::test]
+    async fn augment_rejects_resolved_tool_prefix_with_execute_segment() {
+        let tools = vec![Tool::new(
+            "shell".to_string(),
+            "Shell command execution".to_string(),
+            serde_json::Map::new(),
+        )];
+        let message = Message::assistant().with_text(
+            "<|tool_calls_section_begin|> <|tool_call_begin|> shell:functions.execute:0 <|tool_call_argument_begin|> {\"command\":\"id\"} <|tool_call_end|> <|tool_calls_section_end|>",
+        );
+
+        let augmented = augment_message_with_tool_calls(&FailingInterpreter, message, &tools)
+            .await
+            .unwrap();
+
+        assert!(augmented.content.is_empty());
     }
 
     #[tokio::test]
@@ -1543,10 +1565,12 @@ mod tests {
             .await
             .unwrap();
 
-        assert!(augmented
-            .content
-            .iter()
-            .any(|c| matches!(c, MessageContent::ToolRequest(_))));
+        assert!(
+            augmented
+                .content
+                .iter()
+                .any(|c| matches!(c, MessageContent::ToolRequest(_)))
+        );
     }
 
     // ── Regression tests: malformed marker leakage ──────────────────────

--- a/crates/goose/src/providers/toolshim.rs
+++ b/crates/goose/src/providers/toolshim.rs
@@ -179,9 +179,13 @@ fn normalized_tool_alias(raw_tool_name: &str) -> String {
 
 fn contains_unresolved_execute_alias(raw_tool_header: &str, tools: &[Tool]) -> bool {
     raw_tool_header.split_whitespace().any(|raw_tool_name| {
-        let alias = normalized_tool_alias(raw_tool_name);
         resolve_tool_name(raw_tool_name, tools).is_none()
-            && matches!(alias.as_str(), "execute" | "execute_code")
+            && raw_tool_name.split(':').any(|segment| {
+                matches!(
+                    normalized_tool_alias(segment).as_str(),
+                    "execute" | "execute_code"
+                )
+            })
     })
 }
 
@@ -1440,6 +1444,7 @@ mod tests {
             "<|tool_calls_section_begin|> <|tool_call_begin|> functions.execute:0 <|tool_call_argument_begin|> {\"code\":\"Developer.shell({ command: 'pwd' });\"}",
             "<|tool_calls_section_begin|> <|tool_call_begin|> label functions.execute:0 <|tool_call_argument_begin|> {\"code\":\"Developer.shell({ command: 'pwd' });\"}",
             "<|tool_calls_section_begin|> <|tool_call_begin|> analysis:1 functions.execute:0 <|tool_call_argument_begin|> {\"code\":\"Developer.shell({ command: 'pwd' });\"} <|tool_call_end|> <|tool_calls_section_end|>",
+            "<|tool_calls_section_begin|> <|tool_call_begin|> analysis:1:functions.execute:0 <|tool_call_argument_begin|> {\"code\":\"Developer.shell({ command: 'pwd' });\"} <|tool_call_end|> <|tool_calls_section_end|>",
         ];
 
         for content in rejected {

--- a/crates/goose/src/providers/toolshim.rs
+++ b/crates/goose/src/providers/toolshim.rs
@@ -406,6 +406,12 @@ fn parse_tokenized_tool_calls_with_status(content: &str, tools: &[Tool]) -> Toke
             if let Some(arg_idx) = call_body.find(TOOL_CALL_ARGUMENT_BEGIN) {
                 let name = call_body[..arg_idx].trim();
                 let args = call_body[arg_idx + TOOL_CALL_ARGUMENT_BEGIN.len()..].trim();
+                let non_json_prefix = args.split_once('{').map_or(args, |(prefix, _)| prefix);
+                if contains_unresolved_execute_alias(non_json_prefix, tools) {
+                    rejected_execute = true;
+                    remainder = &after_begin[call_end_offset + TOOL_CALL_END.len()..];
+                    continue;
+                }
                 (name, args)
             } else if let Some(json_start) = call_body.find('{') {
                 let name = call_body[..json_start].trim();
@@ -1445,6 +1451,7 @@ mod tests {
             "<|tool_calls_section_begin|> <|tool_call_begin|> label functions.execute:0 <|tool_call_argument_begin|> {\"code\":\"Developer.shell({ command: 'pwd' });\"}",
             "<|tool_calls_section_begin|> <|tool_call_begin|> analysis:1 functions.execute:0 <|tool_call_argument_begin|> {\"code\":\"Developer.shell({ command: 'pwd' });\"} <|tool_call_end|> <|tool_calls_section_end|>",
             "<|tool_calls_section_begin|> <|tool_call_begin|> analysis:1:functions.execute:0 <|tool_call_argument_begin|> {\"code\":\"Developer.shell({ command: 'pwd' });\"} <|tool_call_end|> <|tool_calls_section_end|>",
+            "<|tool_calls_section_begin|> <|tool_call_begin|> label <|tool_call_argument_begin|> functions.execute:0 {\"code\":\"Developer.shell({ command: 'pwd' });\"} <|tool_call_end|> <|tool_calls_section_end|>",
         ];
 
         for content in rejected {

--- a/crates/goose/src/providers/toolshim.rs
+++ b/crates/goose/src/providers/toolshim.rs
@@ -177,6 +177,14 @@ fn normalized_tool_alias(raw_tool_name: &str) -> String {
         .to_ascii_lowercase()
 }
 
+fn contains_unresolved_execute_alias(raw_tool_header: &str, tools: &[Tool]) -> bool {
+    raw_tool_header.split_whitespace().any(|raw_tool_name| {
+        let alias = normalized_tool_alias(raw_tool_name);
+        resolve_tool_name(raw_tool_name, tools).is_none()
+            && matches!(alias.as_str(), "execute" | "execute_code")
+    })
+}
+
 fn decode_quoted_string(literal: &str) -> Option<String> {
     let quote = literal.chars().next()?;
     if !matches!(quote, '"' | '\'') || !literal.ends_with(quote) {
@@ -381,15 +389,7 @@ fn parse_tokenized_tool_calls_with_status(content: &str, tools: &[Tool]) -> Toke
                 .find(TOOL_CALL_ARGUMENT_BEGIN)
                 .or_else(|| after_begin.find('{'))
                 .unwrap_or(after_begin.len());
-            let contains_unresolved_execute =
-                after_begin[..name_end]
-                    .split_whitespace()
-                    .any(|raw_tool_name| {
-                        let alias = normalized_tool_alias(raw_tool_name);
-                        resolve_tool_name(raw_tool_name, tools).is_none()
-                            && matches!(alias.as_str(), "execute" | "execute_code")
-                    });
-            if contains_unresolved_execute {
+            if contains_unresolved_execute_alias(&after_begin[..name_end], tools) {
                 rejected_execute = true;
             }
             break;
@@ -420,9 +420,8 @@ fn parse_tokenized_tool_calls_with_status(content: &str, tools: &[Tool]) -> Toke
             };
 
         let resolved_tool_name = resolve_tool_name(raw_tool_name, tools);
-        let alias = normalized_tool_alias(raw_tool_name);
         let is_execute_compatibility =
-            resolved_tool_name.is_none() && matches!(alias.as_str(), "execute" | "execute_code");
+            resolved_tool_name.is_none() && contains_unresolved_execute_alias(raw_tool_name, tools);
 
         if let Some(arguments_value) = parse_json_value_tolerant(raw_args) {
             if let Some(tool_name) = resolved_tool_name {
@@ -1443,6 +1442,7 @@ mod tests {
             "<|tool_calls_section_begin|> <|tool_call_begin|> functions.execute:0 <|tool_call_end|> <|tool_calls_section_end|>",
             "<|tool_calls_section_begin|> <|tool_call_begin|> functions.execute:0 <|tool_call_argument_begin|> {\"code\":\"Developer.shell({ command: 'pwd' });\"}",
             "<|tool_calls_section_begin|> <|tool_call_begin|> label functions.execute:0 <|tool_call_argument_begin|> {\"code\":\"Developer.shell({ command: 'pwd' });\"}",
+            "<|tool_calls_section_begin|> <|tool_call_begin|> analysis:1 functions.execute:0 <|tool_call_argument_begin|> {\"code\":\"Developer.shell({ command: 'pwd' });\"} <|tool_call_end|> <|tool_calls_section_end|>",
         ];
 
         for content in rejected {

--- a/crates/goose/src/providers/toolshim.rs
+++ b/crates/goose/src/providers/toolshim.rs
@@ -381,14 +381,15 @@ fn parse_tokenized_tool_calls_with_status(content: &str, tools: &[Tool]) -> Toke
                 .find(TOOL_CALL_ARGUMENT_BEGIN)
                 .or_else(|| after_begin.find('{'))
                 .unwrap_or(after_begin.len());
-            let raw_tool_name = after_begin[..name_end]
-                .split_whitespace()
-                .next()
-                .unwrap_or_default();
-            let alias = normalized_tool_alias(raw_tool_name);
-            if resolve_tool_name(raw_tool_name, tools).is_none()
-                && matches!(alias.as_str(), "execute" | "execute_code")
-            {
+            let contains_unresolved_execute =
+                after_begin[..name_end]
+                    .split_whitespace()
+                    .any(|raw_tool_name| {
+                        let alias = normalized_tool_alias(raw_tool_name);
+                        resolve_tool_name(raw_tool_name, tools).is_none()
+                            && matches!(alias.as_str(), "execute" | "execute_code")
+                    });
+            if contains_unresolved_execute {
                 rejected_execute = true;
             }
             break;
@@ -1441,6 +1442,7 @@ mod tests {
             "<|tool_calls_section_begin|> <|tool_call_begin|> functions.execute:0 <|tool_call_argument_begin|> {\"code\": <|tool_call_end|> <|tool_calls_section_end|>",
             "<|tool_calls_section_begin|> <|tool_call_begin|> functions.execute:0 <|tool_call_end|> <|tool_calls_section_end|>",
             "<|tool_calls_section_begin|> <|tool_call_begin|> functions.execute:0 <|tool_call_argument_begin|> {\"code\":\"Developer.shell({ command: 'pwd' });\"}",
+            "<|tool_calls_section_begin|> <|tool_call_begin|> label functions.execute:0 <|tool_call_argument_begin|> {\"code\":\"Developer.shell({ command: 'pwd' });\"}",
         ];
 
         for content in rejected {

--- a/crates/goose/src/providers/toolshim.rs
+++ b/crates/goose/src/providers/toolshim.rs
@@ -177,24 +177,18 @@ fn normalized_tool_alias(raw_tool_name: &str) -> String {
         .to_ascii_lowercase()
 }
 
-#[allow(clippy::string_slice)] // All markers/delimiters are ASCII; byte indexing is safe.
-fn extract_shell_command_from_execute_code(code: &str) -> Option<String> {
-    let marker = "command";
-    let marker_idx = code.find(marker)?;
-    let after_marker = &code[marker_idx + marker.len()..];
-    let colon_idx = after_marker.find(':')?;
-    let after_colon = after_marker[colon_idx + 1..].trim_start();
-
-    let quote = after_colon.chars().next()?;
-    if quote != '"' && quote != '\'' {
+fn decode_quoted_string(literal: &str) -> Option<String> {
+    let quote = literal.chars().next()?;
+    if !matches!(quote, '"' | '\'') || !literal.ends_with(quote) {
         return None;
     }
 
+    let body = literal.strip_prefix(quote)?.strip_suffix(quote)?;
     let mut escaped = false;
-    let mut command = String::new();
-    for ch in after_colon[1..].chars() {
+    let mut decoded = String::new();
+    for ch in body.chars() {
         if escaped {
-            command.push(ch);
+            decoded.push(ch);
             escaped = false;
             continue;
         }
@@ -204,14 +198,99 @@ fn extract_shell_command_from_execute_code(code: &str) -> Option<String> {
             continue;
         }
 
-        if ch == quote {
-            return Some(command);
-        }
-
-        command.push(ch);
+        decoded.push(ch);
     }
 
-    None
+    (!escaped).then_some(decoded)
+}
+
+fn node_text<'a>(node: tree_sitter::Node<'_>, source: &'a str) -> Option<&'a str> {
+    source.get(node.byte_range())
+}
+
+fn is_developer_shell_call(node: tree_sitter::Node<'_>, source: &str) -> bool {
+    let Some(function) = node.child_by_field_name("function") else {
+        return false;
+    };
+    if function.kind() != "member_expression" {
+        return false;
+    }
+
+    let Some(object) = function.child_by_field_name("object") else {
+        return false;
+    };
+    let Some(property) = function.child_by_field_name("property") else {
+        return false;
+    };
+
+    object.kind() == "identifier"
+        && property.kind() == "property_identifier"
+        && node_text(object, source) == Some("Developer")
+        && node_text(property, source) == Some("shell")
+}
+
+fn shell_command_from_call(node: tree_sitter::Node<'_>, source: &str) -> Option<String> {
+    let arguments = node.child_by_field_name("arguments")?;
+    if arguments.named_child_count() != 1 {
+        return None;
+    }
+
+    let object = arguments.named_child(0)?;
+    if object.kind() != "object" || object.named_child_count() != 1 {
+        return None;
+    }
+
+    let pair = object.named_child(0)?;
+    if pair.kind() != "pair" {
+        return None;
+    }
+
+    let key = pair.child_by_field_name("key")?;
+    let is_command_key = match key.kind() {
+        "property_identifier" => node_text(key, source) == Some("command"),
+        "string" => node_text(key, source)
+            .and_then(decode_quoted_string)
+            .is_some_and(|key| key == "command"),
+        _ => false,
+    };
+    if !is_command_key {
+        return None;
+    }
+
+    let value = pair.child_by_field_name("value")?;
+    if value.kind() != "string" {
+        return None;
+    }
+
+    node_text(value, source).and_then(decode_quoted_string)
+}
+
+fn extract_shell_command_from_execute_code(code: &str) -> Option<String> {
+    let mut parser = tree_sitter::Parser::new();
+    parser
+        .set_language(&tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into())
+        .ok()?;
+    let tree = parser.parse(code, None)?;
+    let root = tree.root_node();
+    if root.has_error() {
+        return None;
+    }
+
+    let mut command = None;
+    let mut nodes = vec![root];
+    while let Some(node) = nodes.pop() {
+        if node.kind() == "call_expression" && is_developer_shell_call(node, code) {
+            if command.is_some() {
+                return None;
+            }
+            command = Some(shell_command_from_call(node, code)?);
+        }
+
+        let mut cursor = node.walk();
+        nodes.extend(node.named_children(&mut cursor));
+    }
+
+    command
 }
 
 fn maybe_convert_execute_to_shell_tool_call(
@@ -1164,6 +1243,70 @@ mod tests {
                 .and_then(|v| v.as_str()),
             Some("cat Cargo.toml")
         );
+    }
+
+    #[test]
+    fn execute_marker_ignores_command_data_before_shell_call() {
+        let tools = vec![Tool::new(
+            "shell".to_string(),
+            "Shell command execution".to_string(),
+            serde_json::Map::new(),
+        )];
+
+        let content = "<|tool_calls_section_begin|> <|tool_call_begin|> functions.execute:0 <|tool_call_argument_begin|> {\"code\":\"async function run() { const data = { command: \\\"cat /etc/shadow\\\" }; return await Developer.shell({ command: \\\"pwd\\\" }); }\"} <|tool_call_end|> <|tool_calls_section_end|>";
+
+        let calls = parse_tokenized_tool_calls(content, &tools);
+
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].name, "shell");
+        assert_eq!(
+            calls[0]
+                .arguments
+                .as_ref()
+                .and_then(|a| a.get("command"))
+                .and_then(|v| v.as_str()),
+            Some("pwd")
+        );
+    }
+
+    #[test]
+    fn execute_code_only_extracts_real_developer_shell_call() {
+        let code = r#"
+            async function run() {
+                const object = { command: "object decoy" };
+                const text = 'Developer.shell({ command: "string decoy" })';
+                const pattern = /Developer\.shell\(\{ command: "regex decoy" \}\)/;
+                // Developer.shell({ command: "comment decoy" })
+                return await Developer.shell({ "command": 'printf \'safe\'' });
+            }
+        "#;
+
+        assert_eq!(
+            extract_shell_command_from_execute_code(code).as_deref(),
+            Some("printf 'safe'")
+        );
+    }
+
+    #[test]
+    fn execute_code_rejects_ambiguous_or_unsupported_shell_calls() {
+        let cases = [
+            "Developer.shell({ command: 'first' }); Developer.shell({ command: 'second' });",
+            "Developer.shell({ command: getCommand() });",
+            "Developer.shell({ command: 'pwd', timeout: 1000 });",
+            "Developer['shell']({ command: 'pwd' });",
+            "OtherDeveloper.shell({ command: 'pwd' });",
+            "Developer.shellish({ command: 'pwd' });",
+            "const text = 'Developer.shell({ command: \\\"pwd\\\" })';",
+            "Developer.shell({ command: 'pwd'",
+        ];
+
+        for code in cases {
+            assert_eq!(
+                extract_shell_command_from_execute_code(code),
+                None,
+                "unexpectedly extracted a command from {code:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/goose/src/providers/toolshim.rs
+++ b/crates/goose/src/providers/toolshim.rs
@@ -179,14 +179,41 @@ fn normalized_tool_alias(raw_tool_name: &str) -> String {
 
 fn contains_unresolved_execute_alias(raw_tool_header: &str, tools: &[Tool]) -> bool {
     raw_tool_header.split_whitespace().any(|raw_tool_name| {
-        resolve_tool_name(raw_tool_name, tools).is_none()
-            && raw_tool_name.split(':').any(|segment| {
-                matches!(
-                    normalized_tool_alias(segment).as_str(),
-                    "execute" | "execute_code"
-                )
-            })
+        raw_tool_name.split(':').any(|segment| {
+            matches!(
+                normalized_tool_alias(segment).as_str(),
+                "execute" | "execute_code"
+            ) && resolve_tool_name(segment, tools).is_none()
+        })
     })
+}
+
+fn malformed_arguments_contain_unresolved_execute_alias(
+    raw_arguments: &str,
+    tools: &[Tool],
+) -> bool {
+    let mut remainder = raw_arguments.trim();
+    while !remainder.is_empty() {
+        let mut values = serde_json::Deserializer::from_str(remainder).into_iter::<Value>();
+        if let Some(Ok(_)) = values.next() {
+            remainder = remainder
+                .get(values.byte_offset()..)
+                .unwrap_or_default()
+                .trim_start();
+            continue;
+        }
+
+        let prefix_end = remainder.find('{').unwrap_or(remainder.len());
+        let (non_json_prefix, json_suffix) = remainder.split_at(prefix_end);
+        if contains_unresolved_execute_alias(non_json_prefix, tools) {
+            return true;
+        }
+        if prefix_end == 0 || prefix_end == remainder.len() {
+            return false;
+        }
+        remainder = json_suffix;
+    }
+    false
 }
 
 fn decode_quoted_string(literal: &str) -> Option<String> {
@@ -406,12 +433,6 @@ fn parse_tokenized_tool_calls_with_status(content: &str, tools: &[Tool]) -> Toke
             if let Some(arg_idx) = call_body.find(TOOL_CALL_ARGUMENT_BEGIN) {
                 let name = call_body[..arg_idx].trim();
                 let args = call_body[arg_idx + TOOL_CALL_ARGUMENT_BEGIN.len()..].trim();
-                let non_json_prefix = args.split_once('{').map_or(args, |(prefix, _)| prefix);
-                if contains_unresolved_execute_alias(non_json_prefix, tools) {
-                    rejected_execute = true;
-                    remainder = &after_begin[call_end_offset + TOOL_CALL_END.len()..];
-                    continue;
-                }
                 (name, args)
             } else if let Some(json_start) = call_body.find('{') {
                 let name = call_body[..json_start].trim();
@@ -426,8 +447,7 @@ fn parse_tokenized_tool_calls_with_status(content: &str, tools: &[Tool]) -> Toke
             };
 
         let resolved_tool_name = resolve_tool_name(raw_tool_name, tools);
-        let is_execute_compatibility =
-            resolved_tool_name.is_none() && contains_unresolved_execute_alias(raw_tool_name, tools);
+        let is_execute_compatibility = contains_unresolved_execute_alias(raw_tool_name, tools);
 
         if let Some(arguments_value) = parse_json_value_tolerant(raw_args) {
             if let Some(tool_name) = resolved_tool_name {
@@ -444,7 +464,9 @@ fn parse_tokenized_tool_calls_with_status(content: &str, tools: &[Tool]) -> Toke
             } else if is_execute_compatibility {
                 rejected_execute = true;
             }
-        } else if is_execute_compatibility {
+        } else if is_execute_compatibility
+            || malformed_arguments_contain_unresolved_execute_alias(raw_args, tools)
+        {
             rejected_execute = true;
         }
 
@@ -1452,9 +1474,15 @@ mod tests {
             "<|tool_calls_section_begin|> <|tool_call_begin|> analysis:1 functions.execute:0 <|tool_call_argument_begin|> {\"code\":\"Developer.shell({ command: 'pwd' });\"} <|tool_call_end|> <|tool_calls_section_end|>",
             "<|tool_calls_section_begin|> <|tool_call_begin|> analysis:1:functions.execute:0 <|tool_call_argument_begin|> {\"code\":\"Developer.shell({ command: 'pwd' });\"} <|tool_call_end|> <|tool_calls_section_end|>",
             "<|tool_calls_section_begin|> <|tool_call_begin|> label <|tool_call_argument_begin|> functions.execute:0 {\"code\":\"Developer.shell({ command: 'pwd' });\"} <|tool_call_end|> <|tool_calls_section_end|>",
+            "<|tool_calls_section_begin|> <|tool_call_begin|> label <|tool_call_argument_begin|> {} functions.execute:0 {\"code\":\"Developer.shell({ command: 'pwd' });\"} <|tool_call_end|> <|tool_calls_section_end|>",
+            "<|tool_calls_section_begin|> <|tool_call_begin|> shell:functions.execute:0 Developer.shell({ command: 'pwd' }) <|tool_call_end|> <|tool_calls_section_end|>",
         ];
 
         for content in rejected {
+            assert!(
+                parse_tokenized_tool_calls_with_status(content, &tools).rejected_execute,
+                "expected execute block to be rejected: {content}"
+            );
             let message = Message::assistant().with_text(content);
             let augmented = augment_message_with_tool_calls(&FailingInterpreter, message, &tools)
                 .await

--- a/crates/goose/src/providers/toolshim.rs
+++ b/crates/goose/src/providers/toolshim.rs
@@ -188,6 +188,24 @@ fn contains_unresolved_execute_alias(raw_tool_header: &str, tools: &[Tool]) -> b
     })
 }
 
+fn contains_structured_unresolved_execute_alias(value: &Value, tools: &[Tool]) -> bool {
+    match value {
+        Value::Object(object) => {
+            object
+                .get("name")
+                .and_then(Value::as_str)
+                .is_some_and(|name| contains_unresolved_execute_alias(name, tools))
+                || object
+                    .values()
+                    .any(|value| contains_structured_unresolved_execute_alias(value, tools))
+        }
+        Value::Array(array) => array
+            .iter()
+            .any(|value| contains_structured_unresolved_execute_alias(value, tools)),
+        _ => false,
+    }
+}
+
 fn malformed_arguments_contain_unresolved_execute_alias(
     raw_arguments: &str,
     tools: &[Tool],
@@ -468,6 +486,8 @@ fn parse_tokenized_tool_calls_with_status(content: &str, tools: &[Tool]) -> Toke
                 .get("name")
                 .and_then(Value::as_str)
                 .filter(|name| contains_unresolved_execute_alias(name, tools));
+            let contains_structured_execute =
+                contains_structured_unresolved_execute_alias(&arguments_value, tools);
             if is_execute_compatibility {
                 if let Some(shell_call) =
                     maybe_convert_execute_to_shell_tool_call(raw_tool_name, &arguments_value, tools)
@@ -495,6 +515,8 @@ fn parse_tokenized_tool_calls_with_status(content: &str, tools: &[Tool]) -> Toke
                 } else {
                     rejected_execute = true;
                 }
+            } else if contains_structured_execute {
+                rejected_execute = true;
             }
         } else if is_execute_compatibility
             || malformed_arguments_contain_unresolved_execute_alias(raw_args, tools)
@@ -1638,6 +1660,80 @@ mod tests {
                 .and_then(Value::as_str),
             Some("functions.execute:0")
         );
+    }
+
+    #[tokio::test]
+    async fn augment_rejects_execute_envelope_in_argument_array() {
+        let tools = vec![Tool::new(
+            "shell".to_string(),
+            "Shell command execution".to_string(),
+            serde_json::Map::new(),
+        )];
+        let message = Message::assistant().with_text(
+            "<|tool_calls_section_begin|> <|tool_call_begin|> label <|tool_call_argument_begin|> [{\"name\":\"functions.execute:0\",\"arguments\":{\"code\":\"Developer.shell({ command: 'id' })\"}}] <|tool_call_end|> <|tool_calls_section_end|>",
+        );
+
+        let augmented = augment_message_with_tool_calls(&FailingInterpreter, message, &tools)
+            .await
+            .unwrap();
+
+        assert!(augmented.content.is_empty());
+    }
+
+    #[tokio::test]
+    async fn augment_rejects_execute_envelope_in_nested_arguments() {
+        let tools = vec![Tool::new(
+            "shell".to_string(),
+            "Shell command execution".to_string(),
+            serde_json::Map::new(),
+        )];
+        let message = Message::assistant().with_text(
+            "<|tool_calls_section_begin|> <|tool_call_begin|> label <|tool_call_argument_begin|> {\"payload\":{\"name\":\"functions.execute:0\",\"arguments\":{\"code\":\"Developer.shell({ command: 'id' })\"}}} <|tool_call_end|> <|tool_calls_section_end|>",
+        );
+
+        let augmented = augment_message_with_tool_calls(&FailingInterpreter, message, &tools)
+            .await
+            .unwrap();
+
+        assert!(augmented.content.is_empty());
+    }
+
+    #[test]
+    fn resolved_tool_accepts_nested_execute_shaped_arguments() {
+        let tools = vec![
+            Tool::new(
+                "workflow".to_string(),
+                "Run a workflow".to_string(),
+                serde_json::Map::new(),
+            ),
+            Tool::new(
+                "shell".to_string(),
+                "Shell command execution".to_string(),
+                serde_json::Map::new(),
+            ),
+        ];
+        let content = "<|tool_calls_section_begin|> <|tool_call_begin|> functions.workflow:0 <|tool_call_argument_begin|> {\"payload\":[{\"name\":\"functions.execute:0\",\"arguments\":{\"code\":\"Developer.shell({ command: 'id' })\"}}]} <|tool_call_end|> <|tool_calls_section_end|>";
+
+        let parsed = parse_tokenized_tool_calls_with_status(content, &tools);
+
+        assert!(!parsed.rejected_execute);
+        assert_eq!(parsed.calls.len(), 1);
+        assert_eq!(parsed.calls[0].name, "workflow");
+    }
+
+    #[test]
+    fn unresolved_header_does_not_reject_benign_nested_json() {
+        let tools = vec![Tool::new(
+            "shell".to_string(),
+            "Shell command execution".to_string(),
+            serde_json::Map::new(),
+        )];
+        let content = "<|tool_calls_section_begin|> <|tool_call_begin|> label <|tool_call_argument_begin|> {\"payload\":[{\"name\":\"transform\",\"arguments\":{\"value\":\"id\"}}]} <|tool_call_end|> <|tool_calls_section_end|>";
+
+        let parsed = parse_tokenized_tool_calls_with_status(content, &tools);
+
+        assert!(parsed.calls.is_empty());
+        assert!(!parsed.rejected_execute);
     }
 
     #[tokio::test]

--- a/crates/goose/src/providers/toolshim.rs
+++ b/crates/goose/src/providers/toolshim.rs
@@ -420,13 +420,15 @@ fn parse_tokenized_tool_calls_with_status(content: &str, tools: &[Tool]) -> Toke
 
         // Find the end of this tool call first
         let Some(call_end_offset) = after_begin.find(TOOL_CALL_END) else {
-            let argument_start = after_begin.find(TOOL_CALL_ARGUMENT_BEGIN);
-            let name_end = argument_start
-                .or_else(|| after_begin.find('{'))
-                .unwrap_or(after_begin.len());
-            let arguments_contain_execute = argument_start.is_some_and(|argument_start| {
+            let argument_marker = after_begin.find(TOOL_CALL_ARGUMENT_BEGIN);
+            let brace_start = after_begin.find('{');
+            let name_end = argument_marker.or(brace_start).unwrap_or(after_begin.len());
+            let arguments_start = argument_marker
+                .map(|argument_marker| argument_marker + TOOL_CALL_ARGUMENT_BEGIN.len())
+                .or(brace_start);
+            let arguments_contain_execute = arguments_start.is_some_and(|arguments_start| {
                 malformed_arguments_contain_unresolved_execute_alias(
-                    &after_begin[argument_start + TOOL_CALL_ARGUMENT_BEGIN.len()..],
+                    &after_begin[arguments_start..],
                     tools,
                 )
             });
@@ -1597,6 +1599,24 @@ mod tests {
             .any(|content| matches!(content, MessageContent::ToolRequest(_))));
     }
 
+    #[tokio::test]
+    async fn augment_rejects_execute_alias_in_unterminated_brace_remainder() {
+        let tools = vec![Tool::new(
+            "shell".to_string(),
+            "Shell command execution".to_string(),
+            serde_json::Map::new(),
+        )];
+        let message = Message::assistant().with_text(
+            "<|tool_calls_section_begin|> <|tool_call_begin|> label {] functions.execute:0 {\"code\":\"Developer.shell({ command: 'id' })\"}",
+        );
+
+        let augmented = augment_message_with_tool_calls(&FailingInterpreter, message, &tools)
+            .await
+            .unwrap();
+
+        assert!(augmented.content.is_empty());
+    }
+
     #[test]
     fn unterminated_non_execute_arguments_are_not_rejected() {
         let tools = vec![Tool::new(
@@ -1604,12 +1624,17 @@ mod tests {
             "Shell command execution".to_string(),
             serde_json::Map::new(),
         )];
-        let content = "<|tool_calls_section_begin|> <|tool_call_begin|> functions.shell:0 <|tool_call_argument_begin|> {\"command\":\"id\"}";
+        let contents = [
+            "<|tool_calls_section_begin|> <|tool_call_begin|> functions.shell:0 <|tool_call_argument_begin|> {\"command\":\"id\"}",
+            "<|tool_calls_section_begin|> <|tool_call_begin|> functions.shell:0 {\"command\":\"id\"}",
+        ];
 
-        let parsed = parse_tokenized_tool_calls_with_status(content, &tools);
+        for content in contents {
+            let parsed = parse_tokenized_tool_calls_with_status(content, &tools);
 
-        assert!(parsed.calls.is_empty());
-        assert!(!parsed.rejected_execute);
+            assert!(parsed.calls.is_empty());
+            assert!(!parsed.rejected_execute);
+        }
     }
 
     #[tokio::test]

--- a/crates/goose/src/providers/toolshim.rs
+++ b/crates/goose/src/providers/toolshim.rs
@@ -462,10 +462,26 @@ fn parse_tokenized_tool_calls_with_status(content: &str, tools: &[Tool]) -> Toke
         let is_execute_compatibility = contains_unresolved_execute_alias(raw_tool_name, tools);
 
         if let Some(arguments_value) = parse_json_value_tolerant(raw_args) {
+            let structured_execute_name = arguments_value
+                .get("name")
+                .and_then(Value::as_str)
+                .filter(|name| contains_unresolved_execute_alias(name, tools));
             if is_execute_compatibility {
                 if let Some(shell_call) =
                     maybe_convert_execute_to_shell_tool_call(raw_tool_name, &arguments_value, tools)
                 {
+                    calls.push(shell_call);
+                } else {
+                    rejected_execute = true;
+                }
+            } else if let Some(structured_execute_name) = structured_execute_name {
+                if let Some(shell_call) = arguments_value.get("arguments").and_then(|arguments| {
+                    maybe_convert_execute_to_shell_tool_call(
+                        structured_execute_name,
+                        arguments,
+                        tools,
+                    )
+                }) {
                     calls.push(shell_call);
                 } else {
                     rejected_execute = true;
@@ -1558,6 +1574,27 @@ mod tests {
             .unwrap();
 
         assert!(augmented.content.is_empty());
+    }
+
+    #[tokio::test]
+    async fn augment_validates_structured_execute_name_without_interpreter() {
+        let tools = vec![Tool::new(
+            "shell".to_string(),
+            "Shell command execution".to_string(),
+            serde_json::Map::new(),
+        )];
+        let message = Message::assistant().with_text(
+            "<|tool_calls_section_begin|> <|tool_call_begin|> label <|tool_call_argument_begin|> {\"name\":\"functions.execute:0\",\"arguments\":{\"code\":\"Developer.shell({ command: 'id' })\"}} <|tool_call_end|> <|tool_calls_section_end|>",
+        );
+
+        let augmented = augment_message_with_tool_calls(&FailingInterpreter, message, &tools)
+            .await
+            .unwrap();
+
+        assert!(augmented
+            .content
+            .iter()
+            .any(|content| matches!(content, MessageContent::ToolRequest(_))));
     }
 
     #[test]

--- a/crates/goose/src/providers/toolshim.rs
+++ b/crates/goose/src/providers/toolshim.rs
@@ -361,9 +361,15 @@ fn parse_json_value_tolerant(input: &str) -> Option<Value> {
     })
 }
 
+struct TokenizedToolCallParse {
+    calls: Vec<CallToolRequestParams>,
+    rejected_execute: bool,
+}
+
 #[allow(clippy::string_slice)] // All markers are ASCII; byte indexing is safe.
-fn parse_tokenized_tool_calls(content: &str, tools: &[Tool]) -> Vec<CallToolRequestParams> {
+fn parse_tokenized_tool_calls_with_status(content: &str, tools: &[Tool]) -> TokenizedToolCallParse {
     let mut calls = Vec::new();
+    let mut rejected_execute = false;
     let mut remainder = content;
 
     while let Some(begin_idx) = remainder.find(TOOL_CALL_BEGIN) {
@@ -387,12 +393,24 @@ fn parse_tokenized_tool_calls(content: &str, tools: &[Tool]) -> Vec<CallToolRequ
                 let args = call_body[json_start..].trim();
                 (name, args)
             } else {
+                let raw_tool_name = call_body.split_whitespace().next().unwrap_or(call_body);
+                let alias = normalized_tool_alias(raw_tool_name);
+                if resolve_tool_name(raw_tool_name, tools).is_none()
+                    && matches!(alias.as_str(), "execute" | "execute_code")
+                {
+                    rejected_execute = true;
+                }
                 remainder = &after_begin[call_end_offset + TOOL_CALL_END.len()..];
                 continue;
             };
 
+        let resolved_tool_name = resolve_tool_name(raw_tool_name, tools);
+        let alias = normalized_tool_alias(raw_tool_name);
+        let is_execute_compatibility =
+            resolved_tool_name.is_none() && matches!(alias.as_str(), "execute" | "execute_code");
+
         if let Some(arguments_value) = parse_json_value_tolerant(raw_args) {
-            if let Some(tool_name) = resolve_tool_name(raw_tool_name, tools) {
+            if let Some(tool_name) = resolved_tool_name {
                 if arguments_value.is_object() {
                     calls.push(
                         CallToolRequestParams::new(tool_name)
@@ -403,13 +421,25 @@ fn parse_tokenized_tool_calls(content: &str, tools: &[Tool]) -> Vec<CallToolRequ
                 maybe_convert_execute_to_shell_tool_call(raw_tool_name, &arguments_value, tools)
             {
                 calls.push(shell_call);
+            } else if is_execute_compatibility {
+                rejected_execute = true;
             }
+        } else if is_execute_compatibility {
+            rejected_execute = true;
         }
 
         remainder = &after_begin[call_end_offset + TOOL_CALL_END.len()..];
     }
 
-    calls
+    TokenizedToolCallParse {
+        calls,
+        rejected_execute,
+    }
+}
+
+#[cfg(test)]
+fn parse_tokenized_tool_calls(content: &str, tools: &[Tool]) -> Vec<CallToolRequestParams> {
+    parse_tokenized_tool_calls_with_status(content, tools).calls
 }
 
 #[allow(clippy::string_slice)] // Indices come from char_indices(); slicing is safe.
@@ -1073,10 +1103,16 @@ pub async fn augment_message_with_tool_calls<T: ToolInterpreter>(
         .iter()
         .any(|content| matches!(content, MessageContent::ToolRequest(_)));
 
-    let direct_tool_calls = parse_tokenized_tool_calls(&content, tools);
-    if !direct_tool_calls.is_empty() {
+    let direct_tool_calls = parse_tokenized_tool_calls_with_status(&content, tools);
+    if direct_tool_calls.rejected_execute {
+        return Ok(sanitize_message_after_tokenized_parse(message));
+    }
+    if !direct_tool_calls.calls.is_empty() {
         let cleaned = sanitize_message_after_tokenized_parse(message);
-        return Ok(append_tool_calls_to_message(cleaned, direct_tool_calls));
+        return Ok(append_tool_calls_to_message(
+            cleaned,
+            direct_tool_calls.calls,
+        ));
     }
 
     let inline_json_tool_calls = parse_inline_json_tool_calls(&content, tools);
@@ -1376,6 +1412,30 @@ mod tests {
             .iter()
             .any(|c| matches!(c, MessageContent::ToolRequest(_))));
         assert!(!augmented.as_concat_text().contains("<|tool_call_begin|>"));
+    }
+
+    #[tokio::test]
+    async fn augment_does_not_interpret_rejected_execute_marker() {
+        let tools = vec![Tool::new(
+            "shell".to_string(),
+            "Shell command execution".to_string(),
+            serde_json::Map::new(),
+        )];
+        let rejected = [
+            "<|tool_calls_section_begin|> <|tool_call_begin|> functions.execute:0 <|tool_call_argument_begin|> {\"code\":\"Developer.shell({ command: 'first' }); Developer.shell({ command: 'second' });\"} <|tool_call_end|> <|tool_calls_section_end|>",
+            "<|tool_calls_section_begin|> <|tool_call_begin|> functions.execute:0 <|tool_call_argument_begin|> {\"code\":\"Developer.shell({ command: getCommand() });\"} <|tool_call_end|> <|tool_calls_section_end|>",
+            "<|tool_calls_section_begin|> <|tool_call_begin|> functions.execute:0 <|tool_call_argument_begin|> {\"code\": <|tool_call_end|> <|tool_calls_section_end|>",
+            "<|tool_calls_section_begin|> <|tool_call_begin|> functions.execute:0 <|tool_call_end|> <|tool_calls_section_end|>",
+        ];
+
+        for content in rejected {
+            let message = Message::assistant().with_text(content);
+            let augmented = augment_message_with_tool_calls(&FailingInterpreter, message, &tools)
+                .await
+                .unwrap();
+
+            assert!(augmented.content.is_empty());
+        }
     }
 
     #[tokio::test]

--- a/crates/goose/src/providers/toolshim.rs
+++ b/crates/goose/src/providers/toolshim.rs
@@ -476,6 +476,13 @@ fn parse_tokenized_tool_calls_with_status(content: &str, tools: &[Tool]) -> Toke
                 } else {
                     rejected_execute = true;
                 }
+            } else if let Some(tool_name) = resolved_tool_name {
+                if arguments_value.is_object() {
+                    calls.push(
+                        CallToolRequestParams::new(tool_name)
+                            .with_arguments(object(arguments_value.clone())),
+                    );
+                }
             } else if let Some(structured_execute_name) = structured_execute_name {
                 if let Some(shell_call) = arguments_value.get("arguments").and_then(|arguments| {
                     maybe_convert_execute_to_shell_tool_call(
@@ -487,13 +494,6 @@ fn parse_tokenized_tool_calls_with_status(content: &str, tools: &[Tool]) -> Toke
                     calls.push(shell_call);
                 } else {
                     rejected_execute = true;
-                }
-            } else if let Some(tool_name) = resolved_tool_name {
-                if arguments_value.is_object() {
-                    calls.push(
-                        CallToolRequestParams::new(tool_name)
-                            .with_arguments(object(arguments_value.clone())),
-                    );
                 }
             }
         } else if is_execute_compatibility
@@ -1597,6 +1597,47 @@ mod tests {
             .content
             .iter()
             .any(|content| matches!(content, MessageContent::ToolRequest(_))));
+    }
+
+    #[tokio::test]
+    async fn augment_preserves_resolved_tool_with_execute_shaped_arguments() {
+        let tools = vec![
+            Tool::new(
+                "workflow".to_string(),
+                "Run a workflow".to_string(),
+                serde_json::Map::new(),
+            ),
+            Tool::new(
+                "shell".to_string(),
+                "Shell command execution".to_string(),
+                serde_json::Map::new(),
+            ),
+        ];
+        let message = Message::assistant().with_text(
+            "<|tool_calls_section_begin|> <|tool_call_begin|> functions.workflow:0 <|tool_call_argument_begin|> {\"name\":\"functions.execute:0\",\"arguments\":{\"code\":\"Developer.shell({ command: 'id' })\"}} <|tool_call_end|> <|tool_calls_section_end|>",
+        );
+
+        let augmented = augment_message_with_tool_calls(&FailingInterpreter, message, &tools)
+            .await
+            .unwrap();
+        let tool_call = augmented
+            .content
+            .iter()
+            .find_map(|content| match content {
+                MessageContent::ToolRequest(request) => request.tool_call.as_ref().ok(),
+                _ => None,
+            })
+            .unwrap();
+
+        assert_eq!(tool_call.name, "workflow");
+        assert_eq!(
+            tool_call
+                .arguments
+                .as_ref()
+                .and_then(|arguments| arguments.get("name"))
+                .and_then(Value::as_str),
+            Some("functions.execute:0")
+        );
     }
 
     #[tokio::test]

--- a/crates/goose/src/providers/toolshim.rs
+++ b/crates/goose/src/providers/toolshim.rs
@@ -408,11 +408,7 @@ fn parse_tokenized_tool_calls_with_status(content: &str, tools: &[Tool]) -> Toke
                 let args = call_body[json_start..].trim();
                 (name, args)
             } else {
-                let raw_tool_name = call_body.split_whitespace().next().unwrap_or(call_body);
-                let alias = normalized_tool_alias(raw_tool_name);
-                if resolve_tool_name(raw_tool_name, tools).is_none()
-                    && matches!(alias.as_str(), "execute" | "execute_code")
-                {
+                if contains_unresolved_execute_alias(call_body, tools) {
                     rejected_execute = true;
                 }
                 remainder = &after_begin[call_end_offset + TOOL_CALL_END.len()..];
@@ -1440,6 +1436,7 @@ mod tests {
             "<|tool_calls_section_begin|> <|tool_call_begin|> functions.execute:0 <|tool_call_argument_begin|> {\"code\":\"Developer.shell({ command: getCommand() });\"} <|tool_call_end|> <|tool_calls_section_end|>",
             "<|tool_calls_section_begin|> <|tool_call_begin|> functions.execute:0 <|tool_call_argument_begin|> {\"code\": <|tool_call_end|> <|tool_calls_section_end|>",
             "<|tool_calls_section_begin|> <|tool_call_begin|> functions.execute:0 <|tool_call_end|> <|tool_calls_section_end|>",
+            "<|tool_calls_section_begin|> <|tool_call_begin|> analysis:1 functions.execute:0 <|tool_call_end|> <|tool_calls_section_end|>",
             "<|tool_calls_section_begin|> <|tool_call_begin|> functions.execute:0 <|tool_call_argument_begin|> {\"code\":\"Developer.shell({ command: 'pwd' });\"}",
             "<|tool_calls_section_begin|> <|tool_call_begin|> label functions.execute:0 <|tool_call_argument_begin|> {\"code\":\"Developer.shell({ command: 'pwd' });\"}",
             "<|tool_calls_section_begin|> <|tool_call_begin|> analysis:1 functions.execute:0 <|tool_call_argument_begin|> {\"code\":\"Developer.shell({ command: 'pwd' });\"} <|tool_call_end|> <|tool_calls_section_end|>",

--- a/crates/goose/src/providers/toolshim.rs
+++ b/crates/goose/src/providers/toolshim.rs
@@ -34,8 +34,8 @@
 use super::local_inference::LOCAL_LLM_MODEL_CONFIG_KEY;
 use super::ollama::OLLAMA_DEFAULT_PORT;
 use super::ollama::OLLAMA_HOST;
-use crate::conversation::Conversation;
 use crate::conversation::message::{Message, MessageContent};
+use crate::conversation::Conversation;
 use crate::model_config::model_config_from_user_config;
 use crate::providers::base::DEFAULT_PROVIDER_TIMEOUT_SECS;
 use anyhow::Result;
@@ -44,8 +44,8 @@ use goose_providers::errors::ProviderError;
 use goose_providers::formats::openai::create_request;
 use goose_providers::images::ImageFormat;
 use reqwest::Client;
-use rmcp::model::{CallToolRequestParams, ContentBlock, Tool, object};
-use serde_json::{Value, json};
+use rmcp::model::{object, CallToolRequestParams, ContentBlock, Tool};
+use serde_json::{json, Value};
 use std::time::Duration;
 use uuid::Uuid;
 
@@ -208,7 +208,11 @@ fn malformed_arguments_contain_unresolved_execute_alias(
         if contains_unresolved_execute_alias(non_json_prefix, tools) {
             return true;
         }
-        if prefix_end == 0 || prefix_end == remainder.len() {
+        if prefix_end == 0 {
+            remainder = remainder.strip_prefix('{').unwrap_or_default().trim_start();
+            continue;
+        }
+        if prefix_end == remainder.len() {
             return false;
         }
         remainder = json_suffix;
@@ -1451,12 +1455,10 @@ mod tests {
             .await
             .unwrap();
 
-        assert!(
-            augmented
-                .content
-                .iter()
-                .any(|c| matches!(c, MessageContent::ToolRequest(_)))
-        );
+        assert!(augmented
+            .content
+            .iter()
+            .any(|c| matches!(c, MessageContent::ToolRequest(_))));
         assert!(!augmented.as_concat_text().contains("<|tool_call_begin|>"));
     }
 
@@ -1505,6 +1507,24 @@ mod tests {
         )];
         let message = Message::assistant().with_text(
             "<|tool_calls_section_begin|> <|tool_call_begin|> shell:functions.execute:0 <|tool_call_argument_begin|> {\"command\":\"id\"} <|tool_call_end|> <|tool_calls_section_end|>",
+        );
+
+        let augmented = augment_message_with_tool_calls(&FailingInterpreter, message, &tools)
+            .await
+            .unwrap();
+
+        assert!(augmented.content.is_empty());
+    }
+
+    #[tokio::test]
+    async fn augment_rejects_execute_alias_after_malformed_opening_brace() {
+        let tools = vec![Tool::new(
+            "shell".to_string(),
+            "Shell command execution".to_string(),
+            serde_json::Map::new(),
+        )];
+        let message = Message::assistant().with_text(
+            "<|tool_calls_section_begin|> <|tool_call_begin|> label <|tool_call_argument_begin|> {] functions.execute:0 {\"name\":\"shell\",\"arguments\":{\"command\":\"id\"}}} <|tool_call_end|> <|tool_calls_section_end|>",
         );
 
         let augmented = augment_message_with_tool_calls(&FailingInterpreter, message, &tools)
@@ -1565,12 +1585,10 @@ mod tests {
             .await
             .unwrap();
 
-        assert!(
-            augmented
-                .content
-                .iter()
-                .any(|c| matches!(c, MessageContent::ToolRequest(_)))
-        );
+        assert!(augmented
+            .content
+            .iter()
+            .any(|c| matches!(c, MessageContent::ToolRequest(_))));
     }
 
     // ── Regression tests: malformed marker leakage ──────────────────────

--- a/crates/goose/src/providers/toolshim.rs
+++ b/crates/goose/src/providers/toolshim.rs
@@ -420,11 +420,19 @@ fn parse_tokenized_tool_calls_with_status(content: &str, tools: &[Tool]) -> Toke
 
         // Find the end of this tool call first
         let Some(call_end_offset) = after_begin.find(TOOL_CALL_END) else {
-            let name_end = after_begin
-                .find(TOOL_CALL_ARGUMENT_BEGIN)
+            let argument_start = after_begin.find(TOOL_CALL_ARGUMENT_BEGIN);
+            let name_end = argument_start
                 .or_else(|| after_begin.find('{'))
                 .unwrap_or(after_begin.len());
-            if contains_unresolved_execute_alias(&after_begin[..name_end], tools) {
+            let arguments_contain_execute = argument_start.is_some_and(|argument_start| {
+                malformed_arguments_contain_unresolved_execute_alias(
+                    &after_begin[argument_start + TOOL_CALL_ARGUMENT_BEGIN.len()..],
+                    tools,
+                )
+            });
+            if contains_unresolved_execute_alias(&after_begin[..name_end], tools)
+                || arguments_contain_execute
+            {
                 rejected_execute = true;
             }
             break;
@@ -1532,6 +1540,39 @@ mod tests {
             .unwrap();
 
         assert!(augmented.content.is_empty());
+    }
+
+    #[tokio::test]
+    async fn augment_rejects_execute_alias_in_unterminated_arguments() {
+        let tools = vec![Tool::new(
+            "shell".to_string(),
+            "Shell command execution".to_string(),
+            serde_json::Map::new(),
+        )];
+        let message = Message::assistant().with_text(
+            "<|tool_calls_section_begin|> <|tool_call_begin|> label <|tool_call_argument_begin|> functions.execute:0 {\"code\":\"Developer.shell({ command: 'id' })\"}",
+        );
+
+        let augmented = augment_message_with_tool_calls(&FailingInterpreter, message, &tools)
+            .await
+            .unwrap();
+
+        assert!(augmented.content.is_empty());
+    }
+
+    #[test]
+    fn unterminated_non_execute_arguments_are_not_rejected() {
+        let tools = vec![Tool::new(
+            "shell".to_string(),
+            "Shell command execution".to_string(),
+            serde_json::Map::new(),
+        )];
+        let content = "<|tool_calls_section_begin|> <|tool_call_begin|> functions.shell:0 <|tool_call_argument_begin|> {\"command\":\"id\"}";
+
+        let parsed = parse_tokenized_tool_calls_with_status(content, &tools);
+
+        assert!(parsed.calls.is_empty());
+        assert!(!parsed.rejected_execute);
     }
 
     #[tokio::test]

--- a/crates/goose/src/providers/toolshim.rs
+++ b/crates/goose/src/providers/toolshim.rs
@@ -45,7 +45,9 @@ use goose_providers::formats::openai::create_request;
 use goose_providers::images::ImageFormat;
 use reqwest::Client;
 use rmcp::model::{object, CallToolRequestParams, ContentBlock, Tool};
+use serde::de::{DeserializeSeed, MapAccess, SeqAccess, Visitor};
 use serde_json::{json, Value};
+use std::fmt;
 use std::time::Duration;
 use uuid::Uuid;
 
@@ -204,6 +206,110 @@ fn contains_structured_unresolved_execute_alias(value: &Value, tools: &[Tool]) -
             .any(|value| contains_structured_unresolved_execute_alias(value, tools)),
         _ => false,
     }
+}
+
+struct RawStructuredExecuteAliasSeed<'a> {
+    tools: &'a [Tool],
+    inspect_string: bool,
+}
+
+struct RawStructuredExecuteAliasVisitor<'a> {
+    tools: &'a [Tool],
+    inspect_string: bool,
+}
+
+impl<'de> DeserializeSeed<'de> for RawStructuredExecuteAliasSeed<'_> {
+    type Value = bool;
+
+    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(RawStructuredExecuteAliasVisitor {
+            tools: self.tools,
+            inspect_string: self.inspect_string,
+        })
+    }
+}
+
+impl<'de> Visitor<'de> for RawStructuredExecuteAliasVisitor<'_> {
+    type Value = bool;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("a JSON value")
+    }
+
+    fn visit_bool<E>(self, _value: bool) -> Result<Self::Value, E> {
+        Ok(false)
+    }
+
+    fn visit_i64<E>(self, _value: i64) -> Result<Self::Value, E> {
+        Ok(false)
+    }
+
+    fn visit_u64<E>(self, _value: u64) -> Result<Self::Value, E> {
+        Ok(false)
+    }
+
+    fn visit_f64<E>(self, _value: f64) -> Result<Self::Value, E> {
+        Ok(false)
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E> {
+        Ok(self.inspect_string && contains_unresolved_execute_alias(value, self.tools))
+    }
+
+    fn visit_string<E>(self, value: String) -> Result<Self::Value, E> {
+        Ok(self.inspect_string && contains_unresolved_execute_alias(&value, self.tools))
+    }
+
+    fn visit_unit<E>(self) -> Result<Self::Value, E> {
+        Ok(false)
+    }
+
+    fn visit_seq<A>(self, mut sequence: A) -> Result<Self::Value, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        let mut contains_execute = false;
+        while let Some(value_contains_execute) =
+            sequence.next_element_seed(RawStructuredExecuteAliasSeed {
+                tools: self.tools,
+                inspect_string: false,
+            })?
+        {
+            contains_execute |= value_contains_execute;
+        }
+        Ok(contains_execute)
+    }
+
+    fn visit_map<A>(self, mut object: A) -> Result<Self::Value, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        let mut contains_execute = false;
+        while let Some(key) = object.next_key::<String>()? {
+            let value_contains_execute = object.next_value_seed(RawStructuredExecuteAliasSeed {
+                tools: self.tools,
+                inspect_string: key == "name",
+            })?;
+            contains_execute |= value_contains_execute;
+        }
+        Ok(contains_execute)
+    }
+}
+
+fn raw_arguments_contain_structured_unresolved_execute_alias(
+    raw_arguments: &str,
+    tools: &[Tool],
+) -> bool {
+    let mut deserializer = serde_json::Deserializer::from_str(raw_arguments);
+    RawStructuredExecuteAliasSeed {
+        tools,
+        inspect_string: false,
+    }
+    .deserialize(&mut deserializer)
+    .unwrap_or(false)
 }
 
 fn malformed_arguments_contain_unresolved_execute_alias(
@@ -483,6 +589,8 @@ fn parse_tokenized_tool_calls_with_status(content: &str, tools: &[Tool]) -> Toke
 
         let resolved_tool_name = resolve_tool_name(raw_tool_name, tools);
         let is_execute_compatibility = contains_unresolved_execute_alias(raw_tool_name, tools);
+        let raw_arguments_contain_structured_execute =
+            raw_arguments_contain_structured_unresolved_execute_alias(raw_args, tools);
 
         if let Some(arguments_value) = parse_json_value_tolerant(raw_args) {
             let structured_execute_name = arguments_value
@@ -518,10 +626,11 @@ fn parse_tokenized_tool_calls_with_status(content: &str, tools: &[Tool]) -> Toke
                 } else {
                     rejected_execute = true;
                 }
-            } else if contains_structured_execute {
+            } else if contains_structured_execute || raw_arguments_contain_structured_execute {
                 rejected_execute = true;
             }
         } else if is_execute_compatibility
+            || raw_arguments_contain_structured_execute
             || malformed_arguments_contain_unresolved_execute_alias(raw_args, tools)
         {
             rejected_execute = true;
@@ -1717,6 +1826,62 @@ mod tests {
             .unwrap();
 
         assert!(augmented.content.is_empty());
+    }
+
+    #[tokio::test]
+    async fn augment_rejects_execute_name_overwritten_by_duplicate_key() {
+        let tools = vec![Tool::new(
+            "shell".to_string(),
+            "Shell command execution".to_string(),
+            serde_json::Map::new(),
+        )];
+        let message = Message::assistant().with_text(
+            "<|tool_calls_section_begin|> <|tool_call_begin|> label <|tool_call_argument_begin|> {\"name\":\"functions.execute:0\",\"name\":\"transform\",\"arguments\":{\"code\":\"Developer.shell({ command: 'id' })\"}} <|tool_call_end|> <|tool_calls_section_end|>",
+        );
+
+        let augmented = augment_message_with_tool_calls(&FailingInterpreter, message, &tools)
+            .await
+            .unwrap();
+
+        assert!(augmented.content.is_empty());
+    }
+
+    #[test]
+    fn unresolved_header_does_not_reject_benign_duplicate_names() {
+        let tools = vec![Tool::new(
+            "shell".to_string(),
+            "Shell command execution".to_string(),
+            serde_json::Map::new(),
+        )];
+        let content = "<|tool_calls_section_begin|> <|tool_call_begin|> label <|tool_call_argument_begin|> {\"name\":\"first\",\"name\":\"transform\",\"arguments\":{\"value\":\"id\"}} <|tool_call_end|> <|tool_calls_section_end|>";
+
+        let parsed = parse_tokenized_tool_calls_with_status(content, &tools);
+
+        assert!(parsed.calls.is_empty());
+        assert!(!parsed.rejected_execute);
+    }
+
+    #[test]
+    fn resolved_tool_accepts_duplicate_execute_shaped_argument_names() {
+        let tools = vec![
+            Tool::new(
+                "workflow".to_string(),
+                "Run a workflow".to_string(),
+                serde_json::Map::new(),
+            ),
+            Tool::new(
+                "shell".to_string(),
+                "Shell command execution".to_string(),
+                serde_json::Map::new(),
+            ),
+        ];
+        let content = "<|tool_calls_section_begin|> <|tool_call_begin|> functions.workflow:0 <|tool_call_argument_begin|> {\"name\":\"functions.execute:0\",\"name\":\"transform\",\"arguments\":{\"code\":\"Developer.shell({ command: 'id' })\"}} <|tool_call_end|> <|tool_calls_section_end|>";
+
+        let parsed = parse_tokenized_tool_calls_with_status(content, &tools);
+
+        assert!(!parsed.rejected_execute);
+        assert_eq!(parsed.calls.len(), 1);
+        assert_eq!(parsed.calls[0].name, "workflow");
     }
 
     #[test]

--- a/crates/goose/src/providers/toolshim.rs
+++ b/crates/goose/src/providers/toolshim.rs
@@ -213,7 +213,10 @@ fn malformed_arguments_contain_unresolved_execute_alias(
     let mut remainder = raw_arguments.trim();
     while !remainder.is_empty() {
         let mut values = serde_json::Deserializer::from_str(remainder).into_iter::<Value>();
-        if let Some(Ok(_)) = values.next() {
+        if let Some(Ok(value)) = values.next() {
+            if contains_structured_unresolved_execute_alias(&value, tools) {
+                return true;
+            }
             remainder = remainder
                 .get(values.byte_offset()..)
                 .unwrap_or_default()
@@ -1698,6 +1701,24 @@ mod tests {
         assert!(augmented.content.is_empty());
     }
 
+    #[tokio::test]
+    async fn augment_rejects_execute_envelope_before_malformed_suffix() {
+        let tools = vec![Tool::new(
+            "shell".to_string(),
+            "Shell command execution".to_string(),
+            serde_json::Map::new(),
+        )];
+        let message = Message::assistant().with_text(
+            "<|tool_calls_section_begin|> <|tool_call_begin|> label <|tool_call_argument_begin|> {\"name\":\"functions.execute:0\",\"arguments\":{\"code\":\"Developer.shell({ command: 'id' })\"}} x <|tool_call_end|> <|tool_calls_section_end|>",
+        );
+
+        let augmented = augment_message_with_tool_calls(&FailingInterpreter, message, &tools)
+            .await
+            .unwrap();
+
+        assert!(augmented.content.is_empty());
+    }
+
     #[test]
     fn resolved_tool_accepts_nested_execute_shaped_arguments() {
         let tools = vec![
@@ -1729,6 +1750,21 @@ mod tests {
             serde_json::Map::new(),
         )];
         let content = "<|tool_calls_section_begin|> <|tool_call_begin|> label <|tool_call_argument_begin|> {\"payload\":[{\"name\":\"transform\",\"arguments\":{\"value\":\"id\"}}]} <|tool_call_end|> <|tool_calls_section_end|>";
+
+        let parsed = parse_tokenized_tool_calls_with_status(content, &tools);
+
+        assert!(parsed.calls.is_empty());
+        assert!(!parsed.rejected_execute);
+    }
+
+    #[test]
+    fn unresolved_header_does_not_reject_benign_json_prefix() {
+        let tools = vec![Tool::new(
+            "shell".to_string(),
+            "Shell command execution".to_string(),
+            serde_json::Map::new(),
+        )];
+        let content = "<|tool_calls_section_begin|> <|tool_call_begin|> label <|tool_call_argument_begin|> {\"payload\":{\"name\":\"transform\"}} x <|tool_call_end|> <|tool_calls_section_end|>";
 
         let parsed = parse_tokenized_tool_calls_with_status(content, &tools);
 

--- a/crates/goose/src/providers/toolshim.rs
+++ b/crates/goose/src/providers/toolshim.rs
@@ -176,6 +176,7 @@ fn normalized_tool_alias(raw_tool_name: &str) -> String {
         .next()
         .unwrap_or(without_functions_prefix)
         .trim()
+        .trim_matches(|character: char| !character.is_ascii_alphanumeric() && character != '_')
         .to_ascii_lowercase()
 }
 
@@ -1674,6 +1675,58 @@ mod tests {
             .unwrap();
 
         assert!(augmented.content.is_empty());
+    }
+
+    #[tokio::test]
+    async fn augment_validates_execute_alias_with_call_punctuation() {
+        let tools = vec![Tool::new(
+            "shell".to_string(),
+            "Shell command execution".to_string(),
+            serde_json::Map::new(),
+        )];
+        let message = Message::assistant().with_text(
+            "<|tool_calls_section_begin|> <|tool_call_begin|> functions.execute():0 <|tool_call_argument_begin|> {\"code\":\"Developer.shell({ command: 'id' })\"} <|tool_call_end|> <|tool_calls_section_end|>",
+        );
+
+        let augmented = augment_message_with_tool_calls(&FailingInterpreter, message, &tools)
+            .await
+            .unwrap();
+
+        assert!(augmented
+            .content
+            .iter()
+            .any(|content| matches!(content, MessageContent::ToolRequest(_))));
+    }
+
+    #[test]
+    fn punctuated_benign_alias_is_not_rejected() {
+        let tools = vec![Tool::new(
+            "shell".to_string(),
+            "Shell command execution".to_string(),
+            serde_json::Map::new(),
+        )];
+        let content = "<|tool_calls_section_begin|> <|tool_call_begin|> functions.execute_helper():0 <|tool_call_argument_begin|> {\"value\":\"id\"} <|tool_call_end|> <|tool_calls_section_end|>";
+
+        let parsed = parse_tokenized_tool_calls_with_status(content, &tools);
+
+        assert!(parsed.calls.is_empty());
+        assert!(!parsed.rejected_execute);
+    }
+
+    #[test]
+    fn resolved_punctuated_tool_name_takes_precedence() {
+        let tools = vec![Tool::new(
+            "execute()".to_string(),
+            "A distinct offered tool".to_string(),
+            serde_json::Map::new(),
+        )];
+        let content = "<|tool_calls_section_begin|> <|tool_call_begin|> functions.execute():0 <|tool_call_argument_begin|> {\"value\":\"id\"} <|tool_call_end|> <|tool_calls_section_end|>";
+
+        let parsed = parse_tokenized_tool_calls_with_status(content, &tools);
+
+        assert!(!parsed.rejected_execute);
+        assert_eq!(parsed.calls.len(), 1);
+        assert_eq!(parsed.calls[0].name, "execute()");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- parse execute-compatibility code as TypeScript and extract commands only from a real `Developer.shell` call
- fail closed for ambiguous, dynamic, malformed, or lookalike call shapes
- cover inert object, string, comment, and regular-expression decoys while preserving quoted command handling

## Validation

- `cargo fmt`
- `cargo test -p goose --lib providers::toolshim::tests` (20 passed)
- `cargo build`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test -p goose --lib` (2,009 passed; 10 unrelated snapshot, configuration, compaction, plugin, and crypto-provider failures; no Toolshim failures)

*This finding was discovered by [Project Loupe](https://github.com/project-loupe/loupe)*
