### PR TITLE
fix(ui): render untagged fenced code blocks as proper code blocks

### DIFF
--- a/ui/desktop/src/components/MarkdownContent.test.tsx
+++ b/ui/desktop/src/components/MarkdownContent.test.tsx
@@ -172,6 +172,41 @@ console.log('Hello, World!');
         expect(screen.getByText('console.log()')).toBeInTheDocument();
       });
     });
+
+    it('renders untagged fenced code blocks (no language) through the same CodeBlock component as tagged blocks', async () => {
+      const plainTextBlock = [
+        'first line of plain text',
+        'second line of plain text',
+        '',
+        'line after a blank line',
+      ].join('\n');
+      const content = ['```', plainTextBlock, '```'].join('\n');
+
+      const { container } = renderWithIntl(<MarkdownContent content={content} />);
+
+      await waitFor(() => {
+        expect(screen.getByText(/first line of plain text/)).toBeInTheDocument();
+      });
+
+      // There should be exactly one <pre> element wrapping exactly one <code>
+      // element that contains the entire multi-line block as a single node,
+      // rather than one <code>/<pre> pairing per line.
+      const preElements = container.querySelectorAll('pre');
+      expect(preElements).toHaveLength(1);
+
+      const codeElementsInsidePre = preElements[0].querySelectorAll('code');
+      expect(codeElementsInsidePre).toHaveLength(1);
+      expect(codeElementsInsidePre[0].textContent).toContain('first line of plain text');
+      expect(codeElementsInsidePre[0].textContent).toContain('line after a blank line');
+
+      // The block should NOT use the small single-line "inline code" badge
+      // style - that would indicate the bug regressed.
+      expect(codeElementsInsidePre[0].className).not.toContain('bg-inline-code');
+
+      // It should get the same hover "copy" button that tagged code blocks
+      // get, since it now renders through the shared CodeBlock component.
+      expect(preElements[0].querySelector('[data-testid="copy-icon"]')).toBeInTheDocument();
+    });
   });
 
   describe('Markdown Features', () => {

--- a/ui/desktop/src/components/MarkdownContent.tsx
+++ b/ui/desktop/src/components/MarkdownContent.tsx
@@ -152,8 +152,15 @@ const MarkdownCode = memo(
     ref: React.Ref<HTMLElement>
   ) {
     const match = /language-(\w+)/.exec(className || '');
-    return !inline && match ? (
-      <CodeBlock language={match[1]}>{String(children).replace(/\n$/, '')}</CodeBlock>
+    const codeContent = String(children ?? '');
+
+    // react-markdown gives untagged fenced blocks no language-xxx className,
+    // so they look like inline code here. Block-level content always ends with
+    // a trailing newline, which inline code spans can never contain.
+    const isBlockLevelCode = !inline && codeContent.endsWith('\n');
+
+    return isBlockLevelCode ? (
+      <CodeBlock language={match ? match[1] : 'text'}>{codeContent.replace(/\n$/, '')}</CodeBlock>
     ) : (
       <code ref={ref} {...props} className="break-all bg-inline-code whitespace-pre-wrap font-mono">
         {children}


### PR DESCRIPTION
## Summary

Fenced code blocks with no language tag (bare ```) were falling through to the inline-code branch, so multi-line output was squeezed into the small single-line badge style, painting a separate highlighted box on every wrapped line and losing the dark background, sizing, and copy button that tagged blocks get.

react-markdown never sets a language-xxx className for untagged or 4-space-indented blocks, so they are indistinguishable from single-backtick inline code by className alone. Block-level code content always ends with a trailing newline added by the parser, while inline code spans can never contain a literal newline, so use that distinction to route untagged blocks through the shared CodeBlock component with a plain "text" language.

Fixes: #11580

### Testing

A unit test is provided which exercises this functionality.

I have also been personally testing this fix with a custom build of Goose for a couple of weeks now.


### Screenshots/Demos (for UX changes)
Before:  

<img width="1158" height="755" alt="Goose Markdown Preformatted Text Before" src="https://github.com/user-attachments/assets/93188f28-20b3-4b74-ab72-529ed48ea30f" />

After:

<img width="1185" height="757" alt="Goose Markdown Preformatted Text After" src="https://github.com/user-attachments/assets/63119df6-2860-4660-a662-63ef7d4d2cfc" />
