### PR TITLE
test: remove racy scheduler message count assertion

### DIFF
--- a/crates/goose/src/scheduler.rs
+++ b/crates/goose/src/scheduler.rs
@@ -1488,20 +1488,6 @@ mod tests {
             .unwrap();
         assert_eq!(sessions.len(), 1);
         assert_eq!(sessions[0].goose_mode, GooseMode::Auto);
-        let session = session_manager
-            .get_session(&sessions[0].id, true)
-            .await
-            .unwrap();
-        assert_eq!(
-            sessions[0].message_count,
-            session
-                .conversation
-                .unwrap()
-                .messages()
-                .iter()
-                .filter(|m| m.is_user_visible())
-                .count()
-        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
Fixes: #11623

## Summary

- remove the final `message_count` equality assertion from `test_job_runs_on_schedule`
- retain the assertions that the job ran, created one scheduled session, and used auto mode
- avoid comparing two independently timed session reads while the one-second cron remains active

### Testing

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p goose --lib scheduler::tests::test_job_runs_on_schedule -- --exact` (30 consecutive post-change runs)
- `cargo test -p goose --lib scheduler::tests` (10 passed)
- `cargo clippy -p goose --lib --tests -- -D warnings`

The unchanged baseline test also passed 30/30 locally; the intermittent failure is documented in the linked issue and its CI evidence.

### Related Issues

- #11623