### PR TITLE
chore: update canonical models json

### DIFF
--- a/crates/goose-provider-types/src/canonical/data/canonical_models.json
+++ b/crates/goose-provider-types/src/canonical/data/canonical_models.json
@@ -4285,7 +4285,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2024-09-30",
     "release_date": "2025-11-13",
     "last_updated": "2025-11-13",
@@ -4407,7 +4407,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2025-12-11",
     "last_updated": "2025-12-11",
@@ -4528,7 +4528,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-02-05",
     "last_updated": "2026-02-05",
@@ -4590,7 +4590,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-05",
     "last_updated": "2026-03-05",
@@ -4621,7 +4621,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-17",
     "last_updated": "2026-03-17",
@@ -4652,7 +4652,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-17",
     "last_updated": "2026-03-17",
@@ -6033,13 +6033,98 @@
     }
   },
   {
+    "id": "agnes/agnes-2.0-flash",
+    "name": "Agnes 2.0 Flash",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-05-25",
+    "last_updated": "2026-05-25",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 512000,
+      "output": 65536
+    }
+  },
+  {
+    "id": "agnes/agnes-2.5-flash",
+    "name": "Agnes 2.5 Flash",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-07",
+    "last_updated": "2026-07",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 512000,
+      "output": 65536
+    }
+  },
+  {
+    "id": "agnes/agnes-2.5-pro-alpha",
+    "name": "Agnes 2.5 Pro Alpha",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-07-24",
+    "last_updated": "2026-07-24",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.45,
+      "output": 0.9,
+      "cache_read": 0.0038
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 65536
+    }
+  },
+  {
     "id": "ai-router/gpt-5.4",
     "name": "GPT-5.4",
     "family": "gpt",
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-05",
     "last_updated": "2026-03-05",
@@ -8659,6 +8744,38 @@
     }
   },
   {
+    "id": "aixy/openai/gpt-4.1-mini",
+    "name": "GPT-4.1 mini",
+    "family": "gpt-mini",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-04",
+    "release_date": "2025-04-14",
+    "last_updated": "2025-04-14",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.4,
+      "output": 1.6,
+      "cache_read": 0.1
+    },
+    "limit": {
+      "context": 1047576,
+      "output": 32768
+    }
+  },
+  {
     "id": "aki-io/deepseek-v4-flash-0731-284b",
     "name": "DeepSeek V4 Flash 0731",
     "family": "deepseek-flash",
@@ -9283,8 +9400,8 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.86,
-      "output": 3.15
+      "input": 0.573,
+      "output": 2.58
     },
     "limit": {
       "context": 202752,
@@ -9311,8 +9428,8 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.87,
-      "output": 3.48,
+      "input": 0.825,
+      "output": 3.301,
       "cache_read": 0.17
     },
     "limit": {
@@ -10886,8 +11003,8 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.43,
-      "output": 2.58
+      "input": 0.172,
+      "output": 1.032
     },
     "limit": {
       "context": 262144,
@@ -16637,10 +16754,10 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.22,
-      "output": 1.32,
-      "cache_read": 0.022,
-      "cache_write": 0.275
+      "input": 0.2,
+      "output": 1.2,
+      "cache_read": 0.02,
+      "cache_write": 0.25
     },
     "limit": {
       "context": 1050000,
@@ -16670,10 +16787,10 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 5.5,
-      "output": 33.0,
-      "cache_read": 0.55,
-      "cache_write": 6.875
+      "input": 4.0,
+      "output": 20.0,
+      "cache_read": 0.4,
+      "cache_write": 5.0
     },
     "limit": {
       "context": 1050000,
@@ -16703,10 +16820,10 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 2.2,
-      "output": 13.2,
-      "cache_read": 0.22,
-      "cache_write": 2.75
+      "input": 2.0,
+      "output": 12.0,
+      "cache_read": 0.2,
+      "cache_write": 2.5
     },
     "limit": {
       "context": 1050000,
@@ -17699,7 +17816,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-05",
     "last_updated": "2026-06-01",
@@ -17812,10 +17929,10 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 5.5,
-      "output": 33.0,
-      "cache_read": 0.55,
-      "cache_write": 6.875
+      "input": 4.4,
+      "output": 22.0,
+      "cache_read": 0.44,
+      "cache_write": 5.5
     },
     "limit": {
       "context": 1050000,
@@ -17873,7 +17990,7 @@
         "text"
       ]
     },
-    "open_weights": false,
+    "open_weights": true,
     "cost": {
       "input": 0.15,
       "output": 0.6
@@ -17901,7 +18018,7 @@
         "text"
       ]
     },
-    "open_weights": false,
+    "open_weights": true,
     "cost": {
       "input": 0.15,
       "output": 0.6
@@ -17929,7 +18046,7 @@
         "text"
       ]
     },
-    "open_weights": false,
+    "open_weights": true,
     "cost": {
       "input": 0.07,
       "output": 0.3
@@ -17957,7 +18074,7 @@
         "text"
       ]
     },
-    "open_weights": false,
+    "open_weights": true,
     "cost": {
       "input": 0.07,
       "output": 0.3
@@ -17985,7 +18102,7 @@
         "text"
       ]
     },
-    "open_weights": false,
+    "open_weights": true,
     "cost": {
       "input": 0.15,
       "output": 0.6
@@ -18013,7 +18130,7 @@
         "text"
       ]
     },
-    "open_weights": false,
+    "open_weights": true,
     "cost": {
       "input": 0.07,
       "output": 0.2
@@ -20117,7 +20234,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2024-09-30",
     "release_date": "2025-11-13",
     "last_updated": "2025-11-13",
@@ -20144,7 +20261,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2025-12-11",
     "last_updated": "2025-12-11",
@@ -20171,7 +20288,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-05",
     "last_updated": "2026-03-05",
@@ -22428,7 +22545,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-05",
     "last_updated": "2026-03-05",
@@ -22460,7 +22577,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-17",
     "last_updated": "2026-03-17",
@@ -22492,7 +22609,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-17",
     "last_updated": "2026-03-17",
@@ -24725,7 +24842,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-05",
     "last_updated": "2026-03-05",
@@ -24757,7 +24874,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-17",
     "last_updated": "2026-03-17",
@@ -24789,7 +24906,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-17",
     "last_updated": "2026-03-17",
@@ -26486,6 +26603,35 @@
     }
   },
   {
+    "id": "baseten/zai-org/GLM-5.3-Flash",
+    "name": "GLM 5.3 Flash",
+    "family": "glm",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-08-26",
+    "last_updated": "2026-08-26",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.15,
+      "output": 0.5
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 131072
+    }
+  },
+  {
     "id": "berget/google/gemma-4-31B-it",
     "name": "Gemma 4 31B Instruct",
     "family": "gemma",
@@ -27777,6 +27923,35 @@
     }
   },
   {
+    "id": "cline-pass/cline-pass/glm-5.3",
+    "name": "GLM-5.3",
+    "family": "glm",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-08-14",
+    "last_updated": "2026-08-14",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.4,
+      "output": 4.4,
+      "cache_read": 0.26
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 131072
+    }
+  },
+  {
     "id": "cline-pass/cline-pass/kimi-k2.6",
     "name": "Kimi K2.6",
     "family": "kimi-k2",
@@ -27961,8 +28136,8 @@
       "cache_read": 0.06
     },
     "limit": {
-      "context": 512000,
-      "output": 128000
+      "context": 1048576,
+      "output": 512000
     }
   },
   {
@@ -28026,6 +28201,39 @@
     "limit": {
       "context": 1000000,
       "output": 64000
+    }
+  },
+  {
+    "id": "cline-pass/cline-pass/qwen3.8-max",
+    "name": "Qwen3.8 Max",
+    "family": "qwen",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-08-03",
+    "last_updated": "2026-08-03",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.0,
+      "output": 6.0,
+      "cache_read": 0.25,
+      "cache_write": 2.5
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 131072
     }
   },
   {
@@ -28171,6 +28379,159 @@
     }
   },
   {
+    "id": "cloudflare-ai-gateway/alibaba/qwen3-max",
+    "name": "Qwen3 Max",
+    "family": "qwen",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-04",
+    "release_date": "2025-09-23",
+    "last_updated": "2025-09-23",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.2,
+      "output": 6.0
+    },
+    "limit": {
+      "context": 262144,
+      "output": 65536
+    }
+  },
+  {
+    "id": "cloudflare-ai-gateway/alibaba/qwen3.5-397b-a17b",
+    "name": "Qwen3.5 397B-A17B",
+    "family": "qwen",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-02-15",
+    "last_updated": "2026-02-15",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.6,
+      "output": 3.6
+    },
+    "limit": {
+      "context": 262144,
+      "output": 65536
+    }
+  },
+  {
+    "id": "cloudflare-ai-gateway/alibaba/qwen3.7-max",
+    "name": "Qwen3.7 Max",
+    "family": "qwen",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-05-21",
+    "last_updated": "2026-05-21",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.25,
+      "output": 3.75,
+      "cache_read": 0.25
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 65536
+    }
+  },
+  {
+    "id": "cloudflare-ai-gateway/alibaba/qwen3.7-plus",
+    "name": "Qwen3.7 Plus",
+    "family": "qwen",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-04",
+    "release_date": "2026-06-02",
+    "last_updated": "2026-06-02",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.32,
+      "output": 1.28,
+      "cache_read": 0.064
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 64000
+    }
+  },
+  {
+    "id": "cloudflare-ai-gateway/alibaba/qwen3.8-max",
+    "name": "Qwen3.8 Max",
+    "family": "qwen",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-08-03",
+    "last_updated": "2026-08-03",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.0,
+      "output": 6.0,
+      "cache_read": 0.25
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 131072
+    }
+  },
+  {
     "id": "cloudflare-ai-gateway/anthropic/claude-fable-5",
     "name": "Claude Fable 5",
     "family": "claude-fable",
@@ -28179,7 +28540,7 @@
     "tool_call": true,
     "temperature": false,
     "knowledge": "2026-01-31",
-    "release_date": "2026-06-07",
+    "release_date": "2026-06-09",
     "last_updated": "2026-06-09",
     "modalities": {
       "input": [
@@ -28278,7 +28639,7 @@
     "tool_call": true,
     "temperature": true,
     "knowledge": "2025-05-31",
-    "release_date": "2026-02-04",
+    "release_date": "2026-02-05",
     "last_updated": "2026-03-13",
     "modalities": {
       "input": [
@@ -28311,7 +28672,7 @@
     "tool_call": true,
     "temperature": false,
     "knowledge": "2026-01-31",
-    "release_date": "2026-04-14",
+    "release_date": "2026-04-16",
     "last_updated": "2026-04-16",
     "modalities": {
       "input": [
@@ -28476,7 +28837,7 @@
     "tool_call": true,
     "temperature": false,
     "knowledge": "2026-01-31",
-    "release_date": "2026-06-29",
+    "release_date": "2026-06-30",
     "last_updated": "2026-06-30",
     "modalities": {
       "input": [
@@ -28501,16 +28862,16 @@
     }
   },
   {
-    "id": "cloudflare-ai-gateway/openai/gpt-3.5-turbo",
-    "name": "GPT-3.5-turbo",
-    "family": "gpt",
+    "id": "cloudflare-ai-gateway/deepseek/deepseek-v4-pro",
+    "name": "DeepSeek V4 Pro",
+    "family": "deepseek-thinking",
     "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
+    "reasoning": true,
+    "tool_call": true,
     "temperature": true,
-    "knowledge": "2021-09-01",
-    "release_date": "2023-03-01",
-    "last_updated": "2023-11-06",
+    "knowledge": "2025-05",
+    "release_date": "2026-04-24",
+    "last_updated": "2026-04-24",
     "modalities": {
       "input": [
         "text"
@@ -28519,74 +28880,46 @@
         "text"
       ]
     },
-    "open_weights": false,
+    "open_weights": true,
     "cost": {
-      "input": 0.5,
-      "output": 1.5,
-      "cache_read": 0.0
+      "input": 1.74,
+      "output": 3.48,
+      "cache_read": 0.145
     },
     "limit": {
-      "context": 16385,
-      "output": 4096
+      "context": 131072,
+      "output": 384000
     }
   },
   {
-    "id": "cloudflare-ai-gateway/openai/gpt-4",
-    "name": "GPT-4",
-    "family": "gpt",
+    "id": "cloudflare-ai-gateway/moonshotai/kimi-k3",
+    "name": "Kimi K3",
+    "family": "kimi-k3",
     "attachment": true,
-    "reasoning": false,
+    "reasoning": true,
     "tool_call": true,
-    "temperature": true,
-    "knowledge": "2023-11",
-    "release_date": "2023-11-06",
-    "last_updated": "2024-04-09",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 30.0,
-      "output": 60.0
-    },
-    "limit": {
-      "context": 8192,
-      "output": 8192
-    }
-  },
-  {
-    "id": "cloudflare-ai-gateway/openai/gpt-4-turbo",
-    "name": "GPT-4 Turbo",
-    "family": "gpt",
-    "attachment": true,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2023-12",
-    "release_date": "2023-11-06",
-    "last_updated": "2024-04-09",
+    "temperature": false,
+    "release_date": "2026-07-16",
+    "last_updated": "2026-07-16",
     "modalities": {
       "input": [
         "text",
-        "image"
+        "image",
+        "video"
       ],
       "output": [
         "text"
       ]
     },
-    "open_weights": false,
+    "open_weights": true,
     "cost": {
-      "input": 10.0,
-      "output": 30.0
+      "input": 3.0,
+      "output": 15.0,
+      "cache_read": 0.3
     },
     "limit": {
-      "context": 128000,
-      "output": 4096
+      "context": 1048576,
+      "output": 131072
     }
   },
   {
@@ -28680,7 +29013,7 @@
       "cache_read": 0.025
     },
     "limit": {
-      "context": 1047576,
+      "context": 1000000,
       "output": 32768
     }
   },
@@ -28775,7 +29108,7 @@
       "cache_read": 0.125
     },
     "limit": {
-      "context": 400000,
+      "context": 128000,
       "output": 128000
     }
   },
@@ -28806,7 +29139,7 @@
       "cache_read": 0.025
     },
     "limit": {
-      "context": 400000,
+      "context": 128000,
       "output": 128000
     }
   },
@@ -28837,38 +29170,8 @@
       "cache_read": 0.005
     },
     "limit": {
-      "context": 400000,
+      "context": 128000,
       "output": 128000
-    }
-  },
-  {
-    "id": "cloudflare-ai-gateway/openai/gpt-5-pro",
-    "name": "GPT-5 Pro",
-    "family": "gpt-pro",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": false,
-    "knowledge": "2024-09-30",
-    "release_date": "2025-10-06",
-    "last_updated": "2025-10-06",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 15.0,
-      "output": 120.0
-    },
-    "limit": {
-      "context": 400000,
-      "output": 272000
     }
   },
   {
@@ -28878,7 +29181,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2024-09-30",
     "release_date": "2025-11-13",
     "last_updated": "2025-11-13",
@@ -28898,195 +29201,8 @@
       "cache_read": 0.125
     },
     "limit": {
-      "context": 400000,
-      "output": 128000
-    }
-  },
-  {
-    "id": "cloudflare-ai-gateway/openai/gpt-5.2",
-    "name": "GPT-5.2",
-    "family": "gpt",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": false,
-    "knowledge": "2025-08-31",
-    "release_date": "2025-12-11",
-    "last_updated": "2025-12-11",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 1.75,
-      "output": 14.0,
-      "cache_read": 0.175
-    },
-    "limit": {
-      "context": 400000,
-      "output": 128000
-    }
-  },
-  {
-    "id": "cloudflare-ai-gateway/openai/gpt-5.2-chat",
-    "name": "GPT-5.2 Chat",
-    "family": "gpt-codex",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": false,
-    "knowledge": "2025-08-31",
-    "release_date": "2025-12-11",
-    "last_updated": "2025-12-11",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 1.75,
-      "output": 14.0,
-      "cache_read": 0.175
-    },
-    "limit": {
       "context": 128000,
-      "output": 16384
-    }
-  },
-  {
-    "id": "cloudflare-ai-gateway/openai/gpt-5.2-pro",
-    "name": "GPT-5.2 Pro",
-    "family": "gpt-pro",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": false,
-    "knowledge": "2025-08-31",
-    "release_date": "2025-12-11",
-    "last_updated": "2025-12-11",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 21.0,
-      "output": 168.0
-    },
-    "limit": {
-      "context": 400000,
       "output": 128000
-    }
-  },
-  {
-    "id": "cloudflare-ai-gateway/openai/gpt-5.3-chat",
-    "name": "GPT-5.3 Chat (latest)",
-    "family": "gpt",
-    "attachment": true,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-08-31",
-    "release_date": "2026-03-03",
-    "last_updated": "2026-03-03",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 1.75,
-      "output": 14.0,
-      "cache_read": 0.175
-    },
-    "limit": {
-      "context": 128000,
-      "output": 16384
-    }
-  },
-  {
-    "id": "cloudflare-ai-gateway/openai/gpt-5.3-codex",
-    "name": "GPT-5.3 Codex",
-    "family": "gpt-codex",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": false,
-    "knowledge": "2025-08-31",
-    "release_date": "2026-02-05",
-    "last_updated": "2026-02-05",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "pdf"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 1.75,
-      "output": 14.0,
-      "cache_read": 0.175
-    },
-    "limit": {
-      "context": 400000,
-      "output": 128000
-    }
-  },
-  {
-    "id": "cloudflare-ai-gateway/openai/gpt-5.3-codex-spark",
-    "name": "GPT-5.3 Codex Spark",
-    "family": "gpt-codex-spark",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": false,
-    "knowledge": "2025-08-31",
-    "release_date": "2026-02-05",
-    "last_updated": "2026-02-05",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "pdf"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 1.75,
-      "output": 14.0,
-      "cache_read": 0.175
-    },
-    "limit": {
-      "context": 128000,
-      "output": 32000
     }
   },
   {
@@ -29096,7 +29212,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-05",
     "last_updated": "2026-03-05",
@@ -29117,7 +29233,7 @@
       "cache_read": 0.25
     },
     "limit": {
-      "context": 1050000,
+      "context": 1000000,
       "output": 128000
     }
   },
@@ -29128,7 +29244,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-17",
     "last_updated": "2026-03-17",
@@ -29148,7 +29264,7 @@
       "cache_read": 0.075
     },
     "limit": {
-      "context": 400000,
+      "context": 128000,
       "output": 128000
     }
   },
@@ -29159,7 +29275,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-17",
     "last_updated": "2026-03-17",
@@ -29179,7 +29295,7 @@
       "cache_read": 0.02
     },
     "limit": {
-      "context": 400000,
+      "context": 128000,
       "output": 128000
     }
   },
@@ -29209,7 +29325,7 @@
       "output": 180.0
     },
     "limit": {
-      "context": 1050000,
+      "context": 1000000,
       "output": 128000
     }
   },
@@ -29237,11 +29353,10 @@
     "open_weights": false,
     "cost": {
       "input": 5.0,
-      "output": 30.0,
-      "cache_read": 0.5
+      "output": 30.0
     },
     "limit": {
-      "context": 1050000,
+      "context": 1000000,
       "output": 128000
     }
   },
@@ -29272,40 +29387,7 @@
       "output": 180.0
     },
     "limit": {
-      "context": 1050000,
-      "output": 128000
-    }
-  },
-  {
-    "id": "cloudflare-ai-gateway/openai/gpt-5.6",
-    "name": "GPT-5.6",
-    "family": "gpt-sol",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": false,
-    "knowledge": "2026-02-16",
-    "release_date": "2026-07-09",
-    "last_updated": "2026-07-09",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "pdf"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 5.0,
-      "output": 30.0,
-      "cache_read": 0.5,
-      "cache_write": 6.25
-    },
-    "limit": {
-      "context": 1050000,
+      "context": 1000000,
       "output": 128000
     }
   },
