### PR TITLE
fix(desktop): flip select menus up when the window clips them

### DIFF
--- a/ui/desktop/src/components/ui/Select.tsx
+++ b/ui/desktop/src/components/ui/Select.tsx
@@ -6,6 +6,9 @@ export const Select = (props: React.ComponentProps<typeof ReactSelect>) => {
     <ReactSelect
       {...props}
       unstyled
+      // react-select opens downwards by default, so a control near the bottom of the
+      // window puts the last options past its edge. 'auto' flips the menu up instead.
+      menuPlacement={props.menuPlacement ?? 'auto'}
       isSearchable={props.isSearchable !== false}
       closeMenuOnSelect={props.closeMenuOnSelect !== false}
       blurInputOnSelect={props.blurInputOnSelect !== false}


### PR DESCRIPTION
Closes #11277.

`Select` never passed `menuPlacement` to react-select, whose default is `bottom`, so the menu always opened downwards regardless of the room left below it. With the 240px cap on `menuList`, a control near the lower edge of the window pushes its last options past that edge. `auto` flips the menu above the control when there is not enough space below.

The `??` keeps the prop overridable: seven components render this `Select`, and an explicit `menuPlacement` from any of them still wins.

No portal is needed. `DialogContent` sets neither `overflow-hidden` nor a max height, so nothing in the tree clips the menu — the window edge does.

## Verification

Layout behaviour cannot be tested in jsdom, which has no box model, so this was measured by mounting the real `Select` in Chromium through an esbuild bundle and reading the rects. Viewport 1366x768, matching the report, with the control 100px above the lower edge and the five Thinking Effort options.

| Scenario | Before | After |
|---|---|---|
| Control near the lower edge | opens `below`, menu 668..850, 82px past the window, `Medium` `High` `Max` unreachable | opens `above`, menu 448..630, all five options inside the window |
| Control near the top, room below | opens `below`, fully visible | unchanged, still `below` |
| Caller passes `menuPlacement="bottom"` | n/a | still `below`, the override is not swallowed |

The second row is the one that matters for the other six call sites: `auto` only differs from `bottom` when the menu would not fit, so nothing changes where the current behaviour was already correct.

`pnpm test` is unchanged by this: the 20 files that fail on my machine fail identically without this branch, from a stale local `node_modules` with zod v3 against v4 usage. `eslint --max-warnings 0`, `prettier` and `tsc` are clean on the changed file.

I did not add a unit test. Asserting the placement would mean mocking react-select and checking that it received the string, which tests the call rather than the behaviour, and the behaviour itself needs a real layout engine. Happy to add the Chromium harness as a checked-in test if you would rather have it in the repo.
