### PR TITLE
docs: correct Telegram gateway setup

### DIFF
--- a/documentation/docs/experimental/remote-access/telegram-gateway.md
+++ b/documentation/docs/experimental/remote-access/telegram-gateway.md
@@ -37,7 +37,7 @@ Keep your bot token secure. Anyone with the token can control your bot.
 
 ## Setup
 
-The Telegram Gateway is currently available through the goose CLI, not goose Desktop. No feature flag is required.
+Use the goose CLI to start the gateway and pair your Telegram account.
 
 ### Start the Gateway
 

--- a/documentation/docs/experimental/remote-access/telegram-gateway.md
+++ b/documentation/docs/experimental/remote-access/telegram-gateway.md
@@ -24,11 +24,12 @@ The Gateway connects your Telegram account to goose through a secure pairing pro
 
 ## Prerequisites
 
-Before setting up the Telegram Gateway, you need to create a Telegram bot:
+Before setting up the Telegram Gateway:
 
-1. Open Telegram and search for [@BotFather](https://t.me/BotFather)
-2. Send `/newbot` and follow the prompts to create your bot
-3. Copy the **bot token** that BotFather provides (looks like `123456789:ABCdefGHIjklMNOpqrsTUVwxyz`)
+1. [Configure goose](/docs/getting-started/providers) with a provider and model.
+2. Open Telegram and search for [@BotFather](https://t.me/BotFather).
+3. Send `/newbot` and follow the prompts to create your bot.
+4. Copy the **bot token** that BotFather provides (it looks like `123456789:ABCdefGHIjklMNOpqrsTUVwxyz`).
 
 :::tip
 Keep your bot token secure. Anyone with the token can control your bot.
@@ -36,39 +37,30 @@ Keep your bot token secure. Anyone with the token can control your bot.
 
 ## Setup
 
-### Desktop App
+The Telegram Gateway is currently available through the goose CLI, not goose Desktop. No feature flag is required.
 
-1. Open goose Desktop
-2. Go to **Settings** > **Gateways**
-3. In the Telegram section, enter your bot token
-4. Click **Start** to activate the gateway
-5. Click **Generate Pairing Code** to get a one-time pairing code
+### Start the Gateway
+
+In one terminal, export your bot token and start the gateway:
+
+```bash
+export TELEGRAM_BOT_TOKEN="YOUR_BOT_TOKEN"
+goose gateway start telegram --bot-token "$TELEGRAM_BOT_TOKEN"
+```
+
+Leave this command running. Your computer must remain awake and online for the bot to respond.
 
 ### Pair Your Telegram Account
 
-1. Open Telegram and find your bot (search for the username you gave it)
-2. Send the pairing code to the bot
-3. The bot will confirm the pairing is complete
-
-You can now chat with goose through Telegram!
-
-### CLI Usage
-
-You can also manage the gateway from the command line:
+In a second terminal, generate a pairing code:
 
 ```bash
-# Check gateway status
-goose gateway status
-
-# Start the Telegram gateway
-goose gateway start telegram --bot-token YOUR_BOT_TOKEN
-
-# Generate a pairing code
 goose gateway pair telegram
-
-# Stop the gateway
-goose gateway stop telegram
 ```
+
+Open your bot in Telegram and send it the six-character pairing code within five minutes. The bot confirms when pairing is complete, and you can then chat with goose through Telegram.
+
+To stop the gateway, press <kbd>Ctrl</kbd>+<kbd>C</kbd> in the terminal where it is running.
 
 ## What You Can Do
 
@@ -76,29 +68,22 @@ Once paired, you can:
 - Send messages to goose and receive responses
 - Get formatted code blocks with syntax highlighting
 - Continue conversations across multiple sessions
-- Access all your configured goose extensions
-
-## Managing Paired Users
-
-From the Desktop app's Gateway settings, you can:
-- View all paired Telegram users
-- See which session each user is connected to
-- Unpair users to revoke their access
+- Access your configured goose extensions
 
 ## Troubleshooting
 
 ### Bot not responding
-- Verify the bot token is correct
-- Check that the gateway is running in goose Desktop
-- Ensure your computer is awake and goose Desktop is open
+- Verify the bot token is correct.
+- Check that the `goose gateway start` command is still running.
+- Ensure your computer is awake and online.
 
 ### Pairing code not working
-- Pairing codes expire after a few minutes—generate a new one
-- Make sure you're sending the code to the correct bot
+- Pairing codes expire after five minutes. Generate a new one and try again.
+- Make sure you're sending the code to the correct bot.
 
 ### Messages not formatting correctly
-- The gateway converts goose's markdown to Telegram-compatible formatting
-- Some complex formatting may be simplified for Telegram compatibility
+- The gateway converts goose's markdown to Telegram-compatible formatting.
+- Some complex formatting may be simplified for Telegram compatibility.
 
 ## Additional Resources
 


### PR DESCRIPTION
## Summary

- remove Telegram gateway setup and management instructions for the nonexistent Desktop UI
- document the supported CLI-only start and pairing flow
- clarify that the gateway process must remain running and that pairing codes expire after five minutes

## Verification

- `cd documentation && npm run build`
- compared documented commands with `GatewayCommand` and `commands/gateway.rs`
- confirmed the page no longer recommends `gateway stop`, `gateway status`, or Desktop gateway settings

Closes #11524