@@ -29365,10 +29447,10 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 5.0,
-      "output": 30.0,
-      "cache_read": 0.5,
-      "cache_write": 6.25
+      "input": 2.0,
+      "output": 10.0,
+      "cache_read": 0.25,
+      "cache_write": 3.125
     },
     "limit": {
       "context": 1050000,
@@ -29406,68 +29488,6 @@
     "limit": {
       "context": 1050000,
       "output": 128000
-    }
-  },
-  {
-    "id": "cloudflare-ai-gateway/openai/o1",
-    "name": "o1",
-    "family": "o",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": false,
-    "knowledge": "2023-09",
-    "release_date": "2024-12-05",
-    "last_updated": "2024-12-05",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "pdf"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 15.0,
-      "output": 60.0,
-      "cache_read": 7.5
-    },
-    "limit": {
-      "context": 200000,
-      "output": 100000
-    }
-  },
-  {
-    "id": "cloudflare-ai-gateway/openai/o1-pro",
-    "name": "o1-pro",
-    "family": "o-pro",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": false,
-    "knowledge": "2023-09",
-    "release_date": "2025-03-19",
-    "last_updated": "2025-03-19",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 150.0,
-      "output": 600.0
-    },
-    "limit": {
-      "context": 200000,
-      "output": 100000
     }
   },
   {
@@ -29533,36 +29553,6 @@
     }
   },
   {
-    "id": "cloudflare-ai-gateway/openai/o3-pro",
-    "name": "o3-pro",
-    "family": "o-pro",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": false,
-    "knowledge": "2024-05",
-    "release_date": "2025-06-10",
-    "last_updated": "2025-06-10",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 20.0,
-      "output": 80.0
-    },
-    "limit": {
-      "context": 200000,
-      "output": 100000
-    }
-  },
-  {
     "id": "cloudflare-ai-gateway/openai/o4-mini",
     "name": "o4-mini",
     "family": "o-mini",
@@ -29594,71 +29584,108 @@
     }
   },
   {
-    "id": "cloudflare-ai-gateway/workers-ai/@cf/aisingapore/gemma-sea-lion-v4-27b-it",
-    "name": "Gemma Sea Lion V4 27B It",
-    "family": "gemma",
-    "attachment": false,
+    "id": "cloudflare-ai-gateway/xai/grok-4.20-0309-non-reasoning",
+    "name": "Grok 4.20 (Non-Reasoning)",
+    "family": "grok",
+    "attachment": true,
     "reasoning": false,
-    "tool_call": false,
+    "tool_call": true,
     "temperature": true,
-    "release_date": "2025-09-23",
-    "last_updated": "2025-09-23",
+    "release_date": "2026-03-09",
+    "last_updated": "2026-03-09",
     "modalities": {
       "input": [
-        "text"
+        "text",
+        "image",
+        "pdf"
       ],
       "output": [
         "text"
       ]
     },
-    "open_weights": true,
+    "open_weights": false,
     "cost": {
-      "input": 0.351,
-      "output": 0.555
+      "input": 2.0,
+      "output": 6.0,
+      "cache_read": 0.2
     },
     "limit": {
-      "context": 128000,
-      "output": 128000
+      "context": 2000000,
+      "output": 30000
     }
   },
   {
-    "id": "cloudflare-ai-gateway/workers-ai/@cf/deepseek-ai/deepseek-r1-distill-qwen-32b",
-    "name": "Deepseek R1 Distill Qwen 32B",
-    "family": "deepseek-thinking",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": false,
-    "temperature": true,
-    "release_date": "2025-01-20",
-    "last_updated": "2025-01-20",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.497,
-      "output": 4.881
-    },
-    "limit": {
-      "context": 80000,
-      "output": 80000
-    }
-  },
-  {
-    "id": "cloudflare-ai-gateway/workers-ai/@cf/google/gemma-4-26b-a4b-it",
-    "name": "Gemma 4 26B A4B IT",
-    "family": "gemma",
+    "id": "cloudflare-ai-gateway/xai/grok-4.20-0309-reasoning",
+    "name": "Grok 4.20 (Reasoning)",
+    "family": "grok",
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "release_date": "2026-04-02",
-    "last_updated": "2026-04-02",
+    "release_date": "2026-03-09",
+    "last_updated": "2026-03-09",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.0,
+      "output": 6.0,
+      "cache_read": 0.2
+    },
+    "limit": {
+      "context": 2000000,
+      "output": 30000
+    }
+  },
+  {
+    "id": "cloudflare-ai-gateway/xai/grok-4.3",
+    "name": "Grok 4.3",
+    "family": "grok",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-17",
+    "last_updated": "2026-04-17",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.25,
+      "output": 2.5,
+      "cache_read": 0.2
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 30000
+    }
+  },
+  {
+    "id": "cloudflare-ai-gateway/xai/grok-4.5",
+    "name": "Grok 4.5",
+    "family": "grok",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-07-08",
+    "last_updated": "2026-07-08",
     "modalities": {
       "input": [
         "text",
@@ -29668,84 +29695,28 @@
         "text"
       ]
     },
-    "open_weights": true,
+    "open_weights": false,
     "cost": {
-      "input": 0.1,
-      "output": 0.3
+      "input": 2.0,
+      "output": 6.0,
+      "cache_read": 0.3
     },
     "limit": {
-      "context": 256000,
-      "output": 16384
+      "context": 500000,
+      "output": 500000
     }
   },
   {
-    "id": "cloudflare-ai-gateway/workers-ai/@cf/ibm-granite/granite-4.0-h-micro",
-    "name": "Granite 4.0 H Micro",
-    "family": "granite",
-    "attachment": false,
-    "reasoning": false,
+    "id": "cloudflare-ai-gateway/xai/grok-4.6",
+    "name": "Grok 4.6",
+    "family": "grok",
+    "attachment": true,
+    "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "release_date": "2025-10-02",
-    "last_updated": "2025-10-02",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.017,
-      "output": 0.112
-    },
-    "limit": {
-      "context": 131000,
-      "output": 131000
-    }
-  },
-  {
-    "id": "cloudflare-ai-gateway/workers-ai/@cf/meta/llama-3.1-8b-instruct-fp8",
-    "name": "Llama 3.1 8B Instruct fp8",
-    "family": "llama",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "temperature": true,
-    "knowledge": "2023-12",
-    "release_date": "2024-07-23",
-    "last_updated": "2024-07-23",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.152,
-      "output": 0.287
-    },
-    "limit": {
-      "context": 32000,
-      "output": 32000
-    }
-  },
-  {
-    "id": "cloudflare-ai-gateway/workers-ai/@cf/meta/llama-3.2-11b-vision-instruct",
-    "name": "Llama 3.2 11B Vision Instruct",
-    "family": "llama",
-    "attachment": true,
-    "reasoning": false,
-    "tool_call": false,
-    "temperature": true,
-    "knowledge": "2023-12",
-    "release_date": "2024-09-25",
-    "last_updated": "2024-09-25",
+    "knowledge": "2026-02-01",
+    "release_date": "2026-08-12",
+    "last_updated": "2026-08-12",
     "modalities": {
       "input": [
         "text",
@@ -29755,478 +29726,15 @@
         "text"
       ]
     },
-    "open_weights": true,
+    "open_weights": false,
     "cost": {
-      "input": 0.0485,
-      "output": 0.676
+      "input": 2.0,
+      "output": 6.0,
+      "cache_read": 0.5
     },
     "limit": {
-      "context": 128000,
-      "output": 128000
-    }
-  },
-  {
-    "id": "cloudflare-ai-gateway/workers-ai/@cf/meta/llama-3.2-1b-instruct",
-    "name": "Llama 3.2 1B Instruct",
-    "family": "llama",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "temperature": true,
-    "knowledge": "2023-12",
-    "release_date": "2024-09-25",
-    "last_updated": "2024-09-25",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.027,
-      "output": 0.201
-    },
-    "limit": {
-      "context": 60000,
-      "output": 60000
-    }
-  },
-  {
-    "id": "cloudflare-ai-gateway/workers-ai/@cf/meta/llama-3.2-3b-instruct",
-    "name": "Llama 3.2 3B Instruct",
-    "family": "llama",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "temperature": true,
-    "knowledge": "2023-12",
-    "release_date": "2024-09-25",
-    "last_updated": "2024-09-25",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.0509,
-      "output": 0.335
-    },
-    "limit": {
-      "context": 80000,
-      "output": 80000
-    }
-  },
-  {
-    "id": "cloudflare-ai-gateway/workers-ai/@cf/meta/llama-3.3-70b-instruct-fp8-fast",
-    "name": "Llama 3.3 70B Instruct fp8 Fast",
-    "family": "llama",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2023-12",
-    "release_date": "2024-12-06",
-    "last_updated": "2024-12-06",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.293,
-      "output": 2.253
-    },
-    "limit": {
-      "context": 24000,
-      "output": 24000
-    }
-  },
-  {
-    "id": "cloudflare-ai-gateway/workers-ai/@cf/meta/llama-4-scout-17b-16e-instruct",
-    "name": "Llama 4 Scout 17B 16E Instruct",
-    "family": "llama",
-    "attachment": true,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-08",
-    "release_date": "2025-04-05",
-    "last_updated": "2025-04-05",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.27,
-      "output": 0.85
-    },
-    "limit": {
-      "context": 131000,
-      "output": 16384
-    }
-  },
-  {
-    "id": "cloudflare-ai-gateway/workers-ai/@cf/meta/llama-guard-3-8b",
-    "name": "Llama Guard 3 8B",
-    "family": "llama",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "temperature": true,
-    "knowledge": "2023-12",
-    "release_date": "2024-07-23",
-    "last_updated": "2024-07-23",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.484,
-      "output": 0.03
-    },
-    "limit": {
-      "context": 131072,
-      "output": 131072
-    }
-  },
-  {
-    "id": "cloudflare-ai-gateway/workers-ai/@cf/mistralai/mistral-small-3.1-24b-instruct",
-    "name": "Mistral Small 3.1 24B Instruct",
-    "family": "mistral-small",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-06",
-    "release_date": "2025-03-17",
-    "last_updated": "2025-03-17",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.351,
-      "output": 0.555
-    },
-    "limit": {
-      "context": 128000,
-      "output": 128000
-    }
-  },
-  {
-    "id": "cloudflare-ai-gateway/workers-ai/@cf/moonshotai/kimi-k2.6",
-    "name": "Kimi K2.6",
-    "family": "kimi-k2",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-01",
-    "release_date": "2026-04-21",
-    "last_updated": "2026-04-21",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.95,
-      "output": 4.0,
-      "cache_read": 0.16
-    },
-    "limit": {
-      "context": 262144,
-      "output": 256000
-    }
-  },
-  {
-    "id": "cloudflare-ai-gateway/workers-ai/@cf/moonshotai/kimi-k2.7-code",
-    "name": "Kimi K2.7 Code",
-    "family": "kimi-k2",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-01",
-    "release_date": "2026-06-12",
-    "last_updated": "2026-06-12",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.95,
-      "output": 4.0,
-      "cache_read": 0.19
-    },
-    "limit": {
-      "context": 262144,
-      "output": 262144
-    }
-  },
-  {
-    "id": "cloudflare-ai-gateway/workers-ai/@cf/nvidia/nemotron-3-120b-a12b",
-    "name": "Nemotron 3 Super 120B",
-    "family": "nemotron",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2026-03-11",
-    "last_updated": "2026-03-11",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.5,
-      "output": 1.5
-    },
-    "limit": {
-      "context": 256000,
-      "output": 256000
-    }
-  },
-  {
-    "id": "cloudflare-ai-gateway/workers-ai/@cf/openai/gpt-oss-120b",
-    "name": "GPT OSS 120B",
-    "family": "gpt-oss",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2025-08-05",
-    "last_updated": "2025-08-05",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.35,
-      "output": 0.75
-    },
-    "limit": {
-      "context": 128000,
-      "output": 16384
-    }
-  },
-  {
-    "id": "cloudflare-ai-gateway/workers-ai/@cf/openai/gpt-oss-20b",
-    "name": "GPT OSS 20B",
-    "family": "gpt-oss",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2025-08-05",
-    "last_updated": "2025-08-05",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.2,
-      "output": 0.3
-    },
-    "limit": {
-      "context": 128000,
-      "output": 16384
-    }
-  },
-  {
-    "id": "cloudflare-ai-gateway/workers-ai/@cf/qwen/qwen2.5-coder-32b-instruct",
-    "name": "Qwen2.5 Coder 32B Instruct",
-    "family": "qwen",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "temperature": true,
-    "release_date": "2024-11-12",
-    "last_updated": "2024-11-12",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.66,
-      "output": 1.0
-    },
-    "limit": {
-      "context": 32768,
-      "output": 32768
-    }
-  },
-  {
-    "id": "cloudflare-ai-gateway/workers-ai/@cf/qwen/qwen3-30b-a3b-fp8",
-    "name": "Qwen3 30B A3b fp8",
-    "family": "qwen",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2025-04-28",
-    "last_updated": "2025-04-28",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.0509,
-      "output": 0.335
-    },
-    "limit": {
-      "context": 32768,
-      "output": 32768
-    }
-  },
-  {
-    "id": "cloudflare-ai-gateway/workers-ai/@cf/qwen/qwq-32b",
-    "name": "Qwq 32B",
-    "family": "qwen",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": false,
-    "temperature": true,
-    "knowledge": "2024-04",
-    "release_date": "2025-03-05",
-    "last_updated": "2025-03-05",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.66,
-      "output": 1.0
-    },
-    "limit": {
-      "context": 24000,
-      "output": 24000
-    }
-  },
-  {
-    "id": "cloudflare-ai-gateway/workers-ai/@cf/zai-org/glm-4.7-flash",
-    "name": "GLM-4.7-Flash",
-    "family": "glm-flash",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-04",
-    "release_date": "2026-01-19",
-    "last_updated": "2026-01-19",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.0605,
-      "output": 0.4
-    },
-    "limit": {
-      "context": 131072,
-      "output": 131072
-    }
-  },
-  {
-    "id": "cloudflare-ai-gateway/workers-ai/@cf/zai-org/glm-5.2",
-    "name": "Glm 5.2",
-    "family": "glm",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2026-06-13",
-    "last_updated": "2026-06-13",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 1.4,
-      "output": 4.4,
-      "cache_read": 0.26
-    },
-    "limit": {
-      "context": 262144,
-      "output": 256000
+      "context": 500000,
+      "output": 500000
     }
   },
   {
@@ -30952,6 +30460,36 @@
     "limit": {
       "context": 262144,
       "output": 256000
+    }
+  },
+  {
+    "id": "cloudflare-workers-ai/@cf/zai-org/glm-5.3-flash",
+    "name": "Glm 5.3 Flash",
+    "family": "glm",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-08-26",
+    "last_updated": "2026-08-26",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.15,
+      "output": 0.5,
+      "cache_read": 0.03
+    },
+    "limit": {
+      "context": 1310720,
+      "output": 1310720
     }
   },
   {
@@ -32784,7 +32322,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2024-09-30",
     "release_date": "2025-11-13",
     "last_updated": "2025-11-13",
@@ -32816,7 +32354,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-05",
     "last_updated": "2026-03-05",
@@ -33710,8 +33248,9 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 1.671,
-      "output": 5.57
+      "input": 1.393,
+      "output": 7.13,
+      "cache_read": 0.139
     },
     "limit": {
       "context": 256000,
@@ -36065,7 +35604,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-05",
     "last_updated": "2026-03-05",
@@ -36097,7 +35636,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-17",
     "last_updated": "2026-03-17",
@@ -36129,7 +35668,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-17",
     "last_updated": "2026-03-17",
@@ -37283,7 +36822,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-05",
     "last_updated": "2026-03-05",
@@ -38030,7 +37569,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2024-09-30",
     "release_date": "2025-11-13",
     "last_updated": "2025-11-13",
@@ -38061,7 +37600,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2025-12-11",
     "last_updated": "2025-12-11",
@@ -38092,7 +37631,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-05",
     "last_updated": "2026-03-05",
@@ -38124,7 +37663,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-17",
     "last_updated": "2026-03-17",
@@ -38155,7 +37694,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-17",
     "last_updated": "2026-03-17",
@@ -38572,7 +38111,7 @@
     },
     "limit": {
       "context": 524288,
-      "output": 128000
+      "output": 512000
     }
   },
   {
@@ -40100,63 +39639,35 @@
     }
   },
   {
-    "id": "deepseek/deepseek-chat",
-    "name": "DeepSeek Chat",
-    "family": "deepseek",
-    "attachment": true,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-09",
-    "release_date": "2025-12-01",
-    "last_updated": "2026-02-28",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.14,
-      "output": 0.28,
-      "cache_read": 0.0028
-    },
-    "limit": {
-      "context": 1000000,
-      "output": 384000
-    }
-  },
-  {
-    "id": "deepseek/deepseek-reasoner",
-    "name": "DeepSeek Reasoner",
-    "family": "deepseek-thinking",
+    "id": "deepinfra/zai-org/GLM-5.3-Flash",
+    "name": "GLM-5.3-Flash",
+    "family": "glm",
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-09",
-    "release_date": "2025-12-01",
-    "last_updated": "2026-02-28",
+    "release_date": "2026-08-26",
+    "last_updated": "2026-08-26",
     "modalities": {
       "input": [
-        "text"
+        "text",
+        "image",
+        "video",
+        "pdf"
       ],
       "output": [
         "text"
       ]
     },
-    "open_weights": true,
+    "open_weights": false,
     "cost": {
-      "input": 0.14,
-      "output": 0.28,
-      "cache_read": 0.0028
+      "input": 0.15,
+      "output": 0.5,
+      "cache_read": 0.03
     },
     "limit": {
-      "context": 1000000,
-      "output": 384000
+      "context": 1048576,
+      "output": 131072
     }
   },
   {
@@ -42412,9 +41923,9 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.1,
-      "output": 0.6,
-      "cache_read": 0.01
+      "input": 0.2,
+      "output": 1.2,
+      "cache_read": 0.02
     },
     "limit": {
       "context": 1050000,
@@ -42443,9 +41954,9 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 2.0,
-      "output": 10.0,
-      "cache_read": 0.2
+      "input": 4.0,
+      "output": 20.0,
+      "cache_read": 0.4
     },
     "limit": {
       "context": 1050000,
@@ -42474,9 +41985,9 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 1.0,
-      "output": 6.0,
-      "cache_read": 0.1
+      "input": 2.0,
+      "output": 12.0,
+      "cache_read": 0.2
     },
     "limit": {
       "context": 1050000,
@@ -44351,7 +43862,39 @@
     "open_weights": true,
     "cost": {
       "input": 0.15001,
-      "output": 0.59997
+      "output": 0.59997,
+      "cache_read": 0.15001,
+      "cache_write": 0.15001
+    },
+    "limit": {
+      "context": 131072,
+      "output": 32768
+    }
+  },
+  {
+    "id": "edenai/databricks/databricks-gpt-oss-120b@eu",
+    "name": "GPT OSS 120B (EU)",
+    "family": "gpt-oss",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2025-08-05",
+    "last_updated": "2025-08-05",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.15001,
+      "output": 0.59997,
+      "cache_read": 0.15001,
+      "cache_write": 0.15001
     },
     "limit": {
       "context": 131072,
@@ -44379,7 +43922,39 @@
     "open_weights": true,
     "cost": {
       "input": 0.07,
-      "output": 0.30002
+      "output": 0.30002,
+      "cache_read": 0.07,
+      "cache_write": 0.07
+    },
+    "limit": {
+      "context": 131072,
+      "output": 32768
+    }
+  },
+  {
+    "id": "edenai/databricks/databricks-gpt-oss-20b@eu",
+    "name": "GPT OSS 20B (EU)",
+    "family": "gpt-oss",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2025-08-05",
+    "last_updated": "2025-08-05",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.07,
+      "output": 0.30002,
+      "cache_read": 0.07,
+      "cache_write": 0.07
     },
     "limit": {
       "context": 131072,
@@ -45037,36 +44612,6 @@
     }
   },
   {
-    "id": "edenai/deepseek/deepseek-reasoner",
-    "name": "DeepSeek Reasoner",
-    "family": "deepseek-thinking",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": false,
-    "temperature": true,
-    "knowledge": "2025-09",
-    "release_date": "2025-12-01",
-    "last_updated": "2026-02-28",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.28,
-      "output": 0.42,
-      "cache_read": 0.028
-    },
-    "limit": {
-      "context": 131072,
-      "output": 384000
-    }
-  },
-  {
     "id": "edenai/deepseek/deepseek-v4-flash",
     "name": "DeepSeek V4 Flash",
     "family": "deepseek-flash",
@@ -45363,35 +44908,6 @@
     }
   },
   {
-    "id": "edenai/flexai/DeepSeek-V4-Flash",
-    "name": "DeepSeek V4 Flash 0731",
-    "family": "deepseek-flash",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": false,
-    "temperature": true,
-    "knowledge": "2025-05",
-    "release_date": "2026-07-31",
-    "last_updated": "2026-07-31",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.08,
-      "output": 0.18
-    },
-    "limit": {
-      "context": 1000000,
-      "output": 384000
-    }
-  },
-  {
     "id": "edenai/flexai/Muse-Glimmer-30B",
     "name": "Muse Glimmer 30B",
     "family": "muse",
@@ -45474,7 +44990,7 @@
       "output": 0.18
     },
     "limit": {
-      "context": 1000000,
+      "context": 786432,
       "output": 384000
     }
   },
