### PR TITLE
fix(desktop): pin FormatJS CLI for Intel macOS

### DIFF
--- a/ui/desktop/package.json
+++ b/ui/desktop/package.json
@@ -116,7 +116,7 @@
     "@electron-forge/plugin-vite": "^7.11.2",
     "@electron/fuses": "^2.1.3",
     "@eslint/js": "^10.0.1",
-    "@formatjs/cli": "^6.16.18",
+    "@formatjs/cli": "6.14.0",
     "@formatjs/icu-messageformat-parser": "3.5.16",
     "@modelcontextprotocol/sdk": "^1.30.0",
     "@playwright/test": "^1.62.1",

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -215,8 +215,8 @@ importers:
         specifier: ^10.0.1
         version: 10.0.1(eslint@9.39.4(jiti@2.7.0))
       '@formatjs/cli':
-        specifier: ^6.16.18
-        version: 6.16.18
+        specifier: 6.14.0
+        version: 6.14.0
       '@formatjs/icu-messageformat-parser':
         specifier: 3.5.16
         version: 3.5.16
@@ -716,7 +716,7 @@ packages:
     engines: {node: '>=22.12.0'}
 
   '@electron/node-gyp@https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2':
-    resolution: {gitHosted: true, tarball: https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2}
+    resolution: {tarball: https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2}
     version: 10.2.0-electron.1
     engines: {node: '>=12.13.0'}
     hasBin: true
@@ -1038,42 +1038,8 @@ packages:
   '@formatjs/bigdecimal@0.2.0':
     resolution: {integrity: sha512-GeaxHZbUoYvHL9tC5eltHLs+1zU70aPw0s7LwqgktIzF5oMhNY4o4deEtusJMsq7WFJF3Ye2zQEzdG8beVk73w==}
 
-  '@formatjs/cli-native-darwin-arm64@1.1.12':
-    resolution: {integrity: sha512-9RKHpBt/Fw+7AVjCsihATyOcC7aYnZJHdNg8Ud2K/yLZiSOfS1V/oSDPK47VCPh98HmclCI/O6tRq9KeXjZrhQ==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@formatjs/cli-native-linux-arm64-musl@1.0.10':
-    resolution: {integrity: sha512-e+C7cssp6RM7YzWoW6cK1dUzcbdDYCtUFI/0ALPU4qx2NI7AMMJCC/iqVwo6pk95T7YcjYYuSjCqm1ni+ZC/4g==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  '@formatjs/cli-native-linux-arm64@1.2.12':
-    resolution: {integrity: sha512-Ge4F8Td5n5bQ26sQlxN+DUa5iWkbxqZY9m+L8edudXEYAo2j9yMg+Y8mieBH+YwKexmBPQFSs9eYaGQYM6CzBw==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@formatjs/cli-native-linux-x64-musl@1.0.10':
-    resolution: {integrity: sha512-ZAYzdqsjv/rL8ntGl/iSmGjuOmEytxrktdsPsFFDeq3NN/LFiQn3LxPR3uLGOlLlN+pUhc8I3yFRgRjE59e1hw==}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@formatjs/cli-native-linux-x64@1.1.12':
-    resolution: {integrity: sha512-sOWoISoova0fDJLpdTYA7lVlIoODUGzoetSq2C+/XQzp/544tWgRlacf7u1dqIxnmYZuKIXmawr5p2trf67IaA==}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@formatjs/cli-native-win32-x64@1.1.13':
-    resolution: {integrity: sha512-5veGmXGU5qqEXA8AFUOAa64vXRtsLuxGFODBCdIRXWLvFiGCzn2CzGnPikdIyj2u1Gy9KdPVXkNdKmdzucKeuQ==}
-    cpu: [x64]
-    os: [win32]
-
-  '@formatjs/cli@6.16.18':
-    resolution: {integrity: sha512-+h3vsuYBTKEpSFZAEWnFuf1fK2a+Hyp0UtgeP5Hw33Lgm+N9veup+XVeT5CAJ21PoZSM/t21dTo4mUu36TEThg==}
+  '@formatjs/cli@6.14.0':
+    resolution: {integrity: sha512-5lqzAyAObZ8J8Ljtua8s4e5GKrPBu/lmuYN5ok5GgKUe+u+QwBPNlR3d2aYJpUbhgYuV8PXPHFXVPOwyhSR1uw==}
     engines: {node: '>= 20.12.0'}
     hasBin: true
     peerDependencies:
@@ -1081,9 +1047,9 @@ packages:
       '@glimmer/reference': '*'
       '@glimmer/syntax': ^0.84.3 || ^0.95.0
       '@glimmer/validator': '*'
-      '@vue/compiler-core': '3'
-      content-tag: '4'
-      vue: '3'
+      '@vue/compiler-core': ^3.5.0
+      content-tag: ^4.1.0
+      vue: ^3.5.0
     peerDependenciesMeta:
       '@glimmer/env':
         optional: true
@@ -3327,6 +3293,7 @@ packages:
   '@xmldom/xmldom@0.9.11':
     resolution: {integrity: sha512-tW8bcK3hsG0/uqSnNz6TK4BkcuZSezoU7DlnYssILmZDktPnSHHuDJJFM0AJv+13gz2r0iGdrj6qqKeUnxXEDg==}
     engines: {node: '>=14.6'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
@@ -8243,32 +8210,7 @@ snapshots:
 
   '@formatjs/bigdecimal@0.2.0': {}
 
-  '@formatjs/cli-native-darwin-arm64@1.1.12':
-    optional: true
-
-  '@formatjs/cli-native-linux-arm64-musl@1.0.10':
-    optional: true
-
-  '@formatjs/cli-native-linux-arm64@1.2.12':
-    optional: true
-
-  '@formatjs/cli-native-linux-x64-musl@1.0.10':
-    optional: true
-
-  '@formatjs/cli-native-linux-x64@1.1.12':
-    optional: true
-
-  '@formatjs/cli-native-win32-x64@1.1.13':
-    optional: true
-
-  '@formatjs/cli@6.16.18':
-    optionalDependencies:
-      '@formatjs/cli-native-darwin-arm64': 1.1.12
-      '@formatjs/cli-native-linux-arm64': 1.2.12
-      '@formatjs/cli-native-linux-arm64-musl': 1.0.10
-      '@formatjs/cli-native-linux-x64': 1.1.12
-      '@formatjs/cli-native-linux-x64-musl': 1.0.10
-      '@formatjs/cli-native-win32-x64': 1.1.13
+  '@formatjs/cli@6.14.0': {}
 
   '@formatjs/ecma402-abstract@3.2.0':
     dependencies:


### PR DESCRIPTION
## Summary

Pin `@formatjs/cli` to 6.14.0 to restore Intel macOS desktop packaging. Version 6.16.18 requires a native CLI binding but does not publish a Darwin x64 package, causing `i18n:compile` to fail with `Native @formatjs/cli-lib binding is unavailable`.

## Verification

- Regenerated `ui/pnpm-lock.yaml` with pnpm 10.30.3.
- Ran `pnpm install --frozen-lockfile` from `ui/`.
- Ran `pnpm --filter goose-app run i18n:compile` successfully.