### PR TITLE
Add PairBook to the extensions directory

### DIFF
--- a/documentation/docs/mcp/pairbook-mcp.md
+++ b/documentation/docs/mcp/pairbook-mcp.md
@@ -1,0 +1,67 @@
+---
+title: PairBook Extension
+description: Add PairBook MCP Server as a goose Extension
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import GooseDesktopInstaller from '@site/src/components/GooseDesktopInstaller';
+import CLIExtensionInstructions from '@site/src/components/CLIExtensionInstructions';
+
+This tutorial covers how to add the [PairBook MCP Server](https://github.com/vj88-coder/pairbook-mcp) as a goose extension to answer correlation and diversification questions about 4,700+ US stocks and ETFs, including issuer-sourced ETF holdings overlap, beta, volatility, drawdowns and fund facts. The data comes from the free PairBook API, refreshes every trading day, and needs no API key or account.
+
+:::tip Quick Install
+
+<Tabs groupId="interface">
+  <TabItem value="ui" label="goose Desktop" default>
+  [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=pairbook-mcp&id=pairbook-mcp&name=PairBook&description=Correlation%20and%20ETF%20overlap%20for%204%2C700%2B%20US%20stocks%20and%20ETFs)
+  </TabItem>
+  <TabItem value="cli" label="goose CLI">
+  **Command**
+  ```sh
+  npx -y pairbook-mcp
+  ```
+  </TabItem>
+</Tabs>
+:::
+
+## Configuration
+
+:::info
+Note that you'll need [Node.js](https://nodejs.org/) installed on your system to run this command, as it uses `npx`.
+:::
+
+<Tabs groupId="interface">
+  <TabItem value="ui" label="goose Desktop" default>
+  <GooseDesktopInstaller
+    extensionId="pairbook-mcp"
+    extensionName="PairBook"
+    description="Correlation and ETF overlap for 4,700+ US stocks and ETFs"
+    command="npx"
+    args={["-y", "pairbook-mcp"]}
+  />
+  </TabItem>
+  <TabItem value="cli" label="goose CLI">
+    <CLIExtensionInstructions
+      name="pairbook"
+      description="Correlation and ETF overlap for 4,700+ US stocks and ETFs"
+      command="npx -y pairbook-mcp"
+    />
+  </TabItem>
+</Tabs>
+
+No environment variables are needed: the server is read-only and talks to the free public PairBook API without any key or account.
+
+## Example Usage
+
+The extension exposes five read-only tools: compare a pair of assets, profile one asset, find diversifiers, fetch weekly return series, and resolve a company name to its ticker. Any of the 11.3 million possible pairs can be compared; popular pairs come precomputed with holdings overlap and the rest are computed on demand.
+
+### goose Prompt
+
+```
+I hold QQQ and I am thinking about adding QQQM and SCHD. Are QQQ and QQQM redundant, and does SCHD actually diversify the position? Compare fees and yields too.
+```
+
+goose will call the PairBook tools to fetch the correlations, the holdings overlap between the funds, and their expense ratios and dividend yields, then answer with the actual figures, for example that QQQ and QQQM hold essentially the same portfolio while SCHD overlaps only slightly and carries a higher yield.
+
+The data covers US-listed stocks and ETFs only, uses weekly closes, and is not investment advice.

--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -545,6 +545,17 @@
     "environmentVariables": []
   },
   {
+    "id": "pairbook-mcp",
+    "name": "PairBook",
+    "description": "Correlation, ETF holdings overlap, beta and volatility for 4,700+ US stocks and ETFs, any of 11.3M pairs, free with no API key",
+    "command": "npx -y pairbook-mcp",
+    "link": "https://github.com/vj88-coder/pairbook-mcp",
+    "installation_notes": "Install using npx package manager. No API key or account needed.",
+    "is_builtin": false,
+    "endorsed": false,
+    "environmentVariables": []
+  },
+  {
     "id": "pdf_read",
     "name": "PDF Reader",
     "description": "Read large and complex PDF documents",
@@ -807,26 +818,25 @@
     "environmentVariables": []
   },
   {
-  "id": "scholar-sidekick",
-  "name": "Scholar Sidekick",
-  "description": "Resolve, format, export, and verify academic citations (DOI, PMID, ISBN, arXiv) plus retraction and open-access checks",
-  "command": "npx -y scholar-sidekick-mcp@latest",
-  "link": "https://github.com/mlava/scholar-sidekick-mcp",
-  "installation_notes": "No API key required — works anonymously on a free, rate-limited tier. Optionally set SCHOLAR_API_KEY (a free first-party ssk_ key from https://scholar-sidekick.com/account) for higher limits, or RAPIDAPI_KEY for paid tiers via RapidAPI.",
-  "is_builtin": false,
-  "endorsed": false,
-  "environmentVariables": [
-    {
-      "name": "SCHOLAR_API_KEY",
-      "description": "Optional first-party API key (ssk_) from https://scholar-sidekick.com/account; raises rate limits. Sent as Authorization: Bearer.",
-      "required": false
-    },
-    {
-      "name": "RAPIDAPI_KEY",
-      "description": "Optional RapidAPI key for paid/managed tiers; routes calls through the RapidAPI gateway.",
-      "required": false
-    }
-  ]
-}
-
+    "id": "scholar-sidekick",
+    "name": "Scholar Sidekick",
+    "description": "Resolve, format, export, and verify academic citations (DOI, PMID, ISBN, arXiv) plus retraction and open-access checks",
+    "command": "npx -y scholar-sidekick-mcp@latest",
+    "link": "https://github.com/mlava/scholar-sidekick-mcp",
+    "installation_notes": "No API key required \u2014 works anonymously on a free, rate-limited tier. Optionally set SCHOLAR_API_KEY (a free first-party ssk_ key from https://scholar-sidekick.com/account) for higher limits, or RAPIDAPI_KEY for paid tiers via RapidAPI.",
+    "is_builtin": false,
+    "endorsed": false,
+    "environmentVariables": [
+      {
+        "name": "SCHOLAR_API_KEY",
+        "description": "Optional first-party API key (ssk_) from https://scholar-sidekick.com/account; raises rate limits. Sent as Authorization: Bearer.",
+        "required": false
+      },
+      {
+        "name": "RAPIDAPI_KEY",
+        "description": "Optional RapidAPI key for paid/managed tiers; routes calls through the RapidAPI gateway.",
+        "required": false
+      }
+    ]
+  }
 ]


### PR DESCRIPTION
Adds PairBook to documentation/static/servers.json (community extensions).

PairBook is a read-only finance MCP server: correlation (1/3/5-year weekly returns), covariance, beta vs S&P 500, volatility, max drawdown, fund facts and issuer-sourced ETF holdings overlap for 4,700+ US stocks and ETFs. Any of the 11.3M possible pairs can be compared; 52,000+ come precomputed and the rest are computed on demand. Free public API, no key, no account, no environment variables.

- Repo: https://github.com/vj88-coder/pairbook-mcp (MIT, tests + CI)
- npm: `npx -y pairbook-mcp`
- Official MCP registry: `io.github.vj88-coder/pairbook-mcp`