### PR TITLE
feat(gdk): expose Anthropic response metadata for observability

### DIFF
--- a/crates/goose-provider-types/src/conversation/token_usage.rs
+++ b/crates/goose-provider-types/src/conversation/token_usage.rs
@@ -16,6 +16,14 @@ pub struct ProviderUsage {
     pub finish_reasons: Option<Vec<String>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub response_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub anthropic: Option<AnthropicResponseMetadata>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AnthropicResponseMetadata {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub service_tier: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -54,6 +62,7 @@ impl ProviderUsage {
             cost_source: None,
             finish_reasons: None,
             response_id: None,
+            anthropic: None,
         }
     }
 

--- a/crates/goose-provider-types/src/conversation/token_usage.rs
+++ b/crates/goose-provider-types/src/conversation/token_usage.rs
@@ -1,6 +1,7 @@
 use std::ops::{Add, AddAssign};
 
 use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProviderUsage {
@@ -16,14 +17,10 @@ pub struct ProviderUsage {
     pub finish_reasons: Option<Vec<String>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub response_id: Option<String>,
+    /// Provider-specific response fields that have no canonical equivalent, kept
+    /// unstructured so new fields flow through without changing this type.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub anthropic: Option<AnthropicResponseMetadata>,
-}
-
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
-pub struct AnthropicResponseMetadata {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub service_tier: Option<String>,
+    pub additional_data: Option<Map<String, Value>>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -62,7 +59,7 @@ impl ProviderUsage {
             cost_source: None,
             finish_reasons: None,
             response_id: None,
-            anthropic: None,
+            additional_data: None,
         }
     }
 

--- a/crates/goose-provider-types/src/formats/anthropic.rs
+++ b/crates/goose-provider-types/src/formats/anthropic.rs
@@ -1,9 +1,7 @@
 use crate::canonical::maybe_get_canonical_model;
 use crate::canonical::ThinkingMode;
 use crate::conversation::message::{Message, MessageContentBlock};
-use crate::conversation::token_usage::{
-    AnthropicResponseMetadata, CostSource, ProviderUsage, Usage,
-};
+use crate::conversation::token_usage::{CostSource, ProviderUsage, Usage};
 use crate::errors::ProviderError;
 use crate::images::{convert_image, ImageFormat};
 use crate::mcp_utils::extract_text_from_resource;
@@ -15,7 +13,7 @@ use rmcp::model::{
     ResourceContents, Role, Tool,
 };
 use rmcp::object as json_object;
-use serde_json::{json, Value};
+use serde_json::{json, Map, Value};
 use std::collections::HashSet;
 use std::fmt;
 use std::str::FromStr;
@@ -649,15 +647,16 @@ pub fn get_usage(data: &Value) -> Result<Usage> {
     }
 }
 
-pub fn get_response_metadata(data: &Value) -> Option<AnthropicResponseMetadata> {
-    let service_tier = data
-        .get("usage")?
-        .get("service_tier")?
-        .as_str()?
-        .to_string();
-    Some(AnthropicResponseMetadata {
-        service_tier: Some(service_tier),
-    })
+/// Anthropic response fields that have no canonical `ProviderUsage` equivalent.
+const ADDITIONAL_USAGE_FIELDS: [&str; 1] = ["service_tier"];
+
+pub fn get_additional_data(data: &Value) -> Option<Map<String, Value>> {
+    let usage = data.get("usage")?.as_object()?;
+    let additional: Map<String, Value> = ADDITIONAL_USAGE_FIELDS
+        .iter()
+        .filter_map(|field| Some(((*field).to_string(), usage.get(*field)?.clone())))
+        .collect();
+    (!additional.is_empty()).then_some(additional)
 }
 
 fn provider_usage_with_cost(
@@ -893,7 +892,7 @@ where
         let mut message_id: Option<String> = None;
         let mut thinking: Option<ThinkingState> = None;
         let mut stop_reason: Option<String> = None;
-        let mut response_metadata: Option<AnthropicResponseMetadata> = None;
+        let mut additional_data: Option<Map<String, Value>> = None;
 
         while let Some(line_result) = stream.next().await {
             let line = line_result?;
@@ -923,7 +922,7 @@ where
             match event.event_type.as_str() {
                 EVENT_MESSAGE_START => {
                     if let Some(message_data) = event.data.get("message") {
-                        response_metadata = get_response_metadata(message_data);
+                        additional_data = get_additional_data(message_data);
                         if let Some(id) = message_data.get("id").and_then(|v| v.as_str()) {
                             message_id = Some(id.to_string());
                         }
@@ -1103,7 +1102,7 @@ where
                             if let Some(mut usage) = final_usage.take() {
                                 usage.finish_reasons = Some(vec![STOP_REASON_REFUSAL.to_string()]);
                                 usage.response_id = message_id.clone();
-                                usage.anthropic = response_metadata.clone();
+                                usage.additional_data = additional_data.clone();
                                 yield (None, Some(usage));
                             }
                             Err(ProviderError::Refusal { details, category })?;
@@ -1185,7 +1184,7 @@ where
             if let Some(id) = message_id {
                 usage.response_id = Some(id);
             }
-            usage.anthropic = response_metadata;
+            usage.additional_data = additional_data;
             yield (None, Some(usage));
         }
     }
@@ -2456,7 +2455,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_streaming_surfaces_anthropic_response_metadata() {
+    async fn test_streaming_surfaces_additional_usage_data() {
         let events = concat!(
             r#"data: {"type":"message_start","message":{"id":"msg_1","role":"assistant","content":[],"model":"claude-sonnet-4-5","usage":{"input_tokens":7,"output_tokens":0,"service_tier":"fast"}}}"#,
             "\n",
@@ -2471,15 +2470,15 @@ mod tests {
             r#"data: {"type":"message_stop"}"#,
         );
 
-        let metadata = streamed_usage(events)
+        let additional = streamed_usage(events)
             .await
-            .anthropic
-            .expect("metadata should be reported");
-        assert_eq!(metadata.service_tier.as_deref(), Some("fast"));
+            .additional_data
+            .expect("additional data should be reported");
+        assert_eq!(additional["service_tier"], json!("fast"));
     }
 
     #[tokio::test]
-    async fn test_streaming_omits_anthropic_response_metadata_when_absent() {
+    async fn test_streaming_omits_additional_usage_data_when_absent() {
         let events = concat!(
             r#"data: {"type":"message_start","message":{"id":"msg_1","role":"assistant","content":[],"model":"claude-sonnet-4-5","usage":{"input_tokens":7,"output_tokens":0}}}"#,
             "\n",
@@ -2494,7 +2493,7 @@ mod tests {
             r#"data: {"type":"message_stop"}"#,
         );
 
-        assert!(streamed_usage(events).await.anthropic.is_none());
+        assert!(streamed_usage(events).await.additional_data.is_none());
     }
 
     #[tokio::test]

--- a/crates/goose-provider-types/src/formats/anthropic.rs
+++ b/crates/goose-provider-types/src/formats/anthropic.rs
@@ -1,7 +1,9 @@
 use crate::canonical::maybe_get_canonical_model;
 use crate::canonical::ThinkingMode;
 use crate::conversation::message::{Message, MessageContentBlock};
-use crate::conversation::token_usage::{CostSource, ProviderUsage, Usage};
+use crate::conversation::token_usage::{
+    AnthropicResponseMetadata, CostSource, ProviderUsage, Usage,
+};
 use crate::errors::ProviderError;
 use crate::images::{convert_image, ImageFormat};
 use crate::mcp_utils::extract_text_from_resource;
@@ -647,6 +649,17 @@ pub fn get_usage(data: &Value) -> Result<Usage> {
     }
 }
 
+pub fn get_response_metadata(data: &Value) -> Option<AnthropicResponseMetadata> {
+    let service_tier = data
+        .get("usage")?
+        .get("service_tier")?
+        .as_str()?
+        .to_string();
+    Some(AnthropicResponseMetadata {
+        service_tier: Some(service_tier),
+    })
+}
+
 fn provider_usage_with_cost(
     model: String,
     usage: Usage,
@@ -880,6 +893,7 @@ where
         let mut message_id: Option<String> = None;
         let mut thinking: Option<ThinkingState> = None;
         let mut stop_reason: Option<String> = None;
+        let mut response_metadata: Option<AnthropicResponseMetadata> = None;
 
         while let Some(line_result) = stream.next().await {
             let line = line_result?;
@@ -909,6 +923,7 @@ where
             match event.event_type.as_str() {
                 EVENT_MESSAGE_START => {
                     if let Some(message_data) = event.data.get("message") {
+                        response_metadata = get_response_metadata(message_data);
                         if let Some(id) = message_data.get("id").and_then(|v| v.as_str()) {
                             message_id = Some(id.to_string());
                         }
@@ -1088,6 +1103,7 @@ where
                             if let Some(mut usage) = final_usage.take() {
                                 usage.finish_reasons = Some(vec![STOP_REASON_REFUSAL.to_string()]);
                                 usage.response_id = message_id.clone();
+                                usage.anthropic = response_metadata.clone();
                                 yield (None, Some(usage));
                             }
                             Err(ProviderError::Refusal { details, category })?;
@@ -1169,6 +1185,7 @@ where
             if let Some(id) = message_id {
                 usage.response_id = Some(id);
             }
+            usage.anthropic = response_metadata;
             yield (None, Some(usage));
         }
     }
@@ -2427,6 +2444,57 @@ mod tests {
             Some(&["end_turn".to_string()][..])
         );
         assert_eq!(usage.response_id.as_deref(), Some("msg_1"));
+    }
+
+    async fn streamed_usage(events: &str) -> ProviderUsage {
+        collect_stream_results(events)
+            .await
+            .into_iter()
+            .filter_map(|r| r.ok().and_then(|(_, usage)| usage))
+            .next_back()
+            .expect("stream should yield usage")
+    }
+
+    #[tokio::test]
+    async fn test_streaming_surfaces_anthropic_response_metadata() {
+        let events = concat!(
+            r#"data: {"type":"message_start","message":{"id":"msg_1","role":"assistant","content":[],"model":"claude-sonnet-4-5","usage":{"input_tokens":7,"output_tokens":0,"service_tier":"fast"}}}"#,
+            "\n",
+            r#"data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}"#,
+            "\n",
+            r#"data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hi"}}"#,
+            "\n",
+            r#"data: {"type":"content_block_stop","index":0}"#,
+            "\n",
+            r#"data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":25}}"#,
+            "\n",
+            r#"data: {"type":"message_stop"}"#,
+        );
+
+        let metadata = streamed_usage(events)
+            .await
+            .anthropic
+            .expect("metadata should be reported");
+        assert_eq!(metadata.service_tier.as_deref(), Some("fast"));
+    }
+
+    #[tokio::test]
+    async fn test_streaming_omits_anthropic_response_metadata_when_absent() {
+        let events = concat!(
+            r#"data: {"type":"message_start","message":{"id":"msg_1","role":"assistant","content":[],"model":"claude-sonnet-4-5","usage":{"input_tokens":7,"output_tokens":0}}}"#,
+            "\n",
+            r#"data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}"#,
+            "\n",
+            r#"data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hi"}}"#,
+            "\n",
+            r#"data: {"type":"content_block_stop","index":0}"#,
+            "\n",
+            r#"data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":25}}"#,
+            "\n",
+            r#"data: {"type":"message_stop"}"#,
+        );
+
+        assert!(streamed_usage(events).await.anthropic.is_none());
     }
 
     #[tokio::test]

--- a/crates/goose-sdk/src/bindings.rs
+++ b/crates/goose-sdk/src/bindings.rs
@@ -14,7 +14,7 @@ use goose_providers::{
     base::{MessageStream, Provider as GooseProvider},
     conversation::{
         message::{Message, MessageContent as GooseMessageContent},
-        token_usage::ProviderUsage,
+        token_usage::{AnthropicResponseMetadata as GooseAnthropicResponseMetadata, ProviderUsage},
     },
     databricks::DatabricksProvider as GooseDatabricksProvider,
     databricks_auth::DatabricksAuth,
@@ -429,6 +429,20 @@ pub struct Usage {
     pub reasoning_tokens: Option<i32>,
     pub model: String,
     pub provider_metadata_json: Option<String>,
+    pub anthropic_metadata: Option<AnthropicResponseMetadata>,
+}
+
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct AnthropicResponseMetadata {
+    pub service_tier: Option<String>,
+}
+
+impl From<&GooseAnthropicResponseMetadata> for AnthropicResponseMetadata {
+    fn from(metadata: &GooseAnthropicResponseMetadata) -> Self {
+        Self {
+            service_tier: metadata.service_tier.clone(),
+        }
+    }
 }
 
 impl Usage {
@@ -442,6 +456,10 @@ impl Usage {
             reasoning_tokens: None,
             model: usage.model.clone(),
             provider_metadata_json: Some(serde_json::to_string(usage)?),
+            anthropic_metadata: usage
+                .anthropic
+                .as_ref()
+                .map(AnthropicResponseMetadata::from),
         })
     }
 }
@@ -1218,6 +1236,37 @@ mod tests {
 
         assert_eq!(tool.name.as_ref(), "lookup");
         assert_eq!(tool.input_schema["type"], "object");
+    }
+
+    #[test]
+    fn usage_exposes_anthropic_response_metadata() {
+        let mut provider_usage = ProviderUsage::new(
+            "claude-sonnet-4-5".to_string(),
+            goose_providers::conversation::token_usage::Usage::new(Some(10), Some(5), None),
+        );
+        provider_usage.anthropic = Some(GooseAnthropicResponseMetadata {
+            service_tier: Some("fast".to_string()),
+        });
+
+        let metadata = Usage::from_provider_usage(&provider_usage)
+            .unwrap()
+            .anthropic_metadata
+            .expect("metadata should be exposed");
+
+        assert_eq!(metadata.service_tier.as_deref(), Some("fast"));
+    }
+
+    #[test]
+    fn usage_omits_anthropic_response_metadata_when_absent() {
+        let provider_usage = ProviderUsage::new(
+            "claude-sonnet-4-5".to_string(),
+            goose_providers::conversation::token_usage::Usage::new(Some(10), Some(5), None),
+        );
+
+        assert!(Usage::from_provider_usage(&provider_usage)
+            .unwrap()
+            .anthropic_metadata
+            .is_none());
     }
 
     #[test]

--- a/crates/goose-sdk/src/bindings.rs
+++ b/crates/goose-sdk/src/bindings.rs
@@ -14,7 +14,7 @@ use goose_providers::{
     base::{MessageStream, Provider as GooseProvider},
     conversation::{
         message::{Message, MessageContent as GooseMessageContent},
-        token_usage::{AnthropicResponseMetadata as GooseAnthropicResponseMetadata, ProviderUsage},
+        token_usage::ProviderUsage,
     },
     databricks::DatabricksProvider as GooseDatabricksProvider,
     databricks_auth::DatabricksAuth,
@@ -429,20 +429,9 @@ pub struct Usage {
     pub reasoning_tokens: Option<i32>,
     pub model: String,
     pub provider_metadata_json: Option<String>,
-    pub anthropic_metadata: Option<AnthropicResponseMetadata>,
-}
-
-#[derive(Debug, Clone, uniffi::Record)]
-pub struct AnthropicResponseMetadata {
-    pub service_tier: Option<String>,
-}
-
-impl From<&GooseAnthropicResponseMetadata> for AnthropicResponseMetadata {
-    fn from(metadata: &GooseAnthropicResponseMetadata) -> Self {
-        Self {
-            service_tier: metadata.service_tier.clone(),
-        }
-    }
+    /// Provider-specific response fields as a JSON object, present only when the
+    /// provider reported fields with no canonical `Usage` equivalent.
+    pub additional_data_json: Option<String>,
 }
 
 impl Usage {
@@ -456,10 +445,11 @@ impl Usage {
             reasoning_tokens: None,
             model: usage.model.clone(),
             provider_metadata_json: Some(serde_json::to_string(usage)?),
-            anthropic_metadata: usage
-                .anthropic
+            additional_data_json: usage
+                .additional_data
                 .as_ref()
-                .map(AnthropicResponseMetadata::from),
+                .map(serde_json::to_string)
+                .transpose()?,
         })
     }
 }
@@ -1239,25 +1229,31 @@ mod tests {
     }
 
     #[test]
-    fn usage_exposes_anthropic_response_metadata() {
+    fn usage_exposes_provider_additional_data() {
         let mut provider_usage = ProviderUsage::new(
             "claude-sonnet-4-5".to_string(),
             goose_providers::conversation::token_usage::Usage::new(Some(10), Some(5), None),
         );
-        provider_usage.anthropic = Some(GooseAnthropicResponseMetadata {
-            service_tier: Some("fast".to_string()),
-        });
+        provider_usage.additional_data = Some(
+            serde_json::json!({ "service_tier": "fast" })
+                .as_object()
+                .unwrap()
+                .clone(),
+        );
 
-        let metadata = Usage::from_provider_usage(&provider_usage)
+        let additional_data_json = Usage::from_provider_usage(&provider_usage)
             .unwrap()
-            .anthropic_metadata
-            .expect("metadata should be exposed");
+            .additional_data_json
+            .expect("additional data should be exposed");
 
-        assert_eq!(metadata.service_tier.as_deref(), Some("fast"));
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&additional_data_json).unwrap(),
+            serde_json::json!({ "service_tier": "fast" })
+        );
     }
 
     #[test]
-    fn usage_omits_anthropic_response_metadata_when_absent() {
+    fn usage_omits_provider_additional_data_when_absent() {
         let provider_usage = ProviderUsage::new(
             "claude-sonnet-4-5".to_string(),
             goose_providers::conversation::token_usage::Usage::new(Some(10), Some(5), None),
@@ -1265,7 +1261,7 @@ mod tests {
 
         assert!(Usage::from_provider_usage(&provider_usage)
             .unwrap()
-            .anthropic_metadata
+            .additional_data_json
             .is_none());
     }
 

--- a/documentation/src/data/gdk-api.json
+++ b/documentation/src/data/gdk-api.json
@@ -629,25 +629,10 @@
               "docs": ""
             },
             {
-              "name": "anthropic_metadata",
-              "type": "Option<AnthropicResponseMetadata>",
-              "default": null,
-              "docs": ""
-            }
-          ],
-          "variants": [],
-          "methods": []
-        },
-        {
-          "name": "AnthropicResponseMetadata",
-          "kind": "record",
-          "docs": "",
-          "fields": [
-            {
-              "name": "service_tier",
+              "name": "additional_data_json",
               "type": "Option<String>",
               "default": null,
-              "docs": ""
+              "docs": "Provider-specific response fields as a JSON object, present only when the provider reported fields with no canonical `Usage` equivalent."
             }
           ],
           "variants": [],

--- a/documentation/src/data/gdk-api.json
+++ b/documentation/src/data/gdk-api.json
@@ -627,6 +627,27 @@
               "type": "Option<String>",
               "default": null,
               "docs": ""
+            },
+            {
+              "name": "anthropic_metadata",
+              "type": "Option<AnthropicResponseMetadata>",
+              "default": null,
+              "docs": ""
+            }
+          ],
+          "variants": [],
+          "methods": []
+        },
+        {
+          "name": "AnthropicResponseMetadata",
+          "kind": "record",
+          "docs": "",
+          "fields": [
+            {
+              "name": "service_tier",
+              "type": "Option<String>",
+              "default": null,
+              "docs": ""
             }
           ],
           "variants": [],


### PR DESCRIPTION
Parses Anthropic's `usage.service_tier` and surfaces it to observability consumers as typed-enough data instead of forcing them to parse raw payloads. Absent metadata stays `None` end-to-end, keeping "not reported" distinguishable from a value.

Provider-specific fields ride on a generic `additional_data: Option<Map<String, Value>>` on `ProviderUsage`, exposed over uniffi as `additional_data_json`. The Anthropic format module chooses which usage fields to forward (`ADDITIONAL_USAGE_FIELDS`), so this is a deliberate passthrough rather than a dump of the raw payload, and adding a field for another provider does not change shared types.

Closes #11354

Review notes:
- An earlier revision exposed a `fast_mode` boolean **derived** from `service_tier == "fast"`. Removed — Anthropic has no `fast_mode` field, so deriving it reported `Some(false)` when the provider had said nothing at all, contradicting the "missing metadata is represented explicitly" criterion. Consumers can compare `service_tier` themselves.
- An earlier revision used a typed `AnthropicResponseMetadata` record. Replaced with the unstructured blob per review feedback.