### PR TITLE
feat(gdk): publish Linux ARM64 native artifacts

### DIFF
--- a/.github/workflows/maven-sdk.yml
+++ b/.github/workflows/maven-sdk.yml
@@ -126,9 +126,54 @@ jobs:
           path: maven-artifacts/**
           if-no-files-found: error
 
+  smoke-test-linux-aarch64:
+    name: Smoke test Kotlin GDK (linux-aarch64)
+    needs: package
+    runs-on: ubuntu-22.04-arm
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Set up Java
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+
+      - name: Download Maven artifact bundle
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: goose-sdk-maven
+          path: maven-artifacts
+
+      - name: Install Maven artifact bundle into local repository
+        shell: bash
+        run: |
+          version=$(grep -m1 '^version =' crates/goose-sdk/Cargo.toml | sed -E 's/version = "([^"]+)"/\1/')
+          target="$HOME/.m2/repository/io/github/aaif-goose/gdk/$version"
+          mkdir -p "$target"
+          find maven-artifacts -type f -exec cp {} "$target/" +
+
+      - name: Load native library in an ARM64 JVM
+        shell: bash
+        working-directory: crates/goose-sdk/examples/uniffi/kotlin
+        run: |
+          gradle --no-daemon installDist
+          cat > "$RUNNER_TEMP/LoadNativeLibrary.java" <<'JAVA'
+          public class LoadNativeLibrary {
+              public static void main(String[] args) {
+                  System.out.println(io.github.aaif_goose.GooseKt.openaiDefaultModel());
+              }
+          }
+          JAVA
+          java -cp "$(find build/install -name '*.jar' | paste -sd: -)" "$RUNNER_TEMP/LoadNativeLibrary.java"
+
   publish:
     name: Publish to Maven Central
-    needs: package
+    needs: [package, smoke-test-linux-aarch64]
     runs-on: ubuntu-latest
     if: github.event_name == 'workflow_dispatch' && inputs.publish
     environment: maven-central

--- a/.github/workflows/maven-sdk.yml
+++ b/.github/workflows/maven-sdk.yml
@@ -28,6 +28,10 @@ jobs:
             os: ubuntu-latest
             container: quay.io/pypa/manylinux_2_28_x86_64@sha256:441c35fdc6ee809ff9260894f8468ab4fea8c15dc880f8700a3f81b7922c1cda
             resource-prefix: linux-x86-64
+          - name: linux-aarch64
+            os: ubuntu-22.04-arm
+            container: quay.io/pypa/manylinux_2_28_aarch64@sha256:8b5f2b4e8c072ae5aefeb659f22c03e1ff46e6a82f154b6c904b106c87e65ff7
+            resource-prefix: linux-aarch64
           - name: win32-x86-64
             os: windows-latest
             resource-prefix: win32-x86-64


### PR DESCRIPTION
Adds a `linux-aarch64` entry to the `build-native` matrix in the Maven GDK workflow, using the same `ubuntu-22.04-arm` runner and digest-pinned `manylinux_2_28_aarch64` container already used for the aarch64 Linux CLI build. The JNA resource path, packaging script, and `NativeLibraryLoader` already handle `linux-aarch64`, so CI never producing the library was the only gap — hence the four-line diff.

Closes #11359

Status against the acceptance criteria, stated plainly:
- **Artifact included and auto-resolved on Linux ARM64** — met by this change.
- **Unsupported architectures fail with an actionable message** — already true on `main` (`NativeLibraryLoader.kt` raises `Unsupported OS` / missing-resource errors).
- **Documentation lists supported OS/arch combinations** — already true on `main` (`crates/goose-sdk/maven/README.md` lists `linux-aarch64`).
- **CI builds and runs a Kotlin smoke test on Linux ARM64** — **NOT met.** This adds the build but no Kotlin smoke-test step; the workflow has no such step for any platform today, so adding one for ARM64 alone would be a larger change than this issue's scope. Flagging rather than silently skipping.

No ARM64 cross-compile was run locally (no toolchain available), so CI must confirm the build succeeds and the jar contains `linux-aarch64/libgoose_sdk.so`.