### PR TITLE
fix(acp): gate persisted session access

### DIFF
--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -232,6 +232,7 @@ const PROVIDER_CONFIG_STATUS_CHECK_CONCURRENCY: usize = 16;
 /// below is keyed by session ID.
 struct GooseAcpSession {
     agent: Arc<Agent>,
+    client_created: bool,
 }
 
 pub struct ActivePromptRun {
@@ -1218,9 +1219,15 @@ impl GooseAcpAgent {
         enabled_extensions_data(session, extensions)
     }
 
-    async fn register_acp_session(&self, session_id: String, agent: Arc<Agent>) {
+    async fn register_acp_session(
+        &self,
+        session_id: String,
+        agent: Arc<Agent>,
+        client_created: bool,
+    ) {
         let acp_session = GooseAcpSession {
             agent: agent.clone(),
+            client_created,
         };
         self.sessions
             .lock()
@@ -1289,9 +1296,10 @@ impl GooseAcpAgent {
         &self,
         cx: &ConnectionTo<Client>,
         session: &Session,
+        client_created: bool,
     ) -> Result<(Arc<Agent>, Vec<ExtensionLoadResult>), agent_client_protocol::Error> {
         let (agent, extension_results) = self.prepare_acp_session_agent(cx, session).await?;
-        self.register_acp_session(session.id.clone(), agent.clone())
+        self.register_acp_session(session.id.clone(), agent.clone(), client_created)
             .await;
 
         Ok((agent, extension_results))
@@ -1868,7 +1876,7 @@ impl GooseAcpAgent {
                 agent_client_protocol::Error::resource_not_found(Some(session_id.to_string()))
                     .data(format!("Session not found: {}", session_id))
             })?;
-        let (agent, _) = self.activate_acp_session(cx, &session).await?;
+        let (agent, _) = self.activate_acp_session(cx, &session, false).await?;
         Ok(agent)
     }
 
@@ -1882,7 +1890,13 @@ impl GooseAcpAgent {
             ))
             .data(format!("Session not found: {session_id}")));
         }
