### PR TITLE
ci: publish GDK packages from version tags

### DIFF
--- a/.github/workflows/gdk-release.yml
+++ b/.github/workflows/gdk-release.yml
@@ -1,73 +1,15 @@
 name: Publish GDK
 
 on:
-  push:
-    tags:
-      - "gdk-v*"
+  pull_request:
 
 permissions:
   contents: read
 
-concurrency:
-  group: gdk-release-${{ github.ref }}
-  cancel-in-progress: false
-
 jobs:
-  validate-version:
-    name: Validate package versions
+  register-workflow:
+    name: Register GDK release workflow
     runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.version.outputs.value }}
     steps:
-      - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - name: Read version from tag
-        id: version
-        shell: bash
-        run: echo "value=${GITHUB_REF_NAME#gdk-v}" >> "$GITHUB_OUTPUT"
-
-      - name: Install just
-        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
-
-      - name: Validate package versions
-        run: just --justfile crates/goose-sdk/justfile check-version "${{ steps.version.outputs.value }}"
-
-  crates-io:
-    name: Publish Rust crates
-    needs: validate-version
-    runs-on: ubuntu-latest
-    environment: crates-io
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - name: Set up Rust
-        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
-
-      - name: Install just
-        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
-
-      - name: Publish to crates.io
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: just --justfile crates/goose-sdk/justfile crates-publish false
-
-  maven-central:
-    name: Publish Maven package
-    needs: validate-version
-    permissions:
-      contents: read
-    uses: ./.github/workflows/maven-sdk.yml
-    with:
-      publish: true
-
-  pypi:
-    name: Publish Python wheels
-    needs: validate-version
-    permissions:
-      contents: read
-      id-token: write
-    uses: ./.github/workflows/python-sdk-wheels.yml
-    with:
-      publish: true
+      - name: No-op
+        run: echo "Registering the GDK release workflow before enabling manual dispatch"

--- a/.github/workflows/gdk-release.yml
+++ b/.github/workflows/gdk-release.yml
@@ -1,0 +1,73 @@
+name: Publish GDK
+
+on:
+  push:
+    tags:
+      - "gdk-v*"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: gdk-release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  validate-version:
+    name: Validate package versions
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.value }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Read version from tag
+        id: version
+        shell: bash
+        run: echo "value=${GITHUB_REF_NAME#gdk-v}" >> "$GITHUB_OUTPUT"
+
+      - name: Install just
+        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
+
+      - name: Validate package versions
+        run: just --justfile crates/goose-sdk/justfile check-version "${{ steps.version.outputs.value }}"
+
+  crates-io:
+    name: Publish Rust crates
+    needs: validate-version
+    runs-on: ubuntu-latest
+    environment: crates-io
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Rust
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+
+      - name: Install just
+        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
+
+      - name: Publish to crates.io
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: just --justfile crates/goose-sdk/justfile crates-publish false
+
+  maven-central:
+    name: Publish Maven package
+    needs: validate-version
+    permissions:
+      contents: read
+    uses: ./.github/workflows/maven-sdk.yml
+    with:
+      publish: true
+
+  pypi:
+    name: Publish Python wheels
+    needs: validate-version
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/python-sdk-wheels.yml
+    with:
+      publish: true

--- a/.github/workflows/gdk-release.yml
+++ b/.github/workflows/gdk-release.yml
@@ -44,6 +44,9 @@ jobs:
   crates-io:
     name: Publish Rust crates
     needs: validate-version
+    permissions:
+      contents: read
+      id-token: write
     runs-on: ubuntu-latest
     environment: crates-io
     steps:
@@ -56,9 +59,13 @@ jobs:
       - name: Install just
         uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
 
+      - name: Authenticate with crates.io
+        id: crates-io-auth
+        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
+
       - name: Publish to crates.io
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}
         run: just --justfile crates/goose-sdk/justfile crates-publish false
 
   maven-central:

--- a/.github/workflows/gdk-release.yml
+++ b/.github/workflows/gdk-release.yml
@@ -39,7 +39,9 @@ jobs:
         uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
 
       - name: Validate package versions
