### PR TITLE
fix: guard MCP streamable-HTTP client redirects against SSRF (loopback/link-local/metadata)

### DIFF
--- a/crates/goose/src/agents/extension_manager.rs
+++ b/crates/goose/src/agents/extension_manager.rs
@@ -786,7 +786,9 @@ async fn connect_with_auth(
         );
     }
     #[allow(unused_mut)]
-    let mut auth_client_builder = reqwest::Client::builder().default_headers(auth_headers);
+    let mut auth_client_builder = reqwest::Client::builder()
+        .redirect(mcp_http_redirect_policy())
+        .default_headers(auth_headers);
     #[cfg(target_os = "linux")]
     {
         auth_client_builder = auth_client_builder.tcp_user_timeout(Some(timeout));
@@ -810,6 +812,51 @@ async fn connect_with_auth(
         extension_manager,
     )
     .await?)
+}
+
+/// Redirect policy for MCP streamable-HTTP clients (SSRF guard, LEAD-6).
+///
+/// The MCP spec permits servers to redirect (301/302/303/307/308) and legitimate
+/// public deployments do (CDNs, moved endpoints), so redirects are followed — but
+/// only within the same network class. A REMOTE server redirecting into the
+/// client's OWN private surface (loopback, link-local, cloud metadata
+/// `169.254.169.254`, IPv6 `::1`) means a client-local service, not the next hop
+/// of the server: following it would (a) read that internal host / metadata
+/// (SSRF, LEAD-6) and (b) replay the extension's configured headers onto it.
+/// Stopping at the boundary turns the 3xx back into the transport, which reports
+/// it instead of secretly hitting internal hosts. Bounded to 10 hops (matching
+/// reqwest's default cap) to avoid A->B->A loops.
+fn mcp_http_redirect_policy() -> reqwest::redirect::Policy {
+    reqwest::redirect::Policy::custom(|attempt| {
+        // previous() = chain of URLs already visited; stop before an 11th hop
+        // (mirrors reqwest's default 10-redirect cap) so A->B->A loops can't spin.
+        if attempt.previous().len() >= 10 {
+            return attempt.stop();
+        }
+        let source_host = attempt.previous().first().and_then(|u| u.host_str());
+        let target_host = attempt.url().host_str();
+        let source_is_internal = source_host.is_some_and(is_internal_host);
+        let target_is_internal = target_host.is_some_and(is_internal_host);
+        if target_is_internal && !source_is_internal {
+            attempt.stop()
+        } else {
+            attempt.follow()
+        }
+    })
+}
+
+/// Loopback, link-local and cloud-metadata hosts — i.e. the client-local surface
+/// a remote server must not be allowed to make the client reach.
+fn is_internal_host(host: &str) -> bool {
+    let lower = host.trim_end_matches('.').to_ascii_lowercase();
+    if lower == "localhost" || lower.ends_with(".localhost") {
+        return true;
+    }
+    match lower.parse::<std::net::IpAddr>() {
+        Ok(std::net::IpAddr::V4(v4)) => v4.is_loopback() || v4.is_link_local(),
+        Ok(std::net::IpAddr::V6(v6)) => v6.is_loopback() || v6.is_unicast_link_local(),
+        Err(_) => false,
+    }
 }
 
 /// Connection parameters needed to re-establish an authorized streamable HTTP