@@ -46222,8 +45738,8 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.75816,
-      "output": 0.75816
+      "input": 0.758485,
+      "output": 0.758485
     },
     "limit": {
       "context": 128000,
@@ -46250,8 +45766,8 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.17496,
-      "output": 0.75816
+      "input": 0.175035,
+      "output": 0.758485
     },
     "limit": {
       "context": 131072,
@@ -46283,7 +45799,7 @@
     },
     "limit": {
       "context": 204800,
-      "output": 128000
+      "output": 131072
     }
   },
   {
@@ -46401,7 +45917,7 @@
     },
     "limit": {
       "context": 524288,
-      "output": 128000
+      "output": 512000
     }
   },
   {
@@ -46455,8 +45971,9 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.4,
-      "output": 2.0
+      "input": 0.44,
+      "output": 2.2,
+      "cache_read": 0.044
     },
     "limit": {
       "context": 262144,
@@ -47270,7 +46787,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2024-09-30",
     "release_date": "2025-11-13",
     "last_updated": "2025-11-13",
@@ -47302,7 +46819,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2025-12-11",
     "last_updated": "2025-12-11",
@@ -47365,7 +46882,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-02-05",
     "last_updated": "2026-02-05",
@@ -47397,7 +46914,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-05",
     "last_updated": "2026-03-05",
@@ -47429,7 +46946,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-17",
     "last_updated": "2026-03-17",
@@ -47461,7 +46978,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-17",
     "last_updated": "2026-03-17",
@@ -47688,7 +47205,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-17",
     "last_updated": "2026-03-17",
@@ -48158,8 +47675,8 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.627,
-      "output": 1.881
+      "input": 0.5808,
+      "output": 1.7424
     },
     "limit": {
       "context": 1000000,
@@ -48407,6 +47924,35 @@
     }
   },
   {
+    "id": "edenai/qwen/qwen3-coder-next@eu",
+    "name": "Qwen3 Coder Next (EU)",
+    "family": "qwen",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-09",
+    "release_date": "2026-02-03",
+    "last_updated": "2026-02-03",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.3,
+      "output": 1.5
+    },
+    "limit": {
+      "context": 262144,
+      "output": 65536
+    }
+  },
+  {
     "id": "edenai/qwen/qwen3-coder-plus",
     "name": "Qwen3 Coder Plus",
     "family": "qwen",
@@ -48440,6 +47986,37 @@
   {
     "id": "edenai/qwen/qwen3-max",
     "name": "Qwen3 Max",
+    "family": "qwen",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-04",
+    "release_date": "2025-09-23",
+    "last_updated": "2025-09-23",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.2,
+      "output": 6.0,
+      "cache_read": 0.24,
+      "cache_write": 1.5
+    },
+    "limit": {
+      "context": 262144,
+      "output": 65536
+    }
+  },
+  {
+    "id": "edenai/qwen/qwen3-max@eu",
+    "name": "Qwen3 Max (EU)",
     "family": "qwen",
     "attachment": false,
     "reasoning": false,
@@ -48717,7 +48294,7 @@
     "family": "deepseek-flash",
     "attachment": false,
     "reasoning": true,
-    "tool_call": true,
+    "tool_call": false,
     "temperature": true,
     "knowledge": "2025-05",
     "release_date": "2026-07-31",
@@ -48732,8 +48309,8 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.46656,
-      "output": 0.93312
+      "input": 0.46676,
+      "output": 0.933521
     },
     "limit": {
       "context": 256000,
@@ -48746,7 +48323,7 @@
     "family": "gpt-oss",
     "attachment": false,
     "reasoning": true,
-    "tool_call": true,
+    "tool_call": false,
     "temperature": true,
     "release_date": "2025-08-05",
     "last_updated": "2025-08-05",
@@ -48760,8 +48337,8 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.17496,
-      "output": 0.69984
+      "input": 0.175035,
+      "output": 0.70014
     },
     "limit": {
       "context": 128000,
@@ -48774,7 +48351,7 @@
     "family": "llama",
     "attachment": false,
     "reasoning": false,
-    "tool_call": true,
+    "tool_call": false,
     "temperature": true,
     "knowledge": "2023-12",
     "release_date": "2024-12-06",
@@ -48789,8 +48366,8 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 1.04976,
-      "output": 1.04976
+      "input": 1.050211,
+      "output": 1.050211
     },
     "limit": {
       "context": 128000,
@@ -50238,6 +49815,37 @@
     }
   },
   {
+    "id": "edenai/zai/glm-5.3-flash",
+    "name": "GLM-5.3-Flash",
+    "family": "glm",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-08-26",
+    "last_updated": "2026-08-26",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.15,
+      "output": 0.5,
+      "cache_read": 0.03
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 131072
+    }
+  },
+  {
     "id": "edenai/zai/glm-5v-turbo",
     "name": "GLM-5V-Turbo",
     "family": "glm",
@@ -50619,6 +50227,38 @@
       "input": 1.4,
       "output": 4.4,
       "cache_read": 1.4
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 131072
+    }
+  },
+  {
+    "id": "empiriolabs/glm-5.3-flash",
+    "name": "GLM 5.3 Flash",
+    "family": "glm",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-08-26",
+    "last_updated": "2026-08-26",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.075,
+      "output": 0.25,
+      "cache_read": 0.075
     },
     "limit": {
       "context": 1000000,
@@ -51585,6 +51225,37 @@
     }
   },
   {
+    "id": "empiriolabs/qwen3-8-flash",
+    "name": "Qwen3.8 Flash",
+    "family": "qwen",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-08-26",
+    "last_updated": "2026-08-26",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.16,
+      "output": 0.47,
+      "cache_read": 0.16
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 131072
+    }
+  },
+  {
     "id": "empiriolabs/qwen3-8-max",
     "name": "Qwen3.8 Max",
     "family": "qwen",
@@ -51942,7 +51613,7 @@
     }
   },
   {
-    "id": "evroc/Qwen/Qwen3.6-35B-A3B-FP8",
+    "id": "evroc/Qwen/Qwen3.6-35B-A3B",
     "name": "Qwen3.6 35B-A3B",
     "family": "qwen",
     "attachment": true,
@@ -51970,6 +51641,35 @@
     "limit": {
       "context": 262144,
       "output": 65536
+    }
+  },
+  {
+    "id": "evroc/Qwen/Qwen3.8-27B",
+    "name": "Qwen3.8-27B",
+    "family": "qwen",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-08-14",
+    "last_updated": "2026-08-14",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.87,
+      "output": 3.5
+    },
+    "limit": {
+      "context": 262144,
+      "output": 262144
     }
   },
   {
@@ -53145,7 +52845,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-02-05",
     "last_updated": "2026-02-05",
@@ -53176,7 +52876,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-17",
     "last_updated": "2026-03-17",
@@ -53206,7 +52906,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-17",
     "last_updated": "2026-03-17",
@@ -54491,7 +54191,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-02-05",
     "last_updated": "2026-02-05",
@@ -54524,7 +54224,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-05",
     "last_updated": "2026-03-05",
@@ -54557,7 +54257,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-17",
     "last_updated": "2026-03-17",
@@ -56136,7 +55836,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2025-12-11",
     "last_updated": "2025-12-11",
@@ -56199,7 +55899,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-02-05",
     "last_updated": "2026-02-05",
@@ -56231,7 +55931,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-05",
     "last_updated": "2026-03-05",
@@ -56263,7 +55963,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-17",
     "last_updated": "2026-03-17",
@@ -56294,7 +55994,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-17",
     "last_updated": "2026-03-17",
@@ -57360,6 +57060,66 @@
     "limit": {
       "context": 1000000,
       "output": 64000
+    }
+  },
+  {
+    "id": "gmicloud/MiniMaxAI/MiniMax-M2.7",
+    "name": "MiniMax-M2.7",
+    "family": "minimax",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-03-18",
+    "last_updated": "2026-03-18",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.3,
+      "output": 1.2,
+      "cache_read": 0.06
+    },
+    "limit": {
+      "context": 196608,
+      "output": 131072
+    }
+  },
+  {
+    "id": "gmicloud/MiniMaxAI/MiniMax-M3",
+    "name": "MiniMax-M3",
+    "family": "minimax",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-06-01",
+    "last_updated": "2026-06-01",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.6,
+      "output": 2.4,
+      "cache_read": 0.12
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 512000
     }
   },
   {
@@ -65284,7 +65044,7 @@
     },
     "limit": {
       "context": 204800,
-      "output": 128000
+      "output": 131072
     }
   },
   {
@@ -65400,7 +65160,7 @@
     },
     "limit": {
       "context": 524288,
-      "output": 128000
+      "output": 512000
     }
   },
   {
@@ -66067,6 +65827,35 @@
     "limit": {
       "context": 262144,
       "output": 131072
+    }
+  },
+  {
+    "id": "huggingface/Qwen/Qwen3.8-27B",
+    "name": "Qwen3.8 27B",
+    "family": "qwen",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-08-14",
+    "last_updated": "2026-08-14",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.4,
+      "output": 3.0
+    },
+    "limit": {
+      "context": 262144,
+      "output": 32768
     }
   },
   {
@@ -67119,6 +66908,34 @@
     }
   },
   {
+    "id": "huggingface/zai-org/GLM-5.3-Flash",
+    "name": "GLM-5.3-Flash",
+    "family": "glm",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-08-26",
+    "last_updated": "2026-08-26",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.15,
+      "output": 0.5
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 131072
+    }
+  },
+  {
     "id": "hyper/deepseek-v4-flash",
     "name": "DeepSeek V4 Flash",
     "family": "deepseek-flash",
@@ -67198,9 +67015,9 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.11,
-      "output": 0.408,
-      "cache_write": 0.055
+      "input": 0.12,
+      "output": 0.42,
+      "cache_write": 0.06
     },
     "limit": {
       "context": 256000,
@@ -67227,9 +67044,9 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.86,
-      "output": 2.784,
-      "cache_write": 0.43
+      "input": 0.9,
+      "output": 2.804,
+      "cache_write": 0.45
     },
     "limit": {
       "context": 202752,
@@ -67256,9 +67073,9 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 1.332,
-      "output": 4.312,
-      "cache_write": 0.666
+      "input": 1.29,
+      "output": 4.22,
+      "cache_write": 0.645
     },
     "limit": {
       "context": 202750,
@@ -67467,9 +67284,9 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.598,
-      "output": 0.738,
-      "cache_write": 0.299
+      "input": 0.6066,
+      "output": 1.0386,
+      "cache_write": 0.3033
     },
     "limit": {
       "context": 128000,
@@ -67526,9 +67343,9 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.41,
-      "output": 1.52,
-      "cache_write": 0.205
+      "input": 0.408,
+      "output": 1.512,
+      "cache_write": 0.204
     },
     "limit": {
       "context": 262100,
@@ -67807,6 +67624,94 @@
     "limit": {
       "context": 1000000,
       "output": 64000
+    }
+  },
+  {
+    "id": "hyper/qwen3.8-2.4t-a95b",
+    "name": "Qwen3.8 2.4T A95B",
+    "family": "qwen",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-08-26",
+    "last_updated": "2026-08-26",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 2.0,
+      "output": 6.0,
+      "cache_read": 0.25
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "hyper/qwen3.8-27b",
+    "name": "Qwen3.8 27B",
+    "family": "qwen",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-08-26",
+    "last_updated": "2026-08-26",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.5,
+      "output": 3.0,
+      "cache_read": 0.1
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "hyper/qwen3.8-flash",
+    "name": "Qwen3.8 Flash",
+    "family": "qwen",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-08-26",
+    "last_updated": "2026-08-26",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.15,
+      "output": 0.47,
+      "cache_read": 0.016
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
     }
   },
   {
@@ -69429,7 +69334,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2024-09-30",
     "release_date": "2025-11-13",
     "last_updated": "2025-11-13",
@@ -69522,7 +69427,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2025-12-11",
     "last_updated": "2025-12-11",
@@ -69585,7 +69490,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-02-05",
     "last_updated": "2026-02-05",
@@ -69617,7 +69522,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-05",
     "last_updated": "2026-03-05",
@@ -69649,7 +69554,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-17",
     "last_updated": "2026-03-17",
@@ -69680,7 +69585,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-17",
     "last_updated": "2026-03-17",
@@ -70709,9 +70614,9 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.57,
-      "output": 3.41,
-      "cache_read": 0.2,
+      "input": 0.56,
+      "output": 3.39,
+      "cache_read": 0.17,
       "cache_write": 0.0
     },
     "limit": {
@@ -70741,9 +70646,9 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.67,
+      "input": 0.66,
       "output": 3.4,
-      "cache_read": 0.19,
+      "cache_read": 0.18,
       "cache_write": 0.0
     },
     "limit": {
@@ -70772,7 +70677,7 @@
     "open_weights": true,
     "cost": {
       "input": 0.75,
-      "output": 2.9,
+      "output": 2.4,
       "cache_read": 0.17,
       "cache_write": 0.0
     },
@@ -72219,6 +72124,37 @@
     }
   },
   {
+    "id": "iteracompute/iteracompute/qwen3.8-27b",
+    "name": "Qwen3.8 27B",
+    "family": "qwen",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-08-14",
+    "last_updated": "2026-08-14",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.35,
+      "output": 3.0,
+      "cache_read": 0.1
+    },
+    "limit": {
+      "context": 262144,
+      "output": 32768
+    }
+  },
+  {
     "id": "jalapeno/DeepSeek-V4-Flash",
     "name": "DeepSeek V4 Flash",
     "family": "deepseek-flash",
@@ -72479,7 +72415,7 @@
     },
     "limit": {
       "context": 524288,
-      "output": 128000
+      "output": 512000
     }
   },
   {
@@ -74923,7 +74859,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-17",
     "last_updated": "2026-03-17",
@@ -75486,8 +75422,8 @@
       "output": 0.0
     },
     "limit": {
-      "context": 512000,
-      "output": 128000
+      "context": 1048576,
+      "output": 512000
     }
   },
   {
@@ -75742,7 +75678,7 @@
     },
     "limit": {
       "context": 32768,
-      "output": 32768
+      "output": 29491
     }
   },
   {
@@ -75770,7 +75706,7 @@
     },
     "limit": {
       "context": 65536,
-      "output": 65536
+      "output": 58982
     }
   },
   {
@@ -76531,7 +76467,7 @@
     },
     "limit": {
       "context": 262144,
-      "output": 262144
+      "output": 235929
     }
   },
   {
@@ -76767,7 +76703,7 @@
     },
     "limit": {
       "context": 262144,
-      "output": 262144
+      "output": 235929
     }
   },
   {
@@ -77025,7 +76961,7 @@
     },
     "limit": {
       "context": 163840,
-      "output": 163840
+      "output": 147456
     }
   },
   {
@@ -77054,7 +76990,7 @@
     },
     "limit": {
       "context": 161000,
-      "output": 161000
+      "output": 144900
     }
   },
   {
@@ -77111,7 +77047,7 @@
     },
     "limit": {
       "context": 8192,
-      "output": 8192
+      "output": 7372
     }
   },
   {
@@ -77170,7 +77106,7 @@
     },
     "limit": {
       "context": 163840,
-      "output": 163840
+      "output": 147456
     }
   },
   {
@@ -77316,7 +77252,7 @@
     },
     "limit": {
       "context": 512000,
-      "output": 512000
+      "output": 460800
     }
   },
   {
@@ -77590,7 +77526,7 @@
       "cache_write": 0.375
     },
     "limit": {
-      "context": 65536,
+      "context": 131072,
       "output": 32768
     }
   },
