### PR TITLE
Add Toolradar MCP server to extensions directory

### DIFF
--- a/documentation/docs/mcp/toolradar-mcp.md
+++ b/documentation/docs/mcp/toolradar-mcp.md
@@ -1,0 +1,69 @@
+---
+title: Toolradar Extension
+description: Add Toolradar MCP Server as a goose Extension
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import CLIExtensionInstructions from '@site/src/components/CLIExtensionInstructions';
+import GooseDesktopInstaller from '@site/src/components/GooseDesktopInstaller';
+
+This tutorial covers how to add the [Toolradar MCP Server](https://github.com/Nadeus/toolradar-mcp) as a goose extension. Toolradar gives goose live access to a curated database of 8,600+ software tools: semantic search, budget-aware recommendations, side-by-side comparisons, real alternatives, and pricing verified from vendors' own pricing pages.
+
+:::tip Quick Install
+<Tabs groupId="interface">
+  <TabItem value="ui" label="goose Desktop" default>
+   [Launch the installer](goose://extension?type=streamable_http&url=https%3A%2F%2Ftoolradar.com%2Fapi%2Fmcp&id=toolradar&name=Toolradar&description=Search%2C%20compare%2C%20and%20get%20verified%20pricing%20for%208%2C600%2B%20software%20tools)
+  </TabItem>
+  <TabItem value="cli" label="goose CLI">
+  Add a `Remote Extension (Streamable HTTP)` extension type with:
+
+  **Endpoint URL**
+  ```
+  https://toolradar.com/api/mcp
+  ```
+  </TabItem>
+</Tabs>
+:::
+
+## Configuration
+
+The remote server works anonymously on a rate-limited free tier, so no API key is needed to get started.
+
+<Tabs groupId="interface">
+  <TabItem value="ui" label="goose Desktop" default>
+    <GooseDesktopInstaller
+      extensionId="toolradar"
+      extensionName="Toolradar"
+      description="Search, compare, and get verified pricing for 8,600+ software tools"
+      type="http"
+      url="https://toolradar.com/api/mcp"
+    />
+  </TabItem>
+  <TabItem value="cli" label="goose CLI">
+    <CLIExtensionInstructions
+      name="toolradar"
+      type="http"
+      url="https://toolradar.com/api/mcp"
+      timeout={300}
+    />
+  </TabItem>
+</Tabs>
+
+For higher rate limits, run the stdio package instead with a free API key from [toolradar.com/dashboard/api-keys](https://toolradar.com/dashboard/api-keys):
+
+```sh
+TOOLRADAR_API_KEY=your_key npx -y toolradar-mcp
+```
+
+## Example Usage
+
+Toolradar exposes 8 tools: `search_tools`, `recommend_tools`, `get_tool`, `compare_tools`, `get_alternatives`, `get_pricing`, `list_categories`, and `report_issue`. All of them are read-only except `report_issue`, which files a data-correction ticket.
+
+### goose Prompt
+
+```
+Compare Notion, Asana and ClickUp for a 10-person team, then show me ClickUp's current pricing.
+```
+
+goose calls `compare_tools` for a side-by-side comparison with a computed top pick, then `get_pricing` for the pricing tiers along with the date Toolradar last verified them against the vendor's pricing page.

--- a/documentation/docs/mcp/toolradar-mcp.md
+++ b/documentation/docs/mcp/toolradar-mcp.md
@@ -43,6 +43,7 @@ The remote server works anonymously on a rate-limited free tier, so no API key i
   <TabItem value="cli" label="goose CLI">
     <CLIExtensionInstructions
       name="toolradar"
+      description="Search, compare, and get verified pricing for 8,600+ software tools"
       type="http"
       url="https://toolradar.com/api/mcp"
       timeout={300}

--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -36,7 +36,7 @@
   {
     "id": "apify",
     "name": "Apify",
-    "description": "Extract data from any website with thousands of scrapers, crawlers, and automations on Apify Store \u26a1",
+    "description": "Extract data from any website with thousands of scrapers, crawlers, and automations on Apify Store ⚡",
     "command": "npx -y @apify/actors-mcp-server",
     "link": "https://github.com/apify/apify-mcp-server",
     "installation_notes": "Install using npx. Requires an Apify API token.",
@@ -797,7 +797,7 @@
   {
     "id": "cash-app",
     "name": "Cash App",
-    "description": "Cash App brings local food ordering into the AI era. Discover nearby sellers, browse menus with calories and allergen info, customize orders, and complete checkout\u2014all conversationally.",
+    "description": "Cash App brings local food ordering into the AI era. Discover nearby sellers, browse menus with calories and allergen info, customize orders, and complete checkout—all conversationally.",
     "type": "streamable-http",
     "url": "https://connect.squareup.com/v2/mcp/cash-app",
     "link": "",
@@ -807,26 +807,37 @@
     "environmentVariables": []
   },
   {
-  "id": "scholar-sidekick",
-  "name": "Scholar Sidekick",
-  "description": "Resolve, format, export, and verify academic citations (DOI, PMID, ISBN, arXiv) plus retraction and open-access checks",
-  "command": "npx -y scholar-sidekick-mcp@latest",
-  "link": "https://github.com/mlava/scholar-sidekick-mcp",
-  "installation_notes": "No API key required — works anonymously on a free, rate-limited tier. Optionally set SCHOLAR_API_KEY (a free first-party ssk_ key from https://scholar-sidekick.com/account) for higher limits, or RAPIDAPI_KEY for paid tiers via RapidAPI.",
-  "is_builtin": false,
-  "endorsed": false,
-  "environmentVariables": [
-    {
-      "name": "SCHOLAR_API_KEY",
-      "description": "Optional first-party API key (ssk_) from https://scholar-sidekick.com/account; raises rate limits. Sent as Authorization: Bearer.",
-      "required": false
-    },
-    {
-      "name": "RAPIDAPI_KEY",
-      "description": "Optional RapidAPI key for paid/managed tiers; routes calls through the RapidAPI gateway.",
-      "required": false
-    }
-  ]
-}
-
+    "id": "scholar-sidekick",
+    "name": "Scholar Sidekick",
+    "description": "Resolve, format, export, and verify academic citations (DOI, PMID, ISBN, arXiv) plus retraction and open-access checks",
+    "command": "npx -y scholar-sidekick-mcp@latest",
+    "link": "https://github.com/mlava/scholar-sidekick-mcp",
+    "installation_notes": "No API key required — works anonymously on a free, rate-limited tier. Optionally set SCHOLAR_API_KEY (a free first-party ssk_ key from https://scholar-sidekick.com/account) for higher limits, or RAPIDAPI_KEY for paid tiers via RapidAPI.",
+    "is_builtin": false,
+    "endorsed": false,
+    "environmentVariables": [
+      {
+        "name": "SCHOLAR_API_KEY",
+        "description": "Optional first-party API key (ssk_) from https://scholar-sidekick.com/account; raises rate limits. Sent as Authorization: Bearer.",
+        "required": false
+      },
+      {
+        "name": "RAPIDAPI_KEY",
+        "description": "Optional RapidAPI key for paid/managed tiers; routes calls through the RapidAPI gateway.",
+        "required": false
+      }
+    ]
+  },
+  {
+    "id": "toolradar",
+    "name": "Toolradar",
+    "description": "Search, compare, and get verified pricing for 8,600+ software tools, with budget-aware recommendations",
+    "url": "https://toolradar.com/api/mcp",
+    "link": "https://github.com/Nadeus/toolradar-mcp",
+    "installation_notes": "Remote server, works anonymously (rate-limited free tier). For higher limits, run the stdio package instead: npx -y toolradar-mcp with a free TOOLRADAR_API_KEY from https://toolradar.com/dashboard/api-keys.",
+    "is_builtin": false,
+    "endorsed": false,
+    "environmentVariables": [],
+    "type": "streamable-http"
+  }
 ]


### PR DESCRIPTION
Adds **Toolradar** to `documentation/static/servers.json`.

Toolradar gives agents live access to a curated database of 8,600+ software tools: semantic search, budget-aware recommendations, side-by-side comparisons, real alternatives, and pricing verified from vendors' own pricing pages.

- Remote streamable-http endpoint, works anonymously (rate-limited free tier): `https://toolradar.com/api/mcp`
- Repo: https://github.com/Nadeus/toolradar-mcp (MIT), npm `toolradar-mcp`
- Also listed on the official MCP registry as `io.github.Nadeus/toolradar`
- 8 tools, all read-only except a feedback tool, annotated with `readOnlyHint`

Tested against the live endpoint: `initialize`, `tools/list`, and tool calls respond correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NcQfvebS9wqkayD9e2PyrR