### PR TITLE
fix: Avoid sending images to non vision capable models

### DIFF
--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -3108,6 +3108,7 @@ mod tests {
                 serde_json::json!(["output-128k-2025-02-19"]),
             )])),
             reasoning: Some(false),
+            supports_vision: Some(true),
             request_headers: None,
         };
 

--- a/crates/goose-provider-types/src/formats/databricks.rs
+++ b/crates/goose-provider-types/src/formats/databricks.rs
@@ -1052,7 +1052,7 @@ mod tests {
         // Non-vision: explicit image content is replaced with a text placeholder
         // at format time — session history is untouched.
         let as_value = serde_json::to_value(format_messages(
-            &[message.clone()],
+            std::slice::from_ref(&message),
             &ImageFormat::OpenAi,
             None,
             false,
@@ -1094,7 +1094,7 @@ mod tests {
         // Non-vision: no separate user image message is emitted — this is what
         // un-bricks sessions (a converted image in the next request 400s).
         let as_value = serde_json::to_value(format_messages(
-            &[tool_response.clone()],
+            std::slice::from_ref(&tool_response),
             &ImageFormat::OpenAi,
             None,
             false,

--- a/crates/goose-provider-types/src/formats/databricks.rs
+++ b/crates/goose-provider-types/src/formats/databricks.rs
@@ -1118,6 +1118,7 @@ mod tests {
             toolshim_model: None,
             request_params: None,
             reasoning: None,
+            supports_vision: None,
             request_headers: None,
         };
         let request = create_request(&model_config, "system", &[], &[], &ImageFormat::OpenAi)?;
@@ -1153,6 +1154,7 @@ mod tests {
             toolshim_model: None,
             request_params: Some(params),
             reasoning: None,
+            supports_vision: None,
             request_headers: None,
         };
         let request = create_request(&model_config, "system", &[], &[], &ImageFormat::OpenAi)?;
@@ -1173,6 +1175,7 @@ mod tests {
             toolshim_model: None,
             request_params: Some(params),
             reasoning: None,
+            supports_vision: None,
             request_headers: None,
         };
         let request = create_request(&model_config, "system", &[], &[], &ImageFormat::OpenAi)?;
@@ -1194,6 +1197,7 @@ mod tests {
             toolshim_model: None,
             request_params: Some(params),
             reasoning: None,
+            supports_vision: None,
             request_headers: None,
         };
         let request = create_request(&model_config, "system", &[], &[], &ImageFormat::OpenAi)?;
@@ -1213,6 +1217,7 @@ mod tests {
             toolshim_model: None,
             request_params: None,
             reasoning: None,
+            supports_vision: None,
             request_headers: None,
         };
         let request = create_request(&model_config, "system", &[], &[], &ImageFormat::OpenAi)?;
@@ -1232,6 +1237,7 @@ mod tests {
             toolshim_model: None,
             request_params: None,
             reasoning: None,
+            supports_vision: None,
             request_headers: None,
         };
         let request = create_request(&model_config, "system", &[], &[], &ImageFormat::OpenAi)?;
@@ -1251,6 +1257,7 @@ mod tests {
             toolshim_model: None,
             request_params: None,
             reasoning: None,
+            supports_vision: None,
             request_headers: None,
         };
         let request = create_request(&model_config, "system", &[], &[], &ImageFormat::OpenAi)?;
@@ -1633,6 +1640,7 @@ mod tests {
             toolshim_model: None,
             request_params: None,
             reasoning: None,
+            supports_vision: None,
             request_headers: None,
         };
 
@@ -1686,6 +1694,7 @@ mod tests {
             toolshim_model: None,
             request_params: None,
             reasoning: None,
+            supports_vision: None,
             request_headers: None,
         };
 

--- a/crates/goose-provider-types/src/formats/databricks.rs
+++ b/crates/goose-provider-types/src/formats/databricks.rs
@@ -30,13 +30,21 @@ struct DatabricksMessage {
     tool_call_id: Option<String>,
 }
 
-fn format_text_content(text: &str, image_format: &ImageFormat) -> (Vec<Value>, bool) {
+fn format_text_content(
+    text: &str,
+    image_format: &ImageFormat,
+    supports_vision: bool,
+) -> (Vec<Value>, bool) {
     let mut items = vec![json!({"type": "text", "text": text})];
-    let has_image = if let Some(path) = detect_image_path(text) {
-        if let Ok(image) = load_image_file(path.as_ref()) {
-            items.push(convert_image(&image, image_format));
+    let has_image = if supports_vision {
+        if let Some(path) = detect_image_path(text) {
+            if let Ok(image) = load_image_file(path.as_ref()) {
+                items.push(convert_image(&image, image_format));
+            }
+            true
+        } else {
+            false
         }
-        true
     } else {
         false
     };
@@ -108,6 +116,7 @@ fn format_messages(
     messages: &[Message],
     image_format: &ImageFormat,
     current_model: Option<&str>,
+    supports_vision: bool,
 ) -> Vec<DatabricksMessage> {
     let mut result = Vec::new();
     for message in messages {
@@ -132,7 +141,8 @@ fn format_messages(
             match content {
                 MessageContentBlock::Text(text) => {
                     if !text.text.is_empty() {
-                        let (items, multi) = format_text_content(&text.text, image_format);
+                        let (items, multi) =
+                            format_text_content(&text.text, image_format, supports_vision);
                         content_array.extend(items);
                         has_multiple_content |= multi;
                     }
@@ -535,7 +545,13 @@ pub fn create_request_for_provider(
         tool_call_id: None,
     };
 
-    let messages_spec = format_messages(messages, image_format, Some(&model_config.model_name));
+    let model_supports_vision = model_config.supports_vision.unwrap_or_default();
+    let messages_spec = format_messages(
+        messages,
+        image_format,
+        Some(&model_config.model_name),
+        model_supports_vision,
+    );
     let mut tools_spec = if !tools.is_empty() {
         format_tools(tools, &model_config.model_name)?
     } else {
@@ -638,7 +654,7 @@ mod tests {
     #[test]
     fn test_format_messages() -> anyhow::Result<()> {
         let message = Message::user().with_text("Hello");
-        let spec = format_messages(&[message], &ImageFormat::OpenAi, None);
+        let spec = format_messages(&[message], &ImageFormat::OpenAi, None, false);
 
         assert_eq!(spec.len(), 1);
         assert_eq!(spec[0].role, "user");
@@ -663,6 +679,7 @@ mod tests {
             &[message],
             &ImageFormat::OpenAi,
             Some("databricks-claude-opus-4-1"),
+            false,
         );
         let has_reasoning = spec[0]
             .content
@@ -689,6 +706,7 @@ mod tests {
             &[message],
             &ImageFormat::OpenAi,
             Some("databricks-claude-sonnet-4-5"),
+            false,
         );
         let has_reasoning = spec[0]
             .content
@@ -716,6 +734,7 @@ mod tests {
             &[message],
             &ImageFormat::OpenAi,
             Some("databricks-claude-opus-4-1"),
+            false,
         );
         let has_reasoning = spec[0]
             .content
@@ -741,7 +760,12 @@ mod tests {
                 provider_session_id: None,
             });
 
-        let spec = format_messages(&[message], &ImageFormat::OpenAi, Some("claude-opus-4.1"));
+        let spec = format_messages(
+            &[message],
+            &ImageFormat::OpenAi,
+            Some("claude-opus-4.1"),
+            false,
+        );
         let has_reasoning = spec[0]
             .content
             .as_array()
@@ -763,7 +787,7 @@ mod tests {
             )])),
         );
 
-        let spec = format_messages(&[message], &ImageFormat::OpenAi, None);
+        let spec = format_messages(&[message], &ImageFormat::OpenAi, None, false);
 
         assert_eq!(spec[0].content, "visibletext");
     }
@@ -830,8 +854,13 @@ mod tests {
             Ok(CallToolResult::success(vec![ContentBlock::text("Result")])),
         ));
 
-        let as_value =
-            serde_json::to_value(format_messages(&messages, &ImageFormat::OpenAi, None)).unwrap();
+        let as_value = serde_json::to_value(format_messages(
+            &messages,
+            &ImageFormat::OpenAi,
+            None,
+            false,
+        ))
+        .unwrap();
         let spec = as_value.as_array().unwrap();
 
         assert_eq!(spec.len(), 4);
@@ -866,8 +895,13 @@ mod tests {
             Ok(CallToolResult::success(vec![ContentBlock::text("Result")])),
         ));
 
-        let as_value =
-            serde_json::to_value(format_messages(&messages, &ImageFormat::OpenAi, None)).unwrap();
+        let as_value = serde_json::to_value(format_messages(
+            &messages,
+            &ImageFormat::OpenAi,
+            None,
+            false,
+        ))
+        .unwrap();
         let spec = as_value.as_array().unwrap();
 
         assert_eq!(spec.len(), 2);
@@ -936,8 +970,13 @@ mod tests {
 
         // Create message with image path
         let message = Message::user().with_text(format!("Here is an image: {}", png_path_str));
-        let as_value =
-            serde_json::to_value(format_messages(&[message], &ImageFormat::OpenAi, None)).unwrap();
+        let as_value = serde_json::to_value(format_messages(
+            &[message],
+            &ImageFormat::OpenAi,
+            None,
+            true,
+        ))
+        .unwrap();
         let spec = as_value.as_array().unwrap();
 
         assert_eq!(spec.len(), 1);
@@ -953,6 +992,41 @@ mod tests {
             .as_str()
             .unwrap()
             .starts_with("data:image/png;base64,"));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_format_messages_with_image_path_passthrough_when_not_vision() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let png_path = temp_dir.path().join("test.png");
+        let png_data = [
+            0x89, 0x50, 0x4E, 0x47, // PNG magic number
+            0x0D, 0x0A, 0x1A, 0x0A, // PNG header
+            0x00, 0x00, 0x00, 0x0D, // Rest of fake PNG data
+        ];
+        std::fs::write(&png_path, png_data)?;
+        let png_path_str = png_path.to_str().unwrap();
+
+        // Without vision support the path must pass through as plain text —
+        // a non-vision model can forward it to a vision subagent instead of
+        // 400ing on an injected image_url block.
+        let message = Message::user().with_text(format!("Here is an image: {}", png_path_str));
+        let as_value = serde_json::to_value(format_messages(
+            &[message],
+            &ImageFormat::OpenAi,
+            None,
+            false,
+        ))
+        .unwrap();
+        let spec = as_value.as_array().unwrap();
+
+        assert_eq!(spec.len(), 1);
+        assert_eq!(spec[0]["role"], "user");
+        let content = spec[0]["content"].as_str().unwrap();
+        assert!(content.contains(png_path_str));
+        assert!(!content.contains("image_url"));
+        assert!(!content.contains("data:image"));
 
         Ok(())
     }
@@ -1497,7 +1571,7 @@ mod tests {
         let message = Message::assistant()
             .with_tool_request("tool1", Ok(CallToolRequestParams::new("test_tool")));
 
-        let spec = format_messages(&[message], &ImageFormat::OpenAi, None);
+        let spec = format_messages(&[message], &ImageFormat::OpenAi, None, false);
         let as_value = serde_json::to_value(spec)?;
         let spec_array = as_value.as_array().unwrap();
 
@@ -1534,7 +1608,12 @@ mod tests {
             final_resp,
         ];
 
-        let spec = serde_json::to_value(format_messages(&messages, &ImageFormat::OpenAi, None))?;
+        let spec = serde_json::to_value(format_messages(
+            &messages,
+            &ImageFormat::OpenAi,
+            None,
+            false,
+        ))?;
         let mut open = std::collections::HashSet::new();
         for m in spec.as_array().unwrap() {
             match m.get("role").and_then(|v| v.as_str()) {
@@ -1569,7 +1648,7 @@ mod tests {
                 .with_arguments(object!({"param": "value", "number": 42}))),
         );
 
-        let spec = format_messages(&[message], &ImageFormat::OpenAi, None);
+        let spec = format_messages(&[message], &ImageFormat::OpenAi, None, false);
         let as_value = serde_json::to_value(spec)?;
         let spec_array = as_value.as_array().unwrap();
 
@@ -1616,7 +1695,7 @@ mod tests {
             None,
         );
 
-        let spec = format_messages(&[message], &ImageFormat::OpenAi, None);
+        let spec = format_messages(&[message], &ImageFormat::OpenAi, None, false);
         let as_value = serde_json::to_value(spec)?;
         let spec_array = as_value.as_array().unwrap();
 
@@ -1750,7 +1829,7 @@ mod tests {
             None,
         );
 
-        let spec = format_messages(&[message], &ImageFormat::OpenAi, None);
+        let spec = format_messages(&[message], &ImageFormat::OpenAi, None, false);
         let as_value = serde_json::to_value(spec)?;
         let spec_array = as_value.as_array().unwrap();
 
@@ -1789,8 +1868,13 @@ mod tests {
                 ),
         ];
 
-        let as_value =
-            serde_json::to_value(format_messages(&messages, &ImageFormat::OpenAi, None)).unwrap();
+        let as_value = serde_json::to_value(format_messages(
+            &messages,
+            &ImageFormat::OpenAi,
+            None,
+            false,
+        ))
+        .unwrap();
         let spec = as_value.as_array().unwrap();
         let roles: Vec<&str> = spec.iter().map(|m| m["role"].as_str().unwrap()).collect();
 
@@ -1823,8 +1907,13 @@ mod tests {
                 ),
         ];
 
-        let as_value =
-            serde_json::to_value(format_messages(&messages, &ImageFormat::OpenAi, None)).unwrap();
+        let as_value = serde_json::to_value(format_messages(
+            &messages,
+            &ImageFormat::OpenAi,
+            None,
+            false,
+        ))
+        .unwrap();
         let spec = as_value.as_array().unwrap();
         let roles: Vec<&str> = spec.iter().map(|m| m["role"].as_str().unwrap()).collect();
 

--- a/crates/goose-provider-types/src/formats/databricks.rs
+++ b/crates/goose-provider-types/src/formats/databricks.rs
@@ -54,6 +54,7 @@ fn format_text_content(
 fn format_tool_response(
     response: &crate::conversation::message::ToolResponse,
     image_format: &ImageFormat,
+    supports_vision: bool,
 ) -> Vec<DatabricksMessage> {
     let mut result = Vec::new();
 
@@ -67,15 +68,21 @@ fn format_tool_response(
             for content in abridged {
                 match content {
                     ContentBlock::Image(image) => {
-                        tool_content.push(ContentBlock::text(
+                        if supports_vision {
+                            tool_content.push(ContentBlock::text(
                             "This tool result included an image that is uploaded in the next message.",
                         ));
-                        image_messages.push(DatabricksMessage {
-                            role: "user".to_string(),
-                            content: [convert_image(&image, image_format)].into(),
-                            tool_calls: None,
-                            tool_call_id: None,
-                        });
+                            image_messages.push(DatabricksMessage {
+                                role: "user".to_string(),
+                                content: [convert_image(&image, image_format)].into(),
+                                tool_calls: None,
+                                tool_call_id: None,
+                            });
+                        } else {
+                            tool_content.push(ContentBlock::text(
+                                "This tool result included an image that was omitted as the model does not support vision.",
+                            ));
+                        }
                     }
                     ContentBlock::Resource(resource) => {
                         let text = extract_text_from_resource(&resource.resource);
@@ -219,7 +226,7 @@ fn format_messages(
                     }
                 }
                 MessageContentBlock::ToolResponse(response) => {
-                    for msg in format_tool_response(response, image_format) {
+                    for msg in format_tool_response(response, image_format, supports_vision) {
                         if msg.role == "user" {
                             pending_image_messages.push(msg);
                         } else {
@@ -228,7 +235,14 @@ fn format_messages(
                     }
                 }
                 MessageContentBlock::Image(image) => {
-                    content_array.push(convert_image(image, image_format));
+                    if supports_vision {
+                        content_array.push(convert_image(image, image_format));
+                    } else {
+                        content_array.push(json!({
+                            "type": "text",
+                            "text": "[image omitted: model does not support vision]"
+                        }));
+                    }
                 }
                 MessageContentBlock::FrontendToolRequest(req) => {
                     let text = match &req.tool_call {
@@ -1027,6 +1041,83 @@ mod tests {
         assert!(content.contains(png_path_str));
         assert!(!content.contains("image_url"));
         assert!(!content.contains("data:image"));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_format_messages_with_image_block_passthrough_when_not_vision() -> anyhow::Result<()> {
+        let message = Message::user().with_image("aW1hZ2VkYXRh", "image/png");
+
+        // Non-vision: explicit image content is replaced with a text placeholder
+        // at format time — session history is untouched.
+        let as_value = serde_json::to_value(format_messages(
+            &[message.clone()],
+            &ImageFormat::OpenAi,
+            None,
+            false,
+        ))
+        .unwrap();
+        let spec = as_value.as_array().unwrap();
+        let content = spec[0]["content"].as_str().unwrap();
+        assert_eq!(content, "[image omitted: model does not support vision]");
+        assert!(!content.contains("image_url"));
+
+        // Vision: the image is converted to an image_url block (existing behavior).
+        let as_value = serde_json::to_value(format_messages(
+            &[message],
+            &ImageFormat::OpenAi,
+            None,
+            true,
+        ))
+        .unwrap();
+        let spec = as_value.as_array().unwrap();
+        let content = spec[0]["content"].as_array().unwrap();
+        assert_eq!(content[0]["type"], "image_url");
+        assert!(content[0]["image_url"]["url"]
+            .as_str()
+            .unwrap()
+            .starts_with("data:image/png;base64,"));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_tool_response_image_omitted_when_not_vision() -> anyhow::Result<()> {
+        let tool_response = Message::user().with_tool_response(
+            "tool1",
+            Ok(rmcp::model::CallToolResult::success(vec![
+                rmcp::model::ContentBlock::image("aW1hZ2VkYXRh", "image/png"),
+            ])),
+        );
+
+        // Non-vision: no separate user image message is emitted — this is what
+        // un-bricks sessions (a converted image in the next request 400s).
+        let as_value = serde_json::to_value(format_messages(
+            &[tool_response.clone()],
+            &ImageFormat::OpenAi,
+            None,
+            false,
+        ))
+        .unwrap();
+        let serialized = as_value.to_string();
+        assert!(!serialized.contains("image_url"));
+        assert!(serialized.contains(
+            "This tool result included an image that was omitted as the model does not support vision."
+        ));
+
+        // Vision: the separate user image message IS emitted (existing behavior).
+        let as_value = serde_json::to_value(format_messages(
+            &[tool_response],
+            &ImageFormat::OpenAi,
+            None,
+            true,
+        ))
+        .unwrap();
+        let serialized = as_value.to_string();
+        assert!(serialized.contains("image_url"));
+        assert!(serialized
+            .contains("This tool result included an image that is uploaded in the next message."));
 
         Ok(())
     }
@@ -1868,13 +1959,9 @@ mod tests {
                 ),
         ];
 
-        let as_value = serde_json::to_value(format_messages(
-            &messages,
-            &ImageFormat::OpenAi,
-            None,
-            false,
-        ))
-        .unwrap();
+        let as_value =
+            serde_json::to_value(format_messages(&messages, &ImageFormat::OpenAi, None, true))
+                .unwrap();
         let spec = as_value.as_array().unwrap();
         let roles: Vec<&str> = spec.iter().map(|m| m["role"].as_str().unwrap()).collect();
 
@@ -1907,13 +1994,9 @@ mod tests {
                 ),
         ];
 
-        let as_value = serde_json::to_value(format_messages(
-            &messages,
-            &ImageFormat::OpenAi,
-            None,
-            false,
-        ))
-        .unwrap();
+        let as_value =
+            serde_json::to_value(format_messages(&messages, &ImageFormat::OpenAi, None, true))
+                .unwrap();
         let spec = as_value.as_array().unwrap();
         let roles: Vec<&str> = spec.iter().map(|m| m["role"].as_str().unwrap()).collect();
 

--- a/crates/goose-provider-types/src/formats/openai.rs
+++ b/crates/goose-provider-types/src/formats/openai.rs
@@ -2398,7 +2398,7 @@ mod tests {
         let user_message = Message::user().with_text(format!("Here is an image: {}", png_path_str));
 
         let spec = format_messages_with_options(
-            &[user_message.clone()],
+            std::slice::from_ref(&user_message),
             &ImageFormat::OpenAi,
             OpenAiFormatOptions {
                 preserve_thinking_context: true,
@@ -2443,7 +2443,7 @@ mod tests {
         let request = create_request(
             &vision,
             "system",
-            &[message.clone()],
+            std::slice::from_ref(&message),
             &[],
             &ImageFormat::OpenAi,
             false,
@@ -2458,7 +2458,7 @@ mod tests {
         let request = create_request(
             &unknown,
             "system",
-            &[message.clone()],
+            std::slice::from_ref(&message),
             &[],
             &ImageFormat::OpenAi,
             false,
@@ -2493,7 +2493,7 @@ mod tests {
         // at format time — session history is untouched, so a vision model (or a
         // delegated vision subagent) can still see the real image later.
         let spec = format_messages_with_options(
-            &[user_message.clone()],
+            std::slice::from_ref(&user_message),
             &ImageFormat::OpenAi,
             OpenAiFormatOptions {
                 preserve_thinking_context: true,
@@ -2540,7 +2540,7 @@ mod tests {
         // Non-vision: the separate user image message is NOT emitted — this is
         // what un-bricks sessions (a converted image in the next request 400s).
         let spec = format_messages_with_options(
-            &[tool_response.clone()],
+            std::slice::from_ref(&tool_response),
             &ImageFormat::OpenAi,
             OpenAiFormatOptions {
                 preserve_thinking_context: true,

--- a/crates/goose-provider-types/src/formats/openai.rs
+++ b/crates/goose-provider-types/src/formats/openai.rs
@@ -355,14 +355,19 @@ pub fn format_messages_with_options(
                             for content in result.content.iter() {
                                 match content {
                                     ContentBlock::Image(image) => {
-                                        // Add placeholder text in the tool response
-                                        tool_content.push(ContentBlock::text("This tool result included an image that is uploaded in the next message."));
+                                        if options.supports_vision {
+                                            // Add placeholder text in the tool response
+                                            tool_content.push(ContentBlock::text("This tool result included an image that is uploaded in the next message."));
 
-                                        // Create a separate image message
-                                        image_messages.push(json!({
-                                            "role": "user",
-                                            "content": [convert_image(&image.clone(), image_format)]
-                                        }));
+                                            // Create a separate image message
+                                            image_messages.push(json!({
+                                                "role": "user",
+                                                "content": [convert_image(&image.clone(), image_format)]
+                                            }));
+                                        } else {
+                                            // Add placeholder text in the tool response
+                                            tool_content.push(ContentBlock::text("This tool result included an image that was omitted as the model does not support vision."));
+                                        }
                                     }
                                     ContentBlock::Resource(resource) => {
                                         let text = extract_text_from_resource(&resource.resource);
@@ -405,8 +410,15 @@ pub fn format_messages_with_options(
                 MessageContentBlock::ActionRequired(_) => {}
                 MessageContentBlock::Image(image) => {
                     if message.role == Role::User {
-                        has_non_text_content = true;
-                        content_array.push(convert_image(image, image_format));
+                        if options.supports_vision {
+                            has_non_text_content = true;
+                            content_array.push(convert_image(image, image_format));
+                        } else {
+                            content_array.push(json!({
+                                "type": "text",
+                                "text": "[image omitted: model does not support vision]"
+                            }));
+                        }
                     } else {
                         content_array.push(json!({
                             "type": "text",
@@ -2474,13 +2486,108 @@ mod tests {
     }
 
     #[test]
+    fn test_format_messages_with_image_block_passthrough_when_not_vision() -> anyhow::Result<()> {
+        let user_message = Message::user().with_image("aW1hZ2VkYXRh", "image/png");
+
+        // Non-vision: explicit image content is replaced with a text placeholder
+        // at format time — session history is untouched, so a vision model (or a
+        // delegated vision subagent) can still see the real image later.
+        let spec = format_messages_with_options(
+            &[user_message.clone()],
+            &ImageFormat::OpenAi,
+            OpenAiFormatOptions {
+                preserve_thinking_context: true,
+                supports_vision: false,
+                ..Default::default()
+            },
+        );
+        assert_eq!(spec.len(), 1);
+        let content = spec[0]["content"].as_str().unwrap();
+        assert_eq!(content, "[image omitted: model does not support vision]");
+        assert!(!content.contains("image_url"));
+        assert!(!content.contains("data:image"));
+
+        // Vision: the image is converted to an image_url block (existing behavior).
+        let spec = format_messages_with_options(
+            &[user_message],
+            &ImageFormat::OpenAi,
+            OpenAiFormatOptions {
+                preserve_thinking_context: true,
+                supports_vision: true,
+                ..Default::default()
+            },
+        );
+        let content = spec[0]["content"].as_array().unwrap();
+        assert_eq!(content.len(), 1);
+        assert_eq!(content[0]["type"], "image_url");
+        assert!(content[0]["image_url"]["url"]
+            .as_str()
+            .unwrap()
+            .starts_with("data:image/png;base64,"));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_tool_response_image_omitted_when_not_vision() -> anyhow::Result<()> {
+        let tool_response = Message::user().with_tool_response(
+            "tool1",
+            Ok(rmcp::model::CallToolResult::success(vec![
+                rmcp::model::ContentBlock::image("aW1hZ2VkYXRh", "image/png"),
+            ])),
+        );
+
+        // Non-vision: the separate user image message is NOT emitted — this is
+        // what un-bricks sessions (a converted image in the next request 400s).
+        let spec = format_messages_with_options(
+            &[tool_response.clone()],
+            &ImageFormat::OpenAi,
+            OpenAiFormatOptions {
+                preserve_thinking_context: true,
+                supports_vision: false,
+                ..Default::default()
+            },
+        );
+        let serialized = serde_json::to_value(&spec).unwrap().to_string();
+        assert!(!serialized.contains("image_url"));
+        assert!(serialized.contains(
+            "This tool result included an image that was omitted as the model does not support vision."
+        ));
+
+        // Vision: the separate user image message IS emitted (existing behavior).
+        let spec = format_messages_with_options(
+            &[tool_response],
+            &ImageFormat::OpenAi,
+            OpenAiFormatOptions {
+                preserve_thinking_context: true,
+                supports_vision: true,
+                ..Default::default()
+            },
+        );
+        let serialized = serde_json::to_value(&spec).unwrap().to_string();
+        assert!(serialized.contains("image_url"));
+        assert!(serialized
+            .contains("This tool result included an image that is uploaded in the next message."));
+
+        Ok(())
+    }
+
+    #[test]
     fn test_format_messages_with_text_and_image_preserves_order() {
         // Text before image: order should be [text, image]
         let msg_text_first = Message::user()
             .with_text("Describe this image")
             .with_image("aW1hZ2VkYXRh", "image/png");
 
-        let spec = format_messages(&[msg_text_first], &ImageFormat::OpenAi);
+        let spec = format_messages_with_options(
+            &[msg_text_first],
+            &ImageFormat::OpenAi,
+            OpenAiFormatOptions {
+                preserve_thinking_context: true,
+                supports_vision: true,
+                ..Default::default()
+            },
+        );
         assert_eq!(spec.len(), 1);
         assert_eq!(spec[0]["role"], "user");
 
@@ -2497,7 +2604,15 @@ mod tests {
             .with_image("aW1hZ2VkYXRh", "image/png")
             .with_text("What do you see?");
 
-        let spec2 = format_messages(&[msg_image_first], &ImageFormat::OpenAi);
+        let spec2 = format_messages_with_options(
+            &[msg_image_first],
+            &ImageFormat::OpenAi,
+            OpenAiFormatOptions {
+                preserve_thinking_context: true,
+                supports_vision: true,
+                ..Default::default()
+            },
+        );
         let content2 = spec2[0]["content"]
             .as_array()
             .expect("content should be an array");

--- a/crates/goose-provider-types/src/formats/openai.rs
+++ b/crates/goose-provider-types/src/formats/openai.rs
@@ -66,6 +66,7 @@ pub fn is_reserved_request_param_key(key: &str) -> bool {
 #[derive(Debug, Clone, Copy, Default)]
 pub struct OpenAiFormatOptions {
     pub preserve_thinking_context: bool,
+    pub supports_vision: bool,
     pub thinking_preservation_format: Option<ThinkingPreservationFormat>,
 }
 
@@ -256,11 +257,17 @@ pub fn format_messages_with_options(
                 MessageContentBlock::Text(text) => {
                     if !text.text.is_empty() {
                         if message.role == Role::User {
-                            if let Some(image_path) = detect_image_path(&text.text) {
-                                if let Ok(image) = load_image_file(image_path.as_ref()) {
-                                    has_non_text_content = true;
-                                    content_array.push(json!({"type": "text", "text": text.text}));
-                                    content_array.push(convert_image(&image, image_format));
+                            if options.supports_vision {
+                                if let Some(image_path) = detect_image_path(&text.text) {
+                                    if let Ok(image) = load_image_file(image_path.as_ref()) {
+                                        has_non_text_content = true;
+                                        content_array
+                                            .push(json!({"type": "text", "text": text.text}));
+                                        content_array.push(convert_image(&image, image_format));
+                                    } else {
+                                        content_array
+                                            .push(json!({"type": "text", "text": text.text}));
+                                    }
                                 } else {
                                     content_array.push(json!({"type": "text", "text": text.text}));
                                 }
@@ -1657,6 +1664,7 @@ pub fn create_request(
         for_streaming,
         OpenAiFormatOptions {
             preserve_thinking_context: true,
+            supports_vision: model_config.supports_vision.unwrap_or_default(),
             ..Default::default()
         },
     )
@@ -2306,9 +2314,17 @@ mod tests {
         std::fs::write(&png_path, png_data)?;
         let png_path_str = png_path.to_str().unwrap();
 
-        // Create user message with image path - should load the image
+        // Create user message with image path - should load the image when vision is supported
         let user_message = Message::user().with_text(format!("Here is an image: {}", png_path_str));
-        let spec = format_messages(&[user_message], &ImageFormat::OpenAi);
+        let spec = format_messages_with_options(
+            &[user_message],
+            &ImageFormat::OpenAi,
+            OpenAiFormatOptions {
+                preserve_thinking_context: true,
+                supports_vision: true,
+                ..Default::default()
+            },
+        );
 
         assert_eq!(spec.len(), 1);
         assert_eq!(spec[0]["role"], "user");
@@ -2327,7 +2343,15 @@ mod tests {
         // Create assistant message with same text - should NOT load the image
         let assistant_message =
             Message::assistant().with_text(format!("I saved the output to {}", png_path_str));
-        let spec = format_messages(&[assistant_message], &ImageFormat::OpenAi);
+        let spec = format_messages_with_options(
+            &[assistant_message],
+            &ImageFormat::OpenAi,
+            OpenAiFormatOptions {
+                preserve_thinking_context: true,
+                supports_vision: true,
+                ..Default::default()
+            },
+        );
 
         assert_eq!(spec.len(), 1);
         assert_eq!(spec[0]["role"], "assistant");
@@ -2339,6 +2363,112 @@ mod tests {
             "Assistant message content should be a string, not an array with image"
         );
         assert!(content.unwrap().contains(png_path_str));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_format_messages_with_image_path_passthrough_when_not_vision() -> anyhow::Result<()> {
+        // Create a temporary PNG file with valid PNG magic numbers
+        let temp_dir = tempfile::tempdir()?;
+        let png_path = temp_dir.path().join("test.png");
+        let png_data = [
+            0x89, 0x50, 0x4E, 0x47, // PNG magic number
+            0x0D, 0x0A, 0x1A, 0x0A, // PNG header
+            0x00, 0x00, 0x00, 0x0D, // Rest of fake PNG data
+        ];
+        std::fs::write(&png_path, png_data)?;
+        let png_path_str = png_path.to_str().unwrap();
+
+        // User message with image path: with vision NOT supported, the path must
+        // pass through as plain text (a non-vision model can forward it to a
+        // vision subagent instead of 400ing on an injected image_url block).
+        let user_message = Message::user().with_text(format!("Here is an image: {}", png_path_str));
+
+        let spec = format_messages_with_options(
+            &[user_message.clone()],
+            &ImageFormat::OpenAi,
+            OpenAiFormatOptions {
+                preserve_thinking_context: true,
+                supports_vision: false,
+                ..Default::default()
+            },
+        );
+        assert_eq!(spec.len(), 1);
+        assert_eq!(spec[0]["role"], "user");
+        // Single text block collapses to a plain string — the path survives verbatim.
+        let content = spec[0]["content"].as_str().unwrap();
+        assert!(content.contains(png_path_str));
+        assert!(!content.contains("image_url"));
+        assert!(!content.contains("data:image"));
+
+        // Default options (bare format_messages wrapper) must behave the same:
+        // unaffirmed vision -> passthrough.
+        let spec = format_messages(&[user_message], &ImageFormat::OpenAi);
+        let content = spec[0]["content"].as_str().unwrap();
+        assert!(content.contains(png_path_str));
+        assert!(!content.contains("image_url"));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_create_request_threads_supports_vision() -> anyhow::Result<()> {
+        // Create a temporary PNG file with valid PNG magic numbers
+        let temp_dir = tempfile::tempdir()?;
+        let png_path = temp_dir.path().join("test.png");
+        let png_data = [
+            0x89, 0x50, 0x4E, 0x47, // PNG magic number
+            0x0D, 0x0A, 0x1A, 0x0A, // PNG header
+            0x00, 0x00, 0x00, 0x0D, // Rest of fake PNG data
+        ];
+        std::fs::write(&png_path, png_data)?;
+        let png_path_str = png_path.to_str().unwrap();
+        let message = Message::user().with_text(format!("Here is an image: {}", png_path_str));
+
+        // Vision affirmed: path is converted to an image_url block.
+        let vision = ModelConfig::new("gpt-4o").with_vision_support(true);
+        let request = create_request(
+            &vision,
+            "system",
+            &[message.clone()],
+            &[],
+            &ImageFormat::OpenAi,
+            false,
+        )?;
+        let messages = request["messages"].as_array().unwrap();
+        let content = messages[1]["content"].as_array().unwrap();
+        assert_eq!(content.len(), 2);
+        assert_eq!(content[1]["type"], "image_url");
+
+        // Unknown (None): passthrough, no image_url.
+        let unknown = ModelConfig::new("gpt-4o");
+        let request = create_request(
+            &unknown,
+            "system",
+            &[message.clone()],
+            &[],
+            &ImageFormat::OpenAi,
+            false,
+        )?;
+        let messages = request["messages"].as_array().unwrap();
+        let content = messages[1]["content"].as_str().unwrap();
+        assert!(content.contains(png_path_str));
+        assert!(!content.contains("image_url"));
+
+        // Explicitly non-vision: passthrough, no image_url.
+        let non_vision = ModelConfig::new("gpt-4o").with_vision_support(false);
+        let request = create_request(
+            &non_vision,
+            "system",
+            &[message],
+            &[],
+            &ImageFormat::OpenAi,
+            false,
+        )?;
+        let messages = request["messages"].as_array().unwrap();
+        let content = messages[1]["content"].as_str().unwrap();
+        assert!(!content.contains("image_url"));
 
         Ok(())
     }
@@ -5225,6 +5355,7 @@ data: [DONE]"#;
             &ImageFormat::OpenAi,
             OpenAiFormatOptions {
                 preserve_thinking_context: true,
+                supports_vision: false,
                 thinking_preservation_format: Some(format),
             },
         )

--- a/crates/goose-provider-types/src/formats/openai_responses.rs
+++ b/crates/goose-provider-types/src/formats/openai_responses.rs
@@ -532,19 +532,18 @@ fn add_message_items(input_items: &mut Vec<Value>, messages: &[Message], support
                                 json!(contents
                                     .content
                                     .iter()
-                                    .filter_map(|c| match c {
-                                        ContentBlock::Text(t) => Some(t.text.clone()),
+                                    .map(|c| match c {
+                                        ContentBlock::Text(t) => t.text.clone(),
                                         ContentBlock::Resource(r) => {
-                                            Some(extract_text_from_resource(&r.resource))
+                                            extract_text_from_resource(&r.resource)
                                         }
-                                        ContentBlock::Audio(_) => Some("[Audio content]".into()),
+                                        ContentBlock::Audio(_) => "[Audio content]".into(),
                                         ContentBlock::ResourceLink(_) => {
-                                            Some("[Resource link]".into())
+                                            "[Resource link]".into()
                                         }
-                                        ContentBlock::Image(_) => Some(
+                                        ContentBlock::Image(_) =>
                                             "[image omitted: model does not support vision]".into(),
-                                        ),
-                                        _ => Some("[Unsupported content]".into()),
+                                        _ => "[Unsupported content]".into(),
                                     })
                                     .collect::<Vec<String>>()
                                     .join("\n"))

--- a/crates/goose-provider-types/src/formats/openai_responses.rs
+++ b/crates/goose-provider-types/src/formats/openai_responses.rs
@@ -399,7 +399,7 @@ pub enum ContentBlockPart {
     },
 }
 
-fn add_message_items(input_items: &mut Vec<Value>, messages: &[Message]) {
+fn add_message_items(input_items: &mut Vec<Value>, messages: &[Message], supports_vision: bool) {
     for message in messages.iter().filter(|m| m.is_agent_visible()) {
         let role = match message.role {
             Role::User => "user",
@@ -468,10 +468,17 @@ fn add_message_items(input_items: &mut Vec<Value>, messages: &[Message]) {
                     }
                 }
                 MessageContentBlock::Image(image) => {
-                    text_items.push(json!({
-                        "type": "input_image",
-                        "image_url": format!("data:{};base64,{}", image.mime_type, image.data)
-                    }));
+                    if supports_vision {
+                        text_items.push(json!({
+                            "type": "input_image",
+                            "image_url": format!("data:{};base64,{}", image.mime_type, image.data)
+                        }));
+                    } else {
+                        text_items.push(json!({
+                            "type": "input_text",
+                            "text": "[image omitted: model does not support vision]"
+                        }));
+                    }
                 }
                 MessageContentBlock::ToolResponse(response) => {
                     if !text_items.is_empty() {
@@ -485,10 +492,11 @@ fn add_message_items(input_items: &mut Vec<Value>, messages: &[Message]) {
 
                     match &response.tool_result {
                         Ok(contents) => {
-                            let has_images = contents
-                                .content
-                                .iter()
-                                .any(|c| matches!(c, ContentBlock::Image(_)));
+                            let has_images = supports_vision
+                                && contents
+                                    .content
+                                    .iter()
+                                    .any(|c| matches!(c, ContentBlock::Image(_)));
 
                             let output = if has_images {
                                 json!(contents
@@ -533,7 +541,9 @@ fn add_message_items(input_items: &mut Vec<Value>, messages: &[Message]) {
                                         ContentBlock::ResourceLink(_) => {
                                             Some("[Resource link]".into())
                                         }
-                                        ContentBlock::Image(_) => None,
+                                        ContentBlock::Image(_) => Some(
+                                            "[image omitted: model does not support vision]".into(),
+                                        ),
                                         _ => Some("[Unsupported content]".into()),
                                     })
                                     .collect::<Vec<String>>()
@@ -663,7 +673,11 @@ pub fn create_responses_request_for_model(
         }));
     }
 
-    add_message_items(&mut input_items, messages);
+    add_message_items(
+        &mut input_items,
+        messages,
+        model_config.supports_vision.unwrap_or_default(),
+    );
 
     let (model_name, legacy_reasoning_effort) = extract_reasoning_effort(capability_model_name);
     // All models routed here are responses-capable; temperature is rejected
@@ -2145,7 +2159,7 @@ mod tests {
             toolshim_model: None,
             request_params: None,
             reasoning: None,
-            supports_vision: None,
+            supports_vision: Some(true),
             request_headers: None,
         };
 
@@ -2195,7 +2209,7 @@ mod tests {
             toolshim_model: None,
             request_params: None,
             reasoning: None,
-            supports_vision: None,
+            supports_vision: Some(true),
             request_headers: None,
         };
 
@@ -2400,7 +2414,7 @@ mod tests {
             toolshim_model: None,
             request_params: None,
             reasoning: None,
-            supports_vision: None,
+            supports_vision: Some(true),
             request_headers: None,
         };
 
@@ -2433,7 +2447,7 @@ mod tests {
             toolshim_model: None,
             request_params: None,
             reasoning: None,
-            supports_vision: None,
+            supports_vision: Some(true),
             request_headers: None,
         };
 
@@ -2449,6 +2463,68 @@ mod tests {
         assert_eq!(content[1]["image_url"], "data:image/png;base64,img1");
         assert_eq!(content[2]["type"], "input_image");
         assert_eq!(content[2]["image_url"], "data:image/jpeg;base64,img2");
+    }
+
+    #[test]
+    fn test_user_image_omitted_when_not_vision() {
+        use crate::conversation::message::Message;
+
+        let messages = vec![Message::user()
+            .with_text("describe this image")
+            .with_image("aW1hZ2VkYXRh", "image/png")];
+
+        // Non-vision: explicit image content is replaced with a text placeholder
+        // at format time — session history is untouched.
+        let model_config = ModelConfig::new("o3-mini");
+        let result = create_responses_request(&model_config, "", &messages, &[]).unwrap();
+        let input = result["input"].as_array().unwrap();
+
+        assert_eq!(input.len(), 1);
+        assert_eq!(input[0]["role"], "user");
+        let content = input[0]["content"].as_array().unwrap();
+        assert_eq!(content.len(), 2);
+        assert_eq!(content[0]["type"], "input_text");
+        assert_eq!(content[0]["text"], "describe this image");
+        assert_eq!(content[1]["type"], "input_text");
+        assert_eq!(
+            content[1]["text"],
+            "[image omitted: model does not support vision]"
+        );
+
+        let serialized = serde_json::to_string(&result).unwrap();
+        assert!(!serialized.contains("input_image"));
+        assert!(!serialized.contains("data:image"));
+    }
+
+    #[test]
+    fn test_tool_response_image_omitted_when_not_vision() {
+        use crate::conversation::message::Message;
+        use rmcp::model::{CallToolResult, ContentBlock};
+
+        let messages = vec![
+            Message::user().with_content(MessageContentBlock::tool_response(
+                "call_1",
+                Ok(CallToolResult::success(vec![
+                    ContentBlock::text("caption"),
+                    ContentBlock::image("a+/=".to_string(), "image/png".to_string()),
+                ])),
+            )),
+        ];
+
+        // Non-vision: images in tool results are omitted from the output
+        // string (with a note) instead of being emitted as input_image items.
+        let model_config = ModelConfig::new("o3-mini");
+        let result = create_responses_request(&model_config, "", &messages, &[]).unwrap();
+        let input = result["input"].as_array().unwrap();
+
+        assert_eq!(input[0]["type"], "function_call_output");
+        let output = input[0]["output"].as_str().unwrap();
+        assert!(output.contains("caption"));
+        assert!(output.contains("[image omitted: model does not support vision]"));
+
+        let serialized = serde_json::to_string(&result).unwrap();
+        assert!(!serialized.contains("input_image"));
+        assert!(!serialized.contains("data:image"));
     }
 
     #[test]

--- a/crates/goose-provider-types/src/formats/openai_responses.rs
+++ b/crates/goose-provider-types/src/formats/openai_responses.rs
@@ -1670,6 +1670,7 @@ mod tests {
             toolshim_model: None,
             request_params: None,
             reasoning: None,
+            supports_vision: None,
             request_headers: None,
         };
 
@@ -1905,6 +1906,7 @@ mod tests {
             toolshim_model: None,
             request_params: None,
             reasoning: None,
+            supports_vision: None,
             request_headers: None,
         };
 
@@ -1949,6 +1951,7 @@ mod tests {
                 toolshim_model: None,
                 request_params: None,
                 reasoning: None,
+                supports_vision: None,
                 request_headers: None,
             };
 
@@ -2037,6 +2040,7 @@ mod tests {
                 toolshim_model: None,
                 request_params: None,
                 reasoning: None,
+                supports_vision: None,
                 request_headers: None,
             };
 
@@ -2088,6 +2092,7 @@ mod tests {
             toolshim_model: None,
             request_params: None,
             reasoning: None,
+            supports_vision: None,
             request_headers: None,
         };
 
@@ -2114,6 +2119,7 @@ mod tests {
                 serde_json::json!(true),
             )])),
             reasoning: None,
+            supports_vision: None,
             request_headers: None,
         };
 
@@ -2139,6 +2145,7 @@ mod tests {
             toolshim_model: None,
             request_params: None,
             reasoning: None,
+            supports_vision: None,
             request_headers: None,
         };
 
@@ -2188,6 +2195,7 @@ mod tests {
             toolshim_model: None,
             request_params: None,
             reasoning: None,
+            supports_vision: None,
             request_headers: None,
         };
 
@@ -2225,6 +2233,7 @@ mod tests {
             toolshim_model: None,
             request_params: None,
             reasoning: None,
+            supports_vision: None,
             request_headers: None,
         };
 
@@ -2257,6 +2266,7 @@ mod tests {
             toolshim_model: None,
             request_params: None,
             reasoning: None,
+            supports_vision: None,
             request_headers: None,
         };
 
@@ -2288,6 +2298,7 @@ mod tests {
             toolshim_model: None,
             request_params: None,
             reasoning: None,
+            supports_vision: None,
             request_headers: None,
         };
 
@@ -2322,6 +2333,7 @@ mod tests {
             toolshim_model: None,
             request_params: None,
             reasoning: None,
+            supports_vision: None,
             request_headers: None,
         };
 
@@ -2361,6 +2373,7 @@ mod tests {
             toolshim_model: None,
             request_params: None,
             reasoning: None,
+            supports_vision: None,
             request_headers: None,
         };
 
@@ -2387,6 +2400,7 @@ mod tests {
             toolshim_model: None,
             request_params: None,
             reasoning: None,
+            supports_vision: None,
             request_headers: None,
         };
 
@@ -2419,6 +2433,7 @@ mod tests {
             toolshim_model: None,
             request_params: None,
             reasoning: None,
+            supports_vision: None,
             request_headers: None,
         };
 
@@ -2451,6 +2466,7 @@ mod tests {
             toolshim_model: None,
             request_params: None,
             reasoning: None,
+            supports_vision: None,
             request_headers: None,
         };
 
@@ -2891,6 +2907,7 @@ mod tests {
             toolshim_model: None,
             request_params: None,
             reasoning: None,
+            supports_vision: None,
             request_headers: None,
         };
 
@@ -2932,6 +2949,7 @@ mod tests {
             toolshim_model: None,
             request_params: None,
             reasoning: None,
+            supports_vision: None,
             request_headers: None,
         };
 
@@ -2964,6 +2982,7 @@ mod tests {
             toolshim_model: None,
             request_params: None,
             reasoning: None,
+            supports_vision: None,
             request_headers: None,
         };
 
@@ -2996,6 +3015,7 @@ mod tests {
             toolshim_model: None,
             request_params: None,
             reasoning: None,
+            supports_vision: None,
             request_headers: None,
         };
 
@@ -3034,6 +3054,7 @@ mod tests {
             toolshim_model: None,
             request_params: None,
             reasoning: None,
+            supports_vision: None,
             request_headers: None,
         };
 

--- a/crates/goose-provider-types/src/model.rs
+++ b/crates/goose-provider-types/src/model.rs
@@ -49,6 +49,8 @@ pub struct ModelConfig {
     pub request_params: Option<HashMap<String, Value>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reasoning: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub supports_vision: Option<bool>,
     /// Per-request HTTP headers attached to outgoing provider calls.
     /// Never serialized into request bodies.
     #[serde(skip)]
@@ -72,6 +74,8 @@ impl<'de> Deserialize<'de> for ModelConfig {
             request_params: Option<HashMap<String, Value>>,
             #[serde(default, skip_serializing_if = "Option::is_none")]
             reasoning: Option<bool>,
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            supports_vision: Option<bool>,
         }
 
         let raw = RawModelConfig::deserialize(deserializer)?;
@@ -84,6 +88,7 @@ impl<'de> Deserialize<'de> for ModelConfig {
             toolshim_model: raw.toolshim_model,
             request_params: raw.request_params,
             reasoning: raw.reasoning,
+            supports_vision: raw.supports_vision,
             request_headers: None,
         };
         config.normalize_effort_suffix();
@@ -102,6 +107,7 @@ impl ModelConfig {
             toolshim_model: None,
             request_params: None,
             reasoning: None,
+            supports_vision: None,
             request_headers: None,
         };
         config.normalize_effort_suffix();
@@ -137,6 +143,14 @@ impl ModelConfig {
             }
             if self.reasoning.is_none() {
                 self.reasoning = canonical.reasoning;
+            }
+            if self.supports_vision.is_none() {
+                self.supports_vision = Some(
+                    canonical
+                        .modalities
+                        .input
+                        .contains(&crate::canonical::Modality::Image),
+                )
             }
         }
 
@@ -221,6 +235,11 @@ impl ModelConfig {
                 self = self.with_thinking_effort(effort);
             }
         }
+        self
+    }
+
+    pub fn with_vision_support(mut self, supports_vision: bool) -> Self {
+        self.supports_vision = Some(supports_vision);
         self
     }
 
@@ -627,6 +646,46 @@ mod tests {
         }
     }
 
+    mod supports_vision {
+        use super::*;
+
+        #[test]
+        fn reads_supports_vision_from_config() {
+            let config: ModelConfig = serde_json::from_str(
+                r#"{"model_name":"gpt-4o","toolshim":false,"supports_vision":true}"#,
+            )
+            .unwrap();
+            assert_eq!(config.supports_vision, Some(true));
+
+            let config: ModelConfig = serde_json::from_str(
+                r#"{"model_name":"gpt-4o","toolshim":false,"supports_vision":false}"#,
+            )
+            .unwrap();
+            assert_eq!(config.supports_vision, Some(false));
+        }
+
+        #[test]
+        fn defaults_supports_vision_to_none_when_absent() {
+            let config: ModelConfig =
+                serde_json::from_str(r#"{"model_name":"deepseek-v4","toolshim":false}"#).unwrap();
+            assert_eq!(config.supports_vision, None);
+        }
+
+        #[test]
+        fn serializes_supports_vision_only_when_some() {
+            let config = ModelConfig::new("gpt-4o").with_vision_support(true);
+            let serialized = serde_json::to_value(&config).unwrap();
+            assert_eq!(
+                serialized.get("supports_vision"),
+                Some(&serde_json::Value::Bool(true))
+            );
+
+            let config = ModelConfig::new("deepseek-v4");
+            let serialized = serde_json::to_value(&config).unwrap();
+            assert!(serialized.get("supports_vision").is_none());
+        }
+    }
+
     mod with_canonical_limits {
         use super::*;
 
@@ -742,6 +801,29 @@ mod tests {
             // "gpt-5.4-nano-low" should resolve via "gpt-5.4-nano"
             let config = ModelConfig::new("gpt-5.4-nano-low").with_canonical_limits("openai");
             assert_eq!(config.context_limit, Some(400_000));
+        }
+
+        #[test]
+        fn fills_supports_vision_from_canonical_model() {
+            let _guard = env_lock::lock_env([
+                ("GOOSE_MAX_TOKENS", None::<&str>),
+                ("GOOSE_CONTEXT_LIMIT", None::<&str>),
+            ]);
+            // gpt-4o is a vision model in the canonical catalog (image input modality).
+            let config = ModelConfig::new("gpt-4o").with_canonical_limits("openai");
+            assert_eq!(config.supports_vision, Some(true));
+        }
+
+        #[test]
+        fn does_not_override_existing_supports_vision() {
+            let _guard = env_lock::lock_env([
+                ("GOOSE_MAX_TOKENS", None::<&str>),
+                ("GOOSE_CONTEXT_LIMIT", None::<&str>),
+            ]);
+            let config = ModelConfig::new("gpt-4o")
+                .with_vision_support(false)
+                .with_canonical_limits("openai");
+            assert_eq!(config.supports_vision, Some(false));
         }
     }
 

--- a/crates/goose-providers/src/openai.rs
+++ b/crates/goose-providers/src/openai.rs
@@ -787,6 +787,7 @@ impl Provider for OpenAiProvider {
                 OpenAiFormatOptions {
                     preserve_thinking_context: self.preserve_thinking_context
                         || thinking_preservation_format.is_some(),
+                    supports_vision: model_config.supports_vision.unwrap_or_default(),
                     thinking_preservation_format,
                 },
             )?;

--- a/crates/goose-providers/src/openai_compatible.rs
+++ b/crates/goose-providers/src/openai_compatible.rs
@@ -73,6 +73,7 @@ impl OpenAiCompatibleProvider {
             for_streaming,
             OpenAiFormatOptions {
                 preserve_thinking_context: true,
+                supports_vision: model_config.supports_vision.unwrap_or_default(),
                 ..Default::default()
             },
         )

--- a/crates/goose/src/context_mgmt/mod.rs
+++ b/crates/goose/src/context_mgmt/mod.rs
@@ -582,6 +582,7 @@ mod tests {
                     toolshim_model: None,
                     request_params: None,
                     reasoning: None,
+                    supports_vision: None,
                     request_headers: None,
                 },
                 max_tool_responses: None,

--- a/crates/goose/src/model_config.rs
+++ b/crates/goose/src/model_config.rs
@@ -221,6 +221,7 @@ fn base_model_config_from_user_config(
         toolshim_model: get_goose_toolshim_model(config)?,
         request_params: None,
         reasoning: None,
+        supports_vision: None,
         request_headers: None,
     };
     if provider_name != goose_providers::azure_foundry::AZURE_FOUNDRY_PROVIDER_NAME {

--- a/crates/goose/src/providers/bedrock.rs
+++ b/crates/goose/src/providers/bedrock.rs
@@ -1085,6 +1085,7 @@ mod tests {
                 toolshim_model: None,
                 request_params: None,
                 reasoning: None,
+                supports_vision: None,
                 request_headers: None,
             },
         )

--- a/crates/goose/src/providers/openrouter.rs
+++ b/crates/goose/src/providers/openrouter.rs
@@ -604,6 +604,7 @@ mod tests {
             toolshim_model: None,
             request_params: None,
             reasoning: None,
+            supports_vision: None,
             request_headers: None,
         }
     }

--- a/crates/goose/src/session/session_manager.rs
+++ b/crates/goose/src/session/session_manager.rs
@@ -2683,6 +2683,7 @@ mod tests {
             toolshim_model: None,
             request_params: None,
             reasoning: None,
+            supports_vision: None,
             request_headers: None,
         })
         .unwrap();


### PR DESCRIPTION
## Summary
Added the configuration for goose to know if a model supports images and using it to prevent routing images to models.

I'm not entirely happy with this PR, I originally wanted to use `Option<ImageContent>` in databricks.rs but it would diverge from openai.rs and openai.rs already has a ModelConfig. I briefly considered changing the signatures to accept an `Option<ImageFormat>` but it has ripple effects because of the signature change...
Open to thoughts/feedback on how to model this.

### Testing
Added tests, also running this build myself since this bug has been a pain to work with. I've verified that it no longer occurs in local testing by explicitly forcing an image path in my TODO list which was what was biting me from time to time.

### Related Issues
Relates to and fixes part of  https://github.com/aaif-goose/goose/issues/10311 
Discussion: https://github.com/aaif-goose/goose/issues/10311#issuecomment-5289156449

### AI Usage
Implemented by hand, reviewed by AI, tests written and updated by AI (deepseek flash V4 on goose)