@@ -77689,7 +77625,7 @@
     },
     "limit": {
       "context": 65536,
-      "output": 65536
+      "output": 58982
     }
   },
   {
@@ -77756,7 +77692,7 @@
     },
     "limit": {
       "context": 65536,
-      "output": 65536
+      "output": 58982
     }
   },
   {
@@ -78087,7 +78023,7 @@
     },
     "limit": {
       "context": 131072,
-      "output": 131072
+      "output": 117964
     }
   },
   {
@@ -78117,34 +78053,6 @@
     "limit": {
       "context": 131072,
       "output": 16384
-    }
-  },
-  {
-    "id": "kilo/google/gemma-3n-e4b-it",
-    "name": "Google: Gemma 3n 4B",
-    "family": "gemma",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "temperature": true,
-    "release_date": "2025-05-20",
-    "last_updated": "2025-05-20",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.06,
-      "output": 0.12
-    },
-    "limit": {
-      "context": 32768,
-      "output": 6554
     }
   },
   {
@@ -78199,13 +78107,13 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.08,
-      "output": 0.35,
-      "cache_read": 0.01
+      "input": 0.09,
+      "output": 0.34,
+      "cache_read": 0.05
     },
     "limit": {
       "context": 262144,
-      "output": 262144
+      "output": 16384
     }
   },
   {
@@ -78292,7 +78200,7 @@
     },
     "limit": {
       "context": 4096,
-      "output": 4096
+      "output": 3686
     }
   },
   {
@@ -78320,7 +78228,7 @@
     },
     "limit": {
       "context": 131000,
-      "output": 131000
+      "output": 117900
     }
   },
   {
@@ -78349,7 +78257,7 @@
     },
     "limit": {
       "context": 131072,
-      "output": 131072
+      "output": 117964
     }
   },
   {
@@ -78819,7 +78727,7 @@
     },
     "limit": {
       "context": 131072,
-      "output": 131072
+      "output": 117964
     }
   },
   {
@@ -78847,7 +78755,7 @@
     },
     "limit": {
       "context": 60000,
-      "output": 60000
+      "output": 54000
     }
   },
   {
@@ -78875,7 +78783,7 @@
     },
     "limit": {
       "context": 131072,
-      "output": 131072
+      "output": 117964
     }
   },
   {
@@ -78903,8 +78811,8 @@
       "output": 0.32
     },
     "limit": {
-      "context": 131072,
-      "output": 16384
+      "context": 128000,
+      "output": 115200
     }
   },
   {
@@ -78961,8 +78869,8 @@
       "output": 0.3
     },
     "limit": {
-      "context": 327680,
-      "output": 16384
+      "context": 131072,
+      "output": 8192
     }
   },
   {
@@ -79023,7 +78931,7 @@
     },
     "limit": {
       "context": 131072,
-      "output": 131072
+      "output": 117964
     }
   },
   {
@@ -79056,7 +78964,7 @@
     },
     "limit": {
       "context": 1048576,
-      "output": 1048576
+      "output": 943718
     }
   },
   {
@@ -79089,7 +78997,7 @@
     },
     "limit": {
       "context": 1048576,
-      "output": 1048576
+      "output": 943718
     }
   },
   {
@@ -79122,7 +79030,7 @@
     },
     "limit": {
       "context": 1048576,
-      "output": 1048576
+      "output": 943718
     }
   },
   {
@@ -79150,7 +79058,7 @@
     },
     "limit": {
       "context": 16384,
-      "output": 16384
+      "output": 14745
     }
   },
   {
@@ -79206,7 +79114,7 @@
     },
     "limit": {
       "context": 1000192,
-      "output": 1000192
+      "output": 900172
     }
   },
   {
@@ -79377,8 +79285,37 @@
       "cache_read": 0.06
     },
     "limit": {
-      "context": 196608,
+      "context": 204800,
       "output": 131072
+    }
+  },
+  {
+    "id": "kilo/minimax/minimax-m2.7:free",
+    "name": "MiniMax: MiniMax M2.7 (free)",
+    "family": "minimax",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-03-18",
+    "last_updated": "2026-03-18",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0,
+      "cache_read": 0.0
+    },
+    "limit": {
+      "context": 196608,
+      "output": 196608
     }
   },
   {
@@ -79413,6 +79350,36 @@
     }
   },
   {
+    "id": "kilo/minimax/minimax-m3:free",
+    "name": "MiniMax: MiniMax M3 (free)",
+    "family": "minimax",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-06-01",
+    "last_updated": "2026-06-01",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0,
+      "cache_read": 0.0
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 1048576
+    }
+  },
+  {
     "id": "kilo/mistralai/codestral",
     "name": "Mistral: Codestral 2508",
     "family": "codestral",
@@ -79439,7 +79406,7 @@
     },
     "limit": {
       "context": 256000,
-      "output": 51200
+      "output": 204800
     }
   },
   {
@@ -79470,7 +79437,7 @@
     },
     "limit": {
       "context": 262144,
-      "output": 262144
+      "output": 209715
     }
   },
   {
@@ -79500,7 +79467,7 @@
     },
     "limit": {
       "context": 262144,
-      "output": 52429
+      "output": 209715
     }
   },
   {
@@ -79530,7 +79497,7 @@
     },
     "limit": {
       "context": 131072,
-      "output": 32768
+      "output": 104857
     }
   },
   {
@@ -79558,7 +79525,7 @@
     },
     "limit": {
       "context": 128000,
-      "output": 128000
+      "output": 102400
     }
   },
   {
@@ -79588,7 +79555,7 @@
     },
     "limit": {
       "context": 128000,
-      "output": 25600
+      "output": 102400
     }
   },
   {
@@ -79619,7 +79586,7 @@
     },
     "limit": {
       "context": 131072,
-      "output": 26215
+      "output": 104857
     }
   },
   {
@@ -79650,7 +79617,7 @@
     },
     "limit": {
       "context": 131072,
-      "output": 26215
+      "output": 104857
     }
   },
   {
@@ -79680,7 +79647,7 @@
     },
     "limit": {
       "context": 262144,
-      "output": 262144
+      "output": 209715
     }
   },
   {
@@ -79740,7 +79707,7 @@
     },
     "limit": {
       "context": 32768,
-      "output": 32768
+      "output": 26214
     }
   },
   {
@@ -79771,7 +79738,7 @@
     },
     "limit": {
       "context": 262144,
-      "output": 262144
+      "output": 209715
     }
   },
   {
@@ -79828,7 +79795,7 @@
     },
     "limit": {
       "context": 128000,
-      "output": 128000
+      "output": 102400
     }
   },
   {
@@ -79888,7 +79855,7 @@
     },
     "limit": {
       "context": 65536,
-      "output": 13108
+      "output": 52428
     }
   },
   {
@@ -79919,7 +79886,7 @@
     },
     "limit": {
       "context": 32000,
-      "output": 6400
+      "output": 25600
     }
   },
   {
@@ -80008,7 +79975,7 @@
     },
     "limit": {
       "context": 262144,
-      "output": 262144
+      "output": 235929
     }
   },
   {
@@ -80039,7 +80006,7 @@
     },
     "limit": {
       "context": 262144,
-      "output": 262144
+      "output": 235929
     }
   },
   {
@@ -80070,7 +80037,7 @@
     },
     "limit": {
       "context": 262144,
-      "output": 262144
+      "output": 235929
     }
   },
   {
@@ -80101,7 +80068,7 @@
     },
     "limit": {
       "context": 1048576,
-      "output": 1048576
+      "output": 943718
     }
   },
   {
@@ -80187,7 +80154,7 @@
     },
     "limit": {
       "context": 262144,
-      "output": 262144
+      "output": 235929
     }
   },
   {
@@ -80217,7 +80184,7 @@
     },
     "limit": {
       "context": 262144,
-      "output": 262144
+      "output": 235929
     }
   },
   {
@@ -80301,7 +80268,7 @@
     },
     "limit": {
       "context": 131072,
-      "output": 26215
+      "output": 117964
     }
   },
   {
@@ -80329,7 +80296,7 @@
     },
     "limit": {
       "context": 131072,
-      "output": 131072
+      "output": 117964
     }
   },
   {
@@ -80358,7 +80325,7 @@
     },
     "limit": {
       "context": 262144,
-      "output": 262144
+      "output": 228000
     }
   },
   {
@@ -80445,7 +80412,7 @@
     },
     "limit": {
       "context": 262144,
-      "output": 262144
+      "output": 235929
     }
   },
   {
@@ -80474,7 +80441,7 @@
     },
     "limit": {
       "context": 512288,
-      "output": 512288
+      "output": 461059
     }
   },
   {
@@ -80676,7 +80643,7 @@
     },
     "limit": {
       "context": 4095,
-      "output": 4096
+      "output": 3685
     }
   },
   {
@@ -81977,7 +81944,7 @@
     },
     "limit": {
       "context": 131072,
-      "output": 131072
+      "output": 117964
     }
   },
   {
@@ -82000,13 +81967,12 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.03,
-      "output": 0.13,
-      "cache_read": 0.03
+      "input": 0.02,
+      "output": 0.1
     },
     "limit": {
       "context": 131072,
-      "output": 131072
+      "output": 117964
     }
   },
   {
@@ -82456,7 +82422,7 @@
     },
     "limit": {
       "context": 127072,
-      "output": 25415
+      "output": 114364
     }
   },
   {
@@ -82484,7 +82450,7 @@
     },
     "limit": {
       "context": 128000,
-      "output": 25600
+      "output": 115200
     }
   },
   {
@@ -82571,7 +82537,7 @@
     },
     "limit": {
       "context": 128000,
-      "output": 25600
+      "output": 115200
     }
   },
   {
@@ -82741,7 +82707,7 @@
     },
     "limit": {
       "context": 32768,
-      "output": 32768
+      "output": 29491
     }
   },
   {
@@ -82769,7 +82735,7 @@
     },
     "limit": {
       "context": 32768,
-      "output": 32768
+      "output": 29491
     }
   },
   {
@@ -82804,34 +82770,6 @@
     }
   },
   {
-    "id": "kilo/qwen/qwen-plus-2025-07-28:thinking",
-    "name": "Qwen: Qwen Plus 0728 (thinking)",
-    "family": "qwen",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2025-09-08",
-    "last_updated": "2025-09-08",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.26,
-      "output": 0.78
-    },
-    "limit": {
-      "context": 1000000,
-      "output": 32768
-    }
-  },
-  {
     "id": "kilo/qwen/qwen2.5-vl-72b-instruct",
     "name": "Qwen: Qwen2.5 VL 72B Instruct",
     "family": "qwen",
@@ -82852,13 +82790,12 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.8,
-      "output": 1.0,
-      "cache_read": 0.4
+      "input": 0.25,
+      "output": 0.75
     },
     "limit": {
-      "context": 128000,
-      "output": 128000
+      "context": 32000,
+      "output": 28800
     }
   },
   {
@@ -82943,7 +82880,7 @@
     },
     "limit": {
       "context": 131072,
-      "output": 262144
+      "output": 117964
     }
   },
   {
@@ -83141,7 +83078,7 @@
     },
     "limit": {
       "context": 262144,
-      "output": 262144
+      "output": 235929
     }
   },
   {
@@ -83201,7 +83138,7 @@
     },
     "limit": {
       "context": 262144,
-      "output": 262144
+      "output": 235929
     }
   },
   {
@@ -83320,7 +83257,7 @@
     },
     "limit": {
       "context": 262144,
-      "output": 262144
+      "output": 235929
     }
   },
   {
@@ -83584,7 +83521,7 @@
     },
     "limit": {
       "context": 262144,
-      "output": 262144
+      "output": 235929
     }
   },
   {
@@ -83644,7 +83581,7 @@
     },
     "limit": {
       "context": 262144,
-      "output": 262144
+      "output": 235929
     }
   },
   {
@@ -83674,7 +83611,7 @@
     },
     "limit": {
       "context": 262144,
-      "output": 262144
+      "output": 65536
     }
   },
   {
@@ -83704,7 +83641,7 @@
     },
     "limit": {
       "context": 262144,
-      "output": 262144
+      "output": 235929
     }
   },
   {
@@ -83825,7 +83762,7 @@
     },
     "limit": {
       "context": 262144,
-      "output": 81920
+      "output": 235929
     }
   },
   {
@@ -83850,13 +83787,13 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.14,
-      "output": 1.0,
+      "input": 0.1,
+      "output": 0.9,
       "cache_read": 0.05
     },
     "limit": {
       "context": 262144,
-      "output": 262144
+      "output": 235929
     }
   },
   {
@@ -84104,7 +84041,39 @@
       "cache_write": 0.53125
     },
     "limit": {
-      "context": 262144,
+      "context": 1000000,
+      "output": 131072
+    }
+  },
+  {
+    "id": "kilo/qwen/qwen3.8-flash",
+    "name": "Qwen3.8 Flash",
+    "family": "qwen",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-08-26",
+    "last_updated": "2026-08-26",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.15,
+      "output": 0.47,
+      "cache_read": 0.016,
+      "cache_write": 0.2
+    },
+    "limit": {
+      "context": 1000000,
       "output": 131072
     }
   },
@@ -84167,7 +84136,7 @@
     },
     "limit": {
       "context": 16384,
-      "output": 16384
+      "output": 14745
     }
   },
   {
@@ -84195,7 +84164,7 @@
     },
     "limit": {
       "context": 65536,
-      "output": 65536
+      "output": 58982
     }
   },
   {
@@ -84338,7 +84307,7 @@
     },
     "limit": {
       "context": 8192,
-      "output": 16384
+      "output": 7372
     }
   },
   {
@@ -84526,36 +84495,6 @@
     }
   },
   {
-    "id": "kilo/stealth/ox-alpha",
-    "name": "Ox Alpha",
-    "family": "alpha",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2026-08-20",
-    "last_updated": "2026-08-20",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "video"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.0,
-      "output": 0.0
-    },
-    "limit": {
-      "context": 1048576,
-      "output": 131072
-    }
-  },
-  {
     "id": "kilo/stealth/qwen3.6-plus",
     "name": "Stealth: Qwen3.6 Plus (50% off)",
     "family": "qwen3.6",
@@ -84642,7 +84581,7 @@
     },
     "limit": {
       "context": 256000,
-      "output": 256000
+      "output": 230400
     }
   },
   {
@@ -84700,7 +84639,7 @@
     },
     "limit": {
       "context": 131072,
-      "output": 131072
+      "output": 117964
     }
   },
   {
@@ -84842,7 +84781,7 @@
     },
     "limit": {
       "context": 262144,
-      "output": 262144
+      "output": 235929
     }
   },
   {
@@ -84899,7 +84838,7 @@
     },
     "limit": {
       "context": 131072,
-      "output": 131072
+      "output": 117964
     }
   },
   {
@@ -84926,7 +84865,7 @@
     },
     "limit": {
       "context": 65536,
-      "output": 65536
+      "output": 58982
     }
   },
   {
@@ -84954,7 +84893,7 @@
     },
     "limit": {
       "context": 32768,
-      "output": 32768
+      "output": 29491
     }
   },
   {
@@ -84981,7 +84920,7 @@
     },
     "limit": {
       "context": 32768,
-      "output": 32768
+      "output": 26214
     }
   },
   {
@@ -85159,7 +85098,7 @@
     },
     "limit": {
       "context": 131072,
-      "output": 131072
+      "output": 117964
     }
   },
   {
@@ -85247,7 +85186,7 @@
     },
     "limit": {
       "context": 2000000,
-      "output": 2000000
+      "output": 1800000
     }
   },
   {
@@ -85278,7 +85217,7 @@
     },
     "limit": {
       "context": 2000000,
-      "output": 2000000
+      "output": 1800000
     }
   },
   {
@@ -85309,7 +85248,7 @@
     },
     "limit": {
       "context": 1000000,
-      "output": 4096
+      "output": 900000
     }
   },
   {
@@ -85340,7 +85279,7 @@
     },
     "limit": {
       "context": 500000,
-      "output": 500000
+      "output": 450000
     }
   },
   {
@@ -85372,7 +85311,7 @@
     },
     "limit": {
       "context": 500000,
-      "output": 500000
+      "output": 450000
     }
   },
   {
@@ -85403,7 +85342,7 @@
     },
     "limit": {
       "context": 256000,
-      "output": 256000
+      "output": 230400
     }
   },
   {
@@ -85581,13 +85520,13 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.5,
-      "output": 2.0,
-      "cache_read": 0.1
+      "input": 0.43,
+      "output": 1.75,
+      "cache_read": 0.08
     },
     "limit": {
-      "context": 202752,
-      "output": 131072
+      "context": 198000,
+      "output": 16384
     }
   },
   {
@@ -85766,7 +85705,7 @@
     },
     "limit": {
       "context": 202752,
-      "output": 202752
+      "output": 182476
     }
   },
   {
@@ -85821,6 +85760,37 @@
       "input": 1.4,
       "output": 4.4,
       "cache_read": 0.26
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 131072
+    }
+  },
+  {
+    "id": "kilo/z-ai/glm-5.3-flash",
+    "name": "GLM-5.3-Flash",
+    "family": "glm",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-08-26",
+    "last_updated": "2026-08-26",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.075,
+      "output": 0.25,
+      "cache_read": 0.015
     },
     "limit": {
       "context": 1048576,
@@ -86007,13 +85977,13 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.035,
-      "output": 0.12,
-      "cache_read": 0.01
+      "input": 0.03,
+      "output": 0.1,
+      "cache_read": 0.007
     },
     "limit": {
       "context": 1048576,
-      "output": 1048576
+      "output": 131072
     }
   },
   {
@@ -86106,13 +86076,13 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 2.6,
-      "output": 13.0,
-      "cache_read": 0.29
+      "input": 2.55,
+      "output": 12.75,
+      "cache_read": 0.256
     },
     "limit": {
-      "context": 974842,
-      "output": 974842
+      "context": 1048576,
+      "output": 943718
     }
   },
   {
@@ -86206,7 +86176,7 @@
     },
     "limit": {
       "context": 500000,
-      "output": 500000
+      "output": 450000
     }
   },
   {
@@ -88827,7 +88797,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2024-09-30",
     "release_date": "2025-11-13",
     "last_updated": "2025-11-13",
@@ -88919,7 +88889,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2025-12-11",
     "last_updated": "2025-12-11",
@@ -89012,7 +88982,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-02-05",
     "last_updated": "2026-02-05",
@@ -89044,7 +89014,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-05",
     "last_updated": "2026-03-05",
@@ -89076,7 +89046,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-17",
     "last_updated": "2026-03-17",
@@ -89107,7 +89077,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-17",
     "last_updated": "2026-03-17",
@@ -89466,9 +89436,9 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.14,
-      "output": 0.28,
-      "cache_read": 0.028
+      "input": 0.44,
+      "output": 1.32,
+      "cache_read": 0.044
     },
     "limit": {
       "context": 1048576,
@@ -89496,9 +89466,9 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 1.69,
-      "output": 3.38,
-      "cache_read": 0.14
+      "input": 1.32,
+      "output": 3.96,
+      "cache_read": 0.132
     },
     "limit": {
       "context": 1048576,
@@ -89582,6 +89552,35 @@
       ]
     },
     "open_weights": true,
+    "cost": {
+      "input": 1.4,
+      "output": 4.4,
+      "cache_read": 0.26
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 131072
+    }
+  },
+  {
+    "id": "llmgateway-providers/baidu/glm-5.3",
+    "name": "GLM-5.3 (Baidu)",
+    "family": "glm",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-08-14",
+    "last_updated": "2026-08-14",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
     "cost": {
       "input": 1.4,
       "output": 4.4,
@@ -90218,6 +90217,36 @@
     }
   },
   {
+    "id": "llmgateway-providers/consensusprotocol/deepseek-v4-flash",
+    "name": "DeepSeek V4 Flash (Consensus Protocol)",
+    "family": "deepseek-flash",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-05",
+    "release_date": "2026-04-24",
+    "last_updated": "2026-04-24",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.13,
+      "output": 0.27,
+      "cache_read": 0.02
+    },
+    "limit": {
+      "context": 524288,
+      "output": 393216
+    }
+  },
+  {
     "id": "llmgateway-providers/deepinfra/deepseek-v3.2",
     "name": "DeepSeek V3.2 (DeepInfra)",
     "family": "deepseek",
@@ -90693,6 +90722,36 @@
     }
   },
   {
+    "id": "llmgateway-providers/deepseek/deepseek-v4-flash-vision-exp",
+    "name": "DeepSeek V4 Flash Vision Exp (DeepSeek)",
+    "family": "deepseek-flash",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-08-21",
+    "last_updated": "2026-08-21",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.14,
+      "output": 0.28,
+      "cache_read": 0.0028
+    },
+    "limit": {
+      "context": 1050000,
+      "output": 393216
+    }
+  },
+  {
     "id": "llmgateway-providers/deepseek/deepseek-v4-pro",
     "name": "DeepSeek V4 Pro (DeepSeek)",
     "family": "deepseek-thinking",
@@ -91132,9 +91191,9 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.075,
-      "output": 0.175,
-      "cache_read": 0.0155
+      "input": 0.051,
+      "output": 0.104,
+      "cache_read": 0.0097
     },
     "limit": {
       "context": 390000,
@@ -93250,7 +93309,7 @@
     },
     "limit": {
       "context": 1048576,
-      "output": 128000
+      "output": 512000
     }
   },
   {
@@ -95182,7 +95241,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2024-09-30",
     "release_date": "2025-11-13",
     "last_updated": "2025-11-13",
@@ -95213,7 +95272,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2025-12-11",
     "last_updated": "2025-12-11",
@@ -95274,7 +95333,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-02-05",
     "last_updated": "2026-02-05",
@@ -95306,7 +95365,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-05",
     "last_updated": "2026-03-05",
@@ -95338,7 +95397,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-17",
     "last_updated": "2026-03-17",
@@ -95369,7 +95428,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-17",
     "last_updated": "2026-03-17",
@@ -97870,6 +97929,35 @@
     }
   },
   {
+    "id": "llmgateway-providers/zai/glm-5.3-flash",
+    "name": "GLM-5.3 Flash (Z AI)",
+    "family": "glm",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-08-26",
+    "last_updated": "2026-08-26",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.15,
+      "output": 0.5,
+      "cache_read": 0.03
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 131072
+    }
+  },
+  {
     "id": "llmgateway/auto",
     "name": "Auto Route",
     "family": "auto",
@@ -98396,9 +98484,39 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.076,
-      "output": 0.153,
-      "cache_read": 0.014
+      "input": 0.051,
+      "output": 0.104,
+      "cache_read": 0.0097
+    },
+    "limit": {
+      "context": 1050000,
+      "output": 384000
+    }
+  },
+  {
+    "id": "llmgateway/deepseek-v4-flash-vision-exp",
+    "name": "DeepSeek V4 Flash Vision Exp",
+    "family": "deepseek-flash",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-08-21",
+    "last_updated": "2026-08-21",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.14,
+      "output": 0.28,
+      "cache_read": 0.0028
     },
     "limit": {
       "context": 1050000,
@@ -99495,7 +99613,39 @@
       "cache_read": 0.26
     },
     "limit": {
-      "context": 1000000,
+      "context": 1048576,
+      "output": 131072
+    }
+  },
+  {
+    "id": "llmgateway/glm-5.3-flash",
+    "name": "GLM-5.3-Flash",
+    "family": "glm",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-08-26",
+    "last_updated": "2026-08-26",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.15,
+      "output": 0.5,
+      "cache_read": 0.03
+    },
+    "limit": {
+      "context": 1048576,
       "output": 131072
     }
   },
@@ -99935,7 +100085,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2024-09-30",
     "release_date": "2025-11-13",
     "last_updated": "2025-11-13",
@@ -100028,7 +100178,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2025-12-11",
     "last_updated": "2025-12-11",
@@ -100121,7 +100271,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-02-05",
     "last_updated": "2026-02-05",
@@ -100153,7 +100303,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-05",
     "last_updated": "2026-03-05",
@@ -100185,7 +100335,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-17",
     "last_updated": "2026-03-17",
@@ -100216,7 +100366,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-17",
     "last_updated": "2026-03-17",
