### PR TITLE
fix(security): build recipes from one validated snapshot

### DIFF
--- a/crates/goose/src/recipe/build_recipe/mod.rs
+++ b/crates/goose/src/recipe/build_recipe/mod.rs
@@ -1,7 +1,5 @@
 use crate::recipe::read_recipe_file_content::read_parameter_file_content;
-use crate::recipe::validate_recipe::{
-    validate_recipe_non_parameter_invariants, validate_recipe_template,
-};
+use crate::recipe::validate_recipe::validate_recipe_template;
 use crate::recipe::{
     Recipe, RecipeParameter, RecipeParameterInputType, RecipeParameterRequirement,
     BUILT_IN_RECIPE_DIR_PARAM,
@@ -23,7 +21,7 @@ fn render_recipe_template<F>(
     recipe_dir: &Path,
     params: Vec<(String, String)>,
     user_prompt_fn: Option<F>,
-) -> Result<(String, Vec<String>)>
+) -> Result<(Option<Recipe>, Vec<String>)>
 where
     F: Fn(&str, &str) -> Result<String, anyhow::Error>,
 {
@@ -35,13 +33,13 @@ where
     let (params_for_template, missing_params) =
         apply_values_to_parameters(&params, recipe_parameters, &recipe_dir_str, user_prompt_fn)?;
 
-    let rendered_content = if missing_params.is_empty() {
-        validated_recipe.render(&params_for_template)?
+    let rendered_recipe = if missing_params.is_empty() {
+        Some(validated_recipe.render(&params_for_template)?)
     } else {
-        String::new()
+        None
     };
 
-    Ok((rendered_content, missing_params))
+    Ok((rendered_recipe, missing_params))
 }
 
 pub fn build_recipe_from_template<F>(
@@ -53,20 +51,15 @@ pub fn build_recipe_from_template<F>(
 where
     F: Fn(&str, &str) -> Result<String, anyhow::Error>,
 {
-    let (rendered_content, missing_params) =
+    let (rendered_recipe, missing_params) =
         render_recipe_template(recipe_content, recipe_dir, params.clone(), user_prompt_fn)
             .map_err(|source| RecipeError::Invalid { source })?;
 
-    if !missing_params.is_empty() {
+    let Some(mut recipe) = rendered_recipe else {
         return Err(RecipeError::MissingParams {
             parameters: missing_params,
         });
-    }
-
-    let mut recipe = Recipe::from_content(&rendered_content)
-        .map_err(|source| RecipeError::Invalid { source })?;
-    validate_recipe_non_parameter_invariants(&recipe)
-        .map_err(|source| RecipeError::Invalid { source })?;
+    };
 
     if let Some(ref mut sub_recipes) = recipe.sub_recipes {
         for sub_recipe in sub_recipes {

--- a/crates/goose/src/recipe/build_recipe/mod.rs
+++ b/crates/goose/src/recipe/build_recipe/mod.rs
@@ -1,6 +1,7 @@
 use crate::recipe::read_recipe_file_content::read_parameter_file_content;
-use crate::recipe::template_recipe::render_recipe_content_with_params;
-use crate::recipe::validate_recipe::validate_recipe_template_from_content;
+use crate::recipe::validate_recipe::{
+    validate_recipe_non_parameter_invariants, validate_recipe_template,
+};
 use crate::recipe::{
     Recipe, RecipeParameter, RecipeParameterInputType, RecipeParameterRequirement,
     BUILT_IN_RECIPE_DIR_PARAM,
@@ -28,15 +29,14 @@ where
 {
     let recipe_dir_str = recipe_dir.display().to_string();
 
-    let recipe_parameters =
-        validate_recipe_template_from_content(&recipe_content, Some(recipe_dir_str.clone()))?
-            .parameters;
+    let validated_recipe = validate_recipe_template(&recipe_content, Some(recipe_dir_str.clone()))?;
+    let recipe_parameters = validated_recipe.recipe().parameters.clone();
 
     let (params_for_template, missing_params) =
         apply_values_to_parameters(&params, recipe_parameters, &recipe_dir_str, user_prompt_fn)?;
 
     let rendered_content = if missing_params.is_empty() {
-        render_recipe_content_with_params(&recipe_content, &params_for_template)?
+        validated_recipe.render(&params_for_template)?
     } else {
         String::new()
     };
@@ -64,6 +64,8 @@ where
     }
 
     let mut recipe = Recipe::from_content(&rendered_content)
+        .map_err(|source| RecipeError::Invalid { source })?;
+    validate_recipe_non_parameter_invariants(&recipe)
         .map_err(|source| RecipeError::Invalid { source })?;
 
     if let Some(ref mut sub_recipes) = recipe.sub_recipes {

--- a/crates/goose/src/recipe/build_recipe/tests.rs
+++ b/crates/goose/src/recipe/build_recipe/tests.rs
@@ -333,6 +333,33 @@ fn test_build_recipe_from_template_missing_prompt_and_instructions() {
 }
 
 #[test]
+fn test_build_recipe_from_template_rejects_empty_rendered_instructions() {
+    let instructions_and_parameters = r#"
+                "instructions": "{{ instructions }}",
+                "parameters": [
+                    {
+                        "key": "instructions",
+                        "input_type": "string",
+                        "requirement": "optional",
+                        "default": "",
+                        "description": "Rendered instructions"
+                    }
+                ]"#;
+    let (_temp_dir, recipe_content, recipe_dir) = setup_recipe_file(instructions_and_parameters);
+
+    let error = build_recipe_from_template(recipe_content, &recipe_dir, Vec::new(), NO_USER_PROMPT)
+        .unwrap_err();
+
+    match error {
+        RecipeError::Invalid { source } => assert_eq!(
+            source.to_string(),
+            "Recipe must specify at least one of `instructions` or `prompt`."
+        ),
+        other => panic!("Expected Invalid error, got: {other:?}"),
+    }
+}
+
+#[test]
 fn test_template_inheritance() {
     let parent_content = r#"
                 version: 1.0.0
@@ -412,6 +439,123 @@ fn test_template_inheritance() {
         child_recipe.parameters.as_ref().unwrap()[1].key,
         "is_enabled"
     );
+}
+
+#[cfg(unix)]
+#[test]
+fn inherited_recipe_is_built_from_the_validated_snapshot() {
+    use std::ffi::CString;
+    use std::io::Write;
+    use std::os::unix::ffi::OsStrExt;
+
+    let temp_dir = tempfile::tempdir().unwrap();
+    let parent_path = temp_dir.path().join("parent.yaml");
+    let retired_fifo_path = temp_dir.path().join("parent.fifo");
+    let secret_path = temp_dir.path().join("secret.txt");
+    let secret = "sensitive file contents";
+    std::fs::write(&secret_path, secret).unwrap();
+
+    let fifo_path = CString::new(parent_path.as_os_str().as_bytes()).unwrap();
+    // SAFETY: fifo_path is a valid, NUL-terminated path and mode contains only permission bits.
+    assert_eq!(unsafe { libc::mkfifo(fifo_path.as_ptr(), 0o600) }, 0);
+
+    let safe_parent = format!(
+        r#"version: 1.0.0
+title: Safe parent
+description: Safe parent
+instructions: "Use {{{{ TARGET }}}}"
+parameters:
+  - key: TARGET
+    input_type: string
+    requirement: optional
+    description: Target value
+    default: "{}"
+"#,
+        secret_path.display()
+    );
+    let swapped_parent = format!(
+        r#"version: 1.0.0
+title: Swapped parent
+description: Swapped parent
+instructions: "Use {{{{ TARGET }}}}"
+retry:
+  max_retries: 0
+parameters:
+  - key: TARGET
+    input_type: file
+    requirement: optional
+    description: Target file
+    default: "{}"
+"#,
+        secret_path.display()
+    );
+
+    let writer_parent_path = parent_path.clone();
+    let writer = std::thread::spawn(move || {
+        let mut fifo = std::fs::OpenOptions::new()
+            .write(true)
+            .open(&writer_parent_path)
+            .unwrap();
+        fifo.write_all(safe_parent.as_bytes()).unwrap();
+        std::fs::rename(&writer_parent_path, retired_fifo_path).unwrap();
+        std::fs::write(&writer_parent_path, swapped_parent).unwrap();
+        drop(fifo);
+    });
+
+    let recipe = build_recipe_from_template(
+        r#"{% extends "parent.yaml" %}"#.to_string(),
+        temp_dir.path(),
+        Vec::new(),
+        NO_USER_PROMPT,
+    )
+    .unwrap();
+    writer.join().unwrap();
+
+    let expected_instructions = format!("Use {}", secret_path.display());
+    assert_eq!(recipe.title, "Safe parent");
+    assert_eq!(
+        recipe.instructions.as_deref(),
+        Some(&*expected_instructions)
+    );
+    assert!(!recipe.instructions.as_deref().unwrap().contains(secret));
+    assert!(recipe.retry.is_none());
+    assert!(matches!(
+        recipe.parameters.unwrap()[0].input_type,
+        RecipeParameterInputType::String
+    ));
+}
+
+#[test]
+fn dependency_not_loaded_during_validation_fails_closed() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    std::fs::write(temp_dir.path().join("extra.txt"), "unvalidated content").unwrap();
+    let recipe_content = r#"version: 1.0.0
+title: Conditional include
+description: Conditional include
+instructions: |
+  Safe instructions
+  {% if LOAD_EXTRA %}{% include "extra.txt" %}{% endif %}
+parameters:
+  - key: LOAD_EXTRA
+    input_type: boolean
+    requirement: required
+    description: Whether to load the extra template
+"#;
+
+    let error = build_recipe_from_template(
+        recipe_content.to_string(),
+        temp_dir.path(),
+        vec![("LOAD_EXTRA".to_string(), "true".to_string())],
+        NO_USER_PROMPT,
+    )
+    .unwrap_err();
+
+    match error {
+        RecipeError::Invalid { source } => {
+            assert!(source.to_string().contains("extra.txt"));
+        }
+        other => panic!("Expected Invalid error, got: {other:?}"),
+    }
 }
 
 mod sub_recipe_path_resolution {

--- a/crates/goose/src/recipe/build_recipe/tests.rs
+++ b/crates/goose/src/recipe/build_recipe/tests.rs
@@ -526,6 +526,44 @@ parameters:
 }
 
 #[test]
+fn rendered_parameter_schema_is_revalidated() {
+    let parent_content = r#"
+version: 1.0.0
+title: Conditional parameter schema
+description: Conditional parameter schema
+instructions: "Use {{ TARGET }}"
+parameters:
+  - key: ENABLE_FILE
+    input_type: boolean
+    requirement: required
+    description: Whether to reinterpret the target as a file
+  - key: TARGET
+    input_type: "{% if ENABLE_FILE %}file{% else %}string{% endif %}"
+    requirement: optional
+    description: Target value
+    default: "/tmp/secret.txt"
+"#;
+    let child_content = r#"{% extends "parent.yaml" %}"#;
+    let (_temp_dir, _parent_recipe_file, child_recipe_file) =
+        setup_yaml_recipe_files(parent_content, child_content);
+
+    let error = build_recipe_from_template(
+        child_recipe_file.content,
+        &child_recipe_file.parent_dir,
+        vec![("ENABLE_FILE".to_string(), "true".to_string())],
+        NO_USER_PROMPT,
+    )
+    .unwrap_err();
+
+    match error {
+        RecipeError::Invalid { source } => assert!(source
+            .to_string()
+            .contains("File parameters cannot have default values")),
+        other => panic!("Expected Invalid error, got: {other:?}"),
+    }
+}
+
+#[test]
 fn dependency_not_loaded_during_validation_fails_closed() {
     let temp_dir = tempfile::tempdir().unwrap();
     std::fs::write(temp_dir.path().join("extra.txt"), "unvalidated content").unwrap();

--- a/crates/goose/src/recipe/template_recipe.rs
+++ b/crates/goose/src/recipe/template_recipe.rs
@@ -12,6 +12,36 @@ const CURRENT_TEMPLATE_NAME: &str = "recipe";
 const OPEN_BRACE: &str = "{{";
 const CLOSE_BRACE: &str = "}}";
 
+pub(crate) struct ParsedRecipeTemplate {
+    recipe: Recipe,
+    template_variables: HashSet<String>,
+    environment: Environment<'static>,
+}
+
+impl ParsedRecipeTemplate {
+    pub(crate) fn recipe(&self) -> &Recipe {
+        &self.recipe
+    }
+
+    pub(crate) fn template_variables(&self) -> &HashSet<String> {
+        &self.template_variables
+    }
+
+    pub(crate) fn into_recipe(self) -> Recipe {
+        self.recipe
+    }
+
+    pub(crate) fn render(mut self, params: &HashMap<String, String>) -> Result<String> {
+        self.environment
+            .set_undefined_behavior(UndefinedBehavior::Strict);
+        self.environment.set_loader(|_| Ok(None));
+        let template = self.environment.get_template(CURRENT_TEMPLATE_NAME)?;
+        template
+            .render(params)
+            .map_err(|error| anyhow::anyhow!("Failed to render the recipe {error}"))
+    }
+}
+
 fn preprocess_template_variables(content: &str) -> Result<String> {
     let all_template_variables = extract_template_variables(content);
     let complex_template_variables = filter_complex_variables(&all_template_variables);
@@ -89,18 +119,17 @@ fn replace_unparseable_vars_with_raw(
     Ok(result)
 }
 
+fn preprocess_recipe_template(content: &str) -> Result<String> {
+    let empty_quotes = Regex::new(r#":\s*"""#).unwrap();
+    let content = empty_quotes.replace_all(content, ": ''");
+    preprocess_template_variables(&content)
+}
+
 pub fn render_recipe_content_with_params(
     content: &str,
     params: &HashMap<String, String>,
 ) -> Result<String> {
-    // Pre-process content to replace empty double quotes with single quotes
-    // This prevents MiniJinja from escaping "" to "\"\"" which would break YAML parsing
-    let re = Regex::new(r#":\s*"""#).unwrap();
-    let content_with_empty_quotes_replaced = re.replace_all(content, ": ''");
-
-    // Pre-process template variables to convert invalid variable names to raw content
-    let content_with_safe_variables =
-        preprocess_template_variables(&content_with_empty_quotes_replaced)?;
+    let content_with_safe_variables = preprocess_recipe_template(content)?;
 
     let env = add_template_in_env(
         &content_with_safe_variables,
@@ -118,7 +147,7 @@ fn add_template_in_env(
     content: &str,
     recipe_dir: Option<String>,
     undefined_behavior: UndefinedBehavior,
-) -> Result<Environment<'_>> {
+) -> Result<Environment<'static>> {
     let mut env = minijinja::Environment::new();
     env.set_undefined_behavior(undefined_behavior);
 
@@ -128,7 +157,7 @@ fn add_template_in_env(
         });
     }
 
-    env.add_template(CURRENT_TEMPLATE_NAME, content)?;
+    env.add_template_owned(CURRENT_TEMPLATE_NAME, content.to_string())?;
     Ok(env)
 }
 
@@ -185,7 +214,7 @@ fn get_env_with_template_variables(
     content: &str,
     recipe_dir: Option<String>,
     undefined_behavior: UndefinedBehavior,
-) -> Result<(Environment<'_>, HashSet<String>)> {
+) -> Result<(Environment<'static>, HashSet<String>)> {
     let env = add_template_in_env(content, recipe_dir, undefined_behavior)?;
     let template_variables = {
         let template = env.get_template(CURRENT_TEMPLATE_NAME).unwrap();
@@ -209,8 +238,15 @@ pub fn parse_recipe_content(
     content: &str,
     recipe_dir: Option<String>,
 ) -> Result<(Recipe, HashSet<String>)> {
-    // Pre-process template variables to handle invalid variable names
-    let preprocessed_content = preprocess_template_variables(content)?;
+    let parsed = parse_recipe_template(content, recipe_dir)?;
+    Ok((parsed.recipe, parsed.template_variables))
+}
+
+pub(crate) fn parse_recipe_template(
+    content: &str,
+    recipe_dir: Option<String>,
+) -> Result<ParsedRecipeTemplate> {
+    let preprocessed_content = preprocess_recipe_template(content)?;
 
     let (env, template_variables) = get_env_with_template_variables(
         &preprocessed_content,
@@ -231,8 +267,11 @@ pub fn parse_recipe_content(
     };
 
     let recipe = Recipe::from_content(&recipe_content)?;
-    // return recipe (without loading any variables) and the variable names that are in the recipe
-    Ok((recipe, template_variables))
+    Ok(ParsedRecipeTemplate {
+        recipe,
+        template_variables,
+        environment: env,
+    })
 }
 
 #[cfg(test)]

--- a/crates/goose/src/recipe/template_recipe.rs
+++ b/crates/goose/src/recipe/template_recipe.rs
@@ -31,14 +31,18 @@ impl ParsedRecipeTemplate {
         self.recipe
     }
 
-    pub(crate) fn render(mut self, params: &HashMap<String, String>) -> Result<String> {
+    pub(crate) fn render(
+        mut self,
+        params: &HashMap<String, String>,
+    ) -> Result<(String, HashSet<String>)> {
         self.environment
             .set_undefined_behavior(UndefinedBehavior::Strict);
         self.environment.set_loader(|_| Ok(None));
         let template = self.environment.get_template(CURRENT_TEMPLATE_NAME)?;
-        template
+        let rendered = template
             .render(params)
-            .map_err(|error| anyhow::anyhow!("Failed to render the recipe {error}"))
+            .map_err(|error| anyhow::anyhow!("Failed to render the recipe {error}"))?;
+        Ok((rendered, self.template_variables))
     }
 }
 

--- a/crates/goose/src/recipe/template_recipe.rs
+++ b/crates/goose/src/recipe/template_recipe.rs
@@ -123,76 +123,14 @@ fn replace_unparseable_vars_with_raw(
     Ok(result)
 }
 
-fn preprocess_empty_yaml_mapping_values(content: &str) -> String {
-    let empty_mapping_value =
-        Regex::new(r#"^([ \t]*(?:-[ \t]+)?[^#\r\n][^:\r\n]*:[ \t]*)""([ \t]*(?:#.*)?)$"#).unwrap();
-    let block_scalar_mapping =
-        Regex::new(r#"^[ \t]*(?:-[ \t]+)?[^#\r\n][^:\r\n]*:[ \t]*[|>][1-9+-]{0,2}[ \t]*(?:#.*)?$"#)
-            .unwrap();
-    let mut block_scalar_parent_indent = None;
-    let mut result = String::with_capacity(content.len());
-
-    for segment in content.split_inclusive('\n') {
-        let line_with_optional_carriage_return = segment.strip_suffix('\n').unwrap_or(segment);
-        let line = line_with_optional_carriage_return
-            .strip_suffix('\r')
-            .unwrap_or(line_with_optional_carriage_return);
-        let line_ending = if segment.ends_with("\r\n") {
-            "\r\n"
-        } else if segment.ends_with('\n') {
-            "\n"
-        } else {
-            ""
-        };
-        let indent = line
-            .bytes()
-            .take_while(|byte| matches!(byte, b' ' | b'\t'))
-            .count();
-
-        let inside_block_scalar = match block_scalar_parent_indent {
-            Some(parent_indent) if line.trim().is_empty() || indent > parent_indent => true,
-            Some(_) => {
-                block_scalar_parent_indent = None;
-                false
-            }
-            None => false,
-        };
-
-        if inside_block_scalar {
-            result.push_str(line);
-        } else {
-            let replaced = empty_mapping_value.replace(line, "$1''$2");
-            result.push_str(&replaced);
-            if block_scalar_mapping.is_match(line) {
-                let sequence_mapping_indent = line
-                    .get(indent..)
-                    .and_then(|content| content.strip_prefix('-'))
-                    .and_then(|rest| {
-                        let spacing = rest
-                            .bytes()
-                            .take_while(|byte| matches!(byte, b' ' | b'\t'))
-                            .count();
-                        (spacing > 0).then_some(indent + 1 + spacing)
-                    });
-                block_scalar_parent_indent = Some(sequence_mapping_indent.unwrap_or(indent));
-            }
-        }
-        result.push_str(line_ending);
-    }
-
-    result
-}
-
-fn preprocess_recipe_template(content: &str) -> Result<String> {
-    let content = preprocess_empty_yaml_mapping_values(content);
-    preprocess_template_variables(&content)
-}
-
 pub fn render_recipe_content_with_params(
     content: &str,
     params: &HashMap<String, String>,
 ) -> Result<String> {
-    let content_with_safe_variables = preprocess_recipe_template(content)?;
+    let empty_quotes = Regex::new(r#":\s*"""#).unwrap();
+    let content_with_empty_quotes_replaced = empty_quotes.replace_all(content, ": ''");
+    let content_with_safe_variables =
+        preprocess_template_variables(&content_with_empty_quotes_replaced)?;
 
     let env = add_template_in_env(
         &content_with_safe_variables,
@@ -309,7 +247,7 @@ pub(crate) fn parse_recipe_template(
     content: &str,
     recipe_dir: Option<String>,
 ) -> Result<ParsedRecipeTemplate> {
-    let preprocessed_content = preprocess_recipe_template(content)?;
+    let preprocessed_content = preprocess_template_variables(content)?;
 
     let (env, template_variables) = get_env_with_template_variables(
         &preprocessed_content,
@@ -340,10 +278,10 @@ pub(crate) fn parse_recipe_template(
 #[cfg(test)]
 mod tests {
     mod parse_recipe_content_tests {
-        use crate::recipe::validate_recipe::validate_recipe_template_from_content;
+        use crate::recipe::{validate_recipe::validate_recipe_template_from_content, Recipe};
 
         #[test]
-        fn preserves_empty_string_examples_in_instructions() {
+        fn preserves_empty_string_json_in_instruction_block_scalar() {
             let content = r#"version: 1.0.0
 title: Empty string example
 description: Empty string example
@@ -353,12 +291,52 @@ instructions: |
   Example: ""
 "#;
 
+            let expected = Recipe::from_content(content).unwrap();
             let recipe = validate_recipe_template_from_content(content, None).unwrap();
 
-            assert_eq!(
-                recipe.instructions.as_deref(),
-                Some("Return this JSON unchanged:\n{\"value\": \"\"}\nExample: \"\"\n")
-            );
+            assert_eq!(recipe.instructions, expected.instructions);
+        }
+
+        #[test]
+        fn preserves_empty_string_in_bare_sequence_block_scalar() {
+            let content = r#"version: 1.0.0
+title: Activity empty string example
+description: Activity empty string example
+instructions: Keep activities unchanged
+activities:
+  - |
+    value: ""
+"#;
+
+            let expected = Recipe::from_content(content).unwrap();
+            let recipe = validate_recipe_template_from_content(content, None).unwrap();
+
+            assert_eq!(recipe.activities, expected.activities);
+        }
+
+        #[test]
+        fn preserves_empty_strings_in_multiline_quoted_instructions() {
+            let single_quoted = r#"version: 1.0.0
+title: Single quoted empty string example
+description: Single quoted empty string example
+instructions: 'Return:
+  value: ""
+  done'
+"#;
+            let double_quoted = r#"version: 1.0.0
+title: Double quoted empty string example
+description: Double quoted empty string example
+instructions: "Return:
+  value: \"\"
+  done"
+"#;
+
+            for content in [single_quoted, double_quoted] {
+                let expected = Recipe::from_content(content).unwrap();
+                let recipe = validate_recipe_template_from_content(content, None).unwrap();
+
+                assert_eq!(recipe.instructions, expected.instructions);
+            }
         }
     }
 
@@ -536,13 +514,6 @@ instructions: |
 prompt: ""
 name: "Simple Recipe"
 description: "A test recipe"
-instructions: |
-  Preserve {"value": ""}
-  Example: ""
-items:
-  - description: |
-      Preserve: ""
-    default: ""
 "#;
             let params = HashMap::from([("recipe_dir".to_string(), "test_dir".to_string())]);
             let result = render_recipe_content_with_params(content, &params).unwrap();
@@ -551,10 +522,6 @@ items:
             assert!(!result.contains(r#"prompt: "\"\"""#)); // Should not contain escaped quotes
 
             assert!(result.contains(r#"name: "Simple Recipe""#));
-            assert!(result.contains(r#"Preserve {"value": ""}"#));
-            assert!(result.contains(r#"Example: """#));
-            assert!(result.contains(r#"      Preserve: """#));
-            assert!(result.contains("    default: ''"));
         }
 
         #[test]

--- a/crates/goose/src/recipe/template_recipe.rs
+++ b/crates/goose/src/recipe/template_recipe.rs
@@ -123,9 +123,68 @@ fn replace_unparseable_vars_with_raw(
     Ok(result)
 }
 
+fn preprocess_empty_yaml_mapping_values(content: &str) -> String {
+    let empty_mapping_value =
+        Regex::new(r#"^([ \t]*(?:-[ \t]+)?[^#\r\n][^:\r\n]*:[ \t]*)""([ \t]*(?:#.*)?)$"#).unwrap();
+    let block_scalar_mapping =
+        Regex::new(r#"^[ \t]*(?:-[ \t]+)?[^#\r\n][^:\r\n]*:[ \t]*[|>][1-9+-]{0,2}[ \t]*(?:#.*)?$"#)
+            .unwrap();
+    let mut block_scalar_parent_indent = None;
+    let mut result = String::with_capacity(content.len());
+
+    for segment in content.split_inclusive('\n') {
+        let line_with_optional_carriage_return = segment.strip_suffix('\n').unwrap_or(segment);
+        let line = line_with_optional_carriage_return
+            .strip_suffix('\r')
+            .unwrap_or(line_with_optional_carriage_return);
+        let line_ending = if segment.ends_with("\r\n") {
+            "\r\n"
+        } else if segment.ends_with('\n') {
+            "\n"
+        } else {
+            ""
+        };
+        let indent = line
+            .bytes()
+            .take_while(|byte| matches!(byte, b' ' | b'\t'))
+            .count();
+
+        let inside_block_scalar = match block_scalar_parent_indent {
+            Some(parent_indent) if line.trim().is_empty() || indent > parent_indent => true,
+            Some(_) => {
+                block_scalar_parent_indent = None;
+                false
+            }
+            None => false,
+        };
+
+        if inside_block_scalar {
+            result.push_str(line);
+        } else {
+            let replaced = empty_mapping_value.replace(line, "$1''$2");
+            result.push_str(&replaced);
+            if block_scalar_mapping.is_match(line) {
+                let sequence_mapping_indent = line
+                    .get(indent..)
+                    .and_then(|content| content.strip_prefix('-'))
+                    .and_then(|rest| {
+                        let spacing = rest
+                            .bytes()
+                            .take_while(|byte| matches!(byte, b' ' | b'\t'))
+                            .count();
+                        (spacing > 0).then_some(indent + 1 + spacing)
+                    });
+                block_scalar_parent_indent = Some(sequence_mapping_indent.unwrap_or(indent));
+            }
+        }
+        result.push_str(line_ending);
+    }
+
+    result
+}
+
 fn preprocess_recipe_template(content: &str) -> Result<String> {
-    let empty_quotes = Regex::new(r#":\s*"""#).unwrap();
-    let content = empty_quotes.replace_all(content, ": ''");
+    let content = preprocess_empty_yaml_mapping_values(content);
     preprocess_template_variables(&content)
 }
 
@@ -280,6 +339,29 @@ pub(crate) fn parse_recipe_template(
 
 #[cfg(test)]
 mod tests {
+    mod parse_recipe_content_tests {
+        use crate::recipe::validate_recipe::validate_recipe_template_from_content;
+
+        #[test]
+        fn preserves_empty_string_examples_in_instructions() {
+            let content = r#"version: 1.0.0
+title: Empty string example
+description: Empty string example
+instructions: |
+  Return this JSON unchanged:
+  {"value": ""}
+  Example: ""
+"#;
+
+            let recipe = validate_recipe_template_from_content(content, None).unwrap();
+
+            assert_eq!(
+                recipe.instructions.as_deref(),
+                Some("Return this JSON unchanged:\n{\"value\": \"\"}\nExample: \"\"\n")
+            );
+        }
+    }
+
     mod template_loader_tests {
         use std::{collections::HashMap, fs};
 
@@ -454,6 +536,13 @@ mod tests {
 prompt: ""
 name: "Simple Recipe"
 description: "A test recipe"
+instructions: |
+  Preserve {"value": ""}
+  Example: ""
+items:
+  - description: |
+      Preserve: ""
+    default: ""
 "#;
             let params = HashMap::from([("recipe_dir".to_string(), "test_dir".to_string())]);
             let result = render_recipe_content_with_params(content, &params).unwrap();
@@ -462,6 +551,10 @@ description: "A test recipe"
             assert!(!result.contains(r#"prompt: "\"\"""#)); // Should not contain escaped quotes
 
             assert!(result.contains(r#"name: "Simple Recipe""#));
+            assert!(result.contains(r#"Preserve {"value": ""}"#));
+            assert!(result.contains(r#"Example: """#));
+            assert!(result.contains(r#"      Preserve: """#));
+            assert!(result.contains("    default: ''"));
         }
 
         #[test]

--- a/crates/goose/src/recipe/validate_recipe.rs
+++ b/crates/goose/src/recipe/validate_recipe.rs
@@ -1,11 +1,31 @@
 use crate::recipe::read_recipe_file_content::RecipeFile;
-use crate::recipe::template_recipe::parse_recipe_content;
+use crate::recipe::template_recipe::{
+    parse_recipe_content, parse_recipe_template, ParsedRecipeTemplate,
+};
 use crate::recipe::{
     Recipe, RecipeParameter, RecipeParameterInputType, RecipeParameterRequirement,
     BUILT_IN_RECIPE_DIR_PARAM,
 };
 use anyhow::Result;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
+
+pub(crate) struct ValidatedRecipeTemplate {
+    parsed: ParsedRecipeTemplate,
+}
+
+impl ValidatedRecipeTemplate {
+    pub(crate) fn recipe(&self) -> &Recipe {
+        self.parsed.recipe()
+    }
+
+    pub(crate) fn into_recipe(self) -> Recipe {
+        self.parsed.into_recipe()
+    }
+
+    pub(crate) fn render(self, params: &HashMap<String, String>) -> Result<String> {
+        self.parsed.render(params)
+    }
+}
 
 pub fn parse_and_validate_parameters(
     recipe_file_content: &str,
@@ -13,10 +33,13 @@ pub fn parse_and_validate_parameters(
 ) -> Result<Recipe> {
     let (recipe_template, template_variables) =
         parse_recipe_content(recipe_file_content, recipe_dir_str)?;
-    let recipe_parameters = &recipe_template.parameters;
-    validate_optional_parameters(recipe_parameters)?;
-    validate_parameters_in_template(recipe_parameters, &template_variables)?;
+    validate_recipe_parameters(&recipe_template, &template_variables)?;
     Ok(recipe_template)
+}
+
+fn validate_recipe_parameters(recipe: &Recipe, template_variables: &HashSet<String>) -> Result<()> {
+    validate_optional_parameters(&recipe.parameters)?;
+    validate_parameters_in_template(&recipe.parameters, template_variables)
 }
 
 fn validate_json_schema(schema: &serde_json::Value) -> Result<()> {
@@ -45,17 +68,30 @@ pub fn validate_recipe_template_from_content(
     recipe_content: &str,
     recipe_dir: Option<String>,
 ) -> Result<Recipe> {
-    let recipe = parse_and_validate_parameters(recipe_content, recipe_dir)?;
+    Ok(validate_recipe_template(recipe_content, recipe_dir)?.into_recipe())
+}
 
-    validate_prompt_or_instructions(&recipe)?;
-    validate_retry_config(&recipe)?;
+pub(crate) fn validate_recipe_template(
+    recipe_content: &str,
+    recipe_dir: Option<String>,
+) -> Result<ValidatedRecipeTemplate> {
+    let parsed = parse_recipe_template(recipe_content, recipe_dir)?;
+    validate_recipe_parameters(parsed.recipe(), parsed.template_variables())?;
+    validate_recipe_non_parameter_invariants(parsed.recipe())?;
+
+    Ok(ValidatedRecipeTemplate { parsed })
+}
+
+pub(crate) fn validate_recipe_non_parameter_invariants(recipe: &Recipe) -> Result<()> {
+    validate_prompt_or_instructions(recipe)?;
+    validate_retry_config(recipe)?;
     if let Some(response) = &recipe.response {
         if let Some(json_schema) = &response.json_schema {
             validate_json_schema(json_schema)?;
         }
     }
 
-    Ok(recipe)
+    Ok(())
 }
 
 fn validate_retry_config(recipe: &Recipe) -> Result<()> {
@@ -322,90 +358,5 @@ response:
         let error = validate_recipe_template_from_content(recipe_content, None).unwrap_err();
 
         assert!(error.to_string().contains("JSON schema validation failed"));
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn inherited_recipe_is_validated_and_returned_from_one_snapshot() {
-        use crate::recipe::build_recipe::apply_values_to_parameters;
-        use std::ffi::CString;
-        use std::io::Write;
-        use std::os::unix::ffi::OsStrExt;
-
-        let temp_dir = tempfile::tempdir().unwrap();
-        let parent_path = temp_dir.path().join("parent.yaml");
-        let retired_fifo_path = temp_dir.path().join("parent.fifo");
-        let secret_path = temp_dir.path().join("secret.txt");
-        let secret = "sensitive file contents";
-        std::fs::write(&secret_path, secret).unwrap();
-
-        let fifo_path = CString::new(parent_path.as_os_str().as_bytes()).unwrap();
-        // SAFETY: fifo_path is a valid, NUL-terminated path and mode contains only permission bits.
-        assert_eq!(unsafe { libc::mkfifo(fifo_path.as_ptr(), 0o600) }, 0);
-
-        let safe_parent = format!(
-            r#"version: 1.0.0
-title: Safe parent
-description: Safe parent
-instructions: "Use {{{{ TARGET }}}}"
-parameters:
-  - key: TARGET
-    input_type: string
-    requirement: optional
-    description: Target value
-    default: "{}"
-"#,
-            secret_path.display()
-        );
-        let swapped_parent = format!(
-            r#"version: 1.0.0
-title: Swapped parent
-description: Swapped parent
-instructions: "Use {{{{ TARGET }}}}"
-parameters:
-  - key: TARGET
-    input_type: file
-    requirement: optional
-    description: Target file
-    default: "{}"
-"#,
-            secret_path.display()
-        );
-
-        let writer_parent_path = parent_path.clone();
-        let writer = std::thread::spawn(move || {
-            let mut fifo = std::fs::OpenOptions::new()
-                .write(true)
-                .open(&writer_parent_path)
-                .unwrap();
-            fifo.write_all(safe_parent.as_bytes()).unwrap();
-            std::fs::rename(&writer_parent_path, retired_fifo_path).unwrap();
-            std::fs::write(&writer_parent_path, swapped_parent).unwrap();
-            drop(fifo);
-        });
-
-        let recipe = validate_recipe_template_from_content(
-            r#"{% extends "parent.yaml" %}"#,
-            Some(temp_dir.path().display().to_string()),
-        )
-        .unwrap();
-        writer.join().unwrap();
-
-        let parameters = recipe.parameters.unwrap();
-        assert!(matches!(
-            parameters[0].input_type,
-            RecipeParameterInputType::String
-        ));
-        let (values, missing) = apply_values_to_parameters(
-            &[],
-            Some(parameters),
-            &temp_dir.path().display().to_string(),
-            None::<fn(&str, &str) -> Result<String>>,
-        )
-        .unwrap();
-
-        assert!(missing.is_empty());
-        assert_eq!(values["TARGET"], secret_path.display().to_string());
-        assert_ne!(values["TARGET"], secret);
     }
 }

--- a/crates/goose/src/recipe/validate_recipe.rs
+++ b/crates/goose/src/recipe/validate_recipe.rs
@@ -45,8 +45,7 @@ pub fn validate_recipe_template_from_content(
     recipe_content: &str,
     recipe_dir: Option<String>,
 ) -> Result<Recipe> {
-    parse_and_validate_parameters(recipe_content, recipe_dir.clone())?;
-    let (recipe, _) = parse_recipe_content(recipe_content, recipe_dir)?;
+    let recipe = parse_and_validate_parameters(recipe_content, recipe_dir)?;
 
     validate_prompt_or_instructions(&recipe)?;
     validate_retry_config(&recipe)?;
@@ -323,5 +322,90 @@ response:
         let error = validate_recipe_template_from_content(recipe_content, None).unwrap_err();
 
         assert!(error.to_string().contains("JSON schema validation failed"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn inherited_recipe_is_validated_and_returned_from_one_snapshot() {
+        use crate::recipe::build_recipe::apply_values_to_parameters;
+        use std::ffi::CString;
+        use std::io::Write;
+        use std::os::unix::ffi::OsStrExt;
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let parent_path = temp_dir.path().join("parent.yaml");
+        let retired_fifo_path = temp_dir.path().join("parent.fifo");
+        let secret_path = temp_dir.path().join("secret.txt");
+        let secret = "sensitive file contents";
+        std::fs::write(&secret_path, secret).unwrap();
+
+        let fifo_path = CString::new(parent_path.as_os_str().as_bytes()).unwrap();
+        // SAFETY: fifo_path is a valid, NUL-terminated path and mode contains only permission bits.
+        assert_eq!(unsafe { libc::mkfifo(fifo_path.as_ptr(), 0o600) }, 0);
+
+        let safe_parent = format!(
+            r#"version: 1.0.0
+title: Safe parent
+description: Safe parent
+instructions: "Use {{{{ TARGET }}}}"
+parameters:
+  - key: TARGET
+    input_type: string
+    requirement: optional
+    description: Target value
+    default: "{}"
+"#,
+            secret_path.display()
+        );
+        let swapped_parent = format!(
+            r#"version: 1.0.0
+title: Swapped parent
+description: Swapped parent
+instructions: "Use {{{{ TARGET }}}}"
+parameters:
+  - key: TARGET
+    input_type: file
+    requirement: optional
+    description: Target file
+    default: "{}"
+"#,
+            secret_path.display()
+        );
+
+        let writer_parent_path = parent_path.clone();
+        let writer = std::thread::spawn(move || {
+            let mut fifo = std::fs::OpenOptions::new()
+                .write(true)
+                .open(&writer_parent_path)
+                .unwrap();
+            fifo.write_all(safe_parent.as_bytes()).unwrap();
+            std::fs::rename(&writer_parent_path, retired_fifo_path).unwrap();
+            std::fs::write(&writer_parent_path, swapped_parent).unwrap();
+            drop(fifo);
+        });
+
+        let recipe = validate_recipe_template_from_content(
+            r#"{% extends "parent.yaml" %}"#,
+            Some(temp_dir.path().display().to_string()),
+        )
+        .unwrap();
+        writer.join().unwrap();
+
+        let parameters = recipe.parameters.unwrap();
+        assert!(matches!(
+            parameters[0].input_type,
+            RecipeParameterInputType::String
+        ));
+        let (values, missing) = apply_values_to_parameters(
+            &[],
+            Some(parameters),
+            &temp_dir.path().display().to_string(),
+            None::<fn(&str, &str) -> Result<String>>,
+        )
+        .unwrap();
+
+        assert!(missing.is_empty());
+        assert_eq!(values["TARGET"], secret_path.display().to_string());
+        assert_ne!(values["TARGET"], secret);
     }
 }

--- a/crates/goose/src/recipe/validate_recipe.rs
+++ b/crates/goose/src/recipe/validate_recipe.rs
@@ -22,8 +22,12 @@ impl ValidatedRecipeTemplate {
         self.parsed.into_recipe()
     }
 
-    pub(crate) fn render(self, params: &HashMap<String, String>) -> Result<String> {
-        self.parsed.render(params)
+    pub(crate) fn render(self, params: &HashMap<String, String>) -> Result<Recipe> {
+        let (rendered_content, template_variables) = self.parsed.render(params)?;
+        let recipe = Recipe::from_content(&rendered_content)?;
+        validate_recipe_parameters(&recipe, &template_variables)?;
+        validate_recipe_non_parameter_invariants(&recipe)?;
+        Ok(recipe)
     }
 }
 


### PR DESCRIPTION
## Summary

- bind recipe construction to the exact template snapshot that passed validation
- disable further template loading before parameterized rendering so changed or uncached dependencies fail closed
- revalidate the rendered recipe and preserve the original parameter-schema invariants before expanding file-backed parameters

## Verification

- `cargo test -p goose recipe::build_recipe`
- `cargo test -p goose recipe::template_recipe`
- `cargo test -p goose recipe::validate_recipe`
- `cargo test -p goose --test state_machine_recipe_toolkit_test inherited_recipe_toolkit_validation`
- `cargo build -p goose`
- `cargo clippy -p goose --all-targets -- -D warnings`
- `cargo fmt --all -- --check`

*This finding was discovered by [Project Loupe](https://github.com/project-loupe/loupe)*