@@ -1159,7 +1206,9 @@ async fn create_streamable_http_client(
     let timeout_duration = Duration::from_secs(resolve_timeout(timeout));
 
     #[allow(unused_mut)]
-    let mut http_client_builder = reqwest::Client::builder().default_headers(default_headers);
+    let mut http_client_builder = reqwest::Client::builder()
+        .redirect(mcp_http_redirect_policy())
+        .default_headers(default_headers);
     #[cfg(target_os = "linux")]
     {
         http_client_builder = http_client_builder.tcp_user_timeout(Some(timeout_duration));


### PR DESCRIPTION
Fix: guard MCP streamable-HTTP client redirects against SSRF (don't follow into loopback / link-local / metadata from a public server)

## Summary

goose's MCP **streamable-HTTP client** follows server redirects to **any host** — up to reqwest's default 10 hops, cross-origin — with **no guard** on the target. A remote (or compromised) MCP server that answers `301/302/307/308` with `Location: http://127.0.0.1:<port>` or `Location: http://169.254.169.254/...` (cloud metadata / IMDSv1) makes the client:

1. silently reach the **client-local** surface (SSRF) — internal services or instance metadata (which can yield cloud IAM/instance credentials);
2. **re-send the user-configured `default_headers`** (extension API keys, auth tokens) onto that internal target;
3. treat the internal service's reply as **the MCP server response** (protocol confusion), because the transport only ever saw "some 200 + JSON".

Closes #11500.

Full write-up + reproducer: **#11500** (issue). Working PoC (goose-exact client built without a policy, vs. this fix): [poc-goose-rust](https://github.com/trickyfalcon/cve-hunt/tree/main/poc-goose-rust).

## Root cause

`crates/goose/src/agents/extension_manager.rs` builds the MCP HTTP client as:

```rust
let mut auth_client_builder = reqwest::Client::builder().default_headers(auth_headers);
// … no .redirect(...) override anywhere …
```

With no override, reqwest applies its **default `Policy::limited(10)`** — follow up to 10 redirects to any host. The transport (`rmcp::transport::StreamableHttpClientTransport::with_client(...)`) performs no HTTP of its own, so redirect handling is entirely governed by this client.

There is a **second reqwest builder** further down in this file (used by the fallback/HTTP connect path) with the same issue; the unix-socket path (`UnixSocketHttpClient`) is unaffected. Both builders are updated here.

## This change

Adds `mcp_http_redirect_policy()` + `is_internal_host()` (private helpers in `extension_manager.rs`) and wires the policy into **both** reqwest builders:

- **Follow** redirects — the MCP spec explicitly permits `301/302/307/308`, and legitimate deployments (CDNs, moved endpoints, load-balanced `/mcp`) do redirect. No regression to legit public→public redirects.
- **Bound** the chain to ≤ 10 hops (mirrors reqwest's own default cap; the new policy otherwise replaces it).
- **STOP** when the redirect target is **loopback / link-local / metadata** (`127.0.0.0/8`, `::1`, `localhost` / `*.localhost`, `169.254.0.0/16`, `fe80::/10`) **and the request did not originate on an internal host** — i.e. a *remote* server must not bounce the client into the **client's own private network**. Stopping surfaces the `3xx` to the transport (the same refusal the official rust-sdk already applies via `Policy::none()`), so no internal request is made and no headers leak.
- **INTERNAL → INTERNAL still follows** — localhost-hosted MCP servers and client-side proxy deployments keep working.

Deliberately **not** blocking RFC1918 (`10.x`, `172.16-31.x`, `192.168.x`) — those can legitimately be the *server's* private network, not the client's; loopback/link-local are client-owned by definition, so they are the safe boundary. Easy to extend `is_internal_host()` if the team wants RFC1918 included.

## Verification

The PoC crate runs a fake "remote" MCP server on a **real non-loopback LAN IP** (so the trust boundary is genuine) that 307s into a local "victim" service which logs every request:

| Scenario | Client | Result |
|---|---|---|
| A | goose-exact (default headers, no policy) | follows → `200`, victim hit, req+fwd-headers recorded at victim (**SSRF + header forward**) |
| B | rmcp default (`Policy::none()`) | `307` surfaced, no hit (safe-by-refusal) |
| C | **this fix** — public → loopback | `307` surfaced, victim delta **0** (blocked) |
| D | **this fix** — loopback → loopback | `200`, victim hit 1 (legit hop kept) |

```
cd poc-goose-rust && cargo run
```

Full expected output is captured in `poc-goose-rust/RUN-OUTPUT.txt` in the linked repo.

## Notes

- Same bug class as modelcontextprotocol/python-sdk #3358 and typescript-sdk #2700 (already reported there); goose was the Rust-side gap because it overrides the SDK's default client with its own redirect-following one.
- Happy to adjust scope (e.g., add RFC1918, or also strip custom headers on cross-boundary follow if we choose follow-over-stop) — opening the discussion here since maintainers may prefer a different policy than "stop at the boundary".

---

Happy to be credited in the advisory/release notes as: Mo (@trickyfalcon, https://trickyfalcon.com)
