### PR TITLE
feat(providers): add Volcengine Ark as a declarative provider

### DIFF
--- a/crates/goose-providers/src/declarative.rs
+++ b/crates/goose-providers/src/declarative.rs
@@ -55,6 +55,7 @@ pub(crate) mod declarative_providers {
         trustedrouter,
         venice,
         vercel_ai_gateway,
+        volcengine,
         zai,
         zhipu,
     );

--- a/crates/goose-providers/src/declarative/definitions/volcengine.json
+++ b/crates/goose-providers/src/declarative/definitions/volcengine.json
@@ -1,0 +1,34 @@
+{
+  "name": "volcengine",
+  "engine": "openai",
+  "display_name": "Volcengine Ark",
+  "description": "ByteDance Doubao models plus hosted DeepSeek and GLM via Volcengine Ark's OpenAI-compatible API. Set ARK_BASE_URL to override the default endpoint (e.g. https://ark.ap-southeast.bytepluses.com/api/v3 for BytePlus outside China Mainland).",
+  "api_key_env": "ARK_API_KEY",
+  "base_url": "${ARK_BASE_URL}",
+  "env_vars": [
+    {
+      "name": "ARK_BASE_URL",
+      "required": false,
+      "secret": false,
+      "default": "https://ark.cn-beijing.volces.com/api/v3",
+      "description": "Volcengine Ark API base URL. Use https://ark.ap-southeast.bytepluses.com/api/v3 for BytePlus access outside China Mainland."
+    }
+  ],
+  "catalog_provider_id": "volcengine",
+  "models": [
+    {"name": "doubao-seed-2-1-pro-260628", "context_limit": 262144, "reasoning": true},
+    {"name": "doubao-seed-2-1-turbo-260628", "context_limit": 262144, "reasoning": true},
+    {"name": "doubao-seed-evolving", "context_limit": 1048576, "reasoning": true},
+    {"name": "doubao-seed-2-0-pro-260215", "context_limit": 262144, "reasoning": true},
+    {"name": "doubao-seed-2-0-lite-260428", "context_limit": 262144, "reasoning": true},
+    {"name": "doubao-seed-2-0-mini-260428", "context_limit": 262144, "reasoning": true},
+    {"name": "doubao-seed-2-0-code-preview-260215", "context_limit": 262144, "reasoning": true},
+    {"name": "doubao-seed-character-260628", "context_limit": 131072, "reasoning": true},
+    {"name": "deepseek-v4-pro-ga-260813", "context_limit": 1048576, "reasoning": true},
+    {"name": "deepseek-v4-flash-ga-260731", "context_limit": 1048576, "reasoning": true},
+    {"name": "glm-5-2-260617", "context_limit": 1048576, "reasoning": true}
+  ],
+  "preserves_thinking": true,
+  "supports_streaming": true,
+  "model_doc_link": "https://www.volcengine.com/docs/82379/1330310"
+}

--- a/crates/goose-providers/src/declarative/definitions/volcengine.json
+++ b/crates/goose-providers/src/declarative/definitions/volcengine.json
@@ -15,6 +15,7 @@
     }
   ],
   "catalog_provider_id": "volcengine",
