### PR TITLE
fix: use provider config context_limit over canonical default

### DIFF
--- a/crates/goose/src/providers/provider_registry.rs
+++ b/crates/goose/src/providers/provider_registry.rs
@@ -1,7 +1,7 @@
 use super::api_client::TlsConfig;
 use super::base::{ConfigKey, ModelInfo, Provider, ProviderDef, ProviderMetadata, ProviderType};
 use super::inventory::{InventoryIdentityInput, InventoryRegistration, InventoryResolvers};
-use crate::config::{DeclarativeProviderConfig, ExtensionConfig};
+use crate::config::{Config, DeclarativeProviderConfig, ExtensionConfig};
 use anyhow::Result;
 use futures::future::BoxFuture;
 use goose_providers::model::ModelConfig;
@@ -57,13 +57,26 @@ impl ProviderEntry {
 
     /// Apply provider-specific normalization to a model config: materialize
     /// global defaults and backfill `context_limit` from the provider's known
-    /// models when the canonical registry didn't already resolve one. Used by
-    /// the agent/session layer to resolve effective limits (e.g. for custom
-    /// providers that declare explicit context limits in their config).
+    /// models. Used by the agent/session layer to resolve effective limits
+    /// (e.g. for custom providers that declare explicit context limits in
+    /// their config).
+    ///
+    /// Priority (highest → lowest):
+    ///   1. `GOOSE_CONTEXT_LIMIT` env var           — user override
+    ///   2. Provider's known model `context_limit`   — provider config
+    ///   3. Canonical model defaults                 — static fallback
     pub fn normalize_model_config(&self, mut model: ModelConfig) -> Result<ModelConfig> {
         model = crate::model_config::materialize_model_config(&self.metadata.name, model)?;
 
-        if model.context_limit.is_none() {
+        // After materialization, context_limit was set by either the env var
+        // (highest priority — keep it) or the canonical registry (static
+        // default). If the provider declares an explicit context_limit for
+        // this model in its own config, it should take priority over the
+        // canonical default.
+        if Config::global()
+            .get_param::<usize>("GOOSE_CONTEXT_LIMIT")
+            .is_err()
+        {
             if let Some(info) = self
                 .metadata
                 .known_models


### PR DESCRIPTION

## Summary

`normalize_model_config` in `provider_registry.rs` first materializes the model config
(which applies canonical limits — static presets like 1M for deepseek models), and only
then tries to backfill `context_limit` from the provider`s `known_models`. But since the
canonical lookup already set `context_limit`, the provider config backfill was silently
skipped.

## Change

After materialization, if `GOOSE_CONTEXT_LIMIT` env var is not set — check the provider`s
`known_models` and apply its `context_limit` over the canonical default.

## Priority (highest → lowest)
1. `GOOSE_CONTEXT_LIMIT` env var           — user override
2. Provider`s known model `context_limit`  — provider config (e.g. custom provider JSON)
3. Canonical model defaults                 — static fallback

## Verification
- `cargo check -p goose` — passes
- `cargo clippy -p goose -- -D warnings` — clean
- `cargo fmt --check` — clean
- All 9 existing `providers::init::tests` pass
