### PR TITLE
fix(desktop): keep custom provider engine on save

### DIFF
--- a/scripts/provider-error-proxy/proxy.py
+++ b/scripts/provider-error-proxy/proxy.py
@@ -84,6 +84,17 @@ COMPLETION_PATHS = [
     '/serving-endpoints',  # Databricks
 ]
 
+# Path fragments identifying known non-inference (metadata) traffic. Used as
+# the exclusion list when classifying requests that do not match
+# COMPLETION_PATHS: a POST to an unrecognized path (e.g. a provider configured
+# with a custom inference base path) is still treated as a completion, but
+# known metadata endpoints are not.
+METADATA_PATHS = [
+    '/models',      # model listing (OpenAI-compatible)
+    '/api/tags',    # Ollama model listing
+    '/embeddings',  # embeddings are not turn completions
+]
+
 
 class ErrorMode(Enum):
     """Error injection modes."""
@@ -421,7 +432,16 @@ class ErrorProxy:
             True if this is a completion request
         """
         path = request.path.lower()
-        return any(fragment in path for fragment in COMPLETION_PATHS)
+        if any(fragment in path for fragment in COMPLETION_PATHS):
+            return True
+        # Providers configured with a custom inference base path (e.g. an
+        # OpenAI-compatible endpoint at "<project_id>/v1") post completions to
+        # routes that match none of the known fragments. Treat any other POST
+        # that is not known metadata traffic as a completion so error
+        # injection still applies to custom inference routes.
+        if request.method.upper() != 'POST':
+            return False
+        return not any(fragment in path for fragment in METADATA_PATHS)
 
     def get_target_url(self, request: Request, provider: str) -> str:
         """

