### PR TITLE
fix(gdk): repair uniffi build broken by semantic merge conflict

### DIFF
--- a/crates/goose-sdk/src/observability.rs
+++ b/crates/goose-sdk/src/observability.rs
@@ -349,6 +349,7 @@ mod tests {
             reasoning_tokens: None,
             model: "claude-sonnet-4".to_string(),
             provider_metadata_json: None,
+            additional_data_json: None,
         }
     }
 


### PR DESCRIPTION
`Check goose-sdk UniFFI` is failing on `main` and on every open PR.

## Cause

A semantic merge conflict between two PRs that were green independently:

- #11630 added `additional_data_json` to `bindings::Usage`
- #11632 added `observability.rs`, whose test helper constructs `Usage`

Neither branch contained the other's change, so neither CI run saw the incompatibility. Merged together, the test helper is missing the new field:

```
error[E0063]: missing field `additional_data_json` in initializer of `bindings::Usage`
   --> crates/goose-sdk/src/observability.rs:343:9
```

The field is only referenced from a `#[cfg(test)]` helper, so this breaks `--all-targets`/`cargo test` but not a plain library build.

## Fix

Set `additional_data_json: None` in the test helper. One line; no production code or behavior change.

## Verification

Both commands from the failing job, run on this branch:

```
cargo check -p goose-sdk --features uniffi --locked   # passes
cargo test  -p goose-sdk --features uniffi --locked   # 25 passed; 0 failed
```

Confirmed the error reproduces on pristine `origin/main` beforehand.