### PR TITLE
fix(desktop): configure proxy for renderer session

### DIFF
--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -28,6 +28,7 @@ import { execFileSync, spawn, execFile } from 'child_process';
 import 'dotenv/config';
 import { checkBackendStatus } from './backendStatus';
 import { installBackendCertificateVerifiers } from './backendCertificateVerifier';
+import { configureProxy } from './proxy';
 import { startGooseServe } from './gooseServe';
 import { getLoginShellPath } from './loginShellPath';
 import { GooseServeLeaseRegistry, type GooseServeLease } from './gooseServeLeaseRegistry';
@@ -291,23 +292,6 @@ function listGitWorktreeDirs(dir: string): Promise<string[]> {
       }
     );
   });
-}
-
-async function configureProxy() {
-  const httpsProxy = process.env.HTTPS_PROXY || process.env.https_proxy;
-  const httpProxy = process.env.HTTP_PROXY || process.env.http_proxy;
-  const noProxy = process.env.NO_PROXY || process.env.no_proxy || '';
-
-  const proxyUrl = httpsProxy || httpProxy;
-
-  if (proxyUrl) {
-    console.log('[Main] Configuring proxy');
-    await session.defaultSession.setProxy({
-      proxyRules: proxyUrl,
-      proxyBypassRules: noProxy,
-    });
-    console.log('[Main] Proxy configured successfully');
-  }
 }
 
 if (started) app.quit();
@@ -2472,7 +2456,8 @@ async function appMain() {
     }
   });
 
-  await configureProxy();
+  const rendererSession = session.fromPartition('persist:goose');
+  await configureProxy(session.defaultSession, rendererSession);
 
   // Ensure Windows shims are available before any MCP processes are spawned
   await ensureWinShims();

--- a/ui/desktop/src/proxy.test.ts
+++ b/ui/desktop/src/proxy.test.ts
@@ -1,0 +1,61 @@
+import type { Session } from 'electron';
+import { describe, expect, it, vi } from 'vitest';
+import { configureProxy } from './proxy';
+
+function createMockSession() {
+  const setProxy = vi.fn<Session['setProxy']>().mockResolvedValue(undefined);
+  return {
+    session: { setProxy } as Pick<Session, 'setProxy'>,
+    setProxy,
+  };
+}
+
+describe('proxy configuration', () => {
+  it('applies the same proxy configuration to both Electron sessions', async () => {
+    const defaultSession = createMockSession();
+    const rendererSession = createMockSession();
+
+    await configureProxy(defaultSession.session, rendererSession.session, {
+      HTTPS_PROXY: 'https://proxy.example:8443',
+      NO_PROXY: 'localhost,127.0.0.1',
+    });
+
+    expect(defaultSession.setProxy).toHaveBeenCalledOnce();
+    expect(rendererSession.setProxy).toHaveBeenCalledOnce();
+    expect(defaultSession.setProxy).toHaveBeenCalledWith({
+      proxyRules: 'https://proxy.example:8443',
+      proxyBypassRules: 'localhost,127.0.0.1',
+    });
+    expect(rendererSession.setProxy.mock.calls[0][0]).toBe(
+      defaultSession.setProxy.mock.calls[0][0]
+    );
+  });
+
+  it('falls back to HTTP_PROXY without changing the default bypass rules', async () => {
+    const defaultSession = createMockSession();
+    const rendererSession = createMockSession();
+
+    await configureProxy(defaultSession.session, rendererSession.session, {
+      HTTP_PROXY: 'http://proxy.example:8080',
+    });
+
+    expect(defaultSession.setProxy).toHaveBeenCalledWith({
+      proxyRules: 'http://proxy.example:8080',
+      proxyBypassRules: '',
+    });
+    expect(rendererSession.setProxy).toHaveBeenCalledWith({
+      proxyRules: 'http://proxy.example:8080',
+      proxyBypassRules: '',
+    });
+  });
+
+  it('leaves both sessions unchanged when no proxy is configured', async () => {
+    const defaultSession = createMockSession();
+    const rendererSession = createMockSession();
+
+    await configureProxy(defaultSession.session, rendererSession.session, {});
+
+    expect(defaultSession.setProxy).not.toHaveBeenCalled();
+    expect(rendererSession.setProxy).not.toHaveBeenCalled();
+  });
+});

--- a/ui/desktop/src/proxy.ts
+++ b/ui/desktop/src/proxy.ts
@@ -1,0 +1,27 @@
+import type { Session } from 'electron';
+
+type ProxySession = Pick<Session, 'setProxy'>;
+type ProxyEnvironment = Record<string, string | undefined>;
+
+export async function configureProxy(
+  defaultSession: ProxySession,
+  rendererSession: ProxySession,
+  environment: ProxyEnvironment = process.env
+): Promise<void> {
+  const httpsProxy = environment.HTTPS_PROXY || environment.https_proxy;
+  const httpProxy = environment.HTTP_PROXY || environment.http_proxy;
+  const proxyUrl = httpsProxy || httpProxy;
+
+  if (!proxyUrl) {
+    return;
+  }
+
+  console.log('[Main] Configuring proxy');
+  const proxyConfig = {
+    proxyRules: proxyUrl,
+    proxyBypassRules: environment.NO_PROXY || environment.no_proxy || '',
+  };
+
+  await Promise.all([defaultSession.setProxy(proxyConfig), rendererSession.setProxy(proxyConfig)]);
+  console.log('[Main] Proxy configured successfully');
+}


### PR DESCRIPTION
## Summary

- apply environment proxy configuration to both Electron's default session and the persistent `persist:goose` renderer session before windows load
- use the same proxy rules and bypass rules for both sessions while preserving existing variable precedence and no-proxy behavior
- add behavioral tests with two distinct session objects covering identical configuration, HTTP fallback, default bypass rules, and the unset no-op

### Testing

- `cargo fmt --check`
- `pnpm --dir ui --filter @aaif/goose-sdk run build`
- `pnpm --dir ui/desktop exec vitest run src/proxy.test.ts` — 3 passed
- `pnpm --dir ui/desktop run lint:check`
- full Desktop suite — 773 passed in sandbox; the 6 environment-restricted loopback/helper cases were rerun outside the sandbox and all 13 associated tests passed

*This finding was discovered by [Project Loupe](https://github.com/project-loupe/loupe)*
