### PR TITLE
fix(openrouter): keep live model metadata instead of discarding it

### DIFF
--- a/crates/goose-provider-types/src/base.rs
+++ b/crates/goose-provider-types/src/base.rs
@@ -264,6 +264,17 @@ pub enum ThinkingPreservationFormat {
     ReasoningContent,
 }
 
+/// A model entry from a provider's live models API, when the API exposes
+/// capability metadata alongside IDs. `None` fields fall back to canonical
+/// enrichment during inventory storage.
+#[derive(Debug, Clone, Default)]
+pub struct ProviderModelMeta {
+    pub id: String,
+    pub context_limit: Option<usize>,
+    pub max_output_tokens: Option<usize>,
+    pub reasoning: Option<bool>,
+}
+
 /// Information about a model's capabilities
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ModelInfo {
@@ -541,6 +552,26 @@ pub trait Provider: Send + Sync {
 
     fn skip_canonical_filtering(&self) -> bool {
         false
+    }
+
+    /// Fetch live models with metadata when the provider's API exposes it.
+    ///
+    /// Default derives from [`Self::fetch_recommended_models`] IDs without
+    /// metadata; providers with richer model APIs override this and inventory
+    /// enrichment falls back to the canonical registry per field.
+    async fn fetch_model_metadata(
+        &self,
+        toolshim: bool,
+    ) -> Result<Vec<ProviderModelMeta>, ProviderError> {
+        Ok(self
+            .fetch_recommended_models(toolshim)
+            .await?
+            .into_iter()
+            .map(|id| ProviderModelMeta {
+                id,
+                ..Default::default()
+            })
+            .collect())
     }
 
     /// Fetch inventory models filtered by canonical registry and usability.

--- a/crates/goose/src/acp/response_builder.rs
+++ b/crates/goose/src/acp/response_builder.rs
@@ -538,6 +538,7 @@ mod tests {
                     family: None,
                     context_limit: None,
                     reasoning: None,
+                    max_output_tokens: None,
                     recommended: false,
                 })
                 .collect(),

--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -1114,6 +1114,17 @@ impl GooseAcpAgent {
         self.apply_acp_extension_overrides(cx, &agent, session)
             .await;
         self.spawn_provider_inventory_refresh(session, &agent);
+        // The background refresh can learn limits/reasoning support that the
+        // build-time catalog lacks; apply whatever the snapshot already holds
+        // so new/restored default-model sessions start with live metadata.
+        if let (Ok(provider), Ok(config)) = (
+            agent.provider().await,
+            agent.model_config_for_session(&session.id).await,
+        ) {
+            let provider_name = provider.get_name().to_string();
+            let config = self.with_inventory_model_info(&provider_name, config).await;
+            let _ = agent.update_provider(provider, config, &session.id).await;
+        }
 
         Ok((agent, agent_result.extension_results))
     }
@@ -2357,6 +2368,9 @@ impl GooseAcpAgent {
                 None,
             )
             .invalid_params_err_ctx("Invalid model config")?;
+        let model_config = self
+            .with_inventory_model_info(&provider_name, model_config)
+            .await;
         agent
             .recreate_provider_for_session(session_id, &provider_name, model_config)
             .await
@@ -2504,6 +2518,9 @@ impl GooseAcpAgent {
                 context_limit,
             )
             .invalid_params_err_ctx("Invalid model config")?;
+        let model_config = self
+            .with_inventory_model_info(&resolved_provider_name, model_config)
+            .await;
 
         agent
             .recreate_provider_for_session(session_id, &resolved_provider_name, model_config)

--- a/crates/goose/src/acp/server/dispatch.rs
+++ b/crates/goose/src/acp/server/dispatch.rs
@@ -251,7 +251,7 @@ impl HandleDispatchFrom<Client> for GooseAcpHandler {
                                         .await
                                         {
                                             Ok(()) => match AssertUnwindSafe(
-                                                provider.fetch_recommended_models(
+                                                provider.fetch_model_metadata(
                                                     crate::model_config::global_toolshim(),
                                                 ),
                                             )

--- a/crates/goose/src/acp/server/providers.rs
+++ b/crates/goose/src/acp/server/providers.rs
@@ -2,6 +2,7 @@ use super::*;
 use crate::config::declarative_providers;
 use crate::providers::inventory::ensure_refresh_identity_current;
 use crate::providers::provider_secrets;
+use goose_providers::base::ProviderModelMeta;
 use std::str::FromStr;
 
 const ACP_READINESS_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
@@ -824,28 +825,28 @@ impl GooseAcpAgent {
                 .catch_unwind()
                 .await;
 
-                let fetch_result: Result<Vec<String>> =
-                    match provider_result {
-                        Ok(Ok(provider)) => {
-                            match ensure_refresh_identity_current(&provider_id, &identity).await {
-                                Ok(()) => match AssertUnwindSafe(provider.fetch_recommended_models(
-                                    crate::model_config::global_toolshim(),
-                                ))
-                                .catch_unwind()
-                                .await
-                                {
-                                    Ok(Ok(models)) => Ok(models),
-                                    Ok(Err(error)) => Err(anyhow::anyhow!(error.to_string())),
-                                    Err(_) => Err(anyhow::anyhow!(
-                                        "provider inventory refresh task panicked"
-                                    )),
-                                },
-                                Err(error) => Err(error),
-                            }
+                let fetch_result: Result<Vec<ProviderModelMeta>> = match provider_result {
+                    Ok(Ok(provider)) => {
+                        match ensure_refresh_identity_current(&provider_id, &identity).await {
+                            Ok(()) => match AssertUnwindSafe(
+                                provider
+                                    .fetch_model_metadata(crate::model_config::global_toolshim()),
+                            )
+                            .catch_unwind()
+                            .await
+                            {
+                                Ok(Ok(models)) => Ok(models),
+                                Ok(Err(error)) => Err(anyhow::anyhow!(error.to_string())),
+                                Err(_) => {
+                                    Err(anyhow::anyhow!("provider inventory refresh task panicked"))
+                                }
+                            },
+                            Err(error) => Err(error),
                         }
-                        Ok(Err(error)) => Err(error),
-                        Err(_) => Err(anyhow::anyhow!("provider inventory refresh task panicked")),
-                    };
+                    }
+                    Ok(Err(error)) => Err(error),
+                    Err(_) => Err(anyhow::anyhow!("provider inventory refresh task panicked")),
+                };
 
                 match fetch_result {
                     Ok(models) => match provider_inventory
@@ -1158,7 +1159,7 @@ impl GooseAcpAgent {
         // Config-declared prices carry the config's currency; without them the
         // response reports registry rates, which are USD.
         let currency = crate::providers::canonical_cost::display_currency(config_info.as_ref());
-        let model_info =
+        let mut model_info =
             crate::providers::canonical::maybe_get_canonical_model(&req.provider, &req.model)
                 .map(|canonical_model| {
                     // Config-declared prices outrank the registry's catalog rates;
@@ -1206,6 +1207,143 @@ impl GooseAcpAgent {
                         })
                 });
 
+        // Live inventory is fresher than the build-time catalog: overlay it
+        // per field when this provider/model has been refreshed.
+        if let Ok(Some(entry)) = self
+            .provider_inventory
+            .entry_for_provider(&req.provider)
+            .await
+        {
+            if let (Some(info), Some(m)) = (
+                model_info.as_mut(),
+                entry.models.iter().find(|m| m.id == req.model),
+            ) {
+                if let Some(ctx) = m.context_limit {
+                    info.context_limit = ctx;
+                }
+                if let Some(r) = m.reasoning {
+                    info.reasoning = r;
+                }
+                if let Some(out) = m.max_output_tokens {
+                    info.max_output_tokens = Some(out);
+                }
+            }
+        }
+
+        let model_info = match model_info {
+            Some(info) => Some(info),
+            None => self.inventory_model_info(&req.provider, &req.model).await,
+        };
+
         Ok(CanonicalModelInfoResponse { model_info })
+    }
+
+    /// Backfill unset capabilities from the provider's live inventory snapshot
+    /// so models missing from the canonical catalog still think and compact
+    /// against real limits.
+    pub(super) async fn with_inventory_model_info(
+        &self,
+        provider_name: &str,
+        mut config: goose_providers::model::ModelConfig,
+    ) -> goose_providers::model::ModelConfig {
+        // An explicitly configured context limit wins over catalog AND
+        // snapshot; it must not suppress unrelated reasoning enrichment.
+        let user_context_limit = crate::config::Config::global()
+            .get_goose_context_limit()
+            .ok()
+            .flatten()
+            .filter(|&limit| config.context_limit == Some(limit));
+
+        let entry = match self
+            .provider_inventory
+            .entry_for_provider(provider_name)
+            .await
+        {
+            Ok(Some(entry)) => entry,
+            _ => return config,
+        };
+        // No live row: keep whatever construction produced rather than
+        // erasing canonical defaults we can't replace.
+        let Some(m) = entry.models.iter().find(|m| m.id == config.model_name) else {
+            return config;
+        };
+
+        let canonical = crate::providers::canonical::maybe_get_canonical_model(
+            provider_name,
+            &config.model_name,
+        );
+
+        // Canonical-derived values are build-time defaults, replaceable by
+        // the live snapshot. Anything else was set explicitly and stays.
+        if user_context_limit.is_none()
+            && config.context_limit == canonical.as_ref().map(|c| c.limit.context)
+        {
+            config.context_limit = None;
+        }
+        if let Some(ctx) = m.context_limit {
+            if config.context_limit.is_none() {
+                config.context_limit = Some(ctx);
+            }
+        }
+
+        if config.reasoning == canonical.as_ref().and_then(|c| c.reasoning) {
+            config.reasoning = None;
+        }
+        if let Some(r) = m.reasoning {
+            if config.reasoning.is_none() {
+                config.reasoning = Some(r);
+            }
+        }
+
+        // Same provenance rule for the completion limit.
+        if crate::config::Config::global()
+            .get_goose_max_tokens()
+            .ok()
+            .flatten()
+            .is_some_and(|explicit| Some(explicit) == config.max_tokens)
+        {
+            return config;
+        }
+        // For uncatalogued models there is no derived default to protect:
+        // None == None matches, so the live completion limit applies.
+        let derived_output = canonical
+            .as_ref()
+            .and_then(|c| c.limit.output.filter(|&o| o < c.limit.context))
+            .map(|o| o as i32);
+        if config.max_tokens == derived_output {
+            if let Some(out) = m.max_output_tokens {
+                config.max_tokens = Some((out as i32).max(1));
+            }
+        }
+
+        config
+    }
+
+    /// Canonical-info fallback backed by live inventory rows (no pricing data).
+    async fn inventory_model_info(
+        &self,
+        provider_id: &str,
+        model_id: &str,
+    ) -> Option<CanonicalModelInfoDto> {
+        let entry = self
+            .provider_inventory
+            .entry_for_provider(provider_id)
+            .await
+            .ok()??;
+        let m = entry.models.iter().find(|m| m.id == model_id)?;
+        Some(CanonicalModelInfoDto {
+            provider: provider_id.to_string(),
+            model: model_id.to_string(),
+            context_limit: m
+                .context_limit
+                .unwrap_or(goose_providers::model::DEFAULT_CONTEXT_LIMIT),
+            max_output_tokens: m.max_output_tokens,
+            reasoning: m.reasoning.unwrap_or(false),
+            input_token_cost: None,
+            output_token_cost: None,
+            cache_read_token_cost: None,
+            cache_write_token_cost: None,
+            currency: "USD".to_string(),
+        })
     }
 }

--- a/crates/goose/src/providers/inventory/mod.rs
+++ b/crates/goose/src/providers/inventory/mod.rs
@@ -11,6 +11,7 @@ use super::canonical::{map_provider_name, map_to_canonical_model, CanonicalModel
 use super::catalog::ProviderSetupCategory;
 use crate::config::declarative_providers::{DeclarativeProviderConfig, ProviderEngine};
 use crate::config::Config;
+use crate::providers::base::ProviderModelMeta;
 use crate::session::session_manager::SessionStorage;
 use crate::utils::bytes_to_hex;
 use anyhow::{Context, Result};
@@ -76,6 +77,8 @@ pub struct InventoryModel {
     pub context_limit: Option<usize>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reasoning: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_output_tokens: Option<usize>,
     /// Whether this model should appear in the compact recommended picker.
     pub recommended: bool,
 }
@@ -454,7 +457,14 @@ impl ProviderInventoryService {
         model_ids: &[String],
     ) -> Result<()> {
         let descriptor = self.require_provider(provider_id).await?;
-        self.store_refreshed_models_for_identity(&descriptor.identity, model_ids)
+        let metas: Vec<ProviderModelMeta> = model_ids
+            .iter()
+            .map(|id| ProviderModelMeta {
+                id: id.clone(),
+                ..Default::default()
+            })
+            .collect();
+        self.store_refreshed_models_for_identity(&descriptor.identity, &metas)
             .await?;
         self.clear_refreshing_many(std::slice::from_ref(&descriptor.identity));
         Ok(())
@@ -463,9 +473,10 @@ impl ProviderInventoryService {
     pub(crate) async fn store_refreshed_models_for_identity(
         &self,
         identity: &InventoryIdentity,
-        model_ids: &[String],
+        metas: &[crate::providers::base::ProviderModelMeta],
     ) -> Result<()> {
-        let models = enrich_model_ids_with_canonical(&identity.provider_family, model_ids);
+        let mut models = enrich_model_ids_with_canonical(&identity.provider_family, metas);
+        apply_live_metadata(&mut models, metas);
         let now = Utc::now();
         let pool = self.storage.pool().await?;
         let mut tx = pool.begin().await?;
@@ -514,8 +525,9 @@ impl ProviderInventoryService {
                     family,
                     context_limit,
                     reasoning,
+                    max_output_tokens,
                     recommended
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
                 "#,
             )
             .bind(&identity.inventory_key)
@@ -525,6 +537,7 @@ impl ProviderInventoryService {
             .bind(&model.family)
             .bind(model.context_limit.map(i64::try_from).transpose()?)
             .bind(model.reasoning)
+            .bind(model.max_output_tokens.map(i64::try_from).transpose()?)
             .bind(model.recommended)
             .execute(&mut *tx)
             .await?;
@@ -628,14 +641,16 @@ impl ProviderInventoryService {
                     .find(|job| job.provider_id == provider_id);
                 if let Some(refresh_job) = refresh_job {
                     let mut refresh_guard = self.refresh_guard(&refresh_job.identity);
-                    let fetch_result: Result<Vec<String>> =
+                    let fetch_result: Result<Vec<crate::providers::base::ProviderModelMeta>> =
                         match ensure_refresh_identity_current(&provider_id, &refresh_job.identity)
                             .await
                         {
                             Ok(()) => {
-                                match AssertUnwindSafe(provider.fetch_recommended_models(
-                                    crate::model_config::global_toolshim(),
-                                ))
+                                match AssertUnwindSafe(
+                                    provider.fetch_model_metadata(
+                                        crate::model_config::global_toolshim(),
+                                    ),
+                                )
                                 .catch_unwind()
                                 .await
                                 {
@@ -825,7 +840,7 @@ impl ProviderInventoryService {
 
         let rows = sqlx::query(
             r#"
-            SELECT model_id, name, family, context_limit, reasoning, recommended
+            SELECT model_id, name, family, context_limit, reasoning, max_output_tokens, recommended
             FROM provider_inventory_models
             WHERE inventory_key = ?
             ORDER BY ordinal
@@ -847,6 +862,10 @@ impl ProviderInventoryService {
                         .map(usize::try_from)
                         .transpose()?,
                     reasoning: row.try_get("reasoning")?,
+                    max_output_tokens: row
+                        .try_get::<Option<i64>, _>("max_output_tokens")?
+                        .map(usize::try_from)
+                        .transpose()?,
                     recommended: row
                         .try_get::<Option<bool>, _>("recommended")?
                         .unwrap_or(false),
@@ -1043,8 +1062,10 @@ fn fallback_inventory_identity(provider_id: &str) -> InventoryIdentityInput {
 
 fn enrich_model_ids_with_canonical(
     provider_family: &str,
-    model_ids: &[String],
+    metas: &[crate::providers::base::ProviderModelMeta],
 ) -> Vec<InventoryModel> {
+    let model_ids: Vec<String> = metas.iter().map(|m| m.id.clone()).collect();
+    let model_ids = &model_ids;
     if provider_family == "litellm" {
         return model_ids
             .iter()
@@ -1054,6 +1075,7 @@ fn enrich_model_ids_with_canonical(
                 family: None,
                 context_limit: None,
                 reasoning: None,
+                max_output_tokens: None,
                 recommended: false,
             })
             .collect();
@@ -1104,6 +1126,29 @@ fn enrich_model_ids_with_canonical(
     }
 
     models
+}
+
+/// Overlay live provider metadata onto enriched rows: live values win per
+/// field, canonical fills the rest.
+fn apply_live_metadata(
+    models: &mut [InventoryModel],
+    metas: &[crate::providers::base::ProviderModelMeta],
+) {
+    let by_id: std::collections::HashMap<&str, &crate::providers::base::ProviderModelMeta> =
+        metas.iter().map(|m| (m.id.as_str(), m)).collect();
+    for model in models.iter_mut() {
+        if let Some(meta) = by_id.get(model.id.as_str()) {
+            if meta.context_limit.is_some() {
+                model.context_limit = meta.context_limit;
+            }
+            if meta.reasoning.is_some() {
+                model.reasoning = meta.reasoning;
+            }
+            if meta.max_output_tokens.is_some() {
+                model.max_output_tokens = meta.max_output_tokens;
+            }
+        }
+    }
 }
 
 fn configured_models_to_inventory(
@@ -1175,6 +1220,7 @@ fn enriched_model(
             .map(|model| model.limit.context)
             .or(fallback_context_limit),
         reasoning: canonical.as_ref().and_then(|model| model.reasoning),
+        max_output_tokens: canonical.as_ref().and_then(|model| model.limit.output),
         recommended: false,
     }
 }
@@ -1215,6 +1261,11 @@ pub async fn create_tables(tx: &mut Transaction<'_, Sqlite>) -> Result<()> {
     .execute(&mut **tx)
     .await?;
 
+    let _ =
+        sqlx::query("ALTER TABLE provider_inventory_models ADD COLUMN max_output_tokens INTEGER")
+            .execute(&mut **tx)
+            .await;
+
     sqlx::query(
         "CREATE INDEX IF NOT EXISTS idx_provider_inventory_provider_id ON provider_inventory_entries(provider_id)",
     )
@@ -1251,6 +1302,28 @@ mod tests {
         assert!(!refreshing_keys.read().unwrap().contains("key-a"));
     }
 
+    #[test]
+    fn live_metadata_overrides_canonical_per_field() {
+        let mut models = vec![InventoryModel {
+            id: "m".into(),
+            name: "Canonical Name".into(),
+            family: None,
+            context_limit: Some(128_000),
+            reasoning: Some(false),
+            max_output_tokens: None,
+            recommended: false,
+        }];
+        let metas = vec![ProviderModelMeta {
+            id: "m".into(),
+            context_limit: Some(1_000_000),
+            max_output_tokens: None,
+            reasoning: None,
+        }];
+        apply_live_metadata(&mut models, &metas);
+        assert_eq!(models[0].context_limit, Some(1_000_000));
+        assert_eq!(models[0].reasoning, Some(false));
+    }
+
     #[tokio::test]
     async fn clear_refreshing_many_removes_all_inserted_keys() {
         let service =
@@ -1281,7 +1354,10 @@ mod tests {
         service
             .store_refreshed_models_for_identity(
                 &plan_time_identity,
-                std::slice::from_ref(&sentinel_model),
+                std::slice::from_ref(&ProviderModelMeta {
+                    id: sentinel_model.clone(),
+                    ..Default::default()
+                }),
             )
             .await
             .unwrap();
@@ -1329,13 +1405,14 @@ mod tests {
 
     #[test]
     fn databricks_v2_inventory_prefers_goose_model_ids_for_duplicate_names() {
-        let models = enrich_model_ids_with_canonical(
-            "databricks_v2",
-            &[
-                "databricks-gpt-5-5".to_string(),
-                "goose-gpt-5-5".to_string(),
-            ],
-        );
+        let metas: Vec<ProviderModelMeta> = ["databricks-gpt-5-5", "goose-gpt-5-5"]
+            .iter()
+            .map(|id| ProviderModelMeta {
+                id: id.to_string(),
+                ..Default::default()
+            })
+            .collect();
+        let models = enrich_model_ids_with_canonical("databricks_v2", &metas);
 
         assert!(
             models.iter().any(|model| model.id == "goose-gpt-5-5"),
@@ -1390,6 +1467,7 @@ mod tests {
                 family: None,
                 context_limit: None,
                 reasoning: None,
+                max_output_tokens: None,
                 recommended: false,
             }],
             last_updated_at: Some(Utc::now()),

--- a/crates/goose/src/providers/openrouter.rs
+++ b/crates/goose/src/providers/openrouter.rs
@@ -1,6 +1,7 @@
 use anyhow::{bail, Result};
 use async_trait::async_trait;
 use futures::future::BoxFuture;
+use goose_providers::base::ProviderModelMeta;
 use goose_providers::images::ImageFormat;
 use serde_json::{json, Value};
 use std::collections::{HashMap, HashSet};
@@ -97,6 +98,32 @@ impl OpenRouterProvider {
         })
         .await
     }
+}
+
+fn parse_openrouter_model(model: &serde_json::Value) -> Option<ProviderModelMeta> {
+    let id = model.get("id").and_then(|v| v.as_str())?.to_string();
+    Some(ProviderModelMeta {
+        context_limit: model
+            .get("context_length")
+            .and_then(|v| v.as_u64())
+            .map(|v| v as usize),
+        max_output_tokens: model
+            .pointer("/top_provider/max_completion_tokens")
+            .and_then(|v| v.as_u64())
+            .map(|v| v as usize),
+        reasoning: model
+            .get("supported_parameters")
+            .and_then(|v| v.as_array())
+            .map(|params| params.iter().any(|p| p.as_str() == Some("reasoning"))),
+        id,
+    })
+}
+
+fn meta_tool_capable(model: &serde_json::Value) -> bool {
+    model
+        .get("supported_parameters")
+        .and_then(|v| v.as_array())
+        .is_some_and(|params| params.iter().any(|p| p.as_str() == Some("tools")))
 }
 
 fn is_mandatory_reasoning_error(error: &ProviderError) -> bool {
@@ -458,7 +485,10 @@ impl Provider for OpenRouterProvider {
         true
     }
 
-    async fn fetch_recommended_models(&self, toolshim: bool) -> Result<Vec<String>, ProviderError> {
+    async fn fetch_model_metadata(
+        &self,
+        toolshim: bool,
+    ) -> Result<Vec<ProviderModelMeta>, ProviderError> {
         let response = self
             .api_client
             .request("api/v1/models")
@@ -493,26 +523,27 @@ impl Provider for OpenRouterProvider {
             ProviderError::UsageError("Missing data field in JSON response".into())
         })?;
 
-        let mut models: Vec<String> = data
+        let mut models: Vec<ProviderModelMeta> = data
             .iter()
             .filter_map(|model| {
-                let id = model.get("id").and_then(|v| v.as_str())?;
-                if toolshim {
-                    return Some(id.to_string());
+                let meta = parse_openrouter_model(model)?;
+                if !toolshim && !meta_tool_capable(model) {
+                    return None;
                 }
-                let supports_tools = model
-                    .get("supported_parameters")
-                    .and_then(|v| v.as_array())
-                    .is_some_and(|params| params.iter().any(|p| p.as_str() == Some("tools")));
-                if supports_tools {
-                    Some(id.to_string())
-                } else {
-                    None
-                }
+                Some(meta)
             })
             .collect();
-        models.sort();
+        models.sort_by(|a, b| a.id.cmp(&b.id));
         Ok(models)
+    }
+
+    async fn fetch_recommended_models(&self, toolshim: bool) -> Result<Vec<String>, ProviderError> {
+        Ok(self
+            .fetch_model_metadata(toolshim)
+            .await?
+            .into_iter()
+            .map(|m| m.id)
+            .collect())
     }
 
     async fn stream(
@@ -607,6 +638,31 @@ mod tests {
             supports_vision: None,
             request_headers: None,
         }
+    }
+
+    #[test]
+    fn parses_live_model_metadata() {
+        use serde_json::json;
+        let m = json!({
+            "id": "stealth/ox-alpha",
+            "context_length": 1000000,
+            "top_provider": { "max_completion_tokens": 64000 },
+            "supported_parameters": ["tools", "reasoning"]
+        });
+        let meta = parse_openrouter_model(&m).unwrap();
+        assert_eq!(meta.id, "stealth/ox-alpha");
+        assert_eq!(meta.context_limit, Some(1_000_000));
+        assert_eq!(meta.max_output_tokens, Some(64_000));
+        assert_eq!(meta.reasoning, Some(true));
+
+        let plain = parse_openrouter_model(&json!({
+            "id": "vendor/model",
+            "context_length": 8192,
+            "supported_parameters": ["tools"]
+        }))
+        .unwrap();
+        assert_eq!(plain.reasoning, Some(false));
+        assert!(parse_openrouter_model(&json!({"context_length": 1})).is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

For OpenRouter (and any provider with a rich models API), goose was fetching `/api/v1/models` at runtime but keeping only the model IDs. `context_length`, `top_provider.max_completion_tokens`, and reasoning support were parsed and thrown away, so any model missing from the build-time catalog (day-zero releases, stealth models, org-private aliases) got:

- a hardcoded 128k context fallback (UI meter *and* auto-compaction math)
- no Thinking Level control, since nothing ever set `ModelConfig.reasoning`

This change keeps the metadata the API already gives us:

- new optional trait method `Provider::fetch_model_metadata`, defaulting to deriving from existing `fetch_recommended_models` IDs so only providers with richer APIs need to override it (currently OpenRouter)
- inventory refresh stores live values; canonical-registry enrichment now fills gaps **per field** instead of being all-or-nothing
- session model config and the canonical-info endpoint backfill unset `context_limit`/`reasoning` from the live inventory snapshot

No UI changes needed — the picker, context meter, and Thinking Level control already read these fields.

### Testing

- New unit tests: OpenRouter response parsing (`parses_live_model_metadata`) and live-over-canonical field precedence (`live_metadata_overrides_canonical_per_field`)
- `cargo test -p goose --lib`: 2016 passing. 8 failures on my machine, all pre-existing/environment-dependent (gcpauth & codex JWT tests, platform-extension prompt list, two state-machine lifecycle tests) — none touch code paths changed here
- Manually verified against a real OpenRouter key: a model absent from the bundled catalog now shows its actual context limit and enables thinking

### Related Issues

Tracking issue: #11558 - includes follow-up scope (extending live metadata to other rich-API providers, mid-session convergence) and notes the specific inventory/session-prep paths this touches, so it can serve as the coordination point for any other OpenRouter work that may collide.
