### PR TITLE
fix(scheduler): propagate scheduled job stream errors as failures

### DIFF
--- a/crates/goose/src/scheduler.rs
+++ b/crates/goose/src/scheduler.rs
@@ -1149,7 +1149,7 @@ async fn execute_job(
     use futures::StreamExt;
     let mut stream = std::pin::pin!(stream);
 
-    let mut stream_error = false;
+    let mut stream_error: Option<anyhow::Error> = None;
     while let Some(message_result) = stream.next().await {
         tokio::task::yield_now().await;
 
@@ -1163,7 +1163,7 @@ async fn execute_job(
             Ok(_) => {}
             Err(e) => {
                 tracing::error!("Error in agent stream: {}", e);
-                stream_error = true;
+                stream_error = Some(anyhow::anyhow!("{}", e));
                 break;
             }
         }
@@ -1171,7 +1171,7 @@ async fn execute_job(
 
     {
         let session_duration = start_time.elapsed();
-        let exit_type = if stream_error { "error" } else { "normal" };
+        let exit_type = if stream_error.is_some() { "error" } else { "normal" };
         let (total_tokens, message_count) = agent
             .config
             .session_manager
@@ -1211,7 +1211,7 @@ async fn execute_job(
     #[cfg(feature = "telemetry")]
     {
         let duration_secs = start_time.elapsed().as_secs();
-        let status = if stream_error { "failed" } else { "completed" };
+        let status = if stream_error.is_some() { "failed" } else { "completed" };
         tokio::spawn(async move {
             let mut props = HashMap::new();
             props.insert(
@@ -1232,11 +1232,8 @@ async fn execute_job(
         });
     }
 
-    if stream_error {
-        Err(anyhow!(
-            "Scheduled job '{}' failed due to an error during execution",
-            job.id
-        ))
+    if let Some(e) = stream_error {
+        Err(anyhow::anyhow!("Scheduled job '{}' failed: {}", job.id, e))
     } else {
         Ok(session.id)
     }

--- a/crates/goose/src/scheduler.rs
+++ b/crates/goose/src/scheduler.rs
@@ -1211,6 +1211,7 @@ async fn execute_job(
     #[cfg(feature = "telemetry")]
     {
         let duration_secs = start_time.elapsed().as_secs();
+        let status = if stream_error { "failed" } else { "completed" };
         tokio::spawn(async move {
             let mut props = HashMap::new();
             props.insert(
@@ -1219,7 +1220,7 @@ async fn execute_job(
             );
             props.insert(
                 "status".to_string(),
-                serde_json::Value::String("completed".to_string()),
+                serde_json::Value::String(status.to_string()),
             );
             props.insert(
                 "duration_seconds".to_string(),
@@ -1231,7 +1232,14 @@ async fn execute_job(
         });
     }
 
-    Ok(session.id)
+    if stream_error {
+        Err(anyhow!(
+            "Scheduled job '{}' failed due to an error during execution",
+            job.id
+        ))
+    } else {
+        Ok(session.id)
+    }
 }
 
 #[async_trait]

--- a/crates/goose/src/scheduler.rs
+++ b/crates/goose/src/scheduler.rs
@@ -1171,7 +1171,11 @@ async fn execute_job(
 
     {
         let session_duration = start_time.elapsed();
-        let exit_type = if stream_error.is_some() { "error" } else { "normal" };
+        let exit_type = if stream_error.is_some() {
+            "error"
+        } else {
+            "normal"
+        };
         let (total_tokens, message_count) = agent
             .config
             .session_manager
@@ -1211,7 +1215,11 @@ async fn execute_job(
     #[cfg(feature = "telemetry")]
     {
         let duration_secs = start_time.elapsed().as_secs();
-        let status = if stream_error.is_some() { "failed" } else { "completed" };
+        let status = if stream_error.is_some() {
+            "failed"
+        } else {
+            "completed"
+        };
         tokio::spawn(async move {
             let mut props = HashMap::new();
             props.insert(

--- a/ui/desktop/src/components/schedule/ScheduleDetailView.tsx
+++ b/ui/desktop/src/components/schedule/ScheduleDetailView.tsx
@@ -166,8 +166,6 @@ const ScheduleDetailView: React.FC<ScheduleDetailViewProps> = ({ scheduleId, onN
       if (result.status === 'completed' && result.sessionId) {
         toastSuccess({ title: intl.formatMessage(i18n.scheduleCompleted), msg: intl.formatMessage(i18n.completedSession, { sessionId: result.sessionId }) });
       }
-      await fetchSessions(scheduleId);
-      await fetchSchedule(scheduleId);
     } catch (err) {
       const errorMsg = errorMessage(err, 'Failed to trigger schedule');
       trackScheduleRunNow(false, getErrorType(err));
@@ -176,6 +174,8 @@ const ScheduleDetailView: React.FC<ScheduleDetailViewProps> = ({ scheduleId, onN
         msg: errorMsg,
       });
     } finally {
+      await fetchSessions(scheduleId);
+      await fetchSchedule(scheduleId);
       setIsActionLoading(false);
     }
   };


### PR DESCRIPTION
Fixes: #11051 

## Summary
When a scheduled recipe run fails mid-stream (provider errors, rate limits, network issues, etc), the failure was silently swallowed and reported as successful. This commit makes changes so the existing error propagation chain fires. Partial sessions are still persisted for inspection.

### Testing
`cargo build -p goose` - works