### PR TITLE
chore(deps): update actions/setup-java to v6

### DIFF
--- a/.github/workflows/maven-sdk.yml
+++ b/.github/workflows/maven-sdk.yml
@@ -77,7 +77,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
 
       - name: Set up Java
-        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
           distribution: temurin
           java-version: "17"
@@ -136,7 +136,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
 
       - name: Set up Java
-        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
           distribution: temurin
           java-version: "17"


### PR DESCRIPTION
## Summary

Updates both pinned `actions/setup-java` references in the Maven SDK workflow to the v6.0.0 commit.

### Testing

- Verified all active workflow references use setup-java v6
- Ran `git diff --check`

### Related Issues
Automated dependency maintenance; no issue.  
Discussion: N/A

### Screenshots/Demos (for UX changes)
Before: N/A  

After: N/A