### PR TITLE
fix(security): escape approval prompt controls

### DIFF
--- a/crates/goose/src/security/security_inspector.rs
+++ b/crates/goose/src/security/security_inspector.rs
@@ -6,6 +6,30 @@ use crate::conversation::message::{Message, ToolRequest};
 use crate::security::{SecurityManager, SecurityResult};
 use crate::tool_inspection::{InspectionAction, InspectionResult, ToolInspector};
 
+fn is_bidi_formatting_control(character: char) -> bool {
+    matches!(
+        character,
+        '\u{61c}'
+            | '\u{200e}'
+            | '\u{200f}'
+            | '\u{202a}'..='\u{202e}'
+            | '\u{2066}'..='\u{2069}'
+    )
+}
+
+fn escape_approval_explanation(explanation: &str) -> String {
+    let mut escaped = String::with_capacity(explanation.len());
+    for character in explanation.chars() {
+        if character == '\n' || (!character.is_control() && !is_bidi_formatting_control(character))
+        {
+            escaped.push(character);
+        } else {
+            escaped.extend(character.escape_default());
+        }
+    }
+    escaped
+}
+
 /// Security inspector that uses pattern matching to detect malicious tool calls
 pub struct SecurityInspector {
     security_manager: SecurityManager,
@@ -32,11 +56,12 @@ impl SecurityInspector {
         tool_request_id: String,
     ) -> InspectionResult {
         let action = if security_result.is_malicious && security_result.should_ask_user {
+            let explanation = escape_approval_explanation(&security_result.explanation);
             InspectionAction::RequireApproval(Some(format!(
                 "🔒 Security Alert\n\n\
                 {}\n\n\
                 Finding ID: {}",
-                security_result.explanation, security_result.finding_id
+                explanation, security_result.finding_id
             )))
         } else {
             InspectionAction::Allow
@@ -150,5 +175,91 @@ mod tests {
     fn test_security_inspector_name() {
         let inspector = SecurityInspector::new();
         assert_eq!(inspector.name(), "security");
+    }
+
+    #[tokio::test]
+    async fn security_prompt_escapes_scanner_explanation_controls() {
+        let inspector = SecurityInspector::enabled();
+        let command = concat!(
+            "rm -rf / # flagged\nordinary 🪿\n",
+            "\t\r\u{8}\u{7}\u{1b}[2J\u{1b}[H\u{1b}]0;spoofed\u{7}\u{9b}31m\u{7f}",
+            "\u{61c}\u{200e}\u{200f}\u{202a}\u{202b}\u{202c}\u{202d}\u{202e}",
+            "\u{2066}\u{2067}\u{2068}\u{2069}"
+        );
+        let tool_requests = vec![ToolRequest {
+            id: "dangerous".to_string(),
+            tool_call: Ok(
+                CallToolRequestParams::new("shell").with_arguments(object!({"command": command}))
+            ),
+            metadata: None,
+            tool_meta: None,
+        }];
+
+        let results = inspector
+            .inspect("test", &tool_requests, &[], GooseMode::Auto)
+            .await
+            .unwrap();
+        let prompt = match &results[0].action {
+            InspectionAction::RequireApproval(Some(prompt)) => prompt,
+            action => panic!("expected security approval, got {action:?}"),
+        };
+
+        assert!(prompt.contains("ordinary 🪿\n"));
+        for visible_escape in [
+            "\\t",
+            "\\r",
+            "\\u{8}",
+            "\\u{7}",
+            "\\u{1b}",
+            "\\u{9b}",
+            "\\u{7f}",
+            "\\u{61c}",
+            "\\u{200e}",
+            "\\u{200f}",
+            "\\u{202a}",
+            "\\u{202b}",
+            "\\u{202c}",
+            "\\u{202d}",
+            "\\u{202e}",
+            "\\u{2066}",
+            "\\u{2067}",
+            "\\u{2068}",
+            "\\u{2069}",
+        ] {
+            assert!(
+                prompt.contains(visible_escape),
+                "missing {visible_escape:?} in {prompt:?}"
+            );
+        }
+        assert!(!prompt.chars().any(|character| {
+            character != '\n'
+                && (character.is_control()
+                    || matches!(
+                        character,
+                        '\u{61c}'
+                            | '\u{200e}'
+                            | '\u{200f}'
+                            | '\u{202a}'..='\u{202e}'
+                            | '\u{2066}'..='\u{2069}'
+                    ))
+        }));
+    }
+
+    #[test]
+    fn non_malicious_security_result_remains_allowed() {
+        let inspector = SecurityInspector::new();
+        let security_result = SecurityResult {
+            is_malicious: false,
+            confidence: 0.0,
+            explanation: "ordinary 🪿\u{1b}[2J".to_string(),
+            should_ask_user: true,
+            finding_id: "SEC-test".to_string(),
+            tool_request_id: "safe".to_string(),
+        };
+
+        let result = inspector.convert_security_result(&security_result, "safe".to_string());
+
+        assert_eq!(result.action, InspectionAction::Allow);
+        assert_eq!(result.reason, security_result.explanation);
     }
 }

--- a/crates/goose/tests/security_approval_prompt.rs
+++ b/crates/goose/tests/security_approval_prompt.rs
@@ -1,0 +1,180 @@
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use futures::StreamExt;
+use goose::agents::{
+    Agent, AgentConfig, AgentEvent, ExtensionConfig, GoosePlatform, SessionConfig,
+};
+use goose::config::permission::PermissionManager;
+use goose::config::GooseMode;
+use goose::conversation::message::{ActionRequiredData, Message, MessageContent};
+use goose::permission::permission_confirmation::PrincipalType;
+use goose::permission::{Permission, PermissionConfirmation};
+use goose::providers::base::{stream_from_single_message, MessageStream, Provider};
+use goose::session::{SessionManager, SessionType};
+use goose_providers::conversation::token_usage::{ProviderUsage, Usage};
+use goose_providers::errors::ProviderError;
+use goose_providers::model::ModelConfig;
+use rmcp::model::{CallToolRequestParams, Tool};
+use rmcp::object;
+
+const DANGEROUS_COMMAND: &str = concat!(
+    "rm -rf / # flagged\nordinary 🪿\n",
+    "\u{1b}[2J\u{1b}]0;spoofed\u{7}\u{202e}"
+);
+
+struct ApprovalProvider {
+    calls: AtomicUsize,
+}
+
+#[async_trait]
+impl Provider for ApprovalProvider {
+    fn get_name(&self) -> &str {
+        "approval-test"
+    }
+
+    async fn stream(
+        &self,
+        _model_config: &ModelConfig,
+        _system: &str,
+        _messages: &[Message],
+        _tools: &[Tool],
+    ) -> Result<MessageStream, ProviderError> {
+        let message = if self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
+            Message::assistant().with_tool_request(
+                "dangerous",
+                Ok(CallToolRequestParams::new("shell")
+                    .with_arguments(object!({"command": DANGEROUS_COMMAND}))),
+            )
+        } else {
+            Message::assistant().with_text("cancelled")
+        };
+        Ok(stream_from_single_message(
+            message,
+            ProviderUsage::new("mock-model".to_string(), Usage::default()),
+        ))
+    }
+}
+
+async fn security_approval_prompt(state_machine: Option<&'static str>) -> Result<String> {
+    let _guard = env_lock::lock_env([
+        ("GOOSE_STATE_MACHINE", state_machine),
+        ("SECURITY_PROMPT_ENABLED_OVERRIDE", Some("true")),
+        (
+            "SECURITY_COMMAND_CLASSIFIER_ENABLED_OVERRIDE",
+            Some("false"),
+        ),
+    ]);
+    let data_root = tempfile::tempdir()?;
+    let session_manager = Arc::new(SessionManager::new(data_root.path().to_path_buf()));
+    let permission_manager = Arc::new(PermissionManager::new(data_root.path().join("permissions")));
+    let agent = Agent::with_config(AgentConfig::new(
+        session_manager.clone(),
+        permission_manager,
+        None,
+        GooseMode::Auto,
+        true,
+        GoosePlatform::GooseCli,
+    ));
+    let session = session_manager
+        .create_session(
+            PathBuf::default(),
+            "security approval".to_string(),
+            SessionType::Hidden,
+            GooseMode::Auto,
+        )
+        .await?;
+    agent
+        .update_provider(
+            Arc::new(ApprovalProvider {
+                calls: AtomicUsize::new(0),
+            }),
+            ModelConfig::new("mock-model"),
+            &session.id,
+        )
+        .await?;
+    agent
+        .add_extension(
+            ExtensionConfig::Platform {
+                name: "developer".to_string(),
+                description: "developer".to_string(),
+                display_name: None,
+                bundled: None,
+                available_tools: vec![],
+            },
+            &session.id,
+        )
+        .await?;
+
+    let stream = agent
+        .reply(
+            Message::user().with_text("run a dangerous command"),
+            SessionConfig {
+                id: session.id,
+                schedule_id: None,
+                max_turns: Some(3),
+                retry_config: None,
+            },
+            None,
+        )
+        .await?;
+    tokio::pin!(stream);
+    let mut approval_prompt = None;
+    while let Some(event) = stream.next().await {
+        if let AgentEvent::Message(message) = event? {
+            for content in message.content {
+                let MessageContent::ActionRequired(action) = content else {
+                    continue;
+                };
+                if let ActionRequiredData::ToolConfirmation { id, prompt, .. } = action.data {
+                    approval_prompt = prompt;
+                    agent
+                        .handle_confirmation(
+                            id,
+                            PermissionConfirmation {
+                                principal_type: PrincipalType::Tool,
+                                permission: Permission::DenyOnce,
+                            },
+                        )
+                        .await;
+                }
+            }
+        }
+    }
+
+    approval_prompt.ok_or_else(|| anyhow::anyhow!("security approval prompt was not emitted"))
+}
+
+fn assert_prompt_is_safe(prompt: &str) {
+    assert!(prompt.contains("ordinary 🪿\n"));
+    assert!(prompt.contains("\\u{1b}[2J"));
+    assert!(prompt.contains("\\u{1b}]0;spoofed\\u{7}"));
+    assert!(prompt.contains("\\u{202e}"));
+    assert!(!prompt.chars().any(|character| {
+        character != '\n'
+            && (character.is_control()
+                || matches!(
+                    character,
+                    '\u{61c}'
+                        | '\u{200e}'
+                        | '\u{200f}'
+                        | '\u{202a}'..='\u{202e}'
+                        | '\u{2066}'..='\u{2069}'
+                ))
+    }));
+}
+
+#[tokio::test]
+async fn legacy_tool_confirmation_uses_safe_security_prompt() -> Result<()> {
+    assert_prompt_is_safe(&security_approval_prompt(None).await?);
+    Ok(())
+}
+
+#[tokio::test]
+async fn state_machine_tool_confirmation_uses_safe_security_prompt() -> Result<()> {
+    assert_prompt_is_safe(&security_approval_prompt(Some("1")).await?);
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- visibly escape terminal control and bidirectional formatting characters in security approval explanations
- preserve line breaks and ordinary Unicode while keeping the displayed command faithful and safe
- verify identical approval prompts in the legacy and state-machine agent loops

## Verification

- `cargo test -p goose --test security_approval_prompt`
- `cargo test -p goose --lib security::`
- `cargo build -p goose`
- `cargo clippy -p goose --all-targets -- -D warnings`
- `cargo fmt --all -- --check`

*This finding was discovered by [Project Loupe](https://github.com/project-loupe/loupe)*