### PR TITLE
feat(gdk): let Kotlin callers configure the Databricks AI Gateway path

### DIFF
--- a/crates/goose-providers/src/databricks_v2.rs
+++ b/crates/goose-providers/src/databricks_v2.rs
@@ -2,7 +2,7 @@ use crate::formats::anthropic::{AnthropicFormatOptions, ANTHROPIC_PROVIDER_NAME}
 use crate::formats::openai::{self, extract_reasoning_effort, is_openai_responses_model};
 use crate::http_status::{read_error_body, read_json_response};
 use crate::images::ImageFormat;
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use async_stream::try_stream;
 use async_trait::async_trait;
 use futures::TryStreamExt;
@@ -37,6 +37,12 @@ use crate::retry::{
 use rmcp::model::Tool;
 
 const DATABRICKS_V2_PROVIDER_NAME: &str = "databricks_v2";
+const DATABRICKS_V2_DEFAULT_GATEWAY_PATH: &str = "ai-gateway";
+const DATABRICKS_V2_ROUTE_SUFFIXES: [&str; 3] = [
+    "openai/v1/responses",
+    "anthropic/v1/messages",
+    "mlflow/v1/chat/completions",
+];
 const DATABRICKS_V2_LIST_ENDPOINTS_PATH: &str = "api/ai-gateway/v2/endpoints";
 const DATABRICKS_V2_LIST_MODEL_SERVICES_PATH: &str = "api/2.1/unity-catalog/model-services";
 const DATABRICKS_V2_MODEL_SERVICE_PREFIX: &str = "model-services/";
@@ -97,6 +103,8 @@ pub struct DatabricksV2Provider {
     token_cache: Arc<Mutex<Option<String>>>,
     #[serde(skip)]
     refresh_hook: Option<DatabricksRefreshHook>,
+    #[serde(skip)]
+    gateway_path: String,
 }
 
 impl DatabricksV2Provider {
@@ -143,7 +151,43 @@ impl DatabricksV2Provider {
             name: DATABRICKS_V2_PROVIDER_NAME.to_string(),
             token_cache,
             refresh_hook,
+            gateway_path: DATABRICKS_V2_DEFAULT_GATEWAY_PATH.to_string(),
         })
+    }
+
+    /// Routes requests through a gateway deployment served under a different
+    /// base path. Accepts either the base path (`my-gateway`) or a full route
+    /// (`my-gateway/openai/v1/responses`), since callers configure the latter.
+    pub fn with_gateway_path(mut self, gateway_path: &str) -> Result<Self> {
+        let trimmed = gateway_path.trim().trim_matches('/');
+        if trimmed.is_empty() {
+            return Err(anyhow!(
+                "Databricks gateway path must not be empty; omit it to use the default `{DATABRICKS_V2_DEFAULT_GATEWAY_PATH}`"
+            ));
+        }
+        if trimmed.contains("://") {
+            return Err(anyhow!(
+                "Databricks gateway path must be a path such as `{DATABRICKS_V2_DEFAULT_GATEWAY_PATH}`, not a URL; configure the workspace URL as the provider host instead"
+            ));
+        }
+
+        self.gateway_path = DATABRICKS_V2_ROUTE_SUFFIXES
+            .iter()
+            .find_map(|suffix| trimmed.strip_suffix(suffix))
+            .map(|base| base.trim_matches('/'))
+            .unwrap_or(trimmed)
+            .to_string();
+
+        Ok(self)
+    }
+
+    fn route_path(&self, route: DatabricksV2Route) -> String {
+        let suffix = match route {
+            DatabricksV2Route::OpenAiResponses => "openai/v1/responses",
+            DatabricksV2Route::AnthropicMessages => "anthropic/v1/messages",
+            DatabricksV2Route::MlflowChatCompletions => "mlflow/v1/chat/completions",
+        };
+        format!("{}/{suffix}", self.gateway_path)
     }
 
     pub fn load_retry_config(get_param: impl Fn(&str) -> Option<String>) -> RetryConfig {
@@ -287,7 +331,7 @@ impl DatabricksV2Provider {
             .with_retry(|| async {
                 let resp = self
                     .api_client
-                    .request("ai-gateway/openai/v1/responses")
+                    .request(&self.route_path(DatabricksV2Route::OpenAiResponses))
                     .model_headers(model_config)?
                     .streaming(true)
                     .response_post(&payload)
@@ -335,7 +379,7 @@ impl DatabricksV2Provider {
             .with_retry(|| async {
                 let resp = self
                     .api_client
-                    .request("ai-gateway/mlflow/v1/chat/completions")
+                    .request(&self.route_path(DatabricksV2Route::MlflowChatCompletions))
                     .model_headers(model_config)?
                     .streaming(true)
                     .response_post(&payload)
@@ -372,7 +416,7 @@ impl DatabricksV2Provider {
             .with_retry(|| async {
                 let resp = self
                     .api_client
-                    .request("ai-gateway/anthropic/v1/messages")
+                    .request(&self.route_path(DatabricksV2Route::AnthropicMessages))
                     .model_headers(model_config)?
                     .streaming(true)
                     .response_post(&payload)
@@ -693,6 +737,152 @@ mod tests {
                 DatabricksV2Route::MlflowChatCompletions,
                 "unexpected route for {model}"
             );
+        }
+    }
+
+    mod gateway_path {
+        use super::*;
+        use serde_json::json;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        fn provider(host: String) -> DatabricksV2Provider {
+            DatabricksV2Provider::new(
+                host,
+                DatabricksAuth::token("test-token".to_string()),
+                RetryConfig::new(0, 0, 1.0, 0),
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .unwrap()
+        }
+
+        fn all_route_paths(provider: &DatabricksV2Provider) -> Vec<String> {
+            [
+                DatabricksV2Route::OpenAiResponses,
+                DatabricksV2Route::AnthropicMessages,
+                DatabricksV2Route::MlflowChatCompletions,
+            ]
+            .into_iter()
+            .map(|route| provider.route_path(route))
+            .collect()
+        }
+
+        #[test]
+        fn default_matches_the_paths_used_before_the_path_became_configurable() {
+            assert_eq!(
+                all_route_paths(&provider("https://workspace".to_string())),
+                vec![
+                    "ai-gateway/openai/v1/responses",
+                    "ai-gateway/anthropic/v1/messages",
+                    "ai-gateway/mlflow/v1/chat/completions",
+                ]
+            );
+        }
+
+        #[test]
+        fn configured_path_is_preserved_for_every_route() {
+            let provider = provider("https://workspace".to_string())
+                .with_gateway_path("/gateways/team-a/")
+                .unwrap();
+
+            assert_eq!(
+                all_route_paths(&provider),
+                vec![
+                    "gateways/team-a/openai/v1/responses",
+                    "gateways/team-a/anthropic/v1/messages",
+                    "gateways/team-a/mlflow/v1/chat/completions",
+                ]
+            );
+        }
+
+        #[test]
+        fn accepts_a_full_route_and_reuses_its_base_for_the_other_routes() {
+            let provider = provider("https://workspace".to_string())
+                .with_gateway_path("ai-gateway/openai/v1/responses")
+                .unwrap();
+
+            assert_eq!(
+                all_route_paths(&provider),
+                vec![
+                    "ai-gateway/openai/v1/responses",
+                    "ai-gateway/anthropic/v1/messages",
+                    "ai-gateway/mlflow/v1/chat/completions",
+                ]
+            );
+        }
+
+        #[test]
+        fn rejects_paths_that_cannot_be_joined_to_a_route() {
+            for (input, expected) in [
+                ("   ", "must not be empty"),
+                ("https://workspace/ai-gateway", "not a URL"),
+            ] {
+                let err = match provider("https://workspace".to_string()).with_gateway_path(input) {
+                    Ok(_) => panic!("{input:?} should be rejected"),
+                    Err(err) => err,
+                };
+                assert!(
+                    err.to_string().contains(expected),
+                    "error for {input:?} should mention {expected:?}, got: {err}"
+                );
+            }
+        }
+
+        #[tokio::test]
+        async fn responses_api_streams_text_tool_calls_and_usage_over_the_configured_path() {
+            let created = r#"data: {"type":"response.created","sequence_number":1,"response":{"id":"resp_1","object":"response","created_at":0,"status":"in_progress","model":"databricks-gpt-5-5","output":[]}}"#;
+            let delta = r#"data: {"type":"response.output_text.delta","sequence_number":2,"item_id":"m1","output_index":0,"content_index":0,"delta":"Hello"}"#;
+            let completed = r#"data: {"type":"response.completed","sequence_number":3,"response":{"id":"resp_1","object":"response","created_at":0,"status":"completed","model":"databricks-gpt-5-5","output":[{"type":"function_call","id":"fc_1","call_id":"call_1","name":"shell","arguments":"{\"command\":\"ls\"}"}],"usage":{"input_tokens":11,"output_tokens":3,"total_tokens":14}}}"#;
+            let body = format!("{created}\n\n{delta}\n\n{completed}\n\ndata: [DONE]\n\n");
+
+            let server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .and(path("/gateways/team-a/openai/v1/responses"))
+                .respond_with(
+                    ResponseTemplate::new(200)
+                        .set_body_string(body)
+                        .append_header("content-type", "text/event-stream"),
+                )
+                .expect(1)
+                .mount(&server)
+                .await;
+
+            let provider = provider(server.uri())
+                .with_gateway_path("gateways/team-a")
+                .unwrap();
+            let (message, usage) = provider
+                .complete(
+                    &ModelConfig::new("databricks-gpt-5-5"),
+                    "system",
+                    &[],
+                    &[Tool::new(
+                        "shell",
+                        "run a shell command",
+                        std::sync::Arc::new(
+                            json!({"type": "object", "properties": {}})
+                                .as_object()
+                                .unwrap()
+                                .clone(),
+                        ),
+                    )],
+                )
+                .await
+                .expect("responses stream should decode");
+
+            assert_eq!(message.as_concat_text(), "Hello");
+            let tool_request = message
+                .content
+                .iter()
+                .find_map(|content| content.as_tool_request())
+                .expect("tool call should decode");
+            assert_eq!(tool_request.tool_call.as_ref().unwrap().name, "shell");
+            assert_eq!(usage.usage.input_tokens, Some(11));
+            assert_eq!(usage.usage.output_tokens, Some(3));
+            assert_eq!(usage.usage.total_tokens, Some(14));
         }
     }
 

--- a/crates/goose-sdk/src/bindings.rs
+++ b/crates/goose-sdk/src/bindings.rs
@@ -1122,8 +1122,12 @@ pub fn databricks_v2_default_model() -> String {
     goose_providers::databricks_v2::DATABRICKS_V2_DEFAULT_MODEL.to_string()
 }
 
-#[uniffi::export]
-pub fn databricks_v2_provider(host: String, token: String) -> Result<Arc<Provider>, GooseError> {
+#[uniffi::export(default(gateway_path = None))]
+pub fn databricks_v2_provider(
+    host: String,
+    token: String,
+    gateway_path: Option<String>,
+) -> Result<Arc<Provider>, GooseError> {
     let retry_config = GooseDatabricksV2Provider::load_retry_config(|key| std::env::var(key).ok());
     let provider = GooseDatabricksV2Provider::new(
         host,
@@ -1135,6 +1139,10 @@ pub fn databricks_v2_provider(host: String, token: String) -> Result<Arc<Provide
         None,
         None,
     )?;
+    let provider = match gateway_path {
+        Some(path) => provider.with_gateway_path(&path)?,
+        None => provider,
+    };
 
     Ok(Provider::new(Box::new(provider)))
 }

--- a/documentation/automation/gdk-api/generate.py
+++ b/documentation/automation/gdk-api/generate.py
@@ -177,7 +177,19 @@ def parse_variants(block: str) -> list[dict]:
     return variants
 
 
-def parse_signature(signature: str, docs: str) -> Func:
+def parse_arg_defaults(attrs: str) -> dict[str, str]:
+    """Reads argument defaults from `#[uniffi::export(default(arg = value))]`."""
+    defaults: dict[str, str] = {}
+    for group in re.findall(r"default\s*\(([^()]*)\)", attrs):
+        for part in split_top_level(group):
+            name, _, value = part.partition("=")
+            if value:
+                defaults[name.strip()] = value.strip()
+    return defaults
+
+
+def parse_signature(signature: str, docs: str, defaults: dict[str, str] | None = None) -> Func:
+    defaults = defaults or {}
     signature = re.sub(r"\s+", " ", signature).strip().rstrip("{;").strip()
     is_async = " async fn " in f" {signature} "
     match = re.search(r"fn\s+(\w+)\s*\((.*)\)\s*(?:->\s*(.+))?$", signature, re.DOTALL)
@@ -191,7 +203,8 @@ def parse_signature(signature: str, docs: str) -> Func:
             continue
         param_name, _, type_text = part.partition(":")
         if type_text:
-            params.append(Param(param_name.strip(), clean_type(type_text)))
+            name_text = param_name.strip()
+            params.append(Param(name_text, clean_type(type_text), defaults.get(name_text)))
 
     returns, throws = None, None
     if raw_return:
@@ -270,7 +283,7 @@ def parse_bindings(source: str) -> dict[str, list[Item] | list[Func]]:
             continue
         if exported and re.match(r"pub\s+(async\s+)?fn", stripped):
             block = scanner.block()
-            functions.append(parse_signature(block.split("{")[0], docs))
+            functions.append(parse_signature(block.split("{")[0], docs, parse_arg_defaults(attrs)))
             continue
 
         scanner.index += 1

--- a/documentation/src/data/gdk-api.json
+++ b/documentation/src/data/gdk-api.json
@@ -92,6 +92,12 @@
               "type": "String",
               "default": null,
               "docs": ""
+            },
+            {
+              "name": "gateway_path",
+              "type": "Option<String>",
+              "default": null,
+              "docs": ""
             }
           ],
           "returns": "Provider",

--- a/documentation/src/data/gdk-api.json
+++ b/documentation/src/data/gdk-api.json
@@ -96,7 +96,7 @@
             {
               "name": "gateway_path",
               "type": "Option<String>",
-              "default": null,
+              "default": "None",
               "docs": ""
             }
           ],

--- a/goose-self-test.yaml
+++ b/goose-self-test.yaml
@@ -9,6 +9,7 @@ activities:
   - Test file operations (create, read, update, delete, undo)
   - Validate shell command execution and error handling
   - Validate Azure AI Foundry provider routing and deployment aliases
+  - Validate the configurable Databricks AI Gateway path across all inference routes
   - Analyze code structure and parsing capabilities
   - Test extension discovery and management
   - Test load tool for knowledge injection and discovery
@@ -173,6 +174,15 @@ prompt: |
   ### Gondola Provider Validation
   When running from a goose source checkout:
   1. Run `cargo test -p goose test_gondola_provider_registry_wiring` to verify Gondola is registered with the correct name, default model (`deepseek-v4-flash`), and a secret `GONDOLA_API_KEY` config key.
+  If the source checkout or Rust toolchain is unavailable, mark this validation as skipped rather than failed.
+
+  ### Databricks AI Gateway Path Validation
+  When running from a goose source checkout:
+  1. Run `cargo test -p goose-providers databricks_v2::tests::gateway_path` to verify the configurable gateway path.
+  2. Verify that omitting the path keeps the default `ai-gateway` routes byte-identical for the OpenAI Responses, Anthropic Messages, and MLflow chat completions routes.
+  3. Verify a configured path applies to all three routes, and that a full route (`ai-gateway/openai/v1/responses`) is accepted and its base reused, since Kotlin callers configure the full route.
+  4. Verify empty paths and URLs are rejected, as neither can be joined to a route.
+  5. Run `python3 documentation/automation/gdk-api/generate.py --check` to verify the generated GDK API data is current and publishes `gateway_path` as an optional argument defaulting to `None`.
   If the source checkout or Rust toolchain is unavailable, mark this validation as skipped rather than failed.
 
   Log results to: {{ workspace_dir }}/phase1_basic_tools.md


### PR DESCRIPTION
`databricks_v2_provider` accepted only host and token, so `createGdkBacked` had nowhere to pass `aiGatewayPath` and the configured path was silently dropped — the three inference paths hardcoded the `ai-gateway` prefix. This adds an optional `gateway_path` argument to the **existing** binding (defaulting to `None`) plus a `with_gateway_path` builder, and composes all three route paths from it.

Closes #11356

**Two things worth checking on review:**

1. **It accepts the value you actually have.** Your config holds the full route (`/ai-gateway/openai/v1/responses`), not a base path, so `with_gateway_path` accepts either and strips a known API suffix to recover the base — then reuses that base for the Anthropic and MLflow routes too. An earlier revision of this PR *rejected* that exact string with "must not include the API suffix", which would have failed on the real input.

2. **Responses API is verified end to end**, since all 14 prod agent configs are `MODEL_PROVIDER_DATABRICKS` and none of the Responses work had a GDK equivalent. `responses_api_streams_text_tool_calls_and_usage_over_the_configured_path` drives a Responses SSE fixture through a wiremock server at the configured path and asserts streamed text, a decoded `function_call` tool call, and input/output/total token usage.

**Backward compatibility:** the argument defaults to `None`, so existing Kotlin callers and `DatabricksV2Provider::new` are untouched, and the default paths are byte-identical to before (pinned by `default_matches_the_paths_used_before_the_path_became_configurable`).

Rejects empty paths and URLs, since neither can be joined to a route.

Note: verification is Rust-level only — no Kotlin bindings were generated, so the generated `databricksV2Provider(host, token, gatewayPath = null)` signature is inferred from the uniffi macro contract rather than confirmed against generated Kotlin.