### PR TITLE
docs: add ClawMetry session observability tutorial

### DIFF
--- a/documentation/docs/tutorials/clawmetry.md
+++ b/documentation/docs/tutorials/clawmetry.md
@@ -1,0 +1,61 @@
+---
+description: Observe your goose sessions locally with ClawMetry, with no configuration
+---
+
+# Observability with ClawMetry
+
+This tutorial covers how to use ClawMetry to see what your goose sessions did, which models they used, and what they cost. Unlike the tracing integrations, there is nothing to configure: ClawMetry reads the session store goose already writes.
+
+## What is ClawMetry
+
+[ClawMetry](https://clawmetry.com/) is an [open-source](https://github.com/vivekchand/clawmetry) (MIT) observability dashboard for AI agents. It runs on your machine, reads the local files your agent already produces, and serves a dashboard at `http://localhost:8900`. goose is a free runtime in the open source app, and the goose adapter ships in the package.
+
+## Why ClawMetry for goose
+
+- **No instrumentation**: No environment variables, no exporter, no SDK. ClawMetry reads `sessions.db` directly, so past sessions show up too.
+- **Local by default**: The dashboard runs on your machine and nothing is sent anywhere. Cloud sync exists but is opt-in and off unless you turn it on.
+- **Read-only**: goose owns its session store. ClawMetry always opens it read-only and never writes to it.
+- **Real token counts**: goose records usage on disk, so token totals come from your sessions rather than an estimate.
+- **Open source**: MIT licensed, and the goose adapter is in the repository you can read.
+
+## Set up ClawMetry
+
+```bash
+pip install clawmetry
+clawmetry
+```
+
+Then open `http://localhost:8900`.
+
+That is the whole setup. There is no goose-side configuration step, because ClawMetry does not sit in the request path.
+
+## Run goose
+
+Use goose exactly as you normally would:
+
+```bash
+goose session
+```
+
+ClawMetry auto-detects the session store at `$XDG_DATA_HOME/goose/sessions/sessions.db`, falling back to `~/.local/share/goose/sessions/sessions.db`, which is the default on macOS and Linux. Sessions you ran before installing ClawMetry appear as well.
+
+## What you see
+
+- **Sessions**: every goose session with its start time, message count, and working directory.
+- **Transcripts**: the full turn by turn conversation, including tool calls and their results.
+- **Models**: which model each session used, and how usage is split across them.
+- **Tokens and cost**: input, output, and total tokens per session, with cost where goose recorded it.
+
+:::note
+goose populates a cost figure only for providers that report one. With a local provider such as Ollama there is no cost to record, so ClawMetry shows the token counts and leaves cost empty rather than inventing a number.
+:::
+
+:::tip
+If you run several agents, the runtime switcher at the top of the dashboard scopes every view to goose alone.
+:::
+
+## Learn more
+
+- [ClawMetry repository](https://github.com/vivekchand/clawmetry)
+- [The goose adapter source](https://github.com/vivekchand/clawmetry/blob/main/clawmetry/adapters/goose.py)
+- [ClawMetry documentation](https://clawmetry.com/docs)

--- a/documentation/docs/tutorials/clawmetry.md
+++ b/documentation/docs/tutorials/clawmetry.md
@@ -37,7 +37,16 @@ Use goose exactly as you normally would:
 goose session
 ```
 
-ClawMetry auto-detects the session store at `$XDG_DATA_HOME/goose/sessions/sessions.db`, falling back to `~/.local/share/goose/sessions/sessions.db`, which is the default on macOS and Linux. Sessions you ran before installing ClawMetry appear as well.
+ClawMetry auto-detects the [session store](/docs/guides/logs#session-records) by resolving goose's data directory the same way goose does:
+
+| Platform | Session store |
+| --- | --- |
+| macOS and Linux | `$XDG_DATA_HOME/goose/sessions/sessions.db`, defaulting to `~/.local/share/goose/sessions/sessions.db` |
+| Windows | `%APPDATA%\Block\goose\data\sessions\sessions.db` |
+
+If [`GOOSE_PATH_ROOT`](/docs/guides/environment-variables) is set, ClawMetry reads `$GOOSE_PATH_ROOT/data/sessions/sessions.db` instead, on every platform. On macOS it also checks `~/Library/Application Support/Block/goose/` last, so an older install that still keeps its data there is picked up.
+
+Sessions you ran before installing ClawMetry appear as well.
 
 ## What you see
 


### PR DESCRIPTION
Closes #11282.

Adds a tutorial page for observing goose sessions with ClawMetry, following the structure of the existing Langfuse and MLflow observability pages.

@jamadeo you asked whether this works without a paid plan. It does now. goose is a free runtime in the open source app, and the adapter ships in the package under MIT, so the whole path is self-hosted:

- [`clawmetry/adapters/goose.py`](https://github.com/vivekchand/clawmetry/blob/main/clawmetry/adapters/goose.py)
- `FREE_RUNTIMES` in the entitlement resolver lists `goose` alongside `openclaw` and `nemoclaw`

**What the page covers.** `pip install clawmetry`, open `http://localhost:8900`, and existing goose sessions appear. There is no goose-side configuration step because ClawMetry is not in the request path: it reads `$XDG_DATA_HOME/goose/sessions/sessions.db` read-only, honouring XDG the same way goose does.

**On accuracy.** The page claims only what the adapter actually surfaces, which is sessions, transcripts, models, and token totals. It states plainly that goose records a cost figure only for providers that report one, so with a local provider such as Ollama the tokens are real and the cost is left empty rather than estimated. No live-stream or agent-control claims, since the goose adapter does not declare those capabilities.

**Notes for review.**
- The tutorials sidebar is `autogenerated`, so no `sidebars.ts` change is needed.
- No screenshot is included yet. The dashboard renders transcript content, so I would rather shoot it against a session I can safely publish than paste one in. Happy to add an image in a follow-up commit if you want one for parity with the other pages.

I am the ClawMetry maintainer. Glad to adjust tone, length, or structure to whatever you prefer.
