### PR TITLE
acp: keep prompt runs executing when the transport drops

### DIFF
--- a/crates/goose-cli/src/commands/roam_full_bridge.rs
+++ b/crates/goose-cli/src/commands/roam_full_bridge.rs
@@ -12,14 +12,14 @@
 //! Each accepted connection gets a **fresh** agent (never one shared across
 //! clients); every client drives its own independent sessions.
 
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
 
 use futures::future::BoxFuture;
 use futures::io::{AsyncRead, AsyncWrite};
 
-use goose::acp::server::serve;
+use goose::acp::server::{serve, GooseAcpAgent};
 use goose::acp::server_factory::AcpServer;
-use goose_roaming::{AcpStreamServer, EndpointId, RevocationSignal};
+use goose_roaming::{AcpStreamServer, EndpointId, RevocableWork, RevocationSignal};
 
 /// An [`AcpStreamServer`] that serves goose's full ACP surface, a fresh agent
 /// per connection.
@@ -48,6 +48,43 @@ impl FullAcpBridge {
     }
 }
 
+/// Revocation handle for a connection-agent's detached runs, registered with
+/// the roaming node so they stay revocable by peer key after the connection
+/// ends: an authorized peer may disconnect normally mid-run, and a later
+/// `peers revoke` must still stop that run even though there is no live
+/// connection left to force-close.
+///
+/// Holds the agent weakly, which encodes the intended lifetime: each detached
+/// prompt task owns an `Arc` of its agent for the task's whole duration (see
+/// the `PromptRequest` handler in `acp/server/dispatch.rs`), so this handle
+/// stays alive exactly while the stream is being served or any of the agent's
+/// runs are still executing, and reports dead — and is pruned by the node —
+/// once both are over.
+struct RevocableAgentRuns {
+    agent: Weak<GooseAcpAgent>,
+}
+
+impl RevocableWork for RevocableAgentRuns {
+    fn is_alive(&self) -> bool {
+        self.agent.strong_count() > 0
+    }
+
+    fn revoke(&self) -> BoxFuture<'static, ()> {
+        let agent = self.agent.upgrade();
+        Box::pin(async move {
+            if let Some(agent) = agent {
+                let cancelled = agent.revoke_and_cancel_own_runs().await;
+                if cancelled > 0 {
+                    tracing::info!(
+                        cancelled,
+                        "roaming: cancelled detached run(s) of revoked peer"
+                    );
+                }
+            }
+        })
+    }
+}
+
 impl AcpStreamServer for FullAcpBridge {
     fn serve_stream(
         &self,
@@ -63,6 +100,14 @@ impl AcpStreamServer for FullAcpBridge {
             let agent = server
                 .create_agent_with_session_cwd(Some(session_cwd))
                 .await?;
+            // Registered before serving so no prompt can start a run that a
+            // revocation cannot reach; the node revokes it by peer key even
+            // after this connection — and this future — are long gone.
+            revocation
+                .register_revocable_work(Arc::new(RevocableAgentRuns {
+                    agent: Arc::downgrade(&agent),
+                }))
+                .await;
             let result = serve(agent.clone(), recv, send).await;
             // Detached prompt runs deliberately survive ordinary transport
             // loss so a reconnecting peer can `session/load` the finished

--- a/crates/goose-cli/src/commands/roam_full_bridge.rs
+++ b/crates/goose-cli/src/commands/roam_full_bridge.rs
@@ -19,7 +19,7 @@ use futures::io::{AsyncRead, AsyncWrite};
 
 use goose::acp::server::serve;
 use goose::acp::server_factory::AcpServer;
-use goose_roaming::{AcpStreamServer, EndpointId};
+use goose_roaming::{AcpStreamServer, EndpointId, RevocationSignal};
 
 /// An [`AcpStreamServer`] that serves goose's full ACP surface, a fresh agent
 /// per connection.
@@ -54,6 +54,7 @@ impl AcpStreamServer for FullAcpBridge {
         client: EndpointId,
         recv: Box<dyn AsyncRead + Send + Unpin>,
         send: Box<dyn AsyncWrite + Send + Unpin>,
+        revocation: RevocationSignal,
     ) -> BoxFuture<'static, anyhow::Result<()>> {
         let server = self.server.clone();
         let session_cwd = self.session_cwd.clone();
@@ -62,7 +63,24 @@ impl AcpStreamServer for FullAcpBridge {
             let agent = server
                 .create_agent_with_session_cwd(Some(session_cwd))
                 .await?;
-            serve(agent, recv, send).await
+            let result = serve(agent.clone(), recv, send).await;
+            // Detached prompt runs deliberately survive ordinary transport
+            // loss so a reconnecting peer can `session/load` the finished
+            // work. Revocation is different: the node force-closed this
+            // connection because the peer's authority was withdrawn, so its
+            // in-flight turns must stop rather than keep executing tools and
+            // consuming the provider.
+            if revocation.is_revoked() {
+                let cancelled = agent.cancel_own_active_runs().await;
+                if cancelled > 0 {
+                    tracing::info!(
+                        %client,
+                        cancelled,
+                        "roaming: cancelled active run(s) of revoked peer"
+                    );
+                }
+            }
+            result
         })
     }
 

--- a/crates/goose-cli/src/commands/roam_full_bridge.rs
+++ b/crates/goose-cli/src/commands/roam_full_bridge.rs
@@ -69,9 +69,14 @@ impl AcpStreamServer for FullAcpBridge {
             // work. Revocation is different: the node force-closed this
             // connection because the peer's authority was withdrawn, so its
             // in-flight turns must stop rather than keep executing tools and
-            // consuming the provider.
+            // consuming the provider — and any prompt still racing through
+            // dispatch must be fenced out, not just the runs already
+            // registered. Fencing this agent permanently is safe because it
+            // is per-connection and this future owns it: an ordinary
+            // disconnect never sets the fence, and a peer that merely lost
+            // its network gets a fresh, unfenced agent on reconnect.
             if revocation.is_revoked() {
-                let cancelled = agent.cancel_own_active_runs().await;
+                let cancelled = agent.revoke_and_cancel_own_runs().await;
                 if cancelled > 0 {
                     tracing::info!(
                         %client,

--- a/crates/goose-cli/tests/roam_acp_client.rs
+++ b/crates/goose-cli/tests/roam_acp_client.rs
@@ -42,6 +42,7 @@ impl AcpStreamServer for StubAcpAgent {
         _client: EndpointId,
         recv: Box<dyn AsyncRead + Send + Unpin>,
         send: Box<dyn AsyncWrite + Send + Unpin>,
+        _revocation: goose_roaming::RevocationSignal,
     ) -> BoxFuture<'static, Result<()>> {
         Box::pin(async move {
             let transport = agent_client_protocol::ByteStreams::new(send, recv);

--- a/crates/goose-roaming/examples/echo_roundtrip.rs
+++ b/crates/goose-roaming/examples/echo_roundtrip.rs
@@ -34,6 +34,7 @@ impl AcpStreamServer for EchoServer {
         _client: EndpointId,
         mut recv: Box<dyn futures::io::AsyncRead + Send + Unpin>,
         mut send: Box<dyn futures::io::AsyncWrite + Send + Unpin>,
+        _revocation: goose_roaming::RevocationSignal,
     ) -> futures::future::BoxFuture<'static, anyhow::Result<()>> {
         Box::pin(async move {
             // Read the client's fixed-size message, reply upper-cased, then stay

--- a/crates/goose-roaming/src/lib.rs
+++ b/crates/goose-roaming/src/lib.rs
@@ -47,8 +47,8 @@ pub fn parse_endpoint_id(s: &str) -> Result<EndpointId, RoamingError> {
 pub use error::RoamingError;
 pub use identity::{default_key_path, RoamingIdentity};
 pub use node::{
-    AcpStreamServer, RevocationSignal, RoamingClientStream, RoamingConfig, RoamingNode,
-    ROAMING_ACP_ALPN,
+    AcpStreamServer, RevocableWork, RevocationSignal, RoamingClientStream, RoamingConfig,
+    RoamingNode, ROAMING_ACP_ALPN,
 };
 pub use peerbook::{PeerBook, PeerRecord};
 pub use relay::{RelayEntry, RelaySettings};

--- a/crates/goose-roaming/src/lib.rs
+++ b/crates/goose-roaming/src/lib.rs
@@ -47,7 +47,8 @@ pub fn parse_endpoint_id(s: &str) -> Result<EndpointId, RoamingError> {
 pub use error::RoamingError;
 pub use identity::{default_key_path, RoamingIdentity};
 pub use node::{
-    AcpStreamServer, RoamingClientStream, RoamingConfig, RoamingNode, ROAMING_ACP_ALPN,
+    AcpStreamServer, RevocationSignal, RoamingClientStream, RoamingConfig, RoamingNode,
+    ROAMING_ACP_ALPN,
 };
 pub use peerbook::{PeerBook, PeerRecord};
 pub use relay::{RelayEntry, RelaySettings};

--- a/crates/goose-roaming/src/node.rs
+++ b/crates/goose-roaming/src/node.rs
@@ -33,22 +33,74 @@ const HANDSHAKE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10
 /// connections for revoked keys. Armed automatically by [`RoamingNode::share`].
 const DEFAULT_REVOCATION_POLL: std::time::Duration = std::time::Duration::from_secs(2);
 
-/// Set by the node when it force-closes a connection because its peer key was
-/// revoked. Lets a stream server distinguish deliberate revocation from
-/// ordinary transport loss after `serve_stream` returns: work that should
-/// survive a network drop must still be stopped when the peer's authority to
-/// run it is withdrawn.
+/// Work a served connection may leave running after it ends (e.g. goose's
+/// detached prompt runs) that must remain revocable by peer key: revoking a
+/// peer must stop its in-flight work even when no connection is live to
+/// force-close. Implemented by the integration layer and registered via
+/// [`RevocationSignal::register_revocable_work`]; this crate never learns the
+/// concrete worker type.
+pub trait RevocableWork: Send + Sync {
+    /// Whether the worker can still own work. Dead handles are pruned lazily
+    /// (on later registrations for the same peer and on trust enforcement).
+    fn is_alive(&self) -> bool;
+
+    /// Stop the worker: fence it against starting new work and cancel what it
+    /// is running. Must be idempotent and a no-op once the worker is gone.
+    fn revoke(&self) -> futures::future::BoxFuture<'static, ()>;
+}
+
+/// Per-connection revocation handle, created by the node for each authorized
+/// inbound connection.
+///
+/// Two jobs:
+/// - The *signal*: set by the node when it force-closes this connection
+///   because its peer key was revoked, letting a stream server distinguish
+///   deliberate revocation from ordinary transport loss after `serve_stream`
+///   returns.
+/// - The *registrar*: [`Self::register_revocable_work`] parks a handle to
+///   work that may outlive this connection in the node's peer-keyed registry,
+///   so a revocation arriving after an ordinary disconnect still reaches it.
 #[derive(Clone, Debug, Default)]
-pub struct RevocationSignal(Arc<std::sync::atomic::AtomicBool>);
+pub struct RevocationSignal {
+    revoked: Arc<std::sync::atomic::AtomicBool>,
+    /// Registrar back-reference; empty on default-constructed signals, which
+    /// makes registration a no-op (only the node mints connected signals).
+    node: std::sync::Weak<RoamingNode>,
+    peer: Option<EndpointId>,
+}
 
 impl RevocationSignal {
+    fn for_connection(node: &Arc<RoamingNode>, peer: EndpointId) -> Self {
+        Self {
+            revoked: Arc::default(),
+            node: Arc::downgrade(node),
+            peer: Some(peer),
+        }
+    }
+
     /// Whether the node closed this connection to enforce a revocation.
     pub fn is_revoked(&self) -> bool {
-        self.0.load(std::sync::atomic::Ordering::Acquire)
+        self.revoked.load(std::sync::atomic::Ordering::Acquire)
     }
 
     fn set(&self) {
-        self.0.store(true, std::sync::atomic::Ordering::Release);
+        self.revoked
+            .store(true, std::sync::atomic::Ordering::Release);
+    }
+
+    /// Keep `work` revocable by this connection's peer key even after the
+    /// connection ends: a later `peers revoke` / trust refresh invokes
+    /// [`RevocableWork::revoke`] although there is no live connection left to
+    /// force-close. If this connection was already closed for a revocation,
+    /// the work is revoked immediately instead of parked.
+    pub async fn register_revocable_work(&self, work: Arc<dyn RevocableWork>) {
+        if self.is_revoked() {
+            work.revoke().await;
+            return;
+        }
+        if let (Some(node), Some(peer)) = (self.node.upgrade(), self.peer) {
+            node.register_revocable_work(peer, work).await;
+        }
     }
 }
 
@@ -160,6 +212,11 @@ pub struct RoamingNode {
     /// into the open data plane: a key that leaves the allowlist gets its
     /// connections force-closed, not just refused on the next dial.
     live: Mutex<std::collections::HashMap<EndpointId, Vec<LiveConnection>>>,
+    /// Work left behind by served connections that must remain revocable by
+    /// peer key after the connection ends (see [`RevocableWork`]). Entries are
+    /// drained when their key is revoked and pruned lazily once dead, so a
+    /// peer that is revoked and later re-accepted starts from a clean slate.
+    revocable_work: Mutex<std::collections::HashMap<EndpointId, Vec<Arc<dyn RevocableWork>>>>,
     revocation_watcher: Mutex<Option<tokio::task::JoinHandle<()>>>,
 }
 
@@ -197,6 +254,7 @@ impl RoamingNode {
             directory: config.directory,
             relay,
             live: Mutex::new(std::collections::HashMap::new()),
+            revocable_work: Mutex::new(std::collections::HashMap::new()),
             revocation_watcher: Mutex::new(None),
         }))
     }
@@ -314,6 +372,17 @@ impl RoamingNode {
             });
     }
 
+    /// Park `work` under `peer` so a later revocation of that key can stop it
+    /// even after every connection is gone. Dead handles for the same peer are
+    /// pruned here, which bounds the registry for peers that reconnect often:
+    /// a handle only stays alive while its worker still has work in flight.
+    pub async fn register_revocable_work(&self, peer: EndpointId, work: Arc<dyn RevocableWork>) {
+        let mut revocable_work = self.revocable_work.lock().await;
+        let entries = revocable_work.entry(peer).or_default();
+        entries.retain(|entry| entry.is_alive());
+        entries.push(work);
+    }
+
     async fn unregister_live(&self, client: EndpointId, connection: &Connection) {
         let mut live = self.live.lock().await;
         if let Some(conns) = live.get_mut(&client) {
@@ -325,9 +394,12 @@ impl RoamingNode {
     }
 
     /// Force-close any live connections whose peer key is no longer allowed by
-    /// `trust`. Revocation reaches into the open data plane: the allowlist is
-    /// not just a gate on new dials, it is authority over connections that
-    /// already exist. Returns the number of connections closed.
+    /// `trust`, and revoke any parked [`RevocableWork`] those keys left behind
+    /// (work that outlived its connection, e.g. detached prompt runs after an
+    /// ordinary disconnect). Revocation reaches into the open data plane: the
+    /// allowlist is not just a gate on new dials, it is authority over
+    /// connections — and work — that already exist. Returns the number of
+    /// connections closed.
     pub async fn enforce_trust(&self, trust: &TrustBook) -> usize {
         let to_close: Vec<(EndpointId, Vec<LiveConnection>)> = {
             let mut live = self.live.lock().await;
@@ -356,6 +428,39 @@ impl RoamingNode {
             }
             tracing::info!(%client, "roaming: force-closed live connection(s) for revoked key");
         }
+
+        // Detached work outlives its connection, so it is revoked by peer key
+        // rather than through a live connection's signal. Entries for revoked
+        // keys are drained — if the peer is later re-accepted, its new
+        // connections register fresh workers — and dead entries for keys that
+        // remain allowed are pruned opportunistically.
+        let revoked_work: Vec<(EndpointId, Vec<Arc<dyn RevocableWork>>)> = {
+            let mut revocable_work = self.revocable_work.lock().await;
+            revocable_work.retain(|key, entries| {
+                if trust.is_allowed(key) {
+                    entries.retain(|entry| entry.is_alive());
+                    !entries.is_empty()
+                } else {
+                    true
+                }
+            });
+            let revoked: Vec<EndpointId> = revocable_work
+                .keys()
+                .filter(|key| !trust.is_allowed(key))
+                .copied()
+                .collect();
+            revoked
+                .into_iter()
+                .filter_map(|key| revocable_work.remove(&key).map(|entries| (key, entries)))
+                .collect()
+        };
+        for (client, entries) in revoked_work {
+            for entry in entries {
+                entry.revoke().await;
+            }
+            tracing::info!(%client, "roaming: revoked detached work for revoked key");
+        }
+
         closed
     }
 
@@ -558,7 +663,7 @@ impl ProtocolHandler for RoamingAcpHandler {
                     tracing::warn!("roaming: failed to send accept ack: {e}");
                     return Ok(());
                 }
-                let revocation = RevocationSignal::default();
+                let revocation = RevocationSignal::for_connection(&self.node, client);
                 self.node
                     .register_live(client, connection.clone(), revocation.clone())
                     .await;

--- a/crates/goose-roaming/src/node.rs
+++ b/crates/goose-roaming/src/node.rs
@@ -33,17 +33,40 @@ const HANDSHAKE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10
 /// connections for revoked keys. Armed automatically by [`RoamingNode::share`].
 const DEFAULT_REVOCATION_POLL: std::time::Duration = std::time::Duration::from_secs(2);
 
+/// Set by the node when it force-closes a connection because its peer key was
+/// revoked. Lets a stream server distinguish deliberate revocation from
+/// ordinary transport loss after `serve_stream` returns: work that should
+/// survive a network drop must still be stopped when the peer's authority to
+/// run it is withdrawn.
+#[derive(Clone, Debug, Default)]
+pub struct RevocationSignal(Arc<std::sync::atomic::AtomicBool>);
+
+impl RevocationSignal {
+    /// Whether the node closed this connection to enforce a revocation.
+    pub fn is_revoked(&self) -> bool {
+        self.0.load(std::sync::atomic::Ordering::Acquire)
+    }
+
+    fn set(&self) {
+        self.0.store(true, std::sync::atomic::Ordering::Release);
+    }
+}
+
 /// Serves an accepted, authorized ACP byte stream. Implemented by the
 /// integration layer (e.g. `goose-cli`) so this crate does not depend on the
 /// concrete agent/session machinery.
 pub trait AcpStreamServer: Send + Sync + 'static {
     /// Drive the ACP protocol to completion over the given stream for the
-    /// accepted peer identified by `client`.
+    /// accepted peer identified by `client`. `revocation` is set by the node
+    /// if it force-closes this connection because the peer's key was revoked;
+    /// check it after the stream ends to stop any work that would otherwise
+    /// outlive the peer's authority.
     fn serve_stream(
         &self,
         client: EndpointId,
         recv: Box<dyn AsyncRead + Send + Unpin>,
         send: Box<dyn AsyncWrite + Send + Unpin>,
+        revocation: RevocationSignal,
     ) -> futures::future::BoxFuture<'static, anyhow::Result<()>>;
 
     /// A stable, human-facing id for the agent being shared, surfaced to
@@ -118,6 +141,13 @@ impl RoamingConfig {
     }
 }
 
+/// A live authorized inbound connection plus the revocation signal shared
+/// with its `serve_stream` future.
+struct LiveConnection {
+    connection: Connection,
+    revocation: RevocationSignal,
+}
+
 /// A bound roaming node.
 pub struct RoamingNode {
     endpoint: Endpoint,
@@ -129,7 +159,7 @@ pub struct RoamingNode {
     /// Live authorized inbound connections, by peer key. Lets revocation reach
     /// into the open data plane: a key that leaves the allowlist gets its
     /// connections force-closed, not just refused on the next dial.
-    live: Mutex<std::collections::HashMap<EndpointId, Vec<Connection>>>,
+    live: Mutex<std::collections::HashMap<EndpointId, Vec<LiveConnection>>>,
     revocation_watcher: Mutex<Option<tokio::task::JoinHandle<()>>>,
 }
 
@@ -267,19 +297,27 @@ impl RoamingNode {
         Ok(())
     }
 
-    async fn register_live(&self, client: EndpointId, connection: Connection) {
+    async fn register_live(
+        &self,
+        client: EndpointId,
+        connection: Connection,
+        revocation: RevocationSignal,
+    ) {
         self.live
             .lock()
             .await
             .entry(client)
             .or_default()
-            .push(connection);
+            .push(LiveConnection {
+                connection,
+                revocation,
+            });
     }
 
     async fn unregister_live(&self, client: EndpointId, connection: &Connection) {
         let mut live = self.live.lock().await;
         if let Some(conns) = live.get_mut(&client) {
-            conns.retain(|c| c.stable_id() != connection.stable_id());
+            conns.retain(|c| c.connection.stable_id() != connection.stable_id());
             if conns.is_empty() {
                 live.remove(&client);
             }
@@ -291,7 +329,7 @@ impl RoamingNode {
     /// not just a gate on new dials, it is authority over connections that
     /// already exist. Returns the number of connections closed.
     pub async fn enforce_trust(&self, trust: &TrustBook) -> usize {
-        let to_close: Vec<(EndpointId, Vec<Connection>)> = {
+        let to_close: Vec<(EndpointId, Vec<LiveConnection>)> = {
             let mut live = self.live.lock().await;
             let revoked: Vec<EndpointId> = live
                 .keys()
@@ -306,7 +344,11 @@ impl RoamingNode {
         let mut closed = 0;
         for (client, conns) in to_close {
             for conn in conns {
-                conn.close(0u32.into(), b"revoked");
+                // Mark the connection revoked *before* closing it so the
+                // serve_stream future observes the signal as soon as its
+                // stream errors out.
+                conn.revocation.set();
+                conn.connection.close(0u32.into(), b"revoked");
                 closed += 1;
                 // One disconnect per closed connection so the directory's
                 // per-peer live count reaches zero.
@@ -516,7 +558,10 @@ impl ProtocolHandler for RoamingAcpHandler {
                     tracing::warn!("roaming: failed to send accept ack: {e}");
                     return Ok(());
                 }
-                self.node.register_live(client, connection.clone()).await;
+                let revocation = RevocationSignal::default();
+                self.node
+                    .register_live(client, connection.clone(), revocation.clone())
+                    .await;
 
                 // Close the accept/register TOCTOU: a revocation that lands
                 // after `authorize` read the allowlist but before the line
@@ -548,7 +593,11 @@ impl ProtocolHandler for RoamingAcpHandler {
                     .await;
                 let recv_box: Box<dyn AsyncRead + Send + Unpin> = Box::new(recv.compat());
                 let send_box: Box<dyn AsyncWrite + Send + Unpin> = Box::new(send.compat_write());
-                if let Err(e) = self.server.serve_stream(client, recv_box, send_box).await {
+                if let Err(e) = self
+                    .server
+                    .serve_stream(client, recv_box, send_box, revocation)
+                    .await
+                {
                     tracing::warn!("roaming: ACP session ended with error: {e}");
                 }
                 self.node.unregister_live(client, &connection).await;

--- a/crates/goose-roaming/src/node.rs
+++ b/crates/goose-roaming/src/node.rs
@@ -91,15 +91,28 @@ impl RevocationSignal {
     /// Keep `work` revocable by this connection's peer key even after the
     /// connection ends: a later `peers revoke` / trust refresh invokes
     /// [`RevocableWork::revoke`] although there is no live connection left to
-    /// force-close. If this connection was already closed for a revocation,
-    /// the work is revoked immediately instead of parked.
+    /// force-close. If this connection was already closed for a revocation, or
+    /// the peer has meanwhile left the allowlist, the work is revoked
+    /// immediately instead of parked.
+    ///
+    /// The revoked-or-not decision is taken by the node inside the same
+    /// critical section its revocation drain uses, so this cannot interleave
+    /// with a concurrent revocation of the peer (see
+    /// [`RoamingNode::register_revocable_work`]).
     pub async fn register_revocable_work(&self, work: Arc<dyn RevocableWork>) {
-        if self.is_revoked() {
-            work.revoke().await;
-            return;
-        }
-        if let (Some(node), Some(peer)) = (self.node.upgrade(), self.peer) {
-            node.register_revocable_work(peer, work).await;
+        match (self.node.upgrade(), self.peer) {
+            (Some(node), Some(peer)) => {
+                node.register_revocable_work_for_connection(peer, work, Some(self))
+                    .await;
+            }
+            // No registrar (a default-constructed signal, or the node is gone):
+            // registration is a no-op, but a signal that is already revoked
+            // must still stop the work it was handed.
+            _ => {
+                if self.is_revoked() {
+                    work.revoke().await;
+                }
+            }
         }
     }
 }
@@ -376,11 +389,72 @@ impl RoamingNode {
     /// even after every connection is gone. Dead handles for the same peer are
     /// pruned here, which bounds the registry for peers that reconnect often:
     /// a handle only stays alive while its worker still has work in flight.
+    ///
+    /// Registering is *mutually exclusive* with revoking: whether to park the
+    /// work or revoke it is decided inside the same `revocable_work` critical
+    /// section that [`Self::enforce_trust`] drains under, so a registration
+    /// cannot land behind a concurrent drain and leave a revoked peer's work
+    /// parked and unrevoked. Work for a peer that is no longer allowed is
+    /// revoked instead of parked.
     pub async fn register_revocable_work(&self, peer: EndpointId, work: Arc<dyn RevocableWork>) {
-        let mut revocable_work = self.revocable_work.lock().await;
-        let entries = revocable_work.entry(peer).or_default();
-        entries.retain(|entry| entry.is_alive());
-        entries.push(work);
+        self.register_revocable_work_for_connection(peer, work, None)
+            .await;
+    }
+
+    /// [`Self::register_revocable_work`] plus the originating connection's
+    /// revocation signal, which is re-read under the registry lock: a
+    /// connection the node already force-closed for a revocation must not be
+    /// able to park anything, even if the allowlist has since changed again.
+    ///
+    /// Lock order: `revocable_work` -> `trust`. Nothing acquires `trust` (or
+    /// `live`) before `revocable_work`, so this cannot deadlock; `enforce_trust`
+    /// takes `live` and `revocable_work` in disjoint critical sections and never
+    /// takes `trust`.
+    async fn register_revocable_work_for_connection(
+        &self,
+        peer: EndpointId,
+        work: Arc<dyn RevocableWork>,
+        signal: Option<&RevocationSignal>,
+    ) {
+        let rejected = {
+            let mut revocable_work = self.revocable_work.lock().await;
+            // Both checks happen here, under the drain's own lock, so no
+            // revocation can slip between the decision and the insert.
+            if signal.is_some_and(RevocationSignal::is_revoked)
+                || !self.peer_is_allowed(&peer).await
+            {
+                Some(work)
+            } else {
+                let entries = revocable_work.entry(peer).or_default();
+                entries.retain(|entry| entry.is_alive());
+                entries.push(work);
+                None
+            }
+        };
+        // `RevocableWork::revoke` is integration-supplied and may do arbitrary
+        // async work, so it runs after the guard is dropped.
+        if let Some(work) = rejected {
+            tracing::info!(%peer, "roaming: refusing to park work for a revoked key; revoking it");
+            work.revoke().await;
+        }
+    }
+
+    /// Whether `peer` is currently allowed, read from the same source of truth
+    /// `enforce_trust`'s callers use: the persisted allowlist when a
+    /// `trust_path` is configured (what the revocation watcher loads and what
+    /// `roam peers revoke` writes), otherwise the in-memory book. A failed load
+    /// fails *closed*, matching the accept path.
+    async fn peer_is_allowed(&self, peer: &EndpointId) -> bool {
+        match &self.trust_path {
+            Some(path) => match TrustBook::load(path) {
+                Ok(book) => book.is_allowed(peer),
+                Err(e) => {
+                    tracing::warn!(%peer, "roaming: trust read failed, refusing to park work: {e}");
+                    false
+                }
+            },
+            None => self.trust.lock().await.is_allowed(peer),
+        }
     }
 
     async fn unregister_live(&self, client: EndpointId, connection: &Connection) {
@@ -400,6 +474,15 @@ impl RoamingNode {
     /// allowlist is not just a gate on new dials, it is authority over
     /// connections — and work — that already exist. Returns the number of
     /// connections closed.
+    ///
+    /// Ordering against [`Self::register_revocable_work`]: every connection's
+    /// revocation signal is set before the parked-work drain runs, and the
+    /// drain shares its critical section with the registration decision. So for
+    /// any concurrent registration exactly one of two things happens — it is
+    /// admitted before the drain and the drain then revokes it, or the drain has
+    /// already run and the registration re-reads the signal/allowlist under the
+    /// same lock and revokes the work itself. Neither order can leave a revoked
+    /// key's work parked.
     pub async fn enforce_trust(&self, trust: &TrustBook) -> usize {
         let to_close: Vec<(EndpointId, Vec<LiveConnection>)> = {
             let mut live = self.live.lock().await;
@@ -434,6 +517,9 @@ impl RoamingNode {
         // keys are drained — if the peer is later re-accepted, its new
         // connections register fresh workers — and dead entries for keys that
         // remain allowed are pruned opportunistically.
+        //
+        // This drain and the registration decision share this one lock: see the
+        // ordering note on this function.
         let revoked_work: Vec<(EndpointId, Vec<Arc<dyn RevocableWork>>)> = {
             let mut revocable_work = self.revocable_work.lock().await;
             revocable_work.retain(|key, entries| {

--- a/crates/goose-roaming/tests/end_to_end.rs
+++ b/crates/goose-roaming/tests/end_to_end.rs
@@ -8,12 +8,46 @@
 
 use std::sync::Arc;
 
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
 use futures::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use goose_roaming::{
-    AcpStreamServer, Directory, RelaySettings, RevocationSignal, RoamingConfig, RoamingIdentity,
-    RoamingNode, TrustBook,
+    AcpStreamServer, Directory, RelaySettings, RevocableWork, RevocationSignal, RoamingConfig,
+    RoamingIdentity, RoamingNode, TrustBook,
 };
 use iroh::EndpointId;
+
+/// A stand-in for goose's detached prompt runs: records revocations so tests
+/// can assert that revoking a peer reaches work that outlived its connection.
+#[derive(Debug)]
+struct FakeDetachedWork {
+    alive: AtomicBool,
+    revocations: AtomicUsize,
+}
+
+impl FakeDetachedWork {
+    fn new(alive: bool) -> Arc<Self> {
+        Arc::new(Self {
+            alive: AtomicBool::new(alive),
+            revocations: AtomicUsize::new(0),
+        })
+    }
+
+    fn revocations(&self) -> usize {
+        self.revocations.load(Ordering::Acquire)
+    }
+}
+
+impl RevocableWork for FakeDetachedWork {
+    fn is_alive(&self) -> bool {
+        self.alive.load(Ordering::Acquire)
+    }
+
+    fn revoke(&self) -> futures::future::BoxFuture<'static, ()> {
+        self.revocations.fetch_add(1, Ordering::AcqRel);
+        Box::pin(async {})
+    }
+}
 
 /// A stand-in ACP server that echoes one line back, upper-cased.
 #[derive(Debug, Default)]
@@ -22,6 +56,10 @@ struct EchoServer {
     /// whether the node marked a connection as force-closed-by-revocation
     /// (versus an ordinary transport close).
     revocations: Arc<std::sync::Mutex<Vec<RevocationSignal>>>,
+    /// When set, registered with the connection's revocation handle at serve
+    /// start — as the real bridge parks its detached-run handle — so tests can
+    /// assert peer-keyed revocation of work that outlives the connection.
+    work_to_register: std::sync::Mutex<Option<Arc<FakeDetachedWork>>>,
 }
 
 impl AcpStreamServer for EchoServer {
@@ -32,8 +70,12 @@ impl AcpStreamServer for EchoServer {
         mut send: Box<dyn AsyncWrite + Send + Unpin>,
         revocation: RevocationSignal,
     ) -> futures::future::BoxFuture<'static, anyhow::Result<()>> {
-        self.revocations.lock().unwrap().push(revocation);
+        self.revocations.lock().unwrap().push(revocation.clone());
+        let work = self.work_to_register.lock().unwrap().take();
         Box::pin(async move {
+            if let Some(work) = work {
+                revocation.register_revocable_work(work).await;
+            }
             let mut buf = [0u8; 5];
             recv.read_exact(&mut buf).await?;
             let upper: Vec<u8> = buf.iter().map(|b| b.to_ascii_uppercase()).collect();
@@ -325,6 +367,111 @@ async fn revocation_watcher_closes_live_connection_from_file() {
             "the watcher's force-close must set the revocation signal"
         );
     }
+
+    host.shutdown().await.unwrap();
+}
+
+/// Detached work must stay revocable after its connection ends: an authorized
+/// peer that disconnects NORMALLY mid-run leaves no live connection to
+/// force-close, yet a later `peers revoke` must still stop the work it left
+/// behind.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn revoking_a_disconnected_peer_stops_its_detached_work() {
+    let host = bind_node().await;
+    let echo = Arc::new(EchoServer::default());
+    let work = FakeDetachedWork::new(true);
+    *echo.work_to_register.lock().unwrap() = Some(work.clone());
+    host.share(echo.clone()).await.expect("share");
+
+    let client = bind_node().await;
+    host_accepts(&host, &client).await;
+
+    let mut stream = connect_direct(&client, &host)
+        .await
+        .expect("client connects while accepted");
+    stream.send.write_all(b"hello").await.unwrap();
+    let mut out = [0u8; 5];
+    stream.recv.read_exact(&mut out).await.unwrap();
+    assert_eq!(&out, b"HELLO");
+
+    // Disconnect normally: close the client's send half and read to EOF so
+    // the host's serve future finishes and the live connection unregisters.
+    stream.send.finish().unwrap();
+    let mut more = [0u8; 1];
+    let _ = stream.recv.read_exact(&mut more).await;
+    drop(stream);
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+    assert_eq!(
+        work.revocations(),
+        0,
+        "an ordinary disconnect must not revoke the peer's detached work"
+    );
+
+    // Revoke the peer AFTER it disconnected.
+    let trust = host.trust();
+    let book = {
+        let mut trust = trust.lock().await;
+        trust.revoke_key(&client.endpoint_id());
+        trust.clone()
+    };
+    let closed = host.enforce_trust(&book).await;
+
+    assert_eq!(closed, 0, "no live connection should remain to force-close");
+    assert_eq!(
+        work.revocations(),
+        1,
+        "revocation must reach detached work by peer key when no connection is live"
+    );
+
+    host.shutdown().await.unwrap();
+}
+
+/// Registry mechanics for detached work: revocation is peer-keyed, finished
+/// work is pruned before it can see a revocation, and entries drain on
+/// revocation so a later re-accepted peer starts from a clean slate.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn revocation_registry_is_peer_keyed_and_prunes_dead_work() {
+    let host = bind_node().await;
+    let peer_a = bind_node().await.endpoint_id();
+    let peer_b = bind_node().await.endpoint_id();
+
+    // A handle whose work already finished is pruned when the same peer
+    // registers again, so it never sees a later revocation.
+    let finished = FakeDetachedWork::new(false);
+    host.register_revocable_work(peer_a, finished.clone()).await;
+    let running_a = FakeDetachedWork::new(true);
+    host.register_revocable_work(peer_a, running_a.clone())
+        .await;
+    let running_b = FakeDetachedWork::new(true);
+    host.register_revocable_work(peer_b, running_b.clone())
+        .await;
+
+    // Revoke A only (B stays accepted).
+    let mut book = TrustBook::new();
+    book.accept(&peer_b);
+    host.enforce_trust(&book).await;
+
+    assert_eq!(
+        running_a.revocations(),
+        1,
+        "the revoked peer's running work must be stopped"
+    );
+    assert_eq!(
+        finished.revocations(),
+        0,
+        "finished work was pruned before the revocation"
+    );
+    assert_eq!(
+        running_b.revocations(),
+        0,
+        "another peer's work must be untouched"
+    );
+
+    // Entries drain on revocation: enforcing again revokes nothing new, so a
+    // peer that is later re-accepted starts from a clean slate.
+    host.enforce_trust(&book).await;
+    assert_eq!(running_a.revocations(), 1);
 
     host.shutdown().await.unwrap();
 }

--- a/crates/goose-roaming/tests/end_to_end.rs
+++ b/crates/goose-roaming/tests/end_to_end.rs
@@ -435,6 +435,13 @@ async fn revocation_registry_is_peer_keyed_and_prunes_dead_work() {
     let host = bind_node().await;
     let peer_a = bind_node().await.endpoint_id();
     let peer_b = bind_node().await.endpoint_id();
+    // Work is only parked for peers that currently hold authority.
+    {
+        let trust = host.trust();
+        let mut trust = trust.lock().await;
+        trust.accept(&peer_a);
+        trust.accept(&peer_b);
+    }
 
     // A handle whose work already finished is pruned when the same peer
     // registers again, so it never sees a later revocation.
@@ -474,6 +481,157 @@ async fn revocation_registry_is_peer_keyed_and_prunes_dead_work() {
     assert_eq!(running_a.revocations(), 1);
 
     host.shutdown().await.unwrap();
+}
+
+/// Registration and revocation are mutually exclusive: once a peer has been
+/// revoked, work registered afterwards is revoked instead of parked. This is
+/// the interleaving the peer-keyed registry exists to close — a worker that
+/// registers *after* the revocation drain must not stay registered and
+/// unrevoked — pinned in the deterministic order (drain first, then register)
+/// rather than by timing.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn revoked_peer_cannot_park_work_after_the_revocation_drain() {
+    let host = bind_node().await;
+    let peer = bind_node().await.endpoint_id();
+    host.trust().lock().await.accept(&peer);
+
+    // While trusted, work registers normally and a later revocation stops it.
+    let before = FakeDetachedWork::new(true);
+    host.register_revocable_work(peer, before.clone()).await;
+
+    let revoked_book = {
+        let trust = host.trust();
+        let mut trust = trust.lock().await;
+        trust.revoke_key(&peer);
+        trust.clone()
+    };
+    host.enforce_trust(&revoked_book).await;
+    assert_eq!(
+        before.revocations(),
+        1,
+        "work parked while trusted must be revoked by the drain"
+    );
+
+    // The drain has run. A registration arriving now — the race window — must
+    // be revoked by the registration path itself, not parked.
+    let after = FakeDetachedWork::new(true);
+    host.register_revocable_work(peer, after.clone()).await;
+    assert_eq!(
+        after.revocations(),
+        1,
+        "work registered for a revoked peer must be revoked, not parked"
+    );
+
+    // And it must not be left in the registry: if it had been parked, this
+    // second enforcement pass would revoke it a second time.
+    host.enforce_trust(&revoked_book).await;
+    assert_eq!(
+        after.revocations(),
+        1,
+        "rejected work must not be left registered under the revoked key"
+    );
+    assert_eq!(before.revocations(), 1, "revocation must stay idempotent");
+
+    host.shutdown().await.unwrap();
+}
+
+/// A peer that is re-accepted registers cleanly again: rejecting work for a
+/// revoked key must not fence the key permanently.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn re_accepted_peer_registers_work_again() {
+    let host = bind_node().await;
+    let peer = bind_node().await.endpoint_id();
+
+    // Revoked: refused.
+    let revoked_book = {
+        let trust = host.trust();
+        let mut trust = trust.lock().await;
+        trust.revoke_key(&peer);
+        trust.clone()
+    };
+    let refused = FakeDetachedWork::new(true);
+    host.register_revocable_work(peer, refused.clone()).await;
+    assert_eq!(refused.revocations(), 1);
+
+    // Re-accepted out of band: the next connection's work parks normally, with
+    // no leftover state from the revoked era.
+    let allowed_book = {
+        let trust = host.trust();
+        let mut trust = trust.lock().await;
+        trust.accept(&peer);
+        trust.clone()
+    };
+    let fresh = FakeDetachedWork::new(true);
+    host.register_revocable_work(peer, fresh.clone()).await;
+    assert_eq!(
+        fresh.revocations(),
+        0,
+        "a re-accepted peer's work must be parked, not revoked"
+    );
+
+    // Enforcing the allowing book keeps it parked; revoking again reaches it.
+    host.enforce_trust(&allowed_book).await;
+    assert_eq!(fresh.revocations(), 0);
+    host.enforce_trust(&revoked_book).await;
+    assert_eq!(
+        fresh.revocations(),
+        1,
+        "the re-registered work must be revocable by peer key"
+    );
+
+    host.shutdown().await.unwrap();
+}
+
+/// The same invariant under a genuinely concurrent registration/enforcement:
+/// whichever order the two critical sections happen to take, the work of a
+/// revoked peer is revoked exactly once and nothing stays parked. Serializing
+/// the decision with the drain is what makes both orders safe — admitted before
+/// the drain (the drain revokes it) or after it (the registration revokes it).
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn concurrent_registration_and_revocation_revoke_exactly_once() {
+    for _ in 0..32 {
+        let host = bind_node().await;
+        let peer = bind_node().await.endpoint_id();
+        host.trust().lock().await.accept(&peer);
+
+        let revoked_book = {
+            let trust = host.trust();
+            let mut trust = trust.lock().await;
+            trust.revoke_key(&peer);
+            trust.clone()
+        };
+
+        let work = FakeDetachedWork::new(true);
+        let registrar = {
+            let host = host.clone();
+            let work = work.clone();
+            tokio::spawn(async move { host.register_revocable_work(peer, work).await })
+        };
+        let enforcer = {
+            let host = host.clone();
+            let book = revoked_book.clone();
+            tokio::spawn(async move { host.enforce_trust(&book).await })
+        };
+        registrar.await.unwrap();
+        enforcer.await.unwrap();
+
+        assert_eq!(
+            work.revocations(),
+            1,
+            "a revoked peer's work must be revoked exactly once, whichever \
+             order registration and enforcement ran in"
+        );
+
+        // Nothing may remain parked under the revoked key.
+        host.enforce_trust(&revoked_book).await;
+        assert_eq!(
+            work.revocations(),
+            1,
+            "no work may be left registered under the revoked key"
+        );
+
+        host.shutdown().await.unwrap();
+    }
 }
 
 /// Dial the host on its live endpoint address (bypassing relay-based discovery,

--- a/crates/goose-roaming/tests/end_to_end.rs
+++ b/crates/goose-roaming/tests/end_to_end.rs
@@ -10,14 +10,19 @@ use std::sync::Arc;
 
 use futures::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use goose_roaming::{
-    AcpStreamServer, Directory, RelaySettings, RoamingConfig, RoamingIdentity, RoamingNode,
-    TrustBook,
+    AcpStreamServer, Directory, RelaySettings, RevocationSignal, RoamingConfig, RoamingIdentity,
+    RoamingNode, TrustBook,
 };
 use iroh::EndpointId;
 
 /// A stand-in ACP server that echoes one line back, upper-cased.
-#[derive(Debug)]
-struct EchoServer;
+#[derive(Debug, Default)]
+struct EchoServer {
+    /// Revocation signals handed to `serve_stream`, so tests can assert
+    /// whether the node marked a connection as force-closed-by-revocation
+    /// (versus an ordinary transport close).
+    revocations: Arc<std::sync::Mutex<Vec<RevocationSignal>>>,
+}
 
 impl AcpStreamServer for EchoServer {
     fn serve_stream(
@@ -25,7 +30,9 @@ impl AcpStreamServer for EchoServer {
         _client: EndpointId,
         mut recv: Box<dyn AsyncRead + Send + Unpin>,
         mut send: Box<dyn AsyncWrite + Send + Unpin>,
+        revocation: RevocationSignal,
     ) -> futures::future::BoxFuture<'static, anyhow::Result<()>> {
+        self.revocations.lock().unwrap().push(revocation);
         Box::pin(async move {
             let mut buf = [0u8; 5];
             recv.read_exact(&mut buf).await?;
@@ -94,7 +101,9 @@ async fn trust_file_refresh_takes_effect_on_running_share() {
     })
     .await
     .expect("bind host");
-    host.share(Arc::new(EchoServer)).await.expect("share");
+    host.share(Arc::new(EchoServer::default()))
+        .await
+        .expect("share");
 
     let client = bind_node().await;
 
@@ -118,7 +127,8 @@ async fn trust_file_refresh_takes_effect_on_running_share() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn accepted_key_connects_and_streams() {
     let host = bind_node().await;
-    host.share(Arc::new(EchoServer)).await.expect("share");
+    let echo = Arc::new(EchoServer::default());
+    host.share(echo.clone()).await.expect("share");
 
     let client = bind_node().await;
     // Host accepts the client's key (mutual, key-based trust).
@@ -139,13 +149,26 @@ async fn accepted_key_connects_and_streams() {
         stream.send.finish().unwrap();
     }
 
+    // An ordinary close is not a revocation: work that survives transport
+    // loss keys off this signal.
+    {
+        let signals = echo.revocations.lock().unwrap();
+        assert_eq!(signals.len(), 1);
+        assert!(
+            !signals[0].is_revoked(),
+            "a clean client close must not be marked as a revocation"
+        );
+    }
+
     host.shutdown().await.unwrap();
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn unaccepted_key_is_rejected() {
     let host = bind_node().await;
-    host.share(Arc::new(EchoServer)).await.expect("share");
+    host.share(Arc::new(EchoServer::default()))
+        .await
+        .expect("share");
 
     // Client's key was never accepted: connection must be refused.
     let client = bind_node().await;
@@ -158,7 +181,9 @@ async fn unaccepted_key_is_rejected() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn revoked_key_is_rejected() {
     let host = bind_node().await;
-    host.share(Arc::new(EchoServer)).await.expect("share");
+    host.share(Arc::new(EchoServer::default()))
+        .await
+        .expect("share");
 
     let client = bind_node().await;
     host_accepts(&host, &client).await;
@@ -178,7 +203,8 @@ async fn revoked_key_is_rejected() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn revocation_closes_live_connection() {
     let host = bind_node().await;
-    host.share(Arc::new(EchoServer)).await.expect("share");
+    let echo = Arc::new(EchoServer::default());
+    host.share(echo.clone()).await.expect("share");
 
     let client = bind_node().await;
     host_accepts(&host, &client).await;
@@ -215,6 +241,17 @@ async fn revocation_closes_live_connection() {
         "read after revocation should fail, got {read:?}"
     );
 
+    // The stream server can tell this close was a revocation, so it can stop
+    // work that would otherwise survive an ordinary transport loss.
+    {
+        let signals = echo.revocations.lock().unwrap();
+        assert_eq!(signals.len(), 1);
+        assert!(
+            signals[0].is_revoked(),
+            "a force-close for a revoked key must set the revocation signal"
+        );
+    }
+
     // And the next dial is refused.
     assert!(
         connect_direct(&client, &host).await.is_err(),
@@ -249,7 +286,8 @@ async fn revocation_watcher_closes_live_connection_from_file() {
     })
     .await
     .expect("bind host");
-    host.share(Arc::new(EchoServer)).await.expect("share");
+    let echo = Arc::new(EchoServer::default());
+    host.share(echo.clone()).await.expect("share");
     host.watch_revocations(std::time::Duration::from_millis(100))
         .await;
 
@@ -276,6 +314,17 @@ async fn revocation_watcher_closes_live_connection_from_file() {
         matches!(read, Ok(Err(_))),
         "watcher should force-close the live connection, got {read:?}"
     );
+
+    // The watcher's force-close is a revocation, and the stream server must
+    // be able to see that.
+    {
+        let signals = echo.revocations.lock().unwrap();
+        assert_eq!(signals.len(), 1);
+        assert!(
+            signals[0].is_revoked(),
+            "the watcher's force-close must set the revocation signal"
+        );
+    }
 
     host.shutdown().await.unwrap();
 }

--- a/crates/goose-roaming/tests/path_upgrade.rs
+++ b/crates/goose-roaming/tests/path_upgrade.rs
@@ -36,6 +36,7 @@ impl AcpStreamServer for StreamingEchoServer {
         _client: EndpointId,
         mut recv: Box<dyn AsyncRead + Send + Unpin>,
         mut send: Box<dyn AsyncWrite + Send + Unpin>,
+        _revocation: goose_roaming::RevocationSignal,
     ) -> futures::future::BoxFuture<'static, anyhow::Result<()>> {
         Box::pin(async move {
             let mut buf = [0u8; 4096];

--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -1628,35 +1628,38 @@ impl GooseAcpAgent {
         let permission_request =
             RequestPermissionRequest::new(session_id, tool_call_update, options);
 
-        let sent =
-            cx.send_request(permission_request)
-                .on_receiving_result(move |result| async move {
-                    callback_pending_request.spawn_response_resolution(async move {
-                        match result {
-                            Ok(response) => {
-                                agent
-                                    .handle_confirmation(
-                                        request_id,
-                                        outcome_to_confirmation(&response.outcome),
-                                    )
-                                    .await;
-                            }
-                            Err(e) => {
-                                error!(error = ?e, "permission request failed");
-                                agent
-                                    .handle_confirmation(
-                                        request_id,
-                                        PermissionConfirmation {
-                                            principal_type: PrincipalType::Tool,
-                                            permission: Permission::Cancel,
-                                        },
-                                    )
-                                    .await;
-                            }
+        let sent = cx
+            .send_request(permission_request)
+            .on_receiving_result(move |result| {
+                // Claim completion here, synchronously, before the resolution is
+                // handed to its own task: the transport-termination fallback must
+                // not be able to turn a client's answer into a cancellation.
+                callback_pending_request.claim_then_spawn_resolution(async move {
+                    match result {
+                        Ok(response) => {
+                            agent
+                                .handle_confirmation(
+                                    request_id,
+                                    outcome_to_confirmation(&response.outcome),
+                                )
+                                .await;
                         }
-                    });
-                    Ok(())
+                        Err(e) => {
+                            error!(error = ?e, "permission request failed");
+                            agent
+                                .handle_confirmation(
+                                    request_id,
+                                    PermissionConfirmation {
+                                        principal_type: PrincipalType::Tool,
+                                        permission: Permission::Cancel,
+                                    },
+                                )
+                                .await;
+                        }
+                    }
                 });
+                std::future::ready(Ok(()))
+            });
 
         if let Err(e) = sent {
             // The connection is gone (e.g. the client dropped mid-turn), so no
@@ -1905,16 +1908,23 @@ impl PendingClientRequest {
         }
     }
 
-    fn spawn_response_resolution<F>(&self, resolution: F)
+    /// Claim completion for the response side, then run `resolution` on a task
+    /// the connection does not own.
+    ///
+    /// Callers must invoke this synchronously from the response callback: the
+    /// claim has to happen the moment the answer arrives, or a concurrent
+    /// transport termination could take the claim first and discard a decision
+    /// the user actually made. Once the claim succeeds the resolution runs on an
+    /// independent Tokio task, so a connection that dies while the resolution is
+    /// in flight cannot strand the run either.
+    fn claim_then_spawn_resolution<F>(&self, resolution: F)
     where
         F: std::future::Future<Output = ()> + Send + 'static,
     {
-        let pending_request = self.clone();
-        tokio::spawn(async move {
-            if pending_request.try_complete() {
-                resolution.await;
-            }
-        });
+        if !self.try_complete() {
+            return;
+        }
+        tokio::spawn(resolution);
     }
 
     async fn complete_on_transport_termination(
@@ -3631,7 +3641,7 @@ print(\"hello, world\")
         let (resolution_started_tx, resolution_started_rx) = tokio::sync::oneshot::channel();
         let (finish_resolution_tx, finish_resolution_rx) = tokio::sync::oneshot::channel();
         let (resolution_finished_tx, resolution_finished_rx) = tokio::sync::oneshot::channel();
-        pending.spawn_response_resolution(async move {
+        pending.claim_then_spawn_resolution(async move {
             resolution_started_tx.send(()).unwrap();
             finish_resolution_rx.await.unwrap();
             resolution_finished_tx.send(()).unwrap();
@@ -3646,6 +3656,50 @@ print(\"hello, world\")
         assert!(
             !pending.try_complete(),
             "fallback must not complete it again"
+        );
+    }
+
+    #[tokio::test]
+    async fn pending_client_response_wins_over_concurrent_transport_termination() {
+        let pending = PendingClientRequest::new();
+        // The transport is already gone, so the fallback would claim completion
+        // the instant it gets a chance to.
+        let transport_terminated = CancellationToken::new();
+        transport_terminated.cancel();
+
+        let resolutions = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let response_resolutions = Arc::clone(&resolutions);
+        let (resolved_tx, resolved_rx) = tokio::sync::oneshot::channel();
+        pending.claim_then_spawn_resolution(async move {
+            response_resolutions.lock().unwrap().push("response");
+            let _ = resolved_tx.send(());
+        });
+
+        // The response side claims completion synchronously, inside the
+        // callback, so nothing is left for the fallback to claim.
+        assert!(
+            !pending.try_complete(),
+            "the response callback must claim completion before it returns"
+        );
+
+        if pending
+            .complete_on_transport_termination(&transport_terminated)
+            .await
+        {
+            resolutions.lock().unwrap().push("cancel");
+        }
+
+        // The resolution runs on a task the connection does not own, so it still
+        // completes.
+        resolved_rx
+            .await
+            .expect("the received response must still be resolved");
+
+        assert_eq!(
+            *resolutions.lock().unwrap(),
+            vec!["response"],
+            "a received response must resolve the request exactly once, and the \
+             transport-termination fallback must not cancel it"
         );
     }
 

--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -336,6 +336,12 @@ pub struct GooseAcpAgentOptions {
 pub struct GooseAcpAgent {
     sessions: Arc<Mutex<HashMap<String, GooseAcpSession>>>,
     active_prompt_runs: Arc<Mutex<HashMap<String, ActivePromptRun>>>,
+    /// Runs this agent started (session id → run id), a per-connection subset
+    /// of the shared `active_prompt_runs`. Lets a transport-level authority
+    /// decision (roaming peer revocation) cancel exactly the revoked
+    /// connection's detached runs via [`Self::cancel_own_active_runs`] without
+    /// touching runs owned by other connections.
+    own_prompt_runs: Mutex<HashMap<String, String>>,
     closed_session_ids: Arc<Mutex<HashSet<String>>>,
     agent_manager: Arc<AgentManager>,
     provider_factory: AcpProviderFactory,
@@ -968,6 +974,7 @@ impl GooseAcpAgent {
         Ok(Self {
             sessions: Arc::new(Mutex::new(HashMap::new())),
             active_prompt_runs: options.active_prompt_runs,
+            own_prompt_runs: Mutex::new(HashMap::new()),
             closed_session_ids: Arc::new(Mutex::new(HashSet::new())),
             agent_manager,
             provider_factory: options.provider_factory,
@@ -1931,15 +1938,31 @@ impl GooseAcpAgent {
         active_prompt_runs.insert(
             session_id.to_string(),
             ActivePromptRun {
-                run_id,
+                run_id: run_id.clone(),
                 cancel_token,
                 agent,
             },
         );
+        drop(active_prompt_runs);
+
+        self.own_prompt_runs
+            .lock()
+            .await
+            .insert(session_id.to_string(), run_id);
         Ok(())
     }
 
     async fn clear_active_run(&self, session_id: &str, run_id: &str) {
+        {
+            let mut own_prompt_runs = self.own_prompt_runs.lock().await;
+            if own_prompt_runs
+                .get(session_id)
+                .is_some_and(|own_run_id| own_run_id == run_id)
+            {
+                own_prompt_runs.remove(session_id);
+            }
+        }
+
         let agent = {
             let mut active_prompt_runs = self.active_prompt_runs.lock().await;
             let Some(active_run) = active_prompt_runs.get(session_id) else {
@@ -1975,6 +1998,40 @@ impl GooseAcpAgent {
                 );
             }
         }
+    }
+
+    /// Cancel every active run this agent started, leaving runs owned by other
+    /// agents on the shared registry untouched. Returns how many were
+    /// cancelled.
+    ///
+    /// Detached prompt runs deliberately survive ordinary transport loss; this
+    /// is the escape hatch for when the connection's *authority* is withdrawn
+    /// (a roaming peer is revoked): the revoked peer's in-flight turns must
+    /// stop consuming the provider and executing tools. Cancellation goes
+    /// through the registry's tokens — the detached task observes it and
+    /// clears its own registry entry, exactly as with `session/cancel`.
+    pub async fn cancel_own_active_runs(&self) -> usize {
+        let own_runs: Vec<(String, String)> = self
+            .own_prompt_runs
+            .lock()
+            .await
+            .iter()
+            .map(|(session_id, run_id)| (session_id.clone(), run_id.clone()))
+            .collect();
+
+        let active_prompt_runs = self.active_prompt_runs.lock().await;
+        let mut cancelled = 0;
+        for (session_id, run_id) in own_runs {
+            // Only cancel a run that is still the one this agent started; the
+            // session may have finished and been re-claimed by another agent.
+            if let Some(active_run) = active_prompt_runs.get(&session_id) {
+                if active_run.run_id == run_id {
+                    active_run.cancel_token.cancel();
+                    cancelled += 1;
+                }
+            }
+        }
+        cancelled
     }
 
     async fn require_active_run(
@@ -2139,22 +2196,31 @@ impl GooseAcpAgent {
 
         if cancel_token.is_cancelled() {
             self.clear_active_run(&session_id, &run_id).await;
-            Self::send_active_run_update(cx, &args.session_id, None)?;
+            let _ = Self::send_active_run_update(cx, &args.session_id, None);
             return Ok(PromptResponse::new(StopReason::Cancelled));
         }
 
+        // Startup sends are fail-soft like the mid-stream ones: a client that
+        // disconnects right after dispatch must not have its prompt silently
+        // discarded — the turn still runs and persists for a later
+        // session/load.
         if let Err(error) = Self::send_active_run_update(cx, &args.session_id, Some(&run_id)) {
-            self.clear_active_run(&session_id, &run_id).await;
-            return Err(error);
+            warn!(
+                session_id = %session_id,
+                %error,
+                "failed to send active-run update; continuing without the client"
+            );
         }
 
         if let Err(error) = self
             .send_local_inference_progress_update(cx, &args.session_id, &session_id, &agent)
             .await
         {
-            self.clear_active_run(&session_id, &run_id).await;
-            let _ = Self::send_active_run_update(cx, &args.session_id, None);
-            return Err(error);
+            warn!(
+                session_id = %session_id,
+                %error,
+                "failed to send local model progress update; continuing without the client"
+            );
         }
 
         let user_message = Self::convert_acp_prompt_to_message(&args.prompt);
@@ -3584,6 +3650,147 @@ print(\"hello, world\")
         let error = thinking_effort_error(anyhow::anyhow!("Failed to persist thinking effort"));
 
         assert_eq!(error.code, agent_client_protocol::ErrorCode::InternalError);
+    }
+
+    /// The startup notifications a prompt sends before the agent turn (the
+    /// active-run update and local-model progress) must be fail-soft: a client
+    /// that disconnects right after dispatch loses its notifications, not its
+    /// prompt. Uses a deterministically dead connection — the transport is
+    /// fully shut down before `on_prompt` runs, so those sends are guaranteed
+    /// to fail — and asserts the turn still completes, clears its run, and
+    /// persists the prompt for a later `session/load`.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn prompt_on_dead_connection_still_runs_and_persists() {
+        let root = tempfile::tempdir().unwrap();
+        let provider_factory: AcpProviderFactory = Arc::new(
+            |_provider_name, _extensions, _working_dir, _use_default_model| {
+                Box::pin(async { Err(anyhow::anyhow!("unused provider factory")) })
+            },
+        );
+        let server = Arc::new(
+            GooseAcpAgent::new(GooseAcpAgentOptions {
+                provider_factory,
+                builtin_selection: AcpBuiltinSelection::default(),
+                data_dir: root.path().to_path_buf(),
+                config_dir: root.path().to_path_buf(),
+                disable_session_naming: true,
+                goose_platform: GoosePlatform::GooseCli,
+                additional_source_roots: Vec::new(),
+                scheduler: None,
+                session_cwd: None,
+                active_prompt_runs: Default::default(),
+            })
+            .await
+            .unwrap(),
+        );
+        let session = server
+            .session_manager
+            .create_session(
+                root.path().to_path_buf(),
+                "Dead connection test".to_string(),
+                SessionType::Acp,
+                GooseMode::Auto,
+            )
+            .await
+            .unwrap();
+        let session_agent = Arc::new(Agent::with_config(AgentConfig::new(
+            server.session_manager.clone(),
+            server.permission_manager.clone(),
+            None,
+            GooseMode::Auto,
+            true,
+            GoosePlatform::GooseCli,
+        )));
+        // Streams no events: the turn completes with just the user message.
+        let provider = Arc::new(AsyncEffortProvider::new());
+        session_agent
+            .update_provider(
+                provider,
+                goose_providers::model::ModelConfig::new("gpt-4o"),
+                &session.id,
+            )
+            .await
+            .unwrap();
+        server
+            .register_acp_session(session.id.clone(), session_agent)
+            .await;
+
+        // Open a real connection only to mint a `ConnectionTo<Client>`, then
+        // let both ends shut down completely so every send on it fails.
+        let (client_read, server_write) = tokio::io::duplex(64 * 1024);
+        let (server_read, client_write) = tokio::io::duplex(64 * 1024);
+        let client = tokio::spawn(async move {
+            Client
+                .builder()
+                .connect_to(ByteStreams::new(
+                    client_write.compat_write(),
+                    client_read.compat(),
+                ))
+                .await
+        });
+        let cx_holder: Arc<Mutex<Option<ConnectionTo<Client>>>> = Arc::new(Mutex::new(None));
+        SacpAgent
+            .builder()
+            .name("dead-connection-test")
+            .connect_with(
+                ByteStreams::new(server_write.compat_write(), server_read.compat()),
+                {
+                    let cx_holder = cx_holder.clone();
+                    async move |cx: ConnectionTo<Client>| {
+                        *cx_holder.lock().await = Some(cx);
+                        Ok(())
+                    }
+                },
+            )
+            .await
+            .unwrap();
+        let _ = client.await;
+        let cx = cx_holder.lock().await.take().unwrap();
+
+        // Prove the connection is dead: the exact kind of send `on_prompt`
+        // opens with fails.
+        let session_id = SessionId::new(session.id.clone());
+        assert!(
+            GooseAcpAgent::send_active_run_update(&cx, &session_id, None).is_err(),
+            "the minted connection must be fully shut down"
+        );
+
+        let request = PromptRequest::new(
+            session_id,
+            vec![ContentBlock::Text(TextContent::new("what is 1+1"))],
+        );
+        let response = server
+            .on_prompt(&cx, request)
+            .await
+            .expect("a dead client must not discard the prompt");
+        assert_eq!(response.stop_reason, StopReason::EndTurn);
+
+        // The run was cleared on completion...
+        assert!(server
+            .test_require_active_run(&session.id, "run-x")
+            .await
+            .is_err());
+        // ...and the prompt is persisted for a later session/load.
+        let persisted = server
+            .session_manager
+            .get_session(&session.id, true)
+            .await
+            .unwrap();
+        let texts: Vec<String> = persisted
+            .conversation
+            .expect("conversation persisted")
+            .messages()
+            .iter()
+            .flat_map(|message| message.content.iter())
+            .filter_map(|content| match content {
+                MessageContent::Text(text) => Some(text.text.clone()),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            texts.iter().any(|text| text.contains("what is 1+1")),
+            "prompt must be persisted despite the dead connection; got {texts:?}"
+        );
     }
 
     #[tokio::test]

--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -1826,6 +1826,52 @@ fn message_usage_update(
     }
 }
 
+/// Latches the first failed client-bound notification of a prompt run so a
+/// turn that keeps executing after its client disconnected does not hammer
+/// the dead channel — and the log — once per stream event: the first failure
+/// warns, every later send for the run is skipped.
+///
+/// Only plain notification sends go through this latch. Interactive requests
+/// (permission, elicitation) keep their own resolve-as-deny/cancel handling —
+/// they must run even on a dead sink so the agent is never left waiting — and
+/// provider-fatal errors still abort the turn.
+#[derive(Default)]
+struct ClientNotificationSink {
+    failed_sends: std::sync::atomic::AtomicUsize,
+}
+
+impl ClientNotificationSink {
+    fn is_dead(&self) -> bool {
+        self.failed_sends.load(std::sync::atomic::Ordering::Acquire) > 0
+    }
+
+    fn record_failure(&self, session_id: &str, error: &agent_client_protocol::Error) {
+        if self
+            .failed_sends
+            .fetch_add(1, std::sync::atomic::Ordering::AcqRel)
+            == 0
+        {
+            warn!(
+                session_id = %session_id,
+                %error,
+                "failed to send a session update; the client appears disconnected — \
+                 skipping further notifications for this run"
+            );
+        } else {
+            debug!(
+                session_id = %session_id,
+                %error,
+                "skipping further client notifications for this run"
+            );
+        }
+    }
+
+    #[cfg(test)]
+    fn failed_send_count(&self) -> usize {
+        self.failed_sends.load(std::sync::atomic::Ordering::Acquire)
+    }
+}
+
 impl GooseAcpAgent {
     async fn on_initialize(
         &self,
@@ -2204,6 +2250,16 @@ impl GooseAcpAgent {
         cx: &ConnectionTo<Client>,
         args: PromptRequest,
     ) -> Result<PromptResponse, agent_client_protocol::Error> {
+        let client_sink = ClientNotificationSink::default();
+        self.on_prompt_with_sink(cx, args, &client_sink).await
+    }
+
+    async fn on_prompt_with_sink(
+        &self,
+        cx: &ConnectionTo<Client>,
+        args: PromptRequest,
+        client_sink: &ClientNotificationSink,
+    ) -> Result<PromptResponse, agent_client_protocol::Error> {
         // The ACP session_id IS the thread ID.
         let session_id = args.session_id.0.to_string();
 
@@ -2245,22 +2301,16 @@ impl GooseAcpAgent {
         // discarded — the turn still runs and persists for a later
         // session/load.
         if let Err(error) = Self::send_active_run_update(cx, &args.session_id, Some(&run_id)) {
-            warn!(
-                session_id = %session_id,
-                %error,
-                "failed to send active-run update; continuing without the client"
-            );
+            client_sink.record_failure(&session_id, &error);
         }
 
-        if let Err(error) = self
-            .send_local_inference_progress_update(cx, &args.session_id, &session_id, &agent)
-            .await
-        {
-            warn!(
-                session_id = %session_id,
-                %error,
-                "failed to send local model progress update; continuing without the client"
-            );
+        if !client_sink.is_dead() {
+            if let Err(error) = self
+                .send_local_inference_progress_update(cx, &args.session_id, &session_id, &agent)
+                .await
+            {
+                client_sink.record_failure(&session_id, &error);
+            }
         }
 
         let user_message = Self::convert_acp_prompt_to_message(&args.prompt);
@@ -2321,29 +2371,42 @@ impl GooseAcpAgent {
                             tool_requests.insert(tool_request.id.clone(), tool_request.clone());
                         }
 
-                        if let Err(error) = self
-                            .handle_message_content(
-                                content_item,
-                                &message,
-                                &args.session_id,
-                                &agent,
-                                &tool_requests,
-                                cx,
-                            )
-                            .await
-                        {
-                            // A failed client send must not end the turn: the
-                            // transport may be gone (network drop, sleep)
-                            // while the detached turn keeps executing and
-                            // persisting for a later session/load. Interactive
-                            // content resolves inside the handler (permission
-                            // and elicitation send failures fall back to
-                            // deny/cancel), so skipping the update is safe.
-                            warn!(
-                                session_id = %session_id,
-                                %error,
-                                "failed to send session update; continuing without the client"
-                            );
+                        // Interactive content must run even on a dead sink:
+                        // its send failures resolve inside the handler as
+                        // deny/cancel, so the agent is never left waiting for
+                        // an answer. Plain updates are skipped once the sink
+                        // is known dead.
+                        let interactive = matches!(content_item, MessageContent::ActionRequired(_));
+                        if interactive || !client_sink.is_dead() {
+                            if let Err(error) = self
+                                .handle_message_content(
+                                    content_item,
+                                    &message,
+                                    &args.session_id,
+                                    &agent,
+                                    &tool_requests,
+                                    cx,
+                                )
+                                .await
+                            {
+                                // A failed client send must not end the turn:
+                                // the transport may be gone (network drop,
+                                // sleep) while the detached turn keeps
+                                // executing and persisting for a later
+                                // session/load.
+                                if interactive {
+                                    // Resolved inside the handler; may be a
+                                    // schema error rather than a dead
+                                    // transport, so it does not latch.
+                                    warn!(
+                                        session_id = %session_id,
+                                        %error,
+                                        "failed to handle interactive content; continuing"
+                                    );
+                                } else {
+                                    client_sink.record_failure(&session_id, &error);
+                                }
+                            }
                         }
 
                         let ready_chain = match content_item {
@@ -2361,7 +2424,11 @@ impl GooseAcpAgent {
                         };
 
                         if let Some(chain) = ready_chain {
-                            self.spawn_ready_chain_summary(chain, &agent, &args.session_id, cx);
+                            // Label enrichment exists only for client display;
+                            // skip its LLM work when no client is listening.
+                            if !client_sink.is_dead() {
+                                self.spawn_ready_chain_summary(chain, &agent, &args.session_id, cx);
+                            }
                         }
                     }
 
@@ -2373,29 +2440,23 @@ impl GooseAcpAgent {
                     if let Some(update) =
                         tool_notifications::tool_notification_update(request_id, notification)
                     {
-                        let tool_call_notifier = ToolCallNotifier::new(cx, &args.session_id);
-                        if let Err(error) = tool_call_notifier.send_update(update) {
-                            warn!(
-                                session_id = %session_id,
-                                %error,
-                                "failed to send tool notification update; continuing without the client"
-                            );
+                        if !client_sink.is_dead() {
+                            let tool_call_notifier = ToolCallNotifier::new(cx, &args.session_id);
+                            if let Err(error) = tool_call_notifier.send_update(update) {
+                                client_sink.record_failure(&session_id, &error);
+                            }
                         }
                     }
                 }
                 Ok(crate::agents::AgentEvent::MessageUsage { message_id, usage }) => {
-                    if self.supports_goose_custom_notifications() {
+                    if self.supports_goose_custom_notifications() && !client_sink.is_dead() {
                         if let Err(error) = cx.send_notification(GooseSessionNotification {
                             session_id: session_id.clone(),
                             update: GooseSessionUpdate::MessageUsage(message_usage_update(
                                 message_id, &usage,
                             )),
                         }) {
-                            warn!(
-                                session_id = %session_id,
-                                %error,
-                                "failed to send message usage update; continuing without the client"
-                            );
+                            client_sink.record_failure(&session_id, &error);
                         }
                     }
                 }
@@ -2410,7 +2471,7 @@ impl GooseAcpAgent {
             }
         }
 
-        if !was_cancelled && stream_error.is_none() {
+        if !was_cancelled && stream_error.is_none() && !client_sink.is_dead() {
             if let Some(chain) = chain_tracker.close_current_chain() {
                 self.spawn_ready_chain_summary(chain, &agent, &args.session_id, cx);
             }
@@ -2418,8 +2479,10 @@ impl GooseAcpAgent {
         self.clear_active_run(&session_id, &run_id).await;
         // From here on the turn's work is complete and persisted; failures to
         // reach a (possibly disconnected) client must not turn it into an error.
-        if let Err(error) = Self::send_active_run_update(cx, &args.session_id, None) {
-            warn!(session_id = %session_id, %error, "failed to send active-run clear update");
+        if !client_sink.is_dead() {
+            if let Err(error) = Self::send_active_run_update(cx, &args.session_id, None) {
+                client_sink.record_failure(&session_id, &error);
+            }
         }
         if let Some(error) = stream_error {
             return Err(error);
@@ -2447,16 +2510,18 @@ impl GooseAcpAgent {
                 .await
                 .internal_err_ctx("Failed to resolve context limit")?;
         let updates = build_usage_updates(&session, &totals, context_limit);
-        if self.supports_goose_custom_notifications() {
+        if self.supports_goose_custom_notifications() && !client_sink.is_dead() {
             if let Err(error) = cx.send_notification(updates.custom) {
-                warn!(session_id = %session_id, %error, "failed to send usage update");
+                client_sink.record_failure(&session_id, &error);
             }
         }
-        if let Err(error) = cx.send_notification(SessionNotification::new(
-            args.session_id.clone(),
-            SessionUpdate::UsageUpdate(updates.standard),
-        )) {
-            warn!(session_id = %session_id, %error, "failed to send usage update");
+        if !client_sink.is_dead() {
+            if let Err(error) = cx.send_notification(SessionNotification::new(
+                args.session_id.clone(),
+                SessionUpdate::UsageUpdate(updates.standard),
+            )) {
+                client_sink.record_failure(&session_id, &error);
+            }
         }
 
         let stop_reason = prompt_stop_reason(was_cancelled, output_token_limit_reached);
@@ -3692,13 +3757,42 @@ print(\"hello, world\")
         assert_eq!(error.code, agent_client_protocol::ErrorCode::InternalError);
     }
 
+    /// Streams a few assistant text chunks so a turn produces several client
+    /// notification opportunities, unlike the empty-stream effort provider.
+    #[derive(Debug)]
+    struct MultiChunkProvider;
+
+    #[async_trait::async_trait]
+    impl Provider for MultiChunkProvider {
+        fn get_name(&self) -> &str {
+            "openai"
+        }
+
+        async fn stream(
+            &self,
+            _model_config: &goose_providers::model::ModelConfig,
+            _system: &str,
+            _messages: &[Message],
+            _tools: &[rmcp::model::Tool],
+        ) -> Result<crate::providers::base::MessageStream, ProviderError> {
+            Ok(Box::pin(futures::stream::iter([
+                Ok((Some(Message::assistant().with_text("chunk-one ")), None)),
+                Ok((Some(Message::assistant().with_text("chunk-two ")), None)),
+                Ok((Some(Message::assistant().with_text("chunk-three")), None)),
+            ])))
+        }
+    }
+
     /// The startup notifications a prompt sends before the agent turn (the
     /// active-run update and local-model progress) must be fail-soft: a client
     /// that disconnects right after dispatch loses its notifications, not its
     /// prompt. Uses a deterministically dead connection — the transport is
     /// fully shut down before `on_prompt` runs, so those sends are guaranteed
     /// to fail — and asserts the turn still completes, clears its run, and
-    /// persists the prompt for a later `session/load`.
+    /// persists the conversation for a later `session/load`. Also pins the
+    /// dead-sink latch: the multi-chunk turn attempts exactly one send — the
+    /// first failure latches, everything after is skipped instead of hammering
+    /// the dead channel once per stream event.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn prompt_on_dead_connection_still_runs_and_persists() {
         let root = tempfile::tempdir().unwrap();
@@ -3741,8 +3835,9 @@ print(\"hello, world\")
             true,
             GoosePlatform::GooseCli,
         )));
-        // Streams no events: the turn completes with just the user message.
-        let provider = Arc::new(AsyncEffortProvider::new());
+        // Streams several chunks: each is a client notification the dead-sink
+        // latch must skip after the first failure.
+        let provider = Arc::new(MultiChunkProvider);
         session_agent
             .update_provider(
                 provider,
@@ -3799,11 +3894,21 @@ print(\"hello, world\")
             session_id,
             vec![ContentBlock::Text(TextContent::new("what is 1+1"))],
         );
+        let client_sink = ClientNotificationSink::default();
         let response = server
-            .on_prompt(&cx, request)
+            .on_prompt_with_sink(&cx, request, &client_sink)
             .await
             .expect("a dead client must not discard the prompt");
         assert_eq!(response.stop_reason, StopReason::EndTurn);
+
+        // The latch: the first failed send marks the sink dead and every later
+        // client-bound send of the run — one per streamed chunk, plus the
+        // post-turn updates — is skipped rather than attempted and logged.
+        assert_eq!(
+            client_sink.failed_send_count(),
+            1,
+            "a dead client sink must be latched after the first send failure"
+        );
 
         // The run was cleared on completion...
         assert!(server
@@ -3830,6 +3935,10 @@ print(\"hello, world\")
         assert!(
             texts.iter().any(|text| text.contains("what is 1+1")),
             "prompt must be persisted despite the dead connection; got {texts:?}"
+        );
+        assert!(
+            texts.iter().any(|text| text.contains("chunk-three")),
+            "assistant reply must be persisted despite the dead connection; got {texts:?}"
         );
     }
 

--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -1631,33 +1631,31 @@ impl GooseAcpAgent {
         let sent =
             cx.send_request(permission_request)
                 .on_receiving_result(move |result| async move {
-                    if !callback_pending_request.try_complete() {
-                        return Ok(());
-                    }
-                    match result {
-                        Ok(response) => {
-                            agent
-                                .handle_confirmation(
-                                    request_id,
-                                    outcome_to_confirmation(&response.outcome),
-                                )
-                                .await;
-                            Ok(())
+                    callback_pending_request.spawn_response_resolution(async move {
+                        match result {
+                            Ok(response) => {
+                                agent
+                                    .handle_confirmation(
+                                        request_id,
+                                        outcome_to_confirmation(&response.outcome),
+                                    )
+                                    .await;
+                            }
+                            Err(e) => {
+                                error!(error = ?e, "permission request failed");
+                                agent
+                                    .handle_confirmation(
+                                        request_id,
+                                        PermissionConfirmation {
+                                            principal_type: PrincipalType::Tool,
+                                            permission: Permission::Cancel,
+                                        },
+                                    )
+                                    .await;
+                            }
                         }
-                        Err(e) => {
-                            error!(error = ?e, "permission request failed");
-                            agent
-                                .handle_confirmation(
-                                    request_id,
-                                    PermissionConfirmation {
-                                        principal_type: PrincipalType::Tool,
-                                        permission: Permission::Cancel,
-                                    },
-                                )
-                                .await;
-                            Ok(())
-                        }
-                    }
+                    });
+                    Ok(())
                 });
 
         if let Err(e) = sent {
@@ -1905,6 +1903,18 @@ impl PendingClientRequest {
         } else {
             false
         }
+    }
+
+    fn spawn_response_resolution<F>(&self, resolution: F)
+    where
+        F: std::future::Future<Output = ()> + Send + 'static,
+    {
+        let pending_request = self.clone();
+        tokio::spawn(async move {
+            if pending_request.try_complete() {
+                resolution.await;
+            }
+        });
     }
 
     async fn complete_on_transport_termination(
@@ -3607,7 +3617,7 @@ print(\"hello, world\")
     }
 
     #[tokio::test]
-    async fn pending_client_response_wins_transport_termination_fallback() {
+    async fn pending_client_response_resolution_survives_transport_termination() {
         let pending = PendingClientRequest::new();
         let transport_terminated = CancellationToken::new();
         let waiter_pending = pending.clone();
@@ -3618,10 +3628,21 @@ print(\"hello, world\")
                 .await
         });
 
-        assert!(pending.try_complete());
+        let (resolution_started_tx, resolution_started_rx) = tokio::sync::oneshot::channel();
+        let (finish_resolution_tx, finish_resolution_rx) = tokio::sync::oneshot::channel();
+        let (resolution_finished_tx, resolution_finished_rx) = tokio::sync::oneshot::channel();
+        pending.spawn_response_resolution(async move {
+            resolution_started_tx.send(()).unwrap();
+            finish_resolution_rx.await.unwrap();
+            resolution_finished_tx.send(()).unwrap();
+        });
+
+        resolution_started_rx.await.unwrap();
+        transport_terminated.cancel();
 
         assert!(!waiter.await.unwrap());
-        transport_terminated.cancel();
+        finish_resolution_tx.send(()).unwrap();
+        resolution_finished_rx.await.unwrap();
         assert!(
             !pending.try_complete(),
             "fallback must not complete it again"

--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -251,11 +251,13 @@ pub struct ActivePromptRun {
 /// one session.
 pub type ActiveRunRegistry = Arc<Mutex<HashMap<String, ActivePromptRun>>>;
 
-/// Releases a registry entry if the owning `on_prompt` future is dropped
-/// without reaching its explicit `clear_active_run` — e.g. a roaming
-/// connection is revoked or lost mid-prompt and the transport drops the
-/// request future. Without this, the shared registry retains the run forever
-/// and every later connection gets "session already has active run".
+/// Releases a registry entry if the prompt task dies without reaching its
+/// explicit `clear_active_run` — e.g. a panic mid-turn. Prompt turns run on
+/// detached runtime tasks (see the `PromptRequest` handler in `dispatch.rs`),
+/// so losing the transport no longer drops the future; the guard is the
+/// backstop for the task itself dying. Without it, the shared registry would
+/// retain the run forever and every later connection would get "session
+/// already has active run".
 ///
 /// The explicit clear still runs on normal paths; this drop is then a no-op
 /// because the entry (matched by run id) is already gone.
@@ -817,9 +819,20 @@ impl GooseAcpAgent {
         session_id: &str,
         run_id: String,
         agent: Arc<Agent>,
-    ) -> Result<(), agent_client_protocol::Error> {
-        self.start_active_run(session_id, run_id, CancellationToken::new(), agent)
-            .await
+    ) -> Result<CancellationToken, agent_client_protocol::Error> {
+        let cancel_token = CancellationToken::new();
+        self.start_active_run(session_id, run_id, cancel_token.clone(), agent)
+            .await?;
+        Ok(cancel_token)
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn test_cancel(&self, session_id: &str) {
+        self.on_cancel(CancelNotification::new(SessionId::new(
+            session_id.to_string(),
+        )))
+        .await
+        .unwrap();
     }
 
     #[cfg(test)]
@@ -1402,7 +1415,8 @@ impl GooseAcpAgent {
                         tool_name.clone(),
                         arguments.clone(),
                         prompt.clone(),
-                    )?;
+                    )
+                    .await?;
                 }
                 ActionRequiredData::Elicitation {
                     id,
@@ -1544,7 +1558,7 @@ impl GooseAcpAgent {
     }
 
     #[allow(clippy::too_many_arguments)]
-    fn handle_tool_permission_request(
+    async fn handle_tool_permission_request(
         &self,
         cx: &ConnectionTo<Client>,
         agent: &Arc<Agent>,
@@ -1557,6 +1571,8 @@ impl GooseAcpAgent {
         let cx = cx.clone();
         let agent = agent.clone();
         let session_id = session_id.clone();
+        let fallback_agent = agent.clone();
+        let fallback_request_id = request_id.clone();
 
         let tool_call_update =
             build_permission_tool_call_update(&request_id, &tool_name, arguments, prompt);
@@ -1579,33 +1595,51 @@ impl GooseAcpAgent {
         let permission_request =
             RequestPermissionRequest::new(session_id, tool_call_update, options);
 
-        cx.send_request(permission_request)
-            .on_receiving_result(move |result| async move {
-                match result {
-                    Ok(response) => {
-                        agent
-                            .handle_confirmation(
-                                request_id,
-                                outcome_to_confirmation(&response.outcome),
-                            )
-                            .await;
-                        Ok(())
+        let sent =
+            cx.send_request(permission_request)
+                .on_receiving_result(move |result| async move {
+                    match result {
+                        Ok(response) => {
+                            agent
+                                .handle_confirmation(
+                                    request_id,
+                                    outcome_to_confirmation(&response.outcome),
+                                )
+                                .await;
+                            Ok(())
+                        }
+                        Err(e) => {
+                            error!(error = ?e, "permission request failed");
+                            agent
+                                .handle_confirmation(
+                                    request_id,
+                                    PermissionConfirmation {
+                                        principal_type: PrincipalType::Tool,
+                                        permission: Permission::Cancel,
+                                    },
+                                )
+                                .await;
+                            Ok(())
+                        }
                     }
-                    Err(e) => {
-                        error!(error = ?e, "permission request failed");
-                        agent
-                            .handle_confirmation(
-                                request_id,
-                                PermissionConfirmation {
-                                    principal_type: PrincipalType::Tool,
-                                    permission: Permission::Cancel,
-                                },
-                            )
-                            .await;
-                        Ok(())
-                    }
-                }
-            })?;
+                });
+
+        if let Err(e) = sent {
+            // The connection is gone (e.g. the client dropped mid-turn), so no
+            // answer can ever arrive. Resolve like the failed-request branch
+            // above: deny the tool so a detached turn keeps moving instead of
+            // waiting on a confirmation forever.
+            error!(error = ?e, "could not send permission request");
+            fallback_agent
+                .handle_confirmation(
+                    fallback_request_id,
+                    PermissionConfirmation {
+                        principal_type: PrincipalType::Tool,
+                        permission: Permission::Cancel,
+                    },
+                )
+                .await;
+        }
 
         Ok(())
     }
@@ -2091,9 +2125,11 @@ impl GooseAcpAgent {
         )
         .await?;
 
-        // Frees the run if this future is dropped mid-prompt (e.g. the roaming
-        // connection carrying it is revoked or lost); a normal completion's
-        // explicit clear wins and makes the guard's cleanup a no-op.
+        // Frees the run if this task dies mid-prompt (e.g. a panic); a normal
+        // completion's explicit clear wins and makes the guard's cleanup a
+        // no-op. Losing the transport no longer drops this future: the turn
+        // runs on a detached task (see the `PromptRequest` handler in
+        // `dispatch.rs`) so it finishes and persists for a later session/load.
         let _run_guard = ActiveRunDropGuard {
             registry: self.active_prompt_runs.clone(),
             session_id: session_id.clone(),
@@ -2190,8 +2226,18 @@ impl GooseAcpAgent {
                             )
                             .await
                         {
-                            stream_error = Some(error);
-                            break;
+                            // A failed client send must not end the turn: the
+                            // transport may be gone (network drop, sleep)
+                            // while the detached turn keeps executing and
+                            // persisting for a later session/load. Interactive
+                            // content resolves inside the handler (permission
+                            // and elicitation send failures fall back to
+                            // deny/cancel), so skipping the update is safe.
+                            warn!(
+                                session_id = %session_id,
+                                %error,
+                                "failed to send session update; continuing without the client"
+                            );
                         }
 
                         let ready_chain = match content_item {
@@ -2222,17 +2268,29 @@ impl GooseAcpAgent {
                         tool_notifications::tool_notification_update(request_id, notification)
                     {
                         let tool_call_notifier = ToolCallNotifier::new(cx, &args.session_id);
-                        tool_call_notifier.send_update(update)?;
+                        if let Err(error) = tool_call_notifier.send_update(update) {
+                            warn!(
+                                session_id = %session_id,
+                                %error,
+                                "failed to send tool notification update; continuing without the client"
+                            );
+                        }
                     }
                 }
                 Ok(crate::agents::AgentEvent::MessageUsage { message_id, usage }) => {
                     if self.supports_goose_custom_notifications() {
-                        cx.send_notification(GooseSessionNotification {
+                        if let Err(error) = cx.send_notification(GooseSessionNotification {
                             session_id: session_id.clone(),
                             update: GooseSessionUpdate::MessageUsage(message_usage_update(
                                 message_id, &usage,
                             )),
-                        })?;
+                        }) {
+                            warn!(
+                                session_id = %session_id,
+                                %error,
+                                "failed to send message usage update; continuing without the client"
+                            );
+                        }
                     }
                 }
                 Ok(_) => {}
@@ -2252,7 +2310,11 @@ impl GooseAcpAgent {
             }
         }
         self.clear_active_run(&session_id, &run_id).await;
-        Self::send_active_run_update(cx, &args.session_id, None)?;
+        // From here on the turn's work is complete and persisted; failures to
+        // reach a (possibly disconnected) client must not turn it into an error.
+        if let Err(error) = Self::send_active_run_update(cx, &args.session_id, None) {
+            warn!(session_id = %session_id, %error, "failed to send active-run clear update");
+        }
         if let Some(error) = stream_error {
             return Err(error);
         }
@@ -2280,12 +2342,16 @@ impl GooseAcpAgent {
                 .internal_err_ctx("Failed to resolve context limit")?;
         let updates = build_usage_updates(&session, &totals, context_limit);
         if self.supports_goose_custom_notifications() {
-            cx.send_notification(updates.custom)?;
+            if let Err(error) = cx.send_notification(updates.custom) {
+                warn!(session_id = %session_id, %error, "failed to send usage update");
+            }
         }
-        cx.send_notification(SessionNotification::new(
+        if let Err(error) = cx.send_notification(SessionNotification::new(
             args.session_id.clone(),
             SessionUpdate::UsageUpdate(updates.standard),
-        ))?;
+        )) {
+            warn!(session_id = %session_id, %error, "failed to send usage update");
+        }
 
         let stop_reason = prompt_stop_reason(was_cancelled, output_token_limit_reached);
 

--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -333,15 +333,33 @@ pub struct GooseAcpAgentOptions {
     pub active_prompt_runs: ActiveRunRegistry,
 }
 
+/// This agent's own prompt runs (session id → run id) plus the connection's
+/// revocation fence, deliberately under one lock.
+///
+/// Registration (`start_active_run`) performs the fence check, the
+/// shared-registry insert, and the per-agent insert inside a single critical
+/// section of this lock, while revocation (`revoke_and_cancel_own_runs`) sets
+/// the fence and snapshots the runs under the same lock before cancelling. A
+/// registration therefore either completes before the fence is set — and is
+/// in the revocation sweep's snapshot — or observes the fence and is refused;
+/// there is no interleaving where a run registers after the sweep, and no
+/// window where the shared registry holds a run this map does not.
+#[derive(Default)]
+struct OwnPromptRuns {
+    revoked: bool,
+    runs: HashMap<String, String>,
+}
+
 pub struct GooseAcpAgent {
     sessions: Arc<Mutex<HashMap<String, GooseAcpSession>>>,
     active_prompt_runs: Arc<Mutex<HashMap<String, ActivePromptRun>>>,
-    /// Runs this agent started (session id → run id), a per-connection subset
-    /// of the shared `active_prompt_runs`. Lets a transport-level authority
-    /// decision (roaming peer revocation) cancel exactly the revoked
-    /// connection's detached runs via [`Self::cancel_own_active_runs`] without
-    /// touching runs owned by other connections.
-    own_prompt_runs: Mutex<HashMap<String, String>>,
+    /// Runs this agent started, a per-connection subset of the shared
+    /// `active_prompt_runs`, plus the revocation fence. Lets a
+    /// transport-level authority decision (roaming peer revocation) stop
+    /// exactly the revoked connection's detached runs — current and future —
+    /// via [`Self::revoke_and_cancel_own_runs`] without touching runs owned
+    /// by other connections.
+    own_prompt_runs: Mutex<OwnPromptRuns>,
     closed_session_ids: Arc<Mutex<HashSet<String>>>,
     agent_manager: Arc<AgentManager>,
     provider_factory: AcpProviderFactory,
@@ -974,7 +992,7 @@ impl GooseAcpAgent {
         Ok(Self {
             sessions: Arc::new(Mutex::new(HashMap::new())),
             active_prompt_runs: options.active_prompt_runs,
-            own_prompt_runs: Mutex::new(HashMap::new()),
+            own_prompt_runs: Mutex::new(OwnPromptRuns::default()),
             closed_session_ids: Arc::new(Mutex::new(HashSet::new())),
             agent_manager,
             provider_factory: options.provider_factory,
@@ -1927,6 +1945,19 @@ impl GooseAcpAgent {
             .data(format!("Session not found: {}", session_id)));
         }
 
+        // Fence check, shared-registry insert, and per-agent insert form one
+        // critical section under the own-runs lock (see `OwnPromptRuns`), so a
+        // revocation can never interleave between them: the shared insert only
+        // happens after the fence check passed, under the same lock hold, so a
+        // refused prompt leaves nothing in the shared registry to unwind.
+        // Nested lock order is own_prompt_runs → active_prompt_runs; no other
+        // path nests them the other way around.
+        let mut own_prompt_runs = self.own_prompt_runs.lock().await;
+        if own_prompt_runs.revoked {
+            return Err(agent_client_protocol::Error::auth_required()
+                .data("connection revoked; prompt refused"));
+        }
+
         let mut active_prompt_runs = self.active_prompt_runs.lock().await;
         if let Some(active_run) = active_prompt_runs.get(session_id) {
             return Err(agent_client_protocol::Error::invalid_params().data(format!(
@@ -1945,10 +1976,7 @@ impl GooseAcpAgent {
         );
         drop(active_prompt_runs);
 
-        self.own_prompt_runs
-            .lock()
-            .await
-            .insert(session_id.to_string(), run_id);
+        own_prompt_runs.runs.insert(session_id.to_string(), run_id);
         Ok(())
     }
 
@@ -1956,10 +1984,11 @@ impl GooseAcpAgent {
         {
             let mut own_prompt_runs = self.own_prompt_runs.lock().await;
             if own_prompt_runs
+                .runs
                 .get(session_id)
                 .is_some_and(|own_run_id| own_run_id == run_id)
             {
-                own_prompt_runs.remove(session_id);
+                own_prompt_runs.runs.remove(session_id);
             }
         }
 
@@ -2000,24 +2029,35 @@ impl GooseAcpAgent {
         }
     }
 
-    /// Cancel every active run this agent started, leaving runs owned by other
-    /// agents on the shared registry untouched. Returns how many were
-    /// cancelled.
+    /// Permanently fence this agent against starting new prompt runs and
+    /// cancel every run it already started, leaving runs owned by other agents
+    /// on the shared registry untouched. Returns how many were cancelled.
     ///
     /// Detached prompt runs deliberately survive ordinary transport loss; this
     /// is the escape hatch for when the connection's *authority* is withdrawn
     /// (a roaming peer is revoked): the revoked peer's in-flight turns must
-    /// stop consuming the provider and executing tools. Cancellation goes
-    /// through the registry's tokens — the detached task observes it and
-    /// clears its own registry entry, exactly as with `session/cancel`.
-    pub async fn cancel_own_active_runs(&self) -> usize {
-        let own_runs: Vec<(String, String)> = self
-            .own_prompt_runs
-            .lock()
-            .await
-            .iter()
-            .map(|(session_id, run_id)| (session_id.clone(), run_id.clone()))
-            .collect();
+    /// stop consuming the provider and executing tools, and a prompt task that
+    /// was dispatched but has not registered yet must not slip in afterwards —
+    /// the fence refuses it (see `OwnPromptRuns` for the atomicity argument).
+    /// The fence is permanent, which is safe because an agent is
+    /// per-connection: a peer that merely lost its network gets a fresh,
+    /// unfenced agent on reconnect, while a revoked agent instance never
+    /// serves another connection. Cancellation goes through the registry's
+    /// tokens — the detached task observes it and clears its own registry
+    /// entry, exactly as with `session/cancel`.
+    pub async fn revoke_and_cancel_own_runs(&self) -> usize {
+        // Set the fence and snapshot under one lock: every run registered
+        // before this point is in the snapshot, and every registration after
+        // it observes the fence and is refused.
+        let own_runs: Vec<(String, String)> = {
+            let mut own_prompt_runs = self.own_prompt_runs.lock().await;
+            own_prompt_runs.revoked = true;
+            own_prompt_runs
+                .runs
+                .iter()
+                .map(|(session_id, run_id)| (session_id.clone(), run_id.clone()))
+                .collect()
+        };
 
         let active_prompt_runs = self.active_prompt_runs.lock().await;
         let mut cancelled = 0;

--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -373,6 +373,11 @@ pub struct GooseAcpAgent {
     client_requests_tool_call_label_enrichment: OnceCell<bool>,
     use_login_shell_path: OnceCell<bool>,
     client_cx: OnceCell<ConnectionTo<Client>>,
+    /// Cancelled when this agent's client transport stops for any reason,
+    /// including I/O errors that bypass the ACP SDK's clean-EOF callback.
+    /// Detached prompt runs watch this only for client interactions; the run
+    /// itself keeps executing and persisting after a disconnect.
+    client_transport_terminated: CancellationToken,
     thinking_effort_update_tx: mpsc::UnboundedSender<String>,
     thinking_effort_update_rx: Mutex<Option<mpsc::UnboundedReceiver<String>>>,
     config_dir: std::path::PathBuf,
@@ -1006,6 +1011,7 @@ impl GooseAcpAgent {
             client_requests_tool_call_label_enrichment: OnceCell::new(),
             use_login_shell_path: OnceCell::new(),
             client_cx: OnceCell::new(),
+            client_transport_terminated: CancellationToken::new(),
             thinking_effort_update_tx,
             thinking_effort_update_rx: Mutex::new(Some(thinking_effort_update_rx)),
             config_dir: options.config_dir,
@@ -1598,6 +1604,8 @@ impl GooseAcpAgent {
         let session_id = session_id.clone();
         let fallback_agent = agent.clone();
         let fallback_request_id = request_id.clone();
+        let pending_request = PendingClientRequest::new();
+        let callback_pending_request = pending_request.clone();
 
         let tool_call_update =
             build_permission_tool_call_update(&request_id, &tool_name, arguments, prompt);
@@ -1623,6 +1631,9 @@ impl GooseAcpAgent {
         let sent =
             cx.send_request(permission_request)
                 .on_receiving_result(move |result| async move {
+                    if !callback_pending_request.try_complete() {
+                        return Ok(());
+                    }
                     match result {
                         Ok(response) => {
                             agent
@@ -1655,15 +1666,35 @@ impl GooseAcpAgent {
             // above: deny the tool so a detached turn keeps moving instead of
             // waiting on a confirmation forever.
             error!(error = ?e, "could not send permission request");
-            fallback_agent
-                .handle_confirmation(
-                    fallback_request_id,
-                    PermissionConfirmation {
-                        principal_type: PrincipalType::Tool,
-                        permission: Permission::Cancel,
-                    },
-                )
-                .await;
+            if pending_request.try_complete() {
+                fallback_agent
+                    .handle_confirmation(
+                        fallback_request_id,
+                        PermissionConfirmation {
+                            principal_type: PrincipalType::Tool,
+                            permission: Permission::Cancel,
+                        },
+                    )
+                    .await;
+            }
+        } else {
+            let transport_terminated = self.client_transport_terminated.clone();
+            tokio::spawn(async move {
+                if pending_request
+                    .complete_on_transport_termination(&transport_terminated)
+                    .await
+                {
+                    fallback_agent
+                        .handle_confirmation(
+                            fallback_request_id,
+                            PermissionConfirmation {
+                                principal_type: PrincipalType::Tool,
+                                permission: Permission::Cancel,
+                            },
+                        )
+                        .await;
+                }
+            });
         }
 
         Ok(())
@@ -1838,6 +1869,53 @@ fn message_usage_update(
 #[derive(Default)]
 struct ClientNotificationSink {
     failed_sends: std::sync::atomic::AtomicUsize,
+}
+
+/// Coordinates an ACP client request's normal response callback with its
+/// transport-termination fallback. The SDK drops response callbacks on some
+/// transport I/O errors, so the fallback runs on a Tokio task independent of
+/// the connection actor. Exactly one side claims completion.
+#[derive(Clone)]
+struct PendingClientRequest {
+    completed: Arc<std::sync::atomic::AtomicBool>,
+    completion: CancellationToken,
+}
+
+impl PendingClientRequest {
+    fn new() -> Self {
+        Self {
+            completed: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            completion: CancellationToken::new(),
+        }
+    }
+
+    fn try_complete(&self) -> bool {
+        if self
+            .completed
+            .compare_exchange(
+                false,
+                true,
+                std::sync::atomic::Ordering::AcqRel,
+                std::sync::atomic::Ordering::Acquire,
+            )
+            .is_ok()
+        {
+            self.completion.cancel();
+            true
+        } else {
+            false
+        }
+    }
+
+    async fn complete_on_transport_termination(
+        &self,
+        transport_terminated: &CancellationToken,
+    ) -> bool {
+        tokio::select! {
+            _ = transport_terminated.cancelled() => self.try_complete(),
+            _ = self.completion.cancelled() => false,
+        }
+    }
 }
 
 impl ClientNotificationSink {
@@ -2828,6 +2906,24 @@ pub struct GooseAcpHandler {
     pub agent: Arc<GooseAcpAgent>,
 }
 
+struct ClientTransportDropGuard {
+    transport_terminated: CancellationToken,
+}
+
+impl ClientTransportDropGuard {
+    fn new(agent: &GooseAcpAgent) -> Self {
+        Self {
+            transport_terminated: agent.client_transport_terminated.clone(),
+        }
+    }
+}
+
+impl Drop for ClientTransportDropGuard {
+    fn drop(&mut self) {
+        self.transport_terminated.cancel();
+    }
+}
+
 pub fn serve<R, W>(
     agent: Arc<GooseAcpAgent>,
     read: R,
@@ -2838,6 +2934,7 @@ where
     W: futures::AsyncWrite + Unpin + Send + 'static,
 {
     Box::pin(async move {
+        let _transport_guard = ClientTransportDropGuard::new(&agent);
         let handler = GooseAcpHandler { agent };
 
         SacpAgent
@@ -2873,6 +2970,7 @@ impl agent_client_protocol::ConnectTo<Client> for GooseAgentConnection {
         client: impl agent_client_protocol::ConnectTo<SacpAgent>,
     ) -> std::result::Result<(), agent_client_protocol::Error> {
         let agent = self.server.create_agent().await.internal_err()?;
+        let _transport_guard = ClientTransportDropGuard::new(&agent);
         let handler = GooseAcpHandler { agent };
         SacpAgent
             .builder()
@@ -3485,6 +3583,49 @@ print(\"hello, world\")
         expected: PermissionConfirmation,
     ) {
         assert_eq!(outcome_to_confirmation(&input), expected);
+    }
+
+    #[tokio::test]
+    async fn pending_client_request_completes_on_transport_termination() {
+        let pending = PendingClientRequest::new();
+        let transport_terminated = CancellationToken::new();
+        let waiter_pending = pending.clone();
+        let waiter_transport = transport_terminated.clone();
+        let waiter = tokio::spawn(async move {
+            waiter_pending
+                .complete_on_transport_termination(&waiter_transport)
+                .await
+        });
+
+        transport_terminated.cancel();
+
+        assert!(waiter.await.unwrap());
+        assert!(
+            !pending.try_complete(),
+            "completion must only be claimed once"
+        );
+    }
+
+    #[tokio::test]
+    async fn pending_client_response_wins_transport_termination_fallback() {
+        let pending = PendingClientRequest::new();
+        let transport_terminated = CancellationToken::new();
+        let waiter_pending = pending.clone();
+        let waiter_transport = transport_terminated.clone();
+        let waiter = tokio::spawn(async move {
+            waiter_pending
+                .complete_on_transport_termination(&waiter_transport)
+                .await
+        });
+
+        assert!(pending.try_complete());
+
+        assert!(!waiter.await.unwrap());
+        transport_terminated.cancel();
+        assert!(
+            !pending.try_complete(),
+            "fallback must not complete it again"
+        );
     }
 
     #[test]

--- a/crates/goose/src/acp/server/dispatch.rs
+++ b/crates/goose/src/acp/server/dispatch.rs
@@ -125,17 +125,26 @@ impl HandleDispatchFrom<Client> for GooseAcpHandler {
                     |req: PromptRequest, responder: Responder<PromptResponse>| async {
                         let agent = agent.clone();
                         let cx_clone = cx.clone();
-                        cx.spawn(async move {
-                            match agent.on_prompt(&cx_clone, req).await {
-                                Ok(response) => {
-                                    responder.respond(response)?;
-                                }
-                                Err(e) => {
-                                    responder.respond_with_error(e)?;
-                                }
+                        // Detached on purpose: connection-scoped tasks
+                        // (`cx.spawn`) are dropped when the transport closes,
+                        // which used to cancel the in-flight turn. On a
+                        // runtime task the turn keeps executing and persisting
+                        // its messages, so a client that lost its connection
+                        // (network drop, sleep) can reconnect and
+                        // `session/load` the finished work. `session/cancel`
+                        // still stops it via the shared active-run registry.
+                        tokio::spawn(async move {
+                            let delivery = match agent.on_prompt(&cx_clone, req).await {
+                                Ok(response) => responder.respond(response),
+                                Err(e) => responder.respond_with_error(e),
+                            };
+                            if let Err(error) = delivery {
+                                tracing::debug!(
+                                    %error,
+                                    "prompt response undeliverable; client disconnected mid-turn"
+                                );
                             }
-                            Ok(())
-                        })?;
+                        });
                         Ok(())
                     },
                 )

--- a/crates/goose/src/acp/server/elicitation.rs
+++ b/crates/goose/src/acp/server/elicitation.rs
@@ -112,29 +112,28 @@ impl super::GooseAcpAgent {
         let sent = cx
             .send_request(CreateElicitationRequestMessage(request))
             .on_receiving_result(move |result| async move {
-                if !callback_pending_request.try_complete() {
-                    return Ok(());
-                }
-                let response = match result {
-                    Ok(response) => elicitation_response_from_acp(response.0),
-                    Err(error) => {
-                        warn!(
-                            error = %error,
-                            session_id = %callback_session_id,
-                            elicitation_id = %callback_elicitation_id,
-                            "ACP elicitation request failed"
-                        );
-                        ElicitationOutcome::Cancel
-                    }
-                };
+                callback_pending_request.spawn_response_resolution(async move {
+                    let response = match result {
+                        Ok(response) => elicitation_response_from_acp(response.0),
+                        Err(error) => {
+                            warn!(
+                                error = %error,
+                                session_id = %callback_session_id,
+                                elicitation_id = %callback_elicitation_id,
+                                "ACP elicitation request failed"
+                            );
+                            ElicitationOutcome::Cancel
+                        }
+                    };
 
-                record_acp_elicitation_response(
-                    &callback_session_manager,
-                    &callback_session_id,
-                    &callback_elicitation_id,
-                    response,
-                )
-                .await;
+                    record_acp_elicitation_response(
+                        &callback_session_manager,
+                        &callback_session_id,
+                        &callback_elicitation_id,
+                        response,
+                    )
+                    .await;
+                });
 
                 Ok(())
             });

--- a/crates/goose/src/acp/server/elicitation.rs
+++ b/crates/goose/src/acp/server/elicitation.rs
@@ -104,9 +104,17 @@ impl super::GooseAcpAgent {
         let callback_session_manager = Arc::clone(&self.session_manager);
         let callback_session_id = session_id.clone();
         let callback_elicitation_id = elicitation_id.clone();
-        if let Err(error) = cx
+        let fallback_session_manager = Arc::clone(&self.session_manager);
+        let fallback_session_id = session_id.clone();
+        let fallback_elicitation_id = elicitation_id.clone();
+        let pending_request = super::PendingClientRequest::new();
+        let callback_pending_request = pending_request.clone();
+        let sent = cx
             .send_request(CreateElicitationRequestMessage(request))
             .on_receiving_result(move |result| async move {
+                if !callback_pending_request.try_complete() {
+                    return Ok(());
+                }
                 let response = match result {
                     Ok(response) => elicitation_response_from_acp(response.0),
                     Err(error) => {
@@ -129,17 +137,36 @@ impl super::GooseAcpAgent {
                 .await;
 
                 Ok(())
-            })
-        {
-            record_acp_elicitation_response(
-                &self.session_manager,
-                &session_id,
-                &elicitation_id,
-                ElicitationOutcome::Cancel,
-            )
-            .await;
+            });
+
+        if let Err(error) = sent {
+            if pending_request.try_complete() {
+                record_acp_elicitation_response(
+                    &fallback_session_manager,
+                    &fallback_session_id,
+                    &fallback_elicitation_id,
+                    ElicitationOutcome::Cancel,
+                )
+                .await;
+            }
             return Err(error);
         }
+
+        let transport_terminated = self.client_transport_terminated.clone();
+        tokio::spawn(async move {
+            if pending_request
+                .complete_on_transport_termination(&transport_terminated)
+                .await
+            {
+                record_acp_elicitation_response(
+                    &fallback_session_manager,
+                    &fallback_session_id,
+                    &fallback_elicitation_id,
+                    ElicitationOutcome::Cancel,
+                )
+                .await;
+            }
+        });
 
         Ok(())
     }

--- a/crates/goose/src/acp/server/elicitation.rs
+++ b/crates/goose/src/acp/server/elicitation.rs
@@ -111,8 +111,11 @@ impl super::GooseAcpAgent {
         let callback_pending_request = pending_request.clone();
         let sent = cx
             .send_request(CreateElicitationRequestMessage(request))
-            .on_receiving_result(move |result| async move {
-                callback_pending_request.spawn_response_resolution(async move {
+            .on_receiving_result(move |result| {
+                // Claim completion here, synchronously, before the resolution is
+                // handed to its own task: the transport-termination fallback must
+                // not be able to turn a client's answer into a cancellation.
+                callback_pending_request.claim_then_spawn_resolution(async move {
                     let response = match result {
                         Ok(response) => elicitation_response_from_acp(response.0),
                         Err(error) => {
@@ -135,7 +138,7 @@ impl super::GooseAcpAgent {
                     .await;
                 });
 
-                Ok(())
+                std::future::ready(Ok(()))
             });
 
         if let Err(error) = sent {

--- a/crates/goose/src/acp/server/load_session.rs
+++ b/crates/goose/src/acp/server/load_session.rs
@@ -229,7 +229,7 @@ fn replay_conversation_to_client(
 }
 
 impl GooseAcpAgent {
-    fn resend_pending_tool_permissions(
+    async fn resend_pending_tool_permissions(
         &self,
         cx: &ConnectionTo<Client>,
         agent: &Arc<Agent>,
@@ -286,7 +286,8 @@ impl GooseAcpAgent {
                 tool_name,
                 arguments,
                 prompt,
-            )?;
+            )
+            .await?;
         }
 
         Ok(())
@@ -333,7 +334,8 @@ impl GooseAcpAgent {
             .await
             .internal_err_ctx("Failed to get provider while loading ACP session")?;
         resume_saved_provider_session(&provider, session.conversation.as_ref()).await;
-        self.resend_pending_tool_permissions(cx, &agent, &session)?;
+        self.resend_pending_tool_permissions(cx, &agent, &session)
+            .await?;
 
         session = self
             .session_manager

--- a/crates/goose/src/acp/server_factory.rs
+++ b/crates/goose/src/acp/server_factory.rs
@@ -208,7 +208,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn dropping_a_prompt_future_releases_the_shared_run() {
+    async fn a_dying_prompt_task_releases_the_shared_run() {
         let root = tempfile::tempdir().unwrap();
         let server = server(root.path().to_path_buf(), false);
 
@@ -219,6 +219,9 @@ mod tests {
             .await
             .unwrap();
 
+        // Prompt turns run on detached tasks, so a lost transport no longer
+        // drops their future; the drop guard now only fires when the task
+        // itself dies (e.g. a panic) before its explicit clear.
         running.test_drop_active_run_guard("session-1", "run-1");
         tokio::task::yield_now().await;
 
@@ -228,8 +231,33 @@ mod tests {
                 .test_require_active_run("session-1", "run-1")
                 .await
                 .is_err(),
-            "a dropped prompt future must release its run so later \
+            "a prompt task that dies mid-run must release its run so later \
              connections are not permanently locked out of the session"
+        );
+    }
+
+    #[tokio::test]
+    async fn cancel_from_another_connection_cancels_a_detached_run() {
+        let root = tempfile::tempdir().unwrap();
+        let server = server(root.path().to_path_buf(), false);
+
+        let running = server.create_agent().await.unwrap();
+        let owner = Arc::new(crate::agents::Agent::new());
+        let cancel_token = running
+            .test_start_active_run("session-1", "run-1".to_string(), owner)
+            .await
+            .unwrap();
+
+        // A detached run outlives the connection that started it, so the
+        // reconnecting client's cancel arrives on a different agent; the
+        // shared registry must still route it to the run's cancel token.
+        let canceling = server.create_agent().await.unwrap();
+        canceling.test_cancel("session-1").await;
+
+        assert!(
+            cancel_token.is_cancelled(),
+            "session/cancel from a later connection must cancel a run that \
+             kept executing after its own connection dropped"
         );
     }
 

--- a/crates/goose/src/acp/server_factory.rs
+++ b/crates/goose/src/acp/server_factory.rs
@@ -262,7 +262,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn cancel_own_active_runs_only_cancels_this_agents_runs() {
+    async fn revocation_only_cancels_this_agents_runs() {
         let root = tempfile::tempdir().unwrap();
         let server = server(root.path().to_path_buf(), false);
 
@@ -281,7 +281,7 @@ mod tests {
         // The roaming bridge calls this when a peer is revoked: only the
         // revoked connection's runs stop; runs owned by other connections on
         // the same shared registry keep executing.
-        let cancelled = revoked.cancel_own_active_runs().await;
+        let cancelled = revoked.revoke_and_cancel_own_runs().await;
 
         assert_eq!(cancelled, 1);
         assert!(
@@ -296,6 +296,49 @@ mod tests {
         // clear, exactly like session/cancel.
         assert!(revoked
             .test_require_active_run("session-revoked", "run-1")
+            .await
+            .is_ok());
+    }
+
+    #[tokio::test]
+    async fn revocation_fences_later_run_registration() {
+        let root = tempfile::tempdir().unwrap();
+        let server = server(root.path().to_path_buf(), false);
+
+        let revoked = server.create_agent().await.unwrap();
+        revoked.revoke_and_cancel_own_runs().await;
+
+        // A prompt task that lost the race with revocation — dispatched
+        // before the sweep but registering after it — must be refused rather
+        // than left running detached under a revoked peer's authority. The
+        // fence check, the shared-registry insert, and the per-agent insert
+        // share one critical section (`OwnPromptRuns`), so the finer
+        // interleaving — revoke landing between the shared insert and the
+        // per-agent insert — is impossible by construction and has no seam to
+        // simulate here.
+        let owner = Arc::new(crate::agents::Agent::new());
+        assert!(
+            revoked
+                .test_start_active_run("session-1", "run-1".to_string(), owner)
+                .await
+                .is_err(),
+            "a revoked connection's agent must refuse to start new runs"
+        );
+
+        // The refused registration must leave nothing behind in the shared
+        // registry...
+        let second = server.create_agent().await.unwrap();
+        assert!(second
+            .test_require_active_run("session-1", "run-1")
+            .await
+            .is_err());
+        // ...and the session stays claimable by a non-revoked connection.
+        assert!(second
+            .test_start_active_run(
+                "session-1",
+                "run-2".to_string(),
+                Arc::new(crate::agents::Agent::new())
+            )
             .await
             .is_ok());
     }

--- a/crates/goose/src/acp/server_factory.rs
+++ b/crates/goose/src/acp/server_factory.rs
@@ -262,6 +262,45 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn cancel_own_active_runs_only_cancels_this_agents_runs() {
+        let root = tempfile::tempdir().unwrap();
+        let server = server(root.path().to_path_buf(), false);
+
+        let revoked = server.create_agent().await.unwrap();
+        let unaffected = server.create_agent().await.unwrap();
+        let owner = Arc::new(crate::agents::Agent::new());
+        let revoked_token = revoked
+            .test_start_active_run("session-revoked", "run-1".to_string(), owner.clone())
+            .await
+            .unwrap();
+        let unaffected_token = unaffected
+            .test_start_active_run("session-other", "run-2".to_string(), owner)
+            .await
+            .unwrap();
+
+        // The roaming bridge calls this when a peer is revoked: only the
+        // revoked connection's runs stop; runs owned by other connections on
+        // the same shared registry keep executing.
+        let cancelled = revoked.cancel_own_active_runs().await;
+
+        assert_eq!(cancelled, 1);
+        assert!(
+            revoked_token.is_cancelled(),
+            "the revoked agent's own run must be cancelled"
+        );
+        assert!(
+            !unaffected_token.is_cancelled(),
+            "another connection's run must survive a peer revocation"
+        );
+        // Cancellation leaves the registry entry for the run's own task to
+        // clear, exactly like session/cancel.
+        assert!(revoked
+            .test_require_active_run("session-revoked", "run-1")
+            .await
+            .is_ok());
+    }
+
+    #[tokio::test]
     async fn start_scheduler_initializes_before_any_client_connects() {
         let root = tempfile::tempdir().unwrap();
         let server = server(root.path().to_path_buf(), true);

--- a/crates/goose/tests/acp_fixtures/mod.rs
+++ b/crates/goose/tests/acp_fixtures/mod.rs
@@ -321,7 +321,7 @@ impl DuplexTransport {
         agent_client_protocol::ByteStreams::new(self.outgoing, self.incoming)
     }
 
-    fn into_parts(self) -> (CompatDuplexStream, CompatDuplexStream) {
+    pub fn into_parts(self) -> (CompatDuplexStream, CompatDuplexStream) {
         (self.outgoing, self.incoming)
     }
 }

--- a/crates/goose/tests/acp_server_test.rs
+++ b/crates/goose/tests/acp_server_test.rs
@@ -1228,3 +1228,183 @@ fn test_shell_terminal_false() {
 fn test_shell_terminal_true() {
     run_test(async { run_shell_terminal_true::<AcpServerConnection>().await });
 }
+
+async fn send_raw_line<W: futures::AsyncWrite + Unpin>(outgoing: &mut W, value: serde_json::Value) {
+    use futures::AsyncWriteExt;
+    outgoing
+        .write_all(format!("{value}\n").as_bytes())
+        .await
+        .unwrap();
+    outgoing.flush().await.unwrap();
+}
+
+async fn raw_response_with_id<R: futures::AsyncRead + Unpin>(
+    incoming: &mut futures::io::Lines<futures::io::BufReader<R>>,
+    id: u64,
+) -> serde_json::Value {
+    use futures::StreamExt;
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(10);
+    loop {
+        let line = tokio::time::timeout_at(deadline, incoming.next())
+            .await
+            .expect("timed out waiting for a response")
+            .expect("ACP connection closed")
+            .unwrap();
+        let message: serde_json::Value = serde_json::from_str(&line).unwrap();
+        if message["id"] == serde_json::json!(id) {
+            return message;
+        }
+    }
+}
+
+/// A client that loses its connection mid-`session/prompt` must not lose the
+/// turn: it keeps executing detached from the transport and persists its
+/// messages, so reconnecting and calling `session/load` shows the finished
+/// work.
+#[test]
+fn test_prompt_keeps_running_after_client_disconnect() {
+    run_test(async {
+        use futures::AsyncBufReadExt;
+        use std::time::Duration;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let data_root = tempfile::tempdir().unwrap();
+        let work_dir = tempfile::tempdir().unwrap();
+
+        // Hand-rolled OpenAI mock instead of OpenAiFixture: the completion is
+        // delayed so the turn is still mid-flight when the transport drops.
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v1/models"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "application/json")
+                    .set_body_string(include_str!("acp_test_data/openai_models.json")),
+            )
+            .mount(&mock_server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/v1/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_delay(Duration::from_millis(1500))
+                    .set_body_string(include_str!("acp_test_data/openai_basic.txt")),
+            )
+            .mount(&mock_server)
+            .await;
+
+        let (transport, _handle, _permission_manager) = spawn_acp_server_in_process(
+            &mock_server.uri(),
+            &[],
+            data_root.path(),
+            GooseMode::default(),
+            None,
+            goose_test_support::TEST_MODEL,
+            true,
+        )
+        .await;
+
+        let (mut outgoing, incoming) = transport.into_parts();
+        let mut incoming = futures::io::BufReader::new(incoming).lines();
+
+        send_raw_line(
+            &mut outgoing,
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {"protocolVersion": 1, "clientCapabilities": {}},
+            }),
+        )
+        .await;
+        raw_response_with_id(&mut incoming, 1).await;
+
+        send_raw_line(
+            &mut outgoing,
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "session/new",
+                "params": {"cwd": work_dir.path(), "mcpServers": []},
+            }),
+        )
+        .await;
+        let response = raw_response_with_id(&mut incoming, 2).await;
+        let session_id = response["result"]["sessionId"]
+            .as_str()
+            .unwrap()
+            .to_string();
+
+        send_raw_line(
+            &mut outgoing,
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "session/prompt",
+                "params": {
+                    "sessionId": session_id,
+                    "prompt": [{"type": "text", "text": "what is 1+1"}],
+                },
+            }),
+        )
+        .await;
+
+        // Wait until the turn is mid-flight (the provider request arrived and
+        // its delayed response is still pending), then drop the client
+        // transport without ever reading the prompt response.
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+        while !mock_server
+            .received_requests()
+            .await
+            .unwrap_or_default()
+            .iter()
+            .any(|request| request.url.path() == "/v1/chat/completions")
+        {
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "timed out waiting for the turn to reach the provider"
+            );
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        drop(outgoing);
+        drop(incoming);
+
+        // The detached turn must finish and persist the assistant reply so a
+        // later session/load sees the completed work.
+        let session_manager = SessionManager::new(data_root.path().to_path_buf());
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(20);
+        loop {
+            let assistant_text: String = session_manager
+                .get_session(&session_id, true)
+                .await
+                .ok()
+                .and_then(|session| session.conversation)
+                .map(|conversation| {
+                    conversation
+                        .messages()
+                        .iter()
+                        .filter(|message| message.role == rmcp::model::Role::Assistant)
+                        .flat_map(|message| message.content.iter())
+                        .filter_map(|content| match content {
+                            goose::conversation::message::MessageContent::Text(text) => {
+                                Some(text.text.clone())
+                            }
+                            _ => None,
+                        })
+                        .collect()
+                })
+                .unwrap_or_default();
+            if assistant_text == "2" {
+                break;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "assistant reply was not persisted after the client disconnected \
+                 mid-turn; got {assistant_text:?}"
+            );
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    });
+}

--- a/crates/goose/tests/acp_server_test.rs
+++ b/crates/goose/tests/acp_server_test.rs
@@ -1257,100 +1257,102 @@ async fn raw_response_with_id<R: futures::AsyncRead + Unpin>(
     }
 }
 
-/// A client that loses its connection mid-`session/prompt` must not lose the
-/// turn: it keeps executing detached from the transport and persists its
-/// messages, so reconnecting and calling `session/load` shows the finished
-/// work.
-#[test]
-fn test_prompt_keeps_running_after_client_disconnect() {
-    run_test(async {
-        use futures::AsyncBufReadExt;
-        use std::time::Duration;
-        use wiremock::matchers::{method, path};
-        use wiremock::{Mock, MockServer, ResponseTemplate};
+/// When the client's connection is lost mid-`session/prompt`, the turn must
+/// not be lost with it: it keeps executing detached from the transport and
+/// persists its messages, so reconnecting and calling `session/load` shows the
+/// finished work. `drop_before_provider_call` controls how early the transport
+/// dies: `false` waits until the provider request is in flight, `true` drops
+/// immediately after the prompt request is written — before the turn has sent
+/// its first notification — pinning that the startup sends are fail-soft too.
+async fn run_prompt_survives_client_disconnect(drop_before_provider_call: bool) {
+    use futures::AsyncBufReadExt;
+    use std::time::Duration;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
 
-        let data_root = tempfile::tempdir().unwrap();
-        let work_dir = tempfile::tempdir().unwrap();
+    let data_root = tempfile::tempdir().unwrap();
+    let work_dir = tempfile::tempdir().unwrap();
 
-        // Hand-rolled OpenAI mock instead of OpenAiFixture: the completion is
-        // delayed so the turn is still mid-flight when the transport drops.
-        let mock_server = MockServer::start().await;
-        Mock::given(method("GET"))
-            .and(path("/v1/models"))
-            .respond_with(
-                ResponseTemplate::new(200)
-                    .insert_header("content-type", "application/json")
-                    .set_body_string(include_str!("acp_test_data/openai_models.json")),
-            )
-            .mount(&mock_server)
-            .await;
-        Mock::given(method("POST"))
-            .and(path("/v1/chat/completions"))
-            .respond_with(
-                ResponseTemplate::new(200)
-                    .insert_header("content-type", "text/event-stream")
-                    .set_delay(Duration::from_millis(1500))
-                    .set_body_string(include_str!("acp_test_data/openai_basic.txt")),
-            )
-            .mount(&mock_server)
-            .await;
-
-        let (transport, _handle, _permission_manager) = spawn_acp_server_in_process(
-            &mock_server.uri(),
-            &[],
-            data_root.path(),
-            GooseMode::default(),
-            None,
-            goose_test_support::TEST_MODEL,
-            true,
+    // Hand-rolled OpenAI mock instead of OpenAiFixture: the completion is
+    // delayed so the turn is still mid-flight when the transport drops.
+    let mock_server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/v1/models"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "application/json")
+                .set_body_string(include_str!("acp_test_data/openai_models.json")),
         )
+        .mount(&mock_server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_delay(Duration::from_millis(1500))
+                .set_body_string(include_str!("acp_test_data/openai_basic.txt")),
+        )
+        .mount(&mock_server)
         .await;
 
-        let (mut outgoing, incoming) = transport.into_parts();
-        let mut incoming = futures::io::BufReader::new(incoming).lines();
+    let (transport, _handle, _permission_manager) = spawn_acp_server_in_process(
+        &mock_server.uri(),
+        &[],
+        data_root.path(),
+        GooseMode::default(),
+        None,
+        goose_test_support::TEST_MODEL,
+        true,
+    )
+    .await;
 
-        send_raw_line(
-            &mut outgoing,
-            serde_json::json!({
-                "jsonrpc": "2.0",
-                "id": 1,
-                "method": "initialize",
-                "params": {"protocolVersion": 1, "clientCapabilities": {}},
-            }),
-        )
-        .await;
-        raw_response_with_id(&mut incoming, 1).await;
+    let (mut outgoing, incoming) = transport.into_parts();
+    let mut incoming = futures::io::BufReader::new(incoming).lines();
 
-        send_raw_line(
-            &mut outgoing,
-            serde_json::json!({
-                "jsonrpc": "2.0",
-                "id": 2,
-                "method": "session/new",
-                "params": {"cwd": work_dir.path(), "mcpServers": []},
-            }),
-        )
-        .await;
-        let response = raw_response_with_id(&mut incoming, 2).await;
-        let session_id = response["result"]["sessionId"]
-            .as_str()
-            .unwrap()
-            .to_string();
+    send_raw_line(
+        &mut outgoing,
+        serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {"protocolVersion": 1, "clientCapabilities": {}},
+        }),
+    )
+    .await;
+    raw_response_with_id(&mut incoming, 1).await;
 
-        send_raw_line(
-            &mut outgoing,
-            serde_json::json!({
-                "jsonrpc": "2.0",
-                "id": 3,
-                "method": "session/prompt",
-                "params": {
-                    "sessionId": session_id,
-                    "prompt": [{"type": "text", "text": "what is 1+1"}],
-                },
-            }),
-        )
-        .await;
+    send_raw_line(
+        &mut outgoing,
+        serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "session/new",
+            "params": {"cwd": work_dir.path(), "mcpServers": []},
+        }),
+    )
+    .await;
+    let response = raw_response_with_id(&mut incoming, 2).await;
+    let session_id = response["result"]["sessionId"]
+        .as_str()
+        .unwrap()
+        .to_string();
 
+    send_raw_line(
+        &mut outgoing,
+        serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "session/prompt",
+            "params": {
+                "sessionId": session_id,
+                "prompt": [{"type": "text", "text": "what is 1+1"}],
+            },
+        }),
+    )
+    .await;
+
+    if !drop_before_provider_call {
         // Wait until the turn is mid-flight (the provider request arrived and
         // its delayed response is still pending), then drop the client
         // transport without ever reading the prompt response.
@@ -1368,43 +1370,57 @@ fn test_prompt_keeps_running_after_client_disconnect() {
             );
             tokio::time::sleep(Duration::from_millis(20)).await;
         }
-        drop(outgoing);
-        drop(incoming);
+    }
+    drop(outgoing);
+    drop(incoming);
 
-        // The detached turn must finish and persist the assistant reply so a
-        // later session/load sees the completed work.
-        let session_manager = SessionManager::new(data_root.path().to_path_buf());
-        let deadline = tokio::time::Instant::now() + Duration::from_secs(20);
-        loop {
-            let assistant_text: String = session_manager
-                .get_session(&session_id, true)
-                .await
-                .ok()
-                .and_then(|session| session.conversation)
-                .map(|conversation| {
-                    conversation
-                        .messages()
-                        .iter()
-                        .filter(|message| message.role == rmcp::model::Role::Assistant)
-                        .flat_map(|message| message.content.iter())
-                        .filter_map(|content| match content {
-                            goose::conversation::message::MessageContent::Text(text) => {
-                                Some(text.text.clone())
-                            }
-                            _ => None,
-                        })
-                        .collect()
-                })
-                .unwrap_or_default();
-            if assistant_text == "2" {
-                break;
-            }
-            assert!(
-                tokio::time::Instant::now() < deadline,
-                "assistant reply was not persisted after the client disconnected \
-                 mid-turn; got {assistant_text:?}"
-            );
-            tokio::time::sleep(Duration::from_millis(50)).await;
+    // The detached turn must finish and persist the assistant reply so a
+    // later session/load sees the completed work.
+    let session_manager = SessionManager::new(data_root.path().to_path_buf());
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(20);
+    loop {
+        let assistant_text: String = session_manager
+            .get_session(&session_id, true)
+            .await
+            .ok()
+            .and_then(|session| session.conversation)
+            .map(|conversation| {
+                conversation
+                    .messages()
+                    .iter()
+                    .filter(|message| message.role == rmcp::model::Role::Assistant)
+                    .flat_map(|message| message.content.iter())
+                    .filter_map(|content| match content {
+                        goose::conversation::message::MessageContent::Text(text) => {
+                            Some(text.text.clone())
+                        }
+                        _ => None,
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        if assistant_text == "2" {
+            break;
         }
-    });
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "assistant reply was not persisted after the client disconnected \
+             mid-turn; got {assistant_text:?}"
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+#[test]
+fn test_prompt_keeps_running_after_client_disconnect() {
+    run_test(async { run_prompt_survives_client_disconnect(false).await });
+}
+
+/// The earliest possible disconnect: the transport dies right after the prompt
+/// request is written, before the turn's startup notifications go out. The
+/// prompt must still run to completion instead of being silently discarded
+/// when those startup sends fail.
+#[test]
+fn test_prompt_survives_disconnect_before_first_notification() {
+    run_test(async { run_prompt_survives_client_disconnect(true).await });
 }


### PR DESCRIPTION
## Problem

The ACP server runs each `session/prompt` inside a connection-scoped task (`cx.spawn` queues it into the connection's event loop). When the client's transport closes — network drop, laptop sleep, client quit — the event loop ends, the task is dropped, and `ActiveRunDropGuard::drop()` cancels the run's `CancellationToken`. The in-flight turn dies with the connection.

For remote clients (an ACP client over an SSH tunnel, `goose roam` peers), this means any disconnect kills work in progress, even though the server, the session, and every subprocess it spawned are perfectly healthy.

## Change

Detach prompt execution from the transport:

- **`server/dispatch.rs`** — the `PromptRequest` arm runs `on_prompt` on `tokio::spawn`, with the `Responder` moved into the task. The responder is the completion channel: it replies as before while the client is connected, and the reply send fails harmlessly (debug log) when it isn't. This also removes a latent hazard where a failed respond inside `cx.spawn` (whose contract shuts the server down on task error) could kill the whole connection loop.
- **`server.rs`** — `ActiveRunDropGuard` moves with the detached task, so it fires only if the task itself dies (panic) before the explicit `clear_active_run`; its registry-leak protection is unchanged. Mid-turn client interactions become fail-soft: message-content, tool-notification, and usage-notification send failures warn and continue instead of aborting the turn. Provider-fatal errors (`auth_required`, credits exhausted) still abort.
- **Permissions** — `handle_tool_permission_request` resolves a send failure on a dead connection through the existing deny path (`Permission::Cancel`), so a detached turn never hangs waiting for an answer that cannot arrive. Elicitation already cancelled on send failure. If the connection dies while an answer is pending, the existing `resend_pending_tool_permissions` on `session/load` re-asks when a client reconnects.
- **No config gate** — detached execution is the new default everywhere. For stdio transports it is behaviorally identical (process exit tears down the runtime and the task with it).

Persistence needed no changes: `Agent::reply` writes messages incrementally via `session_manager.add_message`, and the detached task keeps driving the stream after disconnect, so a reconnecting client sees the completed turn via `session/load`.

Out of scope (follow-up): live re-attach — streaming a still-running turn's updates to a reconnecting client. The shared `ActiveRunRegistry` is the natural anchor (updatable notification sink per run + an attach step on `session/load` + a bounded replay buffer).

## Tests

- New integration test `test_prompt_keeps_running_after_client_disconnect`: raw JSON-RPC over the duplex fixture, drops the transport while the provider call is in flight, then polls session storage until the assistant reply persists. Non-vacuous: fails (timeout) without the dispatch change, passes in ~1.8s with it.
- New `cancel_from_another_connection_cancels_a_detached_run`: `session/cancel` still cancels a detached run via the shared registry.
- `dropping_a_prompt_future_releases_the_shared_run` renamed to `a_dying_prompt_task_releases_the_shared_run` — same registry-leak protection, re-documented for task-death semantics.
- Cross-connection steer and shared-registry tests unchanged and passing.
- `cargo test -p goose --lib 'acp::'` (333) and all seven `acp_*` integration binaries pass; `cargo fmt --check` and `cargo clippy -p goose --all-targets -- -D warnings` clean.

Also verified against a live deployment: a desktop ACP client connected over an SSH local port-forward sent a ~60s tool-using prompt, the tunnel was killed 20 seconds in, the remote turn ran to completion and persisted its final assistant reply, and the reconnected client loaded it via `session/load`.

## Review follow-ups (second commit)

- **Revocation cancels detached runs.** `goose-roaming` gains a per-connection `RevocationSignal`; `enforce_trust` (and the trust-file watcher) set it before force-closing a revoked peer's connection, and it is passed to `AcpStreamServer::serve_stream`. After the stream ends, the full ACP bridge checks it and calls the new `GooseAcpAgent::cancel_own_active_runs()`, which cancels only runs this connection started (via the shared registry tokens), leaving entries for the detached tasks to clear — ordinary transport loss still detaches. Note: the extra `serve_stream` parameter is a breaking change for out-of-tree `AcpStreamServer` implementors.
- **Startup notifications are fail-soft.** The pre-stream `send_active_run_update`, local-inference progress, and cancelled-path clear sends now warn-and-continue, so a disconnect between dispatch and `Agent::reply` no longer silently discards the prompt. Pinned deterministically by `prompt_on_dead_connection_still_runs_and_persists` (runs `on_prompt` on a fully dead connection; fails on the old code), plus an earliest-possible transport-drop variant of the integration test.
