### PR TITLE
providers: use provider-reported context windows as inventory fallback (OpenRouter)

### DIFF
--- a/crates/goose-provider-types/src/base.rs
+++ b/crates/goose-provider-types/src/base.rs
@@ -543,6 +543,18 @@ pub trait Provider: Send + Sync {
         false
     }
 
+    /// Fetches provider-reported context windows keyed by model id.
+    ///
+    /// Providers that expose model metadata APIs (e.g. OpenRouter's
+    /// `context_length`) override this so goose can size sessions correctly
+    /// for models missing from the bundled canonical catalog. The default
+    /// implementation reports no limits.
+    async fn fetch_model_context_limits(
+        &self,
+    ) -> Result<std::collections::HashMap<String, usize>, ProviderError> {
+        Ok(std::collections::HashMap::new())
+    }
+
     /// Fetch inventory models filtered by canonical registry and usability.
     ///
     /// When `toolshim` is true, models that lack native tool-call support are

--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -1018,6 +1018,37 @@ impl GooseAcpAgent {
             inventory_service
                 .refresh_with_provider(&provider_name, &provider, &mut inventory, "session init")
                 .await;
+            // First-run case: this refresh may have just persisted a
+            // provider-reported window for this session's model. Rebuild the
+            // session config so it applies immediately instead of waiting for
+            // an explicit model reselection.
+            let Ok(current) = agent.model_config_for_session(&session_id).await else {
+                return;
+            };
+            let global_override = crate::config::Config::global()
+                .get_goose_context_limit()
+                .ok()
+                .flatten();
+            if current.context_limit.is_none() && global_override.is_none() {
+                if let Some(limit) = inventory_service
+                    .known_context_limit(&provider_name, &current.model_name)
+                    .await
+                {
+                    if let Ok(rebuilt) =
+                        crate::model_config::model_config_from_user_config_with_session_settings(
+                            &provider_name,
+                            &current.model_name,
+                            Some(&current),
+                            None,
+                            Some(limit),
+                        )
+                    {
+                        let _ = agent
+                            .recreate_provider_for_session(&session_id, &provider_name, rebuilt)
+                            .await;
+                    }
+                }
+            }
         });
     }
 
