### PR TITLE
fix(shell): reject cmd.exe commands containing newlines

### DIFF
--- a/crates/goose/src/agents/platform_extensions/developer/mod.rs
+++ b/crates/goose/src/agents/platform_extensions/developer/mod.rs
@@ -131,18 +131,24 @@ impl DeveloperClient {
                 Some(false),
                 Some(false),
             )),
-            Tool::new(
-                "shell".to_string(),
-                format!(
+            {
+                let shell = shell_display_name();
+                let newline_note = if shell == "cmd" {
+                    " Commands must be on a single line — cmd.exe silently truncates at the \
+                     first newline. Use `&` to chain (e.g. `echo a & echo b`) or set \
+                     GOOSE_SHELL=powershell for multi-line support."
+                } else {
+                    ""
+                };
+                let description = format!(
                     "Execute a shell command in the current dir. Commands run under `{shell}` \
                      (set GOOSE_SHELL to override) - write command strings in that shell's \
-                     syntax. Returns an object with stdout and stderr as separate fields. The \
-                     output of each stream is limited to up to 2000 lines, and longer outputs \
-                     will be saved to a temporary file.",
-                    shell = shell_display_name(),
-                ),
-                Self::schema::<ShellParams>(),
-            )
+                     syntax.{newline_note} Returns an object with stdout and stderr as separate \
+                     fields. The output of each stream is limited to up to 2000 lines, and \
+                     longer outputs will be saved to a temporary file.",
+                );
+                Tool::new("shell".to_string(), description, Self::schema::<ShellParams>())
+            }
             .with_output_schema::<ShellOutput>()
             .annotate(ToolAnnotations::from_raw(
                 Some("Shell".to_string()),

--- a/crates/goose/src/agents/platform_extensions/developer/shell.rs
+++ b/crates/goose/src/agents/platform_extensions/developer/shell.rs
@@ -389,6 +389,16 @@ impl ShellTool {
             return Self::error_result("Command cannot be empty.", None);
         }
 
+        #[cfg(windows)]
+        if shell_basename(&windows_shell()) == "cmd" && params.command.contains(['\n', '\r']) {
+            return Self::error_result(
+                "cmd.exe silently truncates commands at newlines — only the first line executes, \
+                 with exit code 0. Use `&` to chain commands on one line \
+                 (e.g. `echo a & echo b`), or set GOOSE_SHELL=powershell.",
+                None,
+            );
+        }
+
         #[cfg(not(windows))]
         let login_path = self.login_path.get().await;
         #[cfg(not(windows))]
@@ -1269,6 +1279,29 @@ mod tests {
                 let slot = tool.call_index.fetch_add(1, Ordering::Relaxed) % OUTPUT_SLOTS;
                 assert_eq!(slot, expected);
             }
+        }
+    }
+
+    #[cfg(windows)]
+    #[tokio::test]
+    async fn cmd_rejects_newline_in_command() {
+        for command in ["echo a\necho b", "echo a\r\necho b", "echo a\recho b"] {
+            let tool = ShellTool::new_for_test().unwrap();
+            let result = tool
+                .shell(ShellParams {
+                    command: command.to_string(),
+                    timeout_secs: None,
+                })
+                .await;
+            assert_eq!(
+                result.is_error,
+                Some(true),
+                "expected error for {command:?}"
+            );
+            assert!(
+                extract_text(&result).contains("cmd.exe"),
+                "error should mention cmd.exe for {command:?}"
+            );
         }
     }
 


### PR DESCRIPTION
fixes : #11259

## Summary

cmd.exe /C silently truncates commands at the first newline — only line one runs, exit code 0, no stderr. Fixed by returning a loud error before spawning when the shell is cmd and the command contains \n/\r. Also updated the tool description so the model avoids multi-line commands on cmd in the first place

### Testing
 - Command with \n, \r\n, or \r → returns error mentioning cmd.exe (covered by #[cfg(windows)] unit test)
  - Single-line commands → unchanged, still work 
  - &-chained commands → unchanged, still work
  - GOOSE_SHELL=powershell → unchanged, still handles newlines fine