@@ -101533,7 +101683,7 @@
     },
     "limit": {
       "context": 196608,
-      "output": 128000
+      "output": 131072
     }
   },
   {
@@ -101740,7 +101890,7 @@
     },
     "limit": {
       "context": 1048576,
-      "output": 128000
+      "output": 512000
     }
   },
   {
@@ -103452,6 +103602,35 @@
     "limit": {
       "context": 128000,
       "output": 4096
+    }
+  },
+  {
+    "id": "llmtech/unsloth/Qwen3.8-27B-NVFP4",
+    "name": "Qwen3.8 27B",
+    "family": "qwen",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-08-14",
+    "last_updated": "2026-08-14",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.25,
+      "output": 2.09,
+      "cache_read": 0.04
+    },
+    "limit": {
+      "context": 262144,
+      "output": 32768
     }
   },
   {
@@ -107935,7 +108114,7 @@
     "attachment": true,
     "reasoning": false,
     "tool_call": false,
-    "temperature": true,
+    "temperature": false,
     "knowledge": "2024-09-30",
     "release_date": "2025-08-07",
     "last_updated": "2025-08-07",
@@ -108031,7 +108210,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2024-09-30",
     "release_date": "2025-11-13",
     "last_updated": "2025-11-13",
@@ -108095,7 +108274,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2025-12-11",
     "last_updated": "2025-12-11",
@@ -108191,7 +108370,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-05",
     "last_updated": "2026-03-05",
@@ -108223,7 +108402,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-17",
     "last_updated": "2026-03-17",
@@ -108255,7 +108434,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-17",
     "last_updated": "2026-03-17",
@@ -108367,8 +108546,8 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 4.0,
-      "output": 24.0,
+      "input": 5.0,
+      "output": 30.0,
       "cache_read": 0.5
     },
     "limit": {
@@ -108947,7 +109126,7 @@
   },
   {
     "id": "merge-gateway/qwen/qwen3-next-80b-a3b-instruct",
-    "name": "Qwen3 Next 80B A3B Instruct",
+    "name": "Qwen3-Next 80B-A3B Instruct",
     "family": "qwen",
     "attachment": false,
     "reasoning": false,
@@ -108977,7 +109156,7 @@
   },
   {
     "id": "merge-gateway/qwen/qwen3-next-80b-a3b-thinking",
-    "name": "Qwen3 Next 80B A3B Thinking",
+    "name": "Qwen3-Next 80B-A3B (Thinking)",
     "family": "qwen",
     "attachment": false,
     "reasoning": true,
@@ -109101,7 +109280,7 @@
     "id": "merge-gateway/qwen/qwen3.5-122b-a10b",
     "name": "Qwen3.5 122B A10B",
     "family": "qwen",
-    "attachment": true,
+    "attachment": false,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
@@ -109109,8 +109288,7 @@
     "last_updated": "2026-02-23",
     "modalities": {
       "input": [
-        "text",
-        "image"
+        "text"
       ],
       "output": [
         "text"
@@ -109123,8 +109301,8 @@
       "cache_read": 0.023
     },
     "limit": {
-      "context": 256000,
-      "output": 64000
+      "context": 131072,
+      "output": 32768
     }
   },
   {
@@ -109161,7 +109339,7 @@
     "id": "merge-gateway/qwen/qwen3.5-35b-a3b",
     "name": "Qwen3.5 35B A3B",
     "family": "qwen",
-    "attachment": true,
+    "attachment": false,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
@@ -109169,8 +109347,7 @@
     "last_updated": "2026-02-23",
     "modalities": {
       "input": [
-        "text",
-        "image"
+        "text"
       ],
       "output": [
         "text"
@@ -109183,15 +109360,15 @@
       "cache_read": 0.020357
     },
     "limit": {
-      "context": 256000,
-      "output": 64000
+      "context": 131072,
+      "output": 32768
     }
   },
   {
     "id": "merge-gateway/qwen/qwen3.5-397b-a17b",
     "name": "Qwen3.5 397B A17B",
     "family": "qwen",
-    "attachment": true,
+    "attachment": false,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
@@ -109199,8 +109376,7 @@
     "last_updated": "2026-02-15",
     "modalities": {
       "input": [
-        "text",
-        "image"
+        "text"
       ],
       "output": [
         "text"
@@ -109213,8 +109389,8 @@
       "cache_read": 0.0344
     },
     "limit": {
-      "context": 256000,
-      "output": 64000
+      "context": 131072,
+      "output": 32768
     }
   },
   {
@@ -110259,6 +110435,38 @@
     }
   },
   {
+    "id": "merge-gateway/zai/glm-5.3-flash",
+    "name": "GLM-5.3 Flash",
+    "family": "glm",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-08-26",
+    "last_updated": "2026-08-26",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.075,
+      "output": 0.25,
+      "cache_read": 0.015
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 131072
+    }
+  },
+  {
     "id": "meta-llama/cerebras-llama-4-maverick-17b-128e-instruct",
     "name": "Cerebras-Llama-4-Maverick-17B-128E-Instruct",
     "family": "llama",
@@ -110585,8 +110793,8 @@
       "output": 0.0
     },
     "limit": {
-      "context": 196608,
-      "output": 128000
+      "context": 204800,
+      "output": 131072
     }
   },
   {
@@ -110767,8 +110975,8 @@
       "cache_write": 0.0
     },
     "limit": {
-      "context": 1000000,
-      "output": 128000
+      "context": 1048576,
+      "output": 512000
     }
   },
   {
@@ -110795,8 +111003,8 @@
       "output": 1.2
     },
     "limit": {
-      "context": 196608,
-      "output": 128000
+      "context": 204800,
+      "output": 131072
     }
   },
   {
@@ -110976,8 +111184,8 @@
       "cache_read": 0.06
     },
     "limit": {
-      "context": 1000000,
-      "output": 128000
+      "context": 1048576,
+      "output": 512000
     }
   },
   {
@@ -111004,8 +111212,8 @@
       "output": 0.0
     },
     "limit": {
-      "context": 196608,
-      "output": 128000
+      "context": 204800,
+      "output": 131072
     }
   },
   {
@@ -111186,8 +111394,8 @@
       "cache_write": 0.0
     },
     "limit": {
-      "context": 1000000,
-      "output": 128000
+      "context": 1048576,
+      "output": 512000
     }
   },
   {
@@ -111214,8 +111422,8 @@
       "output": 1.2
     },
     "limit": {
-      "context": 196608,
-      "output": 128000
+      "context": 204800,
+      "output": 131072
     }
   },
   {
@@ -111395,8 +111603,8 @@
       "cache_read": 0.06
     },
     "limit": {
-      "context": 1000000,
-      "output": 128000
+      "context": 1048576,
+      "output": 512000
     }
   },
   {
@@ -112063,6 +112271,35 @@
     }
   },
   {
+    "id": "mistralai/zai-glm-5.2",
+    "name": "GLM-5.2",
+    "family": "glm",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-06-13",
+    "last_updated": "2026-06-13",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 1.4,
+      "output": 4.4,
+      "cache_read": 0.14
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 131072
+    }
+  },
+  {
     "id": "mixlayer/qwen/qwen3.5-122b-a10b",
     "name": "Qwen3.5 122B A10B",
     "family": "qwen",
@@ -112601,7 +112838,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-05",
     "last_updated": "2026-03-05",
@@ -112629,7 +112866,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-17",
     "last_updated": "2026-03-17",
@@ -112656,7 +112893,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-17",
     "last_updated": "2026-03-17",
@@ -114249,6 +114486,64 @@
     }
   },
   {
+    "id": "nano-gpt/Gemma-4-26B-A4B-MeroMero",
+    "name": "Gemma 4 26B A4B MeroMero",
+    "family": "gemma",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-08-26",
+    "last_updated": "2026-08-26",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.08,
+      "output": 0.33,
+      "cache_read": 0.04
+    },
+    "limit": {
+      "context": 262144,
+      "output": 32768
+    }
+  },
+  {
+    "id": "nano-gpt/Gemma-4-26B-A4B-MeroMero:thinking",
+    "name": "Gemma 4 26B A4B MeroMero Thinking",
+    "family": "gemma",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-08-26",
+    "last_updated": "2026-08-26",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.08,
+      "output": 0.33,
+      "cache_read": 0.04
+    },
+    "limit": {
+      "context": 262144,
+      "output": 32768
+    }
+  },
+  {
     "id": "nano-gpt/Gemma-4-31B-Claude-4.6-Opus-Reasoning-Distilled",
     "name": "Gemma 4 31B Claude 4.6 Opus Reasoning Distilled",
     "family": "claude",
@@ -114389,7 +114684,7 @@
       "cache_read": 0.04
     },
     "limit": {
-      "context": 65536,
+      "context": 262144,
       "output": 32768
     }
   },
@@ -114418,7 +114713,7 @@
       "cache_read": 0.04
     },
     "limit": {
-      "context": 65536,
+      "context": 262144,
       "output": 32768
     }
   },
@@ -115302,15 +115597,14 @@
     "id": "nano-gpt/TEE/gemma-4-26b-a4b-uncensored",
     "name": "Gemma 4 26B A4B Uncensored TEE",
     "family": "gemma",
-    "attachment": true,
+    "attachment": false,
     "reasoning": false,
     "tool_call": true,
     "release_date": "2026-05-23",
     "last_updated": "2026-05-23",
     "modalities": {
       "input": [
-        "text",
-        "image"
+        "text"
       ],
       "output": [
         "text"
@@ -116647,6 +116941,37 @@
     "limit": {
       "context": 991808,
       "output": 65536
+    }
+  },
+  {
+    "id": "nano-gpt/alibaba/qwen3.8-flash",
+    "name": "Qwen3.8 Flash",
+    "family": "qwen",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-08-26",
+    "last_updated": "2026-08-26",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.16,
+      "output": 0.47,
+      "cache_read": 0.016,
+      "cache_write": 0.2
+    },
+    "limit": {
+      "context": 991808,
+      "output": 131072
     }
   },
   {
@@ -118814,16 +119139,14 @@
   {
     "id": "nano-gpt/claw-high",
     "name": "Claw High",
-    "attachment": true,
+    "attachment": false,
     "reasoning": true,
     "tool_call": true,
     "release_date": "2026-05-11",
     "last_updated": "2026-05-11",
     "modalities": {
       "input": [
-        "text",
-        "image",
-        "pdf"
+        "text"
       ],
       "output": [
         "text"
@@ -118831,29 +119154,26 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 5.0,
-      "output": 25.0,
-      "cache_read": 2.5
+      "input": 1.4,
+      "output": 4.4,
+      "cache_read": 0.26
     },
     "limit": {
-      "context": 1000000,
-      "output": 128000
+      "context": 1048576,
+      "output": 131072
     }
   },
   {
     "id": "nano-gpt/claw-low",
     "name": "Claw Low",
-    "attachment": true,
+    "attachment": false,
     "reasoning": true,
     "tool_call": true,
     "release_date": "2026-05-11",
     "last_updated": "2026-05-11",
     "modalities": {
       "input": [
-        "text",
-        "image",
-        "video",
-        "pdf"
+        "text"
       ],
       "output": [
         "text"
@@ -118861,14 +119181,14 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.25,
-      "output": 1.5,
-      "cache_read": 0.025,
+      "input": 1.4,
+      "output": 4.4,
+      "cache_read": 0.26,
       "cache_write": 0.08333
     },
     "limit": {
       "context": 1048576,
-      "output": 65536
+      "output": 131072
     }
   },
   {
@@ -118889,12 +119209,12 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.315,
-      "output": 1.26,
-      "cache_read": 0.1575
+      "input": 1.4,
+      "output": 4.4,
+      "cache_read": 0.26
     },
     "limit": {
-      "context": 204800,
+      "context": 1048576,
       "output": 131072
     }
   },
@@ -122016,7 +122336,7 @@
       "cache_read": 0.04
     },
     "limit": {
-      "context": 131072,
+      "context": 262144,
       "output": 32768
     }
   },
@@ -122045,7 +122365,7 @@
       "cache_read": 0.04
     },
     "limit": {
-      "context": 131072,
+      "context": 262144,
       "output": 32768
     }
   },
@@ -122113,16 +122433,14 @@
     "id": "nano-gpt/hermes-high",
     "name": "Hermes High",
     "family": "hermes",
-    "attachment": true,
+    "attachment": false,
     "reasoning": true,
     "tool_call": true,
     "release_date": "2026-05-11",
     "last_updated": "2026-05-11",
     "modalities": {
       "input": [
-        "text",
-        "image",
-        "pdf"
+        "text"
       ],
       "output": [
         "text"
@@ -122130,30 +122448,27 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 5.0,
-      "output": 25.0,
-      "cache_read": 2.5
+      "input": 1.4,
+      "output": 4.4,
+      "cache_read": 0.26
     },
     "limit": {
-      "context": 1000000,
-      "output": 128000
+      "context": 1048576,
+      "output": 131072
     }
   },
   {
     "id": "nano-gpt/hermes-low",
     "name": "Hermes Low",
     "family": "hermes",
-    "attachment": true,
+    "attachment": false,
     "reasoning": true,
     "tool_call": true,
     "release_date": "2026-05-11",
     "last_updated": "2026-05-11",
     "modalities": {
       "input": [
-        "text",
-        "image",
-        "video",
-        "pdf"
+        "text"
       ],
       "output": [
         "text"
@@ -122161,14 +122476,14 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.25,
-      "output": 1.5,
-      "cache_read": 0.025,
+      "input": 1.4,
+      "output": 4.4,
+      "cache_read": 0.26,
       "cache_write": 0.08333
     },
     "limit": {
       "context": 1048576,
-      "output": 65536
+      "output": 131072
     }
   },
   {
@@ -122190,12 +122505,12 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.315,
-      "output": 1.26,
-      "cache_read": 0.1575
+      "input": 1.4,
+      "output": 4.4,
+      "cache_read": 0.26
     },
     "limit": {
-      "context": 204800,
+      "context": 1048576,
       "output": 131072
     }
   },
@@ -125651,7 +125966,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2024-09-30",
     "release_date": "2025-11-13",
     "last_updated": "2025-11-13",
@@ -125777,7 +126092,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2025-12-11",
     "last_updated": "2025-12-11",
@@ -125841,7 +126156,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-02-05",
     "last_updated": "2026-02-05",
@@ -125873,7 +126188,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-05",
     "last_updated": "2026-03-05",
@@ -125905,7 +126220,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-17",
     "last_updated": "2026-03-17",
@@ -125937,7 +126252,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-17",
     "last_updated": "2026-03-17",
@@ -126799,7 +127114,7 @@
       "cache_read": 0.025
     },
     "limit": {
-      "context": 131072,
+      "context": 262144,
       "output": 32768
     }
   },
@@ -126828,7 +127143,7 @@
       "cache_read": 0.025
     },
     "limit": {
-      "context": 131072,
+      "context": 262144,
       "output": 32768
     }
   },
@@ -128008,7 +128323,7 @@
       "cache_read": 0.075
     },
     "limit": {
-      "context": 65536,
+      "context": 262144,
       "output": 32768
     }
   },
@@ -128037,8 +128352,41 @@
       "cache_read": 0.075
     },
     "limit": {
-      "context": 65536,
+      "context": 262144,
       "output": 32768
+    }
+  },
+  {
+    "id": "nano-gpt/qwen/qwen3.8-2.4t-a95b",
+    "name": "Qwen3.8 2.4T A95B (Max)",
+    "family": "qwen",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-08-12",
+    "last_updated": "2026-08-12",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 2.0,
+      "output": 6.0,
+      "cache_read": 0.25,
+      "cache_write": 2.5
+    },
+    "limit": {
+      "context": 991000,
+      "output": 65536
     }
   },
   {
@@ -128079,6 +128427,64 @@
     "tool_call": true,
     "release_date": "2026-08-24",
     "last_updated": "2026-08-24",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.18,
+      "output": 0.5,
+      "cache_read": 0.075
+    },
+    "limit": {
+      "context": 262144,
+      "output": 32768
+    }
+  },
+  {
+    "id": "nano-gpt/qwen/qwen3.8-27b-uncensored",
+    "name": "Qwen 3.8 27B Uncensored",
+    "family": "qwen",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-08-21",
+    "last_updated": "2026-08-21",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.18,
+      "output": 0.5,
+      "cache_read": 0.075
+    },
+    "limit": {
+      "context": 262144,
+      "output": 32768
+    }
+  },
+  {
+    "id": "nano-gpt/qwen/qwen3.8-27b-uncensored:thinking",
+    "name": "Qwen 3.8 27B Uncensored Thinking",
+    "family": "qwen",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-08-25",
+    "last_updated": "2026-08-25",
     "modalities": {
       "input": [
         "text",
@@ -129385,35 +129791,6 @@
     }
   },
   {
-    "id": "nano-gpt/stealth/ox-alpha",
-    "name": "Ox Alpha",
-    "family": "alpha",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "release_date": "2026-08-21",
-    "last_updated": "2026-08-21",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.05,
-      "output": 0.05,
-      "cache_read": 0.025
-    },
-    "limit": {
-      "context": 1000000,
-      "output": 32768
-    }
-  },
-  {
     "id": "nano-gpt/step-r1-v-mini",
     "name": "Step R1 V Mini",
     "family": "step",
@@ -130562,6 +130939,37 @@
     },
     "limit": {
       "context": 202800,
+      "output": 131072
+    }
+  },
+  {
+    "id": "nano-gpt/z-ai/glm-5.3-flash",
+    "name": "GLM 5.3 Flash",
+    "family": "glm",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-08-26",
+    "last_updated": "2026-08-26",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.075,
+      "output": 0.25,
+      "cache_read": 0.015
+    },
+    "limit": {
+      "context": 1048576,
       "output": 131072
     }
   },
@@ -132258,7 +132666,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2024-09-30",
     "release_date": "2025-11-13",
     "last_updated": "2025-11-13",
@@ -132289,7 +132697,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2025-12-11",
     "last_updated": "2025-12-11",
@@ -132320,7 +132728,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-05",
     "last_updated": "2026-03-05",
@@ -132352,7 +132760,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-17",
     "last_updated": "2026-03-17",
@@ -132383,7 +132791,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-17",
     "last_updated": "2026-03-17",
