### PR TITLE
feat(providers): add OpenLLM BYOK/Subscription gateway as a native provider

### DIFF
--- a/crates/goose-providers/src/declarative.rs
+++ b/crates/goose-providers/src/declarative.rs
@@ -40,6 +40,7 @@ pub(crate) mod declarative_providers {
         omlx,
         opencode_go,
         opencode_zen,
+        openllm,
         opper,
         orcarouter,
         ovhcloud,

--- a/crates/goose-providers/src/declarative/definitions/openllm.json
+++ b/crates/goose-providers/src/declarative/definitions/openllm.json
@@ -1,0 +1,18 @@
+{
+  "name": "openllm",
+  "engine": "openai",
+  "display_name": "OpenLLM",
+  "description": "OpenLLM — one endpoint across every provider. Requires its service running; install: curl -fsSL https://www.openllm.sh/install | bash",
+  "api_key_env": "",
+  "base_url": "http://127.0.0.1:8787/v1",
+  "models": [
+    { "name": "ultra", "context_limit": 1000000 },
+    { "name": "plus", "context_limit": 1000000 },
+    { "name": "lite", "context_limit": 1000000 }
+  ],
+  "dynamic_models": true,
+  "supports_streaming": true,
+  "preserves_thinking": true,
+  "requires_auth": false,
+  "skip_canonical_filtering": true
+}

--- a/crates/goose-providers/src/declarative/definitions/openllm.json
+++ b/crates/goose-providers/src/declarative/definitions/openllm.json
@@ -4,7 +4,17 @@
   "display_name": "OpenLLM",
   "description": "OpenLLM — one endpoint across every provider. Requires its service running; install: curl -fsSL https://www.openllm.sh/install | bash",
   "api_key_env": "",
-  "base_url": "http://127.0.0.1:8787/v1",
+  "base_url": "${OPENLLM_HOST}/v1",
+  "env_vars": [
+    {
+      "name": "OPENLLM_HOST",
+      "required": false,
+      "secret": false,
+      "primary": true,
+      "default": "http://127.0.0.1:8787",
+      "description": "Base URL of the OpenLLM service (default: http://127.0.0.1:8787)"
+    }
+  ],
   "models": [
     { "name": "ultra", "context_limit": 1000000 },
     { "name": "plus", "context_limit": 1000000 },
@@ -14,5 +24,24 @@
   "supports_streaming": true,
   "preserves_thinking": true,
   "requires_auth": false,
-  "skip_canonical_filtering": true
+  "skip_canonical_filtering": true,
+  "setup_steps": [
+    "Install OpenLLM: curl -fsSL https://www.openllm.sh/install | bash",
+    "The installer starts the local service on http://127.0.0.1:8787",
+    "Pick a fallback chain such as ultra, plus, or lite as your model"
+  ],
+  "setup": {
+    "category": "model",
+    "setup_method": "config_fields",
+    "group": "additional",
+    "docs_url": "https://www.openllm.sh",
+    "field_overrides": [
+      {
+        "key": "OPENLLM_HOST",
+        "label": "Host URL",
+        "placeholder": "http://127.0.0.1:8787",
+        "default_value": "http://127.0.0.1:8787"
+      }
+    ]
+  }
 }

--- a/crates/goose/src/providers/catalog_util.rs
+++ b/crates/goose/src/providers/catalog_util.rs
@@ -172,6 +172,21 @@ mod tests {
             host_field.default_value.as_deref(),
             Some("http://localhost:1337")
         );
+
+        let openllm = entries
+            .iter()
+            .find(|entry| entry.provider_id == "openllm")
+            .expect("setup catalog should include openllm declarative provider");
+        assert_eq!(openllm.setup_method, ProviderSetupMethod::ConfigFields);
+        assert_eq!(openllm.fields.len(), 1);
+        assert_eq!(openllm.fields[0].key, "OPENLLM_HOST");
+        assert_eq!(openllm.fields[0].label, "Host URL");
+        assert!(!openllm.fields[0].required);
+        assert!(!openllm.fields[0].secret);
+        assert_eq!(
+            openllm.fields[0].default_value.as_deref(),
+            Some("http://127.0.0.1:8787")
+        );
     }
 
     #[tokio::test]

