### PR TITLE
feat(cli): add --system flag to goose session for parity with goose run

### DIFF
--- a/crates/goose-cli/src/cli.rs
+++ b/crates/goose-cli/src/cli.rs
@@ -954,6 +954,15 @@ enum Command {
         )]
         history: bool,
 
+        /// Additional system prompt to customize agent behavior
+        #[arg(
+            long = "system",
+            value_name = "TEXT",
+            help = "Additional system prompt to customize agent behavior",
+            long_help = "Provide additional system instructions to customize the agent's behavior"
+        )]
+        system: Option<String>,
+
         #[command(flatten)]
         session_opts: SessionOptions,
 
@@ -1983,6 +1992,7 @@ struct InteractiveSessionArgs {
     fork: bool,
     edit: bool,
     history: bool,
+    system: Option<String>,
     session_opts: SessionOptions,
     extension_opts: ExtensionOptions,
     model_opts: ModelOptions,
@@ -1995,6 +2005,7 @@ async fn handle_interactive_session(args: InteractiveSessionArgs) -> Result<()> 
         fork,
         edit,
         history,
+        system,
         session_opts,
         extension_opts,
         model_opts,
@@ -2072,7 +2083,7 @@ async fn handle_interactive_session(args: InteractiveSessionArgs) -> Result<()> 
         builtins: extension_opts.builtins,
         no_profile: extension_opts.no_profile,
         recipe: None,
-        additional_system_prompt: None,
+        additional_system_prompt: system,
         provider: model_opts.provider,
         model: model_opts.model,
         debug: session_opts.debug,
@@ -2851,6 +2862,7 @@ pub async fn cli() -> anyhow::Result<()> {
             fork,
             edit,
             history,
+            system,
             session_opts,
             extension_opts,
             model_opts,
@@ -2861,6 +2873,7 @@ pub async fn cli() -> anyhow::Result<()> {
                 fork,
                 edit,
                 history,
+                system,
                 session_opts,
                 extension_opts,
                 model_opts,
@@ -3029,6 +3042,19 @@ mod tests {
             }) => {
                 assert!(!resume);
                 assert_eq!(model_opts.model.as_deref(), Some("gpt-5.4"));
+            }
+            _ => panic!("expected session command"),
+        }
+    }
+
+    #[test]
+    fn session_accepts_system_prompt() {
+        let cli = Cli::try_parse_from(["goose", "session", "--system", "extra instructions"])
+            .expect("system prompt should work for a new session");
+
+        match cli.command {
+            Some(Command::Session { system, .. }) => {
+                assert_eq!(system.as_deref(), Some("extra instructions"));
             }
             _ => panic!("expected session command"),
         }


### PR DESCRIPTION
Fixes #11644

`goose run` already supports `--system` for launch-time system-instruction injection, but interactive `goose session` had no equivalent. This adds the same flag:

```shell
goose session --system "extra instructions"
```

## Implementation

The plumbing already existed — `SessionBuilderConfig.additional_system_prompt` feeds `agent.extend_system_prompt("additional", …)` and is used by `goose run --system`. The interactive session path simply passed `None`. This change adds the `--system` arg to the `Session` command (same name/help as on `run`) and threads it through `InteractiveSessionArgs` into the existing builder field. No agent-loop behavior change, so the legacy/state-machine parity rule is not implicated.

Scope note: the issue also floats `--system-file` and an env-var form; those are left as possible follow-ups — this PR is the minimal parity change.

## Verification

- `cargo test -p goose-cli` green (includes new arg-parsing test `session_accepts_system_prompt`)
- `cargo clippy --all-targets -- -D warnings` clean, `cargo fmt` applied
- Live end-to-end: `goose session --system "The magic word is ZANZIBAR-42…" --no-profile` with a piped prompt asking for the magic word → model replied `ZANZIBAR-42`, confirming the instruction reaches the live system prompt in interactive mode