### PR TITLE
fix(desktop): stop provider save from overwriting stored config with defaults

### DIFF
--- a/ui/desktop/src/components/onboarding/ProviderConfigForm.tsx
+++ b/ui/desktop/src/components/onboarding/ProviderConfigForm.tsx
@@ -200,8 +200,14 @@ function ApiKeyForm({
 
     const toSubmit = Object.fromEntries(
       Object.entries(configValues)
-        .filter(([, entry]) => !!entry.value)
-        .map(([k, entry]) => [k, entry.value || ''])
+        .filter(
+          ([, entry]) =>
+            !!entry.value || (entry.serverValue != null && typeof entry.serverValue === 'string')
+        )
+        .map(([k, entry]) => [
+          k,
+          entry.value ?? (typeof entry.serverValue === 'string' ? entry.serverValue : ''),
+        ])
     );
 
     setIsSubmitting(true);

--- a/ui/desktop/src/components/settings/providers/modal/subcomponents/forms/CustomProviderForm.test.tsx
+++ b/ui/desktop/src/components/settings/providers/modal/subcomponents/forms/CustomProviderForm.test.tsx
@@ -165,6 +165,40 @@ describe('CustomProviderForm transitions', () => {
     expect(screen.queryByText(/Failed to save provider/)).not.toBeInTheDocument();
   });
 
+  it.each([
+    ['anthropic_compatible', 'anthropic_compatible'],
+    ['ollama_compatible', 'ollama_compatible'],
+    ['openai_compatible', 'openai_compatible'],
+    ['anthropic', 'anthropic_compatible'],
+    ['ollama', 'ollama_compatible'],
+    ['openai', 'openai_compatible'],
+  ])('saves a provider stored as %s with engine %s', async (engine, expectedEngine) => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(
+      <CustomProviderForm
+        initialData={{
+          engine,
+          display_name: 'Existing Provider',
+          api_url: 'https://existing.example.com',
+          api_key: '',
+          models: ['model-a'],
+          supports_streaming: true,
+          requires_auth: true,
+        }}
+        isEditable
+        onSubmit={onSubmit}
+        onCancel={vi.fn()}
+      />,
+      { wrapper: IntlTestWrapper }
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Update Provider' }));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledOnce());
+    expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ engine: expectedEngine }));
+  });
+
   it('clears form validation when returning to the setup choice', async () => {
     const user = userEvent.setup();
     renderForm();

--- a/ui/desktop/src/components/settings/providers/modal/subcomponents/forms/CustomProviderForm.tsx
+++ b/ui/desktop/src/components/settings/providers/modal/subcomponents/forms/CustomProviderForm.tsx
@@ -227,6 +227,20 @@ const i18n = defineMessages({
 
 type Step = 'choice' | 'catalog' | 'form';
 
+type ProviderEngine = 'openai_compatible' | 'anthropic_compatible' | 'ollama_compatible';
+
+const ENGINE_ALIASES: Record<string, ProviderEngine> = {
+  openai: 'openai_compatible',
+  openai_compatible: 'openai_compatible',
+  anthropic: 'anthropic_compatible',
+  anthropic_compatible: 'anthropic_compatible',
+  ollama: 'ollama_compatible',
+  ollama_compatible: 'ollama_compatible',
+};
+
+const normalizeEngine = (engine: string): ProviderEngine =>
+  ENGINE_ALIASES[engine.trim().toLowerCase()] ?? 'openai_compatible';
+
 interface CustomProviderFormProps {
   onSubmit: (data: UpdateCustomProviderRequest) => void | Promise<void>;
   onCancel: () => void;
@@ -245,7 +259,12 @@ export default function CustomProviderForm({
   isEditable,
 }: CustomProviderFormProps) {
   const intl = useIntl();
-  const [engine, setEngine] = useState('openai_compatible');
+  const engineOptions: { value: ProviderEngine; label: string }[] = [
+    { value: 'openai_compatible', label: intl.formatMessage(i18n.openaiCompatible) },
+    { value: 'anthropic_compatible', label: intl.formatMessage(i18n.anthropicCompatible) },
+    { value: 'ollama_compatible', label: intl.formatMessage(i18n.ollamaCompatible) },
+  ];
+  const [engine, setEngine] = useState<ProviderEngine>('openai_compatible');
   const [displayName, setDisplayName] = useState('');
   const [apiUrl, setApiUrl] = useState('');
   const [basePath, setBasePath] = useState('');
@@ -284,12 +303,7 @@ export default function CustomProviderForm({
 
   useEffect(() => {
     if (initialData) {
-      const engineMap: Record<string, string> = {
-        openai: 'openai_compatible',
-        anthropic: 'anthropic_compatible',
-        ollama: 'ollama_compatible',
-      };
-      setEngine(engineMap[initialData.engine] || 'openai_compatible');
+      setEngine(normalizeEngine(initialData.engine));
       setDisplayName(initialData.display_name);
       setApiUrl(initialData.api_url);
       setBasePath(initialData.base_path ?? '');
@@ -320,12 +334,7 @@ export default function CustomProviderForm({
     setSupportsStreaming(template.supportsStreaming);
     setRequiresAuth(true);
 
-    const formatToEngine: Record<string, string> = {
-      openai: 'openai_compatible',
-      anthropic: 'anthropic_compatible',
-      ollama: 'ollama_compatible',
-    };
-    setEngine(formatToEngine[template.format] || 'openai_compatible');
+    setEngine(normalizeEngine(template.format));
 
     const templateModels = template.models.filter((m) => !m.deprecated).map((m) => m.id);
     setModels(templateModels.join(', '));
@@ -633,25 +642,10 @@ export default function CustomProviderForm({
             id="provider-select"
             aria-invalid={!!validationErrors.providerType}
             aria-describedby={validationErrors.providerType ? 'provider-select-error' : undefined}
-            options={[
-              { value: 'openai_compatible', label: intl.formatMessage(i18n.openaiCompatible) },
-              {
-                value: 'anthropic_compatible',
-                label: intl.formatMessage(i18n.anthropicCompatible),
-              },
-              { value: 'ollama_compatible', label: intl.formatMessage(i18n.ollamaCompatible) },
-            ]}
-            value={{
-              value: engine,
-              label:
-                engine === 'openai_compatible'
-                  ? intl.formatMessage(i18n.openaiCompatible)
-                  : engine === 'anthropic_compatible'
-                    ? intl.formatMessage(i18n.anthropicCompatible)
-                    : intl.formatMessage(i18n.ollamaCompatible),
-            }}
+            options={engineOptions}
+            value={engineOptions.find((option) => option.value === engine)}
             onChange={(option: unknown) => {
-              const selectedOption = option as { value: string; label: string } | null;
+              const selectedOption = option as { value: ProviderEngine } | null;
               if (selectedOption) setEngine(selectedOption.value);
             }}
             isSearchable={false}

--- a/ui/desktop/src/components/settings/providers/modal/subcomponents/forms/DefaultProviderSetupForm.tsx
+++ b/ui/desktop/src/components/settings/providers/modal/subcomponents/forms/DefaultProviderSetupForm.tsx
@@ -102,10 +102,13 @@ export default function DefaultProviderSetupForm({
       const values: { [k: string]: ConfigInput } = {};
 
       let fields: Awaited<ReturnType<typeof acpReadProviderConfig>> = [];
+      let readFailed = false;
       try {
         fields = await acpReadProviderConfig(provider.name);
       } catch {
-        // Provider may not be in the registry yet; fall back to defaults below.
+        // A failed read cannot be distinguished from "nothing is stored", so
+        // seeding defaults here would submit them over values already on disk.
+        readFailed = true;
       }
       const fieldByKey = new Map(fields.map((field) => [field.key, field]));
 
@@ -119,7 +122,7 @@ export default function DefaultProviderSetupForm({
             ? { maskedValue: field.value }
             : field.value;
           values[parameter.name] = { serverValue };
-        } else if (parameter.default !== undefined && parameter.default !== null) {
+        } else if (!readFailed && parameter.default !== undefined && parameter.default !== null) {
           values[parameter.name] = { value: parameter.default };
         }
       }

--- a/ui/desktop/src/components/settings/providers/modal/subcomponents/handlers/DefaultSubmitHandler.test.tsx
+++ b/ui/desktop/src/components/settings/providers/modal/subcomponents/handlers/DefaultSubmitHandler.test.tsx
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { acpSaveProviderConfig } from '../../../../../../acp/providers';
+import { providerConfigSubmitHandler } from './DefaultSubmitHandler';
+
+vi.mock('../../../../../../acp/providers', () => ({
+  acpSaveProviderConfig: vi.fn(),
+}));
+
+const litellm = {
+  name: 'litellm',
+  metadata: {
+    config_keys: [
+      { name: 'LITELLM_API_KEY' },
+      { name: 'LITELLM_HOST', default: 'http://localhost:4000' },
+      { name: 'LITELLM_BASE_PATH', default: 'v1/chat/completions' },
+      { name: 'LITELLM_TIMEOUT', default: '600' },
+    ],
+  },
+};
+
+function savedKeys() {
+  const [, fields] = vi.mocked(acpSaveProviderConfig).mock.calls[0];
+  return Object.fromEntries(fields.map(({ key, value }) => [key, value]));
+}
+
+describe('providerConfigSubmitHandler', () => {
+  beforeEach(() => {
+    vi.mocked(acpSaveProviderConfig).mockClear();
+  });
+
+  it('never writes a metadata default for a field the user did not supply', async () => {
+    await providerConfigSubmitHandler(litellm, { LITELLM_API_KEY: 'rotated-key' });
+
+    expect(savedKeys()).toEqual({ LITELLM_API_KEY: 'rotated-key' });
+  });
+
+  it('submits only the values it was given', async () => {
+    await providerConfigSubmitHandler(litellm, {
+      LITELLM_API_KEY: 'rotated-key',
+      LITELLM_HOST: 'http://192.168.1.50:4000',
+    });
+
+    expect(savedKeys()).toEqual({
+      LITELLM_API_KEY: 'rotated-key',
+      LITELLM_HOST: 'http://192.168.1.50:4000',
+    });
+  });
+
+  it('skips empty values rather than falling back to the default', async () => {
+    await providerConfigSubmitHandler(litellm, {
+      LITELLM_API_KEY: 'rotated-key',
+      LITELLM_HOST: '',
+    });
+
+    expect(savedKeys()).toEqual({ LITELLM_API_KEY: 'rotated-key' });
+  });
+
+  it('ignores values for keys the provider does not declare', async () => {
+    await providerConfigSubmitHandler(litellm, {
+      LITELLM_API_KEY: 'rotated-key',
+      SOME_OTHER_KEY: 'ignored',
+    });
+
+    expect(savedKeys()).toEqual({ LITELLM_API_KEY: 'rotated-key' });
+  });
+});

--- a/ui/desktop/src/components/settings/providers/modal/subcomponents/handlers/DefaultSubmitHandler.tsx
+++ b/ui/desktop/src/components/settings/providers/modal/subcomponents/handlers/DefaultSubmitHandler.tsx
@@ -11,18 +11,18 @@ export const providerConfigSubmitHandler = async (
   provider: {
     name: string;
     metadata: {
-      config_keys?: Array<{ name: string; default?: unknown }>;
+      config_keys?: Array<{ name: string }>;
     };
   },
   configValues: Record<string, string>
 ) => {
   const fields: { key: string; value: string }[] = [];
-  for (const { name, default: defaultValue } of provider.metadata.config_keys ?? []) {
-    const value = configValues[name] ?? defaultValue;
-    if (value === undefined || value === null || value === '') {
+  for (const { name } of provider.metadata.config_keys ?? []) {
+    const value = configValues[name];
+    if (value === undefined || value === '') {
       continue;
     }
-    fields.push({ key: name, value: String(value) });
+    fields.push({ key: name, value });
   }
 
   await acpSaveProviderConfig(provider.name, fields);


### PR DESCRIPTION
Fixes #11468

Two bugs, one save path. Both are the same failure mode: **saving a provider overwrites stored config with something the user never typed.**

## 1. LiteLLM host reset (the reported bug)

Saving the LiteLLM provider replaced an already-configured `LITELLM_HOST` with the built-in default `http://localhost:4000`. Users with a proxy on another host saw the app silently point at localhost the moment they touched provider settings — empty model dropdown, and `Could not connect to localhost:4000` on chat.

The default is injected entirely client-side. The ACP server faithfully persists whatever the UI sends; nothing on the Rust side writes defaults into `config.yaml`.

**Root cause.** `DefaultProviderSetupForm` seeds a key's metadata default into `value` — the *user-edited* slot — rather than `serverValue`, the *loaded-from-disk* slot. Downstream nothing can tell it apart from something the user typed, so it is submitted verbatim. The onboarding form additionally dropped `serverValue` when building its payload, so for an already-configured provider the stored host never reached the submit handler and `DefaultSubmitHandler`'s `configValues[name] ?? defaultValue` substituted the default unconditionally.

- **`DefaultSubmitHandler`** — submit only the values actually supplied; never substitute a metadata default. This is the fix that stops a value the user never typed from being written.
- **`ProviderConfigForm`** (onboarding) — forward `serverValue` the way the settings modal does, so stored values survive a submit.
- **`DefaultProviderSetupForm`** — do not seed metadata defaults when the config read failed: a failed read is indistinguishable from "nothing stored", and the seeded defaults would be submitted over values already on disk.

Also fixes a related case: backspacing the host field to empty and submitting previously wrote `http://localhost:4000`, because the filter dropped the empty value and `??` then supplied the default.

## 2. Custom provider engine reset (found while fixing the above)

Source-tracing the same save path turned up a second instance of it. Editing a custom provider whose engine is Anthropic- or Ollama-compatible and saving it — without changing anything — silently converted it to OpenAI-compatible, while the dropdown displayed "OpenAI Compatible" the whole time. The provider then speaks the wrong wire protocol and is broken until the engine is manually re-selected.

The read DTO emits `openai_compatible` / `anthropic_compatible` / `ollama_compatible` (`custom_provider_engine_to_dto`, `crates/goose/src/acp/server/providers.rs:281-287`). The form's prefill map was keyed on the bare `openai` / `anthropic` / `ollama`, so **all three keys always missed** and fell through to the `|| 'openai_compatible'` default. `openai_compatible` was accidentally correct, which is why this survived since the feature shipped — not a regression, the two spellings never agreed.

It compounds: because the submitted engine differs from the stored one, `update_custom_provider` treats it as an engine change and recomputes `preserves_thinking` from `should_preserve_thinking_by_default(OpenAI)` = `true`, discarding an explicit user `false`.

- `normalizeEngine` accepts both spellings — exactly the set the backend's `ProviderEngine::from_str` accepts (`crates/goose-providers/src/declarative.rs:103-114`) — and is used for both the edit prefill and the template `format` prefill (`template.format` only ever carries the bare names).
- `engine` is typed as a `'openai_compatible' | 'anthropic_compatible' | 'ollama_compatible'` union rather than `string`, so the Select options and the state can't drift.
- The Select label is derived from the options array instead of a ternary chain whose final `else` labelled *any* unrecognized engine as "Ollama compatible".

## Verification

- New `DefaultSubmitHandler.test.tsx` covers the reported LiteLLM scenario (edit only the API key) plus the empty-value and undeclared-key cases. Checked against the pre-patch handler logic: an API-key-only edit reproduces the report exactly (`LITELLM_HOST: http://localhost:4000` plus `LITELLM_BASE_PATH` and `LITELLM_TIMEOUT`). All three fail on the old logic and pass on the new.
- New table-driven `CustomProviderForm.test.tsx` asserts a no-op save preserves the engine, covering all six accepted spellings. The `anthropic_compatible` and `ollama_compatible` rows fail against the pre-change map: `engineMap['anthropic_compatible']` is `undefined` → state becomes `openai_compatible` → `onSubmit` receives the wrong engine.
- Also had an independent review of the whole path before pushing, which produced the union-type and Select-label changes.

**Not run locally:** the desktop vitest suite and `pnpm lint:check` — the npm registry proxy is unreachable from this machine (`ECONNRESET` on every tarball) so `node_modules` can't be installed. CI is the authority for the desktop suite and lint; flagging that rather than implying I ran it.

## Not in scope

Two lower-severity findings from the same audit, documented but not fixed here:

- A stored header with an empty value is dropped on any save — `CustomProviderForm.tsx:470` requires `header.value.trim()`, but the backend explicitly permits empty values (`providers.rs:362`).
- A provider with an `env_vars`-templated `base_url` is un-editable: `load_provider` skips `resolve_config`, so the raw `${VAR}` template reaches `url::Url::parse` and fails validation. Fails closed, no corruption.