@@ -134976,6 +135384,126 @@
     }
   },
   {
+    "id": "neosmith/neosmith.intelligent-basic",
+    "name": "NeoSmith Basic",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-26",
+    "last_updated": "2026-08-03",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.17,
+      "output": 4.37,
+      "cache_read": 0.22,
+      "cache_write": 0.0
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "neosmith/neosmith.intelligent-maestro",
+    "name": "NeoSmith Maestro",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-08-03",
+    "last_updated": "2026-08-08",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.4,
+      "output": 12.0,
+      "cache_read": 0.35,
+      "cache_write": 0.0
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "neosmith/neosmith.intelligent-pro",
+    "name": "NeoSmith Pro",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-26",
+    "last_updated": "2026-07-18",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.81,
+      "output": 8.39,
+      "cache_read": 0.3,
+      "cache_write": 0.0
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "neosmith/neosmith.neolite",
+    "name": "NeoSmith NeoLite",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-06-20",
+    "last_updated": "2026-08-03",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.6,
+      "output": 2.4,
+      "cache_read": 0.08,
+      "cache_write": 0.0
+    },
+    "limit": {
+      "context": 512000,
+      "output": 64000
+    }
+  },
+  {
     "id": "neuralwatt/Qwen/Qwen3.5-397B-A17B-FP8",
     "name": "Qwen3.5 397B A17B FP8",
     "family": "qwen",
@@ -135055,13 +135583,73 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.104,
-      "output": 0.207,
-      "cache_read": 0.026
+      "input": 0.14,
+      "output": 0.28,
+      "cache_read": 0.028
     },
     "limit": {
       "context": 1048560,
       "output": 65536
+    }
+  },
+  {
+    "id": "neuralwatt/deepseek-v4-flash-flex",
+    "name": "DeepSeek V4 Flash Flex",
+    "family": "deepseek-flash",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-05",
+    "release_date": "2026-04-24",
+    "last_updated": "2026-04-24",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.091,
+      "output": 0.182,
+      "cache_read": 0.0182
+    },
+    "limit": {
+      "context": 1048560,
+      "output": 65536
+    }
+  },
+  {
+    "id": "neuralwatt/deepseek-v4-pro",
+    "name": "DeepSeek V4 Pro",
+    "family": "deepseek-thinking",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-05",
+    "release_date": "2026-04-24",
+    "last_updated": "2026-04-24",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 1.0,
+      "output": 3.0,
+      "cache_read": 0.1
+    },
+    "limit": {
+      "context": 1048560,
+      "output": 393216
     }
   },
   {
@@ -135567,6 +136155,36 @@
     "limit": {
       "context": 262144,
       "output": 262144
+    }
+  },
+  {
+    "id": "neuralwatt/qwen-3.8-27b",
+    "name": "Qwen3.8 27B",
+    "family": "qwen",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-08-14",
+    "last_updated": "2026-08-14",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.45,
+      "output": 3.2,
+      "cache_read": 0.25
+    },
+    "limit": {
+      "context": 262128,
+      "output": 65536
     }
   },
   {
@@ -143165,8 +143783,8 @@
       "output": 1.2
     },
     "limit": {
-      "context": 200000,
-      "output": 131000
+      "context": 65536,
+      "output": 2048
     }
   },
   {
@@ -143195,8 +143813,8 @@
       "cache_write": 0.375
     },
     "limit": {
-      "context": 196608,
-      "output": 128000
+      "context": 204800,
+      "output": 131072
     }
   },
   {
@@ -143406,8 +144024,8 @@
       "cache_read": 0.12
     },
     "limit": {
-      "context": 512000,
-      "output": 128000
+      "context": 1048576,
+      "output": 512000
     }
   },
   {
@@ -143797,7 +144415,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2024-09-30",
     "release_date": "2025-11-13",
     "last_updated": "2025-11-13",
@@ -143890,7 +144508,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2025-12-11",
     "last_updated": "2025-12-11",
@@ -143953,7 +144571,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-02-05",
     "last_updated": "2026-02-05",
@@ -143985,7 +144603,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-05",
     "last_updated": "2026-03-05",
@@ -144017,7 +144635,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-17",
     "last_updated": "2026-03-17",
@@ -144048,7 +144666,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-17",
     "last_updated": "2026-03-17",
@@ -144266,7 +144884,7 @@
     "id": "ofox/volcengine/doubao-seed-1.6-flash",
     "name": "Seed 1.6 Flash",
     "family": "seed",
-    "attachment": false,
+    "attachment": true,
     "reasoning": false,
     "tool_call": true,
     "temperature": true,
@@ -144274,7 +144892,8 @@
     "last_updated": "2025-08-28",
     "modalities": {
       "input": [
-        "text"
+        "text",
+        "image"
       ],
       "output": [
         "text"
@@ -144325,7 +144944,7 @@
     "id": "ofox/volcengine/doubao-seed-1.8",
     "name": "Seed 1.8",
     "family": "seed",
-    "attachment": false,
+    "attachment": true,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
@@ -144333,7 +144952,8 @@
     "last_updated": "2025-12-28",
     "modalities": {
       "input": [
-        "text"
+        "text",
+        "image"
       ],
       "output": [
         "text"
@@ -145933,7 +146553,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2024-09-30",
     "release_date": "2025-11-13",
     "last_updated": "2025-11-13",
@@ -145964,7 +146584,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2025-12-11",
     "last_updated": "2025-12-11",
@@ -146087,7 +146707,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-02-05",
     "last_updated": "2026-02-05",
@@ -146151,7 +146771,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-05",
     "last_updated": "2026-03-05",
@@ -146183,7 +146803,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-17",
     "last_updated": "2026-03-17",
@@ -146214,7 +146834,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-17",
     "last_updated": "2026-03-17",
@@ -146354,10 +146974,10 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 5.0,
-      "output": 30.0,
-      "cache_read": 0.5,
-      "cache_write": 6.25
+      "input": 4.0,
+      "output": 20.0,
+      "cache_read": 0.4,
+      "cache_write": 5.0
     },
     "limit": {
       "context": 1050000,
@@ -146420,10 +147040,10 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 5.0,
-      "output": 30.0,
-      "cache_read": 0.5,
-      "cache_write": 6.25
+      "input": 4.0,
+      "output": 20.0,
+      "cache_read": 0.4,
+      "cache_write": 5.0
     },
     "limit": {
       "context": 1050000,
@@ -147087,6 +147707,38 @@
     }
   },
   {
+    "id": "opencode-go/glm-5.3-flash",
+    "name": "GLM-5.3-Flash (2x usage)",
+    "family": "glm",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-08-26",
+    "last_updated": "2026-08-26",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.075,
+      "output": 0.25,
+      "cache_read": 0.015
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 131072
+    }
+  },
+  {
     "id": "opencode-go/gpt-5.6-luna",
     "name": "GPT-5.6 Luna",
     "family": "gpt-luna",
@@ -147129,6 +147781,37 @@
     "temperature": true,
     "release_date": "2026-07-08",
     "last_updated": "2026-07-08",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.0,
+      "output": 6.0,
+      "cache_read": 0.3
+    },
+    "limit": {
+      "context": 500000,
+      "output": 500000
+    }
+  },
+  {
+    "id": "opencode-go/grok-4.6",
+    "name": "Grok 4.6",
+    "family": "grok",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2026-02-01",
+    "release_date": "2026-08-12",
+    "last_updated": "2026-08-12",
     "modalities": {
       "input": [
         "text",
@@ -149121,7 +149804,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-05",
     "last_updated": "2026-03-05",
@@ -149428,7 +150111,7 @@
     "cost": {
       "input": 2.0,
       "output": 6.0,
-      "cache_read": 0.5
+      "cache_read": 0.3
     },
     "limit": {
       "context": 500000,
@@ -150797,7 +151480,7 @@
     },
     "limit": {
       "context": 32768,
-      "output": 32768
+      "output": 29491
     }
   },
   {
@@ -150825,7 +151508,7 @@
     },
     "limit": {
       "context": 65536,
-      "output": 65536
+      "output": 58982
     }
   },
   {
@@ -151592,7 +152275,7 @@
     },
     "limit": {
       "context": 262144,
-      "output": 262144
+      "output": 235929
     }
   },
   {
@@ -151830,7 +152513,7 @@
     },
     "limit": {
       "context": 262144,
-      "output": 262144
+      "output": 235929
     }
   },
   {
@@ -152091,7 +152774,7 @@
     },
     "limit": {
       "context": 163840,
-      "output": 163840
+      "output": 147456
     }
   },
   {
@@ -152121,7 +152804,7 @@
     },
     "limit": {
       "context": 163840,
-      "output": 161000
+      "output": 144900
     }
   },
   {
@@ -152179,7 +152862,7 @@
     },
     "limit": {
       "context": 8192,
-      "output": 8192
+      "output": 7372
     }
   },
   {
@@ -152239,7 +152922,7 @@
     },
     "limit": {
       "context": 163840,
-      "output": 163840
+      "output": 147456
     }
   },
   {
@@ -152292,9 +152975,9 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.056,
-      "output": 0.112,
-      "cache_read": 0.0112
+      "input": 0.07952,
+      "output": 0.15904,
+      "cache_read": 0.015904
     },
     "limit": {
       "context": 1048576,
@@ -152352,9 +153035,9 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.522,
-      "output": 1.044,
-      "cache_read": 0.0435
+      "input": 0.87,
+      "output": 1.74,
+      "cache_read": 0.0725
     },
     "limit": {
       "context": 1048576,
@@ -152386,7 +153069,7 @@
     },
     "limit": {
       "context": 512000,
-      "output": 512000
+      "output": 460800
     }
   },
   {
@@ -152756,7 +153439,7 @@
     },
     "limit": {
       "context": 65536,
-      "output": 65536
+      "output": 58982
     }
   },
   {
@@ -152822,7 +153505,7 @@
     },
     "limit": {
       "context": 65536,
-      "output": 65536
+      "output": 58982
     }
   },
   {
@@ -153157,7 +153840,7 @@
     },
     "limit": {
       "context": 262144,
-      "output": 131072
+      "output": 117964
     }
   },
   {
@@ -153188,35 +153871,6 @@
     "limit": {
       "context": 131072,
       "output": 16384
-    }
-  },
-  {
-    "id": "openrouter/google/gemma-3n-e4b-it",
-    "name": "Gemma 3n 4B",
-    "family": "gemma",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "temperature": true,
-    "knowledge": "2024-08-31",
-    "release_date": "2025-05-20",
-    "last_updated": "2025-05-20",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.06,
-      "output": 0.12
-    },
-    "limit": {
-      "context": 32768,
-      "output": 32768
     }
   },
   {
@@ -153301,13 +153955,13 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.1,
+      "input": 0.09,
       "output": 0.34,
-      "cache_read": 0.1
+      "cache_read": 0.05
     },
     "limit": {
       "context": 262144,
-      "output": 262144
+      "output": 16384
     }
   },
   {
@@ -153425,7 +154079,7 @@
     },
     "limit": {
       "context": 8192,
-      "output": 4096
+      "output": 3686
     }
   },
   {
@@ -153453,7 +154107,7 @@
     },
     "limit": {
       "context": 131000,
-      "output": 131000
+      "output": 117900
     }
   },
   {
@@ -153482,7 +154136,7 @@
     },
     "limit": {
       "context": 131072,
-      "output": 131072
+      "output": 117964
     }
   },
   {
@@ -153772,7 +154426,7 @@
     },
     "limit": {
       "context": 131072,
-      "output": 131072
+      "output": 117964
     }
   },
   {
@@ -153801,7 +154455,7 @@
     },
     "limit": {
       "context": 60000,
-      "output": 60000
+      "output": 54000
     }
   },
   {
@@ -153830,7 +154484,7 @@
     },
     "limit": {
       "context": 131072,
-      "output": 131072
+      "output": 117964
     }
   },
   {
@@ -153854,12 +154508,13 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.1,
-      "output": 0.32
+      "input": 0.71,
+      "output": 0.71,
+      "cache_read": 0.71
     },
     "limit": {
       "context": 131072,
-      "output": 16384
+      "output": 115200
     }
   },
   {
@@ -153914,12 +154569,13 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.1,
-      "output": 0.3
+      "input": 0.11,
+      "output": 0.34,
+      "cache_read": 0.055
     },
     "limit": {
       "context": 1310720,
-      "output": 16384
+      "output": 8192
     }
   },
   {
@@ -153948,7 +154604,7 @@
       "output": 0.18
     },
     "limit": {
-      "context": 1048576,
+      "context": 163840,
       "output": 16384
     }
   },
@@ -153980,7 +154636,7 @@
     },
     "limit": {
       "context": 131072,
-      "output": 131072
+      "output": 117964
     }
   },
   {
@@ -154013,7 +154669,7 @@
     },
     "limit": {
       "context": 1048576,
-      "output": 1048576
+      "output": 943718
     }
   },
   {
@@ -154046,7 +154702,7 @@
     },
     "limit": {
       "context": 1048576,
-      "output": 1048576
+      "output": 943718
     }
   },
   {
@@ -154079,7 +154735,7 @@
     },
     "limit": {
       "context": 1048576,
-      "output": 1048576
+      "output": 943718
     }
   },
   {
@@ -154108,7 +154764,7 @@
     },
     "limit": {
       "context": 16384,
-      "output": 16384
+      "output": 14745
     }
   },
   {
@@ -154166,7 +154822,7 @@
     },
     "limit": {
       "context": 1000192,
-      "output": 1000192
+      "output": 900172
     }
   },
   {
@@ -154343,6 +154999,34 @@
     }
   },
   {
+    "id": "openrouter/minimax/minimax-m2.7:free",
+    "name": "MiniMax M2.7 (free)",
+    "family": "minimax",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-03-18",
+    "last_updated": "2026-03-18",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 196608,
+      "output": 176947
+    }
+  },
+  {
     "id": "openrouter/minimax/minimax-m3",
     "name": "MiniMax-M3",
     "family": "minimax",
@@ -154374,6 +155058,36 @@
     }
   },
   {
+    "id": "openrouter/minimax/minimax-m3:free",
+    "name": "MiniMax M3 (free)",
+    "family": "minimax",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-06-01",
+    "last_updated": "2026-06-01",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 943718
+    }
+  },
+  {
     "id": "openrouter/mistralai/codestral",
     "name": "Codestral 2508",
     "family": "codestral",
@@ -154401,7 +155115,7 @@
     },
     "limit": {
       "context": 256000,
-      "output": 256000
+      "output": 204800
     }
   },
   {
@@ -154432,7 +155146,7 @@
     },
     "limit": {
       "context": 262144,
-      "output": 262144
+      "output": 209715
     }
   },
   {
@@ -154462,7 +155176,7 @@
     },
     "limit": {
       "context": 262144,
-      "output": 262144
+      "output": 209715
     }
   },
   {
@@ -154492,7 +155206,7 @@
     },
     "limit": {
       "context": 131072,
-      "output": 131072
+      "output": 104857
     }
   },
   {
@@ -154521,7 +155235,7 @@
     },
     "limit": {
       "context": 128000,
-      "output": 128000
+      "output": 102400
     }
   },
   {
@@ -154552,7 +155266,7 @@
     },
     "limit": {
       "context": 128000,
-      "output": 128000
+      "output": 102400
     }
   },
   {
@@ -154584,7 +155298,7 @@
     },
     "limit": {
       "context": 131072,
-      "output": 131072
+      "output": 104857
     }
   },
   {
@@ -154616,7 +155330,7 @@
     },
     "limit": {
       "context": 131072,
-      "output": 262144
+      "output": 104857
     }
   },
   {
@@ -154646,7 +155360,7 @@
     },
     "limit": {
       "context": 262144,
-      "output": 262144
+      "output": 209715
     }
   },
   {
@@ -154706,7 +155420,7 @@
     },
     "limit": {
       "context": 32768,
-      "output": 32768
+      "output": 26214
     }
   },
   {
@@ -154737,7 +155451,7 @@
     },
     "limit": {
       "context": 262144,
-      "output": 262144
+      "output": 209715
     }
   },
   {
@@ -154796,7 +155510,7 @@
     },
     "limit": {
       "context": 128000,
-      "output": 128000
+      "output": 102400
     }
   },
   {
@@ -154857,7 +155571,7 @@
     },
     "limit": {
       "context": 65536,
-      "output": 65536
+      "output": 52428
     }
   },
   {
@@ -154888,7 +155602,7 @@
     },
     "limit": {
       "context": 32000,
-      "output": 32000
+      "output": 25600
     }
   },
   {
@@ -154978,7 +155692,7 @@
     },
     "limit": {
       "context": 262144,
-      "output": 262144
+      "output": 235929
     }
   },
   {
@@ -155009,7 +155723,7 @@
     },
     "limit": {
       "context": 262144,
-      "output": 262144
+      "output": 235929
     }
   },
   {
@@ -155034,13 +155748,13 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.67,
+      "input": 0.66,
       "output": 3.4,
-      "cache_read": 0.19
+      "cache_read": 0.18
     },
     "limit": {
       "context": 262144,
-      "output": 262144
+      "output": 235929
     }
   },
   {
@@ -155071,7 +155785,7 @@
     },
     "limit": {
       "context": 1048576,
-      "output": 1048576
+      "output": 943718
     }
   },
   {
@@ -155157,7 +155871,7 @@
     },
     "limit": {
       "context": 262144,
-      "output": 262144
+      "output": 235929
     }
   },
   {
@@ -155187,7 +155901,7 @@
     },
     "limit": {
       "context": 262144,
-      "output": 262144
+      "output": 235929
     }
   },
   {
@@ -155274,7 +155988,7 @@
     },
     "limit": {
       "context": 131072,
-      "output": 131072
+      "output": 117964
     }
   },
   {
@@ -155303,7 +156017,7 @@
     },
     "limit": {
       "context": 131072,
-      "output": 131072
+      "output": 117964
     }
   },
   {
@@ -155328,11 +156042,11 @@
     "cost": {
       "input": 0.05,
       "output": 0.2,
-      "cache_read": 0.03
+      "cache_read": 0.025
     },
     "limit": {
       "context": 262144,
-      "output": 262144
+      "output": 228000
     }
   },
   {
@@ -155419,7 +156133,7 @@
     },
     "limit": {
       "context": 262144,
-      "output": 262144
+      "output": 235929
     }
   },
   {
@@ -155448,7 +156162,7 @@
     },
     "limit": {
       "context": 512288,
-      "output": 16384
+      "output": 461059
     }
   },
   {
@@ -155649,7 +156363,7 @@
     },
     "limit": {
       "context": 4095,
-      "output": 4096
+      "output": 3685
     }
   },
   {
@@ -156911,7 +157625,7 @@
     },
     "limit": {
       "context": 131072,
-      "output": 131072
+      "output": 117964
     }
   },
   {
@@ -156940,7 +157654,7 @@
     },
     "limit": {
       "context": 131072,
-      "output": 131072
+      "output": 117964
     }
   },
   {
@@ -157409,7 +158123,7 @@
     },
     "limit": {
       "context": 127072,
-      "output": 127072
+      "output": 114364
     }
   },
   {
@@ -157437,7 +158151,7 @@
     },
     "limit": {
       "context": 128000,
-      "output": 128000
+      "output": 115200
     }
   },
   {
@@ -157524,7 +158238,7 @@
     },
     "limit": {
       "context": 128000,
-      "output": 128000
+      "output": 115200
     }
   },
   {
@@ -157696,7 +158410,7 @@
     },
     "limit": {
       "context": 32768,
-      "output": 32768
+      "output": 29491
     }
   },
   {
@@ -157725,7 +158439,7 @@
     },
     "limit": {
       "context": 32768,
-      "output": 32768
+      "output": 29491
     }
   },
   {
@@ -157760,35 +158474,6 @@
     }
   },
   {
-    "id": "openrouter/qwen/qwen-plus-2025-07-28:thinking",
-    "name": "Qwen Plus 0728 (thinking)",
-    "family": "qwen",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-03-31",
-    "release_date": "2025-09-08",
-    "last_updated": "2025-09-08",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.26,
-      "output": 0.78
-    },
-    "limit": {
-      "context": 1000000,
-      "output": 32768
-    }
-  },
-  {
     "id": "openrouter/qwen/qwen2.5-vl-72b-instruct",
     "name": "Qwen2.5 VL 72B Instruct",
     "family": "qwen",
@@ -157810,13 +158495,12 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.8,
-      "output": 1.0,
-      "cache_read": 0.4
+      "input": 0.25,
+      "output": 0.75
     },
     "limit": {
       "context": 128000,
-      "output": 128000
+      "output": 28800
     }
   },
   {
@@ -157903,7 +158587,7 @@
     },
     "limit": {
       "context": 131072,
-      "output": 32768
+      "output": 117964
     }
   },
   {
@@ -158106,7 +158790,7 @@
     },
     "limit": {
       "context": 262144,
-      "output": 262144
+      "output": 235929
     }
   },
   {
@@ -158167,7 +158851,7 @@
     },
     "limit": {
       "context": 262144,
-      "output": 262144
+      "output": 235929
     }
   },
   {
@@ -158287,7 +158971,7 @@
     },
     "limit": {
       "context": 262144,
-      "output": 262144
+      "output": 235929
     }
   },
   {
@@ -158554,7 +159238,7 @@
     },
     "limit": {
       "context": 262144,
-      "output": 262144
+      "output": 235929
     }
   },
   {
@@ -158615,7 +159299,7 @@
     },
     "limit": {
       "context": 262144,
-      "output": 262144
+      "output": 235929
     }
   },
   {
@@ -158640,13 +159324,12 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.5,
-      "output": 3.6,
-      "cache_read": 0.3
+      "input": 0.39,
+      "output": 2.34
     },
     "limit": {
       "context": 262144,
-      "output": 262144
+      "output": 65536
     }
   },
   {
@@ -158676,7 +159359,7 @@
     },
     "limit": {
       "context": 262144,
-      "output": 262144
+      "output": 235929
     }
   },
   {
@@ -158793,12 +159476,13 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.32,
-      "output": 3.2
+      "input": 0.6,
+      "output": 3.6,
+      "cache_read": 0.12
     },
     "limit": {
       "context": 262144,
-      "output": 81920
+      "output": 235929
     }
   },
   {
@@ -158823,13 +159507,13 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.14,
-      "output": 1.0,
+      "input": 0.1,
+      "output": 0.9,
       "cache_read": 0.05
     },
     "limit": {
       "context": 262144,
-      "output": 262144
+      "output": 235929
     }
   },
   {
@@ -159070,9 +159754,42 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.4,
-      "output": 3.0,
-      "cache_read": 0.05
+      "input": 0.425,
+      "output": 2.55,
+      "cache_read": 0.085,
+      "cache_write": 0.53125
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 131072
+    }
+  },
+  {
+    "id": "openrouter/qwen/qwen3.8-flash",
+    "name": "Qwen3.8 Flash",
+    "family": "qwen",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-08-26",
+    "last_updated": "2026-08-26",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.15,
+      "output": 0.47,
+      "cache_read": 0.016,
+      "cache_write": 0.2
     },
     "limit": {
       "context": 1000000,
@@ -159138,7 +159855,7 @@
     },
     "limit": {
       "context": 16384,
-      "output": 16384
+      "output": 14745
     }
   },
   {
@@ -159167,7 +159884,7 @@
     },
     "limit": {
       "context": 65536,
-      "output": 65536
+      "output": 58982
     }
   },
   {
@@ -159311,7 +160028,7 @@
     },
     "limit": {
       "context": 8192,
-      "output": 16384
+      "output": 7372
     }
   },
   {
@@ -159373,36 +160090,6 @@
     }
   },
   {
-    "id": "openrouter/stealth/ox-alpha",
-    "name": "Ox Alpha",
-    "family": "alpha",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2026-08-20",
-    "last_updated": "2026-08-20",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "video"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.0,
-      "output": 0.0
-    },
-    "limit": {
-      "context": 1048576,
-      "output": 131072
-    }
-  },
-  {
     "id": "openrouter/stepfun/step-3.5-flash",
     "name": "Step 3.5 Flash",
     "attachment": false,
@@ -159458,7 +160145,7 @@
     },
     "limit": {
       "context": 262144,
-      "output": 256000
+      "output": 230400
     }
   },
   {
@@ -159487,7 +160174,7 @@
     },
     "limit": {
       "context": 131072,
-      "output": 131072
+      "output": 117964
     }
   },
   {
@@ -159629,7 +160316,7 @@
     },
     "limit": {
       "context": 262144,
-      "output": 262144
+      "output": 235929
     }
   },
   {
@@ -159658,7 +160345,7 @@
     },
     "limit": {
       "context": 131072,
-      "output": 131072
+      "output": 117964
     }
   },
   {
@@ -159686,7 +160373,7 @@
     },
     "limit": {
       "context": 65536,
-      "output": 65536
+      "output": 58982
     }
   },
   {
@@ -159715,7 +160402,7 @@
     },
     "limit": {
       "context": 32768,
-      "output": 32768
+      "output": 29491
     }
   },
   {
@@ -159743,7 +160430,7 @@
     },
     "limit": {
       "context": 1024000,
-      "output": 32768
+      "output": 26214
     }
   },
   {
@@ -159768,9 +160455,9 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 1.0,
+      "input": 0.95,
       "output": 4.05,
-      "cache_read": 0.17
+      "cache_read": 0.16
     },
     "limit": {
       "context": 1048576,
@@ -159922,7 +160609,7 @@
     },
     "limit": {
       "context": 131072,
-      "output": 131072
+      "output": 117964
     }
   },
   {
@@ -160011,7 +160698,7 @@
     },
     "limit": {
       "context": 2000000,
-      "output": 2000000
+      "output": 1800000
     }
   },
   {
@@ -160043,7 +160730,7 @@
     },
     "limit": {
       "context": 2000000,
-      "output": 2000000
+      "output": 1800000
     }
   },
   {
@@ -160074,7 +160761,7 @@
     },
     "limit": {
       "context": 1000000,
-      "output": 1000000
+      "output": 900000
     }
   },
   {
@@ -160105,7 +160792,7 @@
     },
     "limit": {
       "context": 500000,
-      "output": 500000
+      "output": 450000
     }
   },
   {
@@ -160137,7 +160824,7 @@
     },
     "limit": {
       "context": 500000,
-      "output": 500000
+      "output": 450000
     }
   },
   {
@@ -160168,7 +160855,7 @@
     },
     "limit": {
       "context": 256000,
-      "output": 256000
+      "output": 230400
     }
   },
   {
@@ -160346,13 +161033,13 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.5,
-      "output": 2.0,
-      "cache_read": 0.1
+      "input": 0.43,
+      "output": 1.75,
+      "cache_read": 0.08
     },
     "limit": {
       "context": 204800,
-      "output": 131072
+      "output": 16384
     }
   },
   {
@@ -160525,13 +161212,13 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.966,
-      "output": 3.036,
-      "cache_read": 0.1794
+      "input": 1.26,
+      "output": 3.96,
+      "cache_read": 0.234
     },
     "limit": {
       "context": 204800,
-      "output": 128000
+      "output": 182476
     }
   },
   {
@@ -160554,13 +161241,13 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.966,
-      "output": 3.036,
-      "cache_read": 0.1932
+      "input": 1.19,
+      "output": 3.74,
+      "cache_read": 0.221
     },
     "limit": {
       "context": 1048576,
-      "output": 131072
+      "output": 262144
     }
   },
   {
@@ -160588,7 +161275,7 @@
     },
     "limit": {
       "context": 256000,
-      "output": 256000
+      "output": 230400
     }
   },
   {
@@ -160617,6 +161304,37 @@
     },
     "limit": {
       "context": 1048576,
+      "output": 131072
+    }
+  },
+  {
+    "id": "openrouter/z-ai/glm-5.3-flash",
+    "name": "GLM-5.3-Flash",
+    "family": "glm",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-08-26",
+    "last_updated": "2026-08-26",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.075,
+      "output": 0.25,
+      "cache_read": 0.015
+    },
+    "limit": {
+      "context": 1310720,
       "output": 131072
     }
   },
