### PR TITLE
fix(security): filter scheduled session content

### DIFF
--- a/crates/goose/src/agents/schedule_tool.rs
+++ b/crates/goose/src/agents/schedule_tool.rs
@@ -8,6 +8,7 @@ use crate::mcp_utils::ToolResult;
 use chrono::Utc;
 use rmcp::model::{ContentBlock, ErrorCode, ErrorData};
 
+use crate::conversation::Conversation;
 use crate::recipe::template_recipe::parse_recipe_content;
 use crate::recipe::validate_recipe::validate_recipe_template_from_content;
 use crate::scheduler::{
@@ -494,7 +495,7 @@ impl ScheduleTool {
                 )
             })?;
 
-        let session = match self.session_manager.get_session(session_id, true).await {
+        let mut session = match self.session_manager.get_session(session_id, true).await {
             Ok(metadata) => metadata,
             Err(e) => {
                 return Err(ErrorData::new(
@@ -504,6 +505,10 @@ impl ScheduleTool {
                 ));
             }
         };
+
+        session.conversation = session.conversation.map(|conversation| {
+            Conversation::new_unvalidated(conversation.agent_visible_messages())
+        });
 
         // Format the response with metadata and messages
         let metadata_json = match serde_json::to_string_pretty(&session) {

--- a/crates/goose/src/agents/schedule_tool.rs
+++ b/crates/goose/src/agents/schedule_tool.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 use crate::mcp_utils::ToolResult;
 use chrono::Utc;
-use rmcp::model::{ContentBlock, ErrorCode, ErrorData};
+use rmcp::model::{Annotations, ContentBlock, ErrorCode, ErrorData, Role, TextContent};
 
 use crate::conversation::Conversation;
 use crate::recipe::template_recipe::parse_recipe_content;
@@ -522,9 +522,12 @@ impl ScheduleTool {
             }
         };
 
-        Ok(vec![ContentBlock::text(format!(
-            "Session '{}' Content:\n\nSession:\n{}",
-            session_id, metadata_json
-        ))])
+        Ok(vec![ContentBlock::Text(
+            TextContent::new(format!(
+                "Session '{}' Content:\n\nSession:\n{}",
+                session_id, metadata_json
+            ))
+            .with_annotations(Annotations::default().with_audience(vec![Role::Assistant])),
+        )])
     }
 }

--- a/crates/goose/tests/schedule_tool_security.rs
+++ b/crates/goose/tests/schedule_tool_security.rs
@@ -4,9 +4,12 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use goose::agents::ScheduleTool;
+use goose::config::GooseMode;
+use goose::conversation::message::{Message, MessageContent};
 use goose::scheduler::{ScheduledJob, SchedulerError, ValidatedScheduleRecipe};
 use goose::scheduler_trait::SchedulerTrait;
-use goose::session::{Session, SessionManager};
+use goose::session::{Session, SessionManager, SessionType};
+use rmcp::model::{Annotations, ContentBlock, Role, TextContent};
 use tempfile::TempDir;
 
 struct MockScheduler {
@@ -119,6 +122,80 @@ async fn create_schedule(schedule_tool: &ScheduleTool, recipe_path: &Path) -> Re
         .await
         .map(|_| ())
         .map_err(|error| error.message.to_string())
+}
+
+#[tokio::test]
+async fn session_content_only_serializes_agent_visible_conversation() {
+    let temp_dir = TempDir::new().unwrap();
+    let scheduler = Arc::new(MockScheduler::new());
+    let working_dir = temp_dir.path().join("project");
+    let session_manager = Arc::new(SessionManager::new(temp_dir.path().join("data")));
+    let tool = ScheduleTool::new(scheduler, session_manager.clone());
+    let session = session_manager
+        .create_session(
+            working_dir.clone(),
+            "Project session".to_string(),
+            SessionType::Scheduled,
+            GooseMode::Auto,
+        )
+        .await
+        .unwrap();
+    let user_only = |text: &str| {
+        MessageContent::Text(
+            TextContent::new(text)
+                .with_annotations(Annotations::default().with_audience(vec![Role::User])),
+        )
+    };
+
+    session_manager
+        .add_message(
+            &session.id,
+            &Message::user()
+                .with_text("hidden-message-secret")
+                .user_only(),
+        )
+        .await
+        .unwrap();
+    session_manager
+        .add_message(
+            &session.id,
+            &Message::assistant()
+                .with_content(user_only("hidden-content-secret"))
+                .with_text("shared-content"),
+        )
+        .await
+        .unwrap();
+    session_manager
+        .add_message(&session.id, &Message::user().with_text("visible-message"))
+        .await
+        .unwrap();
+
+    let result = tool
+        .execute(serde_json::json!({
+            "action": "session_content",
+            "session_id": session.id,
+        }))
+        .await
+        .unwrap();
+    let ContentBlock::Text(content) = &result[0] else {
+        panic!("expected text content");
+    };
+    let (_, session_json) = content.text.split_once("\nSession:\n").unwrap();
+    let serialized: serde_json::Value = serde_json::from_str(session_json).unwrap();
+
+    assert_eq!(serialized["id"], session.id);
+    assert_eq!(
+        serialized["working_dir"],
+        working_dir.to_string_lossy().as_ref()
+    );
+    assert_eq!(serialized["name"], "Project session");
+    assert_eq!(serialized["session_type"], "scheduled");
+    assert_eq!(serialized["goose_mode"], "auto");
+    assert_eq!(serialized["message_count"], 3);
+    assert!(!content.text.contains("hidden-message-secret"));
+    assert!(!content.text.contains("hidden-content-secret"));
+    assert!(content.text.contains("shared-content"));
+    assert!(content.text.contains("visible-message"));
 }
 
 #[tokio::test]

--- a/crates/goose/tests/schedule_tool_security.rs
+++ b/crates/goose/tests/schedule_tool_security.rs
@@ -180,6 +180,13 @@ async fn session_content_only_serializes_agent_visible_conversation() {
     let ContentBlock::Text(content) = &result[0] else {
         panic!("expected text content");
     };
+    assert_eq!(
+        content
+            .annotations
+            .as_ref()
+            .and_then(|annotations| annotations.audience.as_deref()),
+        Some(&[Role::Assistant][..])
+    );
     let (_, session_json) = content.text.split_once("\nSession:\n").unwrap();
     let serialized: serde_json::Value = serde_json::from_str(session_json).unwrap();
 


### PR DESCRIPTION
## Summary

- project scheduled `session_content` through the canonical agent-visible conversation filter
- remove whole-message and nested audience-hidden content before model-facing serialization
- mark the projected history assistant-only so retained model context cannot surface in user-visible tool output
- preserve the remaining session metadata and visible conversation content

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p goose --test schedule_tool_security` (7 passed)
- `cargo build -p goose`
- `cargo clippy -p goose --all-targets -- -D warnings`

*This finding was discovered by [Project Loupe](https://github.com/project-loupe/loupe)*