### PR TITLE
fix(ui): drop the slash-command echo of the local user message in the ACP adapter

### DIFF
--- a/crates/goose/src/acp/server.rs
+++ b/crates/goose/src/acp/server.rs
@@ -763,6 +763,17 @@ struct PendingToolPermission {
     prompt: Option<String>,
 }
 
+/// The slash-command branches of `Agent::reply` yield the user's own prompt back
+/// into the reply stream, which the plain prompt path never does. The client
+/// rendered that prompt when it sent it, so forwarding the echo as a
+/// `user_message_chunk` shows the message twice.
+fn is_echoed_prompt(message: &Message, echoed_prompt_id: Option<&str>) -> bool {
+    let Some(prompt_id) = echoed_prompt_id else {
+        return false;
+    };
+    message.role == Role::User && message.id.as_deref() == Some(prompt_id)
+}
+
 fn update_output_token_limit_reached(output_token_limit_reached: &mut bool, message: &Message) {
     if message.role == Role::Assistant {
         *output_token_limit_reached = message.metadata.output_token_limit_reached;
@@ -1364,6 +1375,7 @@ impl GooseAcpAgent {
         message
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn handle_message_content(
         &self,
         content_item: &MessageContent,
@@ -1371,8 +1383,13 @@ impl GooseAcpAgent {
         session_id: &SessionId,
         target: &SessionAgentTarget,
         tool_requests: &HashMap<String, ToolRequest>,
+        echoed_prompt_id: Option<&str>,
         cx: &ConnectionTo<Client>,
     ) -> Result<(), agent_client_protocol::Error> {
+        if is_echoed_prompt(message, echoed_prompt_id) {
+            return Ok(());
+        }
+
         let role = &message.role;
 
         match content_item {
@@ -2124,6 +2141,7 @@ impl GooseAcpAgent {
         Ok(session)
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn forward_agent_stream(
         &self,
         cx: &ConnectionTo<Client>,
@@ -2132,6 +2150,7 @@ impl GooseAcpAgent {
         agent: &Arc<Agent>,
         cancel_token: &CancellationToken,
         mut stream: BoxStream<'_, Result<crate::agents::AgentEvent>>,
+        echoed_prompt_id: Option<&str>,
     ) -> Result<AgentStreamOutcome, agent_client_protocol::Error> {
         let mut was_cancelled = false;
         let mut output_token_limit_reached = false;
@@ -2176,6 +2195,7 @@ impl GooseAcpAgent {
                             acp_session_id,
                             &target,
                             &tool_requests,
+                            echoed_prompt_id,
                             cx,
                         )
                         .await?;
@@ -2302,7 +2322,13 @@ impl GooseAcpAgent {
             return Err(error);
         }
 
-        let user_message = Self::convert_acp_prompt_to_message(&args.prompt);
+        // Slash commands make the agent yield the user's own prompt back into the
+        // reply stream. Tag the prompt here, the way the steer path tags its own
+        // message, so the echo can be recognised and dropped before it leaves the
+        // server as a `user_message_chunk` the client already rendered locally.
+        let prompt_message_id = format!("prompt_{}", Uuid::new_v4());
+        let user_message =
+            Self::convert_acp_prompt_to_message(&args.prompt).with_id(prompt_message_id.clone());
         let session_config = SessionConfig {
             id: session_id.clone(),
             schedule_id: None,
@@ -2330,6 +2356,7 @@ impl GooseAcpAgent {
                 &agent,
                 &cancel_token,
                 stream,
+                Some(prompt_message_id.as_str()),
             )
             .await;
         self.clear_active_run(&session_id, &run_id).await;
@@ -3693,5 +3720,56 @@ print(\"hello, world\")
             .await
             .unwrap();
         client.await.unwrap().unwrap();
+    }
+
+    #[test]
+    fn echoed_prompt_message_is_suppressed() {
+        let message = Message::user()
+            .with_text("/plan add tests")
+            .with_id("prompt_1");
+
+        assert!(is_echoed_prompt(&message, Some("prompt_1")));
+    }
+
+    #[test]
+    fn echoed_prompt_matches_by_id_after_the_prompt_text_is_rewritten() {
+        // convert_acp_prompt_to_message runs sanitize_unicode_tags, so the echo
+        // can carry different text than the client sent.
+        let message = Message::user().with_text("sanitized").with_id("prompt_1");
+
+        assert!(is_echoed_prompt(&message, Some("prompt_1")));
+    }
+
+    #[test]
+    fn steer_message_is_not_suppressed() {
+        let message = Message::user().with_text("steered").with_id("steer_1");
+
+        assert!(!is_echoed_prompt(&message, Some("prompt_1")));
+    }
+
+    #[test]
+    fn assistant_message_is_not_suppressed() {
+        let message = Message::assistant().with_text("reply").with_id("prompt_1");
+
+        assert!(!is_echoed_prompt(&message, Some("prompt_1")));
+    }
+
+    #[test]
+    fn user_message_without_id_is_not_suppressed_when_no_prompt_is_tracked() {
+        let message = Message::user().with_text("hello");
+
+        assert!(!is_echoed_prompt(&message, None));
+    }
+
+    #[test]
+    fn prompt_message_id_survives_the_agent_id_backfill() {
+        // The agent stamps ids on id-less messages on their way out; the id the
+        // server assigns to the prompt has to reach the echo unchanged.
+        let message = Message::user()
+            .with_text("/plan add tests")
+            .with_id("prompt_1")
+            .with_generated_id_if_missing();
+
+        assert_eq!(message.id.as_deref(), Some("prompt_1"));
     }
 }

--- a/crates/goose/src/acp/server/load_session.rs
+++ b/crates/goose/src/acp/server/load_session.rs
@@ -318,6 +318,7 @@ impl GooseAcpAgent {
                     &task_agent,
                     &task_cancel_token,
                     stream,
+                    None,
                 )
                 .await;
             if result.is_ok() {


### PR DESCRIPTION
Closes #11670

## Summary

Reworked to the server-side approach requested in review: the echo now stops in the ACP server, not in the desktop client, so every ACP client is fixed and the guard no longer depends on the prompt text.

Slash-command branches of `Agent::reply` yield the user's own prompt back into the reply stream (`command_preamble` / `yield AgentEvent::Message(user_message)`), which the plain prompt path never does. The server forwarded that echo as a `user_message_chunk`, so the client showed the prompt twice: glued into the local bubble before #10716, and as a second identical bubble now that the chunk carries a message id.

- `on_prompt` tags the prompt message `prompt_{uuid}`, the way `on_steer_session` already tags its own message with `steer_{uuid}`. `Message::with_generated_id_if_missing` leaves an id that is already set alone, so the tag reaches the echo unchanged.
- `handle_message_content` drops content of a user message carrying that id. It is the one point where agent messages leave the server, so this covers all ten echo sites at once.
- The id is threaded through `forward_agent_stream`; the `session/load` resume path passes `None` and is unaffected.

Matching on the id rather than the text also survives the `sanitize_unicode_tags` rewrite that `convert_acp_prompt_to_message` applies to the prompt, which the previous text-equality version missed.

Steer confirmations still reach the client: they carry their own `steer_` id. Session history is unchanged -- the prompt is still persisted, so replay after `session/load` shows it once.

### Testing

- New unit tests in `crates/goose/src/acp/server.rs`: the echo is suppressed by id, it is still suppressed when the prompt text was rewritten, steer and assistant messages with other ids are untouched, an id-less user message is untouched when no prompt id is tracked, and the assigned id survives the agent's id backfill.
- `cargo test -p goose --lib acp::server::tests`: 52 passed, 0 failed. `cargo fmt --check` clean.

### Related Issues

Discussion: #9261 (structured slash-command lifecycle events would remove the need for the echo altogether)
