### PR TITLE
Warn when reasoning consumes the output-token budget

### DIFF
--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -1521,6 +1521,7 @@ impl CliSession {
         let mut markdown_buffer = streaming_buffer::MarkdownBuffer::new();
         let mut prompted_credits_urls: HashSet<String> = HashSet::new();
         let mut thinking_header_shown = false;
+        let mut output_limit_state = output::OutputLimitRenderState::default();
         let run_started = Instant::now();
         let mut first_token_at: Option<Instant> = None;
         let mut last_usage: Option<ProviderUsage> = None;
@@ -1649,7 +1650,7 @@ impl CliSession {
                                 if is_stream_json_mode {
                                     emit_stream_event(&StreamEvent::Message { message: message.clone() });
                                 } else if !is_json_mode {
-                                    output::render_message_streaming(&message, &mut markdown_buffer, &mut thinking_header_shown, self.debug);
+                                    output::render_message_streaming(&message, &mut markdown_buffer, &mut thinking_header_shown, &mut output_limit_state, self.debug);
                                     maybe_open_credits_top_up_url(
                                         &message,
                                         interactive,

--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -1975,9 +1975,9 @@ impl CliSession {
             console::style(format!("{} messages restored", messages.len())).dim()
         );
 
-        // Render each message
-        for message in &messages {
-            output::render_message(message, self.debug);
+        let mut output_limit_state = output::OutputLimitRenderState::default();
+        for message in self.messages.iter() {
+            output::render_message_with_state(message, self.debug, &mut output_limit_state);
         }
 
         println!();

--- a/crates/goose-cli/src/session/output.rs
+++ b/crates/goose-cli/src/session/output.rs
@@ -312,7 +312,6 @@ pub fn render_message(message: &Message, debug: bool) {
 /// and only render when markdown constructs are complete.
 #[derive(Debug, Default)]
 pub struct OutputLimitRenderState {
-    message_id: Option<String>,
     saw_thinking: bool,
     saw_visible_output: bool,
     response_complete: bool,
@@ -320,18 +319,11 @@ pub struct OutputLimitRenderState {
 
 impl OutputLimitRenderState {
     pub fn observe(&mut self, message: &Message) {
-        let incoming = provider_completion_id(message);
-        let new_provider_response =
-            incoming.is_some_and(|id| self.message_id.as_deref() != Some(id));
-        let new_idless_response =
-            incoming.is_none() && message.has_thinking_content() && self.saw_visible_output;
-        if new_provider_response || self.response_complete || new_idless_response {
+        let new_response_after_visible = message.has_thinking_content() && self.saw_visible_output;
+        if self.response_complete || new_response_after_visible {
             self.saw_thinking = false;
             self.saw_visible_output = false;
             self.response_complete = false;
-        }
-        if let Some(id) = incoming {
-            self.message_id = Some(id.to_string());
         }
         self.saw_thinking |= message.has_thinking_content();
         self.saw_visible_output |= message.has_visible_output();
@@ -452,10 +444,6 @@ pub fn render_message_streaming(
 
 fn reached_output_token_limit(message: &Message) -> bool {
     message.role == Role::Assistant && message.metadata.output_token_limit_reached
-}
-
-fn provider_completion_id(message: &Message) -> Option<&str> {
-    message.id.as_deref().filter(|id| !id.starts_with("msg_"))
 }
 
 fn output_token_limit_warning(message: &Message) -> &'static str {
@@ -1887,10 +1875,10 @@ mod tests {
     }
 
     #[test]
-    fn streamed_output_limit_warning_resets_when_message_id_changes() {
+    fn streamed_output_limit_warning_keeps_thinking_across_distinct_chunk_ids() {
         let thinking = Message::assistant()
             .with_id("chatcmpl-1")
-            .with_thinking("previous turn reasoning", "");
+            .with_thinking("I will reason until the budget runs out.", "");
         let mut marker = Message::assistant().with_id("chatcmpl-2");
         marker.metadata.output_token_limit_reached = true;
 
@@ -1898,7 +1886,30 @@ mod tests {
         state.observe(&thinking);
         state.observe(&marker);
 
-        assert_eq!(state.warning(&marker), EMPTY_OUTPUT_TOKEN_LIMIT_WARNING);
+        assert_eq!(state.warning(&marker), REASONING_OUTPUT_TOKEN_LIMIT_WARNING);
+    }
+
+    #[test]
+    fn streamed_output_limit_warning_resets_when_new_thinking_follows_visible_output() {
+        let thinking = Message::assistant()
+            .with_id("chatcmpl-1")
+            .with_thinking("previous turn reasoning", "");
+        let visible = Message::assistant()
+            .with_id("chatcmpl-1")
+            .with_text("previous turn answer");
+        let next_thinking = Message::assistant()
+            .with_id("chatcmpl-2")
+            .with_thinking("next turn reasoning", "");
+        let mut marker = Message::assistant().with_id("chatcmpl-2");
+        marker.metadata.output_token_limit_reached = true;
+
+        let mut state = OutputLimitRenderState::default();
+        state.observe(&thinking);
+        state.observe(&visible);
+        state.observe(&next_thinking);
+        state.observe(&marker);
+
+        assert_eq!(state.warning(&marker), REASONING_OUTPUT_TOKEN_LIMIT_WARNING);
     }
 
     #[test]

--- a/crates/goose-cli/src/session/output.rs
+++ b/crates/goose-cli/src/session/output.rs
@@ -319,14 +319,12 @@ pub struct OutputLimitRenderState {
 
 impl OutputLimitRenderState {
     pub fn observe(&mut self, message: &Message) {
-        if let (Some(current), Some(incoming)) = (&self.message_id, &message.id) {
-            if current != incoming {
+        if let Some(incoming) = provider_completion_id(message) {
+            if self.message_id.as_deref() != Some(incoming) {
+                self.message_id = Some(incoming.to_string());
                 self.saw_thinking = false;
                 self.saw_visible_output = false;
             }
-        }
-        if message.id.is_some() {
-            self.message_id = message.id.clone();
         }
         self.saw_thinking |= message.has_thinking_content();
         self.saw_visible_output |= message.has_visible_output();
@@ -445,6 +443,10 @@ pub fn render_message_streaming(
 
 fn reached_output_token_limit(message: &Message) -> bool {
     message.role == Role::Assistant && message.metadata.output_token_limit_reached
+}
+
+fn provider_completion_id(message: &Message) -> Option<&str> {
+    message.id.as_deref().filter(|id| !id.starts_with("msg_"))
 }
 
 fn output_token_limit_warning(message: &Message) -> &'static str {
@@ -1888,6 +1890,23 @@ mod tests {
         state.observe(&marker);
 
         assert_eq!(state.warning(&marker), EMPTY_OUTPUT_TOKEN_LIMIT_WARNING);
+    }
+
+    #[test]
+    fn streamed_output_limit_warning_keeps_thinking_across_generated_ids() {
+        let thinking = Message::assistant()
+            .with_generated_id()
+            .with_thinking("I will reason until the budget runs out.", "");
+        let mut marker = Message::assistant().with_generated_id();
+        marker.metadata.output_token_limit_reached = true;
+
+        let mut state = OutputLimitRenderState::default();
+        state.observe(&thinking);
+        state.observe(&marker);
+
+        assert_eq!(state.warning(&marker), REASONING_OUTPUT_TOKEN_LIMIT_WARNING);
+        assert_ne!(thinking.id, marker.id);
+        assert!(thinking.id.as_deref().unwrap().starts_with("msg_"));
     }
 
     #[test]

--- a/crates/goose-cli/src/session/output.rs
+++ b/crates/goose-cli/src/session/output.rs
@@ -28,6 +28,10 @@ pub const DEFAULT_CLI_LIGHT_THEME: &str = "GitHub";
 pub const DEFAULT_CLI_DARK_THEME: &str = "zenburn";
 const OUTPUT_TOKEN_LIMIT_WARNING: &str =
     "Warning: Response reached the model's output-token limit and may be incomplete.";
+const EMPTY_OUTPUT_TOKEN_LIMIT_WARNING: &str =
+    "Warning: Response reached the model's output-token limit before returning content.";
+const REASONING_OUTPUT_TOKEN_LIMIT_WARNING: &str =
+    "Warning: Reasoning consumed the model's output-token budget before any visible content was produced. Raise GOOSE_MAX_TOKENS or lower GOOSE_THINKING_EFFORT.";
 
 fn accent<T: Display>(value: T) -> StyledObject<T> {
     style(value).cyan()
@@ -299,7 +303,7 @@ pub fn render_message(message: &Message, debug: bool) {
     }
 
     if reached_output_token_limit(&message) {
-        render_output_token_limit_warning();
+        render_output_token_limit_warning(&message);
     }
     let _ = std::io::stdout().flush();
 }
@@ -401,7 +405,7 @@ pub fn render_message_streaming(
 
     if reached_output_token_limit(&message) {
         flush_markdown_buffer(buffer, theme);
-        render_output_token_limit_warning();
+        render_output_token_limit_warning(&message);
     }
     let _ = std::io::stdout().flush();
 }
@@ -410,8 +414,18 @@ fn reached_output_token_limit(message: &Message) -> bool {
     message.role == Role::Assistant && message.metadata.output_token_limit_reached
 }
 
-fn render_output_token_limit_warning() {
-    println!("\n{}", warning(OUTPUT_TOKEN_LIMIT_WARNING));
+fn output_token_limit_warning(message: &Message) -> &'static str {
+    if message.reasoning_consumed_output_budget() {
+        REASONING_OUTPUT_TOKEN_LIMIT_WARNING
+    } else if !message.has_visible_output() {
+        EMPTY_OUTPUT_TOKEN_LIMIT_WARNING
+    } else {
+        OUTPUT_TOKEN_LIMIT_WARNING
+    }
+}
+
+fn render_output_token_limit_warning(message: &Message) {
+    println!("\n{}", warning(output_token_limit_warning(message)));
 }
 
 fn render_credits_exhausted_notification(notification: &SystemNotificationContent) {
@@ -1751,6 +1765,36 @@ mod tests {
         assert_eq!(
             get_credits_top_up_url(&message).as_deref(),
             Some("https://router.tetrate.ai/billing")
+        );
+    }
+
+    #[test]
+    fn output_token_limit_warning_is_generic_when_content_is_present() {
+        let mut message = Message::assistant().with_text("Partial answer");
+        message.metadata.output_token_limit_reached = true;
+        assert_eq!(
+            output_token_limit_warning(&message),
+            OUTPUT_TOKEN_LIMIT_WARNING
+        );
+    }
+
+    #[test]
+    fn output_token_limit_warning_is_empty_when_no_content_is_present() {
+        let mut message = Message::assistant();
+        message.metadata.output_token_limit_reached = true;
+        assert_eq!(
+            output_token_limit_warning(&message),
+            EMPTY_OUTPUT_TOKEN_LIMIT_WARNING
+        );
+    }
+
+    #[test]
+    fn output_token_limit_warning_names_reasoning_when_content_is_empty() {
+        let mut message = Message::assistant().with_thinking("internal reasoning", "");
+        message.metadata.output_token_limit_reached = true;
+        assert_eq!(
+            output_token_limit_warning(&message),
+            REASONING_OUTPUT_TOKEN_LIMIT_WARNING
         );
     }
 

--- a/crates/goose-cli/src/session/output.rs
+++ b/crates/goose-cli/src/session/output.rs
@@ -319,16 +319,14 @@ pub struct OutputLimitRenderState {
 
 impl OutputLimitRenderState {
     pub fn observe(&mut self, message: &Message) {
-        let new_response_after_visible = message.has_thinking_content() && self.saw_visible_output;
-        if self.response_complete || new_response_after_visible {
+        if self.response_complete {
             self.saw_thinking = false;
             self.saw_visible_output = false;
             self.response_complete = false;
         }
         self.saw_thinking |= message.has_thinking_content();
         self.saw_visible_output |= message.has_visible_output();
-        self.response_complete =
-            message.is_tool_call() || message.metadata.output_token_limit_reached;
+        self.response_complete = message.is_tool_call();
     }
 
     fn warning(&self, message: &Message) -> &'static str {
@@ -1843,6 +1841,16 @@ mod tests {
     }
 
     #[test]
+    fn output_token_limit_warning_ignores_empty_thinking_blocks() {
+        let mut message = Message::assistant().with_thinking("", "");
+        message.metadata.output_token_limit_reached = true;
+        assert_eq!(
+            output_token_limit_warning(&message),
+            EMPTY_OUTPUT_TOKEN_LIMIT_WARNING
+        );
+    }
+
+    #[test]
     fn streamed_output_limit_warning_uses_prior_thinking_for_same_message_id() {
         let thinking = Message::assistant()
             .with_id("chatcmpl-reason-limit")
@@ -1890,26 +1898,20 @@ mod tests {
     }
 
     #[test]
-    fn streamed_output_limit_warning_resets_when_new_thinking_follows_visible_output() {
+    fn streamed_output_limit_warning_keeps_visible_output_when_reasoning_follows() {
+        let visible = Message::assistant().with_id("chatcmpl-1").with_text("Hi");
         let thinking = Message::assistant()
             .with_id("chatcmpl-1")
-            .with_thinking("previous turn reasoning", "");
-        let visible = Message::assistant()
-            .with_id("chatcmpl-1")
-            .with_text("previous turn answer");
-        let next_thinking = Message::assistant()
-            .with_id("chatcmpl-2")
-            .with_thinking("next turn reasoning", "");
-        let mut marker = Message::assistant().with_id("chatcmpl-2");
+            .with_thinking("structured reasoning", "");
+        let mut marker = Message::assistant().with_id("chatcmpl-1");
         marker.metadata.output_token_limit_reached = true;
 
         let mut state = OutputLimitRenderState::default();
-        state.observe(&thinking);
         state.observe(&visible);
-        state.observe(&next_thinking);
+        state.observe(&thinking);
         state.observe(&marker);
 
-        assert_eq!(state.warning(&marker), REASONING_OUTPUT_TOKEN_LIMIT_WARNING);
+        assert_eq!(state.warning(&marker), OUTPUT_TOKEN_LIMIT_WARNING);
     }
 
     #[test]

--- a/crates/goose-cli/src/session/output.rs
+++ b/crates/goose-cli/src/session/output.rs
@@ -310,10 +310,42 @@ pub fn render_message(message: &Message, debug: bool) {
 
 /// Render a streaming message, using a buffer to accumulate text content
 /// and only render when markdown constructs are complete.
+#[derive(Debug, Default)]
+pub struct OutputLimitRenderState {
+    message_id: Option<String>,
+    saw_thinking: bool,
+    saw_visible_output: bool,
+}
+
+impl OutputLimitRenderState {
+    pub fn observe(&mut self, message: &Message) {
+        if let (Some(current), Some(incoming)) = (&self.message_id, &message.id) {
+            if current != incoming {
+                self.saw_thinking = false;
+                self.saw_visible_output = false;
+            }
+        }
+        if message.id.is_some() {
+            self.message_id = message.id.clone();
+        }
+        self.saw_thinking |= message.has_thinking_content();
+        self.saw_visible_output |= message.has_visible_output();
+    }
+
+    fn warning(&self, message: &Message) -> &'static str {
+        output_token_limit_warning_parts(
+            message.metadata.output_token_limit_reached,
+            self.saw_thinking,
+            self.saw_visible_output,
+        )
+    }
+}
+
 pub fn render_message_streaming(
     message: &Message,
     buffer: &mut MarkdownBuffer,
     thinking_header_shown: &mut bool,
+    output_limit_state: &mut OutputLimitRenderState,
     debug: bool,
 ) {
     if !message.is_user_visible() {
@@ -403,9 +435,10 @@ pub fn render_message_streaming(
         }
     }
 
+    output_limit_state.observe(&message);
     if reached_output_token_limit(&message) {
         flush_markdown_buffer(buffer, theme);
-        render_output_token_limit_warning(&message);
+        println!("\n{}", warning(output_limit_state.warning(&message)));
     }
     let _ = std::io::stdout().flush();
 }
@@ -415,9 +448,21 @@ fn reached_output_token_limit(message: &Message) -> bool {
 }
 
 fn output_token_limit_warning(message: &Message) -> &'static str {
-    if message.reasoning_consumed_output_budget() {
+    output_token_limit_warning_parts(
+        message.metadata.output_token_limit_reached,
+        message.has_thinking_content(),
+        message.has_visible_output(),
+    )
+}
+
+fn output_token_limit_warning_parts(
+    output_token_limit_reached: bool,
+    has_thinking: bool,
+    has_visible_output: bool,
+) -> &'static str {
+    if output_token_limit_reached && has_thinking && !has_visible_output {
         REASONING_OUTPUT_TOKEN_LIMIT_WARNING
-    } else if !message.has_visible_output() {
+    } else if output_token_limit_reached && !has_visible_output {
         EMPTY_OUTPUT_TOKEN_LIMIT_WARNING
     } else {
         OUTPUT_TOKEN_LIMIT_WARNING
@@ -1796,6 +1841,53 @@ mod tests {
             output_token_limit_warning(&message),
             REASONING_OUTPUT_TOKEN_LIMIT_WARNING
         );
+    }
+
+    #[test]
+    fn streamed_output_limit_warning_uses_prior_thinking_for_same_message_id() {
+        let thinking = Message::assistant()
+            .with_id("chatcmpl-reason-limit")
+            .with_thinking("I will reason until the budget runs out.", "");
+        let mut marker = Message::assistant().with_id("chatcmpl-reason-limit");
+        marker.metadata.output_token_limit_reached = true;
+
+        let mut state = OutputLimitRenderState::default();
+        state.observe(&thinking);
+        state.observe(&marker);
+
+        assert_eq!(state.warning(&marker), REASONING_OUTPUT_TOKEN_LIMIT_WARNING);
+    }
+
+    #[test]
+    fn streamed_output_limit_warning_stays_generic_when_visible_content_arrives() {
+        let thinking = Message::assistant()
+            .with_id("chatcmpl-partial")
+            .with_thinking("internal reasoning", "");
+        let mut partial = Message::assistant()
+            .with_id("chatcmpl-partial")
+            .with_text("Partial answer");
+        partial.metadata.output_token_limit_reached = true;
+
+        let mut state = OutputLimitRenderState::default();
+        state.observe(&thinking);
+        state.observe(&partial);
+
+        assert_eq!(state.warning(&partial), OUTPUT_TOKEN_LIMIT_WARNING);
+    }
+
+    #[test]
+    fn streamed_output_limit_warning_resets_when_message_id_changes() {
+        let thinking = Message::assistant()
+            .with_id("chatcmpl-1")
+            .with_thinking("previous turn reasoning", "");
+        let mut marker = Message::assistant().with_id("chatcmpl-2");
+        marker.metadata.output_token_limit_reached = true;
+
+        let mut state = OutputLimitRenderState::default();
+        state.observe(&thinking);
+        state.observe(&marker);
+
+        assert_eq!(state.warning(&marker), EMPTY_OUTPUT_TOKEN_LIMIT_WARNING);
     }
 
     #[test]

--- a/crates/goose-cli/src/session/output.rs
+++ b/crates/goose-cli/src/session/output.rs
@@ -243,7 +243,17 @@ pub fn set_thinking_message(s: &String) {
 }
 
 pub fn render_message(message: &Message, debug: bool) {
+    let mut output_limit_state = OutputLimitRenderState::default();
+    render_message_with_state(message, debug, &mut output_limit_state);
+}
+
+pub fn render_message_with_state(
+    message: &Message,
+    debug: bool,
+    output_limit_state: &mut OutputLimitRenderState,
+) {
     if !message.is_user_visible() {
+        output_limit_state.observe(message);
         return;
     }
     let message = message.user_visible_content();
@@ -302,8 +312,9 @@ pub fn render_message(message: &Message, debug: bool) {
         }
     }
 
+    output_limit_state.observe(&message);
     if reached_output_token_limit(&message) {
-        render_output_token_limit_warning(&message);
+        println!("\n{}", warning(output_limit_state.warning(&message)));
     }
     let _ = std::io::stdout().flush();
 }
@@ -319,6 +330,12 @@ pub struct OutputLimitRenderState {
 
 impl OutputLimitRenderState {
     pub fn observe(&mut self, message: &Message) {
+        if message.role != Role::Assistant {
+            self.saw_thinking = false;
+            self.saw_visible_output = false;
+            self.response_complete = false;
+            return;
+        }
         if self.response_complete {
             self.saw_thinking = false;
             self.saw_visible_output = false;
@@ -326,7 +343,9 @@ impl OutputLimitRenderState {
         }
         self.saw_thinking |= message.has_thinking_content();
         self.saw_visible_output |= message.has_visible_output();
-        self.response_complete = message.is_tool_call() || is_provider_call_boundary(message);
+        self.response_complete = message.is_tool_call()
+            || is_provider_call_boundary(message)
+            || message.metadata.output_token_limit_reached;
     }
 
     fn warning(&self, message: &Message) -> &'static str {
@@ -454,6 +473,7 @@ fn is_provider_call_boundary(message: &Message) -> bool {
     })
 }
 
+#[cfg(test)]
 fn output_token_limit_warning(message: &Message) -> &'static str {
     output_token_limit_warning_parts(
         message.metadata.output_token_limit_reached,
@@ -474,10 +494,6 @@ fn output_token_limit_warning_parts(
     } else {
         OUTPUT_TOKEN_LIMIT_WARNING
     }
-}
-
-fn render_output_token_limit_warning(message: &Message) {
-    println!("\n{}", warning(output_token_limit_warning(message)));
 }
 
 fn render_credits_exhausted_notification(notification: &SystemNotificationContent) {
@@ -1961,6 +1977,63 @@ mod tests {
         state.observe(&marker);
 
         assert_eq!(state.warning(&marker), EMPTY_OUTPUT_TOKEN_LIMIT_WARNING);
+    }
+
+    #[test]
+    fn history_output_limit_warning_uses_prior_thinking_across_messages() {
+        let thinking = Message::assistant()
+            .with_generated_id()
+            .with_thinking("I will reason until the budget runs out.", "");
+        let mut marker = Message::assistant().with_generated_id();
+        marker.metadata.output_token_limit_reached = true;
+
+        let mut state = OutputLimitRenderState::default();
+        state.observe(&thinking);
+        state.observe(&marker);
+
+        assert_eq!(state.warning(&marker), REASONING_OUTPUT_TOKEN_LIMIT_WARNING);
+    }
+
+    #[test]
+    fn history_output_limit_warning_resets_after_user_message() {
+        let thinking = Message::assistant()
+            .with_generated_id()
+            .with_thinking("previous turn reasoning", "");
+        let user = Message::user().with_text("continue");
+        let mut marker = Message::assistant().with_generated_id();
+        marker.metadata.output_token_limit_reached = true;
+
+        let mut state = OutputLimitRenderState::default();
+        state.observe(&thinking);
+        state.observe(&user);
+        state.observe(&marker);
+
+        assert_eq!(state.warning(&marker), EMPTY_OUTPUT_TOKEN_LIMIT_WARNING);
+    }
+
+    #[test]
+    fn history_output_limit_warning_resets_after_a_prior_length_hit() {
+        let thinking = Message::assistant()
+            .with_generated_id()
+            .with_thinking("previous call reasoning", "");
+        let mut first_marker = Message::assistant().with_generated_id();
+        first_marker.metadata.output_token_limit_reached = true;
+        let mut second_marker = Message::assistant().with_generated_id();
+        second_marker.metadata.output_token_limit_reached = true;
+
+        let mut state = OutputLimitRenderState::default();
+        state.observe(&thinking);
+        state.observe(&first_marker);
+        assert_eq!(
+            state.warning(&first_marker),
+            REASONING_OUTPUT_TOKEN_LIMIT_WARNING
+        );
+
+        state.observe(&second_marker);
+        assert_eq!(
+            state.warning(&second_marker),
+            EMPTY_OUTPUT_TOKEN_LIMIT_WARNING
+        );
     }
 
     #[test]

--- a/crates/goose-cli/src/session/output.rs
+++ b/crates/goose-cli/src/session/output.rs
@@ -326,7 +326,7 @@ impl OutputLimitRenderState {
         }
         self.saw_thinking |= message.has_thinking_content();
         self.saw_visible_output |= message.has_visible_output();
-        self.response_complete = message.is_tool_call();
+        self.response_complete = message.is_tool_call() || is_provider_call_boundary(message);
     }
 
     fn warning(&self, message: &Message) -> &'static str {
@@ -442,6 +442,16 @@ pub fn render_message_streaming(
 
 fn reached_output_token_limit(message: &Message) -> bool {
     message.role == Role::Assistant && message.metadata.output_token_limit_reached
+}
+
+fn is_provider_call_boundary(message: &Message) -> bool {
+    message.content.iter().any(|content| {
+        matches!(
+            content,
+            MessageContent::SystemNotification(notification)
+                if notification.notification_type == SystemNotificationType::InlineMessage
+        )
+    })
 }
 
 fn output_token_limit_warning(message: &Message) -> &'static str {
@@ -1929,6 +1939,28 @@ mod tests {
         assert_eq!(state.warning(&marker), REASONING_OUTPUT_TOKEN_LIMIT_WARNING);
         assert_ne!(thinking.id, marker.id);
         assert!(thinking.id.as_deref().unwrap().starts_with("msg_"));
+    }
+
+    #[test]
+    fn streamed_output_limit_warning_resets_after_goal_notification() {
+        let thinking = Message::assistant()
+            .with_generated_id()
+            .with_thinking("previous call reasoning", "");
+        let visible = Message::assistant()
+            .with_generated_id()
+            .with_text("previous call answer");
+        let goal = Message::assistant()
+            .with_system_notification(SystemNotificationType::InlineMessage, "Goal: keep going");
+        let mut marker = Message::assistant().with_generated_id();
+        marker.metadata.output_token_limit_reached = true;
+
+        let mut state = OutputLimitRenderState::default();
+        state.observe(&thinking);
+        state.observe(&visible);
+        state.observe(&goal);
+        state.observe(&marker);
+
+        assert_eq!(state.warning(&marker), EMPTY_OUTPUT_TOKEN_LIMIT_WARNING);
     }
 
     #[test]

--- a/crates/goose-cli/src/session/output.rs
+++ b/crates/goose-cli/src/session/output.rs
@@ -315,19 +315,28 @@ pub struct OutputLimitRenderState {
     message_id: Option<String>,
     saw_thinking: bool,
     saw_visible_output: bool,
+    response_complete: bool,
 }
 
 impl OutputLimitRenderState {
     pub fn observe(&mut self, message: &Message) {
-        if let Some(incoming) = provider_completion_id(message) {
-            if self.message_id.as_deref() != Some(incoming) {
-                self.message_id = Some(incoming.to_string());
-                self.saw_thinking = false;
-                self.saw_visible_output = false;
-            }
+        let incoming = provider_completion_id(message);
+        let new_provider_response =
+            incoming.is_some_and(|id| self.message_id.as_deref() != Some(id));
+        let new_idless_response =
+            incoming.is_none() && message.has_thinking_content() && self.saw_visible_output;
+        if new_provider_response || self.response_complete || new_idless_response {
+            self.saw_thinking = false;
+            self.saw_visible_output = false;
+            self.response_complete = false;
+        }
+        if let Some(id) = incoming {
+            self.message_id = Some(id.to_string());
         }
         self.saw_thinking |= message.has_thinking_content();
         self.saw_visible_output |= message.has_visible_output();
+        self.response_complete =
+            message.is_tool_call() || message.metadata.output_token_limit_reached;
     }
 
     fn warning(&self, message: &Message) -> &'static str {
@@ -1907,6 +1916,24 @@ mod tests {
         assert_eq!(state.warning(&marker), REASONING_OUTPUT_TOKEN_LIMIT_WARNING);
         assert_ne!(thinking.id, marker.id);
         assert!(thinking.id.as_deref().unwrap().starts_with("msg_"));
+    }
+
+    #[test]
+    fn streamed_output_limit_warning_resets_after_tool_call() {
+        let thinking = Message::assistant()
+            .with_generated_id()
+            .with_thinking("previous call reasoning", "");
+        let tool_call = Message::assistant()
+            .with_tool_request("call-1", Ok(CallToolRequestParams::new("shell")));
+        let mut marker = Message::assistant().with_generated_id();
+        marker.metadata.output_token_limit_reached = true;
+
+        let mut state = OutputLimitRenderState::default();
+        state.observe(&thinking);
+        state.observe(&tool_call);
+        state.observe(&marker);
+
+        assert_eq!(state.warning(&marker), EMPTY_OUTPUT_TOKEN_LIMIT_WARNING);
     }
 
     #[test]

--- a/crates/goose-provider-types/src/conversation/message.rs
+++ b/crates/goose-provider-types/src/conversation/message.rs
@@ -1158,11 +1158,10 @@ impl Message {
     }
 
     pub fn has_thinking_content(&self) -> bool {
-        self.content.iter().any(|content| {
-            matches!(
-                content,
-                MessageContentBlock::Thinking(_) | MessageContentBlock::RedactedThinking(_)
-            )
+        self.content.iter().any(|content| match content {
+            MessageContentBlock::Thinking(thinking) => !thinking.thinking.trim().is_empty(),
+            MessageContentBlock::RedactedThinking(_) => true,
+            _ => false,
         })
     }
 
@@ -2113,6 +2112,11 @@ mod tests {
         let mut empty_limit = Message::assistant();
         empty_limit.metadata.output_token_limit_reached = true;
         assert!(!empty_limit.reasoning_consumed_output_budget());
+
+        let mut empty_thinking = Message::assistant().with_thinking("   ", "");
+        empty_thinking.metadata.output_token_limit_reached = true;
+        assert!(!empty_thinking.has_thinking_content());
+        assert!(!empty_thinking.reasoning_consumed_output_budget());
     }
 
     #[test]

--- a/crates/goose-provider-types/src/conversation/message.rs
+++ b/crates/goose-provider-types/src/conversation/message.rs
@@ -307,6 +307,24 @@ pub enum MessageContentBlock {
     Error(ErrorContent),
 }
 
+impl MessageContentBlock {
+    pub fn is_visible_output(&self) -> bool {
+        match self {
+            MessageContentBlock::Text(text) => !text.text.trim().is_empty(),
+            MessageContentBlock::Image(_)
+            | MessageContentBlock::ToolRequest(_)
+            | MessageContentBlock::FrontendToolRequest(_) => true,
+            MessageContentBlock::Thinking(_)
+            | MessageContentBlock::RedactedThinking(_)
+            | MessageContentBlock::ToolResponse(_)
+            | MessageContentBlock::ToolConfirmationRequest(_)
+            | MessageContentBlock::ActionRequired(_)
+            | MessageContentBlock::SystemNotification(_)
+            | MessageContentBlock::Error(_) => false,
+        }
+    }
+}
+
 impl fmt::Display for MessageContentBlock {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -1131,6 +1149,27 @@ impl Message {
             .filter_map(|c| c.as_text())
             .collect::<Vec<_>>()
             .join("\n")
+    }
+
+    pub fn has_visible_output(&self) -> bool {
+        self.content
+            .iter()
+            .any(MessageContentBlock::is_visible_output)
+    }
+
+    pub fn has_thinking_content(&self) -> bool {
+        self.content.iter().any(|content| {
+            matches!(
+                content,
+                MessageContentBlock::Thinking(_) | MessageContentBlock::RedactedThinking(_)
+            )
+        })
+    }
+
+    pub fn reasoning_consumed_output_budget(&self) -> bool {
+        self.metadata.output_token_limit_reached
+            && self.has_thinking_content()
+            && !self.has_visible_output()
     }
 
     /// Check if the message is a tool call
@@ -2057,6 +2096,23 @@ mod tests {
         let message: Message = serde_json::from_str(clean_json).unwrap();
 
         assert_eq!(message.as_concat_text(), "Hello world 世界 🌍");
+    }
+
+    #[test]
+    fn reasoning_consumed_output_budget_requires_thinking_without_visible_output() {
+        let mut thinking_only = Message::assistant().with_thinking("internal reasoning", "");
+        thinking_only.metadata.output_token_limit_reached = true;
+        assert!(thinking_only.reasoning_consumed_output_budget());
+
+        let mut partial_answer = Message::assistant()
+            .with_thinking("internal reasoning", "")
+            .with_text("Partial answer");
+        partial_answer.metadata.output_token_limit_reached = true;
+        assert!(!partial_answer.reasoning_consumed_output_budget());
+
+        let mut empty_limit = Message::assistant();
+        empty_limit.metadata.output_token_limit_reached = true;
+        assert!(!empty_limit.reasoning_consumed_output_budget());
     }
 
     #[test]

--- a/crates/goose-provider-types/src/formats/openai.rs
+++ b/crates/goose-provider-types/src/formats/openai.rs
@@ -2686,6 +2686,32 @@ mod tests {
 
         assert_eq!(message.as_concat_text(), "Partial answer");
         assert!(message.metadata.output_token_limit_reached);
+        assert!(!message.reasoning_consumed_output_budget());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_response_to_message_marks_length_with_reasoning_and_empty_content() -> anyhow::Result<()>
+    {
+        let response = json!({
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "reasoning_content": "Let me think through this at length...",
+                    "content": ""
+                },
+                "finish_reason": "length"
+            }]
+        });
+
+        let message = response_to_message(&response)?;
+
+        assert!(message.has_thinking_content());
+        assert!(!message.has_visible_output());
+        assert_eq!(message.as_concat_text(), "");
+        assert!(message.metadata.output_token_limit_reached);
+        assert!(message.reasoning_consumed_output_budget());
 
         Ok(())
     }
@@ -3135,6 +3161,27 @@ mod tests {
     }
 
     #[test]
+    fn test_create_request_does_not_raise_max_tokens_for_unknown_reasoning_model(
+    ) -> anyhow::Result<()> {
+        let mut model_config =
+            test_model_config("nemotron-35-lightning").with_max_tokens(Some(4096));
+        model_config.reasoning = Some(true);
+        let model_config = model_config.with_thinking_effort(ThinkingEffort::High);
+        let request = create_request(
+            &model_config,
+            "system",
+            &[],
+            &[],
+            &ImageFormat::OpenAi,
+            false,
+        )?;
+        let obj = request.as_object().unwrap();
+        assert_eq!(obj.get("max_tokens"), Some(&json!(4096)));
+        assert!(obj.get("max_completion_tokens").is_none());
+        Ok(())
+    }
+
+    #[test]
     fn test_request_params_preserve_reserved_fields() -> anyhow::Result<()> {
         let params = std::collections::HashMap::from([
             (
@@ -3329,6 +3376,7 @@ mod tests {
         tool_calls: Vec<String>,
         has_text_content: bool,
         text: String,
+        thinking: String,
         output_token_limit_message_ids: Vec<Option<String>>,
     }
 
@@ -3344,6 +3392,7 @@ mod tests {
             tool_calls: Vec::new(),
             has_text_content: false,
             text: String::new(),
+            thinking: String::new(),
             output_token_limit_message_ids: Vec::new(),
         };
 
@@ -3366,6 +3415,9 @@ mod tests {
                         MessageContentBlock::Text(text) if !text.text.is_empty() => {
                             result.has_text_content = true;
                             result.text.push_str(&text.text);
+                        }
+                        MessageContentBlock::Thinking(thinking) => {
+                            result.thinking.push_str(&thinking.thinking);
                         }
                         _ => {}
                     }
@@ -3410,6 +3462,28 @@ data: [DONE]
             vec![Some("chatcmpl-limit".to_string())]
         );
         assert_usage_yielded_once(&result, 10, 5, 15);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_streaming_marks_length_with_reasoning_and_empty_content() -> anyhow::Result<()> {
+        let response_lines = r#"
+data: {"id":"chatcmpl-reason-limit","model":"test-model","choices":[{"index":0,"delta":{"role":"assistant","reasoning_content":"I will reason until the budget runs out."},"finish_reason":null}]}
+data: {"id":"chatcmpl-reason-limit","model":"test-model","choices":[{"index":0,"delta":{},"finish_reason":"length"}],"usage":{"prompt_tokens":10,"completion_tokens":40,"total_tokens":50}}
+data: [DONE]
+"#;
+
+        let result = run_streaming_test(response_lines).await?;
+
+        assert!(!result.has_text_content);
+        assert_eq!(result.text, "");
+        assert_eq!(result.thinking, "I will reason until the budget runs out.");
+        assert_eq!(
+            result.output_token_limit_message_ids,
+            vec![Some("chatcmpl-reason-limit".to_string())]
+        );
+        assert_usage_yielded_once(&result, 10, 40, 50);
 
         Ok(())
     }

--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -1365,6 +1365,15 @@ impl GooseAcpAgent {
                     )),
                 ))?;
             }
+            MessageContent::RedactedThinking(_) => {
+                cx.send_notification(SessionNotification::new(
+                    session_id.clone(),
+                    SessionUpdate::AgentThoughtChunk(content_chunk_for_message(
+                        message,
+                        ContentBlock::Text(TextContent::new("Thinking was redacted")),
+                    )),
+                ))?;
+            }
             MessageContent::ActionRequired(action_required) => match &action_required.data {
                 ActionRequiredData::ToolConfirmation {
                     id,

--- a/crates/goose/src/acp/server/load_session.rs
+++ b/crates/goose/src/acp/server/load_session.rs
@@ -199,6 +199,15 @@ fn replay_conversation_to_client(
                         )),
                     ))?;
                 }
+                MessageContent::RedactedThinking(_) => {
+                    cx.send_notification(SessionNotification::new(
+                        session_id.clone(),
+                        SessionUpdate::AgentThoughtChunk(content_chunk_for_message(
+                            message,
+                            ContentBlock::Text(TextContent::new("Thinking was redacted")),
+                        )),
+                    ))?;
+                }
                 MessageContent::Error(error) => {
                     send_replay_content_chunk(
                         cx,

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -4992,6 +4992,7 @@ echo start >> "$PLUGIN_ROOT/hook.log"
 
     struct OutputLimitMarkerProvider {
         include_content: bool,
+        include_thinking: bool,
         call_count: AtomicUsize,
     }
 
@@ -4999,6 +5000,15 @@ echo start >> "$PLUGIN_ROOT/hook.log"
         fn new(include_content: bool) -> Self {
             Self {
                 include_content,
+                include_thinking: false,
+                call_count: AtomicUsize::new(0),
+            }
+        }
+
+        fn thinking_only() -> Self {
+            Self {
+                include_content: false,
+                include_thinking: true,
                 call_count: AtomicUsize::new(0),
             }
         }
@@ -5019,15 +5029,21 @@ echo start >> "$PLUGIN_ROOT/hook.log"
         ) -> Result<MessageStream, ProviderError> {
             self.call_count.fetch_add(1, Ordering::SeqCst);
             let message_id = "provider-output-limit";
-            let content = Message::assistant()
-                .with_text("Partial answer")
-                .with_id(message_id);
+            let content = if self.include_thinking {
+                Message::assistant()
+                    .with_thinking("internal reasoning", "")
+                    .with_id(message_id)
+            } else {
+                Message::assistant()
+                    .with_text("Partial answer")
+                    .with_id(message_id)
+            };
             let mut marker = Message::assistant().with_id(message_id);
             marker.metadata.output_token_limit_reached = true;
             let usage = ProviderUsage::new("mock-model".to_string(), Usage::default());
 
             let mut events = Vec::new();
-            if self.include_content {
+            if self.include_content || self.include_thinking {
                 events.push(Ok((Some(content), None)));
             }
             events.push(Ok((Some(marker), Some(usage))));
@@ -5266,6 +5282,49 @@ echo start >> "$PLUGIN_ROOT/hook.log"
             .agent_visible_messages()
             .iter()
             .all(|message| message.id.as_deref() != Some("provider-output-limit")));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn thinking_only_output_limit_is_emitted_without_empty_response_retry() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let hook_manager = crate::hooks::HookManager::from_plugins_for_test(vec![]);
+        let provider = Arc::new(OutputLimitMarkerProvider::thinking_only());
+        let (agent, session_id) =
+            create_test_agent(temp_dir.path().join("data"), hook_manager, provider.clone()).await?;
+
+        let messages = run_stop_hook_test_turn(&agent, &session_id, "hello").await?;
+        assert_eq!(provider.call_count(), 1);
+        assert!(messages
+            .iter()
+            .any(|message| message.has_thinking_content()));
+        assert!(messages
+            .iter()
+            .any(|message| message.metadata.output_token_limit_reached));
+        assert!(messages.iter().all(|message| {
+            !message
+                .as_concat_text()
+                .contains("The model returned an empty response")
+        }));
+
+        let session = agent
+            .config
+            .session_manager
+            .get_session(&session_id, true)
+            .await?;
+        let conversation = session
+            .conversation
+            .expect("session should have a conversation");
+        let persisted = conversation
+            .messages()
+            .iter()
+            .find(|message| message.id.as_deref() == Some("provider-output-limit"))
+            .expect("thinking-only output-limit response should be persisted");
+        assert!(persisted.has_thinking_content());
+        assert!(!persisted.has_visible_output());
+        assert!(persisted.metadata.output_token_limit_reached);
+        assert!(persisted.reasoning_consumed_output_budget());
 
         Ok(())
     }

--- a/crates/goose/src/agents/state_machine/tests/dummy_api.rs
+++ b/crates/goose/src/agents/state_machine/tests/dummy_api.rs
@@ -45,6 +45,7 @@ enum ApiResponse {
     },
     NoChoices,
     OutputLimit,
+    ReasoningOutputLimit(String),
     ContextLimitError(String),
     ServerError(String),
     EmptyServerError,
@@ -351,6 +352,13 @@ impl<'a> ApiRuleBuilder<'a> {
         self.configured(ApiResponse::OutputLimit)
     }
 
+    pub(super) fn reasoning_output_limit(
+        self,
+        reasoning: impl Into<String>,
+    ) -> ConfiguredResponse<'a> {
+        self.configured(ApiResponse::ReasoningOutputLimit(reasoning.into()))
+    }
+
     pub(super) fn empty_server_error(self) -> ConfiguredResponse<'a> {
         self.configured(ApiResponse::EmptyServerError)
     }
@@ -535,6 +543,9 @@ impl DummyApiState {
             }
             ApiResponse::NoChoices => sse_response(no_choices_events(&id, model)),
             ApiResponse::OutputLimit => sse_response(output_limit_events(&meta(0))),
+            ApiResponse::ReasoningOutputLimit(reasoning) => sse_response(
+                reasoning_output_limit_events(&meta(reasoning.chars().count() as i32), &reasoning),
+            ),
             ApiResponse::ContextLimitError(message) => ResponseTemplate::new(400).set_body_json(
                 context_limit_error(format!("context_length_exceeded: {message}")),
             ),
@@ -733,6 +744,43 @@ fn no_choices_events(id: &str, model: &str) -> String {
 
 fn output_limit_events(meta: &ResponseMeta) -> String {
     let mut events = String::new();
+    push_event(
+        &mut events,
+        json!({
+            "id": meta.id,
+            "object": "chat.completion.chunk",
+            "model": meta.model,
+            "choices": [{
+                "index": 0,
+                "delta": {},
+                "finish_reason": "length"
+            }]
+        }),
+    );
+    if meta.include_usage {
+        push_event(&mut events, usage_event(meta));
+    }
+    events.push_str("data: [DONE]\n\n");
+    events
+}
+
+fn reasoning_output_limit_events(meta: &ResponseMeta, reasoning: &str) -> String {
+    let mut events = String::new();
+    for chunk in split_reply(reasoning) {
+        push_event(
+            &mut events,
+            json!({
+                "id": meta.id,
+                "object": "chat.completion.chunk",
+                "model": meta.model,
+                "choices": [{
+                    "index": 0,
+                    "delta": { "reasoning_content": chunk },
+                    "finish_reason": null
+                }]
+            }),
+        );
+    }
     push_event(
         &mut events,
         json!({

--- a/crates/goose/src/agents/state_machine/tests/provider_lifecycle.rs
+++ b/crates/goose/src/agents/state_machine/tests/provider_lifecycle.rs
@@ -216,6 +216,37 @@ async fn provider_lifecycle() -> Result<()> {
         matches!(event, AgentEvent::Message(message) if message.metadata.output_token_limit_reached)
     }));
 
+    api.on("hit the reasoning output limit")
+        .reasoning_output_limit("I will reason until the budget runs out.");
+    let result = pipeline.run(["hit the reasoning output limit"]).await?;
+    assert!(result.events.iter().any(|event| {
+        matches!(
+            event,
+            AgentEvent::Message(message) if message.has_thinking_content()
+        )
+    }));
+    assert!(result.events.iter().any(|event| {
+        matches!(
+            event,
+            AgentEvent::Message(message) if message.metadata.output_token_limit_reached
+        )
+    }));
+    assert!(result.events.iter().all(|event| {
+        !matches!(
+            event,
+            AgentEvent::Message(message)
+                if message.as_concat_text().contains("model returned an empty response")
+        )
+    }));
+    let thinking_limited = result
+        .conversation()
+        .messages()
+        .iter()
+        .find(|message| message.reasoning_consumed_output_budget())
+        .expect("thinking-only output-limit response should be persisted");
+    assert!(thinking_limited.has_thinking_content());
+    assert!(!thinking_limited.has_visible_output());
+
     api.on("return an empty server error").empty_server_error();
     let result = pipeline.run(["return an empty server error"]).await?;
     result.assert_message(-1, Error, "500");

--- a/ui/desktop/src/components/GooseMessage.tsx
+++ b/ui/desktop/src/components/GooseMessage.tsx
@@ -60,6 +60,13 @@ function GooseMessage({
 
   const timestamp = useMemo(() => formatMessageTimestamp(message.created), [message.created]);
   const toolRequests = getToolRequests(message);
+  const reasoningConsumedOutputBudget =
+    outputTokenLimitReached &&
+    !isOutputTokenLimitFallback &&
+    Boolean(thinkingContent) &&
+    !displayText.trim() &&
+    imagePaths.length === 0 &&
+    toolRequests.length === 0;
   const messageIndex = messages.findIndex((msg) => msg.id === message.id);
   const toolConfirmationContent = getToolConfirmationContent(message);
   const elicitationContent = getElicitationContent(message);
@@ -84,7 +91,9 @@ function GooseMessage({
   const hasElicitation = elicitationContent !== undefined;
   const outputTokenLimitNotice = isOutputTokenLimitFallback
     ? "Response reached the model's output-token limit before returning content."
-    : "Response reached the model's output-token limit and may be incomplete.";
+    : reasoningConsumedOutputBudget
+      ? 'Reasoning consumed the output-token budget before any visible content was produced. Raise GOOSE_MAX_TOKENS or lower GOOSE_THINKING_EFFORT.'
+      : "Response reached the model's output-token limit and may be incomplete.";
   const elicitationData =
     elicitationContent?.data.actionType === 'elicitation'
       ? (elicitationContent.data as typeof elicitationContent.data & {

--- a/ui/desktop/src/components/GooseMessage.tsx
+++ b/ui/desktop/src/components/GooseMessage.tsx
@@ -10,6 +10,7 @@ import {
   getThinkingContent,
   getToolRequests,
   getToolResponses,
+  reasoningConsumedOutputBudget,
   getToolConfirmationContent,
   getElicitationContent,
   getPendingToolConfirmationIds,
@@ -60,14 +61,11 @@ function GooseMessage({
 
   const timestamp = useMemo(() => formatMessageTimestamp(message.created), [message.created]);
   const toolRequests = getToolRequests(message);
-  const reasoningConsumedOutputBudget =
-    outputTokenLimitReached &&
-    !isOutputTokenLimitFallback &&
-    Boolean(thinkingContent) &&
-    !displayText.trim() &&
-    imagePaths.length === 0 &&
-    toolRequests.length === 0;
   const messageIndex = messages.findIndex((msg) => msg.id === message.id);
+  const reasoningConsumedBudget = reasoningConsumedOutputBudget(
+    messages,
+    messageIndex >= 0 ? messageIndex : messages.length - 1
+  );
   const toolConfirmationContent = getToolConfirmationContent(message);
   const elicitationContent = getElicitationContent(message);
 
@@ -89,10 +87,10 @@ function GooseMessage({
   );
   const hasToolConfirmation = toolConfirmationContent !== undefined;
   const hasElicitation = elicitationContent !== undefined;
-  const outputTokenLimitNotice = isOutputTokenLimitFallback
-    ? "Response reached the model's output-token limit before returning content."
-    : reasoningConsumedOutputBudget
-      ? 'Reasoning consumed the output-token budget before any visible content was produced. Raise GOOSE_MAX_TOKENS or lower GOOSE_THINKING_EFFORT.'
+  const outputTokenLimitNotice = reasoningConsumedBudget
+    ? 'Reasoning consumed the output-token budget before any visible content was produced. Raise GOOSE_MAX_TOKENS or lower GOOSE_THINKING_EFFORT.'
+    : isOutputTokenLimitFallback
+      ? "Response reached the model's output-token limit before returning content."
       : "Response reached the model's output-token limit and may be incomplete.";
   const elicitationData =
     elicitationContent?.data.actionType === 'elicitation'

--- a/ui/desktop/src/components/GooseMessage.tsx
+++ b/ui/desktop/src/components/GooseMessage.tsx
@@ -30,6 +30,7 @@ interface GooseMessageProps {
   sessionId: string;
   message: Message;
   messages: Message[];
+  messageIndex: number;
   metadata?: string[];
   toolCallNotifications: Map<string, NotificationEvent[]>;
   append: (value: string) => void;
@@ -44,6 +45,7 @@ function GooseMessage({
   sessionId,
   message,
   messages,
+  messageIndex,
   toolCallNotifications,
   append,
   isStreaming,
@@ -61,11 +63,7 @@ function GooseMessage({
 
   const timestamp = useMemo(() => formatMessageTimestamp(message.created), [message.created]);
   const toolRequests = getToolRequests(message);
-  const messageIndex = messages.findIndex((msg) => msg.id === message.id);
-  const reasoningConsumedBudget = reasoningConsumedOutputBudget(
-    messages,
-    messageIndex >= 0 ? messageIndex : messages.length - 1
-  );
+  const reasoningConsumedBudget = reasoningConsumedOutputBudget(messages, messageIndex);
   const toolConfirmationContent = getToolConfirmationContent(message);
   const elicitationContent = getElicitationContent(message);
 

--- a/ui/desktop/src/components/ProgressiveMessageList.tsx
+++ b/ui/desktop/src/components/ProgressiveMessageList.tsx
@@ -305,6 +305,7 @@ export default function ProgressiveMessageList({
                   sessionId={chat.sessionId}
                   message={message}
                   messages={messages}
+                  messageIndex={index}
                   append={append}
                   toolCallNotifications={toolCallNotifications}
                   isStreaming={

--- a/ui/desktop/src/types/message.reasoningBudget.test.ts
+++ b/ui/desktop/src/types/message.reasoningBudget.test.ts
@@ -115,6 +115,28 @@ describe('reasoningConsumedOutputBudget', () => {
     expect(reasoningConsumedOutputBudget(messages, 1)).toBe(true);
   });
 
+  it('classifies a later ID-less length marker without matching an earlier ID-less message', () => {
+    const messages: Message[] = [
+      assistant({
+        content: [{ type: 'text', text: 'earlier answer' }],
+      }),
+      assistant({
+        content: [{ type: 'thinking', thinking: 'internal reasoning', signature: '' }],
+      }),
+      assistant({
+        content: [],
+        metadata: {
+          agentVisible: false,
+          userVisible: true,
+          outputTokenLimitReached: true,
+        },
+      }),
+    ];
+
+    expect(reasoningConsumedOutputBudget(messages, 0)).toBe(false);
+    expect(reasoningConsumedOutputBudget(messages, 2)).toBe(true);
+  });
+
   it('treats redacted thinking as reasoning', () => {
     const messages: Message[] = [
       assistant({

--- a/ui/desktop/src/types/message.reasoningBudget.test.ts
+++ b/ui/desktop/src/types/message.reasoningBudget.test.ts
@@ -88,4 +88,50 @@ describe('reasoningConsumedOutputBudget', () => {
 
     expect(reasoningConsumedOutputBudget(messages, 1)).toBe(true);
   });
+
+  it('ignores ACP fallback text on the length marker', () => {
+    const messages: Message[] = [
+      assistant({
+        id: 'chatcmpl-1',
+        content: [{ type: 'thinking', thinking: 'internal reasoning', signature: '' }],
+      }),
+      assistant({
+        id: 'chatcmpl-2',
+        content: [
+          {
+            type: 'text',
+            text: 'Response stopped because the model reached its output-token limit.',
+          },
+        ],
+        metadata: {
+          agentVisible: false,
+          userVisible: true,
+          outputTokenLimitReached: true,
+          fallbackContent: true,
+        },
+      }),
+    ];
+
+    expect(reasoningConsumedOutputBudget(messages, 1)).toBe(true);
+  });
+
+  it('treats redacted thinking as reasoning', () => {
+    const messages: Message[] = [
+      assistant({
+        id: 'msg_thinking',
+        content: [{ type: 'redactedThinking', data: 'redacted' }],
+      }),
+      assistant({
+        id: 'msg_marker',
+        content: [],
+        metadata: {
+          agentVisible: false,
+          userVisible: true,
+          outputTokenLimitReached: true,
+        },
+      }),
+    ];
+
+    expect(reasoningConsumedOutputBudget(messages, 1)).toBe(true);
+  });
 });

--- a/ui/desktop/src/types/message.reasoningBudget.test.ts
+++ b/ui/desktop/src/types/message.reasoningBudget.test.ts
@@ -68,4 +68,24 @@ describe('reasoningConsumedOutputBudget', () => {
 
     expect(reasoningConsumedOutputBudget(messages, 2)).toBe(false);
   });
+
+  it('uses preceding thinking when chunk ids differ', () => {
+    const messages: Message[] = [
+      assistant({
+        id: 'chatcmpl-1',
+        content: [{ type: 'thinking', thinking: 'internal reasoning', signature: '' }],
+      }),
+      assistant({
+        id: 'chatcmpl-2',
+        content: [],
+        metadata: {
+          agentVisible: false,
+          userVisible: true,
+          outputTokenLimitReached: true,
+        },
+      }),
+    ];
+
+    expect(reasoningConsumedOutputBudget(messages, 1)).toBe(true);
+  });
 });

--- a/ui/desktop/src/types/message.reasoningBudget.test.ts
+++ b/ui/desktop/src/types/message.reasoningBudget.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { reasoningConsumedOutputBudget, type Message } from './message';
+
+function assistant(partial: Partial<Message> & Pick<Message, 'content'>): Message {
+  return {
+    created: 1,
+    role: 'assistant',
+    metadata: {
+      agentVisible: true,
+      userVisible: true,
+      ...partial.metadata,
+    },
+    ...partial,
+  };
+}
+
+describe('reasoningConsumedOutputBudget', () => {
+  it('uses preceding thinking when the length marker has a generated id', () => {
+    const messages: Message[] = [
+      assistant({
+        id: 'msg_thinking',
+        content: [{ type: 'thinking', thinking: 'internal reasoning', signature: '' }],
+      }),
+      assistant({
+        id: 'msg_marker',
+        content: [],
+        metadata: {
+          agentVisible: false,
+          userVisible: true,
+          outputTokenLimitReached: true,
+          fallbackContent: true,
+        },
+      }),
+    ];
+
+    expect(reasoningConsumedOutputBudget(messages, 1)).toBe(true);
+  });
+
+  it('does not treat a later length hit as reasoning after a tool call', () => {
+    const messages: Message[] = [
+      assistant({
+        id: 'msg_thinking',
+        content: [{ type: 'thinking', thinking: 'previous call reasoning', signature: '' }],
+      }),
+      assistant({
+        id: 'msg_tool',
+        content: [
+          {
+            type: 'toolRequest',
+            id: 'call-1',
+            toolCall: {
+              name: 'shell',
+              arguments: { command: 'echo hi' },
+            },
+          },
+        ],
+      }),
+      assistant({
+        id: 'msg_marker',
+        content: [],
+        metadata: {
+          agentVisible: false,
+          userVisible: true,
+          outputTokenLimitReached: true,
+        },
+      }),
+    ];
+
+    expect(reasoningConsumedOutputBudget(messages, 2)).toBe(false);
+  });
+});

--- a/ui/desktop/src/types/message.reasoningBudget.test.ts
+++ b/ui/desktop/src/types/message.reasoningBudget.test.ts
@@ -115,6 +115,30 @@ describe('reasoningConsumedOutputBudget', () => {
     expect(reasoningConsumedOutputBudget(messages, 1)).toBe(true);
   });
 
+  it('does not treat earlier visible text as this turn when looking back', () => {
+    const messages: Message[] = [
+      assistant({
+        id: 'chatcmpl-1',
+        content: [{ type: 'text', text: 'complete earlier answer' }],
+      }),
+      assistant({
+        id: 'chatcmpl-2',
+        content: [{ type: 'thinking', thinking: 'internal reasoning', signature: '' }],
+      }),
+      assistant({
+        id: 'chatcmpl-2',
+        content: [],
+        metadata: {
+          agentVisible: false,
+          userVisible: true,
+          outputTokenLimitReached: true,
+        },
+      }),
+    ];
+
+    expect(reasoningConsumedOutputBudget(messages, 2)).toBe(true);
+  });
+
   it('classifies a later ID-less length marker without matching an earlier ID-less message', () => {
     const messages: Message[] = [
       assistant({

--- a/ui/desktop/src/types/message.reasoningBudget.test.ts
+++ b/ui/desktop/src/types/message.reasoningBudget.test.ts
@@ -184,12 +184,18 @@ describe('reasoningConsumedOutputBudget', () => {
     expect(reasoningConsumedOutputBudget(messages, 1)).toBe(false);
   });
 
-  it('does not treat earlier visible text as this turn when looking back', () => {
+  it('does not walk through a previous user turn when looking back', () => {
     const messages: Message[] = [
       assistant({
         id: 'chatcmpl-1',
         content: [{ type: 'text', text: 'complete earlier answer' }],
       }),
+      {
+        created: 2,
+        role: 'user',
+        content: [{ type: 'text', text: 'continue' }],
+        metadata: { agentVisible: true, userVisible: true },
+      },
       assistant({
         id: 'chatcmpl-2',
         content: [{ type: 'thinking', thinking: 'internal reasoning', signature: '' }],
@@ -205,14 +211,20 @@ describe('reasoningConsumedOutputBudget', () => {
       }),
     ];
 
-    expect(reasoningConsumedOutputBudget(messages, 2)).toBe(true);
+    expect(reasoningConsumedOutputBudget(messages, 3)).toBe(true);
   });
 
-  it('classifies a later ID-less length marker without matching an earlier ID-less message', () => {
+  it('classifies a later ID-less length marker from its own list index', () => {
     const messages: Message[] = [
       assistant({
         content: [{ type: 'text', text: 'earlier answer' }],
       }),
+      {
+        created: 2,
+        role: 'user',
+        content: [{ type: 'text', text: 'continue' }],
+        metadata: { agentVisible: true, userVisible: true },
+      },
       assistant({
         content: [{ type: 'thinking', thinking: 'internal reasoning', signature: '' }],
       }),
@@ -227,7 +239,7 @@ describe('reasoningConsumedOutputBudget', () => {
     ];
 
     expect(reasoningConsumedOutputBudget(messages, 0)).toBe(false);
-    expect(reasoningConsumedOutputBudget(messages, 2)).toBe(true);
+    expect(reasoningConsumedOutputBudget(messages, 3)).toBe(true);
   });
 
   it('treats redacted thinking as reasoning', () => {

--- a/ui/desktop/src/types/message.reasoningBudget.test.ts
+++ b/ui/desktop/src/types/message.reasoningBudget.test.ts
@@ -115,6 +115,75 @@ describe('reasoningConsumedOutputBudget', () => {
     expect(reasoningConsumedOutputBudget(messages, 1)).toBe(true);
   });
 
+  it('records visible text that precedes later reasoning in the same turn', () => {
+    const messages: Message[] = [
+      assistant({
+        id: 'chatcmpl-1',
+        content: [{ type: 'text', text: 'Hi' }],
+      }),
+      assistant({
+        id: 'chatcmpl-2',
+        content: [{ type: 'thinking', thinking: 'structured reasoning', signature: '' }],
+      }),
+      assistant({
+        id: 'chatcmpl-3',
+        content: [],
+        metadata: {
+          agentVisible: false,
+          userVisible: true,
+          outputTokenLimitReached: true,
+        },
+      }),
+    ];
+
+    expect(reasoningConsumedOutputBudget(messages, 2)).toBe(false);
+  });
+
+  it('stops look-back at a Goal/Grind notification', () => {
+    const messages: Message[] = [
+      assistant({
+        content: [{ type: 'thinking', thinking: 'previous call reasoning', signature: '' }],
+      }),
+      assistant({
+        content: [
+          {
+            type: 'systemNotification',
+            notificationType: 'inlineMessage',
+            msg: 'Goal: keep going',
+          },
+        ],
+      }),
+      assistant({
+        content: [],
+        metadata: {
+          agentVisible: false,
+          userVisible: true,
+          outputTokenLimitReached: true,
+        },
+      }),
+    ];
+
+    expect(reasoningConsumedOutputBudget(messages, 2)).toBe(false);
+  });
+
+  it('does not treat whitespace-only thinking as reasoning', () => {
+    const messages: Message[] = [
+      assistant({
+        content: [{ type: 'thinking', thinking: '   ', signature: '' }],
+      }),
+      assistant({
+        content: [],
+        metadata: {
+          agentVisible: false,
+          userVisible: true,
+          outputTokenLimitReached: true,
+        },
+      }),
+    ];
+
+    expect(reasoningConsumedOutputBudget(messages, 1)).toBe(false);
+  });
+
   it('does not treat earlier visible text as this turn when looking back', () => {
     const messages: Message[] = [
       assistant({

--- a/ui/desktop/src/types/message.ts
+++ b/ui/desktop/src/types/message.ts
@@ -381,6 +381,55 @@ export function getToolRequests(message: Message): (ToolRequest & { type: 'toolR
   );
 }
 
+function isGeneratedMessageId(id: string | undefined): boolean {
+  return Boolean(id?.startsWith('msg_'));
+}
+
+function providerCompletionId(message: Message): string | undefined {
+  if (!message.id || isGeneratedMessageId(message.id)) {
+    return undefined;
+  }
+  return message.id;
+}
+
+function messageHasVisibleOutput(message: Message): boolean {
+  const { textContent, imagePaths } = getTextAndImageContent(message);
+  return (
+    Boolean(textContent.trim()) || imagePaths.length > 0 || getToolRequests(message).length > 0
+  );
+}
+
+export function reasoningConsumedOutputBudget(messages: Message[], messageIndex: number): boolean {
+  const message = messages[messageIndex];
+  if (!message || message.role !== 'assistant' || !message.metadata.outputTokenLimitReached) {
+    return false;
+  }
+
+  let hasThinking = Boolean(getThinkingContent(message));
+  let hasVisibleOutput = messageHasVisibleOutput(message);
+  const currentProviderId = providerCompletionId(message);
+
+  for (let index = messageIndex - 1; index >= 0; index -= 1) {
+    const previous = messages[index];
+    if (previous.role !== 'assistant') {
+      break;
+    }
+
+    const previousProviderId = providerCompletionId(previous);
+    if (currentProviderId && previousProviderId && previousProviderId !== currentProviderId) {
+      break;
+    }
+    if (getToolRequests(previous).length > 0) {
+      break;
+    }
+
+    hasThinking = hasThinking || Boolean(getThinkingContent(previous));
+    hasVisibleOutput = hasVisibleOutput || messageHasVisibleOutput(previous);
+  }
+
+  return hasThinking && !hasVisibleOutput;
+}
+
 export function getToolResponses(message: Message): (ToolResponse & { type: 'toolResponse' })[] {
   return message.content.filter(
     (content): content is ToolResponse & { type: 'toolResponse' } => content.type === 'toolResponse'

--- a/ui/desktop/src/types/message.ts
+++ b/ui/desktop/src/types/message.ts
@@ -384,8 +384,17 @@ export function getToolRequests(message: Message): (ToolRequest & { type: 'toolR
 function messageHasThinking(message: Message): boolean {
   return message.content.some(
     (content) =>
-      (content.type === 'thinking' && 'thinking' in content && Boolean(content.thinking)) ||
+      (content.type === 'thinking' &&
+        'thinking' in content &&
+        Boolean(content.thinking?.trim())) ||
       content.type === 'redactedThinking'
+  );
+}
+
+function isProviderCallBoundary(message: Message): boolean {
+  return message.content.some(
+    (content) =>
+      content.type === 'systemNotification' && content.notificationType === 'inlineMessage'
   );
 }
 
@@ -413,14 +422,18 @@ export function reasoningConsumedOutputBudget(messages: Message[], messageIndex:
     if (previous.role !== 'assistant') {
       break;
     }
-    if (getToolRequests(previous).length > 0) {
+    if (getToolRequests(previous).length > 0 || isProviderCallBoundary(previous)) {
       break;
     }
-    if (messageHasVisibleOutput(previous) || previous.metadata.outputTokenLimitReached) {
+    if (previous.metadata.outputTokenLimitReached) {
       break;
     }
 
+    hasVisibleOutput = hasVisibleOutput || messageHasVisibleOutput(previous);
     hasThinking = hasThinking || messageHasThinking(previous);
+    if (messageHasVisibleOutput(previous)) {
+      break;
+    }
   }
 
   return hasThinking && !hasVisibleOutput;

--- a/ui/desktop/src/types/message.ts
+++ b/ui/desktop/src/types/message.ts
@@ -381,7 +381,18 @@ export function getToolRequests(message: Message): (ToolRequest & { type: 'toolR
   );
 }
 
+function messageHasThinking(message: Message): boolean {
+  return message.content.some(
+    (content) =>
+      (content.type === 'thinking' && 'thinking' in content && Boolean(content.thinking)) ||
+      content.type === 'redactedThinking'
+  );
+}
+
 function messageHasVisibleOutput(message: Message): boolean {
+  if (message.metadata.fallbackContent === true) {
+    return false;
+  }
   const { textContent, imagePaths } = getTextAndImageContent(message);
   return (
     Boolean(textContent.trim()) || imagePaths.length > 0 || getToolRequests(message).length > 0
@@ -394,7 +405,7 @@ export function reasoningConsumedOutputBudget(messages: Message[], messageIndex:
     return false;
   }
 
-  let hasThinking = Boolean(getThinkingContent(message));
+  let hasThinking = messageHasThinking(message);
   let hasVisibleOutput = messageHasVisibleOutput(message);
 
   for (let index = messageIndex - 1; index >= 0; index -= 1) {
@@ -410,7 +421,7 @@ export function reasoningConsumedOutputBudget(messages: Message[], messageIndex:
       break;
     }
 
-    hasThinking = hasThinking || Boolean(getThinkingContent(previous));
+    hasThinking = hasThinking || messageHasThinking(previous);
   }
 
   return hasThinking && !hasVisibleOutput;

--- a/ui/desktop/src/types/message.ts
+++ b/ui/desktop/src/types/message.ts
@@ -381,17 +381,6 @@ export function getToolRequests(message: Message): (ToolRequest & { type: 'toolR
   );
 }
 
-function isGeneratedMessageId(id: string | undefined): boolean {
-  return Boolean(id?.startsWith('msg_'));
-}
-
-function providerCompletionId(message: Message): string | undefined {
-  if (!message.id || isGeneratedMessageId(message.id)) {
-    return undefined;
-  }
-  return message.id;
-}
-
 function messageHasVisibleOutput(message: Message): boolean {
   const { textContent, imagePaths } = getTextAndImageContent(message);
   return (
@@ -407,24 +396,21 @@ export function reasoningConsumedOutputBudget(messages: Message[], messageIndex:
 
   let hasThinking = Boolean(getThinkingContent(message));
   let hasVisibleOutput = messageHasVisibleOutput(message);
-  const currentProviderId = providerCompletionId(message);
 
   for (let index = messageIndex - 1; index >= 0; index -= 1) {
     const previous = messages[index];
     if (previous.role !== 'assistant') {
       break;
     }
-
-    const previousProviderId = providerCompletionId(previous);
-    if (currentProviderId && previousProviderId && previousProviderId !== currentProviderId) {
+    if (getToolRequests(previous).length > 0) {
       break;
     }
-    if (getToolRequests(previous).length > 0) {
+    if (messageHasVisibleOutput(previous)) {
+      hasVisibleOutput = true;
       break;
     }
 
     hasThinking = hasThinking || Boolean(getThinkingContent(previous));
-    hasVisibleOutput = hasVisibleOutput || messageHasVisibleOutput(previous);
   }
 
   return hasThinking && !hasVisibleOutput;

--- a/ui/desktop/src/types/message.ts
+++ b/ui/desktop/src/types/message.ts
@@ -416,8 +416,7 @@ export function reasoningConsumedOutputBudget(messages: Message[], messageIndex:
     if (getToolRequests(previous).length > 0) {
       break;
     }
-    if (messageHasVisibleOutput(previous)) {
-      hasVisibleOutput = true;
+    if (messageHasVisibleOutput(previous) || previous.metadata.outputTokenLimitReached) {
       break;
     }
 


### PR DESCRIPTION
## Summary
- Specialize the CLI/desktop output-token-limit warning when an OpenAI-compatible reasoning model hits `finish_reason: length` with thinking but no visible content.
- Keep `output_token_limit_reached` on thinking-only length responses so the legacy agent loop and state machine persist them instead of treating them as a silent empty reply.
- Pin current Chat Completions `max_tokens` behavior: unknown local `reasoning: true` models are **not** auto-topped up.

Fixes #11142

This is Phase 2 of the accepted #11142 policy (warning/handling). Request-side reservation (Phase 1) is intentionally out of scope until the issue settles whether configured `max_tokens` is an answer budget or a total output cap.

## Test plan
- [x] `cargo fmt`
- [x] `cargo test -p goose-provider-types --lib` focused OpenAI/message tests
- [x] `cargo test -p goose-cli --lib output_token_limit_warning`
- [x] `cargo test -p goose --lib output_limit`
- [x] `cargo test -p goose --lib agents::state_machine::tests::provider_lifecycle`
- [x] `cargo clippy -p goose-provider-types -p goose-cli -p goose --all-targets -- -D warnings`