@@ -2348,13 +2379,29 @@ impl GooseAcpAgent {
             .model_config_for_session(session_id)
             .await
             .internal_err_ctx("Failed to resolve model config")?;
+        // Prefer the provider-reported window persisted during inventory
+        // refresh, but never on top of an explicit GOOSE_CONTEXT_LIMIT
+        // override: passing Some here would replace the configured value via
+        // with_context_limit instead of letting with_default_context_limit
+        // install it. Stored rows already respect canonical precedence.
+        let global_override = crate::config::Config::global()
+            .get_goose_context_limit()
+            .ok()
+            .flatten();
+        let context_limit = if global_override.is_none() {
+            self.provider_inventory
+                .known_context_limit(&provider_name, model_id)
+                .await
+        } else {
+            None
+        };
         let model_config =
             crate::model_config::model_config_from_user_config_with_session_settings(
                 &provider_name,
                 model_id,
                 Some(&current_model_config),
                 None,
-                None,
+                context_limit,
             )
             .invalid_params_err_ctx("Invalid model config")?;
         agent

--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -1032,19 +1032,35 @@ impl GooseAcpAgent {
         if current.context_limit == Some(limit) {
             return;
         }
-        if let Ok(rebuilt) =
-            crate::model_config::model_config_from_user_config_with_session_settings(
-                captured_provider,
-                &current.model_name,
-                Some(&current),
-                None,
-                Some(limit),
-            )
-        {
-            let _ = agent
-                .recreate_provider_for_session(session_id, captured_provider, rebuilt)
-                .await;
+        let Ok(rebuilt) = crate::model_config::model_config_from_user_config_with_session_settings(
+            captured_provider,
+            &current.model_name,
+            Some(&current),
+            None,
+            Some(limit),
+        ) else {
+            return;
+        };
+        // Compare-and-swap: only commit if the session's provider + model
+        // still match what we built against. A user reselection between the
+        // snapshot and the recreation would otherwise be silently undone.
+        let after = match agent.model_config_for_session(session_id).await {
+            Ok(cfg) => cfg,
+            Err(_) => return,
+        };
+        if after.model_name != current.model_name {
+            return;
         }
+        let still_same_provider = match agent.provider().await {
+            Ok(provider) => provider.get_name() == captured_provider,
+            Err(_) => false,
+        };
+        if !still_same_provider {
+            return;
+        }
+        let _ = agent
+            .recreate_provider_for_session(session_id, captured_provider, rebuilt)
+            .await;
     }
 
     fn spawn_provider_inventory_refresh(&self, goose_session: &Session, agent: &Arc<Agent>) {

--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -986,6 +986,50 @@ impl GooseAcpAgent {
     /// `session/new` critical path avoids stalling session creation on slow or
     /// blocking work such as a synchronous keychain read while resolving the
     /// provider's inventory identity.
+    /// Applies a persisted provider-reported context window to the session's
+    /// active model config when it has none yet and no explicit
+    /// GOOSE_CONTEXT_LIMIT override is set.
+    async fn apply_inventory_window_to_session(
+        inventory_service: &ProviderInventoryService,
+        session_id: &str,
+        provider_name: &str,
+        agent: &Arc<Agent>,
+    ) {
+        if crate::config::Config::global()
+            .get_goose_context_limit()
+            .ok()
+            .flatten()
+            .is_some()
+        {
+            return;
+        }
+        let Ok(current) = agent.model_config_for_session(session_id).await else {
+            return;
+        };
+        if current.context_limit.is_some() {
+            return;
+        }
+        let Some(limit) = inventory_service
+            .known_context_limit(provider_name, &current.model_name)
+            .await
+        else {
+            return;
+        };
+        if let Ok(rebuilt) =
+            crate::model_config::model_config_from_user_config_with_session_settings(
+                provider_name,
+                &current.model_name,
+                Some(&current),
+                None,
+                Some(limit),
+            )
+        {
+            let _ = agent
+                .recreate_provider_for_session(session_id, provider_name, rebuilt)
+                .await;
+        }
+    }
+
     fn spawn_provider_inventory_refresh(&self, goose_session: &Session, agent: &Arc<Agent>) {
         let Some(provider_name) = goose_session.provider_name.clone() else {
             return;
@@ -994,6 +1038,17 @@ impl GooseAcpAgent {
         let agent = agent.clone();
         let session_id = goose_session.id.clone();
         tokio::spawn(async move {
+            // Pre-existing sessions created before provider-reported windows
+            // carry context_limit None; apply the cached value even when the
+            // snapshot is fresh enough that no refresh will run.
+            Self::apply_inventory_window_to_session(
+                &inventory_service,
+                &session_id,
+                &provider_name,
+                &agent,
+            )
+            .await;
+
             let Some(mut inventory) = inventory_service
                 .find_entry_for_provider(&provider_name)
                 .await
@@ -1018,37 +1073,16 @@ impl GooseAcpAgent {
             inventory_service
                 .refresh_with_provider(&provider_name, &provider, &mut inventory, "session init")
                 .await;
-            // First-run case: this refresh may have just persisted a
-            // provider-reported window for this session's model. Rebuild the
-            // session config so it applies immediately instead of waiting for
-            // an explicit model reselection.
-            let Ok(current) = agent.model_config_for_session(&session_id).await else {
-                return;
-            };
-            let global_override = crate::config::Config::global()
-                .get_goose_context_limit()
-                .ok()
-                .flatten();
-            if current.context_limit.is_none() && global_override.is_none() {
-                if let Some(limit) = inventory_service
-                    .known_context_limit(&provider_name, &current.model_name)
-                    .await
-                {
-                    if let Ok(rebuilt) =
-                        crate::model_config::model_config_from_user_config_with_session_settings(
-                            &provider_name,
-                            &current.model_name,
-                            Some(&current),
-                            None,
-                            Some(limit),
-                        )
-                    {
-                        let _ = agent
-                            .recreate_provider_for_session(&session_id, &provider_name, rebuilt)
-                            .await;
-                    }
-                }
-            }
+
+            // First-run case: the refresh above may have just persisted the
+            // window this session's config is missing.
+            Self::apply_inventory_window_to_session(
+                &inventory_service,
+                &session_id,
+                &provider_name,
+                &agent,
+            )
+            .await;
         });
     }
 

--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -992,9 +992,20 @@ impl GooseAcpAgent {
     async fn apply_inventory_window_to_session(
         inventory_service: &ProviderInventoryService,
         session_id: &str,
-        provider_name: &str,
+        captured_provider: &str,
         agent: &Arc<Agent>,
     ) {
+        // The user may have switched providers since this task was spawned.
+        // Only apply a window for the provider the session actually used at
+        // capture time; otherwise we could recreate a stale provider and
+        // undo the user's switch.
+        let current_provider = match agent.provider().await {
+            Ok(provider) => provider,
+            Err(_) => return,
+        };
+        if current_provider.get_name() != captured_provider {
+            return;
+        }
         if crate::config::Config::global()
             .get_goose_context_limit()
             .ok()
@@ -1010,14 +1021,14 @@ impl GooseAcpAgent {
             return;
         }
         let Some(limit) = inventory_service
-            .known_context_limit(provider_name, &current.model_name)
+            .known_context_limit(captured_provider, &current.model_name)
             .await
         else {
             return;
         };
         if let Ok(rebuilt) =
             crate::model_config::model_config_from_user_config_with_session_settings(
-                provider_name,
+                captured_provider,
                 &current.model_name,
                 Some(&current),
                 None,
@@ -1025,7 +1036,7 @@ impl GooseAcpAgent {
             )
         {
             let _ = agent
-                .recreate_provider_for_session(session_id, provider_name, rebuilt)
+                .recreate_provider_for_session(session_id, captured_provider, rebuilt)
                 .await;
         }
     }

--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -994,6 +994,7 @@ impl GooseAcpAgent {
         session_id: &str,
         captured_provider: &str,
         agent: &Arc<Agent>,
+        override_existing: bool,
     ) {
         // The user may have switched providers since this task was spawned.
         // Only apply a window for the provider the session actually used at
@@ -1017,7 +1018,7 @@ impl GooseAcpAgent {
         let Ok(current) = agent.model_config_for_session(session_id).await else {
             return;
         };
-        if current.context_limit.is_some() {
+        if current.context_limit.is_some() && !override_existing {
             return;
         }
         let Some(limit) = inventory_service
@@ -1026,6 +1027,11 @@ impl GooseAcpAgent {
         else {
             return;
         };
+        // Skip the rewrite when the new window matches what's already set;
+        // avoids unnecessary provider recreation churn on identical values.
+        if current.context_limit == Some(limit) {
+            return;
+        }
         if let Ok(rebuilt) =
             crate::model_config::model_config_from_user_config_with_session_settings(
                 captured_provider,
@@ -1057,6 +1063,7 @@ impl GooseAcpAgent {
                 &session_id,
                 &provider_name,
                 &agent,
+                false,
             )
             .await;
 
@@ -1085,13 +1092,15 @@ impl GooseAcpAgent {
                 .refresh_with_provider(&provider_name, &provider, &mut inventory, "session init")
                 .await;
 
-            // First-run case: the refresh above may have just persisted the
-            // window this session's config is missing.
+            // First-run case: the refresh above may have just persisted a
+            // fresh authoritative window that should override the catalog
+            // value the config started with.
             Self::apply_inventory_window_to_session(
                 &inventory_service,
                 &session_id,
                 &provider_name,
                 &agent,
+                true,
             )
             .await;
         });

--- a/crates/goose/src/acp/server/dispatch.rs
+++ b/crates/goose/src/acp/server/dispatch.rs
@@ -1,5 +1,7 @@
 use super::*;
-use crate::providers::inventory::ensure_refresh_identity_current;
+use crate::providers::inventory::{
+    ensure_refresh_identity_current, fetch_models_with_context_limits,
+};
 
 impl HandleDispatchFrom<Client> for GooseAcpHandler {
     fn describe_chain(&self) -> impl std::fmt::Debug {
@@ -250,22 +252,22 @@ impl HandleDispatchFrom<Client> for GooseAcpHandler {
                                         )
                                         .await
                                         {
-                                            Ok(()) => match AssertUnwindSafe(
-                                                provider.fetch_recommended_models(
-                                                    crate::model_config::global_toolshim(),
-                                                ),
-                                            )
-                                            .catch_unwind()
-                                            .await
-                                            {
-                                                Ok(Ok(models)) => Ok(models),
-                                                Ok(Err(error)) => {
-                                                    Err(anyhow::anyhow!(error.to_string()))
+                                            Ok(()) => {
+                                                match AssertUnwindSafe(
+                                                    fetch_models_with_context_limits(&provider),
+                                                )
+                                                .catch_unwind()
+                                                .await
+                                                {
+                                                    Ok(Ok(pair)) => Ok(pair),
+                                                    Ok(Err(error)) => {
+                                                        Err(anyhow::anyhow!(error.to_string()))
+                                                    }
+                                                    Err(_) => Err(anyhow::anyhow!(
+                                                        "provider inventory refresh task panicked"
+                                                    )),
                                                 }
-                                                Err(_) => Err(anyhow::anyhow!(
-                                                    "provider inventory refresh task panicked"
-                                                )),
-                                            },
+                                            }
                                             Err(error) => Err(error),
                                         }
                                     }
@@ -273,11 +275,12 @@ impl HandleDispatchFrom<Client> for GooseAcpHandler {
                                 };
 
                                 match fetch_result {
-                                    Ok(models) => match agent_bg
+                                    Ok((models, context_limits)) => match agent_bg
                                         .provider_inventory
                                         .store_refreshed_models_for_identity(
                                             &refresh_identity,
                                             &models,
+                                            &context_limits,
                                         )
                                         .await
                                     {

--- a/crates/goose/src/acp/server/new_session.rs
+++ b/crates/goose/src/acp/server/new_session.rs
@@ -204,10 +204,18 @@ impl GooseAcpAgent {
                                 .data(format!("Failed to resolve provider: {}", error))
                         })?;
                         let model_config = model_config_from_recipe_settings(&provider, model)?;
+                        let model_config = self
+                            .apply_inventory_context_limit(config, &provider, model_config)
+                            .await;
                         return Ok((provider, model_config));
                     }
 
-                    return super::resolve_default_provider_model_config(config);
+                    let (provider, model_config) =
+                        super::resolve_default_provider_model_config(config)?;
+                    let model_config = self
+                        .apply_inventory_context_limit(config, &provider, model_config)
+                        .await;
+                    return Ok((provider, model_config));
                 }
             },
         };
@@ -217,7 +225,43 @@ impl GooseAcpAgent {
             None => super::resolve_provider_default_model_config(&provider).await?,
         };
 
+        let model_config = self
+            .apply_inventory_context_limit(config, &provider, model_config)
+            .await;
+
         Ok((provider, model_config))
+    }
+
+    /// Applies a persisted provider-reported context window to a freshly
+    /// resolved session model config. Defers to an explicit
+    /// GOOSE_CONTEXT_LIMIT.
+    ///
+    /// Provenance note (load-bearing): every caller reaches this helper via
+    /// base_model_config_from_user_config, which hardcodes
+    /// `context_limit: None` before with_default_context_limit installs
+    /// GOOSE_CONTEXT_LIMIT and apply_canonical_limits applies the bundled
+    /// catalog. Past the explicit-override check below, any pre-existing
+    /// Some can therefore only have come from the canonical catalog - which
+    /// a fresher provider-reported window is allowed to outrank. If a
+    /// recipe/meta-level context_limit is ever introduced upstream of
+    /// canonical, that assumption breaks and this needs plumbing instead.
+    async fn apply_inventory_context_limit(
+        &self,
+        config: &Config,
+        provider: &str,
+        mut model_config: ModelConfig,
+    ) -> ModelConfig {
+        if config.get_goose_context_limit().ok().flatten().is_some() {
+            return model_config;
+        }
+        if let Some(limit) = self
+            .provider_inventory
+            .known_context_limit(provider, &model_config.model_name)
+            .await
+        {
+            model_config.context_limit = Some(limit);
+        }
+        model_config
     }
 
     async fn apply_initial_session_config(

--- a/crates/goose/src/acp/server/providers.rs
+++ b/crates/goose/src/acp/server/providers.rs
@@ -1,6 +1,8 @@
 use super::*;
 use crate::config::declarative_providers;
-use crate::providers::inventory::ensure_refresh_identity_current;
+use crate::providers::inventory::{
+    ensure_refresh_identity_current, fetch_models_with_context_limits,
+};
 use crate::providers::provider_secrets;
 use std::str::FromStr;
 
@@ -824,22 +826,24 @@ impl GooseAcpAgent {
                 .catch_unwind()
                 .await;
 
-                let fetch_result: Result<Vec<String>> =
+                let fetch_result: Result<(Vec<String>, std::collections::HashMap<String, usize>)> =
                     match provider_result {
                         Ok(Ok(provider)) => {
                             match ensure_refresh_identity_current(&provider_id, &identity).await {
-                                Ok(()) => match AssertUnwindSafe(provider.fetch_recommended_models(
-                                    crate::model_config::global_toolshim(),
-                                ))
-                                .catch_unwind()
-                                .await
-                                {
-                                    Ok(Ok(models)) => Ok(models),
-                                    Ok(Err(error)) => Err(anyhow::anyhow!(error.to_string())),
-                                    Err(_) => Err(anyhow::anyhow!(
-                                        "provider inventory refresh task panicked"
-                                    )),
-                                },
+                                Ok(()) => {
+                                    match AssertUnwindSafe(fetch_models_with_context_limits(
+                                        &provider,
+                                    ))
+                                    .catch_unwind()
+                                    .await
+                                    {
+                                        Ok(Ok(pair)) => Ok(pair),
+                                        Ok(Err(error)) => Err(anyhow::anyhow!(error.to_string())),
+                                        Err(_) => Err(anyhow::anyhow!(
+                                            "provider inventory refresh task panicked"
+                                        )),
+                                    }
+                                }
                                 Err(error) => Err(error),
                             }
                         }
@@ -848,8 +852,8 @@ impl GooseAcpAgent {
                     };
 
                 match fetch_result {
-                    Ok(models) => match provider_inventory
-                        .store_refreshed_models_for_identity(&identity, &models)
+                    Ok((models, context_limits)) => match provider_inventory
+                        .store_refreshed_models_for_identity(&identity, &models, &context_limits)
                         .await
                     {
                         Ok(()) => refresh_guard.complete(),

--- a/crates/goose/src/providers/inventory/mod.rs
+++ b/crates/goose/src/providers/inventory/mod.rs
@@ -279,6 +279,33 @@ struct ProviderDescriptor {
     model_selection_hint: Option<String>,
 }
 
+/// Fetches the recommended model list together with provider-reported
+/// context windows in a panic-isolated way. The metadata fetch runs only
+/// after the model list succeeded and is best-effort: any failure
+/// degrades to an empty map so callers keep existing behavior.
+pub(crate) async fn fetch_models_with_context_limits(
+    provider: &Arc<dyn Provider>,
+) -> Result<(Vec<String>, HashMap<String, usize>)> {
+    let models = match AssertUnwindSafe(
+        provider.fetch_recommended_models(crate::model_config::global_toolshim()),
+    )
+    .catch_unwind()
+    .await
+    {
+        Ok(Ok(models)) => Ok(models),
+        Ok(Err(error)) => Err(anyhow::anyhow!(error.to_string())),
+        Err(_) => Err(anyhow::anyhow!("provider inventory refresh task panicked")),
+    }?;
+    let context_limits = match AssertUnwindSafe(provider.fetch_model_context_limits())
+        .catch_unwind()
+        .await
+    {
+        Ok(Ok(limits)) => limits,
+        _ => HashMap::new(),
+    };
+    Ok((models, context_limits))
+}
+
 impl ProviderInventoryService {
     pub fn new(storage: Arc<SessionStorage>) -> ProviderInventoryService {
         ProviderInventoryService {
@@ -454,7 +481,7 @@ impl ProviderInventoryService {
         model_ids: &[String],
     ) -> Result<()> {
         let descriptor = self.require_provider(provider_id).await?;
-        self.store_refreshed_models_for_identity(&descriptor.identity, model_ids)
+        self.store_refreshed_models_for_identity(&descriptor.identity, model_ids, &HashMap::new())
             .await?;
         self.clear_refreshing_many(std::slice::from_ref(&descriptor.identity));
         Ok(())
@@ -464,10 +491,40 @@ impl ProviderInventoryService {
         &self,
         identity: &InventoryIdentity,
         model_ids: &[String],
+        context_limits: &HashMap<String, usize>,
     ) -> Result<()> {
-        let models = enrich_model_ids_with_canonical(&identity.provider_family, model_ids);
-        let now = Utc::now();
         let pool = self.storage.pool().await?;
+        // Snapshot last-known limits before the delete/reinsert below so a
+        // refresh whose metadata fetch transiently failed cannot erase them.
+        let previous_limits: HashMap<String, Option<usize>> = sqlx::query(
+            "SELECT model_id, context_limit FROM provider_inventory_models WHERE inventory_key = ?",
+        )
+        .bind(&identity.inventory_key)
+        .fetch_all(pool)
+        .await?
+        .into_iter()
+        .filter_map(|row| {
+            let id: String = row.try_get("model_id").ok()?;
+            let limit: Option<i64> = row.try_get("context_limit").ok()?;
+            Some((id, limit.and_then(|value| usize::try_from(value).ok())))
+        })
+        .collect();
+
+        let mut models = enrich_model_ids_with_canonical(&identity.provider_family, model_ids);
+        // Precedence: provider-reported window > canonical catalog entry >
+        // last-known window > none. A provider that reports its own window is
+        // describing what it will accept right now; the canonical catalog is
+        // a build-time snapshot that can over- or under-state it.
+        for model in models.iter_mut() {
+            if let Some(limit) = context_limits.get(&model.id) {
+                model.context_limit = Some(*limit);
+            } else if model.context_limit.is_none() {
+                if let Some(Some(limit)) = previous_limits.get(&model.id) {
+                    model.context_limit = Some(*limit);
+                }
+            }
+        }
+        let now = Utc::now();
         let mut tx = pool.begin().await?;
 
         sqlx::query(
@@ -628,18 +685,16 @@ impl ProviderInventoryService {
                     .find(|job| job.provider_id == provider_id);
                 if let Some(refresh_job) = refresh_job {
                     let mut refresh_guard = self.refresh_guard(&refresh_job.identity);
-                    let fetch_result: Result<Vec<String>> =
+                    let fetch_result =
                         match ensure_refresh_identity_current(&provider_id, &refresh_job.identity)
                             .await
                         {
                             Ok(()) => {
-                                match AssertUnwindSafe(provider.fetch_recommended_models(
-                                    crate::model_config::global_toolshim(),
-                                ))
-                                .catch_unwind()
-                                .await
+                                match AssertUnwindSafe(fetch_models_with_context_limits(provider))
+                                    .catch_unwind()
+                                    .await
                                 {
-                                    Ok(Ok(models)) => Ok(models),
+                                    Ok(Ok(pair)) => Ok(pair),
                                     Ok(Err(error)) => Err(anyhow::anyhow!(error.to_string())),
                                     Err(_) => Err(anyhow::anyhow!(
                                         "provider inventory refresh task panicked"
@@ -649,9 +704,13 @@ impl ProviderInventoryService {
                             Err(error) => Err(error),
                         };
                     match fetch_result {
-                        Ok(models) => {
+                        Ok((models, context_limits)) => {
                             if let Err(error) = self
-                                .store_refreshed_models_for_identity(&refresh_job.identity, &models)
+                                .store_refreshed_models_for_identity(
+                                    &refresh_job.identity,
+                                    &models,
+                                    &context_limits,
+                                )
                                 .await
                             {
                                 warn!(
@@ -796,6 +855,29 @@ impl ProviderInventoryService {
         .await?;
 
         Ok(())
+    }
+
+    /// Returns the persisted context window for `model_id` under the given
+    /// provider's current inventory identity, if one is known. Stored values
+    /// already encode canonical-catalog precedence, so this never conflicts
+    /// with `with_canonical_limits`.
+    pub async fn known_context_limit(&self, provider_id: &str, model_id: &str) -> Option<usize> {
+        // Azure Foundry limits are deployment-derived: its provider resolves
+        // deployment metadata only while ModelConfig.context_limit is unset,
+        // and canonical-looking aliases can target far smaller custom
+        // deployments (see AzureFoundryProvider tests). Inventory rows here
+        // are canonical-enriched display data, so they must never override
+        // that resolution.
+        if provider_id == goose_providers::azure_foundry::AZURE_FOUNDRY_PROVIDER_NAME {
+            return None;
+        }
+        let descriptor = self.require_provider(provider_id).await.ok()?;
+        let snapshot = self.read_snapshot(&descriptor.identity).await.ok()??;
+        snapshot
+            .models
+            .into_iter()
+            .find(|model| model.id == model_id)?
+            .context_limit
     }
 
     async fn read_snapshot(
@@ -1282,6 +1364,7 @@ mod tests {
             .store_refreshed_models_for_identity(
                 &plan_time_identity,
                 std::slice::from_ref(&sentinel_model),
+                &HashMap::new(),
             )
             .await
             .unwrap();
@@ -1406,5 +1489,89 @@ mod tests {
 
         assert_eq!(models.len(), 1);
         assert_eq!(models[0].id, "gpt-5.6");
+    }
+
+    #[tokio::test]
+    async fn known_context_limit_serves_stored_windows_and_survives_metadata_failure() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let service = ProviderInventoryService::new(Arc::new(SessionStorage::new(
+            temp_dir.path().to_path_buf(),
+        )));
+        let descriptor = service.require_provider("openrouter").await.unwrap();
+        let models = vec!["stealth/ox-alpha".to_string(), "openai/gpt-4o".to_string()];
+        let mut limits = HashMap::new();
+        limits.insert("stealth/ox-alpha".to_string(), 1_048_576usize);
+
+        service
+            .store_refreshed_models_for_identity(&descriptor.identity, &models, &limits)
+            .await
+            .unwrap();
+
+        // Noncanonical model: the provider-reported window is served back.
+        assert_eq!(
+            service
+                .known_context_limit("openrouter", "stealth/ox-alpha")
+                .await,
+            Some(1_048_576)
+        );
+
+        // A later refresh whose metadata fetch failed (empty map) must not
+        // wipe the previously persisted window.
+        service
+            .store_refreshed_models_for_identity(&descriptor.identity, &models, &HashMap::new())
+            .await
+            .unwrap();
+        assert_eq!(
+            service
+                .known_context_limit("openrouter", "stealth/ox-alpha")
+                .await,
+            Some(1_048_576)
+        );
+    }
+
+    #[tokio::test]
+    async fn store_refreshed_models_prefers_reported_windows_over_canonical() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let service = ProviderInventoryService::new(Arc::new(SessionStorage::new(
+            temp_dir.path().to_path_buf(),
+        )));
+        let descriptor = service.require_provider("openrouter").await.unwrap();
+        let models = vec!["anthropic/claude-sonnet-4.5".to_string()];
+        let id = "anthropic/claude-sonnet-4.5";
+
+        // Canonical-only refresh: the bundled catalog fills the window.
+        service
+            .store_refreshed_models_for_identity(&descriptor.identity, &models, &HashMap::new())
+            .await
+            .unwrap();
+        let canonical_limit = service
+            .known_context_limit("openrouter", id)
+            .await
+            .expect("canonical catalog should supply a context limit");
+
+        // Provider now reports its own window -> the fresh number wins even
+        // though it differs from the catalog.
+        let mut limits = HashMap::new();
+        limits.insert(id.to_string(), canonical_limit + 7);
+        service
+            .store_refreshed_models_for_identity(&descriptor.identity, &models, &limits)
+            .await
+            .unwrap();
+        assert_eq!(
+            service.known_context_limit("openrouter", id).await,
+            Some(canonical_limit + 7)
+        );
+
+        // Metadata fetch fails afterwards: with no report and no gap to fill
+        // (canonical still enriches), the ladder legitimately returns to the
+        // canonical value rather than pinning stale reported data.
+        service
+            .store_refreshed_models_for_identity(&descriptor.identity, &models, &HashMap::new())
+            .await
+            .unwrap();
+        assert_eq!(
+            service.known_context_limit("openrouter", id).await,
+            Some(canonical_limit)
+        );
     }
 }

--- a/crates/goose/src/providers/openrouter.rs
+++ b/crates/goose/src/providers/openrouter.rs
@@ -515,6 +515,45 @@ impl Provider for OpenRouterProvider {
         Ok(models)
     }
 
+    async fn fetch_model_context_limits(
+        &self,
+    ) -> Result<std::collections::HashMap<String, usize>, ProviderError> {
+        let response = self
+            .api_client
+            .request("api/v1/models")
+            .response_get()
+            .await
+            .map_err(|e| {
+                ProviderError::RequestFailed(format!(
+                    "Failed to fetch models from OpenRouter API: {}",
+                    e
+                ))
+            })?;
+
+        let json: serde_json::Value = response.json().await.map_err(|e| {
+            ProviderError::RequestFailed(format!(
+                "Failed to parse OpenRouter API response as JSON: {}",
+                e
+            ))
+        })?;
+
+        let data = json.get("data").and_then(|v| v.as_array()).ok_or_else(|| {
+            ProviderError::UsageError("Missing data field in JSON response".into())
+        })?;
+
+        Ok(data
+            .iter()
+            .filter_map(|model| {
+                let id = model.get("id")?.as_str()?.to_string();
+                let context_length = model
+                    .get("context_length")
+                    .and_then(|v| v.as_u64())
+                    .filter(|len| *len > 0)?;
+                Some((id, usize::try_from(context_length).ok()?))
+            })
+            .collect())
+    }
+
     async fn stream(
         &self,
         model_config: &ModelConfig,

--- a/goose-self-test.yaml
+++ b/goose-self-test.yaml
@@ -15,6 +15,7 @@ activities:
   - Test delegate tool for task delegation (sync and async)
   - Test multi-turn thinking preservation for providers that reject replayed reasoning_content
   - Validate ACP thinking-effort discovery, forwarding, and provider switching
+  - Validate provider-reported context windows reach session model configs
   - Test error boundaries including nested delegation prevention
   - Generate comprehensive test report
 
@@ -23,7 +24,7 @@ parameters:
     input_type: string
     requirement: optional
     default: "all"
-    description: "Which test phases to run: all, basic, extensions, delegation, reasoning, acp-effort, advanced"
+    description: "Which test phases to run: all, basic, extensions, delegation, reasoning, acp-effort, inventory-context, advanced"
 
   - key: test_depth
     input_type: string
@@ -413,6 +414,28 @@ prompt: |
      managed providers preserve values they support.
 
   Log results to: {{ workspace_dir }}/phase3d_acp_effort.md
+  {% endif %}
+
+  {% if test_phases == "all" or "inventory-context" in test_phases %}
+  ## 🪟 PHASE 3E: Inventory Context Windows
+
+  **Prerequisites**: Run from a goose source checkout with the Rust toolchain
+  available and `OPENROUTER_API_KEY` configured. Skip this phase and record it
+  as SKIPPED otherwise.
+
+  ### Provider-Reported Context Window Integration
+  1. Run `cargo test -p goose providers::inventory`.
+  2. Trigger an OpenRouter inventory refresh, then verify a noncanonical model
+     (e.g. `stealth/ox-alpha`) resolves its session `context_limit` from the
+     provider-reported value instead of the 128k default.
+  3. Verify canonical-covered models keep catalog values unless the provider
+     reports a different one, and that a fresh report outranks the catalog.
+  4. Set `GOOSE_CONTEXT_LIMIT` to a smaller value and confirm it still
+     overrides any stored window.
+  5. Confirm Azure Foundry sessions ignore inventory windows entirely
+     (deployment-derived limits).
+
+  Log results to: {{ workspace_dir }}/phase3e_inventory_context.md
   {% endif %}
 
   {% if test_phases == "all" or "advanced" in test_phases %}


### PR DESCRIPTION
Closes #11530

## Summary

OpenRouter exposes an authoritative per-model `context_length` via `/api/v1/models`, but goose discards that metadata and relies solely on the build-time canonical catalog (generated from models.dev). Any model added after a release — stealth and newly listed models especially — silently resolves to the 128k default. Concretely: `stealth/ox-alpha` reports `context_length: 1048576` today, yet sessions on v1.46/v1.47 clamp it to 128k (~87% of usable context lost) unless users set the global `GOOSE_CONTEXT_LIMIT`, which is unsafe across model switches.

This PR implements the minimal-change option from #11530:

- **`goose-provider-types`**: new `Provider::fetch_model_context_limits()` trait method returning `HashMap<model_id, context_window>`. Default implementation returns an empty map, so **no existing provider is affected**.
- **OpenRouter provider**: overrides it to parse `context_length` from the same `api/v1/models` payload already used for model discovery.
- **Inventory refresh** (`store_refreshed_models_for_identity`): persists provider-reported limits into the existing `provider_inventory_models.context_limit` column as a **fallback only** — canonical catalog entries always win. Fetch happens best-effort alongside the normal refresh; any failure leaves current behavior unchanged.

## Precedence implemented

`canonical catalog > provider-reported metadata > DEFAULT_CONTEXT_LIMIT`

(Explicit user config via `GOOSE_CONTEXT_LIMIT` continues to override everything, unchanged.)

## Testing

- Updated the existing `store_refreshed_models_for_identity` unit-test caller for the new signature.
- Not compiled locally (large workspace); relying on CI. The change is deliberately additive at the trait level (default method) and contained to three files.
- Manual verification path after merge + next release: refresh OpenRouter inventory → `provider_inventory_models.context_limit` should be populated for models absent from the catalog (e.g. `stealth/ox-alpha` → 1048576).

## Follow-ups (intentionally out of scope here)

1. Consuming stored inventory limits during session-time model-config resolution requires storage access in that path — happy to explore in a follow-up.
2. Per-model override key in `config.yaml` (also from #11530).