### PR TITLE
ci: clippy and unit-test the roaming feature

### DIFF
--- a/.github/scripts/repair-v8-prebuilt.sh
+++ b/.github/scripts/repair-v8-prebuilt.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# v8-goose downloads a prebuilt librusty_v8 archive into target/<profile>/gn_out
+# and emits a rustc-link-search pointing at it. Cargo caches that build script
+# output and replays it on later builds instead of re-running the script, but
+# the Rust cache action prunes target/ before saving, so a restored cache can
+# keep the replayed link-search while the 131MB archive is gone. Linking then
+# fails with "could not find native static library `rusty_v8`".
+#
+# Drop the cached build script output whenever a directory it advertises is
+# missing, which forces the script to re-run and download the archive again.
+set -euo pipefail
+
+[ -d target ] || exit 0
+
+find target -type f -path '*/build/v8-goose-*/output' -print0 |
+  while IFS= read -r -d '' output; do
+    while IFS= read -r dir; do
+      [ -n "$dir" ] || continue
+      [ -d "$dir" ] && continue
+      echo "v8-goose build output references missing $dir; forcing a rebuild"
+      rm -rf "$(dirname "$output")"
+      break
+    done < <(sed -n 's/^cargo:rustc-link-search=\(.*\)$/\1/p' "$output")
+  done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,7 +171,7 @@ jobs:
           cargo test -p goose-roaming
           cargo build -p goose-cli --features roaming
           cargo clippy -p goose-cli --features roaming --all-targets -- -D warnings
-          cargo test -p goose-cli --features roaming --test roam_acp_client
+          cargo test -p goose-cli --features roaming --lib --test roam_acp_client
         env:
           RUST_MIN_STACK: 8388608
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,6 +170,7 @@ jobs:
           export CARGO_INCREMENTAL=0
           cargo test -p goose-roaming
           cargo build -p goose-cli --features roaming
+          cargo clippy -p goose-cli --features roaming --all-targets -- -D warnings
           cargo test -p goose-cli --features roaming --test roam_acp_client
         env:
           RUST_MIN_STACK: 8388608

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,9 @@ jobs:
 
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
 
+      - name: Repair stale v8 prebuilt marker
+        run: .github/scripts/repair-v8-prebuilt.sh
+
       - name: Install Dependencies
         run: |
           sudo apt update -y
@@ -158,6 +161,9 @@ jobs:
         with:
           key: roaming
 
+      - name: Repair stale v8 prebuilt marker
+        run: .github/scripts/repair-v8-prebuilt.sh
+
       - name: Build and Test with roaming
         run: |
           gnome-keyring-daemon --components=secrets --daemonize --unlock <<< 'foobar'
@@ -220,6 +226,9 @@ jobs:
           sudo apt update -y
           sudo apt install -y libdbus-1-dev libxcb1-dev
 
+      - name: Repair stale v8 prebuilt marker
+        run: .github/scripts/repair-v8-prebuilt.sh
+
       - name: Check with MSRV toolchain
         run: cargo check --workspace --locked --all-targets
         env:
@@ -234,6 +243,9 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+
+      - name: Repair stale v8 prebuilt marker
+        run: .github/scripts/repair-v8-prebuilt.sh
 
       - name: Lint
         run: |