-        run: just --justfile crates/goose-sdk/justfile check-version "${{ steps.version.outputs.value }}"
+        env:
+          RELEASE_VERSION: ${{ steps.version.outputs.value }}
+        run: just --justfile crates/goose-sdk/justfile check-version "$RELEASE_VERSION"
 
   crates-io:
     name: Publish Rust crates
@@ -55,6 +57,8 @@ jobs:
 
       - name: Set up Rust
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+        with:
+          cache: false
 
       - name: Install just
         uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4

--- a/.github/workflows/gdk-release.yml
+++ b/.github/workflows/gdk-release.yml
@@ -1,15 +1,81 @@
 name: Publish GDK
 
 on:
-  pull_request:
+  push:
+    tags:
+      - "gdk-v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: GDK version to publish (for example, 0.1.0-alpha.6)
+        required: true
+        type: string
 
 permissions:
   contents: read
 
+concurrency:
+  group: gdk-release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
-  register-workflow:
-    name: Register GDK release workflow
+  validate-version:
+    name: Validate package versions
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.value }}
     steps:
-      - name: No-op
-        run: echo "Registering the GDK release workflow before enabling manual dispatch"
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Resolve release version
+        id: version
+        shell: bash
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: echo "value=${INPUT_VERSION:-${GITHUB_REF_NAME#gdk-v}}" >> "$GITHUB_OUTPUT"
+
+      - name: Install just
+        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
+
+      - name: Validate package versions
+        run: just --justfile crates/goose-sdk/justfile check-version "${{ steps.version.outputs.value }}"
+
+  crates-io:
+    name: Publish Rust crates
+    needs: validate-version
+    runs-on: ubuntu-latest
+    environment: crates-io
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Rust
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+
+      - name: Install just
+        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
+
+      - name: Publish to crates.io
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: just --justfile crates/goose-sdk/justfile crates-publish false
+
+  maven-central:
+    name: Publish Maven package
+    needs: validate-version
+    permissions:
+      contents: read
+    uses: ./.github/workflows/maven-sdk.yml
+    with:
+      publish: true
+
+  pypi:
+    name: Publish Python wheels
+    needs: validate-version
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/python-sdk-wheels.yml
+    with:
+      publish: true

--- a/.github/workflows/gdk-release.yml
+++ b/.github/workflows/gdk-release.yml
@@ -76,6 +76,7 @@ jobs:
     uses: ./.github/workflows/maven-sdk.yml
     with:
       publish: true
+    secrets: inherit
 
   pypi:
     name: Publish Python wheels

--- a/.github/workflows/gdk-release.yml
+++ b/.github/workflows/gdk-release.yml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: gdk-release-${{ github.ref }}
+  group: gdk-release
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/gdk-release.yml
+++ b/.github/workflows/gdk-release.yml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: gdk-release
+  group: gdk-release-${{ github.event_name == 'workflow_dispatch' && format('gdk-v{0}', inputs.version) || github.ref_name }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/maven-sdk.yml
+++ b/.github/workflows/maven-sdk.yml
@@ -202,7 +202,7 @@ jobs:
               --data-urlencode "size=100" \
               "https://central.sonatype.com/api/v1/publisher/deployments")
             if jq --exit-status --arg purl "$purl" \
-              'any(.deployments[]; .deploymentState != "FAILED" and any(.deploymentComponents[]?; .purl == $purl))' \
+              'any(.deployments[]; .deploymentState != "FAILED" and (any(.purls[]?; . == $purl) or any(.deploymentComponents[]?; .purl == $purl)))' \
               <<< "$response" > /dev/null; then
               echo "io.github.aaif-goose:gdk:$VERSION already has a Central deployment; skipping"
               echo "exists=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/maven-sdk.yml
+++ b/.github/workflows/maven-sdk.yml
@@ -135,6 +135,9 @@ jobs:
     runs-on: ubuntu-latest
     if: inputs.publish
     environment: maven-central
+    concurrency:
+      group: gdk-maven-release
+      cancel-in-progress: false
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/.github/workflows/maven-sdk.yml
+++ b/.github/workflows/maven-sdk.yml
@@ -76,6 +76,8 @@ jobs:
     name: Package Maven artifact
     needs: build-native
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.value }}
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -115,12 +117,20 @@ jobs:
         working-directory: crates/goose-sdk/maven
         run: gradle --no-daemon publishToMavenLocal
 
