### PR TITLE
fix(security): enforce subagent platform guards

### DIFF
--- a/crates/goose/src/agents/platform_extensions/ext_manager.rs
+++ b/crates/goose/src/agents/platform_extensions/ext_manager.rs
@@ -2,6 +2,7 @@ use crate::agents::extension::PlatformExtensionContext;
 use crate::agents::mcp_client::{Error, McpClientTrait};
 use crate::agents::tool_execution::ToolCallContext;
 use crate::config::get_extension_by_name;
+use crate::session::SessionType;
 use anyhow::Result;
 use async_trait::async_trait;
 use indoc::indoc;
@@ -122,6 +123,7 @@ impl ExtensionManagerClient {
 
     async fn handle_manage_extensions(
         &self,
+        session_id: &str,
         arguments: Option<JsonObject>,
     ) -> Result<Vec<ContentBlock>, ExtensionManagerToolError> {
         let arguments = arguments.ok_or(ExtensionManagerToolError::MissingParameter {
@@ -132,7 +134,7 @@ impl ExtensionManagerClient {
             serde_json::from_value(serde_json::Value::Object(arguments))?;
 
         match self
-            .manage_extensions_impl(params.action, params.extension_name)
+            .manage_extensions_impl(session_id, params.action, params.extension_name)
             .await
         {
             Ok(content) => Ok(content),
@@ -144,9 +146,30 @@ impl ExtensionManagerClient {
 
     async fn manage_extensions_impl(
         &self,
+        session_id: &str,
         action: ManageExtensionAction,
         extension_name: String,
     ) -> Result<Vec<ContentBlock>, ErrorData> {
+        let session = self
+            .context
+            .session_manager
+            .get_session(session_id, false)
+            .await
+            .map_err(|error| {
+                ErrorData::new(
+                    ErrorCode::INTERNAL_ERROR,
+                    format!("Failed to get caller session: {error}"),
+                    None,
+                )
+            })?;
+        if session.session_type == SessionType::SubAgent {
+            return Err(ErrorData::new(
+                ErrorCode::INVALID_REQUEST,
+                "Subagents cannot manage extensions".to_string(),
+                None,
+            ));
+        }
+
         let extension_manager = self
             .context
             .extension_manager
@@ -264,9 +287,8 @@ impl ExtensionManagerClient {
     }
 
     #[allow(clippy::too_many_lines)]
-    async fn get_tools(&self) -> Vec<Tool> {
-        let mut tools = vec![
-            Tool::new(
+    async fn get_tools(&self, include_manage_extensions: bool) -> Vec<Tool> {
+        let mut tools = vec![Tool::new(
                 SEARCH_AVAILABLE_EXTENSIONS_TOOL_NAME.to_string(),
                 "Searches for additional extensions available to help complete tasks.
         Use this tool when you're unable to find a specific feature or functionality you need to complete your task, or when standard approaches aren't working.
@@ -288,28 +310,34 @@ impl ExtensionManagerClient {
                 Some(false),
                 Some(false),
                 Some(false),
-            )),
-            Tool::new(
-                MANAGE_EXTENSIONS_TOOL_NAME.to_string(),
-                "Tool to manage extensions and tools in goose context.
+            ))];
+
+        if include_manage_extensions {
+            tools.push(
+                Tool::new(
+                    MANAGE_EXTENSIONS_TOOL_NAME.to_string(),
+                    "Tool to manage extensions and tools in goose context.
             Enable or disable extensions to help complete tasks.
             Enable or disable an extension by providing the extension name.
-            ".to_string(),
-                Arc::new(
-                    serde_json::to_value(schema_for!(ManageExtensionsParams))
-                        .expect("Failed to serialize schema")
-                        .as_object()
-                        .expect("Schema must be an object")
-                        .clone()
-                ),
-            ).annotate(ToolAnnotations::from_raw(
-                Some("Enable or disable an extension".to_string()),
-                Some(false),
-                Some(false),
-                Some(false),
-                Some(false),
-            )),
-        ];
+            "
+                    .to_string(),
+                    Arc::new(
+                        serde_json::to_value(schema_for!(ManageExtensionsParams))
+                            .expect("Failed to serialize schema")
+                            .as_object()
+                            .expect("Schema must be an object")
+                            .clone(),
+                    ),
+                )
+                .annotate(ToolAnnotations::from_raw(
+                    Some("Enable or disable an extension".to_string()),
+                    Some(false),
+                    Some(false),
+                    Some(false),
+                    Some(false),
+                )),
+            );
+        }
 
         if let Some(weak_ref) = &self.context.extension_manager {
             if let Some(extension_manager) = weak_ref.upgrade() {
@@ -400,12 +428,19 @@ impl McpClientTrait for ExtensionManagerClient {
 
     async fn list_tools(
         &self,
-        _session_id: &str,
+        session_id: &str,
         _next_cursor: Option<String>,
         _cancellation_token: CancellationToken,
     ) -> Result<ListToolsResult, Error> {
+        let can_manage_extensions = self
+            .context
+            .session_manager
+            .get_session(session_id, false)
+            .await
+            .is_ok_and(|session| session.session_type != SessionType::SubAgent);
+
         Ok(ListToolsResult {
-            tools: self.get_tools().await,
+            tools: self.get_tools(can_manage_extensions).await,
             next_cursor: None,
             meta: None,
             ..Default::default()
@@ -424,7 +459,9 @@ impl McpClientTrait for ExtensionManagerClient {
             SEARCH_AVAILABLE_EXTENSIONS_TOOL_NAME => {
                 self.handle_search_available_extensions().await
             }
-            MANAGE_EXTENSIONS_TOOL_NAME => self.handle_manage_extensions(arguments).await,
+            MANAGE_EXTENSIONS_TOOL_NAME => {
+                self.handle_manage_extensions(session_id, arguments).await
+            }
             LIST_RESOURCES_TOOL_NAME => self.handle_list_resources(session_id, arguments).await,
             READ_RESOURCE_TOOL_NAME => self.handle_read_resource(session_id, arguments).await,
             _ => Err(ExtensionManagerToolError::UnknownTool {
@@ -465,5 +502,131 @@ impl McpClientTrait for ExtensionManagerClient {
 
     fn get_info(&self) -> Option<&InitializeResult> {
         Some(&self.info)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agents::extension_manager::ExtensionManager;
+    use crate::config::GooseMode;
+    use std::path::PathBuf;
+
+    fn client_for(manager: &Arc<ExtensionManager>) -> ExtensionManagerClient {
+        ExtensionManagerClient::new(PlatformExtensionContext {
+            extension_manager: Some(Arc::downgrade(manager)),
+            session_manager: manager.get_context().session_manager.clone(),
+            scheduler: None,
+            session: None,
+            use_login_shell_path: false,
+        })
+        .unwrap()
+    }
+
+    async fn create_session(manager: &ExtensionManager, session_type: SessionType) -> String {
+        manager
+            .get_context()
+            .session_manager
+            .create_session(
+                PathBuf::from("/tmp/extension-manager-test"),
+                "extension manager test".to_string(),
+                session_type,
+                GooseMode::default(),
+            )
+            .await
+            .unwrap()
+            .id
+    }
+
+    fn manage_arguments(action: &str) -> JsonObject {
+        serde_json::json!({
+            "action": action,
+            "extension_name": "developer",
+        })
+        .as_object()
+        .unwrap()
+        .clone()
+    }
+
+    async fn manage(
+        client: &ExtensionManagerClient,
+        session_id: &str,
+        action: &str,
+    ) -> CallToolResult {
+        client
+            .call_tool(
+                &ToolCallContext::new(session_id.to_string(), None, None),
+                MANAGE_EXTENSIONS_TOOL_NAME,
+                Some(manage_arguments(action)),
+                CancellationToken::default(),
+            )
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn subagent_direct_calls_cannot_enable_or_disable_extensions() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let manager = Arc::new(ExtensionManager::new_without_provider(
+            temp_dir.path().to_path_buf(),
+        ));
+        let client = client_for(&manager);
+        let user_id = create_session(&manager, SessionType::User).await;
+        let subagent_id = create_session(&manager, SessionType::SubAgent).await;
+
+        let enable = manage(&client, &subagent_id, "enable").await;
+        assert!(enable.is_error.unwrap_or(false));
+        assert!(!manager.is_extension_enabled("developer").await);
+
+        let user_enable = manage(&client, &user_id, "enable").await;
+        assert!(!user_enable.is_error.unwrap_or(false));
+        assert!(manager.is_extension_enabled("developer").await);
+
+        let disable = manage(&client, &subagent_id, "disable").await;
+        assert!(disable.is_error.unwrap_or(false));
+        assert!(manager.is_extension_enabled("developer").await);
+
+        let user_disable = manage(&client, &user_id, "disable").await;
+        assert!(!user_disable.is_error.unwrap_or(false));
+        assert!(!manager.is_extension_enabled("developer").await);
+    }
+
+    #[tokio::test]
+    async fn subagent_and_unknown_callers_are_not_offered_extension_management() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let manager = Arc::new(ExtensionManager::new_without_provider(
+            temp_dir.path().to_path_buf(),
+        ));
+        let client = client_for(&manager);
+        let user_id = create_session(&manager, SessionType::User).await;
+        let subagent_id = create_session(&manager, SessionType::SubAgent).await;
+
+        let user_tools = client
+            .list_tools(&user_id, None, CancellationToken::default())
+            .await
+            .unwrap();
+        assert!(user_tools
+            .tools
+            .iter()
+            .any(|tool| tool.name == MANAGE_EXTENSIONS_TOOL_NAME));
+
+        for session_id in [&subagent_id, "missing-session"] {
+            let tools = client
+                .list_tools(session_id, None, CancellationToken::default())
+                .await
+                .unwrap();
+            assert!(tools
+                .tools
+                .iter()
+                .any(|tool| tool.name == SEARCH_AVAILABLE_EXTENSIONS_TOOL_NAME));
+            assert!(tools
+                .tools
+                .iter()
+                .all(|tool| tool.name != MANAGE_EXTENSIONS_TOOL_NAME));
+        }
+
+        let unknown_enable = manage(&client, "missing-session", "enable").await;
+        assert!(unknown_enable.is_error.unwrap_or(false));
+        assert!(!manager.is_extension_enabled("developer").await);
     }
 }

--- a/crates/goose/src/agents/platform_extensions/orchestrator.rs
+++ b/crates/goose/src/agents/platform_extensions/orchestrator.rs
@@ -450,15 +450,47 @@ impl OrchestratorClient {
     }
 
     async fn authorize_start_agent(&self, session_id: &str) -> Result<(), String> {
-        let session = self
-            .context
+        if self.caller_session_type(session_id).await? == SessionType::SubAgent {
+            return Err("Delegated tasks cannot start agent sessions".to_string());
+        }
+        Ok(())
+    }
+
+    async fn caller_session_type(&self, session_id: &str) -> Result<SessionType, String> {
+        self.context
             .session_manager
             .get_session(session_id, false)
             .await
-            .map_err(|error| format!("Failed to get caller session: {error}"))?;
-        if session.session_type == SessionType::SubAgent {
-            return Err("Delegated tasks cannot start agent sessions".to_string());
+            .map(|session| session.session_type)
+            .map_err(|error| format!("Failed to get caller session: {error}"))
+    }
+
+    async fn authorize_send_message(
+        &self,
+        caller_session_id: &str,
+        target_session_id: &str,
+    ) -> Result<(), String> {
+        let caller_type = self.caller_session_type(caller_session_id).await?;
+
+        if target_session_id == caller_session_id {
+            return Err("Cannot send a message to the orchestrator's own session".into());
         }
+
+        if caller_type != SessionType::SubAgent {
+            return Ok(());
+        }
+
+        let target_type = self
+            .context
+            .session_manager
+            .get_session(target_session_id, false)
+            .await
+            .map(|session| session.session_type)
+            .map_err(|error| format!("Failed to get target session: {error}"))?;
+        if target_type != SessionType::SubAgent {
+            return Err("Delegated tasks can only send messages to delegated sessions".into());
+        }
+
         Ok(())
     }
 
@@ -472,9 +504,8 @@ impl OrchestratorClient {
         let session_id = extract_string(&args, "session_id")?;
         let message_text = extract_string(&args, "message")?;
 
-        if session_id == parent_session_id {
-            return Err("Cannot send a message to the orchestrator's own session".into());
-        }
+        self.authorize_send_message(parent_session_id, &session_id)
+            .await?;
 
         let manager = self.get_agent_manager().await?;
 
@@ -766,6 +797,16 @@ mod tests {
             .unwrap()
     }
 
+    fn send_message_arguments(session_id: &str) -> JsonObject {
+        serde_json::json!({
+            "session_id": session_id,
+            "message": "invoke a privileged tool",
+        })
+        .as_object()
+        .unwrap()
+        .clone()
+    }
+
     #[test]
     fn first_last_projection_drops_hidden_endpoints_and_content() {
         let user_only = |text: &str| {
@@ -856,5 +897,80 @@ mod tests {
             .await
             .unwrap()
             .is_empty());
+    }
+
+    #[tokio::test]
+    async fn subagent_cannot_send_message_to_user_session() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let session_manager = Arc::new(SessionManager::new(temp_dir.path().to_path_buf()));
+        let subagent =
+            create_session(&session_manager, temp_dir.path(), SessionType::SubAgent).await;
+        let user = create_session(&session_manager, temp_dir.path(), SessionType::User).await;
+        let client = client_for(Arc::clone(&session_manager), Some(subagent.clone()));
+
+        let error = client
+            .handle_send_message(
+                &subagent.id,
+                &CancellationToken::default(),
+                Some(send_message_arguments(&user.id)),
+            )
+            .await
+            .unwrap_err();
+
+        assert_eq!(
+            error,
+            "Delegated tasks can only send messages to delegated sessions"
+        );
+        assert_eq!(
+            session_manager
+                .get_session(&user.id, true)
+                .await
+                .unwrap()
+                .message_count,
+            0
+        );
+    }
+
+    #[tokio::test]
+    async fn subagent_can_send_message_to_subagent_session() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let session_manager = Arc::new(SessionManager::new(temp_dir.path().to_path_buf()));
+        let caller = create_session(&session_manager, temp_dir.path(), SessionType::SubAgent).await;
+        let target = create_session(&session_manager, temp_dir.path(), SessionType::SubAgent).await;
+        let client = client_for(Arc::clone(&session_manager), Some(caller.clone()));
+
+        assert!(client
+            .authorize_send_message(&caller.id, &target.id)
+            .await
+            .is_ok());
+    }
+
+    #[tokio::test]
+    async fn user_can_send_message_to_user_session() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let session_manager = Arc::new(SessionManager::new(temp_dir.path().to_path_buf()));
+        let caller = create_session(&session_manager, temp_dir.path(), SessionType::User).await;
+        let target = create_session(&session_manager, temp_dir.path(), SessionType::User).await;
+        let client = client_for(Arc::clone(&session_manager), Some(caller.clone()));
+
+        assert!(client
+            .authorize_send_message(&caller.id, &target.id)
+            .await
+            .is_ok());
+    }
+
+    #[tokio::test]
+    async fn unknown_caller_cannot_send_message() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let session_manager = Arc::new(SessionManager::new(temp_dir.path().to_path_buf()));
+        let target = create_session(&session_manager, temp_dir.path(), SessionType::User).await;
+        let client = client_for(Arc::clone(&session_manager), None);
+
+        let error = client
+            .authorize_send_message("missing-session", &target.id)
+            .await
+            .unwrap_err();
+
+        assert!(error.starts_with("Failed to get caller session:"));
     }
 }

--- a/crates/goose/src/agents/platform_extensions/orchestrator.rs
+++ b/crates/goose/src/agents/platform_extensions/orchestrator.rs
@@ -10,7 +10,7 @@ use crate::execution::manager::AgentManager;
 use crate::providers;
 use crate::providers::base::Provider;
 use crate::session::extension_data::EnabledExtensionsState;
-use crate::session::session_manager::SessionType;
+use crate::session::session_manager::{Session, SessionType};
 use anyhow::Result;
 use async_trait::async_trait;
 use futures::StreamExt;
@@ -450,18 +450,17 @@ impl OrchestratorClient {
     }
 
     async fn authorize_start_agent(&self, session_id: &str) -> Result<(), String> {
-        if self.caller_session_type(session_id).await? == SessionType::SubAgent {
+        if self.caller_session(session_id).await?.session_type == SessionType::SubAgent {
             return Err("Delegated tasks cannot start agent sessions".to_string());
         }
         Ok(())
     }
 
-    async fn caller_session_type(&self, session_id: &str) -> Result<SessionType, String> {
+    async fn caller_session(&self, session_id: &str) -> Result<Session, String> {
         self.context
             .session_manager
             .get_session(session_id, false)
             .await
-            .map(|session| session.session_type)
             .map_err(|error| format!("Failed to get caller session: {error}"))
     }
 
@@ -470,25 +469,32 @@ impl OrchestratorClient {
         caller_session_id: &str,
         target_session_id: &str,
     ) -> Result<(), String> {
-        let caller_type = self.caller_session_type(caller_session_id).await?;
+        let caller = self.caller_session(caller_session_id).await?;
 
         if target_session_id == caller_session_id {
             return Err("Cannot send a message to the orchestrator's own session".into());
         }
 
-        if caller_type != SessionType::SubAgent {
+        if caller.session_type != SessionType::SubAgent {
             return Ok(());
         }
 
-        let target_type = self
+        let caller_parent_id = caller
+            .parent_session_id
+            .as_deref()
+            .ok_or("Delegated tasks without a parent session cannot send messages")?;
+        let target = self
             .context
             .session_manager
             .get_session(target_session_id, false)
             .await
-            .map(|session| session.session_type)
             .map_err(|error| format!("Failed to get target session: {error}"))?;
-        if target_type != SessionType::SubAgent {
-            return Err("Delegated tasks can only send messages to delegated sessions".into());
+        if target.session_type != SessionType::SubAgent
+            || target.parent_session_id.as_deref() != Some(caller_parent_id)
+        {
+            return Err(
+                "Delegated tasks can only send messages to sibling delegated sessions".into(),
+            );
         }
 
         Ok(())
@@ -775,6 +781,24 @@ mod tests {
             .unwrap()
     }
 
+    async fn create_subagent_session(
+        session_manager: &SessionManager,
+        working_dir: &std::path::Path,
+        parent_session_id: &str,
+    ) -> crate::session::Session {
+        let session = create_session(session_manager, working_dir, SessionType::SubAgent).await;
+        session_manager
+            .update(&session.id)
+            .parent_session_id(Some(parent_session_id.to_string()))
+            .apply()
+            .await
+            .unwrap();
+        session_manager
+            .get_session(&session.id, false)
+            .await
+            .unwrap()
+    }
+
     async fn start_agent(
         client: &OrchestratorClient,
         session_id: &str,
@@ -900,12 +924,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn subagent_cannot_send_message_to_user_session() {
+    async fn subagent_cannot_send_message_to_parent_user_session() {
         let temp_dir = tempfile::tempdir().unwrap();
         let session_manager = Arc::new(SessionManager::new(temp_dir.path().to_path_buf()));
-        let subagent =
-            create_session(&session_manager, temp_dir.path(), SessionType::SubAgent).await;
         let user = create_session(&session_manager, temp_dir.path(), SessionType::User).await;
+        let subagent = create_subagent_session(&session_manager, temp_dir.path(), &user.id).await;
         let client = client_for(Arc::clone(&session_manager), Some(subagent.clone()));
 
         let error = client
@@ -919,7 +942,7 @@ mod tests {
 
         assert_eq!(
             error,
-            "Delegated tasks can only send messages to delegated sessions"
+            "Delegated tasks can only send messages to sibling delegated sessions"
         );
         assert_eq!(
             session_manager
@@ -932,17 +955,95 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn subagent_can_send_message_to_subagent_session() {
+    async fn subagent_can_send_message_to_sibling_session() {
         let temp_dir = tempfile::tempdir().unwrap();
         let session_manager = Arc::new(SessionManager::new(temp_dir.path().to_path_buf()));
-        let caller = create_session(&session_manager, temp_dir.path(), SessionType::SubAgent).await;
-        let target = create_session(&session_manager, temp_dir.path(), SessionType::SubAgent).await;
+        let parent = create_session(&session_manager, temp_dir.path(), SessionType::User).await;
+        let caller = create_subagent_session(&session_manager, temp_dir.path(), &parent.id).await;
+        let target = create_subagent_session(&session_manager, temp_dir.path(), &parent.id).await;
         let client = client_for(Arc::clone(&session_manager), Some(caller.clone()));
 
         assert!(client
             .authorize_send_message(&caller.id, &target.id)
             .await
             .is_ok());
+    }
+
+    #[tokio::test]
+    async fn subagent_cannot_send_message_across_delegation_trees() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let session_manager = Arc::new(SessionManager::new(temp_dir.path().to_path_buf()));
+        let caller_parent =
+            create_session(&session_manager, temp_dir.path(), SessionType::User).await;
+        let target_parent =
+            create_session(&session_manager, temp_dir.path(), SessionType::User).await;
+        let caller =
+            create_subagent_session(&session_manager, temp_dir.path(), &caller_parent.id).await;
+        let target =
+            create_subagent_session(&session_manager, temp_dir.path(), &target_parent.id).await;
+        let client = client_for(Arc::clone(&session_manager), Some(caller.clone()));
+
+        let error = client
+            .handle_send_message(
+                &caller.id,
+                &CancellationToken::default(),
+                Some(send_message_arguments(&target.id)),
+            )
+            .await
+            .unwrap_err();
+
+        assert_eq!(
+            error,
+            "Delegated tasks can only send messages to sibling delegated sessions"
+        );
+        assert_eq!(
+            session_manager
+                .get_session(&target.id, true)
+                .await
+                .unwrap()
+                .message_count,
+            0
+        );
+    }
+
+    #[tokio::test]
+    async fn subagent_cannot_send_message_to_descendant_session() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let session_manager = Arc::new(SessionManager::new(temp_dir.path().to_path_buf()));
+        let parent = create_session(&session_manager, temp_dir.path(), SessionType::User).await;
+        let caller = create_subagent_session(&session_manager, temp_dir.path(), &parent.id).await;
+        let descendant =
+            create_subagent_session(&session_manager, temp_dir.path(), &caller.id).await;
+        let client = client_for(Arc::clone(&session_manager), Some(caller.clone()));
+
+        let error = client
+            .authorize_send_message(&caller.id, &descendant.id)
+            .await
+            .unwrap_err();
+
+        assert_eq!(
+            error,
+            "Delegated tasks can only send messages to sibling delegated sessions"
+        );
+    }
+
+    #[tokio::test]
+    async fn subagent_without_parent_cannot_send_message() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let session_manager = Arc::new(SessionManager::new(temp_dir.path().to_path_buf()));
+        let caller = create_session(&session_manager, temp_dir.path(), SessionType::SubAgent).await;
+        let target = create_session(&session_manager, temp_dir.path(), SessionType::SubAgent).await;
+        let client = client_for(Arc::clone(&session_manager), Some(caller.clone()));
+
+        let error = client
+            .authorize_send_message(&caller.id, &target.id)
+            .await
+            .unwrap_err();
+
+        assert_eq!(
+            error,
+            "Delegated tasks without a parent session cannot send messages"
+        );
     }
 
     #[tokio::test]

--- a/crates/goose/src/agents/platform_extensions/orchestrator.rs
+++ b/crates/goose/src/agents/platform_extensions/orchestrator.rs
@@ -383,8 +383,11 @@ impl OrchestratorClient {
 
     async fn handle_start_agent(
         &self,
+        session_id: &str,
         arguments: Option<JsonObject>,
     ) -> Result<CallToolResult, String> {
+        self.authorize_start_agent(session_id).await?;
+
         let args = arguments.ok_or("Missing arguments")?;
         let working_dir = extract_string(&args, "working_dir")?;
         let name = args
@@ -444,6 +447,19 @@ impl OrchestratorClient {
             "Started agent session '{}' with ID: {}\n\nUse send_message with this session_id to interact with it.",
             name, session.id
         ))]))
+    }
+
+    async fn authorize_start_agent(&self, session_id: &str) -> Result<(), String> {
+        let session = self
+            .context
+            .session_manager
+            .get_session(session_id, false)
+            .await
+            .map_err(|error| format!("Failed to get caller session: {error}"))?;
+        if session.session_type == SessionType::SubAgent {
+            return Err("Delegated tasks cannot start agent sessions".to_string());
+        }
+        Ok(())
     }
 
     async fn handle_send_message(
@@ -591,11 +607,11 @@ fn agent_visible_session_messages(conversation: &Conversation) -> Vec<Message> {
 impl McpClientTrait for OrchestratorClient {
     async fn list_tools(
         &self,
-        _session_id: &str,
+        session_id: &str,
         _next_cursor: Option<String>,
         _cancel_token: CancellationToken,
     ) -> Result<ListToolsResult, Error> {
-        let tools = vec![
+        let mut tools = vec![
             Tool::new(
                 "list_sessions".to_string(),
                 "List agent sessions with their status (loaded, busy, idle). Returns the most recent 10 by default. Optionally filter by session type."
@@ -608,12 +624,18 @@ impl McpClientTrait for OrchestratorClient {
                     .to_string(),
                 schema::<ViewSessionParams>(),
             ),
-            Tool::new(
+        ];
+
+        if self.authorize_start_agent(session_id).await.is_ok() {
+            tools.push(Tool::new(
                 "start_agent".to_string(),
                 "Start a new agent session with its own working directory. Inherits the current provider and model. Returns a session_id for future interaction."
                     .to_string(),
                 schema::<StartAgentParams>(),
-            ),
+            ));
+        }
+
+        tools.extend([
             Tool::new(
                 "send_message".to_string(),
                 "Send a message to an existing agent session and get the response. Returns an error if the agent is currently busy."
@@ -626,7 +648,7 @@ impl McpClientTrait for OrchestratorClient {
                     .to_string(),
                 schema::<InterruptAgentParams>(),
             ),
-        ];
+        ]);
 
         Ok(ListToolsResult {
             tools,
@@ -646,7 +668,7 @@ impl McpClientTrait for OrchestratorClient {
         let result = match name {
             "list_sessions" => self.handle_list_sessions(arguments).await,
             "view_session" => self.handle_view_session(&ctx.session_id, arguments).await,
-            "start_agent" => self.handle_start_agent(arguments).await,
+            "start_agent" => self.handle_start_agent(&ctx.session_id, arguments).await,
             "send_message" => {
                 self.handle_send_message(&ctx.session_id, &cancel_token, arguments)
                     .await
@@ -689,7 +711,60 @@ fn extract_string(args: &JsonObject, key: &str) -> Result<String, String> {
 mod tests {
     use super::*;
     use crate::conversation::message::MessageContent;
+    use crate::session::SessionManager;
     use rmcp::model::{Annotations, Role, TextContent};
+
+    fn client_for(
+        session_manager: Arc<SessionManager>,
+        session: Option<crate::session::Session>,
+    ) -> OrchestratorClient {
+        OrchestratorClient::new(PlatformExtensionContext {
+            extension_manager: None,
+            session_manager,
+            scheduler: None,
+            session: session.map(Arc::new),
+            use_login_shell_path: false,
+        })
+        .unwrap()
+    }
+
+    async fn create_session(
+        session_manager: &SessionManager,
+        working_dir: &std::path::Path,
+        session_type: SessionType,
+    ) -> crate::session::Session {
+        session_manager
+            .create_session(
+                working_dir.to_path_buf(),
+                "orchestrator test".to_string(),
+                session_type,
+                GooseMode::default(),
+            )
+            .await
+            .unwrap()
+    }
+
+    async fn start_agent(
+        client: &OrchestratorClient,
+        session_id: &str,
+        working_dir: &std::path::Path,
+    ) -> CallToolResult {
+        let arguments = serde_json::json!({
+            "working_dir": working_dir.to_string_lossy(),
+        })
+        .as_object()
+        .unwrap()
+        .clone();
+        client
+            .call_tool(
+                &ToolCallContext::new(session_id.to_string(), None, None),
+                "start_agent",
+                Some(arguments),
+                CancellationToken::default(),
+            )
+            .await
+            .unwrap()
+    }
 
     #[test]
     fn first_last_projection_drops_hidden_endpoints_and_content() {
@@ -713,5 +788,73 @@ mod tests {
         assert_eq!(messages.len(), 2);
         assert_eq!(messages[0].as_concat_text(), "visible first");
         assert_eq!(messages[1].as_concat_text(), "visible last");
+    }
+
+    #[tokio::test]
+    async fn subagent_direct_call_cannot_persist_peer_user_session() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let session_manager = Arc::new(SessionManager::new(temp_dir.path().to_path_buf()));
+        let subagent =
+            create_session(&session_manager, temp_dir.path(), SessionType::SubAgent).await;
+        let client = client_for(Arc::clone(&session_manager), Some(subagent.clone()));
+
+        let result = start_agent(&client, &subagent.id, temp_dir.path()).await;
+
+        assert!(result.is_error.unwrap_or(false));
+        assert!(session_manager
+            .list_sessions_by_types(&[SessionType::User])
+            .await
+            .unwrap()
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn start_agent_listing_is_scoped_to_authorized_callers() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let session_manager = Arc::new(SessionManager::new(temp_dir.path().to_path_buf()));
+        let user = create_session(&session_manager, temp_dir.path(), SessionType::User).await;
+        let subagent =
+            create_session(&session_manager, temp_dir.path(), SessionType::SubAgent).await;
+        let client = client_for(Arc::clone(&session_manager), Some(user.clone()));
+
+        assert!(client.authorize_start_agent(&user.id).await.is_ok());
+        let user_tools = client
+            .list_tools(&user.id, None, CancellationToken::default())
+            .await
+            .unwrap();
+        assert!(user_tools
+            .tools
+            .iter()
+            .any(|tool| tool.name == "start_agent"));
+
+        for session_id in [&subagent.id, "missing-session"] {
+            let tools = client
+                .list_tools(session_id, None, CancellationToken::default())
+                .await
+                .unwrap();
+            assert!(tools.tools.iter().all(|tool| tool.name != "start_agent"));
+            assert!(tools.tools.iter().any(|tool| tool.name == "send_message"));
+        }
+
+        assert!(client
+            .authorize_start_agent("missing-session")
+            .await
+            .is_err());
+    }
+
+    #[tokio::test]
+    async fn unknown_caller_cannot_persist_user_session() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let session_manager = Arc::new(SessionManager::new(temp_dir.path().to_path_buf()));
+        let client = client_for(Arc::clone(&session_manager), None);
+
+        let result = start_agent(&client, "missing-session", temp_dir.path()).await;
+
+        assert!(result.is_error.unwrap_or(false));
+        assert!(session_manager
+            .list_sessions_by_types(&[SessionType::User])
+            .await
+            .unwrap()
+            .is_empty());
     }
 }


### PR DESCRIPTION
## Summary

- authorize Extension Manager mutations against the persisted caller session
- prevent delegated sessions from creating peer user sessions through Orchestrator
- prevent delegated sessions from using `send_message` to invoke privileged tools through user sessions
- scope delegated `send_message` targets to sibling sessions in the same persisted delegation lineage
- fail closed when the Orchestrator caller session cannot be resolved
- hide only the restricted mutating tools while preserving allowed discovery and interaction tools

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p goose --lib agents::platform_extensions::ext_manager::tests` (2 passed)
- `cargo test -p goose --lib agents::platform_extensions::orchestrator::tests` (11 passed)
- `cargo build -p goose`
- `cargo clippy -p goose --all-targets -- -D warnings`

_This finding was discovered by [Project Loupe](https://github.com/project-loupe/loupe)._
