### PR TITLE
fix(providers): sync OpenAI + Google pre-key model lists with the canonical registry

### DIFF
--- a/crates/goose-providers/src/google.rs
+++ b/crates/goose-providers/src/google.rs
@@ -1,11 +1,14 @@
 use crate::api_client::{ApiClient, AuthMethod};
 use crate::base::MessageStream;
+use crate::canonical::recommended_models_from_registry;
 use crate::conversation::message::Message;
 use crate::errors::ProviderError;
 use crate::openai_compatible::{handle_status, map_http_error_to_provider_error, sanitize_url};
 use crate::retry::ProviderRetry;
 
-use crate::base::{ConfigKey, Provider, ProviderMetadata};
+use crate::base::{
+    model_info_for_provider_model, ConfigKey, ModelInfo, Provider, ProviderMetadata,
+};
 use crate::formats::google::{create_request_with_thinking_budget, response_to_streaming_message};
 use crate::model::ModelConfig;
 use crate::request_log::{start_log, LoggerHandleExt};
@@ -25,33 +28,50 @@ pub const GOOGLE_PROVIDER_NAME: &str = "google";
 pub const GOOGLE_API_HOST: &str = "https://generativelanguage.googleapis.com";
 pub const GOOGLE_DEFAULT_MODEL: &str = "gemini-2.5-pro";
 pub const GOOGLE_DEFAULT_FAST_MODEL: &str = "gemini-2.5-flash";
+// Fallback only, used if the bundled canonical registry fails to load.
 pub const GOOGLE_KNOWN_MODELS: &[&str] = &[
     "gemini-3.6-flash",
     "gemini-3.5-flash",
     "gemini-3.5-flash-lite",
-    // Gemini 3 models
     "gemini-3-pro-preview",
     "gemini-3-pro-image-preview",
-    // Gemini 2.5 Pro models
     "gemini-2.5-pro",
     "gemini-2.5-pro-preview-tts",
-    // Gemini 2.5 Flash models
     "gemini-2.5-flash",
     "gemini-2.5-flash-preview-09-2025",
     "gemini-2.5-flash-image",
     "gemini-2.5-flash-image-preview",
     "gemini-2.5-flash-native-audio-preview-09-2025",
     "gemini-2.5-flash-preview-tts",
-    // Gemini 2.5 Flash-Lite models
     "gemini-2.5-flash-lite",
     "gemini-2.5-flash-lite-preview-09-2025",
-    // Gemini 2.0 Flash models
     "gemini-2.0-flash",
     "gemini-2.0-flash-001",
     "gemini-2.0-flash-exp",
     "gemini-2.0-flash-preview-image-generation",
     "gemini-2.0-flash-live-001",
-    // Gemini 2.0 Flash-Lite models
+    "gemini-2.0-flash-lite",
+    "gemini-2.0-flash-lite-001",
+];
+
+// recommended_models_from_registry() only returns text+tool-calling models, so
+// the 2.0 series (absent from the registry entirely) and the TTS/image-only
+// variants it filters out are merged in here rather than dropped from the picker.
+const GOOGLE_LEGACY_MODELS: &[&str] = &[
+    "gemini-3-pro-preview",
+    "gemini-3-pro-image-preview",
+    "gemini-2.5-pro-preview-tts",
+    "gemini-2.5-flash-preview-09-2025",
+    "gemini-2.5-flash-image",
+    "gemini-2.5-flash-image-preview",
+    "gemini-2.5-flash-native-audio-preview-09-2025",
+    "gemini-2.5-flash-preview-tts",
+    "gemini-2.5-flash-lite-preview-09-2025",
+    "gemini-2.0-flash",
+    "gemini-2.0-flash-001",
+    "gemini-2.0-flash-exp",
+    "gemini-2.0-flash-preview-image-generation",
+    "gemini-2.0-flash-live-001",
     "gemini-2.0-flash-lite",
     "gemini-2.0-flash-lite-001",
 ];
@@ -114,14 +134,38 @@ impl GoogleProvider {
     }
 }
 