+  "dynamic_models": false,
   "models": [
     {"name": "doubao-seed-2-1-pro-260628", "context_limit": 262144, "reasoning": true},
     {"name": "doubao-seed-2-1-turbo-260628", "context_limit": 262144, "reasoning": true},
@@ -24,6 +25,8 @@
     {"name": "doubao-seed-2-0-mini-260428", "context_limit": 262144, "reasoning": true},
     {"name": "doubao-seed-2-0-code-preview-260215", "context_limit": 262144, "reasoning": true},
     {"name": "doubao-seed-character-260628", "context_limit": 131072, "reasoning": true},
+    {"name": "doubao-seed-1-8-251228", "context_limit": 262144, "reasoning": true},
+    {"name": "doubao-seed-1-6-251015", "context_limit": 262144, "reasoning": true},
     {"name": "deepseek-v4-pro-ga-260813", "context_limit": 1048576, "reasoning": true},
     {"name": "deepseek-v4-flash-ga-260731", "context_limit": 1048576, "reasoning": true},
     {"name": "glm-5-2-260617", "context_limit": 1048576, "reasoning": true}

--- a/documentation/docs/getting-started/providers.md
+++ b/documentation/docs/getting-started/providers.md
@@ -64,6 +64,7 @@ goose is compatible with a wide range of LLM providers, allowing you to choose a
 | [Tetrate Agent Router Service](https://router.tetrate.ai)                   | Unified API gateway for AI models including Claude, Gemini, GPT, open-weight models, and others. Supports PKCE authentication flow for secure API key generation.                                                                                | `TETRATE_API_KEY`, `TETRATE_HOST` (optional)                                                                                                                                        |
 | [TrustedRouter](https://trustedrouter.com)                                  | Models from OpenAI, Anthropic, Google, DeepSeek and others via TrustedRouter's OpenAI-compatible API, with per-request routing and failover.                                                                                                     | `TRUSTEDROUTER_API_KEY`                                                                                                                                                             |
 | [Venice AI](https://venice.ai/home)                                         | Provides access to open source models like Llama, Mistral, and Qwen while prioritizing user privacy. **Requires an account and an [API key](https://docs.venice.ai/overview/guides/generating-api-key)**.                 | `VENICE_API_KEY`, `VENICE_HOST` (optional), `VENICE_BASE_PATH` (optional), `VENICE_MODELS_PATH` (optional)                                                                          |
+| [Volcengine Ark](https://www.volcengine.com/product/ark)                    | ByteDance's model platform. Serves the Doubao family plus hosted DeepSeek and GLM models through an OpenAI-compatible API. Set `ARK_BASE_URL` to reach BytePlus outside China Mainland.                                                                 | `ARK_API_KEY`, `ARK_BASE_URL` (optional)                                                                                   |
 | [Cerebras](https://cerebras.ai/)                                            | Fast inference on Cerebras wafer-scale engines with models like Llama, Qwen, and others.                                                                                                                                  | `CEREBRAS_API_KEY`                                                                                                                                                                  |
 | [xAI](https://x.ai/)                                                        | Access to xAI's Grok models including grok-3, grok-3-mini, and grok-3-fast with 131,072 token context window.                                                                                                            | `XAI_API_KEY`, `XAI_HOST` (optional)                                                                                                                                                |
 
@@ -910,6 +911,46 @@ To set up SayGM with goose, follow these steps:
     3. Follow the prompts to choose `SayGM` as the provider.
     4. Enter your API key when prompted.
     5. Select the SayGM model of your choice.
+  </TabItem>
+</Tabs>
+
+### Volcengine Ark
+[Volcengine Ark](https://www.volcengine.com/product/ark) (火山方舟) is ByteDance's model platform. It serves the Doubao model family alongside hosted DeepSeek and GLM models through an OpenAI-compatible API. To use Ark with goose, you need an API key from the [Ark console](https://console.volcengine.com/ark/region:cn-beijing/apiKey).
+
+Ark supports many models, including:
+- **doubao-seed-2-1-pro-260628** — flagship Doubao model, 256k context
+- **doubao-seed-evolving** — rolling alias tracking the newest Seed release, 1M context
+- **deepseek-v4-pro-ga-260813** — DeepSeek V4 Pro hosted on Ark, 1M context
+- **glm-5-2-260617** — GLM-5.2 hosted on Ark, 1M context
+
+Model IDs must be fully versioned. The short names shown in the Ark console (for example `doubao-seed-2.1-pro`) return `InvalidEndpointOrModel.NotFound`; `doubao-seed-evolving` is the one rolling alias that resolves without a date suffix.
+
+`ARK_BASE_URL` defaults to the China Mainland endpoint. Set it to `https://ark.ap-southeast.bytepluses.com/api/v3` to use BytePlus from outside China Mainland.
+
+To set up Volcengine Ark with goose, follow these steps:
+
+<Tabs groupId="interface">
+  <TabItem value="ui" label="goose Desktop" default>
+  **To update your LLM provider and API key:**
+
+    1. Click the <PanelLeft className="inline" size={16} /> button in the top-left to open the sidebar.
+    2. Click the `Settings` button on the sidebar.
+    3. Click the `Models` tab.
+    4. Click `Configure Providers`
+    5. Choose `Volcengine Ark` as provider from the list.
+    6. Click `Configure`, enter your API key, and click `Submit`.
+    7. Select the Ark model of your choice.
+
+  </TabItem>
+  <TabItem value="cli" label="goose CLI">
+    1. Run:
+    ```sh
+    goose configure
+    ```
+    2. Select `Configure Providers` from the menu.
+    3. Follow the prompts to choose `Volcengine Ark` as the provider.
+    4. Enter your API key when prompted.
+    5. Select the Ark model of your choice.
   </TabItem>
 </Tabs>
 


### PR DESCRIPTION
Fixes: n/a — see note below.

> On the issues-first process: I couldn't find an existing issue for Ark on the
> board. Searching issues for `volcengine`/`doubao`/`ark` returns one unrelated,
> closed result (#3777). I opened this as a two-file declarative-definition
> change modelled on #11372 (Lynkr), which merged the same way. If you'd rather
> have an issue first, say so and I'll open one and let it go through triage —
> happy to have this closed in the meantime.

## Summary

Adds **Volcengine Ark** (火山方舟) as a declarative provider. Ark is ByteDance's
model platform — it serves the Doubao family plus hosted DeepSeek and GLM models
over an OpenAI-compatible API, so it drops straight into the `"engine": "openai"`
declarative mechanism.

Two files, matching #11372:

- `crates/goose-providers/src/declarative/definitions/volcengine.json`
- one line in the `expose_declarative_providers!` list

The bundled definitions already cover `alibaba`, `deepseek`, `iflytek`,
`minimax`, `moonshot`, `zai` and `zhipu` — Ark was the notable gap among the
major Chinese providers.

Details worth knowing for review:

- `ARK_BASE_URL` is overridable and defaults to the mainland endpoint, following
  `moonshot.json` and `zhipu.json`. Users outside China Mainland can point it at
  BytePlus (`https://ark.ap-southeast.bytepluses.com/api/v3`).
- `catalog_provider_id` is `volcengine`, matching the entry on models.dev.
- `dynamic_models` is `false` on purpose. Ark's `GET /models` responds 200, but
  returns account-scoped endpoint records — 523 entries on my account, 143 of
  them test junk (`Model_Example-FirstVersion_0227`, `ddd-1.0.0`, `test-v1`) —
  not a model catalog. The engine only falls back to the static list on a 404,
  so leaving this unset would have replaced the curated models with that.
- Ark only resolves **fully versioned** model IDs. The short names shown in the
  console (`doubao-seed-2.1-pro`) come back as `InvalidEndpointOrModel.NotFound`;
  `doubao-seed-evolving` is the one rolling alias that works without a date
  suffix. That's why every entry in `models` carries the dated form.

### Testing

- `cargo test -p goose-providers --lib` — 155 passed, 0 failed. That includes
  `expose_declarative_providers_enumerates_all_bundled_json_files` and
  `all_bundled_providers_are_valid`, the two that actually gate this change.
- `cargo clippy -p goose-providers --all-targets` — clean.
- `cargo fmt --check -p goose-providers` — clean.
- All 13 model IDs called against the live Ark API: each returned a completion,
  and each returns `tool_calls` for a tool-using prompt — worth checking
  explicitly since goose is a coding agent.
- `supports_streaming` and `preserves_thinking` aren't guesses: streaming returns
  SSE deltas (including `reasoning_content` deltas), and non-streaming responses
  carry a populated `reasoning_content`.

### Related Issues

Discussion: none. Precedent PR: #11372 (Lynkr declarative provider).

### Screenshots/Demos (for UX changes)

Not a UX change — provider definition only.
