### PR TITLE
docs: require issues before pull requests

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,8 @@
+Fixes: #ISSUE_ID
+
+> [!IMPORTANT]
+> Goose follows an [issues-first contribution process](https://github.com/aaif-goose/goose/blob/main/CONTRIBUTING.md#from-issue-to-pull-request). Before opening an external pull request, make sure the linked issue is on the [Goose Issues board](https://github.com/orgs/aaif-goose/projects/1) with the **Ready** status. Pull requests for issues in **Inbox**, **Needs info**, or **Accepted / design** are not ready for implementation. PRs without a linked issue or an issue in the wrong state can be closed with a one-liner "no correct issue".
+
 ## Summary
 <!-- Describe your change -->
 
@@ -5,12 +10,10 @@
 <!-- How have this change been tested? Unit/integration tests? Manual testing? -->
 
 ### Related Issues
-Relates to #ISSUE_ID  
 Discussion: LINK (if any)
 
 
 ### Screenshots/Demos (for UX changes)
 Before:  
 
-After:   
-
+After:


### PR DESCRIPTION
## Summary

- require a closing issue link at the top of the pull request template
- warn contributors that external pull requests require an issue in Ready status
- link to the relevant contribution guide section and Goose Issues board

### Testing

Not run (Markdown-only change).

### Related Issues

Maintainer-directed process update; no issue required.

### Screenshots/Demos (for UX changes)

N/A