+// Builds the picker list from the bundled canonical registry so it stays in
+// sync automatically, falling back to GOOGLE_KNOWN_MODELS if the registry
+// fails to load. GOOGLE_LEGACY_MODELS is merged in either way since the
+// registry's tool-calling filter excludes real, still-useful entries (see
+// its comment above).
+fn google_model_list() -> Vec<ModelInfo> {
+    let registry_names = recommended_models_from_registry(GOOGLE_PROVIDER_NAME);
+    let names: Vec<&str> = if registry_names.is_empty() {
+        // GOOGLE_KNOWN_MODELS already includes every GOOGLE_LEGACY_MODELS entry.
+        GOOGLE_KNOWN_MODELS.to_vec()
+    } else {
+        registry_names
+            .iter()
+            .map(String::as_str)
+            .chain(GOOGLE_LEGACY_MODELS.iter().copied())
+            .collect()
+    };
+
+    names
+        .into_iter()
+        .map(|name| model_info_for_provider_model(GOOGLE_PROVIDER_NAME, name))
+        .collect()
+}
+
 impl crate::base::ProviderDescriptor for GoogleProvider {
     fn metadata() -> ProviderMetadata {
-        ProviderMetadata::new(
+        ProviderMetadata::with_models(
             GOOGLE_PROVIDER_NAME,
             "Google Gemini (API Key)",
             "Gemini models from Google AI",
             GOOGLE_DEFAULT_MODEL,
-            GOOGLE_KNOWN_MODELS.to_vec(),
+            google_model_list(),
             GOOGLE_DOC_URL,
             vec![
                 ConfigKey::new("GOOGLE_API_KEY", true, true, None, true),
@@ -219,5 +263,54 @@ impl Provider for GoogleProvider {
                 yield (message, usage);
             }
         }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::base::ProviderDescriptor;
+
+    #[test]
+    fn metadata_includes_models_missing_from_the_hardcoded_list() {
+        let metadata = GoogleProvider::metadata();
+        for name in ["gemini-3.1-pro-preview", "gemini-3.7-flash"] {
+            assert!(
+                metadata.known_models.iter().any(|m| m.name == name),
+                "expected {name} to be in the registry-derived list"
+            );
+        }
+    }
+
+    #[test]
+    fn metadata_keeps_models_the_registry_filter_would_otherwise_drop() {
+        // gemini-2.0-flash has no registry entry at all; gemini-2.5-flash-image
+        // is in the registry but tool_call=false, so recommended_models_from_registry()
+        // filters it out. Both must survive via GOOGLE_LEGACY_MODELS.
+        let metadata = GoogleProvider::metadata();
+        for name in ["gemini-2.0-flash", "gemini-2.5-flash-image"] {
+            assert!(
+                metadata.known_models.iter().any(|m| m.name == name),
+                "expected {name} to survive via GOOGLE_LEGACY_MODELS"
+            );
+        }
+    }
+
+    #[test]
+    fn metadata_has_no_duplicate_model_names() {
+        let metadata = GoogleProvider::metadata();
+        let mut names: Vec<&str> = metadata
+            .known_models
+            .iter()
+            .map(|m| m.name.as_str())
+            .collect();
+        let count_before = names.len();
+        names.sort();
+        names.dedup();
+        assert_eq!(
+            names.len(),
+            count_before,
+            "duplicate model name in known_models"
+        );
     }
 }

--- a/crates/goose-providers/src/openai.rs
+++ b/crates/goose-providers/src/openai.rs
@@ -2,6 +2,7 @@ use super::api_client::ApiClient;
 use super::base::{ConfigKey, ModelInfo, Provider, ProviderMetadata};
 use super::retry::ProviderRetry;
 use crate::api_client::{AuthMethod, TlsConfig};
+use crate::canonical::{maybe_get_canonical_model, recommended_models_from_registry};
 use crate::conversation::message::Message;
 use crate::conversation::token_usage::{CostSource, ProviderUsage};
 use crate::declarative::{DeclarativeProviderConfig, KeyResolver};
@@ -40,6 +41,8 @@ const OPEN_AI_DEFAULT_RESPONSES_PATH: &str = "v1/responses";
 const OPEN_AI_DEFAULT_MODELS_PATH: &str = "v1/models";
 pub const OPEN_AI_DEFAULT_MODEL: &str = "gpt-4o";
 pub const OPEN_AI_DEFAULT_FAST_MODEL: &str = "gpt-4o-mini";
+
+// Fallback only, used if the bundled canonical registry fails to load.
 pub const OPEN_AI_KNOWN_MODELS: &[(&str, usize)] = &[
     ("gpt-4o", 128_000),
     ("gpt-4o-mini", 128_000),
@@ -73,6 +76,9 @@ pub const OPEN_AI_KNOWN_MODELS: &[(&str, usize)] = &[
     ("gpt-5.6-terra", 1_050_000),
     ("gpt-5.6-luna", 1_050_000),
 ];
+
+// Deprecated by OpenAI, absent from the canonical registry; kept so existing configs don't lose it.
+const OPEN_AI_LEGACY_MODELS: &[(&str, usize)] = &[("gpt-3.5-turbo", 16_385)];
 
 pub const OPEN_AI_DOC_URL: &str = "https://platform.openai.com/docs/models";
 const DEFAULT_TIMEOUT_SECONDS: u64 = 600;
@@ -630,12 +636,39 @@ fn parse_n_ctx_from_models(json: &serde_json::Value, model_name: &str) -> Option
     }
 }
 
-impl ProviderDescriptor for OpenAiProvider {
-    fn metadata() -> ProviderMetadata {
-        let models = OPEN_AI_KNOWN_MODELS
+// Builds the picker list from the bundled canonical registry so it stays in
+// sync automatically, falling back to OPEN_AI_KNOWN_MODELS if the registry
+// fails to load. The hand-maintained list previously backed metadata()
+// directly and had silently drifted (missing gpt-4, gpt-5.2-chat,
+// gpt-5.3-chat, gpt-5.3-codex-spark, gpt-realtime-2.1).
+fn openai_model_list() -> Vec<ModelInfo> {
+    let registry_names = recommended_models_from_registry(OPEN_AI_PROVIDER_NAME);
+    if registry_names.is_empty() {
+        return OPEN_AI_KNOWN_MODELS
             .iter()
             .map(|(name, limit)| ModelInfo::new(*name, *limit))
             .collect();
+    }
+
+    registry_names
+        .into_iter()
+        .map(|name| {
+            let context_limit = maybe_get_canonical_model(OPEN_AI_PROVIDER_NAME, &name)
+                .map(|canonical| canonical.limit.context)
+                .unwrap_or(128_000);
+            ModelInfo::new(name, context_limit)
+        })
+        .chain(
+            OPEN_AI_LEGACY_MODELS
+                .iter()
+                .map(|(name, limit)| ModelInfo::new(*name, *limit)),
+        )
+        .collect()
+}
+
+impl ProviderDescriptor for OpenAiProvider {
+    fn metadata() -> ProviderMetadata {
+        let models = openai_model_list();
         ProviderMetadata::with_models(
             OPEN_AI_PROVIDER_NAME,
             "OpenAI",
@@ -1781,5 +1814,27 @@ mod tests {
         assert_eq!(payload["stream"], json!(true));
         assert_eq!(payload["stream_options"], json!({"include_usage": true}));
         assert_eq!(payload["messages"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn metadata_includes_models_missing_from_the_hardcoded_list() {
+        // Regression guard: OPEN_AI_KNOWN_MODELS had silently drifted, missing
+        // gpt-5.2-chat, gpt-5.3-chat, and gpt-5.3-codex-spark.
+        let metadata = OpenAiProvider::metadata();
+        for name in ["gpt-5.2-chat", "gpt-5.3-chat", "gpt-5.3-codex-spark"] {
+            assert!(
+                metadata.known_models.iter().any(|m| m.name == name),
+                "expected {name} to be in the registry-derived list"
+            );
+        }
+    }
+
+    #[test]
+    fn metadata_includes_legacy_model_with_no_registry_counterpart() {
+        let metadata = OpenAiProvider::metadata();
+        assert!(metadata
+            .known_models
+            .iter()
+            .any(|m| m.name == "gpt-3.5-turbo"));
     }
 }


### PR DESCRIPTION
Fixes #11069

Follow-up to #11475 (Anthropic). Same drift bug found in the other two: `OPEN_AI_KNOWN_MODELS` and `GOOGLE_KNOWN_MODELS` are hand-maintained lists backing the pre-key model picker, and both had silently drifted.

- OpenAI: missing `gpt-4`, `gpt-5.2-chat`, `gpt-5.3-chat`, `gpt-5.3-codex-spark`, `gpt-realtime-2.1`. No wire-alias mapping needed — OpenAI's canonical names are already valid model ids.
- Google: the registry helper only returns text-input, tool-calling models. The entire Gemini 2.0 series has no registry entry, and several TTS/image-only variants are present but `tool_call: false` — a blind swap would have dropped 16 models from the picker. `GOOGLE_LEGACY_MODELS` merges those back in so nothing currently supported is lost, while gaining what the registry now has (`gemini-3.1-pro-preview`, `gemini-3.7-flash`, etc.).

Both fall back to their hardcoded list if the registry fails to load, same pattern as #11475.

Happy to fold this into #11475 instead if you'd rather review both providers in one pass — two separate commits here either way, so it merges cleanly either direction.

### Testing

- `cargo test -p goose-providers` — 154/154
- `cargo clippy -p goose-providers --all-targets -- -D warnings` — clean
- `cargo check -p goose -p goose-cli` — clean
- Regression tests for both providers proven fail-first (reverted the fix, confirmed the exact missing-model assertion fails, restored, confirmed green)