### PR TITLE
docs: stop enumerating crates in AGENTS.md Structure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,15 +69,9 @@ cd ui/desktop && pnpm test   # test UI
 
 ## Structure
 ```
-crates/
-├── goose              # core logic
-├── goose-acp-macros   # ACP proc macros
-├── goose-cli          # CLI entry
-├── goose-mcp          # MCP extensions
-├── goose-test         # test utilities
-└── goose-test-support # test helpers
-
-ui/desktop/            # Electron app
+crates/       # Rust workspace members — see root Cargo.toml (`members = ["crates/*"]`)
+ui/desktop/   # Electron app
+ui/text/      # deprecated ACP TUI (see ui/text/README.md)
 ```
 
 ## Development Loop


### PR DESCRIPTION
Fixes #11569

## Summary
AGENTS.md Structure listed 6 crates as if it were the workspace. Main has 15 members (`crates/*` in Cargo.toml), so the tree was already wrong and would rot again on every crate add.

Jack's call on the issue: don't enumerate crates here. This drops the inventory, points at the workspace manifest, and keeps high-level UI dirs. `ui/text/` is on disk but deprecated — labeled that way so we don't teach a dead TUI.

Docs-only. No behavior change.

### Testing
Read `AGENTS.md` Structure against root `Cargo.toml` (`members = ["crates/*"]`) and `ui/text/README.md` (deprecated). No code path.

### Related Issues
Discussion: https://github.com/aaif-goose/goose/discussions/10768

— *Assisted by Grok · Approved by James Wolfe*

Made with [Cursor](https://cursor.com)