### PR TITLE
fix: provider configured state correctness

### DIFF
--- a/crates/goose/src/acp/server/providers.rs
+++ b/crates/goose/src/acp/server/providers.rs
@@ -1073,14 +1073,13 @@ impl GooseAcpAgent {
         config
             .delete_secret_values(&secret_keys)
             .internal_err_ctx("Failed to delete provider secret fields")?;
-        if metadata.setup.as_ref().is_some_and(|setup| setup.acp) {
-            if let Some(mut provider) = crate::config::get_provider_entry(config, &req.provider_id)
-            {
+        if let Some(mut provider) = crate::config::get_provider_entry(config, &req.provider_id) {
+            provider.configured = false;
+            if metadata.setup.as_ref().is_some_and(|setup| setup.acp) {
                 provider.enabled = false;
-                provider.configured = false;
-                crate::config::set_provider_entry(config, &req.provider_id, &provider)
-                    .internal_err_ctx("Failed to disable ACP provider")?;
             }
+            crate::config::set_provider_entry(config, &req.provider_id, &provider)
+                .internal_err_ctx("Failed to clear provider configured state")?;
         }
         crate::providers::cleanup_provider(&req.provider_id)
             .await

--- a/crates/goose/src/providers/init.rs
+++ b/crates/goose/src/providers/init.rs
@@ -87,7 +87,18 @@ async fn init_registry() -> RwLock<ProviderRegistry> {
             false,
             Some(registrations::claude_acp_inventory()),
         );
-        registry.register::<ClaudeCodeProvider>(true);
+        registry.register_with_inventory::<ClaudeCodeProvider>(
+            true,
+            Some(registrations::cli_agent_inventory(
+                || {
+                    crate::config::Config::global()
+                        .get_claude_code_command()
+                        .unwrap_or_default()
+                        .into()
+                },
+                false,
+            )),
+        );
         registry.register_with_inventory::<CodexAcpProvider>(
             false,
             Some(registrations::codex_acp_inventory()),
@@ -96,10 +107,29 @@ async fn init_registry() -> RwLock<ProviderRegistry> {
             false,
             Some(registrations::copilot_acp_inventory()),
         );
-        registry.register::<CodexProvider>(true);
+        registry.register_with_inventory::<CodexProvider>(
+            true,
+            Some(registrations::cli_agent_inventory(
+                || {
+                    crate::config::Config::global()
+                        .get_codex_command()
+                        .unwrap_or_default()
+                        .into()
+                },
+                false,
+            )),
+        );
         registry.register_with_inventory::<CursorAgentProvider>(
             false,
-            Some(registrations::refresh_only()),
+            Some(registrations::cli_agent_inventory(
+                || {
+                    crate::config::Config::global()
+                        .get_cursor_agent_command()
+                        .unwrap_or_default()
+                        .into()
+                },
+                true,
+            )),
         );
         registry.register_with_inventory::<DatabricksProviderDef>(
             true,
@@ -113,7 +143,18 @@ async fn init_registry() -> RwLock<ProviderRegistry> {
             false,
             Some(registrations::refresh_only()),
         );
-        registry.register::<GeminiCliProvider>(false);
+        registry.register_with_inventory::<GeminiCliProvider>(
+            false,
+            Some(registrations::cli_agent_inventory(
+                || {
+                    crate::config::Config::global()
+                        .get_gemini_cli_command()
+                        .unwrap_or_default()
+                        .into()
+                },
+                false,
+            )),
+        );
         registry.register_with_inventory::<GeminiOAuthProvider>(
             false,
             Some(registrations::gemini_oauth_inventory()),

--- a/crates/goose/src/providers/inventory/mod.rs
+++ b/crates/goose/src/providers/inventory/mod.rs
@@ -908,11 +908,6 @@ pub fn default_inventory_configured(
     config: &Config,
     declaration_is_configuration: bool,
 ) -> bool {
-    if crate::config::get_provider_entry(config, provider_id).is_some_and(|entry| entry.configured)
-    {
-        return true;
-    }
-
     let has_value = |key: &ConfigKey| {
         if key.secret {
             config.get_secret::<serde_json::Value>(&key.name).is_ok()
@@ -924,8 +919,16 @@ pub fn default_inventory_configured(
     let required_keys_satisfied = config_keys
         .iter()
         .all(|key| !key.required || key.default.is_some() || has_value(key));
+    if !required_keys_satisfied {
+        return false;
+    }
 
-    required_keys_satisfied && (declaration_is_configuration || config_keys.iter().any(&has_value))
+    if crate::config::get_provider_entry(config, provider_id).is_some_and(|entry| entry.configured)
+    {
+        return true;
+    }
+
+    declaration_is_configuration || config_keys.iter().any(&has_value)
 }
 
 pub fn declarative_inventory_identity(

--- a/crates/goose/src/providers/inventory/mod.rs
+++ b/crates/goose/src/providers/inventory/mod.rs
@@ -899,26 +899,10 @@ pub fn default_inventory_identity(
     identity
 }
 
+/// `declaration_is_configuration` is set for authless custom providers, whose
+/// declaration supplies the base URL and models and is itself the user-supplied
+/// configuration.
 pub fn default_inventory_configured(
-    provider_id: &str,
-    config_keys: &[ConfigKey],
-    config: &Config,
-) -> bool {
-    inventory_configured(provider_id, config_keys, config, false)
-}
-
-/// A custom provider declaration supplies its own base URL and models, so an
-/// authless declaration is itself the user-supplied configuration.
-pub fn declared_inventory_configured(
-    provider_id: &str,
-    config_keys: &[ConfigKey],
-    config: &Config,
-    requires_auth: bool,
-) -> bool {
-    inventory_configured(provider_id, config_keys, config, !requires_auth)
-}
-
-fn inventory_configured(
     provider_id: &str,
     config_keys: &[ConfigKey],
     config: &Config,
@@ -1491,21 +1475,40 @@ mod tests {
         assert!(!default_inventory_configured(
             "defaulted",
             &defaulted_key,
-            &config
+            &config,
+            false
         ));
 
-        assert!(!default_inventory_configured("no_keys", &[], &config));
+        assert!(!default_inventory_configured(
+            "no_keys",
+            &[],
+            &config,
+            false
+        ));
+        assert!(default_inventory_configured("authless", &[], &config, true));
 
         let secret_key = vec![ConfigKey::new("GOOSE_TEST_API_KEY", true, true, None, true)];
         assert!(!default_inventory_configured(
             "secret",
             &secret_key,
-            &config
+            &config,
+            false
+        ));
+        assert!(!default_inventory_configured(
+            "secret",
+            &secret_key,
+            &config,
+            true
         ));
         config
             .set_secret("GOOSE_TEST_API_KEY", &"sk-test".to_string())
             .unwrap();
-        assert!(default_inventory_configured("secret", &secret_key, &config));
+        assert!(default_inventory_configured(
+            "secret",
+            &secret_key,
+            &config,
+            false
+        ));
 
         crate::config::set_provider_entry(
             &config,
@@ -1520,44 +1523,6 @@ mod tests {
         assert!(default_inventory_configured(
             "defaulted",
             &defaulted_key,
-            &config
-        ));
-    }
-
-    #[test]
-    fn declared_inventory_configured_treats_authless_declaration_as_configuration() {
-        let config_file = tempfile::NamedTempFile::new().unwrap();
-        let secrets_file = tempfile::NamedTempFile::new().unwrap();
-        let config =
-            Config::new_with_file_secrets(config_file.path(), secrets_file.path()).unwrap();
-
-        assert!(declared_inventory_configured(
-            "authless",
-            &[],
-            &config,
-            false
-        ));
-        assert!(!declared_inventory_configured(
-            "authful",
-            &[],
-            &config,
-            true
-        ));
-
-        let secret_key = vec![ConfigKey::new("GOOSE_TEST_API_KEY", true, true, None, true)];
-        assert!(!declared_inventory_configured(
-            "needs_key",
-            &secret_key,
-            &config,
-            false
-        ));
-
-        config
-            .set_secret("GOOSE_TEST_API_KEY", &"sk-test".to_string())
-            .unwrap();
-        assert!(declared_inventory_configured(
-            "needs_key",
-            &secret_key,
             &config,
             false
         ));

--- a/crates/goose/src/providers/inventory/mod.rs
+++ b/crates/goose/src/providers/inventory/mod.rs
@@ -899,20 +899,28 @@ pub fn default_inventory_identity(
     identity
 }
 
-pub fn default_inventory_configured(config_keys: &[ConfigKey], config: &Config) -> bool {
-    config_keys.iter().all(|key| {
-        if !key.required {
-            return true;
-        }
-        if key.default.is_some() {
-            return true;
-        }
+pub fn default_inventory_configured(
+    provider_id: &str,
+    config_keys: &[ConfigKey],
+    config: &Config,
+) -> bool {
+    if crate::config::get_provider_entry(config, provider_id).is_some_and(|entry| entry.configured)
+    {
+        return true;
+    }
+
+    let has_value = |key: &ConfigKey| {
         if key.secret {
             config.get_secret::<serde_json::Value>(&key.name).is_ok()
         } else {
             config.get_param::<serde_json::Value>(&key.name).is_ok()
         }
-    })
+    };
+
+    config_keys.iter().any(&has_value)
+        && config_keys
+            .iter()
+            .all(|key| !key.required || key.default.is_some() || has_value(key))
 }
 
 pub fn declarative_inventory_identity(
@@ -1443,5 +1451,55 @@ mod tests {
 
         assert_eq!(models.len(), 1);
         assert_eq!(models[0].id, "gpt-5.6");
+    }
+
+    #[test]
+    fn default_inventory_configured_requires_user_supplied_configuration() {
+        let config_file = tempfile::NamedTempFile::new().unwrap();
+        let secrets_file = tempfile::NamedTempFile::new().unwrap();
+        let config =
+            Config::new_with_file_secrets(config_file.path(), secrets_file.path()).unwrap();
+
+        let defaulted_key = vec![ConfigKey::new(
+            "GOOSE_TEST_COMMAND",
+            true,
+            false,
+            Some("some-binary"),
+            true,
+        )];
+        assert!(!default_inventory_configured(
+            "defaulted",
+            &defaulted_key,
+            &config
+        ));
+
+        assert!(!default_inventory_configured("no_keys", &[], &config));
+
+        let secret_key = vec![ConfigKey::new("GOOSE_TEST_API_KEY", true, true, None, true)];
+        assert!(!default_inventory_configured(
+            "secret",
+            &secret_key,
+            &config
+        ));
+        config
+            .set_secret("GOOSE_TEST_API_KEY", &"sk-test".to_string())
+            .unwrap();
+        assert!(default_inventory_configured("secret", &secret_key, &config));
+
+        crate::config::set_provider_entry(
+            &config,
+            "defaulted",
+            &crate::config::ProviderEntry {
+                enabled: true,
+                model: "some-model".to_string(),
+                configured: true,
+            },
+        )
+        .unwrap();
+        assert!(default_inventory_configured(
+            "defaulted",
+            &defaulted_key,
+            &config
+        ));
     }
 }

--- a/crates/goose/src/providers/inventory/mod.rs
+++ b/crates/goose/src/providers/inventory/mod.rs
@@ -904,6 +904,26 @@ pub fn default_inventory_configured(
     config_keys: &[ConfigKey],
     config: &Config,
 ) -> bool {
+    inventory_configured(provider_id, config_keys, config, false)
+}
+
+/// A custom provider declaration supplies its own base URL and models, so an
+/// authless declaration is itself the user-supplied configuration.
+pub fn declared_inventory_configured(
+    provider_id: &str,
+    config_keys: &[ConfigKey],
+    config: &Config,
+    requires_auth: bool,
+) -> bool {
+    inventory_configured(provider_id, config_keys, config, !requires_auth)
+}
+
+fn inventory_configured(
+    provider_id: &str,
+    config_keys: &[ConfigKey],
+    config: &Config,
+    declaration_is_configuration: bool,
+) -> bool {
     if crate::config::get_provider_entry(config, provider_id).is_some_and(|entry| entry.configured)
     {
         return true;
@@ -917,10 +937,11 @@ pub fn default_inventory_configured(
         }
     };
 
-    config_keys.iter().any(&has_value)
-        && config_keys
-            .iter()
-            .all(|key| !key.required || key.default.is_some() || has_value(key))
+    let required_keys_satisfied = config_keys
+        .iter()
+        .all(|key| !key.required || key.default.is_some() || has_value(key));
+
+    required_keys_satisfied && (declaration_is_configuration || config_keys.iter().any(&has_value))
 }
 
 pub fn declarative_inventory_identity(
@@ -1500,6 +1521,45 @@ mod tests {
             "defaulted",
             &defaulted_key,
             &config
+        ));
+    }
+
+    #[test]
+    fn declared_inventory_configured_treats_authless_declaration_as_configuration() {
+        let config_file = tempfile::NamedTempFile::new().unwrap();
+        let secrets_file = tempfile::NamedTempFile::new().unwrap();
+        let config =
+            Config::new_with_file_secrets(config_file.path(), secrets_file.path()).unwrap();
+
+        assert!(declared_inventory_configured(
+            "authless",
+            &[],
+            &config,
+            false
+        ));
+        assert!(!declared_inventory_configured(
+            "authful",
+            &[],
+            &config,
+            true
+        ));
+
+        let secret_key = vec![ConfigKey::new("GOOSE_TEST_API_KEY", true, true, None, true)];
+        assert!(!declared_inventory_configured(
+            "needs_key",
+            &secret_key,
+            &config,
+            false
+        ));
+
+        config
+            .set_secret("GOOSE_TEST_API_KEY", &"sk-test".to_string())
+            .unwrap();
+        assert!(declared_inventory_configured(
+            "needs_key",
+            &secret_key,
+            &config,
+            false
         ));
     }
 }

--- a/crates/goose/src/providers/inventory/registrations.rs
+++ b/crates/goose/src/providers/inventory/registrations.rs
@@ -239,6 +239,21 @@ pub fn acp_inventory(
     .with_configured(move || acp_adapter_installed(command))
 }
 
+/// CLI agent providers declare a required command key with a default, so the
+/// command is usable without any stored config. Installation of that command is
+/// the user-supplied configuration.
+pub fn cli_agent_inventory(
+    command: impl Fn() -> String + Send + Sync + 'static,
+    supports_refresh: bool,
+) -> InventoryRegistration {
+    InventoryRegistration {
+        supports_refresh,
+        identity: default_inventory_identity_resolver(),
+        configured: None,
+    }
+    .with_configured(move || acp_adapter_installed(&command()))
+}
+
 pub fn amp_acp_inventory() -> InventoryRegistration {
     acp_inventory(AMP_ACP_PROVIDER_NAME, AMP_ACP_BINARY, false)
 }
@@ -286,6 +301,21 @@ mod tests {
         assert!(azure_foundry_configured_values(
             Some("https://hub.services.ai.azure.com"),
             None,
+        ));
+    }
+
+    #[test]
+    fn cli_agent_inventory_configured_tracks_command_installation() {
+        let missing = cli_agent_inventory(|| "goose-cli-agent-not-installed".to_string(), false);
+        assert!(!(missing
+            .configured
+            .expect("CLI agent should define configured resolver"))(
+        ));
+
+        let installed = cli_agent_inventory(|| "sh".to_string(), false);
+        assert!((installed
+            .configured
+            .expect("CLI agent should define configured resolver"))(
         ));
     }
 

--- a/crates/goose/src/providers/inventory/resolver.rs
+++ b/crates/goose/src/providers/inventory/resolver.rs
@@ -68,7 +68,7 @@ impl InventoryResolvers {
         let config_keys = metadata.config_keys.clone();
         let provider_id = metadata.name.clone();
         let default_configured = Arc::new(move || {
-            default_inventory_configured(&provider_id, &config_keys, Config::global())
+            default_inventory_configured(&provider_id, &config_keys, Config::global(), false)
         });
 
         match registration {

--- a/crates/goose/src/providers/inventory/resolver.rs
+++ b/crates/goose/src/providers/inventory/resolver.rs
@@ -66,8 +66,10 @@ impl InventoryResolvers {
         });
 
         let config_keys = metadata.config_keys.clone();
-        let default_configured =
-            Arc::new(move || default_inventory_configured(&config_keys, Config::global()));
+        let provider_id = metadata.name.clone();
+        let default_configured = Arc::new(move || {
+            default_inventory_configured(&provider_id, &config_keys, Config::global())
+        });
 
         match registration {
             Some(registration) => Self {

--- a/crates/goose/src/providers/provider_registry.rs
+++ b/crates/goose/src/providers/provider_registry.rs
@@ -287,11 +287,13 @@ impl ProviderRegistry {
         };
         let inventory_config_keys = custom_metadata.config_keys.clone();
         let inventory_provider_id = custom_metadata.name.clone();
+        let inventory_requires_auth = config.requires_auth;
         let default_inventory_configured = Arc::new(move || {
-            super::inventory::default_inventory_configured(
+            super::inventory::declared_inventory_configured(
                 &inventory_provider_id,
                 &inventory_config_keys,
                 crate::config::Config::global(),
+                inventory_requires_auth,
             )
         });
 

--- a/crates/goose/src/providers/provider_registry.rs
+++ b/crates/goose/src/providers/provider_registry.rs
@@ -286,8 +286,10 @@ impl ProviderRegistry {
             deprecated: None,
         };
         let inventory_config_keys = custom_metadata.config_keys.clone();
+        let inventory_provider_id = custom_metadata.name.clone();
         let default_inventory_configured = Arc::new(move || {
             super::inventory::default_inventory_configured(
+                &inventory_provider_id,
                 &inventory_config_keys,
                 crate::config::Config::global(),
             )

--- a/crates/goose/src/providers/provider_registry.rs
+++ b/crates/goose/src/providers/provider_registry.rs
@@ -289,11 +289,11 @@ impl ProviderRegistry {
         let inventory_provider_id = custom_metadata.name.clone();
         let inventory_requires_auth = config.requires_auth;
         let default_inventory_configured = Arc::new(move || {
-            super::inventory::declared_inventory_configured(
+            super::inventory::default_inventory_configured(
                 &inventory_provider_id,
                 &inventory_config_keys,
                 crate::config::Config::global(),
-                inventory_requires_auth,
+                !inventory_requires_auth,
             )
         });
 

--- a/crates/goose/src/providers/provider_registry.rs
+++ b/crates/goose/src/providers/provider_registry.rs
@@ -287,7 +287,7 @@ impl ProviderRegistry {
         };
         let inventory_config_keys = custom_metadata.config_keys.clone();
         let inventory_provider_id = custom_metadata.name.clone();
-        let inventory_requires_auth = config.requires_auth;
+        let inventory_requires_auth = config.requires_auth && config.auth.is_none();
         let default_inventory_configured = Arc::new(move || {
             super::inventory::default_inventory_configured(
                 &inventory_provider_id,


### PR DESCRIPTION
Fixes: https://github.com/aaif-goose/goose/issues/11331

## Summary
* Before, we had some false positives on providers looking configured if every config key had a default value
* This makes it so we check `ProviderEntry.configured`
* Things appear configured if the user supplied at least one key
 
### Testing
Local desktop run

### Related Issues
https://github.com/aaif-goose/goose/issues/11331

### Screenshots/Demos (for UX changes)
N/A - It just shows the correct ones configured now 