-        if self.sessions.lock().await.contains_key(session_id) {
+        if self
+            .sessions
+            .lock()
+            .await
+            .get(session_id)
+            .is_some_and(|session| session.client_created)
+        {
             return Ok(());
         }
         if self
@@ -3604,7 +3618,7 @@ print(\"hello, world\")
             .await
             .unwrap();
         server
-            .register_acp_session(session.id.clone(), session_agent)
+            .register_acp_session(session.id.clone(), session_agent, false)
             .await;
 
         let (client_read, server_write) = tokio::io::duplex(64 * 1024);

--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -1225,14 +1225,17 @@ impl GooseAcpAgent {
         agent: Arc<Agent>,
         client_created: bool,
     ) {
+        let mut sessions = self.sessions.lock().await;
+        let client_created = client_created
+            || sessions
+                .get(&session_id)
+                .is_some_and(|session| session.client_created);
         let acp_session = GooseAcpSession {
             agent: agent.clone(),
             client_created,
         };
-        self.sessions
-            .lock()
-            .await
-            .insert(session_id.clone(), acp_session);
+        sessions.insert(session_id.clone(), acp_session);
+        drop(sessions);
         self.subscribe_thinking_effort_updates(&session_id, &agent)
             .await;
     }

--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -2477,6 +2477,8 @@ impl GooseAcpAgent {
         session_id: &str,
         mode_id: &str,
     ) -> Result<SetSessionModeResponse, agent_client_protocol::Error> {
+        self.ensure_session_access(session_id).await?;
+
         let mode = mode_id.parse::<GooseMode>().map_err(|_| {
             agent_client_protocol::Error::invalid_params()
                 .data(format!("Invalid mode: {}", mode_id))

--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -1853,6 +1853,8 @@ impl GooseAcpAgent {
         &self,
         session_id: &str,
     ) -> Result<Arc<Agent>, agent_client_protocol::Error> {
+        self.ensure_session_access(session_id).await?;
+
         if self.closed_session_ids.lock().await.contains(session_id) {
             return Err(agent_client_protocol::Error::resource_not_found(Some(
                 session_id.to_string(),

--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -1872,6 +1872,34 @@ impl GooseAcpAgent {
         Ok(agent)
     }
 
+    async fn ensure_session_access(
+        &self,
+        session_id: &str,
+    ) -> Result<(), agent_client_protocol::Error> {
+        if self.closed_session_ids.lock().await.contains(session_id) {
+            return Err(agent_client_protocol::Error::resource_not_found(Some(
+                session_id.to_string(),
+            ))
+            .data(format!("Session not found: {session_id}")));
+        }
+        if self.sessions.lock().await.contains_key(session_id) {
+            return Ok(());
+        }
+        if self
+            .session_manager
+            .session_exists_with_types(session_id, &ACP_VISIBLE_SESSION_TYPES)
+            .await
+            .internal_err()?
+        {
+            return Ok(());
+        }
+
+        Err(
+            agent_client_protocol::Error::resource_not_found(Some(session_id.to_string()))
+                .data(format!("Session not found: {session_id}")),
+        )
+    }
+
     async fn start_active_run(
         &self,
         session_id: &str,

--- a/crates/goose/src/acp/server/dispatch.rs
+++ b/crates/goose/src/acp/server/dispatch.rs
@@ -165,6 +165,10 @@ impl HandleDispatchFrom<Client> for GooseAcpHandler {
                             };
                             let session_id = req.session_id.clone();
                             let config_id = req.config_id.0.to_string();
+                            if let Err(error) = agent.ensure_session_access(&session_id.0).await {
+                                responder.respond_with_error(error)?;
+                                return Ok(());
+                            }
                             match config_id.as_ref() {
                                 "provider" => {
                                     Config::global().invalidate_secrets_cache();

--- a/crates/goose/src/acp/server/fork_session.rs
+++ b/crates/goose/src/acp/server/fork_session.rs
@@ -9,6 +9,7 @@ impl GooseAcpAgent {
     ) -> Result<ForkSessionResponse, agent_client_protocol::Error> {
         let conversation_before = conversation_before_from_meta(args.meta.as_ref())?;
         let source_session_id = &*args.session_id.0;
+        self.ensure_session_access(source_session_id).await?;
 
         let source = self
             .session_manager

--- a/crates/goose/src/acp/server/fork_session.rs
+++ b/crates/goose/src/acp/server/fork_session.rs
@@ -53,7 +53,7 @@ impl GooseAcpAgent {
 
         let (agent, extension_results) = self.prepare_acp_session_agent(cx, &goose_session).await?;
         self.apply_session_recipe(&agent, &goose_session).await?;
-        self.register_acp_session(goose_session.id.clone(), agent.clone())
+        self.register_acp_session(goose_session.id.clone(), agent.clone(), true)
             .await;
         let provider = agent
             .provider()

--- a/crates/goose/src/acp/server/load_session.rs
+++ b/crates/goose/src/acp/server/load_session.rs
@@ -300,6 +300,7 @@ impl GooseAcpAgent {
         debug!(?args, "load session request");
 
         let session_id_str = args.session_id.0.to_string();
+        self.ensure_session_access(&session_id_str).await?;
 
         let mut session = self
             .session_manager

--- a/crates/goose/src/acp/server/load_session.rs
+++ b/crates/goose/src/acp/server/load_session.rs
@@ -326,7 +326,7 @@ impl GooseAcpAgent {
         )?;
         let (agent, extension_results) = self.prepare_acp_session_agent(cx, &session).await?;
         self.apply_session_recipe(&agent, &session).await?;
-        self.register_acp_session(session_id_str.clone(), agent.clone())
+        self.register_acp_session(session_id_str.clone(), agent.clone(), false)
             .await;
         let provider = agent
             .provider()

--- a/crates/goose/src/acp/server/manage_sessions.rs
+++ b/crates/goose/src/acp/server/manage_sessions.rs
@@ -14,6 +14,8 @@ impl GooseAcpAgent {
         validate_absolute_cwd(&path)?;
         let session_id = &req.session_id;
 
+        self.ensure_session_access(session_id).await?;
+
         let session = self
             .session_manager
             .get_session(session_id, false)

--- a/crates/goose/src/acp/server/new_session.rs
+++ b/crates/goose/src/acp/server/new_session.rs
@@ -86,7 +86,9 @@ impl GooseAcpAgent {
             .await?;
 
         let reloaded_session = self.reload_session(&session.id).await?;
-        let (agent, extension_results) = self.activate_acp_session(cx, &reloaded_session).await?;
+        let (agent, extension_results) = self
+            .activate_acp_session(cx, &reloaded_session, true)
+            .await?;
         if let Some(recipe) = &rendered_recipe {
             self.apply_recipe(&agent, recipe).await?;
         }

--- a/crates/goose/src/session/session_manager.rs
+++ b/crates/goose/src/session/session_manager.rs
@@ -448,6 +448,16 @@ impl SessionManager {
             .await
     }
 
+    pub(crate) async fn session_exists_with_types(
+        &self,
+        id: &str,
+        session_types: &[SessionType],
+    ) -> Result<bool> {
+        self.storage
+            .session_exists_with_types(id, session_types)
+            .await
+    }
+
     async fn apply_update_inner(&self, builder: SessionUpdateBuilder<'_>) -> Result<()> {
         self.storage.apply_update(builder).await
     }
@@ -1860,6 +1870,32 @@ impl SessionStorage {
         }
 
         Ok(query.execute(pool).await?.rows_affected() == 1)
+    }
+
+    async fn session_exists_with_types(
+        &self,
+        id: &str,
+        session_types: &[SessionType],
+    ) -> Result<bool> {
+        if session_types.is_empty() {
+            return Ok(false);
+        }
+
+        let placeholders = session_types
+            .iter()
+            .map(|_| "?")
+            .collect::<Vec<_>>()
+            .join(", ");
+        let query = format!(
+            "SELECT EXISTS(SELECT 1 FROM sessions WHERE id = ? AND session_type IN ({placeholders}))"
+        );
+        let pool = self.pool().await?;
+        let mut query = sqlx::query_scalar::<_, bool>(AssertSqlSafe(query)).bind(id);
+        for session_type in session_types {
+            query = query.bind(session_type.to_string());
+        }
+
+        Ok(query.fetch_one(pool).await?)
     }
 
     async fn get_conversation(&self, session_id: &str) -> Result<Conversation> {

--- a/crates/goose/tests/acp_fork_session_test.rs
+++ b/crates/goose/tests/acp_fork_session_test.rs
@@ -168,3 +168,39 @@ fn fork_session_conversation_before_matches_rest_cutoff() {
         );
     });
 }
+
+#[test]
+fn fork_session_rejects_hidden_persisted_source_without_copying() {
+    run_test(async {
+        let data_root = tempfile::tempdir().unwrap();
+        let cwd = tempfile::tempdir().unwrap();
+        let session_manager = SessionManager::new(data_root.path().to_path_buf());
+        let hidden = session_manager
+            .create_session(
+                cwd.path().to_path_buf(),
+                "Hidden source".to_string(),
+                SessionType::Hidden,
+                GooseMode::default(),
+            )
+            .await
+            .unwrap();
+        let conn = new_connection(data_root.path()).await;
+
+        let error = fork_session_request(
+            &conn,
+            ForkSessionRequest::new(SessionId::new(hidden.id.clone()), cwd.path()),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(error.to_string().contains("Session not found"));
+        assert_eq!(
+            session_manager
+                .list_sessions_by_types(&[SessionType::Hidden])
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
+    });
+}

--- a/crates/goose/tests/acp_server_test.rs
+++ b/crates/goose/tests/acp_server_test.rs
@@ -3,9 +3,9 @@
 #[path = "acp_common_tests/mod.rs"]
 mod common_tests;
 use agent_client_protocol::schema::v1::{
-    ContentBlock, ListSessionsRequest, ListSessionsResponse, NewSessionRequest, PromptRequest,
-    SessionConfigKind, SessionConfigOptionCategory, SessionConfigOptionValue, SessionInfo,
-    SetSessionConfigOptionRequest, SetSessionModeRequest, StopReason, TextContent,
+    ContentBlock, ListSessionsRequest, ListSessionsResponse, LoadSessionRequest, NewSessionRequest,
+    PromptRequest, SessionConfigKind, SessionConfigOptionCategory, SessionConfigOptionValue,
+    SessionInfo, SetSessionConfigOptionRequest, SetSessionModeRequest, StopReason, TextContent,
 };
 use agent_client_protocol::ErrorCode;
 use common_tests::fixtures::server::{
@@ -149,6 +149,18 @@ async fn set_session_mode_legacy(
             session_id.to_string(),
             mode.to_string(),
         ))
+        .block_task()
+        .await
+        .map(|_| ())
+}
+
+async fn load_session(
+    conn: &AcpServerConnection,
+    session_id: &str,
+    working_dir: &Path,
+) -> Result<(), agent_client_protocol::Error> {
+    conn.cx()
+        .send_request(LoadSessionRequest::new(session_id.to_string(), working_dir))
         .block_task()
         .await
         .map(|_| ())
@@ -941,6 +953,70 @@ fn test_session_mutations_allow_active_client_created_hidden_session() {
         assert_eq!(stored.session_type, SessionType::Hidden);
         assert_eq!(stored.goose_mode, GooseMode::Approve);
         assert_eq!(stored.working_dir, replacement_dir.path());
+    });
+}
+
+#[test]
+fn test_session_mutations_reject_loaded_hidden_session() {
+    run_test(async {
+        let data_root = tempfile::tempdir().unwrap();
+        let working_dir = tempfile::tempdir().unwrap();
+        let replacement_dir = tempfile::tempdir().unwrap();
+        let session_manager = SessionManager::new(data_root.path().to_path_buf());
+        let seed_conn = new_connection(data_root.path()).await;
+        let seed_session_id =
+            new_session_with_meta(&seed_conn, working_dir.path(), serde_json::Map::new())
+                .await
+                .unwrap();
+        let seed_session = session_manager
+            .get_session(&seed_session_id, false)
+            .await
+            .unwrap();
+        drop(seed_conn);
+
+        let hidden = session_manager
+            .create_session(
+                working_dir.path().to_path_buf(),
+                "Hidden session".to_string(),
+                SessionType::Hidden,
+                GooseMode::default(),
+            )
+            .await
+            .unwrap();
+        session_manager
+            .update(&hidden.id)
+            .provider_name(seed_session.provider_name.as_ref().unwrap())
+            .model_config(seed_session.model_config.unwrap())
+            .apply()
+            .await
+            .unwrap();
+
+        let conn = new_connection(data_root.path()).await;
+        load_session(&conn, &hidden.id, working_dir.path())
+            .await
+            .unwrap();
+
+        let error = set_session_mode(&conn, &hidden.id, "approve")
+            .await
+            .unwrap_err();
+        assert_eq!(error.code, ErrorCode::ResourceNotFound);
+
+        let error = set_session_mode_legacy(&conn, &hidden.id, "approve")
+            .await
+            .unwrap_err();
+        assert_eq!(error.code, ErrorCode::ResourceNotFound);
+
+        let error = update_working_dir(&conn, &hidden.id, replacement_dir.path())
+            .await
+            .unwrap_err();
+        assert_eq!(error.code, ErrorCode::ResourceNotFound);
+
+        let stored = session_manager
+            .get_session(&hidden.id, false)
+            .await
+            .unwrap();
+        assert_eq!(stored.goose_mode, GooseMode::default());
+        assert_eq!(stored.working_dir, working_dir.path());
     });
 }
 

--- a/crates/goose/tests/acp_server_test.rs
+++ b/crates/goose/tests/acp_server_test.rs
@@ -935,6 +935,9 @@ fn test_session_mutations_allow_active_client_created_hidden_session() {
         )
         .await
         .unwrap();
+        load_session(&conn, &session_id, working_dir.path())
+            .await
+            .unwrap();
 
         set_session_mode(&conn, &session_id, "smart_approve")
             .await

--- a/crates/goose/tests/acp_server_test.rs
+++ b/crates/goose/tests/acp_server_test.rs
@@ -957,7 +957,7 @@ fn test_session_mutations_allow_active_client_created_hidden_session() {
 }
 
 #[test]
-fn test_session_mutations_reject_loaded_hidden_session() {
+fn test_load_session_rejects_hidden_session_without_changes() {
     run_test(async {
         let data_root = tempfile::tempdir().unwrap();
         let working_dir = tempfile::tempdir().unwrap();
@@ -992,9 +992,10 @@ fn test_session_mutations_reject_loaded_hidden_session() {
             .unwrap();
 
         let conn = new_connection(data_root.path()).await;
-        load_session(&conn, &hidden.id, working_dir.path())
+        let error = load_session(&conn, &hidden.id, replacement_dir.path())
             .await
-            .unwrap();
+            .unwrap_err();
+        assert_eq!(error.code, ErrorCode::ResourceNotFound);
 
         let error = set_session_mode(&conn, &hidden.id, "approve")
             .await

--- a/crates/goose/tests/acp_server_test.rs
+++ b/crates/goose/tests/acp_server_test.rs
@@ -33,6 +33,7 @@ use goose::config::GooseMode;
 use goose::conversation::message::{Message, MessageMetadata};
 use goose::custom_requests::{
     GetSessionInfoRequest, GetSessionInfoResponse, UpdateSessionProjectRequest,
+    UpdateWorkingDirRequest,
 };
 use goose::recipe::{Recipe, Settings};
 use goose::recipe_deeplink;
@@ -120,6 +121,37 @@ async fn get_session_info_request(
         .block_task()
         .await
         .map_err(Into::into)
+}
+
+async fn set_session_mode(
+    conn: &AcpServerConnection,
+    session_id: &str,
+    mode: &str,
+) -> Result<(), agent_client_protocol::Error> {
+    conn.cx()
+        .send_request(SetSessionConfigOptionRequest::new(
+            session_id.to_string(),
+            "mode".to_string(),
+            SessionConfigOptionValue::value_id(mode.to_string()),
+        ))
+        .block_task()
+        .await
+        .map(|_| ())
+}
+
+async fn update_working_dir(
+    conn: &AcpServerConnection,
+    session_id: &str,
+    working_dir: &Path,
+) -> Result<(), agent_client_protocol::Error> {
+    conn.cx()
+        .send_request(UpdateWorkingDirRequest {
+            session_id: session_id.to_string(),
+            working_dir: working_dir.to_string_lossy().to_string(),
+        })
+        .block_task()
+        .await
+        .map(|_| ())
 }
 
 fn assert_invalid_params(error: anyhow::Error) {
@@ -683,6 +715,201 @@ fn test_update_session_project_allows_visible_session_types() {
                 None
             );
         }
+    });
+}
+
+#[test]
+fn test_session_mutations_reject_internal_session_types_without_changes() {
+    run_test(async {
+        let data_root = tempfile::tempdir().unwrap();
+        let working_dir = tempfile::tempdir().unwrap();
+        let replacement_dir = tempfile::tempdir().unwrap();
+        let session_manager = SessionManager::new(data_root.path().to_path_buf());
+        let mut internal_sessions = Vec::new();
+
+        for session_type in [
+            SessionType::Gateway,
+            SessionType::SubAgent,
+            SessionType::Hidden,
+            SessionType::Terminal,
+        ] {
+            internal_sessions.push(
+                session_manager
+                    .create_session(
+                        working_dir.path().to_path_buf(),
+                        format!("{session_type} session"),
+                        session_type,
+                        GooseMode::default(),
+                    )
+                    .await
+                    .unwrap(),
+            );
+        }
+
+        let conn = new_connection(data_root.path()).await;
+        for session in internal_sessions {
+            let error = set_session_mode(&conn, &session.id, "approve")
+                .await
+                .unwrap_err();
+            assert_eq!(error.code, ErrorCode::ResourceNotFound);
+
+            let error = update_working_dir(&conn, &session.id, replacement_dir.path())
+                .await
+                .unwrap_err();
+            assert_eq!(error.code, ErrorCode::ResourceNotFound);
+
+            let stored = session_manager
+                .get_session(&session.id, false)
+                .await
+                .unwrap();
+            assert_eq!(stored.goose_mode, GooseMode::default());
+            assert_eq!(stored.working_dir, working_dir.path());
+        }
+    });
+}
+
+#[test]
+fn test_session_mutations_reject_unknown_raw_type_including_same_path() {
+    run_test(async {
+        let data_root = tempfile::tempdir().unwrap();
+        let working_dir = tempfile::tempdir().unwrap();
+        let session_manager = SessionManager::new(data_root.path().to_path_buf());
+        let session = session_manager
+            .create_session(
+                working_dir.path().to_path_buf(),
+                "Future session".to_string(),
+                SessionType::User,
+                GooseMode::default(),
+            )
+            .await
+            .unwrap();
+        let db_path = data_root
+            .path()
+            .join(goose::session::session_manager::SESSIONS_FOLDER)
+            .join(goose::session::session_manager::DB_NAME);
+        let pool = sqlx::sqlite::SqlitePoolOptions::new()
+            .connect_with(sqlx::sqlite::SqliteConnectOptions::new().filename(db_path))
+            .await
+            .unwrap();
+        sqlx::query("UPDATE sessions SET session_type = 'future_type' WHERE id = ?")
+            .bind(&session.id)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let conn = new_connection(data_root.path()).await;
+        let error = set_session_mode(&conn, &session.id, "approve")
+            .await
+            .unwrap_err();
+        assert_eq!(error.code, ErrorCode::ResourceNotFound);
+
+        let error = update_working_dir(&conn, &session.id, working_dir.path())
+            .await
+            .unwrap_err();
+        assert_eq!(error.code, ErrorCode::ResourceNotFound);
+
+        let (session_type, goose_mode, stored_working_dir) =
+            sqlx::query_as::<_, (String, String, String)>(
+                "SELECT session_type, goose_mode, working_dir FROM sessions WHERE id = ?",
+            )
+            .bind(&session.id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(session_type, "future_type");
+        assert_eq!(goose_mode, GooseMode::default().to_string());
+        assert_eq!(stored_working_dir, working_dir.path().to_string_lossy());
+    });
+}
+
+#[test]
+fn test_session_mutations_allow_visible_persisted_session_types() {
+    run_test(async {
+        let data_root = tempfile::tempdir().unwrap();
+        let working_dir = tempfile::tempdir().unwrap();
+        let replacement_dir = tempfile::tempdir().unwrap();
+        let session_manager = SessionManager::new(data_root.path().to_path_buf());
+        let seed_conn = new_connection(data_root.path()).await;
+        let seed_session_id =
+            new_session_with_meta(&seed_conn, working_dir.path(), serde_json::Map::new())
+                .await
+                .unwrap();
+        let seed_session = session_manager
+            .get_session(&seed_session_id, false)
+            .await
+            .unwrap();
+        drop(seed_conn);
+        let mut visible_sessions = Vec::new();
+
+        for session_type in [SessionType::User, SessionType::Scheduled, SessionType::Acp] {
+            let session = session_manager
+                .create_session(
+                    working_dir.path().to_path_buf(),
+                    format!("{session_type} session"),
+                    session_type,
+                    GooseMode::default(),
+                )
+                .await
+                .unwrap();
+            session_manager
+                .update(&session.id)
+                .provider_name(seed_session.provider_name.as_ref().unwrap())
+                .model_config(seed_session.model_config.clone().unwrap())
+                .apply()
+                .await
+                .unwrap();
+            visible_sessions.push(session);
+        }
+
+        let conn = new_connection(data_root.path()).await;
+        for session in visible_sessions {
+            set_session_mode(&conn, &session.id, "approve")
+                .await
+                .unwrap();
+            update_working_dir(&conn, &session.id, replacement_dir.path())
+                .await
+                .unwrap();
+
+            let stored = session_manager
+                .get_session(&session.id, false)
+                .await
+                .unwrap();
+            assert_eq!(stored.goose_mode, GooseMode::Approve);
+            assert_eq!(stored.working_dir, replacement_dir.path());
+        }
+    });
+}
+
+#[test]
+fn test_session_mutations_allow_active_client_created_hidden_session() {
+    run_test(async {
+        let data_root = tempfile::tempdir().unwrap();
+        let working_dir = tempfile::tempdir().unwrap();
+        let replacement_dir = tempfile::tempdir().unwrap();
+        let session_manager = SessionManager::new(data_root.path().to_path_buf());
+        let conn = new_connection(data_root.path()).await;
+        let session_id = new_session_with_meta(
+            &conn,
+            working_dir.path(),
+            serde_json::from_value(serde_json::json!({ "hidden": true })).unwrap(),
+        )
+        .await
+        .unwrap();
+
+        set_session_mode(&conn, &session_id, "approve")
+            .await
+            .unwrap();
+        update_working_dir(&conn, &session_id, replacement_dir.path())
+            .await
+            .unwrap();
+
+        let stored = session_manager
+            .get_session(&session_id, false)
+            .await
+            .unwrap();
+        assert_eq!(stored.session_type, SessionType::Hidden);
+        assert_eq!(stored.goose_mode, GooseMode::Approve);
+        assert_eq!(stored.working_dir, replacement_dir.path());
     });
 }
 

--- a/crates/goose/tests/acp_server_test.rs
+++ b/crates/goose/tests/acp_server_test.rs
@@ -5,7 +5,7 @@ mod common_tests;
 use agent_client_protocol::schema::v1::{
     ContentBlock, ListSessionsRequest, ListSessionsResponse, NewSessionRequest, PromptRequest,
     SessionConfigKind, SessionConfigOptionCategory, SessionConfigOptionValue, SessionInfo,
-    SetSessionConfigOptionRequest, StopReason, TextContent,
+    SetSessionConfigOptionRequest, SetSessionModeRequest, StopReason, TextContent,
 };
 use agent_client_protocol::ErrorCode;
 use common_tests::fixtures::server::{
@@ -133,6 +133,21 @@ async fn set_session_mode(
             session_id.to_string(),
             "mode".to_string(),
             SessionConfigOptionValue::value_id(mode.to_string()),
+        ))
+        .block_task()
+        .await
+        .map(|_| ())
+}
+
+async fn set_session_mode_legacy(
+    conn: &AcpServerConnection,
+    session_id: &str,
+    mode: &str,
+) -> Result<(), agent_client_protocol::Error> {
+    conn.cx()
+        .send_request(SetSessionModeRequest::new(
+            session_id.to_string(),
+            mode.to_string(),
         ))
         .block_task()
         .await
@@ -753,6 +768,11 @@ fn test_session_mutations_reject_internal_session_types_without_changes() {
                 .unwrap_err();
             assert_eq!(error.code, ErrorCode::ResourceNotFound);
 
+            let error = set_session_mode_legacy(&conn, &session.id, "approve")
+                .await
+                .unwrap_err();
+            assert_eq!(error.code, ErrorCode::ResourceNotFound);
+
             let error = update_working_dir(&conn, &session.id, replacement_dir.path())
                 .await
                 .unwrap_err();
@@ -799,6 +819,11 @@ fn test_session_mutations_reject_unknown_raw_type_including_same_path() {
 
         let conn = new_connection(data_root.path()).await;
         let error = set_session_mode(&conn, &session.id, "approve")
+            .await
+            .unwrap_err();
+        assert_eq!(error.code, ErrorCode::ResourceNotFound);
+
+        let error = set_session_mode_legacy(&conn, &session.id, "approve")
             .await
             .unwrap_err();
         assert_eq!(error.code, ErrorCode::ResourceNotFound);
@@ -863,7 +888,10 @@ fn test_session_mutations_allow_visible_persisted_session_types() {
 
         let conn = new_connection(data_root.path()).await;
         for session in visible_sessions {
-            set_session_mode(&conn, &session.id, "approve")
+            set_session_mode(&conn, &session.id, "smart_approve")
+                .await
+                .unwrap();
+            set_session_mode_legacy(&conn, &session.id, "approve")
                 .await
                 .unwrap();
             update_working_dir(&conn, &session.id, replacement_dir.path())
@@ -896,7 +924,10 @@ fn test_session_mutations_allow_active_client_created_hidden_session() {
         .await
         .unwrap();
 
-        set_session_mode(&conn, &session_id, "approve")
+        set_session_mode(&conn, &session_id, "smart_approve")
+            .await
+            .unwrap();
+        set_session_mode_legacy(&conn, &session_id, "approve")
             .await
             .unwrap();
         update_working_dir(&conn, &session_id, replacement_dir.path())

--- a/crates/goose/tests/acp_server_test.rs
+++ b/crates/goose/tests/acp_server_test.rs
@@ -801,6 +801,41 @@ fn test_session_mutations_reject_internal_session_types_without_changes() {
 }
 
 #[test]
+fn test_prompt_rejects_hidden_persisted_session_without_changes() {
+    run_test(async {
+        let data_root = tempfile::tempdir().unwrap();
+        let working_dir = tempfile::tempdir().unwrap();
+        let session_manager = SessionManager::new(data_root.path().to_path_buf());
+        let hidden = session_manager
+            .create_session(
+                working_dir.path().to_path_buf(),
+                "Hidden session".to_string(),
+                SessionType::Hidden,
+                GooseMode::default(),
+            )
+            .await
+            .unwrap();
+        let conn = new_connection(data_root.path()).await;
+
+        let error = conn
+            .cx()
+            .send_request(PromptRequest::new(
+                agent_client_protocol::schema::v1::SessionId::new(hidden.id.clone()),
+                vec![ContentBlock::Text(TextContent::new("unauthorized prompt"))],
+            ))
+            .block_task()
+            .await
+            .unwrap_err();
+
+        assert_eq!(error.code, ErrorCode::ResourceNotFound);
+        let stored = session_manager.get_session(&hidden.id, true).await.unwrap();
+        assert!(stored
+            .conversation
+            .is_none_or(|conversation| conversation.messages().is_empty()));
+    });
+}
+
+#[test]
 fn test_session_mutations_reject_unknown_raw_type_including_same_path() {
     run_test(async {
         let data_root = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## Summary

- gate ACP load, prompt, fork, and mutation requests on connection ownership or an allowed persisted session type
- reject internal and unknown persisted session types before activation, copying, or state changes
- preserve mutations for visible persisted sessions and active connection-created sessions, including reloads

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p goose --test acp_server_test` (63 passed)
- `cargo test -p goose --test acp_fork_session_test` (3 passed)
- `cargo build -p goose`
- `cargo clippy --all-targets -- -D warnings`

*This finding was discovered by [Project Loupe](https://github.com/project-loupe/loupe)*