--- a/scripts/provider-error-proxy/proxy.py
+++ b/scripts/provider-error-proxy/proxy.py
@@ -94,6 +94,7 @@ COMPLETION_PATHS = [
 METADATA_PATH_SUFFIXES = [
     '/models',      # model listing (OpenAI-compatible)
     '/api/tags',    # Ollama model listing
+    '/api/show',    # Ollama model info (POSTed before completions for context limits)
     '/embeddings',  # embeddings are not turn completions
 ]
 

--- a/scripts/provider-error-proxy/proxy.py
+++ b/scripts/provider-error-proxy/proxy.py
@@ -62,6 +62,28 @@ ALWAYS_FORWARD_PATHS = [
     '/api/2.0/',  # Databricks management API
 ]
 
+# Path fragments identifying an inference/completion request.
+#
+# Error injection only applies to these. Every error mode the proxy offers
+# describes a completion failure (context length exceeded, rate limited,
+# upstream 500), so injecting them into metadata traffic such as model listing
+# is meaningless. It is also actively harmful in count mode: a pre-flight
+# request would silently consume the error budget intended for a completion,
+# making "inject N errors" depend on goose's incidental call pattern rather
+# than on the completions the test is actually exercising.
+COMPLETION_PATHS = [
+    '/chat/completions',  # OpenAI and compatible
+    '/completions',       # OpenAI legacy
+    '/messages',          # Anthropic
+    '/responses',         # OpenAI Responses API
+    ':generatecontent',   # Google Gemini
+    ':streamgeneratecontent',
+    '/converse',          # Bedrock
+    '/invoke',            # Bedrock / Databricks serving
+    '/invocations',
+    '/serving-endpoints',  # Databricks
+]
+
 
 class ErrorMode(Enum):
     """Error injection modes."""
@@ -383,7 +405,23 @@ class ErrorProxy:
         for forward_path in ALWAYS_FORWARD_PATHS:
             if forward_path in path:
                 return True
-        return False
+        return not self.is_completion_request(request)
+
+    def is_completion_request(self, request: Request) -> bool:
+        """
+        Check whether this request is an inference/completion call.
+
+        Only completion requests are eligible for error injection; see
+        COMPLETION_PATHS.
+
+        Args:
+            request: The incoming HTTP request
+
+        Returns:
+            True if this is a completion request
+        """
+        path = request.path.lower()
+        return any(fragment in path for fragment in COMPLETION_PATHS)
 
     def get_target_url(self, request: Request, provider: str) -> str:
         """
@@ -462,7 +500,13 @@ class ErrorProxy:
 
         # Check if this request should always be forwarded
         if self.should_always_forward(request):
-            logger.info(f"🔄 Always forwarding: {request.path}")
+            if self.is_completion_request(request):
+                logger.info(f"🔄 Always forwarding: {request.path}")
+            else:
+                logger.info(
+                    f"🔄 Forwarding non-completion request (not eligible for "
+                    f"error injection): {request.path}"
+                )
         else:
             # Capture the error mode BEFORE checking if we should inject (since that modifies state)
             mode_before_check = self.get_error_mode()

--- a/scripts/provider-error-proxy/proxy.py
+++ b/scripts/provider-error-proxy/proxy.py
@@ -84,12 +84,14 @@ COMPLETION_PATHS = [
     '/serving-endpoints',  # Databricks
 ]
 
-# Path fragments identifying known non-inference (metadata) traffic. Used as
+# Path suffixes identifying known non-inference (metadata) traffic. Used as
 # the exclusion list when classifying requests that do not match
 # COMPLETION_PATHS: a POST to an unrecognized path (e.g. a provider configured
 # with a custom inference base path) is still treated as a completion, but
-# known metadata endpoints are not.
-METADATA_PATHS = [
+# known metadata endpoints are not. Matched as suffixes, not substrings, so a
+# custom inference path that merely contains one of these segments (e.g.
+# /v1/models/my-model/predict) is still classified as a completion.
+METADATA_PATH_SUFFIXES = [
     '/models',      # model listing (OpenAI-compatible)
     '/api/tags',    # Ollama model listing
     '/embeddings',  # embeddings are not turn completions
@@ -441,7 +443,8 @@ class ErrorProxy:
         # injection still applies to custom inference routes.
         if request.method.upper() != 'POST':
             return False
-        return not any(fragment in path for fragment in METADATA_PATHS)
+        path = path.rstrip('/')
+        return not any(path.endswith(suffix) for suffix in METADATA_PATH_SUFFIXES)
 
     def get_target_url(self, request: Request, provider: str) -> str:
         """

--- a/scripts/test_compaction.sh
+++ b/scripts/test_compaction.sh
@@ -37,6 +37,16 @@ if [ -n "$COMPACTION_PROVIDER" ] || [ -n "$COMPACTION_MODEL" ]; then
   echo ""
 fi
 
+# Print the error proxy's request ledger. Without this, a TEST 3 failure gives
+# no way to tell which upstream requests were made or which one received the
+# injected error, leaving the request ordering to guesswork.
+dump_proxy_log() {
+  if [ -n "$PROXY_LOG" ] && [ -s "$PROXY_LOG" ]; then
+    echo "   Proxy request log:"
+    cat "$PROXY_LOG"
+  fi
+}
+
 # Validation function to check compaction structure in session JSON
 validate_compaction() {
   local session_id=$1
@@ -265,12 +275,10 @@ else
 
   # Start the error proxy in context-length error mode.
   #
-  # Inject exactly ONE error. The proxy's count mode decrements on every
-  # forwarded request regardless of purpose (see provider-error-proxy/proxy.py
-  # should_inject_error), so the count directly controls how many of goose's
-  # upstream calls fail. This test wants the *turn completion* to fail with a
-  # context-length error and the *summarizer* call that follows to succeed, so
-  # that compaction actually produces a summary message to validate.
+  # Inject exactly ONE error. The proxy only injects into completion requests
+  # (see COMPLETION_PATHS in provider-error-proxy/proxy.py), so this error lands
+  # on the turn completion and the summarizer call that follows succeeds,
+  # producing the summary message this test validates.
   #
   # Do not raise this number to "give compaction more retries". A context-length
   # error is deterministic for a fixed prompt, so retrying an identical request
@@ -312,6 +320,14 @@ else
     export GOOSE_PROVIDER=anthropic
     export GOOSE_MODEL=claude-haiku-4-5
 
+    # Session naming runs as a background completion request spawned at the
+    # start of the turn, so it races the turn completion for the proxy's single
+    # injected error. When it wins, the naming call absorbs the error (it only
+    # logs a warning), the turn succeeds, and no compaction ever happens.
+    # Disable it so the turn completion is deterministically the first
+    # completion request the proxy sees.
+    export GOOSE_DISABLE_SESSION_NAMING=true
+
     echo "Step 1: Creating session (should trigger context-length error and compaction)..."
     (cd "$TESTDIR" && "$GOOSE_BIN" run --text "hello world" 2>&1) | tee "$OUTPUT"
 
@@ -332,6 +348,7 @@ else
         echo "✗ FAILED: Compaction was attempted but returned an error"
         echo "   Output:"
         cat "$OUTPUT"
+        dump_proxy_log
         RESULTS+=("✗ Out-of-Context Test Error (compaction errored)")
       elif grep -qi "context.*length\|compacting\|compacted\|compaction" "$OUTPUT"; then
         echo "✓ SUCCESS: Out-of-context Test error triggered compaction"
@@ -339,12 +356,14 @@ else
         if validate_compaction "$SESSION_ID" "out-of-context error compaction"; then
           RESULTS+=("✓ Out-of-Context Test Error")
         else
+          dump_proxy_log
           RESULTS+=("✗ Out-of-Context Test Error (structure validation failed)")
         fi
       else
         echo "✗ FAILED: No evidence of compaction after context-length error"
         echo "   Output:"
         cat "$OUTPUT"
+        dump_proxy_log
         RESULTS+=("✗ Out-of-Context Test Error")
       fi
     fi

--- a/scripts/test_compaction.sh
+++ b/scripts/test_compaction.sh
@@ -263,9 +263,21 @@ if ! (cd "$PROXY_DIR" && uv sync 2>&1 | tee "$PROXY_SETUP_LOG"); then
 else
   echo "✓ Dependencies installed"
 
-  # Start the error proxy in context-length error mode (3 errors)
+  # Start the error proxy in context-length error mode.
+  #
+  # Inject exactly ONE error. The proxy's count mode decrements on every
+  # forwarded request regardless of purpose (see provider-error-proxy/proxy.py
+  # should_inject_error), so the count directly controls how many of goose's
+  # upstream calls fail. This test wants the *turn completion* to fail with a
+  # context-length error and the *summarizer* call that follows to succeed, so
+  # that compaction actually produces a summary message to validate.
+  #
+  # Do not raise this number to "give compaction more retries". A context-length
+  # error is deterministic for a fixed prompt, so retrying an identical request
+  # is not a scenario worth asserting; a higher count just consumes the
+  # summarizer's own calls and prevents the summary this test exists to check.
   echo "Starting error proxy on port $PROXY_PORT with context-length error mode..."
-  (cd "$PROXY_DIR" && UV_INDEX_URL="https://pypi.org/simple" uv run proxy.py --port "$PROXY_PORT" --mode "c 3" --no-stdin > "$PROXY_LOG" 2>&1) &
+  (cd "$PROXY_DIR" && UV_INDEX_URL="https://pypi.org/simple" uv run proxy.py --port "$PROXY_PORT" --mode "c 1" --no-stdin > "$PROXY_LOG" 2>&1) &
   PROXY_PID=$!
 
   # Wait for proxy to be ready (check if port is listening)
@@ -313,8 +325,15 @@ else
       echo "Session created: $SESSION_ID"
       echo "Checking for compaction evidence..."
 
-      # Check for compaction in the output
-      if grep -qi "context.*length\|compacting\|compacted\|compaction" "$OUTPUT"; then
+      # The compaction failure message itself contains the word "compact", so a
+      # bare keyword grep matches it and reports success on a failed run. Fail
+      # explicitly on the error text before checking for evidence of compaction.
+      if grep -qi "error trying to compact" "$OUTPUT"; then
+        echo "✗ FAILED: Compaction was attempted but returned an error"
+        echo "   Output:"
+        cat "$OUTPUT"
+        RESULTS+=("✗ Out-of-Context Test Error (compaction errored)")
+      elif grep -qi "context.*length\|compacting\|compacted\|compaction" "$OUTPUT"; then
         echo "✓ SUCCESS: Out-of-context Test error triggered compaction"
 
         if validate_compaction "$SESSION_ID" "out-of-context error compaction"; then

--- a/ui/desktop/src/components/settings/providers/modal/subcomponents/forms/CustomProviderForm.test.tsx
+++ b/ui/desktop/src/components/settings/providers/modal/subcomponents/forms/CustomProviderForm.test.tsx
@@ -165,6 +165,40 @@ describe('CustomProviderForm transitions', () => {
     expect(screen.queryByText(/Failed to save provider/)).not.toBeInTheDocument();
   });
 
+  it.each([
+    ['anthropic_compatible', 'anthropic_compatible'],
+    ['ollama_compatible', 'ollama_compatible'],
+    ['openai_compatible', 'openai_compatible'],
+    ['anthropic', 'anthropic_compatible'],
+    ['ollama', 'ollama_compatible'],
+    ['openai', 'openai_compatible'],
+  ])('saves a provider stored as %s with engine %s', async (engine, expectedEngine) => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(
+      <CustomProviderForm
+        initialData={{
+          engine,
+          display_name: 'Existing Provider',
+          api_url: 'https://existing.example.com',
+          api_key: '',
+          models: ['model-a'],
+          supports_streaming: true,
+          requires_auth: true,
+        }}
+        isEditable
+        onSubmit={onSubmit}
+        onCancel={vi.fn()}
+      />,
+      { wrapper: IntlTestWrapper }
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Update Provider' }));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledOnce());
+    expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ engine: expectedEngine }));
+  });
+
   it('clears form validation when returning to the setup choice', async () => {
     const user = userEvent.setup();
     renderForm();

--- a/ui/desktop/src/components/settings/providers/modal/subcomponents/forms/CustomProviderForm.tsx
+++ b/ui/desktop/src/components/settings/providers/modal/subcomponents/forms/CustomProviderForm.tsx
@@ -227,6 +227,20 @@ const i18n = defineMessages({
 
 type Step = 'choice' | 'catalog' | 'form';
 
+type ProviderEngine = 'openai_compatible' | 'anthropic_compatible' | 'ollama_compatible';
+
+const ENGINE_ALIASES: Record<string, ProviderEngine> = {
+  openai: 'openai_compatible',
+  openai_compatible: 'openai_compatible',
+  anthropic: 'anthropic_compatible',
+  anthropic_compatible: 'anthropic_compatible',
+  ollama: 'ollama_compatible',
+  ollama_compatible: 'ollama_compatible',
+};
+
+const normalizeEngine = (engine: string): ProviderEngine =>
+  ENGINE_ALIASES[engine.trim().toLowerCase()] ?? 'openai_compatible';
+
 interface CustomProviderFormProps {
   onSubmit: (data: UpdateCustomProviderRequest) => void | Promise<void>;
   onCancel: () => void;
@@ -245,7 +259,12 @@ export default function CustomProviderForm({
   isEditable,
 }: CustomProviderFormProps) {
   const intl = useIntl();
-  const [engine, setEngine] = useState('openai_compatible');
+  const engineOptions: { value: ProviderEngine; label: string }[] = [
+    { value: 'openai_compatible', label: intl.formatMessage(i18n.openaiCompatible) },
+    { value: 'anthropic_compatible', label: intl.formatMessage(i18n.anthropicCompatible) },
+    { value: 'ollama_compatible', label: intl.formatMessage(i18n.ollamaCompatible) },
+  ];
+  const [engine, setEngine] = useState<ProviderEngine>('openai_compatible');
   const [displayName, setDisplayName] = useState('');
   const [apiUrl, setApiUrl] = useState('');
   const [basePath, setBasePath] = useState('');
@@ -284,12 +303,7 @@ export default function CustomProviderForm({
 
   useEffect(() => {
     if (initialData) {
-      const engineMap: Record<string, string> = {
-        openai: 'openai_compatible',
-        anthropic: 'anthropic_compatible',
-        ollama: 'ollama_compatible',
-      };
-      setEngine(engineMap[initialData.engine] || 'openai_compatible');
+      setEngine(normalizeEngine(initialData.engine));
       setDisplayName(initialData.display_name);
       setApiUrl(initialData.api_url);
       setBasePath(initialData.base_path ?? '');
@@ -320,12 +334,7 @@ export default function CustomProviderForm({
     setSupportsStreaming(template.supportsStreaming);
     setRequiresAuth(true);
 
-    const formatToEngine: Record<string, string> = {
-      openai: 'openai_compatible',
-      anthropic: 'anthropic_compatible',
-      ollama: 'ollama_compatible',
-    };
-    setEngine(formatToEngine[template.format] || 'openai_compatible');
+    setEngine(normalizeEngine(template.format));
 
     const templateModels = template.models.filter((m) => !m.deprecated).map((m) => m.id);
     setModels(templateModels.join(', '));
@@ -633,25 +642,10 @@ export default function CustomProviderForm({
             id="provider-select"
             aria-invalid={!!validationErrors.providerType}
             aria-describedby={validationErrors.providerType ? 'provider-select-error' : undefined}
-            options={[
-              { value: 'openai_compatible', label: intl.formatMessage(i18n.openaiCompatible) },
-              {
-                value: 'anthropic_compatible',
-                label: intl.formatMessage(i18n.anthropicCompatible),
-              },
-              { value: 'ollama_compatible', label: intl.formatMessage(i18n.ollamaCompatible) },
-            ]}
-            value={{
-              value: engine,
-              label:
-                engine === 'openai_compatible'
-                  ? intl.formatMessage(i18n.openaiCompatible)
-                  : engine === 'anthropic_compatible'
-                    ? intl.formatMessage(i18n.anthropicCompatible)
-                    : intl.formatMessage(i18n.ollamaCompatible),
-            }}
+            options={engineOptions}
+            value={engineOptions.find((option) => option.value === engine)}
             onChange={(option: unknown) => {
-              const selectedOption = option as { value: string; label: string } | null;
+              const selectedOption = option as { value: ProviderEngine } | null;
               if (selectedOption) setEngine(selectedOption.value);
             }}
             isSearchable={false}


### PR DESCRIPTION
Fixes #11540.

Editing an Anthropic- or Ollama-compatible custom provider and saving it — without touching anything — silently converted it to OpenAI-compatible, while the dropdown displayed "OpenAI Compatible" the whole time.

The read DTO emits `openai_compatible` / `anthropic_compatible` / `ollama_compatible` (`custom_provider_engine_to_dto`, `crates/goose/src/acp/server/providers.rs:281-287`). The form's prefill map was keyed on the bare `openai` / `anthropic` / `ollama`, so **all three keys always missed** and fell through to the `|| 'openai_compatible'` default. `openai_compatible` was accidentally correct, which is why this survived since the feature shipped.

## Changes

- `normalizeEngine` accepts both spellings — exactly the set the backend's `ProviderEngine::from_str` accepts (`crates/goose-providers/src/declarative.rs:103-114`) — and is used for both the edit prefill and the template `format` prefill (`template.format` only ever carries the bare names, via `ProviderFormat::as_str`).
- `engine` is now typed as a `'openai_compatible' | 'anthropic_compatible' | 'ollama_compatible'` union rather than `string`, so the Select options and the state can't drift.
- The Select label is derived from the options array instead of a ternary chain whose final `else` labelled *any* unrecognized engine as "Ollama compatible".

## Verification

Table-driven test on `CustomProviderForm` asserting a no-op save preserves the engine, covering all six accepted spellings. Confirmed by reasoning through the old code that the `anthropic_compatible` and `ollama_compatible` rows **fail** against the pre-change map: `engineMap['anthropic_compatible']` is `undefined` → state becomes `openai_compatible` → `onSubmit` receives `openai_compatible`, and the assertion fails.

I could not execute the suite locally — the npm registry proxy is unreachable from this machine so `node_modules` can't be installed (`ECONNRESET` on every tarball). CI is the executor for the test run; flagging that explicitly rather than implying I ran it.

Also got an independent review of the whole path before pushing, which produced the union-type and Select-label changes above.

## Not in scope

Two lower-severity findings from the same audit are documented in #11540 but not fixed here: empty-valued stored headers are dropped on save, and an `env_vars`-templated `base_url` makes a provider un-editable.

## Issue status

#11540 was filed as part of this turn and is not yet triaged to **Ready** on the board — this is maintainer-directed follow-up from the #11468 investigation, so I've opened the PR alongside it rather than waiting. Happy to hold if you'd rather triage first.


## Also: repair the `Compaction Tests` CI job (supersedes #11544)

The `Compaction Tests` job has failed on every main run since 3a65236210d7 (#10500), which correctly made the summarizer fast-fail instead of silently retrying an identical prompt. TEST 3 was coupled to that internal retry count: it injected 3 context-length errors and relied on the summarizer's removal-percentage loop absorbing two of them.

Fixes, carried here as two commits so the red on this PR is actually resolved rather than explained away:

- Inject exactly **one** error, so the turn completion fails and the summarizer call succeeds — which is what the test's title describes.
- Scope proxy error injection to completion requests only (`COMPLETION_PATHS`); every error mode the proxy offers describes a completion failure, and in count mode injecting into metadata traffic silently spent the error budget.
- Disable session naming in TEST 3: it runs as a background completion spawned at turn start and **raced** the turn completion for the single injected error. The proxy ledger from the failed #11544 run shows the naming request taking the 400 and the turn succeeding with no compaction at all. `GOOSE_DISABLE_SESSION_NAMING=true` makes the turn completion deterministically the first completion the proxy sees.
- Fail explicitly on the "error trying to compact" text before the keyword grep — previously a failed run printed "✓ SUCCESS" right before failing validation.
- Dump the proxy's request ledger on TEST 3 failure so ordering is observable instead of guessed.