--- a/documentation/docs/getting-started/providers.md
+++ b/documentation/docs/getting-started/providers.md
@@ -281,11 +281,10 @@ To configure your chosen provider, see available options, or select a model, vis
 
 [OpenLLM](https://openllm.sh/) manages both BYOK API providers and subscription providers for goose. You arrange them into fallback chains, then select a chain such as `ultra`, `plus`, or `lite` as your model. If the first provider is unavailable, rate-limited, or cannot fit the request, OpenLLM tries the next one without changing your goose configuration.
 
-Install OpenLLM and start its local service:
+Install OpenLLM (the installer also starts its local service):
 
 ```sh
 curl -fsSL https://www.openllm.sh/install | bash
-openllm start
 ```
 
 Then choose **OpenLLM** in goose and select `ultra`, `plus`, `lite`, or another model returned by OpenLLM. You can create and reorder fallback chains in the OpenLLM dashboard. Since goose refers to the chain by name, you can change the models behind it without updating goose.

--- a/documentation/docs/getting-started/providers.md
+++ b/documentation/docs/getting-started/providers.md
@@ -287,7 +287,7 @@ Install OpenLLM (the installer also starts its local service):
 curl -fsSL https://www.openllm.sh/install | bash
 ```
 
-Then choose **OpenLLM** in goose and select `ultra`, `plus`, `lite`, or another model returned by OpenLLM. You can create and reorder fallback chains in the OpenLLM dashboard. Since goose refers to the chain by name, you can change the models behind it without updating goose.
+Then choose **OpenLLM** in goose and select `ultra`, `plus`, `lite`, or another model returned by OpenLLM. No API key is needed. The service listens on `http://127.0.0.1:8787` by default; set `OPENLLM_HOST` if it runs elsewhere. You can create and reorder fallback chains in the OpenLLM dashboard. Since goose refers to the chain by name, you can change the models behind it without updating goose.
 
 To add semantic code search and persistent memory, see the [OpenLLM extension guide](/docs/mcp/openllm-mcp).
 

--- a/documentation/docs/getting-started/providers.md
+++ b/documentation/docs/getting-started/providers.md
@@ -51,6 +51,7 @@ goose is compatible with a wide range of LLM providers, allowing you to choose a
 | [Ollama](https://ollama.com/)                                               | Local model runner supporting Qwen, Llama, DeepSeek, and other open-source models. **Because this provider runs locally, you must first [download and run a model](#local-llms).**  | `OLLAMA_HOST`                                                                                                                                                                       |
 | [Ollama Cloud](https://ollama.com/)                                         | Access hosted models on ollama.com via OpenAI-compatible API. Requires an Ollama account and API key.  | `OLLAMA_CLOUD_API_KEY`                                                                                                                                                                       |
 | [OpenAI](https://platform.openai.com/api-keys)                              | Provides gpt-4o, o1, and other advanced language models. Also supports OpenAI-compatible endpoints (e.g., self-hosted LLaMA, vLLM, KServe). **o1-mini and o1-preview are not supported because goose uses tool calling.** | `OPENAI_API_KEY`, `OPENAI_HOST` (optional), `OPENAI_ORGANIZATION` (optional), `OPENAI_PROJECT` (optional), `OPENAI_CUSTOM_HEADERS` (optional)                                       |
+| [OpenLLM](https://openllm.sh/)                                              | Manages BYOK and subscription providers through configurable fallback chains. Requires the local OpenLLM service. | None |
 | [OpenRouter](https://openrouter.ai/)                                        | API gateway for unified access to various models with features like rate-limiting management.                                                                                                                             | `OPENROUTER_API_KEY`, `OPENROUTER_HOST` (optional), `OPENROUTER_PARAMETERS` (optional)                                                                                              |
 | [Perplexity](https://www.perplexity.ai/)                                    | Chat models with built-in real-time web search grounding. OpenAI-compatible chat completions API at `https://api.perplexity.ai`.                                                                                          | `PERPLEXITY_API_KEY`                                                                                                                                                                |
 | [OVHcloud AI](https://www.ovhcloud.com/en/public-cloud/ai-endpoints/)       | Provides access to open-source models including Qwen, Llama, Mistral, and DeepSeek through AI Endpoints service.                                                       | `OVHCLOUD_API_KEY`                                                                                                                                                                  |
@@ -275,6 +276,21 @@ To configure your chosen provider, see available options, or select a model, vis
 
   </TabItem>
 </Tabs>
+
+### OpenLLM
+
+[OpenLLM](https://openllm.sh/) manages both BYOK API providers and subscription providers for goose. You arrange them into fallback chains, then select a chain such as `ultra`, `plus`, or `lite` as your model. If the first provider is unavailable, rate-limited, or cannot fit the request, OpenLLM tries the next one without changing your goose configuration.
+
+Install OpenLLM and start its local service:
+
+```sh
+curl -fsSL https://www.openllm.sh/install | bash
+openllm start
+```
+
+Then choose **OpenLLM** in goose and select `ultra`, `plus`, `lite`, or another model returned by OpenLLM. You can create and reorder fallback chains in the OpenLLM dashboard. Since goose refers to the chain by name, you can change the models behind it without updating goose.
+
+To add semantic code search and persistent memory, see the [OpenLLM extension guide](/docs/mcp/openllm-mcp).
 
 ### Using Custom OpenAI Endpoints
 

--- a/documentation/docs/mcp/openllm-mcp.md
+++ b/documentation/docs/mcp/openllm-mcp.md
@@ -1,0 +1,60 @@
+---
+title: OpenLLM Extension
+description: Add OpenLLM MCP tools as a goose Extension
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import CLIExtensionInstructions from '@site/src/components/CLIExtensionInstructions';
+import GooseDesktopInstaller from '@site/src/components/GooseDesktopInstaller';
+
+The [OpenLLM](https://openllm.sh/) extension gives goose semantic search across code and documentation, plus persistent memory that can be recalled across sessions.
+
+## Prerequisite
+
+The launcher uses `npx` and Bun. If the OpenLLM CLI is not installed, the first run starts the official installer and guides you through setup.
+
+## Configuration
+
+:::tip Quick Install
+<Tabs groupId="interface">
+  <TabItem value="ui" label="goose Desktop" default>
+  [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=%40openllmsh%2Fnpm&arg=mcp&id=openllm&name=OpenLLM&description=Semantic%20code%20search%20and%20persistent%20memory)
+  </TabItem>
+  <TabItem value="cli" label="goose CLI">
+  **Command**
+  ```sh
+  npx -y @openllmsh/npm mcp
+  ```
+  </TabItem>
+</Tabs>
+:::
+
+<Tabs groupId="interface">
+  <TabItem value="ui" label="goose Desktop" default>
+  <GooseDesktopInstaller
+    extensionId="openllm"
+    extensionName="OpenLLM"
+    description="Semantic code search and persistent memory"
+    type="stdio"
+    command="npx"
+    args={["-y", "@openllmsh/npm", "mcp"]}
+  />
+  </TabItem>
+  <TabItem value="cli" label="goose CLI">
+  <CLIExtensionInstructions
+    name="OpenLLM"
+    description="Semantic code search and persistent memory"
+    type="stdio"
+    command="npx -y @openllmsh/npm mcp"
+    timeout={300}
+  />
+  </TabItem>
+</Tabs>
+
+## Included Tools
+
+| Tool group | What it provides |
+|------------|------------------|
+| Code and documentation search | Index and semantically search local codebases and documentation sites |
+| Memory | Save useful context and recall it in later sessions |

--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -516,6 +516,17 @@
     "environmentVariables": []
   },
   {
+    "id": "openllm",
+    "name": "OpenLLM",
+    "description": "Semantic search across code and documentation with persistent memory",
+    "command": "npx -y @openllmsh/npm mcp",
+    "link": "https://github.com/openllmsh/npm",
+    "installation_notes": "The npm launcher installs or invokes the native OpenLLM CLI.",
+    "is_builtin": false,
+    "endorsed": false,
+    "environmentVariables": []
+  },
+  {
     "id": "openmetadata",
     "name": "OpenMetadata",
     "description": "Bring OpenMetadata's single source of truth across your data systems to agents",


### PR DESCRIPTION
[OpenLLM](https://openllm.sh) is a fully compliant BYOK/Subscription LLM gateway with fallback-chains: one endpoint (`127.0.0.1:8787`) that fans out to every provider, Anthropic, OpenAI, Google, Alibaba, OpenCode, AWS Bedrock + custom endpoints, and subscription plans (Claude, ChatGPT, Kimi, Grok, Cursor), behind a single API: messages / responses / chat-completions / embeddings / images / video / …, full v1 surface at [openllm.sh/api/swagger/ui](https://www.openllm.sh/api/swagger/ui).

### How it works
- **No API key**: it talks to the OpenLLM CLI's local daemon over loopback (`requires_auth: false`); the daemon carries its own credentials.
- **Live model list**: `dynamic_models: true` reads models straight from the daemon's `/v1/models` (the user's configured models), with the `ultra` / `plus` / `lite` tier aliases as a static fallback.
- `skip_canonical_filtering` so the gateway's curated list shows through verbatim.

### Documentation
- Added OpenLLM to the provider guide with BYOK, subscription provider, and fallback-chain setup.
- Added the OpenLLM MCP guide for semantic code and documentation search plus persistent memory.
- Added OpenLLM to the Extensions directory using `npx -y @openllmsh/npm mcp`.

### Issue

Closes #11791.

### Verification

- CI passes, including Rust build/tests, formatting, clippy, generated schemas, conformance, Electron tests, MSRV, TLS backends, Semgrep, and zizmor.
- Verified OpenLLM model discovery against `/v1/models`, including `meta.n_ctx` context limits and the `ultra` / `plus` / `lite` fallback aliases.
- Verified a chat turn through the local OpenLLM daemon.

