### PR TITLE
feat(providers): add Opper as a declarative OpenAI-compatible provider

### DIFF
--- a/crates/goose-providers/src/declarative.rs
+++ b/crates/goose-providers/src/declarative.rs
@@ -40,6 +40,7 @@ pub(crate) mod declarative_providers {
         omlx,
         opencode_go,
         opencode_zen,
+        opper,
         orcarouter,
         ovhcloud,
         perplexity,

--- a/crates/goose-providers/src/declarative/definitions/opper.json
+++ b/crates/goose-providers/src/declarative/definitions/opper.json
@@ -1,0 +1,31 @@
+{
+  "name": "opper",
+  "engine": "openai",
+  "display_name": "Opper",
+  "description": "European AI gateway: 600+ chat models from Anthropic, OpenAI, Google, Mistral, xAI and open-weights hosts behind one OpenAI-compatible endpoint, with EU-region variants of the same models.",
+  "api_key_env": "OPPER_API_KEY",
+  "base_url": "https://api.opper.ai/v3/compat/chat/completions",
+  "catalog_provider_id": "opper",
+  "models": [
+    { "name": "anthropic/claude-opus-5", "context_limit": 1000000, "reasoning": true },
+    { "name": "anthropic/claude-sonnet-5", "context_limit": 1000000, "reasoning": true },
+    { "name": "anthropic/claude-haiku-4-5", "context_limit": 200000 },
+    { "name": "aws/claude-sonnet-4-6-eu", "context_limit": 1000000, "reasoning": true },
+    { "name": "openai/gpt-5.6-sol", "context_limit": 1050000, "reasoning": true },
+    { "name": "openai/gpt-5.5", "context_limit": 1050000, "reasoning": true },
+    { "name": "gemini/gemini-3.1-pro-preview", "context_limit": 1048576 },
+    { "name": "gemini/gemini-3.6-flash", "context_limit": 1048576 },
+    { "name": "xai/grok-4.6", "context_limit": 500000, "reasoning": true },
+    { "name": "mistral/devstral-2512", "context_limit": 256000 },
+    { "name": "mistral/mistral-large-2512", "context_limit": 256000 }
+  ],
+  "dynamic_models": true,
+  "supports_streaming": true,
+  "fast_model": "anthropic/claude-haiku-4-5",
+  "model_doc_link": "https://opper.ai/models",
+  "setup_steps": [
+    "Sign up at https://opper.ai",
+    "Create an API key at https://platform.opper.ai",
+    "Paste the key above as OPPER_API_KEY"
+  ]
+}


### PR DESCRIPTION
Fixes: #11588

@DOsinga assigned that issue to himself and okayed this PR directly ("happy to take a PR that adds the .json file"), which is the core-team exemption in CONTRIBUTING rather than the board reaching Ready.

Opper speaks the OpenAI wire format and serves an OpenAI-shaped models endpoint, so this is a definition plus one line of registration, no engine code. Same shape as Lynkr in #11372.

### Changes
- New `crates/goose-providers/src/declarative/definitions/opper.json`
- Registered `opper` in the `expose_declarative_providers!` macro in `declarative.rs`

### Notes on the definition
- `base_url` is the full `https://api.opper.ai/v3/compat/chat/completions` rather than the bare gateway root. `derive_base_path` would otherwise append `/v1/chat/completions` to `/v3/compat`, which Opper does not serve; from the full path, `map_base_path` derives the models endpoint as `v3/compat/models`, which is the OpenAI-shaped list.
- `dynamic_models: true`, so the picker fetches the live catalogue and only falls back to the listed models. The static list is deliberately small — the two design questions raised in the issue resolved as: keep the fallback short, and leave Opper out of `is_meta_provider` for now, since that changes shared pricing behaviour and belongs in its own change.
- Model ids include region-pinned variants (e.g. `aws/claude-sonnet-4-6-eu`), which is the reason EU teams reach for the gateway.

### Testing
- Every model id and context limit in the definition verified against the live `/v3/compat/models` response.
- Ten of the eleven listed ids return a completion end to end; `moonshot/kimi-k3` was dropped from the fallback list after returning an upstream 429 twice, and replaced with `mistral/devstral-2512`.
- Tool calls and streaming both verified against `/v3/compat/chat/completions`.
- `opper.json` parses against `DeclarativeProviderConfig`, provider id `opper` passes `validate_provider_id`, and it is present in both the definitions dir and the macro list so `expose_declarative_providers_enumerates_all_bundled_json_files` stays green.

For provenance: Opper is a registered provider on [models.dev](https://models.dev) (the open provider registry maintained by the OpenCode team, consumed by OpenCode, Cline, Kilo Code and Copilot for Obsidian), with 40 models listed. That registry is also where this repo's bundled `canonical/data/provider_metadata.json` is generated from, so an `opper` entry should appear there on the next `build_canonical_models` run.
