### PR TITLE
[RFC] feat(desktop,cli): add Catppuccin themes with previews and accents

### DIFF
--- a/crates/goose-cli/src/session/input.rs
+++ b/crates/goose-cli/src/session/input.rs
@@ -262,7 +262,7 @@ fn handle_slash_command(input: &str) -> Option<InputResult> {
                 .unwrap_or_default()
                 .trim()
                 .to_lowercase();
-            if super::output::CLI_THEME_NAMES.contains(&t.as_str()) {
+            if super::output::is_cli_theme_name(&t) {
                 Some(InputResult::SelectTheme(t))
             } else {
                 println!(
@@ -587,6 +587,11 @@ mod tests {
             assert_eq!(name, "latte");
         } else {
             panic!("Expected SelectTheme(latte)");
+        }
+        if let Some(InputResult::SelectTheme(name)) = handle_slash_command("/t catppuccin-mocha") {
+            assert_eq!(name, "catppuccin-mocha");
+        } else {
+            panic!("Expected SelectTheme(catppuccin-mocha)");
         }
         assert!(matches!(
             handle_slash_command("/t unknown-theme"),

--- a/crates/goose-cli/src/session/input.rs
+++ b/crates/goose-cli/src/session/input.rs
@@ -262,12 +262,13 @@ fn handle_slash_command(input: &str) -> Option<InputResult> {
                 .unwrap_or_default()
                 .trim()
                 .to_lowercase();
-            if ["light", "dark", "ansi"].contains(&t.as_str()) {
+            if super::output::CLI_THEME_NAMES.contains(&t.as_str()) {
                 Some(InputResult::SelectTheme(t))
             } else {
                 println!(
-                    "Theme Unavailable: {} Available themes are: light, dark, ansi",
-                    t
+                    "Theme Unavailable: {} Available themes are: {}",
+                    t,
+                    super::output::CLI_THEME_NAMES.join(", ")
                 );
                 Some(InputResult::Retry)
             }
@@ -471,7 +472,7 @@ fn help_text() -> String {
         "Available commands:
 /exit or /quit - Exit the session
 /t - Toggle Light/Dark/Ansi theme
-/t <name> - Set theme directly (light, dark, ansi)
+/t <name> - Set theme directly (light, dark, ansi, latte, frappe, macchiato, mocha)
 /r - Toggle full tool output display (show complete tool parameters without truncation)
 /extension <command> - Add a stdio extension (format: ENV1=val1 command args...)
 /builtin <names> - Add builtin extensions by name (comma-separated)
@@ -576,6 +577,20 @@ mod tests {
         assert!(matches!(
             handle_slash_command("/t"),
             Some(InputResult::ToggleTheme)
+        ));
+        if let Some(InputResult::SelectTheme(name)) = handle_slash_command("/t mocha") {
+            assert_eq!(name, "mocha");
+        } else {
+            panic!("Expected SelectTheme(mocha)");
+        }
+        if let Some(InputResult::SelectTheme(name)) = handle_slash_command("/t latte") {
+            assert_eq!(name, "latte");
+        } else {
+            panic!("Expected SelectTheme(latte)");
+        }
+        assert!(matches!(
+            handle_slash_command("/t unknown-theme"),
+            Some(InputResult::Retry)
         ));
 
         // Test full tool output toggle

--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -848,38 +848,22 @@ impl CliSession {
     fn handle_toggle_theme(&self) {
         let current = output::get_theme();
         let new_theme = match current {
-            output::Theme::Ansi => {
-                println!("Switching to Light theme");
-                output::Theme::Light
-            }
-            output::Theme::Light => {
-                println!("Switching to Dark theme");
-                output::Theme::Dark
-            }
-            output::Theme::Dark => {
-                println!("Switching to Ansi theme");
-                output::Theme::Ansi
-            }
+            output::Theme::Ansi => output::Theme::Light,
+            output::Theme::Light => output::Theme::Dark,
+            output::Theme::Dark => output::Theme::Ansi,
+            // Named Catppuccin flavors stay opt-in via `/t <name>`.
+            output::Theme::CatppuccinLatte
+            | output::Theme::CatppuccinFrappe
+            | output::Theme::CatppuccinMacchiato
+            | output::Theme::CatppuccinMocha => output::Theme::Light,
         };
+        println!("Switching to {} theme", new_theme.display_name());
         output::set_theme(new_theme);
     }
 
     fn handle_select_theme(&self, theme_name: &str) {
-        let new_theme = match theme_name {
-            "light" => {
-                println!("Switching to Light theme");
-                output::Theme::Light
-            }
-            "dark" => {
-                println!("Switching to Dark theme");
-                output::Theme::Dark
-            }
-            "ansi" => {
-                println!("Switching to Ansi theme");
-                output::Theme::Ansi
-            }
-            _ => output::Theme::Dark,
-        };
+        let new_theme = output::Theme::from_config_str(theme_name);
+        println!("Switching to {} theme", new_theme.display_name());
         output::set_theme(new_theme);
     }
 

--- a/crates/goose-cli/src/session/output.rs
+++ b/crates/goose-cli/src/session/output.rs
@@ -67,6 +67,24 @@ pub const CLI_THEME_NAMES: &[&str] = &[
     "mocha",
 ];
 
+pub fn is_cli_theme_name(name: &str) -> bool {
+    matches!(
+        name.to_ascii_lowercase().as_str(),
+        "light"
+            | "dark"
+            | "ansi"
+            | "latte"
+            | "frappe"
+            | "frappé"
+            | "macchiato"
+            | "mocha"
+            | "catppuccin-latte"
+            | "catppuccin-frappe"
+            | "catppuccin-macchiato"
+            | "catppuccin-mocha"
+    )
+}
+
 impl Theme {
     fn as_str(&self) -> String {
         match self {
@@ -1817,5 +1835,8 @@ mod tests {
         assert_eq!(Theme::from_config_str("dark"), Theme::Dark);
         assert_eq!(Theme::from_config_str("ansi"), Theme::Ansi);
         assert!(CLI_THEME_NAMES.contains(&"mocha"));
+        assert!(is_cli_theme_name("catppuccin-mocha"));
+        assert!(is_cli_theme_name("frappé"));
+        assert!(!is_cli_theme_name("unknown-theme"));
     }
 }

--- a/crates/goose-cli/src/session/output.rs
+++ b/crates/goose-cli/src/session/output.rs
@@ -46,12 +46,26 @@ fn danger<T: Display>(value: T) -> StyledObject<T> {
 }
 
 // Re-export theme for use in main
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Theme {
     Light,
     Dark,
     Ansi,
+    CatppuccinLatte,
+    CatppuccinFrappe,
+    CatppuccinMacchiato,
+    CatppuccinMocha,
 }
+
+pub const CLI_THEME_NAMES: &[&str] = &[
+    "light",
+    "dark",
+    "ansi",
+    "latte",
+    "frappe",
+    "macchiato",
+    "mocha",
+];
 
 impl Theme {
     fn as_str(&self) -> String {
@@ -63,24 +77,47 @@ impl Theme {
                 .get_param::<String>("GOOSE_CLI_DARK_THEME")
                 .unwrap_or(DEFAULT_CLI_DARK_THEME.to_string()),
             Theme::Ansi => "base16".to_string(),
+            Theme::CatppuccinLatte => "Catppuccin Latte".to_string(),
+            Theme::CatppuccinFrappe => "Catppuccin Frappe".to_string(),
+            Theme::CatppuccinMacchiato => "Catppuccin Macchiato".to_string(),
+            Theme::CatppuccinMocha => "Catppuccin Mocha".to_string(),
         }
     }
 
-    fn from_config_str(val: &str) -> Self {
-        if val.eq_ignore_ascii_case("light") {
-            Theme::Light
-        } else if val.eq_ignore_ascii_case("ansi") {
-            Theme::Ansi
-        } else {
-            Theme::Dark
+    pub fn from_config_str(val: &str) -> Self {
+        match val.to_ascii_lowercase().as_str() {
+            "light" => Theme::Light,
+            "ansi" => Theme::Ansi,
+            "latte" | "catppuccin-latte" => Theme::CatppuccinLatte,
+            "frappe" | "frappé" | "catppuccin-frappe" => Theme::CatppuccinFrappe,
+            "macchiato" | "catppuccin-macchiato" => Theme::CatppuccinMacchiato,
+            "mocha" | "catppuccin-mocha" => Theme::CatppuccinMocha,
+            "dark" => Theme::Dark,
+            _ => Theme::Dark,
         }
     }
 
-    fn as_config_string(&self) -> String {
+    pub fn as_config_string(&self) -> &'static str {
         match self {
-            Theme::Light => "light".to_string(),
-            Theme::Dark => "dark".to_string(),
-            Theme::Ansi => "ansi".to_string(),
+            Theme::Light => "light",
+            Theme::Dark => "dark",
+            Theme::Ansi => "ansi",
+            Theme::CatppuccinLatte => "latte",
+            Theme::CatppuccinFrappe => "frappe",
+            Theme::CatppuccinMacchiato => "macchiato",
+            Theme::CatppuccinMocha => "mocha",
+        }
+    }
+
+    pub fn display_name(&self) -> &'static str {
+        match self {
+            Theme::Light => "Light",
+            Theme::Dark => "Dark",
+            Theme::Ansi => "Ansi",
+            Theme::CatppuccinLatte => "Catppuccin Latte",
+            Theme::CatppuccinFrappe => "Catppuccin Frappé",
+            Theme::CatppuccinMacchiato => "Catppuccin Macchiato",
+            Theme::CatppuccinMocha => "Catppuccin Mocha",
         }
     }
 }
@@ -101,20 +138,10 @@ thread_local! {
 }
 
 pub fn set_theme(theme: Theme) {
-    let config = Config::global();
-    config
-        .set_param("GOOSE_CLI_THEME", theme.as_config_string())
-        .expect("Failed to set theme");
     CURRENT_THEME.with(|t| *t.borrow_mut() = theme);
 
     let config = Config::global();
-    let theme_str = match theme {
-        Theme::Light => "light",
-        Theme::Dark => "dark",
-        Theme::Ansi => "ansi",
-    };
-
-    if let Err(e) = config.set_param("GOOSE_CLI_THEME", theme_str) {
+    if let Err(e) = config.set_param("GOOSE_CLI_THEME", theme.as_config_string()) {
         eprintln!("Failed to save theme setting to config: {}", e);
     }
 }
@@ -1762,5 +1789,33 @@ mod tests {
             json!({"top_up_url": "https://router.tetrate.ai/billing"}),
         );
         assert_eq!(get_credits_top_up_url(&message), None);
+    }
+
+    #[test]
+    fn test_catppuccin_theme_names_round_trip() {
+        for (input, expected, bat_theme) in [
+            ("latte", Theme::CatppuccinLatte, "Catppuccin Latte"),
+            ("frappe", Theme::CatppuccinFrappe, "Catppuccin Frappe"),
+            (
+                "macchiato",
+                Theme::CatppuccinMacchiato,
+                "Catppuccin Macchiato",
+            ),
+            ("mocha", Theme::CatppuccinMocha, "Catppuccin Mocha"),
+            (
+                "catppuccin-mocha",
+                Theme::CatppuccinMocha,
+                "Catppuccin Mocha",
+            ),
+        ] {
+            let theme = Theme::from_config_str(input);
+            assert_eq!(theme, expected);
+            assert_eq!(theme.as_str(), bat_theme);
+            assert_eq!(Theme::from_config_str(theme.as_config_string()), expected);
+        }
+        assert_eq!(Theme::from_config_str("light"), Theme::Light);
+        assert_eq!(Theme::from_config_str("dark"), Theme::Dark);
+        assert_eq!(Theme::from_config_str("ansi"), Theme::Ansi);
+        assert!(CLI_THEME_NAMES.contains(&"mocha"));
     }
 }

--- a/documentation/docs/guides/config-files.md
+++ b/documentation/docs/guides/config-files.md
@@ -56,7 +56,7 @@ The following settings can be configured at the root level of your config.yaml f
 | `GOOSE_TOOLSHIM_OLLAMA_MODEL` | Model for tool interpretation | Model name (e.g., "llama3.2") | System default | No |
 | `GOOSE_INPUT_LIMIT` | Override input token limit for Ollama (maps to `num_ctx`) | Positive integer | Model default | No |
 | `GOOSE_CLI_MIN_PRIORITY` | Tool output verbosity | Float between 0.0 and 1.0 | 0.0 | No |
-| `GOOSE_CLI_THEME` | [Theme](/docs/guides/goose-cli-commands#themes) for CLI response markdown | "light", "dark", "ansi" | "ansi" | No |
+| `GOOSE_CLI_THEME` | [Theme](/docs/guides/goose-cli-commands#themes) for CLI response markdown | "light", "dark", "ansi", "latte", "frappe", "macchiato", "mocha" | "ansi" | No |
 | `GOOSE_CLI_LIGHT_THEME` | Custom syntax highlighting theme for light mode | [bat theme name](https://github.com/sharkdp/bat#adding-new-themes) | "GitHub" | No |
 | `GOOSE_CLI_DARK_THEME` | Custom syntax highlighting theme for dark mode | [bat theme name](https://github.com/sharkdp/bat#adding-new-themes) | "zenburn" | No |
 | `GOOSE_CLI_SHOW_COST` | Show estimated cost for token use in the CLI | true/false | false | No |

--- a/documentation/docs/guides/environment-variables.md
+++ b/documentation/docs/guides/environment-variables.md
@@ -161,7 +161,7 @@ These variables control how goose manages conversation sessions and context.
 | `CONTEXT_FILE_NAMES` | Specifies custom filenames for [hint/context files](/docs/guides/context-engineering/using-goosehints#custom-context-files) | JSON array of strings (e.g., `["CLAUDE.md", ".goosehints"]`) | `[".goosehints", "AGENTS.md"]` |
 | `GOOSE_DISABLE_SESSION_NAMING` | Disables automatic AI-generated session naming; avoids the background model call and keeps the default "CLI Session" (goose CLI) or "New Chat" (goose Desktop) | "1", "true" (case-insensitive) to enable | false |
 | `GOOSE_PROMPT_EDITOR` | [External editor](/docs/guides/goose-cli-commands#external-editor-mode) to use for composing prompts instead of CLI input | Editor command (e.g., "vim", "code --wait") | Unset (uses CLI input) |
-| `GOOSE_CLI_THEME` | [Theme](/docs/guides/goose-cli-commands#themes) for CLI response markdown | "light", "dark", "ansi" | "ansi" |
+| `GOOSE_CLI_THEME` | [Theme](/docs/guides/goose-cli-commands#themes) for CLI response markdown | "light", "dark", "ansi", "latte", "frappe", "macchiato", "mocha" | "ansi" |
 | `GOOSE_CLI_LIGHT_THEME` | Custom [bat theme](https://github.com/sharkdp/bat#adding-new-themes) for syntax highlighting when using light mode | bat theme name (e.g., "Solarized (light)", "OneHalfLight") | "GitHub" |
 | `GOOSE_CLI_DARK_THEME` | Custom [bat theme](https://github.com/sharkdp/bat#adding-new-themes) for syntax highlighting when using dark mode | bat theme name (e.g., "Dracula", "Nord") | "zenburn" |
 | `GOOSE_CLI_NEWLINE_KEY` | Customize the keyboard shortcut for [inserting newlines in CLI input](/docs/guides/goose-cli-commands#keyboard-shortcuts) | Single character (e.g., "n", "m") | "j" (Ctrl+J) |

--- a/documentation/docs/guides/goose-cli-commands.md
+++ b/documentation/docs/guides/goose-cli-commands.md
@@ -802,7 +802,7 @@ Once you're in an interactive session (via `goose session` or `goose run --inter
 - **`/r`** - Toggle full tool output display (show complete tool parameters without truncation)
 - **`/skills [<name>...]`** - List available skills, or load one or more skills by name
 - **`/t`** - Toggle between `light`, `dark`, and `ansi` themes. [More info](#themes).
-- **`/t <name>`** - Set theme directly (light, dark, ansi)
+- **`/t <name>`** - Set theme directly (`light`, `dark`, `ansi`, `latte`, `frappe`, `macchiato`, `mocha`)
 
 **Examples:**
 ```bash
@@ -834,6 +834,7 @@ The `/t` command controls the syntax highlighting theme for markdown content in 
 - `/t light` - Sets `light` theme (subtle light colors)
 - `/t dark` - Sets `dark` theme (subtle darker colors)
 - `/t ansi` - Sets `ansi` theme (most visually distinct option with brighter colors)
+- `/t latte` / `/t frappe` / `/t macchiato` / `/t mocha` - Sets the matching [Catppuccin](https://catppuccin.com/) syntax theme. These flavors are opt-in and are not part of the `/t` cycle.
 
 **Configuration:**
 - The default theme is `dark`

--- a/ui/desktop/src/components/GooseSidebar/ThemeSelector.test.tsx
+++ b/ui/desktop/src/components/GooseSidebar/ThemeSelector.test.tsx
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import ThemeSelector from './ThemeSelector';
+import { IntlTestWrapper } from '../../i18n/test-utils';
+import type { CatppuccinAccent, ThemePreference } from '../../theme/types';
+
+const setUserThemePreference = vi.fn();
+const setCatppuccinAccent = vi.fn();
+
+let preference: ThemePreference = 'light';
+let accent: CatppuccinAccent = 'mauve';
+
+vi.mock('../../contexts/ThemeContext', () => ({
+  useTheme: () => ({
+    userThemePreference: preference,
+    setUserThemePreference,
+    catppuccinAccent: accent,
+    setCatppuccinAccent,
+    resolvedThemeId: preference === 'system' ? 'light' : preference,
+    resolvedTheme: 'light',
+    mcpHostStyles: { variables: {} },
+  }),
+}));
+
+function renderSelector() {
+  return render(
+    <IntlTestWrapper>
+      <ThemeSelector hideTitle />
+    </IntlTestWrapper>
+  );
+}
+
+describe('ThemeSelector', () => {
+  it('keeps built-in theme buttons', () => {
+    preference = 'light';
+    renderSelector();
+    expect(screen.getByTestId('light-mode-button')).toBeInTheDocument();
+    expect(screen.getByTestId('dark-mode-button')).toBeInTheDocument();
+    expect(screen.getByTestId('aura-mode-button')).toBeInTheDocument();
+    expect(screen.getByTestId('system-mode-button')).toBeInTheDocument();
+  });
+
+  it('shows Catppuccin flavor previews', () => {
+    preference = 'light';
+    renderSelector();
+    expect(screen.getByTestId('catppuccin-latte-theme-button')).toBeInTheDocument();
+    expect(screen.getByTestId('catppuccin-frappe-theme-button')).toBeInTheDocument();
+    expect(screen.getByTestId('catppuccin-macchiato-theme-button')).toBeInTheDocument();
+    expect(screen.getByTestId('catppuccin-mocha-theme-button')).toBeInTheDocument();
+    expect(screen.queryByTestId('catppuccin-accent-mauve')).not.toBeInTheDocument();
+  });
+
+  it('selects a Catppuccin flavor', () => {
+    preference = 'light';
+    renderSelector();
+    fireEvent.click(screen.getByTestId('catppuccin-mocha-theme-button'));
+    expect(setUserThemePreference).toHaveBeenCalledWith('catppuccin-mocha');
+  });
+
+  it('shows accent swatches only for a Catppuccin theme', () => {
+    preference = 'catppuccin-mocha';
+    renderSelector();
+    expect(screen.getByTestId('catppuccin-accent-mauve')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('catppuccin-accent-teal'));
+    expect(setCatppuccinAccent).toHaveBeenCalledWith('teal');
+  });
+});

--- a/ui/desktop/src/components/GooseSidebar/ThemeSelector.tsx
+++ b/ui/desktop/src/components/GooseSidebar/ThemeSelector.tsx
@@ -4,7 +4,7 @@ import { Button } from '../ui/button';
 import { useTheme } from '../../contexts/ThemeContext';
 import { defineMessages, useIntl } from '../../i18n';
 import { CATPPUCCIN_ACCENTS, CATPPUCCIN_THEME_IDS, isCatppuccinThemeId } from '../../theme/types';
-import { catppuccinFlavors, getCatppuccinPreview } from '../../theme/catppuccin';
+import { getCatppuccinPreview } from '../../theme/catppuccin';
 import type { CatppuccinAccent, CatppuccinThemeId } from '../../theme/types';
 
 const i18n = defineMessages({
@@ -234,13 +234,12 @@ const CatppuccinFlavorCard: React.FC<CatppuccinFlavorCardProps> = ({
   onSelect,
 }) => {
   const preview = getCatppuccinPreview(flavorId, accent);
-  const flavorName = catppuccinFlavors[flavorId].name;
 
   return (
     <button
       type="button"
       data-testid={`${flavorId}-theme-button`}
-      aria-label={flavorName}
+      aria-label={label}
       aria-pressed={selected}
       onClick={onSelect}
       className={`overflow-hidden rounded-md border text-left transition-colors ${

--- a/ui/desktop/src/components/GooseSidebar/ThemeSelector.tsx
+++ b/ui/desktop/src/components/GooseSidebar/ThemeSelector.tsx
@@ -3,6 +3,9 @@ import { Moon, Sliders, Sparkles, Sun } from 'lucide-react';
 import { Button } from '../ui/button';
 import { useTheme } from '../../contexts/ThemeContext';
 import { defineMessages, useIntl } from '../../i18n';
+import { CATPPUCCIN_ACCENTS, CATPPUCCIN_THEME_IDS, isCatppuccinThemeId } from '../../theme/types';
+import { catppuccinFlavors, getCatppuccinPreview } from '../../theme/catppuccin';
+import type { CatppuccinAccent, CatppuccinThemeId } from '../../theme/types';
 
 const i18n = defineMessages({
   theme: {
@@ -25,12 +28,69 @@ const i18n = defineMessages({
     id: 'themeSelector.system',
     defaultMessage: 'System',
   },
+  builtinGroup: {
+    id: 'themeSelector.builtinGroup',
+    defaultMessage: 'Built-in',
+  },
+  catppuccinGroup: {
+    id: 'themeSelector.catppuccinGroup',
+    defaultMessage: 'Catppuccin',
+  },
+  accent: {
+    id: 'themeSelector.accent',
+    defaultMessage: 'Accent',
+  },
+  latte: {
+    id: 'themeSelector.catppuccinLatte',
+    defaultMessage: 'Latte',
+  },
+  frappe: {
+    id: 'themeSelector.catppuccinFrappe',
+    defaultMessage: 'Frappé',
+  },
+  macchiato: {
+    id: 'themeSelector.catppuccinMacchiato',
+    defaultMessage: 'Macchiato',
+  },
+  mocha: {
+    id: 'themeSelector.catppuccinMocha',
+    defaultMessage: 'Mocha',
+  },
+  rosewater: { id: 'themeSelector.accentRosewater', defaultMessage: 'Rosewater' },
+  flamingo: { id: 'themeSelector.accentFlamingo', defaultMessage: 'Flamingo' },
+  pink: { id: 'themeSelector.accentPink', defaultMessage: 'Pink' },
+  mauve: { id: 'themeSelector.accentMauve', defaultMessage: 'Mauve' },
+  red: { id: 'themeSelector.accentRed', defaultMessage: 'Red' },
+  maroon: { id: 'themeSelector.accentMaroon', defaultMessage: 'Maroon' },
+  peach: { id: 'themeSelector.accentPeach', defaultMessage: 'Peach' },
+  yellow: { id: 'themeSelector.accentYellow', defaultMessage: 'Yellow' },
+  green: { id: 'themeSelector.accentGreen', defaultMessage: 'Green' },
+  teal: { id: 'themeSelector.accentTeal', defaultMessage: 'Teal' },
+  sky: { id: 'themeSelector.accentSky', defaultMessage: 'Sky' },
+  sapphire: { id: 'themeSelector.accentSapphire', defaultMessage: 'Sapphire' },
+  blue: { id: 'themeSelector.accentBlue', defaultMessage: 'Blue' },
+  lavender: { id: 'themeSelector.accentLavender', defaultMessage: 'Lavender' },
 });
+
+const flavorMessage: Record<CatppuccinThemeId, keyof typeof i18n> = {
+  'catppuccin-latte': 'latte',
+  'catppuccin-frappe': 'frappe',
+  'catppuccin-macchiato': 'macchiato',
+  'catppuccin-mocha': 'mocha',
+};
 
 interface ThemeSelectorProps {
   className?: string;
   hideTitle?: boolean;
   horizontal?: boolean;
+}
+
+function builtinButtonClass(selected: boolean): string {
+  return `flex items-center justify-center gap-1 p-2 rounded-md border transition-colors text-xs ${
+    selected
+      ? 'bg-background-inverse text-text-inverse border-text-inverse hover:!bg-background-inverse hover:!text-text-inverse'
+      : 'border-border-primary hover:!bg-background-secondary text-text-secondary hover:text-text-primary'
+  }`;
 }
 
 const ThemeSelector: React.FC<ThemeSelectorProps> = ({
@@ -39,75 +99,190 @@ const ThemeSelector: React.FC<ThemeSelectorProps> = ({
   horizontal = false,
 }) => {
   const intl = useIntl();
-  const { userThemePreference, setUserThemePreference } = useTheme();
+  const {
+    userThemePreference,
+    setUserThemePreference,
+    catppuccinAccent,
+    setCatppuccinAccent,
+  } = useTheme();
+
+  const catppuccinSelected = isCatppuccinThemeId(userThemePreference);
 
   return (
-    <div className={`${!horizontal ? 'px-1 py-2 space-y-2' : ''} ${className}`}>
-      {!hideTitle && <div className="text-xs text-text-primary px-3">{intl.formatMessage(i18n.theme)}</div>}
-      <div
-        className={`${horizontal ? 'flex' : 'grid grid-cols-4'} gap-1 ${!horizontal ? 'px-3' : ''}`}
-      >
-        <Button
-          data-testid="light-mode-button"
-          onClick={() => setUserThemePreference('light')}
-          className={`flex items-center justify-center gap-1 p-2 rounded-md border transition-colors text-xs ${
-            userThemePreference === 'light'
-              ? 'bg-background-inverse text-text-inverse border-text-inverse hover:!bg-background-inverse hover:!text-text-inverse'
-              : 'border-border-primary hover:!bg-background-secondary text-text-secondary hover:text-text-primary'
-          }`}
-          variant="ghost"
-          size="sm"
-        >
-          <Sun className="h-3 w-3" />
-          <span>{intl.formatMessage(i18n.light)}</span>
-        </Button>
+    <div className={`space-y-4 ${className}`}>
+      {!hideTitle && (
+        <div className="text-xs text-text-primary">{intl.formatMessage(i18n.theme)}</div>
+      )}
 
-        <Button
-          data-testid="dark-mode-button"
-          onClick={() => setUserThemePreference('dark')}
-          className={`flex items-center justify-center gap-1 p-2 rounded-md border transition-colors text-xs ${
-            userThemePreference === 'dark'
-              ? 'bg-background-inverse text-text-inverse border-text-inverse hover:!bg-background-inverse hover:!text-text-inverse'
-              : 'border-border-primary hover:!bg-background-secondary text-text-secondary hover:text-text-primary'
-          }`}
-          variant="ghost"
-          size="sm"
+      <div className="space-y-2">
+        <div className="text-[11px] uppercase tracking-wide text-text-tertiary">
+          {intl.formatMessage(i18n.builtinGroup)}
+        </div>
+        <div
+          className={`${horizontal ? 'flex flex-wrap' : 'grid grid-cols-4'} gap-1`}
         >
-          <Moon className="h-3 w-3" />
-          <span>{intl.formatMessage(i18n.dark)}</span>
-        </Button>
+          <Button
+            data-testid="light-mode-button"
+            onClick={() => setUserThemePreference('light')}
+            className={builtinButtonClass(userThemePreference === 'light')}
+            variant="ghost"
+            size="sm"
+          >
+            <Sun className="h-3 w-3" />
+            <span>{intl.formatMessage(i18n.light)}</span>
+          </Button>
 
-        <Button
-          data-testid="aura-mode-button"
-          onClick={() => setUserThemePreference('aura')}
-          className={`flex items-center justify-center gap-1 p-2 rounded-md border transition-colors text-xs ${
-            userThemePreference === 'aura'
-              ? 'bg-background-inverse text-text-inverse border-text-inverse hover:!bg-background-inverse hover:!text-text-inverse'
-              : 'border-border-primary hover:!bg-background-secondary text-text-secondary hover:text-text-primary'
-          }`}
-          variant="ghost"
-          size="sm"
-        >
-          <Sparkles className="h-3 w-3" />
-          <span>{intl.formatMessage(i18n.aura)}</span>
-        </Button>
+          <Button
+            data-testid="dark-mode-button"
+            onClick={() => setUserThemePreference('dark')}
+            className={builtinButtonClass(userThemePreference === 'dark')}
+            variant="ghost"
+            size="sm"
+          >
+            <Moon className="h-3 w-3" />
+            <span>{intl.formatMessage(i18n.dark)}</span>
+          </Button>
 
-        <Button
-          data-testid="system-mode-button"
-          onClick={() => setUserThemePreference('system')}
-          className={`flex items-center justify-center gap-1 p-2 rounded-md border transition-colors text-xs ${
-            userThemePreference === 'system'
-              ? 'bg-background-inverse text-text-inverse border-text-inverse hover:!bg-background-inverse hover:!text-text-inverse'
-              : 'border-border-primary hover:!bg-background-secondary text-text-secondary hover:text-text-primary'
-          }`}
-          variant="ghost"
-          size="sm"
-        >
-          <Sliders className="h-3 w-3" />
-          <span>{intl.formatMessage(i18n.system)}</span>
-        </Button>
+          <Button
+            data-testid="aura-mode-button"
+            onClick={() => setUserThemePreference('aura')}
+            className={builtinButtonClass(userThemePreference === 'aura')}
+            variant="ghost"
+            size="sm"
+          >
+            <Sparkles className="h-3 w-3" />
+            <span>{intl.formatMessage(i18n.aura)}</span>
+          </Button>
+
+          <Button
+            data-testid="system-mode-button"
+            onClick={() => setUserThemePreference('system')}
+            className={builtinButtonClass(userThemePreference === 'system')}
+            variant="ghost"
+            size="sm"
+          >
+            <Sliders className="h-3 w-3" />
+            <span>{intl.formatMessage(i18n.system)}</span>
+          </Button>
+        </div>
       </div>
+
+      <div className="space-y-2">
+        <div className="text-[11px] uppercase tracking-wide text-text-tertiary">
+          {intl.formatMessage(i18n.catppuccinGroup)}
+        </div>
+        <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+          {CATPPUCCIN_THEME_IDS.map((flavorId) => (
+            <CatppuccinFlavorCard
+              key={flavorId}
+              flavorId={flavorId}
+              selected={userThemePreference === flavorId}
+              accent={catppuccinAccent}
+              label={intl.formatMessage(i18n[flavorMessage[flavorId]])}
+              onSelect={() => setUserThemePreference(flavorId)}
+            />
+          ))}
+        </div>
+      </div>
+
+      {catppuccinSelected && (
+        <div className="space-y-2">
+          <div className="text-[11px] uppercase tracking-wide text-text-tertiary">
+            {intl.formatMessage(i18n.accent)}
+          </div>
+          <div className="flex flex-wrap gap-1.5">
+            {CATPPUCCIN_ACCENTS.map((accent) => {
+              const preview = getCatppuccinPreview(userThemePreference, accent);
+              const selected = catppuccinAccent === accent;
+              return (
+                <button
+                  key={accent}
+                  type="button"
+                  data-testid={`catppuccin-accent-${accent}`}
+                  aria-label={intl.formatMessage(i18n[accent])}
+                  title={intl.formatMessage(i18n[accent])}
+                  onClick={() => setCatppuccinAccent(accent)}
+                  className={`h-5 w-5 rounded-full border transition-transform ${
+                    selected
+                      ? 'scale-110 ring-2 ring-offset-2 ring-text-primary ring-offset-background-primary'
+                      : 'border-border-primary hover:scale-105'
+                  }`}
+                  style={{ backgroundColor: preview.accent }}
+                />
+              );
+            })}
+          </div>
+        </div>
+      )}
     </div>
+  );
+};
+
+interface CatppuccinFlavorCardProps {
+  flavorId: CatppuccinThemeId;
+  selected: boolean;
+  accent: CatppuccinAccent;
+  label: string;
+  onSelect: () => void;
+}
+
+const CatppuccinFlavorCard: React.FC<CatppuccinFlavorCardProps> = ({
+  flavorId,
+  selected,
+  accent,
+  label,
+  onSelect,
+}) => {
+  const preview = getCatppuccinPreview(flavorId, accent);
+  const flavorName = catppuccinFlavors[flavorId].name;
+
+  return (
+    <button
+      type="button"
+      data-testid={`${flavorId}-theme-button`}
+      aria-label={flavorName}
+      aria-pressed={selected}
+      onClick={onSelect}
+      className={`overflow-hidden rounded-md border text-left transition-colors ${
+        selected
+          ? 'border-text-primary ring-1 ring-text-primary'
+          : 'border-border-primary hover:border-border-secondary'
+      }`}
+    >
+      <div className="flex h-14" style={{ backgroundColor: preview.background }}>
+        <div className="w-3 shrink-0" style={{ backgroundColor: preview.sidebar }} />
+        <div className="flex flex-1 flex-col justify-between p-1.5">
+          <div className="flex items-center gap-1">
+            <span
+              className="h-1.5 w-8 rounded-sm"
+              style={{ backgroundColor: preview.text, opacity: 0.85 }}
+            />
+            <span
+              className="h-1.5 w-3 rounded-sm"
+              style={{ backgroundColor: preview.accent }}
+            />
+          </div>
+          <div
+            className="h-5 rounded-sm"
+            style={{ backgroundColor: preview.surface }}
+          >
+            <div className="flex h-full items-center gap-1 px-1">
+              <span
+                className="h-1 w-6 rounded-sm"
+                style={{ backgroundColor: preview.muted }}
+              />
+              <span
+                className="ml-auto h-2 w-2 rounded-full"
+                style={{ backgroundColor: preview.accent }}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div className="bg-background-primary px-2 py-1 text-[11px] text-text-secondary">
+        {label}
+      </div>
+    </button>
   );
 };
 

--- a/ui/desktop/src/contexts/ThemeContext.test.tsx
+++ b/ui/desktop/src/contexts/ThemeContext.test.tsx
@@ -1,3 +1,4 @@
+import type { IpcRendererEvent } from 'electron';
 import { act, render, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ThemeProvider, useTheme } from './ThemeContext';
@@ -86,8 +87,11 @@ describe('ThemeContext broadcasts', () => {
   });
 
   it('applies a theme-only IPC update without resetting the local accent', async () => {
-    const listeners = new Map<string, (...args: unknown[]) => void>();
-    vi.mocked(window.electron.on).mockImplementation((channel: string, callback: (...args: unknown[]) => void) => {
+    const listeners = new Map<
+      string,
+      (event: IpcRendererEvent, ...args: unknown[]) => void
+    >();
+    vi.mocked(window.electron.on).mockImplementation((channel, callback) => {
       listeners.set(channel, callback);
     });
 
@@ -102,7 +106,7 @@ describe('ThemeContext broadcasts', () => {
     });
 
     await act(async () => {
-      listeners.get('theme-changed')?.(null, {
+      listeners.get('theme-changed')?.({} as IpcRendererEvent, {
         useSystemTheme: false,
         theme: 'catppuccin-latte',
       });

--- a/ui/desktop/src/contexts/ThemeContext.test.tsx
+++ b/ui/desktop/src/contexts/ThemeContext.test.tsx
@@ -1,0 +1,114 @@
+import { act, render, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ThemeProvider, useTheme } from './ThemeContext';
+
+function ThemeProbe() {
+  const { userThemePreference, catppuccinAccent, setUserThemePreference, setCatppuccinAccent } =
+    useTheme();
+  return (
+    <div>
+      <span data-testid="preference">{userThemePreference}</span>
+      <span data-testid="accent">{catppuccinAccent}</span>
+      <button type="button" data-testid="select-mocha" onClick={() => setUserThemePreference('catppuccin-mocha')}>
+        mocha
+      </button>
+      <button type="button" data-testid="select-teal" onClick={() => setCatppuccinAccent('teal')}>
+        teal
+      </button>
+    </div>
+  );
+}
+
+describe('ThemeContext broadcasts', () => {
+  beforeEach(() => {
+    vi.mocked(window.electron.getSetting).mockImplementation((key: string) => {
+      if (key === 'useSystemTheme') return Promise.resolve(false);
+      if (key === 'theme') return Promise.resolve('catppuccin-mocha');
+      if (key === 'catppuccinAccent') return Promise.resolve('mauve');
+      return Promise.resolve(undefined);
+    });
+    vi.mocked(window.electron.setSetting).mockResolvedValue(undefined);
+    vi.mocked(window.electron.broadcastThemeChange).mockClear();
+  });
+
+  afterEach(() => {
+    vi.mocked(window.electron.getSetting).mockReset();
+    vi.mocked(window.electron.setSetting).mockReset();
+  });
+
+  it('does not include a stale accent on theme-only broadcasts', async () => {
+    const { getByTestId } = render(
+      <ThemeProvider>
+        <ThemeProbe />
+      </ThemeProvider>
+    );
+
+    await waitFor(() => {
+      expect(getByTestId('preference').textContent).toBe('catppuccin-mocha');
+    });
+
+    await act(async () => {
+      getByTestId('select-mocha').click();
+    });
+
+    const themeBroadcasts = vi
+      .mocked(window.electron.broadcastThemeChange)
+      .mock.calls.map(([payload]) => payload);
+    expect(themeBroadcasts.some((payload) => 'catppuccinAccent' in payload)).toBe(false);
+    expect(themeBroadcasts.at(-1)).toMatchObject({
+      theme: 'catppuccin-mocha',
+      useSystemTheme: false,
+    });
+  });
+
+  it('broadcasts only the accent when the swatch changes', async () => {
+    const { getByTestId } = render(
+      <ThemeProvider>
+        <ThemeProbe />
+      </ThemeProvider>
+    );
+
+    await waitFor(() => {
+      expect(getByTestId('accent').textContent).toBe('mauve');
+    });
+
+    await act(async () => {
+      getByTestId('select-teal').click();
+    });
+
+    await waitFor(() => {
+      expect(getByTestId('accent').textContent).toBe('teal');
+    });
+
+    expect(window.electron.broadcastThemeChange).toHaveBeenCalledWith({
+      catppuccinAccent: 'teal',
+    });
+  });
+
+  it('applies a theme-only IPC update without resetting the local accent', async () => {
+    const listeners = new Map<string, (...args: unknown[]) => void>();
+    vi.mocked(window.electron.on).mockImplementation((channel: string, callback: (...args: unknown[]) => void) => {
+      listeners.set(channel, callback);
+    });
+
+    const { getByTestId } = render(
+      <ThemeProvider>
+        <ThemeProbe />
+      </ThemeProvider>
+    );
+
+    await waitFor(() => {
+      expect(getByTestId('preference').textContent).toBe('catppuccin-mocha');
+    });
+
+    await act(async () => {
+      listeners.get('theme-changed')?.(null, {
+        useSystemTheme: false,
+        theme: 'catppuccin-latte',
+      });
+    });
+
+    expect(getByTestId('preference').textContent).toBe('catppuccin-latte');
+    expect(getByTestId('accent').textContent).toBe('mauve');
+  });
+});

--- a/ui/desktop/src/contexts/ThemeContext.tsx
+++ b/ui/desktop/src/contexts/ThemeContext.tsx
@@ -1,27 +1,35 @@
 import React, { createContext, useContext, useEffect, useState, useCallback, useMemo } from 'react';
 import { applyThemeTokens, buildMcpHostStyles, themes } from '../theme/theme-tokens';
-import type { ThemeId, ThemeVariant } from '../theme/theme-tokens';
+import {
+  DEFAULT_CATPPUCCIN_ACCENT,
+  isCatppuccinAccent,
+  isThemeId,
+  isThemePreference,
+  type CatppuccinAccent,
+  type ThemeId,
+  type ThemePreference,
+  type ThemeVariant,
+} from '../theme/types';
 import type { McpUiHostStyles } from '@modelcontextprotocol/ext-apps/app-bridge';
-
-type ThemePreference = 'light' | 'dark' | 'aura' | 'system';
-type ResolvedTheme = ThemeVariant;
 
 interface ThemeContextValue {
   userThemePreference: ThemePreference;
   setUserThemePreference: (pref: ThemePreference) => void;
   resolvedThemeId: ThemeId;
-  resolvedTheme: ResolvedTheme;
+  resolvedTheme: ThemeVariant;
+  catppuccinAccent: CatppuccinAccent;
+  setCatppuccinAccent: (accent: CatppuccinAccent) => void;
   mcpHostStyles: McpUiHostStyles;
 }
 
 const ThemeContext = createContext<ThemeContextValue | null>(null);
 
-function getSystemTheme(): ResolvedTheme {
+function getSystemTheme(): ThemeVariant {
   return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
 }
 
 // Resolve a user preference to a concrete theme id. 'system' picks the light or
-// dark built-in from the OS; named themes (light/dark/aura) map to themselves.
+// dark built-in from the OS; named themes map to themselves.
 function resolveThemeId(preference: ThemePreference): ThemeId {
   if (preference === 'system') {
     return getSystemTheme();
@@ -29,7 +37,7 @@ function resolveThemeId(preference: ThemePreference): ThemeId {
   return preference;
 }
 
-function applyThemeToDocument(theme: ResolvedTheme): void {
+function applyThemeToDocument(theme: ThemeVariant): void {
   const toRemove = theme === 'dark' ? 'light' : 'dark';
   document.documentElement.classList.add(theme);
   document.documentElement.classList.remove(toRemove);
@@ -44,21 +52,34 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
   // Start with light theme to avoid flash, will update once settings load
   const [userThemePreference, setUserThemePreferenceState] = useState<ThemePreference>('light');
   const [resolvedThemeId, setResolvedThemeId] = useState<ThemeId>('light');
+  const [catppuccinAccent, setCatppuccinAccentState] =
+    useState<CatppuccinAccent>(DEFAULT_CATPPUCCIN_ACCENT);
   const resolvedTheme = themes[resolvedThemeId].variant;
-  const mcpHostStyles = useMemo(() => buildMcpHostStyles(resolvedThemeId), [resolvedThemeId]);
+  const mcpHostStyles = useMemo(
+    () => buildMcpHostStyles(resolvedThemeId, catppuccinAccent),
+    [resolvedThemeId, catppuccinAccent]
+  );
 
   useEffect(() => {
     async function loadThemeFromSettings() {
       try {
-        const [useSystemTheme, savedTheme] = await Promise.all([
+        const [useSystemTheme, savedTheme, savedAccent] = await Promise.all([
           window.electron.getSetting('useSystemTheme'),
           window.electron.getSetting('theme'),
+          window.electron.getSetting('catppuccinAccent'),
         ]);
 
-        const preference: ThemePreference = useSystemTheme ? 'system' : savedTheme;
+        const preference: ThemePreference = useSystemTheme
+          ? 'system'
+          : isThemePreference(savedTheme)
+            ? savedTheme
+            : 'light';
 
         setUserThemePreferenceState(preference);
         setResolvedThemeId(resolveThemeId(preference));
+        setCatppuccinAccentState(
+          isCatppuccinAccent(savedAccent) ? savedAccent : DEFAULT_CATPPUCCIN_ACCENT
+        );
       } catch (error) {
         console.warn('[ThemeContext] Failed to load theme settings:', error);
       }
@@ -73,7 +94,6 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
     const resolvedId = resolveThemeId(preference);
     setResolvedThemeId(resolvedId);
 
-    // Save to settings
     try {
       if (preference === 'system') {
         await window.electron.setSetting('useSystemTheme', true);
@@ -85,13 +105,30 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
       console.warn('[ThemeContext] Failed to save theme settings:', error);
     }
 
-    // Broadcast to other windows via Electron
     window.electron?.broadcastThemeChange({
       mode: themes[resolvedId].variant,
       useSystemTheme: preference === 'system',
       theme: resolvedId,
+      catppuccinAccent,
     });
-  }, []);
+  }, [catppuccinAccent]);
+
+  const setCatppuccinAccent = useCallback(async (accent: CatppuccinAccent) => {
+    setCatppuccinAccentState(accent);
+
+    try {
+      await window.electron.setSetting('catppuccinAccent', accent);
+    } catch (error) {
+      console.warn('[ThemeContext] Failed to save Catppuccin accent:', error);
+    }
+
+    window.electron?.broadcastThemeChange({
+      mode: themes[resolvedThemeId].variant,
+      useSystemTheme: userThemePreference === 'system',
+      theme: resolvedThemeId,
+      catppuccinAccent: accent,
+    });
+  }, [resolvedThemeId, userThemePreference]);
 
   // Listen for system theme changes when preference is 'system'
   useEffect(() => {
@@ -112,20 +149,31 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
     if (!window.electron) return;
 
     const handleThemeChanged = (_event: unknown, ...args: unknown[]) => {
-      const themeData = args[0] as { useSystemTheme: boolean; theme: ThemeId };
+      const themeData = args[0] as {
+        useSystemTheme: boolean;
+        theme: ThemeId;
+        catppuccinAccent?: CatppuccinAccent;
+      };
       const newPreference: ThemePreference = themeData.useSystemTheme
         ? 'system'
-        : themeData.theme;
+        : isThemeId(themeData.theme)
+          ? themeData.theme
+          : 'light';
 
       setUserThemePreferenceState(newPreference);
       setResolvedThemeId(resolveThemeId(newPreference));
+      if (isCatppuccinAccent(themeData.catppuccinAccent)) {
+        setCatppuccinAccentState(themeData.catppuccinAccent);
+      }
 
-      // Save to settings (don't await, fire and forget)
       if (newPreference === 'system') {
         window.electron.setSetting('useSystemTheme', true);
       } else {
         window.electron.setSetting('useSystemTheme', false);
         window.electron.setSetting('theme', newPreference);
+      }
+      if (isCatppuccinAccent(themeData.catppuccinAccent)) {
+        window.electron.setSetting('catppuccinAccent', themeData.catppuccinAccent);
       }
     };
 
@@ -135,18 +183,21 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
     };
   }, []);
 
-  // Apply theme class and CSS tokens whenever the resolved theme changes
+  // Apply theme class and CSS tokens whenever the resolved theme or accent changes
   useEffect(() => {
     applyThemeToDocument(themes[resolvedThemeId].variant);
-    applyThemeTokens(resolvedThemeId);
+    applyThemeTokens(resolvedThemeId, catppuccinAccent);
     document.documentElement.dataset.theme = resolvedThemeId;
-  }, [resolvedThemeId]);
+    document.documentElement.dataset.catppuccinAccent = catppuccinAccent;
+  }, [resolvedThemeId, catppuccinAccent]);
 
   const value: ThemeContextValue = {
     userThemePreference,
     setUserThemePreference,
     resolvedThemeId,
     resolvedTheme,
+    catppuccinAccent,
+    setCatppuccinAccent,
     mcpHostStyles,
   };
 

--- a/ui/desktop/src/contexts/ThemeContext.tsx
+++ b/ui/desktop/src/contexts/ThemeContext.tsx
@@ -105,13 +105,13 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
       console.warn('[ThemeContext] Failed to save theme settings:', error);
     }
 
+    // Theme-only: a newer accent can save+broadcast while these writes are in flight.
     window.electron?.broadcastThemeChange({
       mode: themes[resolvedId].variant,
       useSystemTheme: preference === 'system',
       theme: resolvedId,
-      catppuccinAccent,
     });
-  }, [catppuccinAccent]);
+  }, []);
 
   const setCatppuccinAccent = useCallback(async (accent: CatppuccinAccent) => {
     setCatppuccinAccentState(accent);
@@ -123,12 +123,9 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
     }
 
     window.electron?.broadcastThemeChange({
-      mode: themes[resolvedThemeId].variant,
-      useSystemTheme: userThemePreference === 'system',
-      theme: resolvedThemeId,
       catppuccinAccent: accent,
     });
-  }, [resolvedThemeId, userThemePreference]);
+  }, []);
 
   // Listen for system theme changes when preference is 'system'
   useEffect(() => {
@@ -150,29 +147,33 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
 
     const handleThemeChanged = (_event: unknown, ...args: unknown[]) => {
       const themeData = args[0] as {
-        useSystemTheme: boolean;
-        theme: ThemeId;
+        useSystemTheme?: boolean;
+        theme?: ThemeId;
         catppuccinAccent?: CatppuccinAccent;
       };
-      const newPreference: ThemePreference = themeData.useSystemTheme
-        ? 'system'
-        : isThemeId(themeData.theme)
-          ? themeData.theme
-          : 'light';
+      const hasThemeUpdate =
+        typeof themeData.useSystemTheme === 'boolean' || isThemeId(themeData.theme);
 
-      setUserThemePreferenceState(newPreference);
-      setResolvedThemeId(resolveThemeId(newPreference));
+      if (hasThemeUpdate) {
+        const newPreference: ThemePreference = themeData.useSystemTheme
+          ? 'system'
+          : isThemeId(themeData.theme)
+            ? themeData.theme
+            : 'light';
+
+        setUserThemePreferenceState(newPreference);
+        setResolvedThemeId(resolveThemeId(newPreference));
+
+        if (newPreference === 'system') {
+          window.electron.setSetting('useSystemTheme', true);
+        } else {
+          window.electron.setSetting('useSystemTheme', false);
+          window.electron.setSetting('theme', newPreference);
+        }
+      }
+
       if (isCatppuccinAccent(themeData.catppuccinAccent)) {
         setCatppuccinAccentState(themeData.catppuccinAccent);
-      }
-
-      if (newPreference === 'system') {
-        window.electron.setSetting('useSystemTheme', true);
-      } else {
-        window.electron.setSetting('useSystemTheme', false);
-        window.electron.setSetting('theme', newPreference);
-      }
-      if (isCatppuccinAccent(themeData.catppuccinAccent)) {
         window.electron.setSetting('catppuccinAccent', themeData.catppuccinAccent);
       }
     };

--- a/ui/desktop/src/i18n/messages/de.json
+++ b/ui/desktop/src/i18n/messages/de.json
@@ -4676,5 +4676,68 @@
   },
   "providerConfigurationModal.deviceCodeVisit": {
     "defaultMessage": "Besuchen Sie"
+  },
+  "themeSelector.builtinGroup": {
+    "defaultMessage": "Integriert"
+  },
+  "themeSelector.catppuccinGroup": {
+    "defaultMessage": "Catppuccin"
+  },
+  "themeSelector.accent": {
+    "defaultMessage": "Akzent"
+  },
+  "themeSelector.catppuccinLatte": {
+    "defaultMessage": "Latte"
+  },
+  "themeSelector.catppuccinFrappe": {
+    "defaultMessage": "Frappé"
+  },
+  "themeSelector.catppuccinMacchiato": {
+    "defaultMessage": "Macchiato"
+  },
+  "themeSelector.catppuccinMocha": {
+    "defaultMessage": "Mocha"
+  },
+  "themeSelector.accentRosewater": {
+    "defaultMessage": "Rosenwasser"
+  },
+  "themeSelector.accentFlamingo": {
+    "defaultMessage": "Flamingo"
+  },
+  "themeSelector.accentPink": {
+    "defaultMessage": "Pink"
+  },
+  "themeSelector.accentMauve": {
+    "defaultMessage": "Mauve"
+  },
+  "themeSelector.accentRed": {
+    "defaultMessage": "Rot"
+  },
+  "themeSelector.accentMaroon": {
+    "defaultMessage": "Kastanienbraun"
+  },
+  "themeSelector.accentPeach": {
+    "defaultMessage": "Pfirsich"
+  },
+  "themeSelector.accentYellow": {
+    "defaultMessage": "Gelb"
+  },
+  "themeSelector.accentGreen": {
+    "defaultMessage": "Grün"
+  },
+  "themeSelector.accentTeal": {
+    "defaultMessage": "Petrol"
+  },
+  "themeSelector.accentSky": {
+    "defaultMessage": "Himmelblau"
+  },
+  "themeSelector.accentSapphire": {
+    "defaultMessage": "Saphir"
+  },
+  "themeSelector.accentBlue": {
+    "defaultMessage": "Blau"
+  },
+  "themeSelector.accentLavender": {
+    "defaultMessage": "Lavendel"
   }
 }

--- a/ui/desktop/src/i18n/messages/en.json
+++ b/ui/desktop/src/i18n/messages/en.json
@@ -4493,8 +4493,71 @@
   "telemetrySettings.updateError": {
     "defaultMessage": "Failed to update telemetry settings."
   },
+  "themeSelector.accent": {
+    "defaultMessage": "Accent"
+  },
+  "themeSelector.accentBlue": {
+    "defaultMessage": "Blue"
+  },
+  "themeSelector.accentFlamingo": {
+    "defaultMessage": "Flamingo"
+  },
+  "themeSelector.accentGreen": {
+    "defaultMessage": "Green"
+  },
+  "themeSelector.accentLavender": {
+    "defaultMessage": "Lavender"
+  },
+  "themeSelector.accentMaroon": {
+    "defaultMessage": "Maroon"
+  },
+  "themeSelector.accentMauve": {
+    "defaultMessage": "Mauve"
+  },
+  "themeSelector.accentPeach": {
+    "defaultMessage": "Peach"
+  },
+  "themeSelector.accentPink": {
+    "defaultMessage": "Pink"
+  },
+  "themeSelector.accentRed": {
+    "defaultMessage": "Red"
+  },
+  "themeSelector.accentRosewater": {
+    "defaultMessage": "Rosewater"
+  },
+  "themeSelector.accentSapphire": {
+    "defaultMessage": "Sapphire"
+  },
+  "themeSelector.accentSky": {
+    "defaultMessage": "Sky"
+  },
+  "themeSelector.accentTeal": {
+    "defaultMessage": "Teal"
+  },
+  "themeSelector.accentYellow": {
+    "defaultMessage": "Yellow"
+  },
   "themeSelector.aura": {
     "defaultMessage": "Aura"
+  },
+  "themeSelector.builtinGroup": {
+    "defaultMessage": "Built-in"
+  },
+  "themeSelector.catppuccinFrappe": {
+    "defaultMessage": "Frappé"
+  },
+  "themeSelector.catppuccinGroup": {
+    "defaultMessage": "Catppuccin"
+  },
+  "themeSelector.catppuccinLatte": {
+    "defaultMessage": "Latte"
+  },
+  "themeSelector.catppuccinMacchiato": {
+    "defaultMessage": "Macchiato"
+  },
+  "themeSelector.catppuccinMocha": {
+    "defaultMessage": "Mocha"
   },
   "themeSelector.dark": {
     "defaultMessage": "Dark"

--- a/ui/desktop/src/i18n/messages/es.json
+++ b/ui/desktop/src/i18n/messages/es.json
@@ -4677,5 +4677,68 @@
   },
   "providerConfigurationModal.deviceCodeVisit": {
     "defaultMessage": "Visita"
+  },
+  "themeSelector.builtinGroup": {
+    "defaultMessage": "Integrados"
+  },
+  "themeSelector.catppuccinGroup": {
+    "defaultMessage": "Catppuccin"
+  },
+  "themeSelector.accent": {
+    "defaultMessage": "Acento"
+  },
+  "themeSelector.catppuccinLatte": {
+    "defaultMessage": "Latte"
+  },
+  "themeSelector.catppuccinFrappe": {
+    "defaultMessage": "Frappé"
+  },
+  "themeSelector.catppuccinMacchiato": {
+    "defaultMessage": "Macchiato"
+  },
+  "themeSelector.catppuccinMocha": {
+    "defaultMessage": "Mocha"
+  },
+  "themeSelector.accentRosewater": {
+    "defaultMessage": "Agua de rosas"
+  },
+  "themeSelector.accentFlamingo": {
+    "defaultMessage": "Flamenco"
+  },
+  "themeSelector.accentPink": {
+    "defaultMessage": "Rosa"
+  },
+  "themeSelector.accentMauve": {
+    "defaultMessage": "Malva"
+  },
+  "themeSelector.accentRed": {
+    "defaultMessage": "Rojo"
+  },
+  "themeSelector.accentMaroon": {
+    "defaultMessage": "Granate"
+  },
+  "themeSelector.accentPeach": {
+    "defaultMessage": "Melocotón"
+  },
+  "themeSelector.accentYellow": {
+    "defaultMessage": "Amarillo"
+  },
+  "themeSelector.accentGreen": {
+    "defaultMessage": "Verde"
+  },
+  "themeSelector.accentTeal": {
+    "defaultMessage": "Verde azulado"
+  },
+  "themeSelector.accentSky": {
+    "defaultMessage": "Cielo"
+  },
+  "themeSelector.accentSapphire": {
+    "defaultMessage": "Zafiro"
+  },
+  "themeSelector.accentBlue": {
+    "defaultMessage": "Azul"
+  },
+  "themeSelector.accentLavender": {
+    "defaultMessage": "Lavanda"
   }
 }

--- a/ui/desktop/src/i18n/messages/fr.json
+++ b/ui/desktop/src/i18n/messages/fr.json
@@ -4677,5 +4677,68 @@
   },
   "providerConfigurationModal.deviceCodeVisit": {
     "defaultMessage": "Visitez"
+  },
+  "themeSelector.builtinGroup": {
+    "defaultMessage": "Intégrés"
+  },
+  "themeSelector.catppuccinGroup": {
+    "defaultMessage": "Catppuccin"
+  },
+  "themeSelector.accent": {
+    "defaultMessage": "Accent"
+  },
+  "themeSelector.catppuccinLatte": {
+    "defaultMessage": "Latte"
+  },
+  "themeSelector.catppuccinFrappe": {
+    "defaultMessage": "Frappé"
+  },
+  "themeSelector.catppuccinMacchiato": {
+    "defaultMessage": "Macchiato"
+  },
+  "themeSelector.catppuccinMocha": {
+    "defaultMessage": "Mocha"
+  },
+  "themeSelector.accentRosewater": {
+    "defaultMessage": "Eau de rose"
+  },
+  "themeSelector.accentFlamingo": {
+    "defaultMessage": "Flamant"
+  },
+  "themeSelector.accentPink": {
+    "defaultMessage": "Rose"
+  },
+  "themeSelector.accentMauve": {
+    "defaultMessage": "Mauve"
+  },
+  "themeSelector.accentRed": {
+    "defaultMessage": "Rouge"
+  },
+  "themeSelector.accentMaroon": {
+    "defaultMessage": "Bordeaux"
+  },
+  "themeSelector.accentPeach": {
+    "defaultMessage": "Pêche"
+  },
+  "themeSelector.accentYellow": {
+    "defaultMessage": "Jaune"
+  },
+  "themeSelector.accentGreen": {
+    "defaultMessage": "Vert"
+  },
+  "themeSelector.accentTeal": {
+    "defaultMessage": "Sarcelle"
+  },
+  "themeSelector.accentSky": {
+    "defaultMessage": "Ciel"
+  },
+  "themeSelector.accentSapphire": {
+    "defaultMessage": "Saphir"
+  },
+  "themeSelector.accentBlue": {
+    "defaultMessage": "Bleu"
+  },
+  "themeSelector.accentLavender": {
+    "defaultMessage": "Lavande"
   }
 }

--- a/ui/desktop/src/i18n/messages/hi.json
+++ b/ui/desktop/src/i18n/messages/hi.json
@@ -4677,5 +4677,68 @@
   },
   "providerConfigurationModal.deviceCodeVisit": {
     "defaultMessage": "जाएं"
+  },
+  "themeSelector.builtinGroup": {
+    "defaultMessage": "Built-in"
+  },
+  "themeSelector.catppuccinGroup": {
+    "defaultMessage": "Catppuccin"
+  },
+  "themeSelector.accent": {
+    "defaultMessage": "Accent"
+  },
+  "themeSelector.catppuccinLatte": {
+    "defaultMessage": "Latte"
+  },
+  "themeSelector.catppuccinFrappe": {
+    "defaultMessage": "Frappé"
+  },
+  "themeSelector.catppuccinMacchiato": {
+    "defaultMessage": "Macchiato"
+  },
+  "themeSelector.catppuccinMocha": {
+    "defaultMessage": "Mocha"
+  },
+  "themeSelector.accentRosewater": {
+    "defaultMessage": "Rosewater"
+  },
+  "themeSelector.accentFlamingo": {
+    "defaultMessage": "Flamingo"
+  },
+  "themeSelector.accentPink": {
+    "defaultMessage": "Pink"
+  },
+  "themeSelector.accentMauve": {
+    "defaultMessage": "Mauve"
+  },
+  "themeSelector.accentRed": {
+    "defaultMessage": "Red"
+  },
+  "themeSelector.accentMaroon": {
+    "defaultMessage": "Maroon"
+  },
+  "themeSelector.accentPeach": {
+    "defaultMessage": "Peach"
+  },
+  "themeSelector.accentYellow": {
+    "defaultMessage": "Yellow"
+  },
+  "themeSelector.accentGreen": {
+    "defaultMessage": "Green"
+  },
+  "themeSelector.accentTeal": {
+    "defaultMessage": "Teal"
+  },
+  "themeSelector.accentSky": {
+    "defaultMessage": "Sky"
+  },
+  "themeSelector.accentSapphire": {
+    "defaultMessage": "Sapphire"
+  },
+  "themeSelector.accentBlue": {
+    "defaultMessage": "Blue"
+  },
+  "themeSelector.accentLavender": {
+    "defaultMessage": "Lavender"
   }
 }

--- a/ui/desktop/src/i18n/messages/id.json
+++ b/ui/desktop/src/i18n/messages/id.json
@@ -4677,5 +4677,68 @@
   },
   "providerConfigurationModal.deviceCodeVisit": {
     "defaultMessage": "Kunjungi"
+  },
+  "themeSelector.builtinGroup": {
+    "defaultMessage": "Built-in"
+  },
+  "themeSelector.catppuccinGroup": {
+    "defaultMessage": "Catppuccin"
+  },
+  "themeSelector.accent": {
+    "defaultMessage": "Accent"
+  },
+  "themeSelector.catppuccinLatte": {
+    "defaultMessage": "Latte"
+  },
+  "themeSelector.catppuccinFrappe": {
+    "defaultMessage": "Frappé"
+  },
+  "themeSelector.catppuccinMacchiato": {
+    "defaultMessage": "Macchiato"
+  },
+  "themeSelector.catppuccinMocha": {
+    "defaultMessage": "Mocha"
+  },
+  "themeSelector.accentRosewater": {
+    "defaultMessage": "Rosewater"
+  },
+  "themeSelector.accentFlamingo": {
+    "defaultMessage": "Flamingo"
+  },
+  "themeSelector.accentPink": {
+    "defaultMessage": "Pink"
+  },
+  "themeSelector.accentMauve": {
+    "defaultMessage": "Mauve"
+  },
+  "themeSelector.accentRed": {
+    "defaultMessage": "Red"
+  },
+  "themeSelector.accentMaroon": {
+    "defaultMessage": "Maroon"
+  },
+  "themeSelector.accentPeach": {
+    "defaultMessage": "Peach"
+  },
+  "themeSelector.accentYellow": {
+    "defaultMessage": "Yellow"
+  },
+  "themeSelector.accentGreen": {
+    "defaultMessage": "Green"
+  },
+  "themeSelector.accentTeal": {
+    "defaultMessage": "Teal"
+  },
+  "themeSelector.accentSky": {
+    "defaultMessage": "Sky"
+  },
+  "themeSelector.accentSapphire": {
+    "defaultMessage": "Sapphire"
+  },
+  "themeSelector.accentBlue": {
+    "defaultMessage": "Blue"
+  },
+  "themeSelector.accentLavender": {
+    "defaultMessage": "Lavender"
   }
 }

--- a/ui/desktop/src/i18n/messages/it.json
+++ b/ui/desktop/src/i18n/messages/it.json
@@ -4677,5 +4677,68 @@
   },
   "providerConfigurationModal.deviceCodeVisit": {
     "defaultMessage": "Visita"
+  },
+  "themeSelector.builtinGroup": {
+    "defaultMessage": "Integrati"
+  },
+  "themeSelector.catppuccinGroup": {
+    "defaultMessage": "Catppuccin"
+  },
+  "themeSelector.accent": {
+    "defaultMessage": "Accento"
+  },
+  "themeSelector.catppuccinLatte": {
+    "defaultMessage": "Latte"
+  },
+  "themeSelector.catppuccinFrappe": {
+    "defaultMessage": "Frappé"
+  },
+  "themeSelector.catppuccinMacchiato": {
+    "defaultMessage": "Macchiato"
+  },
+  "themeSelector.catppuccinMocha": {
+    "defaultMessage": "Mocha"
+  },
+  "themeSelector.accentRosewater": {
+    "defaultMessage": "Acqua di rose"
+  },
+  "themeSelector.accentFlamingo": {
+    "defaultMessage": "Fenicottero"
+  },
+  "themeSelector.accentPink": {
+    "defaultMessage": "Rosa"
+  },
+  "themeSelector.accentMauve": {
+    "defaultMessage": "Malva"
+  },
+  "themeSelector.accentRed": {
+    "defaultMessage": "Rosso"
+  },
+  "themeSelector.accentMaroon": {
+    "defaultMessage": "Bordeaux"
+  },
+  "themeSelector.accentPeach": {
+    "defaultMessage": "Pesca"
+  },
+  "themeSelector.accentYellow": {
+    "defaultMessage": "Giallo"
+  },
+  "themeSelector.accentGreen": {
+    "defaultMessage": "Verde"
+  },
+  "themeSelector.accentTeal": {
+    "defaultMessage": "Ottanio"
+  },
+  "themeSelector.accentSky": {
+    "defaultMessage": "Cielo"
+  },
+  "themeSelector.accentSapphire": {
+    "defaultMessage": "Zaffiro"
+  },
+  "themeSelector.accentBlue": {
+    "defaultMessage": "Blu"
+  },
+  "themeSelector.accentLavender": {
+    "defaultMessage": "Lavanda"
   }
 }

--- a/ui/desktop/src/i18n/messages/ja.json
+++ b/ui/desktop/src/i18n/messages/ja.json
@@ -4677,5 +4677,68 @@
   },
   "providerConfigurationModal.deviceCodeVisit": {
     "defaultMessage": "次のURLにアクセスし、"
+  },
+  "themeSelector.builtinGroup": {
+    "defaultMessage": "組み込み"
+  },
+  "themeSelector.catppuccinGroup": {
+    "defaultMessage": "Catppuccin"
+  },
+  "themeSelector.accent": {
+    "defaultMessage": "アクセント"
+  },
+  "themeSelector.catppuccinLatte": {
+    "defaultMessage": "Latte"
+  },
+  "themeSelector.catppuccinFrappe": {
+    "defaultMessage": "Frappé"
+  },
+  "themeSelector.catppuccinMacchiato": {
+    "defaultMessage": "Macchiato"
+  },
+  "themeSelector.catppuccinMocha": {
+    "defaultMessage": "Mocha"
+  },
+  "themeSelector.accentRosewater": {
+    "defaultMessage": "ローズウォーター"
+  },
+  "themeSelector.accentFlamingo": {
+    "defaultMessage": "フラミンゴ"
+  },
+  "themeSelector.accentPink": {
+    "defaultMessage": "ピンク"
+  },
+  "themeSelector.accentMauve": {
+    "defaultMessage": "モーブ"
+  },
+  "themeSelector.accentRed": {
+    "defaultMessage": "レッド"
+  },
+  "themeSelector.accentMaroon": {
+    "defaultMessage": "マルーン"
+  },
+  "themeSelector.accentPeach": {
+    "defaultMessage": "ピーチ"
+  },
+  "themeSelector.accentYellow": {
+    "defaultMessage": "イエロー"
+  },
+  "themeSelector.accentGreen": {
+    "defaultMessage": "グリーン"
+  },
+  "themeSelector.accentTeal": {
+    "defaultMessage": "ティール"
+  },
+  "themeSelector.accentSky": {
+    "defaultMessage": "スカイ"
+  },
+  "themeSelector.accentSapphire": {
+    "defaultMessage": "サファイア"
+  },
+  "themeSelector.accentBlue": {
+    "defaultMessage": "ブルー"
+  },
+  "themeSelector.accentLavender": {
+    "defaultMessage": "ラベンダー"
   }
 }

--- a/ui/desktop/src/i18n/messages/ko.json
+++ b/ui/desktop/src/i18n/messages/ko.json
@@ -4677,5 +4677,68 @@
   },
   "providerConfigurationModal.deviceCodeVisit": {
     "defaultMessage": "방문하여"
+  },
+  "themeSelector.builtinGroup": {
+    "defaultMessage": "기본"
+  },
+  "themeSelector.catppuccinGroup": {
+    "defaultMessage": "Catppuccin"
+  },
+  "themeSelector.accent": {
+    "defaultMessage": "액센트"
+  },
+  "themeSelector.catppuccinLatte": {
+    "defaultMessage": "Latte"
+  },
+  "themeSelector.catppuccinFrappe": {
+    "defaultMessage": "Frappé"
+  },
+  "themeSelector.catppuccinMacchiato": {
+    "defaultMessage": "Macchiato"
+  },
+  "themeSelector.catppuccinMocha": {
+    "defaultMessage": "Mocha"
+  },
+  "themeSelector.accentRosewater": {
+    "defaultMessage": "로즈워터"
+  },
+  "themeSelector.accentFlamingo": {
+    "defaultMessage": "플라밍고"
+  },
+  "themeSelector.accentPink": {
+    "defaultMessage": "핑크"
+  },
+  "themeSelector.accentMauve": {
+    "defaultMessage": "모브"
+  },
+  "themeSelector.accentRed": {
+    "defaultMessage": "레드"
+  },
+  "themeSelector.accentMaroon": {
+    "defaultMessage": "마룬"
+  },
+  "themeSelector.accentPeach": {
+    "defaultMessage": "피치"
+  },
+  "themeSelector.accentYellow": {
+    "defaultMessage": "옐로"
+  },
+  "themeSelector.accentGreen": {
+    "defaultMessage": "그린"
+  },
+  "themeSelector.accentTeal": {
+    "defaultMessage": "틸"
+  },
+  "themeSelector.accentSky": {
+    "defaultMessage": "스카이"
+  },
+  "themeSelector.accentSapphire": {
+    "defaultMessage": "사파이어"
+  },
+  "themeSelector.accentBlue": {
+    "defaultMessage": "블루"
+  },
+  "themeSelector.accentLavender": {
+    "defaultMessage": "라벤더"
   }
 }

--- a/ui/desktop/src/i18n/messages/ms.json
+++ b/ui/desktop/src/i18n/messages/ms.json
@@ -4677,5 +4677,68 @@
   },
   "providerConfigurationModal.deviceCodeVisit": {
     "defaultMessage": "Lawati"
+  },
+  "themeSelector.builtinGroup": {
+    "defaultMessage": "Built-in"
+  },
+  "themeSelector.catppuccinGroup": {
+    "defaultMessage": "Catppuccin"
+  },
+  "themeSelector.accent": {
+    "defaultMessage": "Accent"
+  },
+  "themeSelector.catppuccinLatte": {
+    "defaultMessage": "Latte"
+  },
+  "themeSelector.catppuccinFrappe": {
+    "defaultMessage": "Frappé"
+  },
+  "themeSelector.catppuccinMacchiato": {
+    "defaultMessage": "Macchiato"
+  },
+  "themeSelector.catppuccinMocha": {
+    "defaultMessage": "Mocha"
+  },
+  "themeSelector.accentRosewater": {
+    "defaultMessage": "Rosewater"
+  },
+  "themeSelector.accentFlamingo": {
+    "defaultMessage": "Flamingo"
+  },
+  "themeSelector.accentPink": {
+    "defaultMessage": "Pink"
+  },
+  "themeSelector.accentMauve": {
+    "defaultMessage": "Mauve"
+  },
+  "themeSelector.accentRed": {
+    "defaultMessage": "Red"
+  },
+  "themeSelector.accentMaroon": {
+    "defaultMessage": "Maroon"
+  },
+  "themeSelector.accentPeach": {
+    "defaultMessage": "Peach"
+  },
+  "themeSelector.accentYellow": {
+    "defaultMessage": "Yellow"
+  },
+  "themeSelector.accentGreen": {
+    "defaultMessage": "Green"
+  },
+  "themeSelector.accentTeal": {
+    "defaultMessage": "Teal"
+  },
+  "themeSelector.accentSky": {
+    "defaultMessage": "Sky"
+  },
+  "themeSelector.accentSapphire": {
+    "defaultMessage": "Sapphire"
+  },
+  "themeSelector.accentBlue": {
+    "defaultMessage": "Blue"
+  },
+  "themeSelector.accentLavender": {
+    "defaultMessage": "Lavender"
   }
 }

--- a/ui/desktop/src/i18n/messages/pt.json
+++ b/ui/desktop/src/i18n/messages/pt.json
@@ -4677,5 +4677,68 @@
   },
   "providerConfigurationModal.deviceCodeVisit": {
     "defaultMessage": "Acesse"
+  },
+  "themeSelector.builtinGroup": {
+    "defaultMessage": "Integrados"
+  },
+  "themeSelector.catppuccinGroup": {
+    "defaultMessage": "Catppuccin"
+  },
+  "themeSelector.accent": {
+    "defaultMessage": "Acento"
+  },
+  "themeSelector.catppuccinLatte": {
+    "defaultMessage": "Latte"
+  },
+  "themeSelector.catppuccinFrappe": {
+    "defaultMessage": "Frappé"
+  },
+  "themeSelector.catppuccinMacchiato": {
+    "defaultMessage": "Macchiato"
+  },
+  "themeSelector.catppuccinMocha": {
+    "defaultMessage": "Mocha"
+  },
+  "themeSelector.accentRosewater": {
+    "defaultMessage": "Água de rosas"
+  },
+  "themeSelector.accentFlamingo": {
+    "defaultMessage": "Flamingo"
+  },
+  "themeSelector.accentPink": {
+    "defaultMessage": "Rosa"
+  },
+  "themeSelector.accentMauve": {
+    "defaultMessage": "Malva"
+  },
+  "themeSelector.accentRed": {
+    "defaultMessage": "Vermelho"
+  },
+  "themeSelector.accentMaroon": {
+    "defaultMessage": "Bordô"
+  },
+  "themeSelector.accentPeach": {
+    "defaultMessage": "Pêssego"
+  },
+  "themeSelector.accentYellow": {
+    "defaultMessage": "Amarelo"
+  },
+  "themeSelector.accentGreen": {
+    "defaultMessage": "Verde"
+  },
+  "themeSelector.accentTeal": {
+    "defaultMessage": "Azul-petróleo"
+  },
+  "themeSelector.accentSky": {
+    "defaultMessage": "Céu"
+  },
+  "themeSelector.accentSapphire": {
+    "defaultMessage": "Safira"
+  },
+  "themeSelector.accentBlue": {
+    "defaultMessage": "Azul"
+  },
+  "themeSelector.accentLavender": {
+    "defaultMessage": "Lavanda"
   }
 }

--- a/ui/desktop/src/i18n/messages/ru.json
+++ b/ui/desktop/src/i18n/messages/ru.json
@@ -4677,5 +4677,68 @@
   },
   "providerConfigurationModal.deviceCodeVisit": {
     "defaultMessage": "Перейдите на"
+  },
+  "themeSelector.builtinGroup": {
+    "defaultMessage": "Встроенные"
+  },
+  "themeSelector.catppuccinGroup": {
+    "defaultMessage": "Catppuccin"
+  },
+  "themeSelector.accent": {
+    "defaultMessage": "Акцент"
+  },
+  "themeSelector.catppuccinLatte": {
+    "defaultMessage": "Latte"
+  },
+  "themeSelector.catppuccinFrappe": {
+    "defaultMessage": "Frappé"
+  },
+  "themeSelector.catppuccinMacchiato": {
+    "defaultMessage": "Macchiato"
+  },
+  "themeSelector.catppuccinMocha": {
+    "defaultMessage": "Mocha"
+  },
+  "themeSelector.accentRosewater": {
+    "defaultMessage": "Розовая вода"
+  },
+  "themeSelector.accentFlamingo": {
+    "defaultMessage": "Фламинго"
+  },
+  "themeSelector.accentPink": {
+    "defaultMessage": "Розовый"
+  },
+  "themeSelector.accentMauve": {
+    "defaultMessage": "Лиловый"
+  },
+  "themeSelector.accentRed": {
+    "defaultMessage": "Красный"
+  },
+  "themeSelector.accentMaroon": {
+    "defaultMessage": "Бордовый"
+  },
+  "themeSelector.accentPeach": {
+    "defaultMessage": "Персиковый"
+  },
+  "themeSelector.accentYellow": {
+    "defaultMessage": "Жёлтый"
+  },
+  "themeSelector.accentGreen": {
+    "defaultMessage": "Зелёный"
+  },
+  "themeSelector.accentTeal": {
+    "defaultMessage": "Бирюзовый"
+  },
+  "themeSelector.accentSky": {
+    "defaultMessage": "Небесный"
+  },
+  "themeSelector.accentSapphire": {
+    "defaultMessage": "Сапфировый"
+  },
+  "themeSelector.accentBlue": {
+    "defaultMessage": "Синий"
+  },
+  "themeSelector.accentLavender": {
+    "defaultMessage": "Лавандовый"
   }
 }

--- a/ui/desktop/src/i18n/messages/tr.json
+++ b/ui/desktop/src/i18n/messages/tr.json
@@ -4677,5 +4677,68 @@
   },
   "providerConfigurationModal.deviceCodeVisit": {
     "defaultMessage": "Ziyaret edin"
+  },
+  "themeSelector.builtinGroup": {
+    "defaultMessage": "Built-in"
+  },
+  "themeSelector.catppuccinGroup": {
+    "defaultMessage": "Catppuccin"
+  },
+  "themeSelector.accent": {
+    "defaultMessage": "Accent"
+  },
+  "themeSelector.catppuccinLatte": {
+    "defaultMessage": "Latte"
+  },
+  "themeSelector.catppuccinFrappe": {
+    "defaultMessage": "Frappé"
+  },
+  "themeSelector.catppuccinMacchiato": {
+    "defaultMessage": "Macchiato"
+  },
+  "themeSelector.catppuccinMocha": {
+    "defaultMessage": "Mocha"
+  },
+  "themeSelector.accentRosewater": {
+    "defaultMessage": "Rosewater"
+  },
+  "themeSelector.accentFlamingo": {
+    "defaultMessage": "Flamingo"
+  },
+  "themeSelector.accentPink": {
+    "defaultMessage": "Pink"
+  },
+  "themeSelector.accentMauve": {
+    "defaultMessage": "Mauve"
+  },
+  "themeSelector.accentRed": {
+    "defaultMessage": "Red"
+  },
+  "themeSelector.accentMaroon": {
+    "defaultMessage": "Maroon"
+  },
+  "themeSelector.accentPeach": {
+    "defaultMessage": "Peach"
+  },
+  "themeSelector.accentYellow": {
+    "defaultMessage": "Yellow"
+  },
+  "themeSelector.accentGreen": {
+    "defaultMessage": "Green"
+  },
+  "themeSelector.accentTeal": {
+    "defaultMessage": "Teal"
+  },
+  "themeSelector.accentSky": {
+    "defaultMessage": "Sky"
+  },
+  "themeSelector.accentSapphire": {
+    "defaultMessage": "Sapphire"
+  },
+  "themeSelector.accentBlue": {
+    "defaultMessage": "Blue"
+  },
+  "themeSelector.accentLavender": {
+    "defaultMessage": "Lavender"
   }
 }

--- a/ui/desktop/src/i18n/messages/vi.json
+++ b/ui/desktop/src/i18n/messages/vi.json
@@ -4677,5 +4677,68 @@
   },
   "providerConfigurationModal.deviceCodeVisit": {
     "defaultMessage": "Truy cập"
+  },
+  "themeSelector.builtinGroup": {
+    "defaultMessage": "Built-in"
+  },
+  "themeSelector.catppuccinGroup": {
+    "defaultMessage": "Catppuccin"
+  },
+  "themeSelector.accent": {
+    "defaultMessage": "Accent"
+  },
+  "themeSelector.catppuccinLatte": {
+    "defaultMessage": "Latte"
+  },
+  "themeSelector.catppuccinFrappe": {
+    "defaultMessage": "Frappé"
+  },
+  "themeSelector.catppuccinMacchiato": {
+    "defaultMessage": "Macchiato"
+  },
+  "themeSelector.catppuccinMocha": {
+    "defaultMessage": "Mocha"
+  },
+  "themeSelector.accentRosewater": {
+    "defaultMessage": "Rosewater"
+  },
+  "themeSelector.accentFlamingo": {
+    "defaultMessage": "Flamingo"
+  },
+  "themeSelector.accentPink": {
+    "defaultMessage": "Pink"
+  },
+  "themeSelector.accentMauve": {
+    "defaultMessage": "Mauve"
+  },
+  "themeSelector.accentRed": {
+    "defaultMessage": "Red"
+  },
+  "themeSelector.accentMaroon": {
+    "defaultMessage": "Maroon"
+  },
+  "themeSelector.accentPeach": {
+    "defaultMessage": "Peach"
+  },
+  "themeSelector.accentYellow": {
+    "defaultMessage": "Yellow"
+  },
+  "themeSelector.accentGreen": {
+    "defaultMessage": "Green"
+  },
+  "themeSelector.accentTeal": {
+    "defaultMessage": "Teal"
+  },
+  "themeSelector.accentSky": {
+    "defaultMessage": "Sky"
+  },
+  "themeSelector.accentSapphire": {
+    "defaultMessage": "Sapphire"
+  },
+  "themeSelector.accentBlue": {
+    "defaultMessage": "Blue"
+  },
+  "themeSelector.accentLavender": {
+    "defaultMessage": "Lavender"
   }
 }

--- a/ui/desktop/src/i18n/messages/zh-CN.json
+++ b/ui/desktop/src/i18n/messages/zh-CN.json
@@ -4677,5 +4677,68 @@
   },
   "providerConfigurationModal.deviceCodeVisit": {
     "defaultMessage": "访问"
+  },
+  "themeSelector.builtinGroup": {
+    "defaultMessage": "内置"
+  },
+  "themeSelector.catppuccinGroup": {
+    "defaultMessage": "Catppuccin"
+  },
+  "themeSelector.accent": {
+    "defaultMessage": "强调色"
+  },
+  "themeSelector.catppuccinLatte": {
+    "defaultMessage": "Latte"
+  },
+  "themeSelector.catppuccinFrappe": {
+    "defaultMessage": "Frappé"
+  },
+  "themeSelector.catppuccinMacchiato": {
+    "defaultMessage": "Macchiato"
+  },
+  "themeSelector.catppuccinMocha": {
+    "defaultMessage": "Mocha"
+  },
+  "themeSelector.accentRosewater": {
+    "defaultMessage": "玫瑰水"
+  },
+  "themeSelector.accentFlamingo": {
+    "defaultMessage": "火烈鸟"
+  },
+  "themeSelector.accentPink": {
+    "defaultMessage": "粉色"
+  },
+  "themeSelector.accentMauve": {
+    "defaultMessage": "淡紫"
+  },
+  "themeSelector.accentRed": {
+    "defaultMessage": "红色"
+  },
+  "themeSelector.accentMaroon": {
+    "defaultMessage": "栗色"
+  },
+  "themeSelector.accentPeach": {
+    "defaultMessage": "桃色"
+  },
+  "themeSelector.accentYellow": {
+    "defaultMessage": "黄色"
+  },
+  "themeSelector.accentGreen": {
+    "defaultMessage": "绿色"
+  },
+  "themeSelector.accentTeal": {
+    "defaultMessage": "青色"
+  },
+  "themeSelector.accentSky": {
+    "defaultMessage": "天空蓝"
+  },
+  "themeSelector.accentSapphire": {
+    "defaultMessage": "宝石蓝"
+  },
+  "themeSelector.accentBlue": {
+    "defaultMessage": "蓝色"
+  },
+  "themeSelector.accentLavender": {
+    "defaultMessage": "薰衣草"
   }
 }

--- a/ui/desktop/src/i18n/messages/zh-TW.json
+++ b/ui/desktop/src/i18n/messages/zh-TW.json
@@ -4677,5 +4677,68 @@
   },
   "providerConfigurationModal.deviceCodeVisit": {
     "defaultMessage": "前往"
+  },
+  "themeSelector.builtinGroup": {
+    "defaultMessage": "內建"
+  },
+  "themeSelector.catppuccinGroup": {
+    "defaultMessage": "Catppuccin"
+  },
+  "themeSelector.accent": {
+    "defaultMessage": "強調色"
+  },
+  "themeSelector.catppuccinLatte": {
+    "defaultMessage": "Latte"
+  },
+  "themeSelector.catppuccinFrappe": {
+    "defaultMessage": "Frappé"
+  },
+  "themeSelector.catppuccinMacchiato": {
+    "defaultMessage": "Macchiato"
+  },
+  "themeSelector.catppuccinMocha": {
+    "defaultMessage": "Mocha"
+  },
+  "themeSelector.accentRosewater": {
+    "defaultMessage": "玫瑰水"
+  },
+  "themeSelector.accentFlamingo": {
+    "defaultMessage": "紅鶴"
+  },
+  "themeSelector.accentPink": {
+    "defaultMessage": "粉紅"
+  },
+  "themeSelector.accentMauve": {
+    "defaultMessage": "淡紫"
+  },
+  "themeSelector.accentRed": {
+    "defaultMessage": "紅色"
+  },
+  "themeSelector.accentMaroon": {
+    "defaultMessage": "栗色"
+  },
+  "themeSelector.accentPeach": {
+    "defaultMessage": "桃色"
+  },
+  "themeSelector.accentYellow": {
+    "defaultMessage": "黃色"
+  },
+  "themeSelector.accentGreen": {
+    "defaultMessage": "綠色"
+  },
+  "themeSelector.accentTeal": {
+    "defaultMessage": "青色"
+  },
+  "themeSelector.accentSky": {
+    "defaultMessage": "天空藍"
+  },
+  "themeSelector.accentSapphire": {
+    "defaultMessage": "寶石藍"
+  },
+  "themeSelector.accentBlue": {
+    "defaultMessage": "藍色"
+  },
+  "themeSelector.accentLavender": {
+    "defaultMessage": "薰衣草"
   }
 }

--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -40,6 +40,7 @@ import { formatAppName, errorMessage, formatErrorForLogging } from './utils/conv
 import { isRetiredGooseChatApp } from './utils/retiredApps';
 import type { Settings, SettingKey } from './utils/settings';
 import { defaultSettings, getKeyboardShortcuts } from './utils/settings';
+import { isCatppuccinAccent, isThemeId } from './theme/types';
 import * as crypto from 'crypto';
 import * as yaml from 'yaml';
 import windowStateKeeper from 'electron-window-state';
@@ -1981,6 +1982,7 @@ const validSettingKeys: Set<string> = new Set([
   'keyboardShortcuts',
   'theme',
   'useSystemTheme',
+  'catppuccinAccent',
   'language',
   'responseStyle',
   'showPricing',
@@ -1998,6 +2000,16 @@ ipcMain.handle('set-setting', (_event, key: SettingKey, value: unknown) => {
 
   if (key === 'language' && !isValidLanguageSetting(value)) {
     console.error(`Invalid language setting rejected: ${String(value)}`);
+    return;
+  }
+
+  if (key === 'theme' && !isThemeId(value)) {
+    console.error(`Invalid theme setting rejected: ${String(value)}`);
+    return;
+  }
+
+  if (key === 'catppuccinAccent' && !isCatppuccinAccent(value)) {
+    console.error(`Invalid Catppuccin accent rejected: ${String(value)}`);
     return;
   }
 

--- a/ui/desktop/src/preload.ts
+++ b/ui/desktop/src/preload.ts
@@ -9,6 +9,7 @@ import type { OpenExternalUrlResult } from './utils/urlSecurity';
 const localStorageKeyMap: Partial<Record<SettingKey, string>> = {
   theme: 'theme',
   useSystemTheme: 'use_system_theme',
+  catppuccinAccent: 'catppuccin_accent',
   responseStyle: 'response_style',
   showPricing: 'show_pricing',
   seenAnnouncementIds: 'seenAnnouncementIds',
@@ -22,9 +23,13 @@ function parseLocalStorageValue<K extends SettingKey>(
   try {
     switch (key) {
       case 'theme':
-        return (rawValue === 'dark' || rawValue === 'light' ? rawValue : null) as Settings[K];
+        return (
+          rawValue === 'dark' || rawValue === 'light' || rawValue === 'aura' ? rawValue : null
+        ) as Settings[K];
       case 'useSystemTheme':
         return (rawValue === 'true') as unknown as Settings[K];
+      case 'catppuccinAccent':
+        return rawValue as Settings[K];
       case 'responseStyle':
         return rawValue as Settings[K];
       case 'showPricing':
@@ -157,6 +162,7 @@ type ElectronAPI = {
     mode: string;
     useSystemTheme: boolean;
     theme: string;
+    catppuccinAccent?: string;
     tokensUpdated?: boolean;
   }) => void;
   openExternal: (url: string) => Promise<OpenExternalUrlResult>;
@@ -297,6 +303,7 @@ const electronAPI: ElectronAPI = {
     mode: string;
     useSystemTheme: boolean;
     theme: string;
+    catppuccinAccent?: string;
     tokensUpdated?: boolean;
   }) => {
     ipcRenderer.send('broadcast-theme-change', themeData);

--- a/ui/desktop/src/preload.ts
+++ b/ui/desktop/src/preload.ts
@@ -4,6 +4,7 @@ import type { GooseApp } from './types/apps';
 import type { Settings, SettingKey } from './utils/settings';
 import { defaultSettings } from './utils/settings';
 import type { OpenExternalUrlResult } from './utils/urlSecurity';
+import { isCatppuccinAccent, isThemeId } from './theme/types';
 
 // Mapping from settings keys to their old localStorage keys for lazy migration
 const localStorageKeyMap: Partial<Record<SettingKey, string>> = {
@@ -23,13 +24,11 @@ function parseLocalStorageValue<K extends SettingKey>(
   try {
     switch (key) {
       case 'theme':
-        return (
-          rawValue === 'dark' || rawValue === 'light' || rawValue === 'aura' ? rawValue : null
-        ) as Settings[K];
+        return (isThemeId(rawValue) ? rawValue : null) as Settings[K];
       case 'useSystemTheme':
         return (rawValue === 'true') as unknown as Settings[K];
       case 'catppuccinAccent':
-        return rawValue as Settings[K];
+        return (isCatppuccinAccent(rawValue) ? rawValue : null) as Settings[K];
       case 'responseStyle':
         return rawValue as Settings[K];
       case 'showPricing':
@@ -159,9 +158,9 @@ type ElectronAPI = {
   ) => void;
   emit: (channel: string, ...args: unknown[]) => void;
   broadcastThemeChange: (themeData: {
-    mode: string;
-    useSystemTheme: boolean;
-    theme: string;
+    mode?: string;
+    useSystemTheme?: boolean;
+    theme?: string;
     catppuccinAccent?: string;
     tokensUpdated?: boolean;
   }) => void;
@@ -300,9 +299,9 @@ const electronAPI: ElectronAPI = {
     ipcRenderer.emit(channel, ...args);
   },
   broadcastThemeChange: (themeData: {
-    mode: string;
-    useSystemTheme: boolean;
-    theme: string;
+    mode?: string;
+    useSystemTheme?: boolean;
+    theme?: string;
     catppuccinAccent?: string;
     tokensUpdated?: boolean;
   }) => {

--- a/ui/desktop/src/test/setup.ts
+++ b/ui/desktop/src/test/setup.ts
@@ -67,6 +67,7 @@ const mockSettings: Record<string, unknown> = {
   },
   theme: 'light',
   useSystemTheme: true,
+  catppuccinAccent: 'mauve',
   language: 'system',
   responseStyle: 'concise',
   showPricing: true,
@@ -88,5 +89,6 @@ Object.defineProperty(window, 'electron', {
     getIsFullScreen: vi.fn(() => Promise.resolve(false)),
     on: vi.fn(),
     off: vi.fn(),
+    broadcastThemeChange: vi.fn(),
   },
 });

--- a/ui/desktop/src/theme/catppuccin.test.ts
+++ b/ui/desktop/src/theme/catppuccin.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildCatppuccinColorTokens,
+  catppuccinFlavors,
+  getCatppuccinAccentColor,
+  getCatppuccinPreview,
+} from './catppuccin';
+import { CATPPUCCIN_ACCENTS, CATPPUCCIN_THEME_IDS, DEFAULT_CATPPUCCIN_ACCENT } from './types';
+import { applyThemeTokens, getThemeTokens, themes } from './theme-tokens';
+
+describe('Catppuccin palettes', () => {
+  it('ships official hex values for all four flavors', () => {
+    expect(catppuccinFlavors['catppuccin-latte'].palette.base).toBe('#eff1f5');
+    expect(catppuccinFlavors['catppuccin-frappe'].palette.base).toBe('#303446');
+    expect(catppuccinFlavors['catppuccin-macchiato'].palette.base).toBe('#24273a');
+    expect(catppuccinFlavors['catppuccin-mocha'].palette.base).toBe('#1e1e2e');
+    expect(catppuccinFlavors['catppuccin-latte'].variant).toBe('light');
+    expect(catppuccinFlavors['catppuccin-mocha'].variant).toBe('dark');
+  });
+
+  it('maps the selected accent onto info and inverse tokens', () => {
+    const tokens = buildCatppuccinColorTokens('catppuccin-mocha', 'teal');
+    expect(tokens['--color-text-info']).toBe(
+      getCatppuccinAccentColor('catppuccin-mocha', 'teal')
+    );
+    expect(tokens['--color-background-inverse']).toBe(
+      getCatppuccinAccentColor('catppuccin-mocha', 'teal')
+    );
+    expect(tokens['--color-background-danger']).toBe(
+      catppuccinFlavors['catppuccin-mocha'].palette.red
+    );
+    expect(tokens['--color-background-success']).toBe(
+      catppuccinFlavors['catppuccin-mocha'].palette.green
+    );
+  });
+
+  it('defaults the accent to mauve', () => {
+    const preview = getCatppuccinPreview('catppuccin-mocha');
+    expect(preview.accent).toBe(
+      getCatppuccinAccentColor('catppuccin-mocha', DEFAULT_CATPPUCCIN_ACCENT)
+    );
+    expect(CATPPUCCIN_ACCENTS).toContain(DEFAULT_CATPPUCCIN_ACCENT);
+  });
+
+  it('registers each flavor in the theme map', () => {
+    for (const flavorId of CATPPUCCIN_THEME_IDS) {
+      expect(themes[flavorId].variant).toBe(catppuccinFlavors[flavorId].variant);
+      const tokens = getThemeTokens(flavorId, 'pink');
+      expect(tokens['--color-background-primary']).toBe(
+        catppuccinFlavors[flavorId].palette.base
+      );
+      expect(tokens['--color-text-info']).toBe(
+        getCatppuccinAccentColor(flavorId, 'pink')
+      );
+    }
+  });
+
+  it('applies flavor tokens to the document root', () => {
+    applyThemeTokens('catppuccin-mocha', 'blue');
+    expect(document.documentElement.style.getPropertyValue('--color-background-primary')).toBe(
+      '#1e1e2e'
+    );
+    expect(document.documentElement.style.getPropertyValue('--color-text-info')).toBe(
+      getCatppuccinAccentColor('catppuccin-mocha', 'blue')
+    );
+  });
+});

--- a/ui/desktop/src/theme/catppuccin.ts
+++ b/ui/desktop/src/theme/catppuccin.ts
@@ -1,0 +1,307 @@
+import type { CatppuccinAccent, CatppuccinThemeId, ThemeVariant } from './types';
+import { DEFAULT_CATPPUCCIN_ACCENT } from './types';
+
+// Official Catppuccin palette: https://catppuccin.com/palette
+export interface CatppuccinPalette {
+  rosewater: string;
+  flamingo: string;
+  pink: string;
+  mauve: string;
+  red: string;
+  maroon: string;
+  peach: string;
+  yellow: string;
+  green: string;
+  teal: string;
+  sky: string;
+  sapphire: string;
+  blue: string;
+  lavender: string;
+  text: string;
+  subtext1: string;
+  subtext0: string;
+  overlay2: string;
+  overlay1: string;
+  overlay0: string;
+  surface2: string;
+  surface1: string;
+  surface0: string;
+  base: string;
+  mantle: string;
+  crust: string;
+}
+
+export interface CatppuccinFlavorMeta {
+  id: CatppuccinThemeId;
+  name: string;
+  variant: ThemeVariant;
+  palette: CatppuccinPalette;
+}
+
+export const catppuccinFlavors: Record<CatppuccinThemeId, CatppuccinFlavorMeta> = {
+  'catppuccin-latte': {
+    id: 'catppuccin-latte',
+    name: 'Latte',
+    variant: 'light',
+    palette: {
+      rosewater: '#dc8a78',
+      flamingo: '#dd7878',
+      pink: '#ea76cb',
+      mauve: '#8839ef',
+      red: '#d20f39',
+      maroon: '#e64553',
+      peach: '#fe640b',
+      yellow: '#df8e1d',
+      green: '#40a02b',
+      teal: '#179299',
+      sky: '#04a5e5',
+      sapphire: '#209fb5',
+      blue: '#1e66f5',
+      lavender: '#7287fd',
+      text: '#4c4f69',
+      subtext1: '#5c5f77',
+      subtext0: '#6c6f85',
+      overlay2: '#7c7f93',
+      overlay1: '#8c8fa1',
+      overlay0: '#9ca0b0',
+      surface2: '#acb0be',
+      surface1: '#bcc0cc',
+      surface0: '#ccd0da',
+      base: '#eff1f5',
+      mantle: '#e6e9ef',
+      crust: '#dce0e8',
+    },
+  },
+  'catppuccin-frappe': {
+    id: 'catppuccin-frappe',
+    name: 'Frappé',
+    variant: 'dark',
+    palette: {
+      rosewater: '#f2d5cf',
+      flamingo: '#eebebe',
+      pink: '#f4b8e4',
+      mauve: '#ca9ee6',
+      red: '#e78284',
+      maroon: '#ea999c',
+      peach: '#ef9f76',
+      yellow: '#e5c890',
+      green: '#a6d189',
+      teal: '#81c8be',
+      sky: '#99d1db',
+      sapphire: '#85c1dc',
+      blue: '#8caaee',
+      lavender: '#babbf1',
+      text: '#c6d0f5',
+      subtext1: '#b5bfe2',
+      subtext0: '#a5adce',
+      overlay2: '#949cbb',
+      overlay1: '#838ba7',
+      overlay0: '#737994',
+      surface2: '#626880',
+      surface1: '#51576d',
+      surface0: '#414559',
+      base: '#303446',
+      mantle: '#292c3c',
+      crust: '#232634',
+    },
+  },
+  'catppuccin-macchiato': {
+    id: 'catppuccin-macchiato',
+    name: 'Macchiato',
+    variant: 'dark',
+    palette: {
+      rosewater: '#f4dbd6',
+      flamingo: '#f0c6c6',
+      pink: '#f5bde6',
+      mauve: '#c6a0f6',
+      red: '#ed8796',
+      maroon: '#ee99a0',
+      peach: '#f5a97f',
+      yellow: '#eed49f',
+      green: '#a6da95',
+      teal: '#8bd5ca',
+      sky: '#91d7e3',
+      sapphire: '#7dc4e4',
+      blue: '#8aadf4',
+      lavender: '#b7bdf8',
+      text: '#cad3f5',
+      subtext1: '#b8c0e0',
+      subtext0: '#a5adcb',
+      overlay2: '#939ab7',
+      overlay1: '#8087a2',
+      overlay0: '#6e738d',
+      surface2: '#5b6078',
+      surface1: '#494d64',
+      surface0: '#363a4f',
+      base: '#24273a',
+      mantle: '#1e2030',
+      crust: '#181926',
+    },
+  },
+  'catppuccin-mocha': {
+    id: 'catppuccin-mocha',
+    name: 'Mocha',
+    variant: 'dark',
+    palette: {
+      rosewater: '#f5e0dc',
+      flamingo: '#f2cdcd',
+      pink: '#f5c2e7',
+      mauve: '#cba6f7',
+      red: '#f38ba8',
+      maroon: '#eba0ac',
+      peach: '#fab387',
+      yellow: '#f9e2af',
+      green: '#a6e3a1',
+      teal: '#94e2d5',
+      sky: '#89dceb',
+      sapphire: '#74c7ec',
+      blue: '#89b4fa',
+      lavender: '#b4befe',
+      text: '#cdd6f4',
+      subtext1: '#bac2de',
+      subtext0: '#a6adc8',
+      overlay2: '#9399b2',
+      overlay1: '#7f849c',
+      overlay0: '#6c7086',
+      surface2: '#585b70',
+      surface1: '#45475a',
+      surface0: '#313244',
+      base: '#1e1e2e',
+      mantle: '#181825',
+      crust: '#11111b',
+    },
+  },
+};
+
+export interface CatppuccinPreview {
+  background: string;
+  surface: string;
+  sidebar: string;
+  text: string;
+  muted: string;
+  accent: string;
+}
+
+export function getCatppuccinPreview(
+  flavorId: CatppuccinThemeId,
+  accent: CatppuccinAccent = DEFAULT_CATPPUCCIN_ACCENT
+): CatppuccinPreview {
+  const { palette } = catppuccinFlavors[flavorId];
+  return {
+    background: palette.base,
+    surface: palette.mantle,
+    sidebar: palette.crust,
+    text: palette.text,
+    muted: palette.overlay0,
+    accent: palette[accent],
+  };
+}
+
+export function getCatppuccinAccentColor(
+  flavorId: CatppuccinThemeId,
+  accent: CatppuccinAccent
+): string {
+  return catppuccinFlavors[flavorId].palette[accent];
+}
+
+export interface CatppuccinColorTokens {
+  '--color-background-primary': string;
+  '--color-background-secondary': string;
+  '--color-background-tertiary': string;
+  '--color-background-inverse': string;
+  '--color-background-ghost': string;
+  '--color-background-info': string;
+  '--color-background-danger': string;
+  '--color-background-success': string;
+  '--color-background-warning': string;
+  '--color-background-disabled': string;
+  '--color-text-primary': string;
+  '--color-text-secondary': string;
+  '--color-text-tertiary': string;
+  '--color-text-inverse': string;
+  '--color-text-ghost': string;
+  '--color-text-info': string;
+  '--color-text-danger': string;
+  '--color-text-success': string;
+  '--color-text-warning': string;
+  '--color-text-disabled': string;
+  '--color-border-primary': string;
+  '--color-border-secondary': string;
+  '--color-border-tertiary': string;
+  '--color-border-inverse': string;
+  '--color-border-ghost': string;
+  '--color-border-info': string;
+  '--color-border-danger': string;
+  '--color-border-success': string;
+  '--color-border-warning': string;
+  '--color-border-disabled': string;
+  '--color-ring-primary': string;
+  '--color-ring-secondary': string;
+  '--color-ring-inverse': string;
+  '--color-ring-info': string;
+  '--color-ring-danger': string;
+  '--color-ring-success': string;
+  '--color-ring-warning': string;
+  '--shadow-hairline': string;
+  '--shadow-sm': string;
+  '--shadow-md': string;
+  '--shadow-lg': string;
+}
+
+export function buildCatppuccinColorTokens(
+  flavorId: CatppuccinThemeId,
+  accent: CatppuccinAccent = DEFAULT_CATPPUCCIN_ACCENT
+): CatppuccinColorTokens {
+  const { palette, variant } = catppuccinFlavors[flavorId];
+  const accentColor = palette[accent];
+  const inverseText = variant === 'light' ? palette.base : palette.crust;
+  const shadowRgb = variant === 'light' ? '76, 79, 105' : '17, 17, 27';
+
+  return {
+    '--color-background-primary': palette.base,
+    '--color-background-secondary': palette.mantle,
+    '--color-background-tertiary': palette.surface0,
+    '--color-background-inverse': accentColor,
+    '--color-background-ghost': 'transparent',
+    '--color-background-info': accentColor,
+    '--color-background-danger': palette.red,
+    '--color-background-success': palette.green,
+    '--color-background-warning': palette.yellow,
+    '--color-background-disabled': palette.surface0,
+
+    '--color-text-primary': palette.text,
+    '--color-text-secondary': palette.subtext0,
+    '--color-text-tertiary': palette.overlay1,
+    '--color-text-inverse': inverseText,
+    '--color-text-ghost': palette.subtext0,
+    '--color-text-info': accentColor,
+    '--color-text-danger': palette.red,
+    '--color-text-success': palette.green,
+    '--color-text-warning': palette.yellow,
+    '--color-text-disabled': palette.overlay0,
+
+    '--color-border-primary': palette.surface0,
+    '--color-border-secondary': palette.surface1,
+    '--color-border-tertiary': palette.surface2,
+    '--color-border-inverse': palette.text,
+    '--color-border-ghost': 'transparent',
+    '--color-border-info': accentColor,
+    '--color-border-danger': palette.red,
+    '--color-border-success': palette.green,
+    '--color-border-warning': palette.yellow,
+    '--color-border-disabled': palette.surface0,
+
+    '--color-ring-primary': palette.surface1,
+    '--color-ring-secondary': palette.surface0,
+    '--color-ring-inverse': palette.base,
+    '--color-ring-info': accentColor,
+    '--color-ring-danger': palette.red,
+    '--color-ring-success': palette.green,
+    '--color-ring-warning': palette.yellow,
+
+    '--shadow-hairline': `0 0 0 1px rgba(${shadowRgb}, 0.12)`,
+    '--shadow-sm': `0 1px 2px 0 rgba(${shadowRgb}, 0.16)`,
+    '--shadow-md': `0 4px 6px -1px rgba(${shadowRgb}, 0.2), 0 2px 4px -2px rgba(${shadowRgb}, 0.14)`,
+    '--shadow-lg': `0 10px 15px -3px rgba(${shadowRgb}, 0.22), 0 4px 6px -4px rgba(${shadowRgb}, 0.16)`,
+  };
+}

--- a/ui/desktop/src/theme/theme-tokens.ts
+++ b/ui/desktop/src/theme/theme-tokens.ts
@@ -18,6 +18,32 @@ import type {
   McpUiStyleVariableKey,
   McpUiStyles,
 } from '@modelcontextprotocol/ext-apps/app-bridge';
+import { buildCatppuccinColorTokens } from './catppuccin';
+import {
+  DEFAULT_CATPPUCCIN_ACCENT,
+  isCatppuccinAccent,
+  isCatppuccinThemeId,
+  isThemeId,
+  type CatppuccinAccent,
+  type CatppuccinThemeId,
+  type ThemeId,
+  type ThemeVariant,
+} from './types';
+
+export type { ThemeId, ThemeVariant } from './types';
+export {
+  CATPPUCCIN_ACCENTS,
+  CATPPUCCIN_THEME_IDS,
+  DEFAULT_CATPPUCCIN_ACCENT,
+  THEME_IDS,
+  isCatppuccinAccent,
+  isCatppuccinThemeId,
+  isThemeId,
+  isThemePreference,
+  type CatppuccinAccent,
+  type CatppuccinThemeId,
+  type ThemePreference,
+} from './types';
 
 type ThemeTokens = Record<McpUiStyleVariableKey, string>;
 
@@ -271,15 +297,16 @@ export const lightTokens: ThemeTokens = { ...baseTokens, ...lightColorTokens };
 export const darkTokens: ThemeTokens = { ...baseTokens, ...darkColorTokens };
 export const auraTokens: ThemeTokens = { ...baseTokens, ...auraFontTokens, ...auraColorTokens };
 
+function catppuccinTokens(flavorId: CatppuccinThemeId, accent: CatppuccinAccent): ThemeTokens {
+  return { ...baseTokens, ...buildCatppuccinColorTokens(flavorId, accent) };
+}
+
 // ---------------------------------------------------------------------------
 // Theme registry — the set of selectable named themes.
 // `variant` drives the .dark/.light class and colorScheme for anything outside
 // the token system; `tokens` is the map applied to :root. Adding a future theme
 // is a single entry here plus its token map above.
 // ---------------------------------------------------------------------------
-export type ThemeId = 'light' | 'dark' | 'aura';
-export type ThemeVariant = 'light' | 'dark';
-
 interface ThemeDefinition {
   variant: ThemeVariant;
   tokens: ThemeTokens;
@@ -289,7 +316,33 @@ export const themes: Record<ThemeId, ThemeDefinition> = {
   light: { variant: 'light', tokens: lightTokens },
   dark: { variant: 'dark', tokens: darkTokens },
   aura: { variant: 'dark', tokens: auraTokens },
+  'catppuccin-latte': {
+    variant: 'light',
+    tokens: catppuccinTokens('catppuccin-latte', DEFAULT_CATPPUCCIN_ACCENT),
+  },
+  'catppuccin-frappe': {
+    variant: 'dark',
+    tokens: catppuccinTokens('catppuccin-frappe', DEFAULT_CATPPUCCIN_ACCENT),
+  },
+  'catppuccin-macchiato': {
+    variant: 'dark',
+    tokens: catppuccinTokens('catppuccin-macchiato', DEFAULT_CATPPUCCIN_ACCENT),
+  },
+  'catppuccin-mocha': {
+    variant: 'dark',
+    tokens: catppuccinTokens('catppuccin-mocha', DEFAULT_CATPPUCCIN_ACCENT),
+  },
 };
+
+export function getThemeTokens(
+  themeId: ThemeId,
+  accent: CatppuccinAccent = DEFAULT_CATPPUCCIN_ACCENT
+): ThemeTokens {
+  if (isCatppuccinThemeId(themeId)) {
+    return catppuccinTokens(themeId, accent);
+  }
+  return themes[themeId].tokens;
+}
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -338,8 +391,11 @@ const HOST_FONT_CSS = `
  * Aura's monospace font family reach the guest.
  * css.fonts provides @font-face rules so sandboxed apps can load host fonts.
  */
-export function buildMcpHostStyles(themeId: ThemeId = 'light'): McpUiHostStyles {
-  const tokens = (themes[themeId] ?? themes.light).tokens;
+export function buildMcpHostStyles(
+  themeId: ThemeId = 'light',
+  accent: CatppuccinAccent = DEFAULT_CATPPUCCIN_ACCENT
+): McpUiHostStyles {
+  const tokens = getThemeTokens(themeId, accent);
   const isBuiltinVariant = themeId === 'light' || themeId === 'dark';
   const variables: McpUiStyles = {} as McpUiStyles;
   for (const key of Object.keys(lightTokens) as McpUiStyleVariableKey[]) {
@@ -363,17 +419,24 @@ export function getResolvedTheme(): ThemeId {
     return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
   }
   const stored = localStorage.getItem('theme');
-  if (stored === 'aura') return 'aura';
-  return stored === 'dark' ? 'dark' : 'light';
+  return isThemeId(stored) ? stored : 'light';
+}
+
+export function getStoredCatppuccinAccent(): CatppuccinAccent {
+  const stored = localStorage.getItem('catppuccin_accent');
+  return isCatppuccinAccent(stored) ? stored : DEFAULT_CATPPUCCIN_ACCENT;
 }
 
 /**
  * Apply a theme's tokens to the document root as CSS custom properties.
  * When called without an argument, resolves the theme from localStorage.
  */
-export function applyThemeTokens(theme?: ThemeId): void {
+export function applyThemeTokens(
+  theme?: ThemeId,
+  accent: CatppuccinAccent = getStoredCatppuccinAccent()
+): void {
   const resolved = theme ?? getResolvedTheme();
-  const { tokens } = themes[resolved] ?? themes.light;
+  const tokens = getThemeTokens(resolved, accent);
   const root = document.documentElement;
   for (const [key, value] of Object.entries(tokens)) {
     root.style.setProperty(key, value);

--- a/ui/desktop/src/theme/types.ts
+++ b/ui/desktop/src/theme/types.ts
@@ -1,0 +1,62 @@
+export const THEME_IDS = [
+  'light',
+  'dark',
+  'aura',
+  'catppuccin-latte',
+  'catppuccin-frappe',
+  'catppuccin-macchiato',
+  'catppuccin-mocha',
+] as const;
+
+export type ThemeId = (typeof THEME_IDS)[number];
+
+export const CATPPUCCIN_THEME_IDS = [
+  'catppuccin-latte',
+  'catppuccin-frappe',
+  'catppuccin-macchiato',
+  'catppuccin-mocha',
+] as const;
+
+export type CatppuccinThemeId = (typeof CATPPUCCIN_THEME_IDS)[number];
+
+export const CATPPUCCIN_ACCENTS = [
+  'rosewater',
+  'flamingo',
+  'pink',
+  'mauve',
+  'red',
+  'maroon',
+  'peach',
+  'yellow',
+  'green',
+  'teal',
+  'sky',
+  'sapphire',
+  'blue',
+  'lavender',
+] as const;
+
+export type CatppuccinAccent = (typeof CATPPUCCIN_ACCENTS)[number];
+
+export const DEFAULT_CATPPUCCIN_ACCENT: CatppuccinAccent = 'mauve';
+
+export type ThemePreference = ThemeId | 'system';
+export type ThemeVariant = 'light' | 'dark';
+
+export function isThemeId(value: unknown): value is ThemeId {
+  return typeof value === 'string' && (THEME_IDS as readonly string[]).includes(value);
+}
+
+export function isCatppuccinThemeId(value: unknown): value is CatppuccinThemeId {
+  return (
+    typeof value === 'string' && (CATPPUCCIN_THEME_IDS as readonly string[]).includes(value)
+  );
+}
+
+export function isCatppuccinAccent(value: unknown): value is CatppuccinAccent {
+  return typeof value === 'string' && (CATPPUCCIN_ACCENTS as readonly string[]).includes(value);
+}
+
+export function isThemePreference(value: unknown): value is ThemePreference {
+  return value === 'system' || isThemeId(value);
+}

--- a/ui/desktop/src/utils/settings.ts
+++ b/ui/desktop/src/utils/settings.ts
@@ -1,3 +1,6 @@
+import type { CatppuccinAccent, ThemeId } from '../theme/types';
+import { DEFAULT_CATPPUCCIN_ACCENT } from '../theme/types';
+
 export type RecentModel = {
   provider: string;
   model: string;
@@ -48,8 +51,9 @@ export interface Settings {
   keyboardShortcuts: KeyboardShortcuts;
 
   // UI preferences (migrated from localStorage)
-  theme: 'dark' | 'light' | 'aura';
+  theme: ThemeId;
   useSystemTheme: boolean;
+  catppuccinAccent: CatppuccinAccent;
   language: LanguageSetting;
   responseStyle: string;
   showPricing: boolean;
@@ -91,6 +95,7 @@ export const defaultSettings: Settings = {
   // UI preferences
   theme: 'light',
   useSystemTheme: true,
+  catppuccinAccent: DEFAULT_CATPPUCCIN_ACCENT,
   language: 'system',
   responseStyle: 'concise',
   showPricing: true,


### PR DESCRIPTION
Implements #11584

## What it does

Adds the four Catppuccin flavors (Latte, Frappé, Macchiato, Mocha) to the desktop theme picker, with live previews and per-flavor accent selection, plus matching ANSI palettes for the CLI so terminal sessions match the desktop.

- **Desktop**: `ThemeContext` + `settings` gain `theme` flavor values and a `catppuccinAccent` setting; the existing `ThemeSelector` in `GooseSidebar` renders flavor previews and accent swatches; accent changes broadcast over IPC to open windows (typed listener).
- **CLI**: flavors map to ANSI color palettes for chat/session rendering.
- Implemented on top of the existing light/dark CSS-variable mechanism — no new theme engine.

## Screenshots

*(to follow — capturing with themes active)*

## Verification

- `ui/desktop`: `pnpm run typecheck` and unit tests (`ThemeContext` broadcast covered by a new test) pass on this branch.
- `goose-cli`: `cargo clippy --all-targets -- -D warnings` clean; `cargo fmt` applied.
- Manual: all four flavors and accents verified in daily use on a fork build (desktop + CLI).

## Note on base `main`

Clean `aaif-goose/goose` `main` currently fails `tsc --noEmit` with 2 pre-existing errors in `src/acp/providers.ts` and `src/components/settings/providers/ProviderGrid.tsx` (generated ACP types appear stale vs the server schema). Reproduced on unmodified `main`; this PR does not touch those files and does not attempt to fix that drift.
