### PR TITLE
ci: enforce locked Cargo dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,8 +71,8 @@ jobs:
         run: |
           gnome-keyring-daemon --components=secrets --daemonize --unlock <<< 'foobar'
           export CARGO_INCREMENTAL=0
-          cargo test -- --skip scenario_tests::scenarios::tests
-          cargo test --jobs 1 scenario_tests::scenarios::tests
+          cargo test --locked -- --skip scenario_tests::scenarios::tests
+          cargo test --locked --jobs 1 scenario_tests::scenarios::tests
         working-directory: crates
         env:
           RUST_MIN_STACK: 8388608

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5559,7 +5559,7 @@ dependencies = [
 
 [[package]]
 name = "goose-roaming"
-version = "1.47.0"
+version = "1.48.0"
 dependencies = [
  "anyhow",
  "base64 0.23.1",


### PR DESCRIPTION
## Summary
- update the workspace lockfile for `goose-roaming` 1.48.0
- run the main Rust build-and-test job with `--locked` so stale lockfiles fail immediately