-      - name: Stage Maven local artifacts
+      - name: Resolve Maven version
+        id: version
         shell: bash
         run: |
           version=$(grep -m1 '^version =' crates/goose-sdk/Cargo.toml | sed -E 's/version = "([^"]+)"/\1/')
+          echo "value=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Stage Maven local artifacts
+        shell: bash
+        env:
+          VERSION: ${{ steps.version.outputs.value }}
+        run: |
           mkdir -p maven-artifacts
-          cp -R "$HOME/.m2/repository/io/github/aaif-goose/gdk/$version" maven-artifacts/
+          cp -R "$HOME/.m2/repository/io/github/aaif-goose/gdk/$VERSION" maven-artifacts/
 
       - name: Upload Maven artifact bundle
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -136,7 +146,7 @@ jobs:
     if: inputs.publish
     environment: maven-central
     concurrency:
-      group: gdk-maven-release
+      group: gdk-maven-release-${{ needs.package.outputs.version }}
       cancel-in-progress: false
     steps:
       - name: Checkout code
@@ -173,24 +183,39 @@ jobs:
         shell: bash
         run: cp -R native-artifacts/* crates/goose-sdk/maven/src/main/resources/
 
-      - name: Check Maven Central
+      - name: Check Maven Central deployments
         id: central
         shell: bash
+        env:
+          MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_TOKEN_USERNAME }}
+          MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_TOKEN_PASSWORD }}
+          VERSION: ${{ needs.package.outputs.version }}
         run: |
-          version=$(grep -m1 '^version =' crates/goose-sdk/Cargo.toml | sed -E 's/version = "([^"]+)"/\1/')
-          url="https://repo.maven.apache.org/maven2/io/github/aaif-goose/gdk/$version/gdk-$version.pom"
-          status=$(curl --silent --output /dev/null --write-out '%{http_code}' "$url")
-          case "$status" in
-            200)
-              echo "io.github.aaif-goose:gdk:$version is already published; skipping"
-              echo "published=true" >> "$GITHUB_OUTPUT"
-              ;;
-            404) echo "published=false" >> "$GITHUB_OUTPUT" ;;
-            *) echo "Maven Central returned HTTP $status while checking $url" >&2; exit 1 ;;
-          esac
+          purl="pkg:maven/io.github.aaif-goose/gdk@$VERSION"
+          page=0
+          while true; do
+            response=$(curl --fail-with-body --silent --show-error \
+              --user "$MAVEN_CENTRAL_USERNAME:$MAVEN_CENTRAL_PASSWORD" \
+              --get \
+              --data-urlencode "namespace=io.github.aaif-goose" \
+              --data-urlencode "page=$page" \
+              --data-urlencode "size=100" \
+              "https://central.sonatype.com/api/v1/publisher/deployments")
+            if jq --exit-status --arg purl "$purl" \
+              'any(.deployments[]; .deploymentState != "FAILED" and any(.deploymentComponents[]?; .purl == $purl))' \
+              <<< "$response" > /dev/null; then
+              echo "io.github.aaif-goose:gdk:$VERSION already has a Central deployment; skipping"
+              echo "exists=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            page_count=$(jq --exit-status '.pageCount' <<< "$response")
+            page=$((page + 1))
+            ((page < page_count)) || break
+          done
+          echo "exists=false" >> "$GITHUB_OUTPUT"
 
       - name: Publish to Maven Central
-        if: steps.central.outputs.published == 'false'
+        if: steps.central.outputs.exists == 'false'
         working-directory: crates/goose-sdk/maven
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_TOKEN_USERNAME }}

--- a/.github/workflows/maven-sdk.yml
+++ b/.github/workflows/maven-sdk.yml
@@ -1,6 +1,13 @@
 name: Maven GDK
 
 on:
+  workflow_call:
+    inputs:
+      publish:
+        description: "Publish gdk to Maven Central after building"
+        required: false
+        default: false
+        type: boolean
   workflow_dispatch:
     inputs:
       publish:
@@ -126,7 +133,7 @@ jobs:
     name: Publish to Maven Central
     needs: package
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch' && inputs.publish
+    if: inputs.publish
     environment: maven-central
     steps:
       - name: Checkout code

--- a/.github/workflows/maven-sdk.yml
+++ b/.github/workflows/maven-sdk.yml
@@ -183,39 +183,7 @@ jobs:
         shell: bash
         run: cp -R native-artifacts/* crates/goose-sdk/maven/src/main/resources/
 
-      - name: Check Maven Central deployments
-        id: central
-        shell: bash
-        env:
-          MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_TOKEN_USERNAME }}
-          MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_TOKEN_PASSWORD }}
-          VERSION: ${{ needs.package.outputs.version }}
-        run: |
-          purl="pkg:maven/io.github.aaif-goose/gdk@$VERSION"
-          page=0
-          while true; do
-            response=$(curl --fail-with-body --silent --show-error \
-              --user "$MAVEN_CENTRAL_USERNAME:$MAVEN_CENTRAL_PASSWORD" \
-              --get \
-              --data-urlencode "namespace=io.github.aaif-goose" \
-              --data-urlencode "page=$page" \
-              --data-urlencode "size=100" \
-              "https://central.sonatype.com/api/v1/publisher/deployments")
-            if jq --exit-status --arg purl "$purl" \
-              'any(.deployments[]; .deploymentState != "FAILED" and (any(.purls[]?; . == $purl) or any(.deploymentComponents[]?; .purl == $purl)))' \
-              <<< "$response" > /dev/null; then
-              echo "io.github.aaif-goose:gdk:$VERSION already has a Central deployment; skipping"
-              echo "exists=true" >> "$GITHUB_OUTPUT"
-              exit 0
-            fi
-            page_count=$(jq --exit-status '.pageCount' <<< "$response")
-            page=$((page + 1))
-            ((page < page_count)) || break
-          done
-          echo "exists=false" >> "$GITHUB_OUTPUT"
-
       - name: Publish to Maven Central
-        if: steps.central.outputs.exists == 'false'
         working-directory: crates/goose-sdk/maven
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_TOKEN_USERNAME }}

--- a/.github/workflows/maven-sdk.yml
+++ b/.github/workflows/maven-sdk.yml
@@ -170,7 +170,24 @@ jobs:
         shell: bash
         run: cp -R native-artifacts/* crates/goose-sdk/maven/src/main/resources/
 
+      - name: Check Maven Central
+        id: central
+        shell: bash
+        run: |
+          version=$(grep -m1 '^version =' crates/goose-sdk/Cargo.toml | sed -E 's/version = "([^"]+)"/\1/')
+          url="https://repo.maven.apache.org/maven2/io/github/aaif-goose/gdk/$version/gdk-$version.pom"
+          status=$(curl --silent --output /dev/null --write-out '%{http_code}' "$url")
+          case "$status" in
+            200)
+              echo "io.github.aaif-goose:gdk:$version is already published; skipping"
+              echo "published=true" >> "$GITHUB_OUTPUT"
+              ;;
+            404) echo "published=false" >> "$GITHUB_OUTPUT" ;;
+            *) echo "Maven Central returned HTTP $status while checking $url" >&2; exit 1 ;;
+          esac
+
       - name: Publish to Maven Central
+        if: steps.central.outputs.published == 'false'
         working-directory: crates/goose-sdk/maven
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_TOKEN_USERNAME }}

--- a/.github/workflows/python-sdk-wheels.yml
+++ b/.github/workflows/python-sdk-wheels.yml
@@ -125,3 +125,4 @@ jobs:
         uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           packages-dir: dist
+          skip-existing: true

--- a/.github/workflows/python-sdk-wheels.yml
+++ b/.github/workflows/python-sdk-wheels.yml
@@ -32,7 +32,7 @@ jobs:
           - name: macos-arm64
             os: macos-14
           - name: macos-x86_64
-            os: macos-13
+            os: macos-15-intel
           - name: linux-x86_64
             os: ubuntu-latest
             container: quay.io/pypa/manylinux_2_28_x86_64@sha256:441c35fdc6ee809ff9260894f8468ab4fea8c15dc880f8700a3f81b7922c1cda

--- a/.github/workflows/python-sdk-wheels.yml
+++ b/.github/workflows/python-sdk-wheels.yml
@@ -46,7 +46,12 @@ jobs:
       - name: Set up Rust
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
 
+      - name: Select Linux Python
+        if: runner.os == 'Linux'
+        run: echo "/opt/python/cp312-cp312/bin" >> "$GITHUB_PATH"
+
       - name: Set up Python
+        if: runner.os != 'Linux'
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"

--- a/.github/workflows/python-sdk-wheels.yml
+++ b/.github/workflows/python-sdk-wheels.yml
@@ -1,6 +1,13 @@
 name: Python GDK Wheels
 
 on:
+  workflow_call:
+    inputs:
+      publish:
+        description: "Publish wheels to PyPI after building"
+        required: false
+        default: false
+        type: boolean
   workflow_dispatch:
     inputs:
       publish:
@@ -99,7 +106,7 @@ jobs:
     name: Publish wheels to PyPI
     needs: build-wheels
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch' && inputs.publish
+    if: inputs.publish
     environment: pypi
     steps:
       - name: Download wheel artifacts

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5329,7 +5329,7 @@ dependencies = [
 
 [[package]]
 name = "goose-agent"
-version = "0.1.0-alpha.6"
+version = "0.1.0-alpha.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5409,7 +5409,7 @@ dependencies = [
 
 [[package]]
 name = "goose-context-management"
-version = "0.1.0-alpha.6"
+version = "0.1.0-alpha.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5425,7 +5425,7 @@ dependencies = [
 
 [[package]]
 name = "goose-download-manager"
-version = "0.1.0-alpha.6"
+version = "0.1.0-alpha.7"
 dependencies = [
  "anyhow",
  "once_cell",
@@ -5437,7 +5437,7 @@ dependencies = [
 
 [[package]]
 name = "goose-local-inference"
-version = "0.1.0-alpha.6"
+version = "0.1.0-alpha.7"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -5501,7 +5501,7 @@ dependencies = [
 
 [[package]]
 name = "goose-provider-types"
-version = "0.1.0-alpha.6"
+version = "0.1.0-alpha.7"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -5530,7 +5530,7 @@ dependencies = [
 
 [[package]]
 name = "goose-providers"
-version = "0.1.0-alpha.6"
+version = "0.1.0-alpha.7"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -5582,7 +5582,7 @@ dependencies = [
 
 [[package]]
 name = "goose-sdk"
-version = "0.1.0-alpha.6"
+version = "0.1.0-alpha.7"
 dependencies = [
  "agent-client-protocol",
  "agent-client-protocol-schema",
@@ -5602,7 +5602,7 @@ dependencies = [
 
 [[package]]
 name = "goose-sdk-types"
-version = "0.1.0-alpha.6"
+version = "0.1.0-alpha.7"
 dependencies = [
  "agent-client-protocol",
  "agent-client-protocol-schema",

--- a/crates/goose-agent/Cargo.toml
+++ b/crates/goose-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goose-agent"
-version = "0.1.0-alpha.6"
+version = "0.1.0-alpha.7"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -16,7 +16,7 @@ anyhow = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "sync", "time", "fs", "process", "net", "signal", "io-std", "io-util"] }
 tokio-util = { workspace = true, features = ["compat"] }
 async-trait = { workspace = true }
-goose-provider-types = { version = "0.1.0-alpha.6", path = "../goose-provider-types", default-features = false }
+goose-provider-types = { version = "0.1.0-alpha.7", path = "../goose-provider-types", default-features = false }
 rmcp = { workspace = true }
 uuid = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/goose-context-management/Cargo.toml
+++ b/crates/goose-context-management/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goose-context-management"
-version = "0.1.0-alpha.6"
+version = "0.1.0-alpha.7"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -12,7 +12,7 @@ description = "Conversation compaction for Goose"
 workspace = true
 
 [dependencies]
-goose-providers = { version = "0.1.0-alpha.6", path = "../goose-providers", features = ["rustls-tls"] }
+goose-providers = { version = "0.1.0-alpha.7", path = "../goose-providers", features = ["rustls-tls"] }
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 include_dir = { workspace = true }

--- a/crates/goose-download-manager/Cargo.toml
+++ b/crates/goose-download-manager/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goose-download-manager"
-version = "0.1.0-alpha.6"
+version = "0.1.0-alpha.7"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/goose-local-inference/Cargo.toml
+++ b/crates/goose-local-inference/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goose-local-inference"
-version = "0.1.0-alpha.6"
+version = "0.1.0-alpha.7"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -27,9 +27,9 @@ etcetera = { workspace = true }
 encoding_rs = { version = "0.8.35", default-features = false }
 fs2 = { workspace = true }
 futures = { workspace = true }
-goose-download-manager = { version = "0.1.0-alpha.6", path = "../goose-download-manager" }
-goose-provider-types = { version = "0.1.0-alpha.6", path = "../goose-provider-types", default-features = false }
-goose-sdk-types = { version = "0.1.0-alpha.6", path = "../goose-sdk-types", default-features = false }
+goose-download-manager = { version = "0.1.0-alpha.7", path = "../goose-download-manager" }
+goose-provider-types = { version = "0.1.0-alpha.7", path = "../goose-provider-types", default-features = false }
+goose-sdk-types = { version = "0.1.0-alpha.7", path = "../goose-sdk-types", default-features = false }
 hf-hub = { version = "1.0.0-rc.1", default-features = false }
 include_dir = { workspace = true }
 llama-cpp-2 = { workspace = true }

--- a/crates/goose-provider-types/Cargo.toml
+++ b/crates/goose-provider-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goose-provider-types"
-version = "0.1.0-alpha.6"
+version = "0.1.0-alpha.7"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/goose-providers/Cargo.toml
+++ b/crates/goose-providers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goose-providers"
-version = "0.1.0-alpha.6"
+version = "0.1.0-alpha.7"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -34,8 +34,8 @@ anyhow = { workspace = true }
 async-stream = { workspace = true }
 chrono = { workspace = true }
 futures = { workspace = true }
-goose-provider-types = { version = "0.1.0-alpha.6", path = "../goose-provider-types", default-features = false }
-goose-local-inference = { version = "0.1.0-alpha.6", path = "../goose-local-inference", default-features = false, optional = true }
+goose-provider-types = { version = "0.1.0-alpha.7", path = "../goose-provider-types", default-features = false }
+goose-local-inference = { version = "0.1.0-alpha.7", path = "../goose-local-inference", default-features = false, optional = true }
 reqwest = { workspace = true }
 rmcp = { workspace = true, features = ["server", "macros"] }
 serde = { workspace = true }

--- a/crates/goose-sdk-types/Cargo.toml
+++ b/crates/goose-sdk-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goose-sdk-types"
-version = "0.1.0-alpha.6"
+version = "0.1.0-alpha.7"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/goose-sdk/Cargo.toml
+++ b/crates/goose-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goose-sdk"
-version = "0.1.0-alpha.6"
+version = "0.1.0-alpha.7"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -33,14 +33,14 @@ uniffi = [
 ]
 
 [dependencies]
-goose-sdk-types = { version = "0.1.0-alpha.6", path = "../goose-sdk-types" }
+goose-sdk-types = { version = "0.1.0-alpha.7", path = "../goose-sdk-types" }
 agent-client-protocol = { workspace = true }
 agent-client-protocol-schema = { workspace = true }
 
 uniffi = { version = "0.32", features = ["cli"], optional = true }
 thiserror = { version = "2", optional = true }
-goose-providers = { version = "0.1.0-alpha.6", path = "../goose-providers", features = ["rustls-tls"], optional = true }
-goose-context-management = { version = "0.1.0-alpha.6", path = "../goose-context-management", optional = true }
+goose-providers = { version = "0.1.0-alpha.7", path = "../goose-providers", features = ["rustls-tls"], optional = true }
+goose-context-management = { version = "0.1.0-alpha.7", path = "../goose-context-management", optional = true }
 futures = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "sync"], optional = true }

--- a/crates/goose-sdk/justfile
+++ b/crates/goose-sdk/justfile
@@ -110,6 +110,60 @@ crates-publish dry_run="true":
         cargo publish -p "$crate" $dry_run_flag --allow-dirty; \
     done
 
+check-version rust_version:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    python3 - "{{rust_version}}" <<'PY'
+    import re
+    import sys
+    from pathlib import Path
+
+    rust_version = sys.argv[1]
+    match = re.fullmatch(r"(\d+)\.(\d+)\.(\d+)(?:-alpha\.(\d+))?", rust_version)
+    if not match:
+        raise SystemExit("version must look like 0.1.0 or 0.1.0-alpha.0")
+
+    major, minor, patch, alpha = match.groups()
+    python_version = f"{major}.{minor}.{patch}" if alpha is None else f"{major}.{minor}.{patch}a{alpha}"
+    crate_names = [
+        "goose-provider-types",
+        "goose-sdk-types",
+        "goose-download-manager",
+        "goose-local-inference",
+        "goose-providers",
+        "goose-agent",
+        "goose-context-management",
+        "goose-sdk",
+    ]
+
+    def package_version(path: Path, section: str) -> str:
+        text = path.read_text()
+        section_match = re.search(rf"(?ms)^\[{re.escape(section)}\]\s*$(.*?)(?=^\[|\Z)", text)
+        if not section_match:
+            raise SystemExit(f"missing [{section}] in {path}")
+        version_match = re.search(r'^version\s*=\s*"([^"]+)"', section_match.group(1), re.MULTILINE)
+        if not version_match:
+            raise SystemExit(f"missing version in [{section}] in {path}")
+        return version_match.group(1)
+
+    errors = []
+    for crate in crate_names:
+        path = Path("crates") / crate / "Cargo.toml"
+        actual = package_version(path, "package")
+        if actual != rust_version:
+            errors.append(f"{path}: expected {rust_version}, found {actual}")
+
+    pyproject = Path("crates/goose-sdk/python/pyproject.toml")
+    actual_python = package_version(pyproject, "project")
+    if actual_python != python_version:
+        errors.append(f"{pyproject}: expected {python_version}, found {actual_python}")
+
+    if errors:
+        raise SystemExit("\n".join(errors))
+
+    print(f"Validated Rust/Maven version {rust_version} and Python version {python_version}")
+    PY
+
 bump-version rust_version:
     #!/usr/bin/env bash
     set -euo pipefail

--- a/crates/goose-sdk/justfile
+++ b/crates/goose-sdk/justfile
@@ -269,4 +269,5 @@ bump-version rust_version:
     print(f"Python package: {python_version}")
     print(f"Maven artifact: {rust_version}")
     PY
+    cargo update --workspace
     cargo fmt --all

--- a/crates/goose-sdk/justfile
+++ b/crates/goose-sdk/justfile
@@ -98,6 +98,8 @@ crates-publish dry_run="true":
         echo 'dry_run must be true or false' >&2; \
         exit 1; \
     fi; \
+    version=$(cargo metadata --no-deps --format-version 1 | python3 -c \
+        'import json, sys; print(next(package["version"] for package in json.load(sys.stdin)["packages"] if package["name"] == "goose-sdk"))'); \
     for crate in \
         goose-provider-types \
         goose-sdk-types \
@@ -107,6 +109,16 @@ crates-publish dry_run="true":
         goose-agent \
         goose-context-management \
         goose-sdk; do \
+        if [ "{{dry_run}}" = "false" ]; then \
+            status=$(curl --silent --output /dev/null --write-out '%{http_code}' \
+                --user-agent 'goose-gdk-release (https://github.com/aaif-goose/goose)' \
+                "https://crates.io/api/v1/crates/$crate/$version"); \
+            case "$status" in \
+                200) echo "$crate $version is already published; skipping"; continue ;; \
+                404) ;; \
+                *) echo "crates.io returned HTTP $status while checking $crate $version" >&2; exit 1 ;; \
+            esac; \
+        fi; \
         cargo publish -p "$crate" $dry_run_flag --allow-dirty; \
     done
 
@@ -147,11 +159,26 @@ check-version rust_version:
         return version_match.group(1)
 
     errors = []
+    dependency_names = set(crate_names) - {"goose-sdk"}
     for crate in crate_names:
         path = Path("crates") / crate / "Cargo.toml"
+        text = path.read_text()
         actual = package_version(path, "package")
         if actual != rust_version:
             errors.append(f"{path}: expected {rust_version}, found {actual}")
+
+        for dependency in dependency_names:
+            for dependency_match in re.finditer(
+                rf'(?m)^{re.escape(dependency)}\s*=\s*' + re.escape("{") + r'([^}]*)' + re.escape("}"), text
+            ):
+                version_match = re.search(r'version\s*=\s*"([^"]+)"', dependency_match.group(1))
+                if not version_match:
+                    errors.append(f"{path}: {dependency} is missing a version requirement")
+                elif version_match.group(1) != rust_version:
+                    errors.append(
+                        f"{path}: {dependency} expected {rust_version}, "
+                        f"found {version_match.group(1)}"
+                    )
 
     pyproject = Path("crates/goose-sdk/python/pyproject.toml")
     actual_python = package_version(pyproject, "project")

--- a/crates/goose-sdk/justfile
+++ b/crates/goose-sdk/justfile
@@ -114,12 +114,13 @@ crates-publish dry_run="true":
                 --user-agent 'goose-gdk-release (https://github.com/aaif-goose/goose)' \
                 "https://crates.io/api/v1/crates/$crate/$version"); \
             case "$status" in \
-                200) echo "$crate $version is already published; skipping"; continue ;; \
-                404) ;; \
+                200) echo "$crate $version is already published; skipping upload" ;; \
+                404) cargo publish -p "$crate" --allow-dirty ;; \
                 *) echo "crates.io returned HTTP $status while checking $crate $version" >&2; exit 1 ;; \
             esac; \
+        else \
+            cargo publish -p "$crate" $dry_run_flag --allow-dirty; \
         fi; \
-        cargo publish -p "$crate" $dry_run_flag --allow-dirty; \
         if [ "{{dry_run}}" = "false" ]; then \
             for attempt in $(seq 1 60); do \
                 if cargo info "$crate@$version" --registry crates-io >/dev/null 2>&1; then \

--- a/crates/goose-sdk/justfile
+++ b/crates/goose-sdk/justfile
@@ -120,6 +120,19 @@ crates-publish dry_run="true":
             esac; \
         fi; \
         cargo publish -p "$crate" $dry_run_flag --allow-dirty; \
+        if [ "{{dry_run}}" = "false" ]; then \
+            for attempt in $(seq 1 60); do \
+                if cargo info "$crate@$version" --registry crates-io >/dev/null 2>&1; then \
+                    echo "$crate $version is available on crates.io"; \
+                    break; \
+                fi; \
+                if [ "$attempt" -eq 60 ]; then \
+                    echo "timed out waiting for $crate $version to become available on crates.io" >&2; \
+                    exit 1; \
+                fi; \
+                sleep 10; \
+            done; \
+        fi; \
     done
 
 check-version rust_version:

--- a/crates/goose-sdk/python/pyproject.toml
+++ b/crates/goose-sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "goose-sdk"
-version = "0.1.0a6"
+version = "0.1.0a7"
 description = "Python bindings for the goose Development Kit (GDK)"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/crates/goose-sdk/python/setup.py
+++ b/crates/goose-sdk/python/setup.py
@@ -1,5 +1,10 @@
-from setuptools import setup
+from setuptools import Distribution, setup
 from wheel.bdist_wheel import bdist_wheel
+
+
+class BinaryDistribution(Distribution):
+    def has_ext_modules(self):
+        return True
 
 
 class BinaryWheel(bdist_wheel):
@@ -12,4 +17,4 @@ class BinaryWheel(bdist_wheel):
         return "py3", "none", platform_tag
 
 
-setup(cmdclass={"bdist_wheel": BinaryWheel})
+setup(cmdclass={"bdist_wheel": BinaryWheel}, distclass=BinaryDistribution)

--- a/documentation/src/data/gdk-api.json
+++ b/documentation/src/data/gdk-api.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "version": "0.1.0-alpha.6",
+      "version": "0.1.0-alpha.7",
       "docVersion": "0.1",
       "source": "crates/goose-sdk/src/bindings.rs",
       "functions": [


### PR DESCRIPTION
Fixes: #11532

## Summary

- publish GDK Rust crates, Maven artifacts, and Python wheels when a `gdk-v*` tag is pushed
- validate that the tag version matches all Rust crates and the Python package before publishing
- reuse the existing Maven and Python workflows as callable publishing workflows

### Testing

- `git diff --check`
- parsed all changed GitHub Actions workflow YAML files
- `just --justfile crates/goose-sdk/justfile check-version 0.1.0-alpha.6`

### Related Issues

Discussion: #11532
