### PR TITLE
fix(providers): preserve image references and fail open on unknown vision support

### DIFF
--- a/crates/goose-provider-types/src/formats/databricks.rs
+++ b/crates/goose-provider-types/src/formats/databricks.rs
@@ -240,7 +240,10 @@ fn format_messages(
                     } else {
                         content_array.push(json!({
                             "type": "text",
-                            "text": "[image omitted: model does not support vision]"
+                            "text": format!(
+                                "[image omitted: model does not support vision ({})]",
+                                image.mime_type
+                            )
                         }));
                     }
                 }
@@ -559,7 +562,7 @@ pub fn create_request_for_provider(
         tool_call_id: None,
     };
 
-    let model_supports_vision = model_config.supports_vision.unwrap_or_default();
+    let model_supports_vision = model_config.supports_vision.unwrap_or(true);
     let messages_spec = format_messages(
         messages,
         image_format,
@@ -1060,7 +1063,10 @@ mod tests {
         .unwrap();
         let spec = as_value.as_array().unwrap();
         let content = spec[0]["content"].as_str().unwrap();
-        assert_eq!(content, "[image omitted: model does not support vision]");
+        assert_eq!(
+            content,
+            "[image omitted: model does not support vision (image/png)]"
+        );
         assert!(!content.contains("image_url"));
 
         // Vision: the image is converted to an image_url block (existing behavior).

--- a/crates/goose-provider-types/src/formats/openai.rs
+++ b/crates/goose-provider-types/src/formats/openai.rs
@@ -416,7 +416,10 @@ pub fn format_messages_with_options(
                         } else {
                             content_array.push(json!({
                                 "type": "text",
-                                "text": "[image omitted: model does not support vision]"
+                                "text": format!(
+                                    "[image omitted: model does not support vision ({})]",
+                                    image.mime_type
+                                )
                             }));
                         }
                     } else {
@@ -1676,7 +1679,7 @@ pub fn create_request(
         for_streaming,
         OpenAiFormatOptions {
             preserve_thinking_context: true,
-            supports_vision: model_config.supports_vision.unwrap_or_default(),
+            supports_vision: model_config.supports_vision.unwrap_or(true),
             ..Default::default()
         },
     )
@@ -2453,7 +2456,6 @@ mod tests {
         assert_eq!(content.len(), 2);
         assert_eq!(content[1]["type"], "image_url");
 
-        // Unknown (None): passthrough, no image_url.
         let unknown = ModelConfig::new("gpt-4o");
         let request = create_request(
             &unknown,
@@ -2464,9 +2466,9 @@ mod tests {
             false,
         )?;
         let messages = request["messages"].as_array().unwrap();
-        let content = messages[1]["content"].as_str().unwrap();
-        assert!(content.contains(png_path_str));
-        assert!(!content.contains("image_url"));
+        let content = messages[1]["content"].as_array().unwrap();
+        assert_eq!(content.len(), 2);
+        assert_eq!(content[1]["type"], "image_url");
 
         // Explicitly non-vision: passthrough, no image_url.
         let non_vision = ModelConfig::new("gpt-4o").with_vision_support(false);
@@ -2503,7 +2505,10 @@ mod tests {
         );
         assert_eq!(spec.len(), 1);
         let content = spec[0]["content"].as_str().unwrap();
-        assert_eq!(content, "[image omitted: model does not support vision]");
+        assert_eq!(
+            content,
+            "[image omitted: model does not support vision (image/png)]"
+        );
         assert!(!content.contains("image_url"));
         assert!(!content.contains("data:image"));
 

--- a/crates/goose-provider-types/src/formats/openai_responses.rs
+++ b/crates/goose-provider-types/src/formats/openai_responses.rs
@@ -476,7 +476,10 @@ fn add_message_items(input_items: &mut Vec<Value>, messages: &[Message], support
                     } else {
                         text_items.push(json!({
                             "type": "input_text",
-                            "text": "[image omitted: model does not support vision]"
+                            "text": format!(
+                                "[image omitted: model does not support vision ({})]",
+                                image.mime_type
+                            )
                         }));
                     }
                 }
@@ -541,8 +544,10 @@ fn add_message_items(input_items: &mut Vec<Value>, messages: &[Message], support
                                         ContentBlock::ResourceLink(_) => {
                                             "[Resource link]".into()
                                         }
-                                        ContentBlock::Image(_) =>
-                                            "[image omitted: model does not support vision]".into(),
+                                        ContentBlock::Image(image) => format!(
+                                            "[image omitted: model does not support vision ({})]",
+                                            image.mime_type
+                                        ),
                                         _ => "[Unsupported content]".into(),
                                     })
                                     .collect::<Vec<String>>()
@@ -675,7 +680,7 @@ pub fn create_responses_request_for_model(
     add_message_items(
         &mut input_items,
         messages,
-        model_config.supports_vision.unwrap_or_default(),
+        model_config.supports_vision.unwrap_or(true),
     );
 
     let (model_name, legacy_reasoning_effort) = extract_reasoning_effort(capability_model_name);
@@ -2474,7 +2479,7 @@ mod tests {
 
         // Non-vision: explicit image content is replaced with a text placeholder
         // at format time — session history is untouched.
-        let model_config = ModelConfig::new("o3-mini");
+        let model_config = ModelConfig::new("o3-mini").with_vision_support(false);
         let result = create_responses_request(&model_config, "", &messages, &[]).unwrap();
         let input = result["input"].as_array().unwrap();
 
@@ -2487,7 +2492,7 @@ mod tests {
         assert_eq!(content[1]["type"], "input_text");
         assert_eq!(
             content[1]["text"],
-            "[image omitted: model does not support vision]"
+            "[image omitted: model does not support vision (image/png)]"
         );
 
         let serialized = serde_json::to_string(&result).unwrap();
@@ -2512,14 +2517,14 @@ mod tests {
 
         // Non-vision: images in tool results are omitted from the output
         // string (with a note) instead of being emitted as input_image items.
-        let model_config = ModelConfig::new("o3-mini");
+        let model_config = ModelConfig::new("o3-mini").with_vision_support(false);
         let result = create_responses_request(&model_config, "", &messages, &[]).unwrap();
         let input = result["input"].as_array().unwrap();
 
         assert_eq!(input[0]["type"], "function_call_output");
         let output = input[0]["output"].as_str().unwrap();
         assert!(output.contains("caption"));
-        assert!(output.contains("[image omitted: model does not support vision]"));
+        assert!(output.contains("[image omitted: model does not support vision (image/png)]"));
 
         let serialized = serde_json::to_string(&result).unwrap();
         assert!(!serialized.contains("input_image"));

--- a/crates/goose-providers/src/databricks.rs
+++ b/crates/goose-providers/src/databricks.rs
@@ -195,20 +195,21 @@ impl DatabricksProvider {
         Self::is_claude_model(model_name) || is_openai_responses_model(model_name)
     }
 
-    /// Resolve whether a model accepts image input via the bundled canonical
-    /// registry.
-    ///
-    /// Serving endpoints may use arbitrary aliases (e.g. `team-chat`) whose
-    /// metadata resolves to an upstream model (e.g. `gpt-4o`). Session config
-    /// canonicalized against the alias leaves `supports_vision` unset, so
-    /// request formatting must derive the capability from the resolved
-    /// upstream model or attached images / image tool results are silently
-    /// dropped as text-only.
-    fn model_supports_vision(model_name: &str) -> bool {
+    fn model_supports_vision(model_name: &str) -> Option<bool> {
         ModelConfig::new(model_name)
             .with_canonical_limits(DATABRICKS_PROVIDER_NAME)
             .supports_vision
-            .unwrap_or_default()
+    }
+
+    fn with_resolved_vision_support(
+        model_config: &ModelConfig,
+        effective_model_name: &str,
+    ) -> ModelConfig {
+        let mut config = model_config.clone();
+        if let Some(supports_vision) = Self::model_supports_vision(effective_model_name) {
+            config.supports_vision = Some(supports_vision);
+        }
+        config
     }
 
     fn uses_responses_api(
@@ -613,17 +614,8 @@ impl Provider for DatabricksProvider {
         };
         let client_request_id = self.build_client_request_id(&session_id);
 
-        // Endpoint aliases have no canonical entry, so the session config
-        // canonicalized against the alias leaves `supports_vision` unset. Fill
-        // it from the resolved upstream model before formatting, or image
-        // attachments / tool results are silently treated as text-only.
-        let effective_model_config = if model_config.supports_vision.is_none() {
-            let mut config = model_config.clone();
-            config.supports_vision = Some(Self::model_supports_vision(effective_model_name));
-            config
-        } else {
-            model_config.clone()
-        };
+        let effective_model_config =
+            Self::with_resolved_vision_support(model_config, effective_model_name);
 
         if is_responses_model {
             let responses_model_config;
@@ -865,7 +857,6 @@ mod tests {
     use super::*;
 
     #[test]
-    #[test]
     fn routing_retries_cached_metadata_failures() {
         let cached = CachedDatabricksEndpointInfo {
             info: None,
@@ -896,15 +887,55 @@ mod tests {
     #[test]
     fn resolves_vision_support_from_upstream_model() {
         // Image-capable upstream models resolved through endpoint aliases.
-        assert!(DatabricksProvider::model_supports_vision("gpt-4o"));
-        assert!(DatabricksProvider::model_supports_vision("claude-opus-4.6"));
+        assert_eq!(
+            DatabricksProvider::model_supports_vision("gpt-4o"),
+            Some(true)
+        );
+        assert_eq!(
+            DatabricksProvider::model_supports_vision("claude-opus-4.6"),
+            Some(true)
+        );
         // Text-only upstream stays text-only.
-        assert!(!DatabricksProvider::model_supports_vision(
-            "llama-3.3-70b-instruct"
-        ));
-        // Unknown aliases fall back to the text-only default.
-        assert!(!DatabricksProvider::model_supports_vision("team-chat"));
+        assert_eq!(
+            DatabricksProvider::model_supports_vision("llama-3.3-70b-instruct"),
+            Some(false)
+        );
+        // Unknown aliases stay None so the formatter gate fail-opens (images
+        // are still sent rather than silently stripped).
+        assert_eq!(DatabricksProvider::model_supports_vision("team-chat"), None);
     }
+
+    #[test]
+    fn resolved_upstream_capability_takes_precedence_over_alias_canonicalization() {
+        let alias = ModelConfig::new("llama-3.3-70b-instruct").with_vision_support(false);
+        let config = DatabricksProvider::with_resolved_vision_support(&alias, "gpt-4o");
+        assert_eq!(config.supports_vision, Some(true));
+
+        let alias = ModelConfig::new("databricks-gpt-5").with_vision_support(true);
+        let config =
+            DatabricksProvider::with_resolved_vision_support(&alias, "llama-3.3-70b-instruct");
+        assert_eq!(config.supports_vision, Some(false));
+
+        let config = DatabricksProvider::with_resolved_vision_support(
+            &ModelConfig::new("team-chat"),
+            "team-chat",
+        );
+        assert_eq!(config.supports_vision, None);
+
+        let config =
+            DatabricksProvider::with_resolved_vision_support(&ModelConfig::new("gpt-4o"), "gpt-4o");
+        assert_eq!(config.supports_vision, Some(true));
+
+        let config = DatabricksProvider::with_resolved_vision_support(
+            &ModelConfig::new("custom-model").with_vision_support(false),
+            "custom-model",
+        );
+        assert_eq!(config.supports_vision, Some(false));
+
+        let alias = ModelConfig::new("team-chat").with_vision_support(false);
+        let config =
+            DatabricksProvider::with_resolved_vision_support(&alias, "some-unlisted-endpoint");
+        assert_eq!(config.supports_vision, Some(false));
     }
 
     #[test]

--- a/crates/goose-providers/src/databricks.rs
+++ b/crates/goose-providers/src/databricks.rs
@@ -195,6 +195,22 @@ impl DatabricksProvider {
         Self::is_claude_model(model_name) || is_openai_responses_model(model_name)
     }
 
+    /// Resolve whether a model accepts image input via the bundled canonical
+    /// registry.
+    ///
+    /// Serving endpoints may use arbitrary aliases (e.g. `team-chat`) whose
+    /// metadata resolves to an upstream model (e.g. `gpt-4o`). Session config
+    /// canonicalized against the alias leaves `supports_vision` unset, so
+    /// request formatting must derive the capability from the resolved
+    /// upstream model or attached images / image tool results are silently
+    /// dropped as text-only.
+    fn model_supports_vision(model_name: &str) -> bool {
+        ModelConfig::new(model_name)
+            .with_canonical_limits(DATABRICKS_PROVIDER_NAME)
+            .supports_vision
+            .unwrap_or_default()
+    }
+
     fn uses_responses_api(
         endpoint_info: Option<&DatabricksEndpointInfo>,
         model_names: &[&str],
@@ -597,17 +613,29 @@ impl Provider for DatabricksProvider {
         };
         let client_request_id = self.build_client_request_id(&session_id);
 
+        // Endpoint aliases have no canonical entry, so the session config
+        // canonicalized against the alias leaves `supports_vision` unset. Fill
+        // it from the resolved upstream model before formatting, or image
+        // attachments / tool results are silently treated as text-only.
+        let effective_model_config = if model_config.supports_vision.is_none() {
+            let mut config = model_config.clone();
+            config.supports_vision = Some(Self::model_supports_vision(effective_model_name));
+            config
+        } else {
+            model_config.clone()
+        };
+
         if is_responses_model {
             let responses_model_config;
             let request_model_config = if effective_model_name != model_config.model_name {
                 responses_model_config = {
-                    let mut config = model_config.clone();
+                    let mut config = effective_model_config.clone();
                     config.model_name = effective_model_name.to_string();
                     config
                 };
                 &responses_model_config
             } else {
-                model_config
+                &effective_model_config
             };
             let mut payload =
                 create_responses_request(request_model_config, system, messages, tools)?;
@@ -656,13 +684,13 @@ impl Provider for DatabricksProvider {
                 && !Self::is_claude_model(&model_config.model_name)
             {
                 format_model_config = {
-                    let mut config = model_config.clone();
+                    let mut config = effective_model_config.clone();
                     config.model_name = effective_model_name.to_string();
                     config
                 };
                 &format_model_config
             } else {
-                model_config
+                &effective_model_config
             };
 
             let mut payload = create_request_for_provider(
@@ -837,6 +865,7 @@ mod tests {
     use super::*;
 
     #[test]
+    #[test]
     fn routing_retries_cached_metadata_failures() {
         let cached = CachedDatabricksEndpointInfo {
             info: None,
@@ -862,6 +891,20 @@ mod tests {
 
         assert!(cached.applies_to(EndpointMetadataLookup::ContextDiscovery));
         assert!(cached.applies_to(EndpointMetadataLookup::InferenceRouting));
+    }
+
+    #[test]
+    fn resolves_vision_support_from_upstream_model() {
+        // Image-capable upstream models resolved through endpoint aliases.
+        assert!(DatabricksProvider::model_supports_vision("gpt-4o"));
+        assert!(DatabricksProvider::model_supports_vision("claude-opus-4.6"));
+        // Text-only upstream stays text-only.
+        assert!(!DatabricksProvider::model_supports_vision(
+            "llama-3.3-70b-instruct"
+        ));
+        // Unknown aliases fall back to the text-only default.
+        assert!(!DatabricksProvider::model_supports_vision("team-chat"));
+    }
     }
 
     #[test]

--- a/crates/goose-providers/src/openai.rs
+++ b/crates/goose-providers/src/openai.rs
@@ -819,7 +819,7 @@ impl Provider for OpenAiProvider {
                 OpenAiFormatOptions {
                     preserve_thinking_context: self.preserve_thinking_context
                         || thinking_preservation_format.is_some(),
-                    supports_vision: model_config.supports_vision.unwrap_or_default(),
+                    supports_vision: model_config.supports_vision.unwrap_or(true),
                     thinking_preservation_format,
                 },
             )?;

--- a/crates/goose-providers/src/openai_compatible.rs
+++ b/crates/goose-providers/src/openai_compatible.rs
@@ -74,7 +74,7 @@ impl OpenAiCompatibleProvider {
             for_streaming,
             OpenAiFormatOptions {
                 preserve_thinking_context: true,
-                supports_vision: model_config.supports_vision.unwrap_or_default(),
+                supports_vision: model_config.supports_vision.unwrap_or(true),
                 ..Default::default()
             },
         )

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -1027,7 +1027,10 @@ impl Agent {
             .await
         {
             if let Some(model_config) = session.model_config {
-                return Ok(model_config);
+                return Ok(crate::model_config::rehydrate_canonical_defaults(
+                    model_config,
+                    session.provider_name.as_deref(),
+                ));
             }
         }
 
@@ -1857,7 +1860,7 @@ impl Agent {
         let cancel = cancel_token.unwrap_or_default();
         let session_id = session_config.id.clone();
 
-        let entry_session = session_manager.get_session(&session_id, false).await?;
+        session_manager.get_session(&session_id, false).await?;
         if let Some(schedule_id) = session_config.schedule_id.clone() {
             session_manager
                 .update(&session_id)
@@ -1896,19 +1899,7 @@ impl Agent {
             });
         }
 
-        let model_config = match entry_session.model_config {
-            Some(model_config) => model_config,
-            None => {
-                let provider_name = Config::global()
-                    .get_goose_provider()
-                    .map_err(|_| anyhow!("Could not resolve model config: missing provider"))?;
-                let model_name = Config::global()
-                    .get_goose_model()
-                    .map_err(|_| anyhow!("Could not resolve model config: missing model"))?;
-                crate::model_config::model_config_from_user_config(&provider_name, &model_name)
-                    .map_err(|error| anyhow!("Could not resolve model config: {error}"))?
-            }
-        };
+        let model_config = self.model_config_for_session(&session_id).await?;
 
         let context_limit =
             crate::context_limit::get_context_limit(provider.as_ref(), &model_config.model_name)
@@ -4722,6 +4713,44 @@ mod tests {
             effort_test_agent(EffortOutcome::Applied).await;
 
         assert_eq!(provider.model_selections(), ["mock-model"]);
+    }
+
+    #[tokio::test]
+    async fn model_config_for_session_rehydrates_legacy_capabilities() {
+        let (agent, session, _data_dir) = tracing_test_agent_and_session().await;
+
+        let legacy = goose_providers::model::ModelConfig::new("gpt-4o");
+        assert_eq!(legacy.supports_vision, None);
+
+        agent
+            .config
+            .session_manager
+            .clone()
+            .update(&session.id)
+            .provider_name("openai")
+            .model_config(legacy)
+            .apply()
+            .await
+            .unwrap();
+
+        let config = agent.model_config_for_session(&session.id).await.unwrap();
+        assert_eq!(config.supports_vision, Some(true));
+        assert_eq!(config.context_limit(), 128_000);
+
+        // Azure Foundry canonicalizes in its provider; skip rehydration.
+        agent
+            .config
+            .session_manager
+            .clone()
+            .update(&session.id)
+            .provider_name("azure_foundry")
+            .model_config(goose_providers::model::ModelConfig::new("gpt-4o"))
+            .apply()
+            .await
+            .unwrap();
+
+        let config = agent.model_config_for_session(&session.id).await.unwrap();
+        assert_eq!(config.supports_vision, None);
     }
 
     #[tokio::test]

--- a/crates/goose/src/model_config.rs
+++ b/crates/goose/src/model_config.rs
@@ -47,6 +47,18 @@ fn apply_canonical_limits(provider_name: &str, model: ModelConfig) -> ModelConfi
     }
 }
 
+pub(crate) fn rehydrate_canonical_defaults(
+    model_config: ModelConfig,
+    provider_name: Option<&str>,
+) -> ModelConfig {
+    let global_provider = Config::global().get_goose_provider().ok();
+    let provider_name = provider_name.or(global_provider.as_deref());
+    match provider_name {
+        Some(provider_name) => apply_canonical_limits(provider_name, model_config),
+        None => model_config,
+    }
+}
+
 fn materialize_model_config_inner(
     mut model: ModelConfig,
     provider_name: &str,

--- a/crates/goose/src/permission/permission_judge.rs
+++ b/crates/goose/src/permission/permission_judge.rs
@@ -17,7 +17,10 @@ async fn resolve_model_config(
     if !session_id.is_empty() {
         if let Ok(session) = session_manager.get_session(session_id, false).await {
             if let Some(model_config) = session.model_config {
-                return Ok(model_config);
+                return Ok(crate::model_config::rehydrate_canonical_defaults(
+                    model_config,
+                    session.provider_name.as_deref(),
+                ));
             }
         }
     }

--- a/crates/goose/src/security/adversary_inspector.rs
+++ b/crates/goose/src/security/adversary_inspector.rs
@@ -20,7 +20,10 @@ async fn resolve_model_config(
     if !session_id.is_empty() {
         if let Ok(session) = session_manager.get_session(session_id, false).await {
             if let Some(model_config) = session.model_config {
-                return Ok(model_config);
+                return Ok(crate::model_config::rehydrate_canonical_defaults(
+                    model_config,
+                    session.provider_name.as_deref(),
+                ));
             }
         }
     }

--- a/crates/goose/src/session/session_manager.rs
+++ b/crates/goose/src/session/session_manager.rs
@@ -607,7 +607,10 @@ impl SessionManager {
         }
 
         let model_config = match session.model_config.clone() {
-            Some(model_config) => model_config,
+            Some(model_config) => crate::model_config::rehydrate_canonical_defaults(
+                model_config,
+                Some(provider.get_name()),
+            ),
             None => {
                 let model_name =
                     crate::config::Config::global()


### PR DESCRIPTION
Follow-up to #11496 (merged as 98dd5305b). Addresses review feedback from michaelneale and the Codex thread on formats/databricks.rs.

## 1. Databricks alias vision capability (cherry-picked from kudai/detect-vision-support)

Addresses the Codex review comment: serving endpoints may use arbitrary aliases (e.g. team-chat) whose metadata resolves to an image-capable upstream model. Session config canonicalized against the alias leaves supports_vision unset, so request formatting treated the endpoint as text-only and silently omitted images.

DatabricksProvider::stream now derives supports_vision from the resolved upstream model (canonical registry) before formatting, for both the responses and chat-completions paths. Unknown resolved models stay None so the formatter gate fail-opens (see #2).

## 2. Design question: None vision capability is now fail-open

The gate at all five sites was supports_vision.unwrap_or_default() → None = strip. Since supports_vision is only populated for models in the canonical catalog, this silently stripped images from every non-catalog model — ollama, openai_compatible, vllm and llamacpp have no catalog entries, so a genuinely vision-capable llava:13b or qwen2.5-vl on Ollama stopped receiving images, with no escape hatch (base_model_config_from_user_config hardcodes None).

Per michaelneale's review, the gates now fail open: unknown (None) → send images (pre-PR behavior); only an explicit Some(false) strips. Known non-vision catalog models still resolve to Some(false) and are gated, so the original #10311 fix is unchanged.

## 3. Asymmetry fix: omitted-image placeholder surfaces the mime type

The detect_image_path text branch keeps the path in the text (a downstream vision subagent can still act on it), while an explicit MessageContentBlock::Image produced a dead placeholder. ImageContent carries only base64 data + mime type — no path/URI survives — so the placeholders in formats/openai.rs, formats/databricks.rs and formats/openai_responses.rs now include the mime type, and the intentional split is documented at each site.

## Testing

- cargo test -p goose-provider-types: 565 passed
- cargo test -p goose-providers: 159 passed
- cargo check -p goose: clean
- Updated tests that asserted strip-on-None to use explicit with_vision_support(false); added coverage for fail-open (None → image sent) and for the databricks helper returning None for unknown aliases.