### PR TITLE
ci: repair stale v8 prebuilt cache markers before building

### DIFF
--- a/.github/scripts/repair-v8-prebuilt.sh
+++ b/.github/scripts/repair-v8-prebuilt.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# v8-goose downloads a prebuilt librusty_v8 archive into target/<profile>/gn_out
+# and emits a rustc-link-search pointing at it. Cargo caches that build script
+# output and replays it on later builds instead of re-running the script, but
+# the Rust cache action prunes target/ before saving, so a restored cache can
+# keep the replayed link-search while the 131MB archive is gone. Linking then
+# fails with "could not find native static library `rusty_v8`".
+#
+# Drop the cached build script output whenever a directory it advertises is
+# missing, which forces the script to re-run and download the archive again.
+set -euo pipefail
+
+[ -d target ] || exit 0
+
+find target -type f -path '*/build/v8-goose-*/output' -print0 |
+  while IFS= read -r -d '' output; do
+    while IFS= read -r dir; do
+      [ -n "$dir" ] || continue
+      [ -d "$dir" ] && continue
+      echo "v8-goose build output references missing $dir; forcing a rebuild"
+      rm -rf "$(dirname "$output")"
+      break
+    done < <(sed -n 's/^cargo:rustc-link-search=\(.*\)$/\1/p' "$output")
+  done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,9 @@ jobs:
 
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
 
+      - name: Repair stale v8 prebuilt marker
+        run: .github/scripts/repair-v8-prebuilt.sh
+
       - name: Install Dependencies
         run: |
           sudo apt update -y
@@ -189,6 +192,9 @@ jobs:
           sudo apt update -y
           sudo apt install -y libdbus-1-dev libxcb1-dev
 
+      - name: Repair stale v8 prebuilt marker
+        run: .github/scripts/repair-v8-prebuilt.sh
+
       - name: Check with MSRV toolchain
         run: cargo check --workspace --locked --all-targets
         env:
@@ -203,6 +209,9 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+
+      - name: Repair stale v8 prebuilt marker
+        run: .github/scripts/repair-v8-prebuilt.sh
 
       - name: Lint
         run: |


### PR DESCRIPTION
## Summary

Quickfix for a recurring CI infra failure: `could not find native static library rusty_v8, perhaps an -L flag is missing?` in the **Lint Rust Code**, **Check MSRV**, and **Build and Test Rust Project** jobs.

### Mechanism

- `v8-goose` (pulled in by the default `code-mode` feature via deno_core) downloads a 131MB prebuilt `librusty_v8` archive into `target/<profile>/gn_out` during its build script, and emits a `cargo:rustc-link-search` pointing at it.
- Cargo caches that build-script output and **replays** it on later builds instead of re-running the script (fingerprint unchanged).
- `Swatinem/rust-cache` prunes `target/` before saving, so every saved cache entry keeps the replayed link-search while the archive itself is gone.
- A job that restores such an entry (typically a fallback/partial restore-key match, e.g. a fresh branch whose `Cargo.lock` changed) links against a directory that no longer exists → hard failure before any workspace code compiles.

### Fix

`.github/scripts/repair-v8-prebuilt.sh` runs right after the cache restore in the three affected jobs: if a cached `v8-goose` build output advertises a directory that no longer exists, delete that cached output so the build script re-runs and re-downloads the archive. No-op when the cache is intact or `target/` is absent.

### Evidence

- Reproduced on the first CI run of #11516 (run 32679390562): Lint, MSRV, and Build+Test all failed with the rusty_v8 link error while compiling `v8-goose`, after restoring caches with `full match: false`.
- With the script in place, subsequent runs went green, and the script's log line (`v8-goose build output references missing …gn_out/obj; forcing a rebuild`) fires on caches saved by prior green runs — confirming every rust-cache save of these jobs produces a poisoned entry, and any fallback restore can trip it.

Extracted from #11516 so that PR stays purely about roaming; once this merges the workaround commit will be dropped from that branch.

🤖 Opened by Mic's AI agent (Galadriel).