@@ -160800,13 +161518,13 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.035,
-      "output": 0.12,
-      "cache_read": 0.01
+      "input": 0.03,
+      "output": 0.1,
+      "cache_read": 0.007
     },
     "limit": {
       "context": 1310720,
-      "output": 1048576
+      "output": 131072
     }
   },
   {
@@ -160901,13 +161619,13 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 2.6,
-      "output": 13.0,
-      "cache_read": 0.29
+      "input": 2.55,
+      "output": 12.75,
+      "cache_read": 0.256
     },
     "limit": {
       "context": 1048576,
-      "output": 974842
+      "output": 943718
     }
   },
   {
@@ -161003,7 +161721,7 @@
     },
     "limit": {
       "context": 500000,
-      "output": 1000000
+      "output": 450000
     }
   },
   {
@@ -161562,7 +162280,7 @@
     },
     "limit": {
       "context": 1048576,
-      "output": 128000
+      "output": 512000
     }
   },
   {
@@ -161723,7 +162441,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-02-05",
     "last_updated": "2026-02-05",
@@ -161755,7 +162473,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-05",
     "last_updated": "2026-03-05",
@@ -161787,7 +162505,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-17",
     "last_updated": "2026-03-17",
@@ -161818,7 +162536,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-17",
     "last_updated": "2026-03-17",
@@ -163630,7 +164348,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": false,
-    "temperature": true,
+    "temperature": false,
     "knowledge": "2024-09-30",
     "release_date": "2025-08-07",
     "last_updated": "2025-08-07",
@@ -163784,7 +164502,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2024-09-30",
     "release_date": "2025-11-13",
     "last_updated": "2025-11-13",
@@ -163939,7 +164657,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2025-12-11",
     "last_updated": "2025-12-11",
@@ -164094,7 +164812,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-02-05",
     "last_updated": "2026-02-05",
@@ -164126,7 +164844,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-05",
     "last_updated": "2026-03-05",
@@ -164158,7 +164876,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-17",
     "last_updated": "2026-03-17",
@@ -164189,7 +164907,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-17",
     "last_updated": "2026-03-17",
@@ -165140,6 +165858,179 @@
     "limit": {
       "context": 32768,
       "output": 16384
+    }
+  },
+  {
+    "id": "pendra/deepseek-v4-flash",
+    "name": "DeepSeek V4 Flash",
+    "family": "deepseek-flash",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-05",
+    "release_date": "2026-04-24",
+    "last_updated": "2026-04-24",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 384000
+    }
+  },
+  {
+    "id": "pendra/glm-4.7-flash",
+    "name": "GLM-4.7-Flash",
+    "family": "glm-flash",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-04",
+    "release_date": "2026-01-19",
+    "last_updated": "2026-01-19",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 200000,
+      "output": 131072
+    }
+  },
+  {
+    "id": "pendra/gpt-oss:120b",
+    "name": "GPT OSS 120B",
+    "family": "gpt-oss",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2025-08-05",
+    "last_updated": "2025-08-05",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 131072,
+      "output": 32768
+    }
+  },
+  {
+    "id": "pendra/llama3.3:70b",
+    "name": "Llama-3.3-70B-Instruct",
+    "family": "llama",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2023-12",
+    "release_date": "2024-12-06",
+    "last_updated": "2024-12-06",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 128000,
+      "output": 4096
+    }
+  },
+  {
+    "id": "pendra/qwen3-coder:30b",
+    "name": "Qwen3-Coder 30B-A3B Instruct",
+    "family": "qwen",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-04",
+    "release_date": "2025-04",
+    "last_updated": "2025-04",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 262144,
+      "output": 65536
+    }
+  },
+  {
+    "id": "pendra/qwen3.6:27b",
+    "name": "Qwen3.6 27B",
+    "family": "qwen",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-22",
+    "last_updated": "2026-04-22",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 262144,
+      "output": 65536
     }
   },
   {
@@ -167800,7 +168691,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2024-09-30",
     "release_date": "2025-11-13",
     "last_updated": "2025-11-13",
@@ -167832,7 +168723,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-02-05",
     "last_updated": "2026-02-05",
@@ -167865,7 +168756,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-05",
     "last_updated": "2026-03-05",
@@ -167898,7 +168789,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-17",
     "last_updated": "2026-03-17",
@@ -167930,7 +168821,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-17",
     "last_updated": "2026-03-17",
@@ -178234,6 +179125,38 @@
     }
   },
   {
+    "id": "requesty/glm-5.3-flash",
+    "name": "GLM-5.3-Flash",
+    "family": "glm",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-08-26",
+    "last_updated": "2026-08-26",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.135,
+      "output": 0.45,
+      "cache_read": 0.027
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
     "id": "requesty/gpt-4.1-mini@eu",
     "name": "GPT-4.1 mini (EU)",
     "family": "gpt-mini",
@@ -178429,7 +179352,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2024-09-30",
     "release_date": "2025-11-13",
     "last_updated": "2025-11-13",
@@ -178489,7 +179412,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-02-05",
     "last_updated": "2026-02-05",
@@ -178521,7 +179444,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-05",
     "last_updated": "2026-03-05",
@@ -178553,7 +179476,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-17",
     "last_updated": "2026-03-17",
@@ -178584,7 +179507,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-17",
     "last_updated": "2026-03-17",
@@ -178646,7 +179569,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-05",
     "last_updated": "2026-03-05",
@@ -182599,7 +183522,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2025-12-11",
     "last_updated": "2025-12-11",
@@ -182630,7 +183553,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-05",
     "last_updated": "2026-03-05",
@@ -183964,8 +184887,8 @@
       "cache_read": 0.0
     },
     "limit": {
-      "context": 512000,
-      "output": 128000
+      "context": 1048576,
+      "output": 512000
     }
   },
   {
@@ -187349,7 +188272,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2024-09-30",
     "release_date": "2025-11-13",
     "last_updated": "2025-11-13",
@@ -187376,7 +188299,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2025-12-11",
     "last_updated": "2025-12-11",
@@ -187403,7 +188326,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-05",
     "last_updated": "2026-03-05",
@@ -187787,6 +188710,35 @@
     "limit": {
       "context": 131072,
       "output": 8192
+    }
+  },
+  {
+    "id": "standardcompute/standardcompute",
+    "name": "Standard Compute",
+    "family": "auto",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-03-01",
+    "last_updated": "2026-08-24",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 24576
     }
   },
   {
@@ -192471,7 +193423,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2025-12-11",
     "last_updated": "2025-12-11",
@@ -192501,7 +193453,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-05",
     "last_updated": "2026-03-05",
@@ -192532,7 +193484,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-05",
     "last_updated": "2026-03-05",
@@ -193394,10 +194346,10 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 3.0,
-      "output": 15.0,
-      "cache_read": 0.3,
-      "cache_write": 3.75
+      "input": 2.0,
+      "output": 10.000000000000002,
+      "cache_read": 0.2,
+      "cache_write": 2.5000000000000004
     },
     "limit": {
       "context": 1000000,
@@ -193683,9 +194635,9 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 1.875,
-      "output": 9.375,
-      "cache_read": 0.1875
+      "input": 0.9375,
+      "output": 4.6875,
+      "cache_read": 0.09375
     },
     "limit": {
       "context": 1000000,
@@ -193716,9 +194668,9 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 1.875,
-      "output": 9.375,
-      "cache_read": 0.1875
+      "input": 0.9375,
+      "output": 4.6875,
+      "cache_read": 0.09375
     },
     "limit": {
       "context": 1000000,
@@ -194615,7 +195567,7 @@
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2025-12-13",
     "last_updated": "2026-06-11",
@@ -194676,7 +195628,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-02-24",
     "last_updated": "2026-06-11",
@@ -194707,7 +195659,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-05",
     "last_updated": "2026-06-11",
@@ -194738,7 +195690,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-27",
     "last_updated": "2026-06-11",
@@ -195581,36 +196533,6 @@
     }
   },
   {
-    "id": "venice/stealth-ox-alpha",
-    "name": "Ox Alpha",
-    "family": "alpha",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "release_date": "2026-08-21",
-    "last_updated": "2026-08-21",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "video"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.0,
-      "output": 0.0,
-      "cache_read": 0.0
-    },
-    "limit": {
-      "context": 1048576,
-      "output": 131072
-    }
-  },
-  {
     "id": "venice/venice-uncensored-1.2",
     "name": "Venice Uncensored 1.2",
     "family": "venice",
@@ -195754,6 +196676,37 @@
     },
     "limit": {
       "context": 1000000,
+      "output": 131072
+    }
+  },
+  {
+    "id": "venice/z-ai-glm-5.3-flash",
+    "name": "GLM 5.3 Flash",
+    "family": "glm",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-08-21",
+    "last_updated": "2026-08-26",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.15,
+      "output": 0.5,
+      "cache_read": 0.03
+    },
+    "limit": {
+      "context": 1048576,
       "output": 131072
     }
   },
@@ -196858,6 +197811,37 @@
     }
   },
   {
+    "id": "vercel/alibaba/qwen3.8-flash",
+    "name": "Qwen 3.8 Flash",
+    "family": "qwen",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-08-26",
+    "last_updated": "2026-08-26",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.16,
+      "output": 0.47,
+      "cache_read": 0.016,
+      "cache_write": 0.2
+    },
+    "limit": {
+      "context": 991000,
+      "output": 128000
+    }
+  },
+  {
     "id": "vercel/alibaba/qwen3.8-max",
     "name": "Qwen 3.8 Max",
     "family": "qwen",
@@ -197076,6 +198060,31 @@
     "modalities": {
       "input": [
         "text"
+      ],
+      "output": [
+        "video"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 0,
+      "output": 0
+    }
+  },
+  {
+    "id": "vercel/alibaba/wan-v3.0-video",
+    "name": "Wan v3.0 Video",
+    "family": "o",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": false,
+    "release_date": "2026-08-23",
+    "last_updated": "2026-08-23",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
       ],
       "output": [
         "video"
@@ -199381,6 +200390,57 @@
     }
   },
   {
+    "id": "vercel/google/gemini-3.5-transcribe",
+    "name": "Gemini 3.5 Transcribe",
+    "family": "gemini",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "release_date": "2026-08-26",
+    "last_updated": "2026-08-26",
+    "modalities": {
+      "input": [
+        "audio"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.0,
+      "output": 12.0
+    },
+    "limit": {
+      "context": 0,
+      "output": 0
+    }
+  },
+  {
+    "id": "vercel/google/gemini-3.5-transcribe-live",
+    "name": "Gemini 3.5 Transcribe Live",
+    "family": "gemini",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "release_date": "2026-08-26",
+    "last_updated": "2026-08-26",
+    "modalities": {
+      "input": [
+        "audio"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 0,
+      "output": 0
+    }
+  },
+  {
     "id": "vercel/google/gemini-3.6-flash",
     "name": "Gemini 3.6 Flash",
     "family": "gemini-flash",
@@ -200373,6 +201433,31 @@
     }
   },
   {
+    "id": "vercel/meta/muse-image-1.0",
+    "name": "Muse Image 1.0",
+    "family": "muse",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": false,
+    "release_date": "2026-08-26",
+    "last_updated": "2026-08-26",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "image"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 0,
+      "output": 0
+    }
+  },
+  {
     "id": "vercel/meta/muse-spark-1.1",
     "name": "Muse Spark 1.1",
     "family": "muse",
@@ -200672,6 +201757,34 @@
     }
   },
   {
+    "id": "vercel/minimax/minimax-m2.7-free",
+    "name": "Minimax M2.7 (Free)",
+    "family": "minimax",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-03-18",
+    "last_updated": "2026-03-18",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 196608,
+      "output": 196608
+    }
+  },
+  {
     "id": "vercel/minimax/minimax-m2.7-highspeed",
     "name": "MiniMax M2.7 High Speed",
     "family": "minimax",
@@ -200730,6 +201843,36 @@
     "limit": {
       "context": 1000000,
       "output": 1000000
+    }
+  },
+  {
+    "id": "vercel/minimax/minimax-m3-free",
+    "name": "MiniMax M3 (Free)",
+    "family": "minimax",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-06-01",
+    "last_updated": "2026-06-01",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0,
+      "cache_read": 0.0
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 1048576
     }
   },
   {
@@ -201545,40 +202688,13 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.0,
-      "output": 0.0
+      "input": 0.05,
+      "output": 0.15,
+      "cache_read": 0.05
     },
     "limit": {
-      "context": 1000000,
-      "output": 32768
-    }
-  },
-  {
-    "id": "vercel/nvidia/nemotron-3.5-lightning-free",
-    "name": "Nemotron 3.5 Lightning 30B (Free)",
-    "family": "nemotron",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2026-08-11",
-    "last_updated": "2026-08-11",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.0,
-      "output": 0.0
-    },
-    "limit": {
-      "context": 1000000,
-      "output": 32768
+      "context": 262144,
+      "output": 131072
     }
   },
   {
@@ -202522,7 +203638,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2025-12-11",
     "last_updated": "2025-12-11",
@@ -202617,7 +203733,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-02-05",
     "last_updated": "2026-02-05",
@@ -202681,7 +203797,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-05",
     "last_updated": "2026-03-05",
@@ -202745,7 +203861,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-17",
     "last_updated": "2026-03-17",
@@ -203301,6 +204417,34 @@
     }
   },
   {
+    "id": "vercel/openai/gpt-oss-safeguard-120b",
+    "name": "GPT OSS Safeguard 120B",
+    "family": "gpt-oss",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2025-10-29",
+    "last_updated": "2025-10-29",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.15,
+      "output": 0.6
+    },
+    "limit": {
+      "context": 128000,
+      "output": 16000
+    }
+  },
+  {
     "id": "vercel/openai/gpt-oss-safeguard-20b",
     "name": "gpt-oss-safeguard-20b",
     "family": "gpt-oss",
@@ -203321,13 +204465,12 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.075,
-      "output": 0.3,
-      "cache_read": 0.037
+      "input": 0.07,
+      "output": 0.2
     },
     "limit": {
-      "context": 131072,
-      "output": 65536
+      "context": 128000,
+      "output": 16000
     }
   },
   {
@@ -204591,8 +205734,9 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "release_date": "2026-04-30",
-    "last_updated": "2026-04-30",
+    "temperature": true,
+    "release_date": "2026-04-17",
+    "last_updated": "2026-04-17",
     "modalities": {
       "input": [
         "text",
@@ -204621,6 +205765,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
+    "temperature": true,
     "release_date": "2026-07-08",
     "last_updated": "2026-07-08",
     "modalities": {
@@ -204651,6 +205796,8 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
+    "temperature": true,
+    "knowledge": "2026-02-01",
     "release_date": "2026-08-12",
     "last_updated": "2026-08-12",
     "modalities": {
@@ -204680,8 +205827,9 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "release_date": "2026-05-20",
-    "last_updated": "2026-05-20",
+    "temperature": true,
+    "release_date": "2026-04-16",
+    "last_updated": "2026-04-16",
     "modalities": {
       "input": [
         "text",
@@ -204733,6 +205881,7 @@
     "attachment": false,
     "reasoning": false,
     "tool_call": false,
+    "temperature": false,
     "release_date": "2026-08-07",
     "last_updated": "2026-08-07",
     "modalities": {
@@ -204781,8 +205930,9 @@
     "attachment": false,
     "reasoning": false,
     "tool_call": false,
-    "release_date": "2026-06-22",
-    "last_updated": "2026-06-22",
+    "temperature": false,
+    "release_date": "2026-05-30",
+    "last_updated": "2026-05-30",
     "modalities": {
       "input": [
         "text"
@@ -205899,6 +207049,36 @@
     }
   },
   {
+    "id": "vercel/zai/glm-5.3-flash",
+    "name": "GLM 5.3 Flash",
+    "family": "glm",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-08-26",
+    "last_updated": "2026-08-26",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.15,
+      "output": 0.5,
+      "cache_read": 0.03
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 131000
+    }
+  },
+  {
     "id": "vercel/zai/glm-5v-turbo",
     "name": "GLM 5V Turbo",
     "family": "glm",
@@ -206081,6 +207261,40 @@
       "input": 2.0,
       "output": 12.0,
       "cache_read": 0.2
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    }
+  },
+  {
+    "id": "vivgrid/gemini-3.7-flash",
+    "name": "Gemini 3.7 Flash",
+    "family": "gemini-flash",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2026-03",
+    "release_date": "2026-08-13",
+    "last_updated": "2026-08-13",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.75,
+      "output": 3.75,
+      "cache_read": 0.075
     },
     "limit": {
       "context": 1048576,
@@ -206559,6 +207773,461 @@
     }
   },
   {
+    "id": "volcengine/deepseek-v4-flash-ga-260731",
+    "name": "DeepSeek V4 Flash 0731",
+    "family": "deepseek-flash",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-05",
+    "release_date": "2026-07-31",
+    "last_updated": "2026-07-31",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.4453,
+      "output": 1.3359,
+      "cache_read": 0.01484
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 384000
+    }
+  },
+  {
+    "id": "volcengine/deepseek-v4-pro-ga-260813",
+    "name": "DeepSeek V4 Pro 0813",
+    "family": "deepseek-thinking",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-08-12",
+    "last_updated": "2026-08-22",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 1.3359,
+      "output": 4.00771,
+      "cache_read": 0.04453
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 384000
+    }
+  },
+  {
+    "id": "volcengine/doubao-seed-1.6-251015",
+    "name": "Seed 1.6",
+    "family": "seed",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2025-10-15",
+    "last_updated": "2025-10-15",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.11875,
+      "output": 1.18747,
+      "cache_read": 0.02375
+    },
+    "limit": {
+      "context": 256000,
+      "output": 64000
+    }
+  },
+  {
+    "id": "volcengine/doubao-seed-1.6-flash-250828",
+    "name": "Seed 1.6 Flash",
+    "family": "seed",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2025-08-28",
+    "last_updated": "2025-08-28",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.02227,
+      "output": 0.22265,
+      "cache_read": 0.00445
+    },
+    "limit": {
+      "context": 256000,
+      "output": 32000
+    }
+  },
+  {
+    "id": "volcengine/doubao-seed-1.6-vision-250815",
+    "name": "Seed 1.6 Vision",
+    "family": "seed",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2025-08-15",
+    "last_updated": "2025-08-15",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.11875,
+      "output": 1.18747,
+      "cache_read": 0.02375
+    },
+    "limit": {
+      "context": 256000,
+      "output": 32000
+    }
+  },
+  {
+    "id": "volcengine/doubao-seed-1.8-251228",
+    "name": "Seed 1.8",
+    "family": "seed",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2025-12-28",
+    "last_updated": "2025-12-28",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.11875,
+      "output": 1.18747,
+      "cache_read": 0.02375
+    },
+    "limit": {
+      "context": 256000,
+      "output": 64000
+    }
+  },
+  {
+    "id": "volcengine/doubao-seed-2.0-code-preview-260215",
+    "name": "Seed 2.0 Code",
+    "family": "seed",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-02-14",
+    "last_updated": "2026-02-14",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.47499,
+      "output": 2.37494,
+      "cache_read": 0.095
+    },
+    "limit": {
+      "context": 262144,
+      "output": 131072
+    }
+  },
+  {
+    "id": "volcengine/doubao-seed-2.0-lite-260428",
+    "name": "Seed 2.0 Lite",
+    "family": "seed",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-02-14",
+    "last_updated": "2026-02-14",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.08906,
+      "output": 0.53436,
+      "cache_read": 0.01781
+    },
+    "limit": {
+      "context": 256000,
+      "output": 32000
+    }
+  },
+  {
+    "id": "volcengine/doubao-seed-2.0-mini-260428",
+    "name": "Seed 2.0 Mini",
+    "family": "seed",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-02-14",
+    "last_updated": "2026-02-14",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.02969,
+      "output": 0.29687,
+      "cache_read": 0.00594
+    },
+    "limit": {
+      "context": 256000,
+      "output": 32000
+    }
+  },
+  {
+    "id": "volcengine/doubao-seed-2.0-pro-260215",
+    "name": "Seed 2.0 Pro",
+    "family": "seed",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-02-14",
+    "last_updated": "2026-02-14",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.47499,
+      "output": 2.37494,
+      "cache_read": 0.095
+    },
+    "limit": {
+      "context": 256000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "volcengine/doubao-seed-2.1-pro-260628",
+    "name": "Seed 2.1 Pro",
+    "family": "seed",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-06-23",
+    "last_updated": "2026-06-23",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.8906,
+      "output": 4.45301,
+      "cache_read": 0.17812
+    },
+    "limit": {
+      "context": 256000,
+      "output": 256000
+    }
+  },
+  {
+    "id": "volcengine/doubao-seed-2.1-turbo-260628",
+    "name": "Seed 2.1 Turbo",
+    "family": "seed",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-06-23",
+    "last_updated": "2026-06-23",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.4453,
+      "output": 2.22651,
+      "cache_read": 0.08906
+    },
+    "limit": {
+      "context": 256000,
+      "output": 256000
+    }
+  },
+  {
+    "id": "volcengine/doubao-seed-character-260628",
+    "name": "Seed Character",
+    "family": "seed",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-06-23",
+    "last_updated": "2026-06-23",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.11875,
+      "output": 0.29687,
+      "cache_read": 0.02375
+    },
+    "limit": {
+      "context": 256000,
+      "output": 256000
+    }
+  },
+  {
+    "id": "volcengine/doubao-seed-evolving",
+    "name": "Seed Evolving",
+    "family": "seed",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-06-23",
+    "last_updated": "2026-06-23",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.8906,
+      "output": 4.45301,
+      "cache_read": 0.17812
+    },
+    "limit": {
+      "context": 256000,
+      "output": 256000
+    }
+  },
+  {
+    "id": "volcengine/glm-5.2-260617",
+    "name": "GLM-5.2",
+    "family": "glm",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-06-13",
+    "last_updated": "2026-06-13",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 1.18747,
+      "output": 4.15615,
+      "cache_read": 0.29687
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 131072
+    }
+  },
+  {
     "id": "vultr/MiniMaxAI/MiniMax-M2.7",
     "name": "MiniMax-M2.7",
     "family": "minimax",
@@ -206972,7 +208641,7 @@
     },
     "limit": {
       "context": 1048576,
-      "output": 128000
+      "output": 512000
     }
   },
   {
@@ -207031,35 +208700,6 @@
     "limit": {
       "context": 131072,
       "output": 131072
-    }
-  },
-  {
-    "id": "wandb/MiniMaxAI/MiniMax-M2.5",
-    "name": "MiniMax M2.5",
-    "family": "minimax-m2.5",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2026-02-12",
-    "last_updated": "2026-02-12",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.3,
-      "output": 1.2,
-      "cache_read": 0.3
-    },
-    "limit": {
-      "context": 196608,
-      "output": 196608
     }
   },
   {
@@ -207144,36 +208784,6 @@
       "input": 0.1,
       "output": 0.3,
       "cache_read": 0.1
-    },
-    "limit": {
-      "context": 262144,
-      "output": 262144
-    }
-  },
-  {
-    "id": "wandb/Qwen/Qwen3-Coder-480B-A35B-Instruct",
-    "name": "Qwen3 Coder 480B A35B",
-    "family": "qwen",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-04",
-    "release_date": "2025-07-22",
-    "last_updated": "2025-07-22",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 1.0,
-      "output": 1.5,
-      "cache_read": 1.0
     },
     "limit": {
       "context": 262144,
@@ -207449,6 +209059,35 @@
     }
   },
   {
+    "id": "wandb/ibm-granite/granite-4.2-8b",
+    "name": "Granite 4.2 8B",
+    "family": "granite",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-08-24",
+    "last_updated": "2026-08-24",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.1,
+      "output": 0.15,
+      "cache_read": 0.05
+    },
+    "limit": {
+      "context": 131072,
+      "output": 131072
+    }
+  },
+  {
     "id": "wandb/meta-llama/Llama-3.1-70B-Instruct",
     "name": "Llama 3.1 70B",
     "family": "llama",
@@ -207473,8 +209112,8 @@
       "cache_read": 0.8
     },
     "limit": {
-      "context": 128000,
-      "output": 128000
+      "context": 131072,
+      "output": 131072
     }
   },
   {
@@ -207503,8 +209142,8 @@
       "cache_read": 0.22
     },
     "limit": {
-      "context": 128000,
-      "output": 128000
+      "context": 131072,
+      "output": 131072
     }
   },
   {
@@ -207630,35 +209269,6 @@
     }
   },
   {
-    "id": "wandb/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8",
-    "name": "Nemotron 3 Super",
-    "family": "nemotron",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2026-03-11",
-    "last_updated": "2026-03-11",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.2,
-      "output": 0.8,
-      "cache_read": 0.2
-    },
-    "limit": {
-      "context": 262144,
-      "output": 262144
-    }
-  },
-  {
     "id": "wandb/nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B",
     "name": "Nemotron 3 Ultra",
     "family": "nemotron",
@@ -207775,35 +209385,6 @@
     }
   },
   {
-    "id": "wandb/zai-org/GLM-5.1",
-    "name": "GLM 5.1",
-    "family": "glm",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2026-04-07",
-    "last_updated": "2026-04-07",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 1.4,
-      "output": 4.4,
-      "cache_read": 0.26
-    },
-    "limit": {
-      "context": 202752,
-      "output": 202752
-    }
-  },
-  {
     "id": "wandb/zai-org/GLM-5.2",
     "name": "GLM 5.2",
     "family": "glm",
@@ -207828,8 +209409,8 @@
       "cache_read": 0.14
     },
     "limit": {
-      "context": 262144,
-      "output": 262144
+      "context": 1048576,
+      "output": 1048576
     }
   },
   {
@@ -209287,7 +210868,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-05",
     "last_updated": "2026-03-05",
@@ -209318,7 +210899,7 @@
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-17",
     "last_updated": "2026-03-17",
@@ -209651,6 +211232,69 @@
   {
     "id": "zai-coding-plan/glm-5.3",
     "name": "GLM-5.3",
+    "family": "glm",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-08-14",
+    "last_updated": "2026-08-14",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0,
+      "cache_read": 0.0,
+      "cache_write": 0.0
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 131072
+    }
+  },
+  {
+    "id": "zai-coding-plan/glm-5.3-flash",
+    "name": "GLM-5.3-Flash",
+    "family": "glm",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-08-26",
+    "last_updated": "2026-08-26",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0,
+      "cache_read": 0.0,
+      "cache_write": 0.0
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 131072
+    }
+  },
+  {
+    "id": "zai-coding-plan/glm-5.3-highspeed",
+    "name": "GLM-5.3 Highspeed",
     "family": "glm",
     "attachment": false,
     "reasoning": true,
@@ -210070,6 +211714,69 @@
       "input": 1.4,
       "output": 4.4,
       "cache_read": 0.26,
+      "cache_write": 0.0
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 131072
+    }
+  },
+  {
+    "id": "zai/glm-5.3",
+    "name": "GLM-5.3",
+    "family": "glm",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-08-14",
+    "last_updated": "2026-08-14",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.4,
+      "output": 4.4,
+      "cache_read": 0.26,
+      "cache_write": 0.0
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 131072
+    }
+  },
+  {
+    "id": "zai/glm-5.3-flash",
+    "name": "GLM-5.3-Flash",
+    "family": "glm",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-08-26",
+    "last_updated": "2026-08-26",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.075,
+      "output": 0.25,
+      "cache_read": 0.015,
       "cache_write": 0.0
     },
     "limit": {
@@ -211404,8 +213111,8 @@
       "output": 2.4
     },
     "limit": {
-      "context": 512000,
-      "output": 128000
+      "context": 1048576,
+      "output": 512000
     }
   },
   {
@@ -214029,6 +215736,69 @@
     }
   },
   {
+    "id": "zhipuai-coding-plan/glm-5.3-flash",
+    "name": "GLM-5.3-Flash",
+    "family": "glm",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-08-26",
+    "last_updated": "2026-08-26",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0,
+      "cache_read": 0.0,
+      "cache_write": 0.0
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 131072
+    }
+  },
+  {
+    "id": "zhipuai-coding-plan/glm-5.3-highspeed",
+    "name": "GLM-5.3 Highspeed",
+    "family": "glm",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-08-14",
+    "last_updated": "2026-08-14",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0,
+      "cache_read": 0.0,
+      "cache_write": 0.0
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 131072
+    }
+  },
+  {
     "id": "zhipuai-coding-plan/glm-5v-turbo",
     "name": "GLM-5V-Turbo",
     "family": "glm",
@@ -214423,6 +216193,69 @@
       "input": 1.4,
       "output": 4.4,
       "cache_read": 0.26,
+      "cache_write": 0.0
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 131072
+    }
+  },
+  {
+    "id": "zhipuai/glm-5.3",
+    "name": "GLM-5.3",
+    "family": "glm",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-08-14",
+    "last_updated": "2026-08-14",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.4,
+      "output": 4.4,
+      "cache_read": 0.26,
+      "cache_write": 0.0
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 131072
+    }
+  },
+  {
+    "id": "zhipuai/glm-5.3-flash",
+    "name": "GLM-5.3-Flash",
+    "family": "glm",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-08-26",
+    "last_updated": "2026-08-26",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.075,
+      "output": 0.25,
+      "cache_read": 0.015,
       "cache_write": 0.0
     },
     "limit": {

--- a/crates/goose-provider-types/src/canonical/data/provider_metadata.json
+++ b/crates/goose-provider-types/src/canonical/data/provider_metadata.json
@@ -44,6 +44,17 @@
     "model_count": 3
   },
   {
+    "id": "agnes",
+    "display_name": "Agnes AI",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://apihub.agnes-ai.com/v1",
+    "doc": "https://agnes-ai.com/doc",
+    "env": [
+      "AGNES_API_KEY"
+    ],
+    "model_count": 3
+  },
+  {
     "id": "ai-router",
     "display_name": "AI-ROUTER",
     "npm": "@ai-sdk/openai-compatible",
@@ -64,6 +75,17 @@
       "AIAND_API_KEY"
     ],
     "model_count": 9