--- a/crates/goose-cli/src/cli.rs
+++ b/crates/goose-cli/src/cli.rs
@@ -1723,7 +1723,12 @@ async fn start_roam_share(
     .await?;
 
     let agent_id = node.endpoint_id().to_string();
-    node.share(Arc::new(FullAcpBridge::new(server, agent_id)))
+    // Roaming sessions run where `goose serve` was started: the connector's
+    // machine-local path is meaningless on this host, and the serve-wide
+    // server keeps `session_cwd: None` for local ACP clients.
+    let session_cwd =
+        std::env::current_dir().map_err(|e| anyhow::anyhow!("could not determine cwd: {e}"))?;
+    node.share(Arc::new(FullAcpBridge::new(server, agent_id, session_cwd)))
         .await?;
 
     if !node.wait_online(std::time::Duration::from_secs(15)).await {

--- a/crates/goose-cli/src/cli.rs
+++ b/crates/goose-cli/src/cli.rs
@@ -1653,33 +1653,6 @@ struct ServeCommandArgs {
     roam: bool,
 }
 
-/// Roaming is an app-level service: every backend loads the same persisted
-/// identity, so only one process may advertise the endpoint at a time. An OS
-/// advisory lock decides ownership across all goose processes (desktop
-/// windows, CLI serves); it auto-releases when the owner dies — even on
-/// SIGKILL — so a standby can promote itself and paired devices keep access.
-#[cfg(feature = "roaming")]
-fn try_acquire_roam_lock() -> Result<std::fs::File> {
-    use fs2::FileExt as _;
-    use std::io::Write as _;
-
-    let lock_path = goose::config::paths::Paths::data_dir().join("roam/serve.lock");
-    if let Some(parent) = lock_path.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
-    let mut file = std::fs::OpenOptions::new()
-        .write(true)
-        .create(true)
-        .truncate(false)
-        .open(&lock_path)?;
-    file.try_lock_exclusive().map_err(|_| {
-        anyhow::anyhow!("another goose process is already running the roaming endpoint")
-    })?;
-    file.set_len(0)?;
-    writeln!(file, "{}", std::process::id())?;
-    Ok(file)
-}
-
 #[cfg(feature = "roaming")]
 type RoamShareSlot =
     std::sync::Arc<tokio::sync::RwLock<Option<std::sync::Arc<goose_roaming::RoamingNode>>>>;
@@ -1688,6 +1661,8 @@ type RoamShareSlot =
 fn spawn_roam_share(
     server: std::sync::Arc<goose::acp::server_factory::AcpServer>,
 ) -> RoamShareSlot {
+    use crate::commands::roam::try_acquire_roam_lock;
+
     let slot = RoamShareSlot::default();
     let task_slot = slot.clone();
     tokio::spawn(async move {
@@ -1738,7 +1713,7 @@ async fn start_roam_share(
     let identity = load_identity()?;
     let node = RoamingNode::bind(RoamingConfig {
         identity,
-        relay: resolve_relay_settings(),
+        relay: resolve_relay_settings()?,
         trust: TrustBook::new(),
         trust_path: Some(trust_path()),
         directory: goose_roaming::Directory::persistent(directory_path()),

--- a/crates/goose-cli/src/commands/roam.rs
+++ b/crates/goose-cli/src/commands/roam.rs
@@ -674,7 +674,11 @@ async fn handle_share(
         enable_scheduler: false,
     }));
     let agent_id = node.endpoint_id().to_string();
-    let bridge = Arc::new(FullAcpBridge::new(acp_server, agent_id));
+    let bridge = Arc::new(FullAcpBridge::new(
+        acp_server,
+        agent_id,
+        session_cwd.clone(),
+    ));
     node.share(bridge).await?;
 
     eprintln!("contacting relay...");

--- a/crates/goose-cli/src/commands/roam.rs
+++ b/crates/goose-cli/src/commands/roam.rs
@@ -75,17 +75,25 @@ const DEFAULT_ROAM_RELAYS: &[&str] = &[
 /// Uses `GOOSE_ROAM_RELAYS` (env or config file) when set — optionally
 /// authenticated with the `GOOSE_ROAM_RELAY_TOKEN` secret applied to each —
 /// otherwise the default managed relays. Never iroh's public n0 relays.
-pub(crate) fn resolve_relay_settings() -> RelaySettings {
+///
+/// Fails when `GOOSE_ROAM_RELAYS` is set but unreadable: a deployment that
+/// configured private relays must not silently fall back to the managed ones.
+pub(crate) fn resolve_relay_settings() -> Result<RelaySettings> {
     let config = Config::global();
     let urls: Vec<String> = match config.get_param::<Vec<String>>(CONFIG_ROAM_RELAYS_KEY) {
         Ok(urls) => urls,
         Err(ConfigError::NotFound(_)) => Vec::new(),
-        Err(_) => Vec::new(),
+        Err(error) => {
+            return Err(anyhow::anyhow!(
+                "{CONFIG_ROAM_RELAYS_KEY} is set but could not be read as a list of relay \
+                 URLs; refusing to fall back to the default relays: {error}"
+            ))
+        }
     };
     let token = config
         .get_secret::<String>(CONFIG_ROAM_RELAY_TOKEN_KEY)
         .ok();
-    build_relay_settings(urls, token)
+    Ok(build_relay_settings(urls, token))
 }
 
 /// Pure relay-settings builder. With no configured URLs, use the default
@@ -304,7 +312,7 @@ async fn handle_id(qr: bool) -> Result<()> {
     let identity = load_identity()?;
     let node = RoamingNode::bind(RoamingConfig {
         identity,
-        relay: resolve_relay_settings(),
+        relay: resolve_relay_settings()?,
         trust: TrustBook::new(),
         trust_path: None,
         directory: Directory::new(),
@@ -338,7 +346,7 @@ async fn handle_pair(name: Option<String>) -> Result<()> {
     let identity = load_identity()?;
     let node = RoamingNode::bind(RoamingConfig {
         identity,
-        relay: resolve_relay_settings(),
+        relay: resolve_relay_settings()?,
         trust: TrustBook::new(),
         trust_path: None,
         directory: Directory::new(),
@@ -571,11 +579,42 @@ pub(crate) fn load_identity() -> Result<RoamingIdentity> {
     RoamingIdentity::load_or_create(&path).context("failed to load roaming identity")
 }
 
+/// Roaming is an app-level service: every backend loads the same persisted
+/// identity, so only one process may advertise the endpoint at a time. An OS
+/// advisory lock decides ownership across all goose processes (desktop
+/// windows, CLI serves, standalone shares); it auto-releases when the owner
+/// dies — even on SIGKILL — so a standby can promote itself and paired
+/// devices keep access.
+pub(crate) fn try_acquire_roam_lock() -> Result<std::fs::File> {
+    use fs2::FileExt as _;
+    use std::io::Write as _;
+
+    let lock_path = Paths::data_dir().join("roam/serve.lock");
+    if let Some(parent) = lock_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&lock_path)?;
+    file.try_lock_exclusive().map_err(|_| {
+        anyhow::anyhow!("another goose process is already running the roaming endpoint")
+    })?;
+    file.set_len(0)?;
+    writeln!(file, "{}", std::process::id())?;
+    Ok(file)
+}
+
 async fn handle_share(
     builtins: Vec<String>,
     cwd: Option<std::path::PathBuf>,
     qr: bool,
 ) -> Result<()> {
+    // Same app-level lock as `serve --roam`: both bind the one persisted
+    // identity, and two processes advertising the same endpoint ID would race
+    // for connections while hosting different working directories.
+    let _roam_lock = try_acquire_roam_lock()?;
     let identity = load_identity()?;
 
     // The hosted agent runs in `--cwd` or the directory `roam share` was started
@@ -607,7 +646,7 @@ async fn handle_share(
 
     let node = RoamingNode::bind(RoamingConfig {
         identity,
-        relay: resolve_relay_settings(),
+        relay: resolve_relay_settings()?,
         trust,
         // Re-read acceptance on each connection so `peers accept`/`revoke` from
         // another process take effect against this live share without restart.
@@ -682,10 +721,11 @@ async fn dial_target(
     let card = resolve_card(target)?;
     let node = RoamingNode::bind(RoamingConfig {
         identity: load_identity()?,
-        relay: resolve_relay_settings(),
+        relay: resolve_relay_settings()?,
         trust: TrustBook::new(),
         trust_path: None,
-        directory: Directory::new(),
+        // Persist outbound observations so `roam connections` can show them.
+        directory: Directory::persistent(directory_path()),
         bind_addr: None,
         relay_tls: None,
     })

--- a/crates/goose-cli/src/commands/roam.rs
+++ b/crates/goose-cli/src/commands/roam.rs
@@ -393,8 +393,9 @@ async fn handle_pair(name: Option<String>) -> Result<()> {
         return Ok(());
     }
 
-    let mut book = goose_roaming::PeerBook::load(peerbook_path())?;
-    book.save(&name, device_card, now_ms())?;
+    goose_roaming::PeerBook::update(peerbook_path(), |book| {
+        book.save(&name, device_card, now_ms())
+    })?;
     let path = trust_path();
     TrustBook::update(&path, |trust| trust.accept(&decoded.endpoint_id)).with_context(|| {
         format!(
@@ -417,12 +418,14 @@ fn read_stdin_line() -> Result<String> {
 }
 
 async fn handle_peers(command: PeersCommand) -> Result<()> {
-    let mut book = goose_roaming::PeerBook::load(peerbook_path())?;
+    let book = goose_roaming::PeerBook::load(peerbook_path())?;
     match command {
         PeersCommand::Add { card, name } => {
             let decoded = ConnectionCard::decode(&card)?;
             let name = name.unwrap_or_else(|| short_id(&decoded.endpoint_id.to_string()));
-            book.save(&name, &card, now_ms())?;
+            goose_roaming::PeerBook::update(peerbook_path(), |book| {
+                book.save(&name, &card, now_ms())
+            })?;
             eprintln!(
                 "saved peer `{name}` -> {} (fingerprint {})",
                 decoded.endpoint_id,
@@ -436,7 +439,9 @@ async fn handle_peers(command: PeersCommand) -> Result<()> {
             let card = match ConnectionCard::decode(&target) {
                 Ok(card) => {
                     let name = name.unwrap_or_else(|| short_id(&card.endpoint_id.to_string()));
-                    book.save(&name, &target, now_ms())?;
+                    goose_roaming::PeerBook::update(peerbook_path(), |book| {
+                        book.save(&name, &target, now_ms())
+                    })?;
                     card
                 }
                 Err(_) => {
@@ -480,7 +485,9 @@ async fn handle_peers(command: PeersCommand) -> Result<()> {
             Ok(())
         }
         PeersCommand::Remove { name } => {
-            if book.remove(&name)? {
+            let existed =
+                goose_roaming::PeerBook::update(peerbook_path(), |book| book.remove(&name))?;
+            if existed {
                 eprintln!("removed peer `{name}` from the address book");
             } else {
                 eprintln!("no peer named `{name}`");
@@ -488,7 +495,7 @@ async fn handle_peers(command: PeersCommand) -> Result<()> {
             Ok(())
         }
         PeersCommand::Rename { from, to } => {
-            book.rename(&from, &to)?;
+            goose_roaming::PeerBook::update(peerbook_path(), |book| book.rename(&from, &to))?;
             eprintln!("renamed `{from}` -> `{to}`");
             Ok(())
         }

--- a/crates/goose-cli/src/commands/roam.rs
+++ b/crates/goose-cli/src/commands/roam.rs
@@ -631,6 +631,13 @@ async fn handle_share(
             .with_context(|| format!("invalid --cwd: {}", dir.display()))?,
         None => std::env::current_dir().context("could not determine current directory")?,
     };
+    // Fail here rather than advertising a share whose every session activation
+    // would reject the host-imposed path.
+    anyhow::ensure!(
+        session_cwd.is_dir(),
+        "--cwd must be a directory: {}",
+        session_cwd.display()
+    );
 
     // Load the accepted-peer allowlist. Peers are accepted out of band with
     // `roam peers accept`; this serve loop re-reads it per connection.

--- a/crates/goose-cli/src/commands/roam_client.rs
+++ b/crates/goose-cli/src/commands/roam_client.rs
@@ -118,6 +118,7 @@ pub async fn delegate(
     let transport = agent_client_protocol::ByteStreams::new(send, recv);
     let collected = std::sync::Arc::new(std::sync::Mutex::new(String::new()));
     let sink = collected.clone();
+    let replay_sink = collected.clone();
 
     Client
         .builder()
@@ -159,6 +160,10 @@ pub async fn delegate(
                     cx.send_request(LoadSessionRequest::new(session_id.clone(), cwd))
                         .block_task()
                         .await?;
+                    // Loading replays the session's history as message chunks,
+                    // which the notification handler collected. Discard them so
+                    // the result is only the new response to this task.
+                    replay_sink.lock().unwrap().clear();
                     cx.send_request(PromptRequest::new(session_id, vec![task.clone().into()]))
                         .block_task()
                         .await?;

--- a/crates/goose-cli/src/commands/roam_full_bridge.rs
+++ b/crates/goose-cli/src/commands/roam_full_bridge.rs
@@ -26,13 +26,24 @@ use goose_roaming::{AcpStreamServer, EndpointId};
 pub struct FullAcpBridge {
     server: Arc<AcpServer>,
     agent_id: String,
+    /// Host-controlled working directory for sessions created over roaming.
+    /// The connector's machine-local absolute path is meaningless on this
+    /// host, so every roaming agent gets this instead — even when the shared
+    /// `AcpServer` (e.g. `goose serve`) leaves `session_cwd` unset for its
+    /// local clients.
+    session_cwd: std::path::PathBuf,
 }
 
 impl FullAcpBridge {
-    pub fn new(server: Arc<AcpServer>, agent_id: impl Into<String>) -> Self {
+    pub fn new(
+        server: Arc<AcpServer>,
+        agent_id: impl Into<String>,
+        session_cwd: std::path::PathBuf,
+    ) -> Self {
         Self {
             server,
             agent_id: agent_id.into(),
+            session_cwd,
         }
     }
 }
@@ -45,9 +56,12 @@ impl AcpStreamServer for FullAcpBridge {
         send: Box<dyn AsyncWrite + Send + Unpin>,
     ) -> BoxFuture<'static, anyhow::Result<()>> {
         let server = self.server.clone();
+        let session_cwd = self.session_cwd.clone();
         Box::pin(async move {
             tracing::info!(%client, "roaming: serving full ACP surface");
-            let agent = server.create_agent().await?;
+            let agent = server
+                .create_agent_with_session_cwd(Some(session_cwd))
+                .await?;
             serve(agent, recv, send).await
         })
     }

--- a/crates/goose-roaming/src/directory.rs
+++ b/crates/goose-roaming/src/directory.rs
@@ -124,11 +124,15 @@ impl Directory {
             .collect();
         for entry in map.values() {
             match merged.get(&entry.endpoint_id) {
-                // This process owns live connections with the peer, or has the
-                // fresher observation.
+                // Keep the on-disk entry unless this process owns live
+                // connections with the peer or has a strictly fresher
+                // observation. Equal timestamps mean this process merely
+                // loaded the entry and has nothing new to say — overwriting
+                // would clobber another process's live state with our stale
+                // snapshot.
                 Some(existing)
                     if entry.live_connections == 0
-                        && existing.last_seen_ms > entry.last_seen_ms => {}
+                        && existing.last_seen_ms >= entry.last_seen_ms => {}
                 _ => {
                     merged.insert(entry.endpoint_id.clone(), entry.clone());
                 }

--- a/crates/goose-roaming/src/directory.rs
+++ b/crates/goose-roaming/src/directory.rs
@@ -88,16 +88,63 @@ impl Directory {
         entries
     }
 
+    /// Flush this node's view to disk, merged with whatever other processes
+    /// have written (a share and an outbound `connect`/`delegate` may run
+    /// concurrently). The whole reload-merge-write runs under a cross-process
+    /// advisory lock and lands via a unique temp file renamed into place, so
+    /// concurrent flushes can neither interleave bytes nor drop each other's
+    /// observations.
     async fn flush(&self, map: &HashMap<String, PeerEntry>) {
+        use fs2::FileExt as _;
+
         let Some(path) = &self.path else { return };
-        let mut entries: Vec<&PeerEntry> = map.values().collect();
+        if let Some(parent) = path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+
+        let lock_path = path.with_extension("json.lock");
+        let Ok(lock) = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&lock_path)
+        else {
+            return;
+        };
+        if lock.lock_exclusive().is_err() {
+            return;
+        }
+
+        let mut merged: HashMap<String, PeerEntry> = std::fs::read(path)
+            .ok()
+            .and_then(|bytes| serde_json::from_slice::<Vec<PeerEntry>>(&bytes).ok())
+            .unwrap_or_default()
+            .into_iter()
+            .map(|e| (e.endpoint_id.clone(), e))
+            .collect();
+        for entry in map.values() {
+            match merged.get(&entry.endpoint_id) {
+                // This process owns live connections with the peer, or has the
+                // fresher observation.
+                Some(existing)
+                    if entry.live_connections == 0
+                        && existing.last_seen_ms > entry.last_seen_ms => {}
+                _ => {
+                    merged.insert(entry.endpoint_id.clone(), entry.clone());
+                }
+            }
+        }
+
+        let mut entries: Vec<&PeerEntry> = merged.values().collect();
         entries.sort_by_key(|e| std::cmp::Reverse(e.last_seen_ms));
         if let Ok(json) = serde_json::to_vec_pretty(&entries) {
-            if let Some(parent) = path.parent() {
-                let _ = std::fs::create_dir_all(parent);
+            let tmp = path.with_extension(format!("tmp.{}", std::process::id()));
+            if std::fs::write(&tmp, json).is_ok() {
+                let _ = std::fs::rename(&tmp, path);
             }
-            let _ = std::fs::write(path, json);
         }
+
+        let _ = fs2::FileExt::unlock(&lock);
     }
 
     /// Record the start of a connection, creating or updating the entry.

--- a/crates/goose-roaming/src/directory.rs
+++ b/crates/goose-roaming/src/directory.rs
@@ -36,6 +36,11 @@ pub struct PeerEntry {
     pub last_seen_ms: u64,
     /// Whether a session is currently active with this peer.
     pub connected: bool,
+    /// Live connections with this peer in the current process. Not persisted:
+    /// only the process owning the endpoint knows what is live, so a restart
+    /// starts from zero rather than trusting a stale flag from disk.
+    #[serde(skip)]
+    live_connections: u32,
 }
 
 /// A shared directory of peers, optionally persisted to disk so that a separate
@@ -59,7 +64,13 @@ impl Directory {
             .and_then(|bytes| serde_json::from_slice::<Vec<PeerEntry>>(&bytes).ok())
             .unwrap_or_default()
             .into_iter()
-            .map(|e| (e.endpoint_id.clone(), e))
+            .map(|mut e| {
+                // A persisted `connected` flag outlives the process that owned
+                // the connection (crash, SIGKILL, reboot). Only this process's
+                // own observations may claim a peer is live.
+                e.connected = false;
+                (e.endpoint_id.clone(), e)
+            })
             .collect::<HashMap<_, _>>();
         Self {
             inner: Arc::new(Mutex::new(entries)),
@@ -104,6 +115,7 @@ impl Directory {
             .and_modify(|e| {
                 e.last_seen_ms = now_ms;
                 e.connected = true;
+                e.live_connections = e.live_connections.saturating_add(1);
                 if label.is_some() {
                     e.label = label.clone();
                 }
@@ -119,16 +131,20 @@ impl Directory {
                 first_seen_ms: now_ms,
                 last_seen_ms: now_ms,
                 connected: true,
+                live_connections: 1,
             });
         self.flush(&map).await;
     }
 
-    /// Record that a connection with a peer has ended.
+    /// Record that a connection with a peer has ended. The peer is only marked
+    /// disconnected when its *last* live connection ends; a peer with several
+    /// simultaneous sessions stays `connected` until all of them close.
     pub(crate) async fn record_disconnect(&self, endpoint_id: EndpointId, now_ms: u64) {
         let key = endpoint_id.to_string();
         let mut map = self.inner.lock().await;
         if let Some(entry) = map.get_mut(&key) {
-            entry.connected = false;
+            entry.live_connections = entry.live_connections.saturating_sub(1);
+            entry.connected = entry.live_connections > 0;
             entry.last_seen_ms = now_ms;
         }
         self.flush(&map).await;

--- a/crates/goose-roaming/src/identity.rs
+++ b/crates/goose-roaming/src/identity.rs
@@ -37,13 +37,30 @@ impl RoamingIdentity {
 
     /// Load the node identity from `path`, creating and persisting a new one if
     /// the file does not exist.
+    ///
+    /// Creation is atomic (`O_EXCL`): when two processes race to create the
+    /// first identity, exactly one key wins and the loser loads it, so both
+    /// end up advertising the same endpoint ID.
     pub fn load_or_create(path: &Path) -> Result<Self, RoamingError> {
         if path.exists() {
             return Self::load(path);
         }
+
+        let parent = path.parent().ok_or_else(|| {
+            RoamingError::Identity(format!("key path {} has no parent", path.display()))
+        })?;
+        ensure_private_dir(parent)?;
+
         let identity = Self::generate();
-        identity.save(path)?;
-        Ok(identity)
+        let encoded = encode_hex_key(&identity.secret.to_bytes());
+        match create_exclusive(path, encoded.as_bytes()) {
+            Ok(()) => {
+                ensure_private_file(path)?;
+                Ok(identity)
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => Self::load(path),
+            Err(err) => Err(err.into()),
+        }
     }
 
     /// Load the node identity from a hex-encoded key file.
@@ -107,6 +124,17 @@ fn decode_hex_key(hex: &str) -> Result<[u8; 32], RoamingError> {
             .map_err(|_| RoamingError::Identity("node key has invalid hex".into()))?;
     }
     Ok(bytes)
+}
+
+fn create_exclusive(path: &Path, contents: &[u8]) -> std::io::Result<()> {
+    use std::io::Write as _;
+
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)?;
+    file.write_all(contents)?;
+    file.sync_all()
 }
 
 fn write_atomically(path: &Path, contents: &[u8]) -> Result<(), RoamingError> {

--- a/crates/goose-roaming/src/identity.rs
+++ b/crates/goose-roaming/src/identity.rs
@@ -38,10 +38,14 @@ impl RoamingIdentity {
     /// Load the node identity from `path`, creating and persisting a new one if
     /// the file does not exist.
     ///
-    /// Creation is atomic (`O_EXCL`): when two processes race to create the
-    /// first identity, exactly one key wins and the loser loads it, so both
-    /// end up advertising the same endpoint ID.
+    /// First creation is serialized on a sidecar advisory lock and lands via a
+    /// fully written temporary file renamed into place, so racing processes
+    /// agree on one key and a crash mid-write can never leave a truncated key
+    /// at the final path (which would permanently disable roaming until the
+    /// user deletes it — changing the endpoint ID peers trusted).
     pub fn load_or_create(path: &Path) -> Result<Self, RoamingError> {
+        use fs2::FileExt as _;
+
         if path.exists() {
             return Self::load(path);
         }
@@ -51,16 +55,26 @@ impl RoamingIdentity {
         })?;
         ensure_private_dir(parent)?;
 
-        let identity = Self::generate();
-        let encoded = encode_hex_key(&identity.secret.to_bytes());
-        match create_exclusive(path, encoded.as_bytes()) {
-            Ok(()) => {
-                ensure_private_file(path)?;
-                Ok(identity)
+        let lock_path = path.with_extension("lock");
+        let lock = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&lock_path)?;
+        lock.lock_exclusive()?;
+
+        let result = (|| {
+            // A racer may have created the key while we waited for the lock.
+            if path.exists() {
+                return Self::load(path);
             }
-            Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => Self::load(path),
-            Err(err) => Err(err.into()),
-        }
+            let identity = Self::generate();
+            identity.save(path)?;
+            Ok(identity)
+        })();
+
+        let _ = fs2::FileExt::unlock(&lock);
+        result
     }
 
     /// Load the node identity from a hex-encoded key file.
@@ -124,17 +138,6 @@ fn decode_hex_key(hex: &str) -> Result<[u8; 32], RoamingError> {
             .map_err(|_| RoamingError::Identity("node key has invalid hex".into()))?;
     }
     Ok(bytes)
-}
-
-fn create_exclusive(path: &Path, contents: &[u8]) -> std::io::Result<()> {
-    use std::io::Write as _;
-
-    let mut file = std::fs::OpenOptions::new()
-        .write(true)
-        .create_new(true)
-        .open(path)?;
-    file.write_all(contents)?;
-    file.sync_all()
 }
 
 fn write_atomically(path: &Path, contents: &[u8]) -> Result<(), RoamingError> {

--- a/crates/goose-roaming/src/node.rs
+++ b/crates/goose-roaming/src/node.rs
@@ -418,6 +418,18 @@ impl RoamingNode {
                         now_ms(),
                     )
                     .await;
+                // Balance the connect when the dialed connection closes for
+                // any reason (normal command teardown included), so the
+                // directory doesn't report the remote connected forever.
+                {
+                    let directory = self.directory.clone();
+                    let remote = conn.remote_id();
+                    let watched = conn.clone();
+                    tokio::spawn(async move {
+                        watched.closed().await;
+                        directory.record_disconnect(remote, now_ms()).await;
+                    });
+                }
                 Ok(RoamingClientStream {
                     agent_id,
                     conn,

--- a/crates/goose-roaming/src/node.rs
+++ b/crates/goose-roaming/src/node.rs
@@ -308,9 +308,11 @@ impl RoamingNode {
             for conn in conns {
                 conn.close(0u32.into(), b"revoked");
                 closed += 1;
+                // One disconnect per closed connection so the directory's
+                // per-peer live count reaches zero.
+                self.directory.record_disconnect(client, now_ms()).await;
             }
             tracing::info!(%client, "roaming: force-closed live connection(s) for revoked key");
-            self.directory.record_disconnect(client, now_ms()).await;
         }
         closed
     }

--- a/crates/goose-roaming/src/peerbook.rs
+++ b/crates/goose-roaming/src/peerbook.rs
@@ -104,6 +104,40 @@ impl PeerBook {
         self.peers.values().collect()
     }
 
+    /// Read-modify-write the peer book under a cross-process advisory lock.
+    ///
+    /// Mirrors [`crate::TrustBook::update`]: atomic replacement protects
+    /// readers from partial JSON but not writers from lost updates — two
+    /// concurrent `goose roam peers`/pairing commands each load the whole
+    /// book, mutate, and save, so the last writer clobbers the other's add,
+    /// remove, or rename. The lock is held on a sidecar `.lock` file and
+    /// auto-releases if the holder dies.
+    pub fn update<T>(
+        path: PathBuf,
+        mutate: impl FnOnce(&mut Self) -> Result<T, RoamingError>,
+    ) -> Result<T, RoamingError> {
+        use fs2::FileExt as _;
+
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let lock_path = path.with_extension("json.lock");
+        let lock = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&lock_path)?;
+        lock.lock_exclusive()?;
+
+        let result = (|| {
+            let mut book = Self::load(path)?;
+            mutate(&mut book)
+        })();
+
+        let _ = fs2::FileExt::unlock(&lock);
+        result
+    }
+
     fn flush(&self) -> Result<(), RoamingError> {
         let Some(path) = &self.path else {
             return Ok(());
@@ -118,7 +152,9 @@ impl PeerBook {
 }
 
 fn write_file(path: &Path, contents: &[u8]) -> Result<(), RoamingError> {
-    let tmp = path.with_extension("tmp");
+    // Unique per writer so concurrent flushes cannot rename each other's
+    // half-written bytes into place or fail on a stolen temporary file.
+    let tmp = path.with_extension(format!("tmp.{}", std::process::id()));
     std::fs::write(&tmp, contents)?;
     std::fs::rename(&tmp, path)?;
     Ok(())

--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -244,6 +244,46 @@ pub struct ActivePromptRun {
 /// one session.
 pub type ActiveRunRegistry = Arc<Mutex<HashMap<String, ActivePromptRun>>>;
 
+/// Releases a registry entry if the owning `on_prompt` future is dropped
+/// without reaching its explicit `clear_active_run` — e.g. a roaming
+/// connection is revoked or lost mid-prompt and the transport drops the
+/// request future. Without this, the shared registry retains the run forever
+/// and every later connection gets "session already has active run".
+///
+/// The explicit clear still runs on normal paths; this drop is then a no-op
+/// because the entry (matched by run id) is already gone.
+struct ActiveRunDropGuard {
+    registry: ActiveRunRegistry,
+    session_id: String,
+    run_id: String,
+    cancel_token: CancellationToken,
+}
+
+impl Drop for ActiveRunDropGuard {
+    fn drop(&mut self) {
+        self.cancel_token.cancel();
+        let registry = self.registry.clone();
+        let session_id = std::mem::take(&mut self.session_id);
+        let run_id = std::mem::take(&mut self.run_id);
+        if let Ok(handle) = tokio::runtime::Handle::try_current() {
+            handle.spawn(async move {
+                let agent = {
+                    let mut runs = registry.lock().await;
+                    match runs.get(&session_id) {
+                        Some(run) if run.run_id == run_id => {
+                            runs.remove(&session_id).map(|run| run.agent)
+                        }
+                        _ => None,
+                    }
+                };
+                if let Some(agent) = agent {
+                    agent.discard_pending_steers(&session_id).await;
+                }
+            });
+        }
+    }
+}
+
 #[derive(Clone, Debug, Default)]
 pub struct AcpBuiltinSelection {
     pub defaults: Vec<String>,
@@ -784,6 +824,16 @@ impl GooseAcpAgent {
     ) -> Result<(), agent_client_protocol::Error> {
         self.start_active_run(session_id, run_id, CancellationToken::new(), agent)
             .await
+    }
+
+    #[cfg(test)]
+    pub(crate) fn test_drop_active_run_guard(&self, session_id: &str, run_id: &str) {
+        drop(ActiveRunDropGuard {
+            registry: self.active_prompt_runs.clone(),
+            session_id: session_id.to_string(),
+            run_id: run_id.to_string(),
+            cancel_token: CancellationToken::new(),
+        });
     }
 
     #[cfg(test)]
@@ -2023,6 +2073,16 @@ impl GooseAcpAgent {
             agent.clone(),
         )
         .await?;
+
+        // Frees the run if this future is dropped mid-prompt (e.g. the roaming
+        // connection carrying it is revoked or lost); a normal completion's
+        // explicit clear wins and makes the guard's cleanup a no-op.
+        let _run_guard = ActiveRunDropGuard {
+            registry: self.active_prompt_runs.clone(),
+            session_id: session_id.clone(),
+            run_id: run_id.clone(),
+            cancel_token: cancel_token.clone(),
+        };
 
         if cancel_token.is_cancelled() {
             self.clear_active_run(&session_id, &run_id).await;

--- a/crates/goose/src/acp/server/fork_session.rs
+++ b/crates/goose/src/acp/server/fork_session.rs
@@ -15,6 +15,15 @@ impl GooseAcpAgent {
             .get_session(source_session_id, false)
             .await
             .internal_err()?;
+
+        // Resolve and validate the effective cwd before copying anything, so a
+        // bad request cannot leave a stray "(copy)" session in the store. The
+        // copy inherits the source's working dir, so it is the stored
+        // fallback.
+        let cwd =
+            effective_session_cwd(self.session_cwd.as_deref(), &args.cwd, &source.working_dir);
+        validate_absolute_cwd(&cwd)?;
+
         let fork_name = if source.name.trim().is_empty() {
             "(copy)".to_string()
         } else {
@@ -40,13 +49,6 @@ impl GooseAcpAgent {
             .get_session(&new_session_id, true)
             .await
             .internal_err()?;
-
-        let cwd = effective_session_cwd(
-            self.session_cwd.as_deref(),
-            &args.cwd,
-            &new_session.working_dir,
-        );
-        validate_absolute_cwd(&cwd)?;
 
         let goose_session = self
             .prepare_session_for_activation(new_session.clone(), cwd, args.mcp_servers, true)

--- a/crates/goose/src/acp/server_factory.rs
+++ b/crates/goose/src/acp/server_factory.rs
@@ -67,6 +67,21 @@ impl AcpServer {
     }
 
     pub async fn create_agent(&self) -> Result<Arc<GooseAcpAgent>> {
+        self.create_agent_with_session_cwd(self.config.session_cwd.clone())
+            .await
+    }
+
+    /// Create an agent whose sessions use `session_cwd` instead of this
+    /// server's configured default. Used by the roaming bridge on `goose
+    /// serve --roam`: the serve-wide server keeps `session_cwd: None` for
+    /// local ACP clients whose paths are real on this machine, while each
+    /// roaming connection gets a host-controlled working directory (the
+    /// connector's absolute path is meaningless here). The agent still shares
+    /// this server's active-run registry.
+    pub async fn create_agent_with_session_cwd(
+        &self,
+        session_cwd: Option<std::path::PathBuf>,
+    ) -> Result<Arc<GooseAcpAgent>> {
         let config = crate::config::Config::global();
         let disable_session_naming = config.get_goose_disable_session_naming().unwrap_or(false);
         let scheduler = self.scheduler().await?;
@@ -106,7 +121,7 @@ impl AcpServer {
             disable_session_naming,
             goose_platform: self.config.goose_platform.clone(),
             additional_source_roots: self.config.additional_source_roots.clone(),
-            session_cwd: self.config.session_cwd.clone(),
+            session_cwd,
             scheduler,
             active_prompt_runs: self.active_prompt_runs.clone(),
         })

--- a/crates/goose/src/acp/server_factory.rs
+++ b/crates/goose/src/acp/server_factory.rs
@@ -193,6 +193,32 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn dropping_a_prompt_future_releases_the_shared_run() {
+        let root = tempfile::tempdir().unwrap();
+        let server = server(root.path().to_path_buf(), false);
+
+        let running = server.create_agent().await.unwrap();
+        let owner = Arc::new(crate::agents::Agent::new());
+        running
+            .test_start_active_run("session-1", "run-1".to_string(), owner)
+            .await
+            .unwrap();
+
+        running.test_drop_active_run_guard("session-1", "run-1");
+        tokio::task::yield_now().await;
+
+        let second = server.create_agent().await.unwrap();
+        assert!(
+            second
+                .test_require_active_run("session-1", "run-1")
+                .await
+                .is_err(),
+            "a dropped prompt future must release its run so later \
+             connections are not permanently locked out of the session"
+        );
+    }
+
+    #[tokio::test]
     async fn start_scheduler_initializes_before_any_client_connects() {
         let root = tempfile::tempdir().unwrap();
         let server = server(root.path().to_path_buf(), true);

--- a/crates/goose/src/config/base.rs
+++ b/crates/goose/src/config/base.rs
@@ -1173,18 +1173,19 @@ impl Config {
         use std::sync::mpsc;
         use std::time::Duration;
 
-        // One long-lived worker performs every keyring read. If a read blocks
-        // indefinitely (e.g. a pending keychain ACL prompt on a headless
-        // host), later reads queue behind it and time out without spawning
-        // another permanently blocked thread; at most one thread is ever
-        // stuck. Replies to abandoned requests land in dropped receivers and
+        // One long-lived worker performs every keyring read through a
+        // single-slot queue. If a read blocks indefinitely (e.g. a pending
+        // keychain ACL prompt on a headless host), at most one thread is ever
+        // stuck and at most one request is ever queued behind it — later
+        // lookups fail fast with a timeout instead of growing an unbounded
+        // queue. Replies to abandoned requests land in dropped receivers and
         // are discarded.
         type ReadRequest = (String, mpsc::Sender<Result<String, keyring::Error>>);
-        static WORKER: std::sync::OnceLock<std::sync::Mutex<mpsc::Sender<ReadRequest>>> =
+        static WORKER: std::sync::OnceLock<std::sync::Mutex<mpsc::SyncSender<ReadRequest>>> =
             std::sync::OnceLock::new();
 
         let worker = WORKER.get_or_init(|| {
-            let (tx, rx) = mpsc::channel::<ReadRequest>();
+            let (tx, rx) = mpsc::sync_channel::<ReadRequest>(1);
             std::thread::Builder::new()
                 .name("goose-keyring-read".to_string())
                 .spawn(move || {
@@ -1202,7 +1203,7 @@ impl Config {
         worker
             .lock()
             .unwrap()
-            .send((service.to_string(), tx))
+            .try_send((service.to_string(), tx))
             .map_err(|_| KeyringReadError::TimedOut)?;
 
         match rx.recv_timeout(Duration::from_secs(3)) {

--- a/crates/goose/src/config/base.rs
+++ b/crates/goose/src/config/base.rs
@@ -1173,12 +1173,37 @@ impl Config {
         use std::sync::mpsc;
         use std::time::Duration;
 
-        let service = service.to_string();
-        let (tx, rx) = mpsc::channel();
-        std::thread::spawn(move || {
-            let result = Self::get_keyring_entry(&service).and_then(|entry| entry.get_password());
-            let _ = tx.send(result);
+        // One long-lived worker performs every keyring read. If a read blocks
+        // indefinitely (e.g. a pending keychain ACL prompt on a headless
+        // host), later reads queue behind it and time out without spawning
+        // another permanently blocked thread; at most one thread is ever
+        // stuck. Replies to abandoned requests land in dropped receivers and
+        // are discarded.
+        type ReadRequest = (String, mpsc::Sender<Result<String, keyring::Error>>);
+        static WORKER: std::sync::OnceLock<std::sync::Mutex<mpsc::Sender<ReadRequest>>> =
+            std::sync::OnceLock::new();
+
+        let worker = WORKER.get_or_init(|| {
+            let (tx, rx) = mpsc::channel::<ReadRequest>();
+            std::thread::Builder::new()
+                .name("goose-keyring-read".to_string())
+                .spawn(move || {
+                    while let Ok((service, reply)) = rx.recv() {
+                        let result = Self::get_keyring_entry(&service)
+                            .and_then(|entry| entry.get_password());
+                        let _ = reply.send(result);
+                    }
+                })
+                .expect("failed to spawn keyring reader thread");
+            std::sync::Mutex::new(tx)
         });
+
+        let (tx, rx) = mpsc::channel();
+        worker
+            .lock()
+            .unwrap()
+            .send((service.to_string(), tx))
+            .map_err(|_| KeyringReadError::TimedOut)?;
 
         match rx.recv_timeout(Duration::from_secs(3)) {
             Ok(Ok(password)) => Ok(password),


### PR DESCRIPTION
Two one-line additions to the `rust-build-and-test-roaming` job, for #11516:

- The lint job runs clippy with default features, so everything behind `cfg(feature = "roaming")` in goose-cli is cfg'd out of it — the roaming CLI code never sees clippy in a `-D warnings` repo. This adds `cargo clippy -p goose-cli --features roaming --all-targets -- -D warnings` to the roaming job, where the feature's artifacts are already warm. It's clean at the current head (verified locally, exit 0), so this is purely a net for future changes.
- `--test roam_acp_client` skips lib unit tests, and the default job builds goose-cli without the feature, so the relay-settings and proxy-splice tests in `roam.rs`/`roam_proxy.rs` currently run in no CI job at all. Adding `--lib` runs them; verified locally at this head: 321 passed, 0 failed, all six roaming tests included.
