### PR TITLE
fix(bedrock): prefer HTTP bearer auth when a bearer token is configured

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5196,6 +5196,7 @@ dependencies = [
  "aws-lc-rs",
  "aws-sdk-bedrockruntime",
  "aws-sdk-sagemakerruntime",
+ "aws-smithy-runtime-api",
  "aws-smithy-types",
  "axum",
  "axum-server",
@@ -5559,7 +5560,7 @@ dependencies = [
 
 [[package]]
 name = "goose-roaming"
-version = "1.47.0"
+version = "1.48.0"
 dependencies = [
  "anyhow",
  "base64 0.23.1",

--- a/crates/goose/Cargo.toml
+++ b/crates/goose/Cargo.toml
@@ -34,6 +34,7 @@ aws-providers = [
     "dep:aws-config",
     "dep:aws-smithy-types",
     "dep:aws-sdk-bedrockruntime",
+    "dep:aws-smithy-runtime-api",
     "dep:aws-sdk-sagemakerruntime",
     "dep:smithy-transport-reqwest",
 ]
@@ -157,6 +158,7 @@ sqlx = { version = "0.9.0", default-features = false, features = [
 aws-config = { version = "1.8", default-features = false, features = ["credentials-process", "rt-tokio", "sso", "behavior-version-latest"], optional = true }
 aws-smithy-types = { version = "1.3.4", default-features = false, features = ["rt-tokio"], optional = true }
 aws-sdk-bedrockruntime = { version = "1.132", default-features = false, features = ["rt-tokio"], optional = true }
+aws-smithy-runtime-api = { version = "1.13", default-features = false, features = ["client"], optional = true }
 smithy-transport-reqwest = { version = "0.1", default-features = false, features = ["http2", "system-proxy"], optional = true }
 
 # For SageMaker TGI provider (optional, behind "aws-providers" feature)

--- a/crates/goose/src/providers/bedrock.rs
+++ b/crates/goose/src/providers/bedrock.rs
@@ -276,6 +276,9 @@ impl BedrockProvider {
                     token.clone(),
                     None,
                 ))
+                .auth_scheme_preference([
+                    aws_smithy_runtime_api::client::auth::http::HTTP_BEARER_AUTH_SCHEME_ID,
+                ])
                 .build();
 
             Client::from_conf(bedrock_config)


### PR DESCRIPTION
Fixes https://github.com/aaif-goose/goose/issues/10676

Used goose to create two cli builds. One based on `origin/main` and one based on this branch to verify the fix.