+  },
+  {
+    "id": "aixy",
+    "display_name": "Aixy",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.aixy-gateway.com/v1",
+    "doc": "https://docs.aixy-gateway.com/integrations/overview",
+    "env": [
+      "AIXY_API_KEY"
+    ],
+    "model_count": 1
   },
   {
     "id": "aki-io",
@@ -228,7 +250,7 @@
     "env": [
       "BASETEN_API_KEY"
     ],
-    "model_count": 19
+    "model_count": 20
   },
   {
     "id": "berget",
@@ -294,7 +316,7 @@
     "env": [
       "CLINE_API_KEY"
     ],
-    "model_count": 11
+    "model_count": 13
   },
   {
     "id": "cloudferro-sherlock",
@@ -317,7 +339,7 @@
       "CLOUDFLARE_ACCOUNT_ID",
       "CLOUDFLARE_API_KEY"
     ],
-    "model_count": 25
+    "model_count": 26
   },
   {
     "id": "coralbricks",
@@ -406,7 +428,7 @@
     "env": [
       "DEEPSEEK_API_KEY"
     ],
-    "model_count": 5
+    "model_count": 3
   },
   {
     "id": "digitalocean",
@@ -472,7 +494,7 @@
     "env": [
       "EDENAI_API_KEY"
     ],
-    "model_count": 232
+    "model_count": 235
   },
   {
     "id": "empiriolabs",
@@ -483,7 +505,7 @@
     "env": [
       "EMPIRIOLABS_API_KEY"
     ],
-    "model_count": 55
+    "model_count": 57
   },
   {
     "id": "evroc",
@@ -494,7 +516,7 @@
     "env": [
       "EVROC_API_KEY"
     ],
-    "model_count": 15
+    "model_count": 16
   },
   {
     "id": "fastrouter",
@@ -571,7 +593,7 @@
     "env": [
       "GMICLOUD_API_KEY"
     ],
-    "model_count": 13
+    "model_count": 15
   },
   {
     "id": "greenpt",
@@ -626,7 +648,7 @@
     "env": [
       "HF_TOKEN"
     ],
-    "model_count": 69
+    "model_count": 71
   },
   {
     "id": "hyper",
@@ -637,7 +659,7 @@
     "env": [
       "HYPER_API_KEY"
     ],
-    "model_count": 26
+    "model_count": 29
   },
   {
     "id": "iflowcn",
@@ -729,6 +751,17 @@
     "model_count": 17
   },
   {
+    "id": "iteracompute",
+    "display_name": "IteraCompute",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.iteracompute.com/v1",
+    "doc": "https://iteracompute.com/docs.html",
+    "env": [
+      "ITERACOMPUTE_API_KEY"
+    ],
+    "model_count": 1
+  },
+  {
     "id": "jalapeno",
     "display_name": "Jalapeno Cloud",
     "npm": "@ai-sdk/openai-compatible",
@@ -770,7 +803,7 @@
     "env": [
       "KILO_API_KEY"
     ],
-    "model_count": 365
+    "model_count": 366
   },
   {
     "id": "kimi-for-coding",
@@ -825,7 +858,7 @@
     "env": [
       "LLMGATEWAY_API_KEY"
     ],
-    "model_count": 187
+    "model_count": 189
   },
   {
     "id": "llmgateway-providers",
@@ -836,7 +869,18 @@
     "env": [
       "LLMGATEWAY_API_KEY"
     ],
-    "model_count": 377
+    "model_count": 381
+  },
+  {
+    "id": "llmtech",
+    "display_name": "LLM Tech",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.llmtech.eu/v1",
+    "doc": "https://llmtech.eu/models/qwen3.8-27b",
+    "env": [
+      "LLMTECH_API_KEY"
+    ],
+    "model_count": 1
   },
   {
     "id": "llmtr",
@@ -1078,7 +1122,7 @@
     "env": [
       "NANO_GPT_API_KEY"
     ],
-    "model_count": 606
+    "model_count": 612
   },
   {
     "id": "nearai",
@@ -1115,6 +1159,17 @@
     "model_count": 42
   },
   {
+    "id": "neosmith",
+    "display_name": "NeoSmith",
+    "npm": "@ai-sdk/openai",
+    "api": "https://router.neosmith.ai/v1",
+    "doc": "https://neosmith.ai/docs",
+    "env": [
+      "NEOSMITH_API_KEY"
+    ],
+    "model_count": 4
+  },
+  {
     "id": "neuralwatt",
     "display_name": "Neuralwatt",
     "npm": "@ai-sdk/openai-compatible",
@@ -1123,7 +1178,7 @@
     "env": [
       "NEURALWATT_API_KEY"
     ],
-    "model_count": 22
+    "model_count": 25
   },
   {
     "id": "nova",
@@ -1200,7 +1255,7 @@
     "env": [
       "OPENCODE_API_KEY"
     ],
-    "model_count": 29
+    "model_count": 31
   },
   {
     "id": "opper",
@@ -1234,6 +1289,17 @@
       "OVHCLOUD_API_KEY"
     ],
     "model_count": 14
+  },
+  {
+    "id": "pendra",
+    "display_name": "Pendra",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.pendra.ai/api/v1",
+    "doc": "https://pendra.ai/docs/integrations/opencode",
+    "env": [
+      "PENDRA_API_KEY"
+    ],
+    "model_count": 6
   },
   {
     "id": "perplexity-agent",
@@ -1333,7 +1399,7 @@
     "env": [
       "REQUESTY_API_KEY"
     ],
-    "model_count": 139
+    "model_count": 140
   },
   {
     "id": "routing-run",
@@ -1456,6 +1522,17 @@
       "STACKIT_API_KEY"
     ],
     "model_count": 8
+  },
+  {
+    "id": "standardcompute",
+    "display_name": "Standard Compute",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.stdcmpt.com/v1",
+    "doc": "https://standardcompute.com/models",
+    "env": [
+      "STANDARDCOMPUTE_API_KEY"
+    ],
+    "model_count": 1
   },
   {
     "id": "stepfun",
@@ -1675,7 +1752,18 @@
     "env": [
       "VIVGRID_API_KEY"
     ],
-    "model_count": 20
+    "model_count": 21
+  },
+  {
+    "id": "volcengine",
+    "display_name": "Volcengine Ark",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://ark.cn-beijing.volces.com/api/v3",
+    "doc": "https://www.volcengine.com/docs/82379/1330310",
+    "env": [
+      "ARK_API_KEY"
+    ],
+    "model_count": 15
   },
   {
     "id": "vultr",
@@ -1708,7 +1796,7 @@
     "env": [
       "WANDB_API_KEY"
     ],
-    "model_count": 29
+    "model_count": 26
   },
   {
     "id": "xiaomi",
@@ -1774,7 +1862,7 @@
     "env": [
       "ZHIPU_API_KEY"
     ],
-    "model_count": 14
+    "model_count": 16
   },
   {
     "id": "zai-coding-plan",
@@ -1785,7 +1873,7 @@
     "env": [
       "ZHIPU_API_KEY"
     ],
-    "model_count": 5
+    "model_count": 7
   },
   {
     "id": "zeldoc",
@@ -1829,7 +1917,7 @@
     "env": [
       "ZHIPU_API_KEY"
     ],
-    "model_count": 13
+    "model_count": 15
   },
   {
     "id": "zhipuai-coding-plan",
@@ -1840,6 +1928,6 @@
     "env": [
       "ZHIPU_API_KEY"
     ],
-    "model_count": 8
+    "model_count": 10
   }
 ]

--- a/crates/goose-provider-types/src/canonical/name_builder.rs
+++ b/crates/goose-provider-types/src/canonical/name_builder.rs
@@ -524,8 +524,8 @@ mod tests {
             Some("mistralai/codestral".to_string())
         );
         assert_eq!(
-            map_to_canonical_model("databricks", "deepseek-deepseek-chat", r),
-            Some("deepseek/deepseek-chat".to_string())
+            map_to_canonical_model("databricks", "deepseek-deepseek-v4-flash", r),
+            Some("deepseek/deepseek-v4-flash".to_string())
         );
         assert_eq!(
             map_to_canonical_model("databricks", "x-ai-grok-4.3", r),

--- a/crates/goose-provider-types/src/canonical/name_builder.rs
+++ b/crates/goose-provider-types/src/canonical/name_builder.rs
@@ -473,12 +473,12 @@ mod tests {
 
         // === DeepSeek ===
         assert_eq!(
-            map_to_canonical_model("databricks", "databricks-deepseek-chat", r),
-            Some("deepseek/deepseek-chat".to_string())
+            map_to_canonical_model("databricks", "databricks-deepseek-v4-flash", r),
+            Some("deepseek/deepseek-v4-flash".to_string())
         );
         assert_eq!(
-            map_to_canonical_model("databricks", "deepseek-reasoner", r),
-            Some("deepseek/deepseek-reasoner".to_string())
+            map_to_canonical_model("databricks", "deepseek-v4-pro", r),
+            Some("deepseek/deepseek-v4-pro".to_string())
         );
 
         // === Grok (X.AI) ===

--- a/crates/goose/src/providers/formats/bedrock.rs
+++ b/crates/goose/src/providers/formats/bedrock.rs
@@ -1670,25 +1670,7 @@ mod tests {
 
     #[test]
     fn test_bedrock_inference_config_omits_temperature_for_unsupported_model() {
-        // The Anthropic canonical registry maps this id and reports whether a
-        // custom temperature may be sent; when it cannot, temperature is left
-        // unset so the server default is used.
-        let mut config = ModelConfig::new("us.anthropic.claude-sonnet-4-5-20250929-v1:0");
-        config.temperature = Some(0.5);
-
-        let supported = bedrock_model_supports_temperature(&config);
-        let inference_config = bedrock_inference_config(&config);
-
-        if supported {
-            assert_eq!(inference_config.temperature(), Some(0.5));
-        } else {
-            assert_eq!(inference_config.temperature(), None);
-        }
-    }
-
-    #[test]
-    fn test_bedrock_inference_config_omits_temperature_for_bedrock_registry_unsupported_model() {
-        let mut config = ModelConfig::new("openai.gpt-5.4");
+        let mut config = ModelConfig::new("global.anthropic.claude-sonnet-5");
         config.temperature = Some(0.5);
 
         let inference_config = bedrock_inference_config(&config);


### PR DESCRIPTION
Rebuild canonical model registry and provider metadata from models.dev via `just build-canonical-models`.

- canonical_models.json: 7205 models (4094 insertions, 2173 deletions)
- provider_metadata.json: 175 providers
- adds GLM 5.3 Flash across multiple providers (baseten, deepinfra, huggingface, openrouter, etc.)
- adds DeepSeek V4 Flash/Pro variants across providers
- adds Mistral Large 2512, Mistral Medium 2604, Mistral Small 2603
- adds GPT-5.1, GPT-5.4 mini/nano variants
- adds Claude Opus 4.5, Claude Haiku 4.5, Claude Sonnet 4.5 aliases
- adds Kimi K2 0905 variant across providers