### PR TITLE
fix(security): keep pasted slash commands visible

### DIFF
--- a/crates/goose-cli/src/session/paste.rs
+++ b/crates/goose-cli/src/session/paste.rs
@@ -154,7 +154,7 @@ enum PeekedBurst {
 fn peek_pending_chars() -> Option<PeekedBurst> {
     use winapi::um::processenv::GetStdHandle;
     use winapi::um::winbase::STD_INPUT_HANDLE;
-    use winapi::um::wincon::{INPUT_RECORD, PeekConsoleInputW};
+    use winapi::um::wincon::{PeekConsoleInputW, INPUT_RECORD};
 
     const PEEK_CAP: u32 = 512;
     let pending = console_pending_events();

--- a/crates/goose-cli/src/session/paste.rs
+++ b/crates/goose-cli/src/session/paste.rs
@@ -321,11 +321,15 @@ fn normalize_paste_text(text: &str) -> String {
     text.replace("\r\n", "\n").replace('\r', "\n")
 }
 
-/// Build the chip shown in place of a pasted block, or `None` when the paste is
-/// small enough to keep inline. `id` makes the marker unique to this paste
-/// instance so a cleared chip can never be expanded into a later, identical-
-/// looking one (see [`expand_pastes`]).
+/// Build the chip shown in place of a pasted block, or `None` when the paste must
+/// remain visible. `id` makes the marker unique to this paste instance so a
+/// cleared chip can never be expanded into a later, identical-looking one (see
+/// [`expand_pastes`]).
 fn paste_marker(content: &str, id: usize) -> Option<String> {
+    if content.starts_with('/') {
+        return None;
+    }
+
     let lines = content.trim_end_matches('\n').matches('\n').count() + 1;
     if lines >= PASTE_CHIP_MIN_LINES {
         Some(format!("[Pasted {lines} lines #{id}]"))
@@ -394,6 +398,19 @@ mod tests {
         assert_eq!(
             paste_marker(&long, 3),
             Some(format!("[Pasted {PASTE_CHIP_MIN_CHARS} chars #3]"))
+        );
+    }
+
+    #[test]
+    fn test_paste_marker_keeps_slash_commands_visible() {
+        assert_eq!(paste_marker("/extension example\nignored", 4), None);
+
+        let long = format!("/mode auto {}", "x".repeat(PASTE_CHIP_MIN_CHARS));
+        assert_eq!(paste_marker(&long, 5), None);
+
+        assert_eq!(
+            paste_marker("explain /extension\ncontinued", 6),
+            Some("[Pasted 2 lines #6]".to_string())
         );
     }
 

--- a/crates/goose-cli/src/session/paste.rs
+++ b/crates/goose-cli/src/session/paste.rs
@@ -154,7 +154,7 @@ enum PeekedBurst {
 fn peek_pending_chars() -> Option<PeekedBurst> {
     use winapi::um::processenv::GetStdHandle;
     use winapi::um::winbase::STD_INPUT_HANDLE;
-    use winapi::um::wincon::{PeekConsoleInputW, INPUT_RECORD};
+    use winapi::um::wincon::{INPUT_RECORD, PeekConsoleInputW};
 
     const PEEK_CAP: u32 = 512;
     let pending = console_pending_events();
@@ -383,17 +383,46 @@ fn expand_pastes(line: &str, pastes: &[Paste]) -> String {
     result
 }
 
+enum PasteSubmission {
+    Ready(String),
+    NeedsReview(String),
+}
+
+fn prepare_paste_submission(line: &str, pastes: &[Paste]) -> PasteSubmission {
+    let contained_chip = pastes.iter().any(|paste| line.contains(&paste.marker));
+    let expanded = expand_pastes(line, pastes);
+    if contained_chip && expanded.starts_with('/') {
+        PasteSubmission::NeedsReview(expanded)
+    } else {
+        PasteSubmission::Ready(expanded)
+    }
+}
+
 pub(super) fn read_paste_aware_input(
     editor: &mut Editor<GooseCompleter, rustyline::history::DefaultHistory>,
     paste_state: Arc<std::sync::RwLock<PasteState>>,
 ) -> rustyline::Result<String> {
-    let input = editor.readline("> ")?;
-    let expanded = paste_state
-        .read()
-        .ok()
-        .map(|state| expand_pastes(&input, &state.pastes))
-        .unwrap_or(input);
-    Ok(expanded)
+    let mut prefill: Option<String> = None;
+    loop {
+        let input = match prefill.take() {
+            Some(text) => editor.readline_with_initial("> ", (&text, ""))?,
+            None => editor.readline("> ")?,
+        };
+        let submission = paste_state
+            .read()
+            .ok()
+            .map(|state| prepare_paste_submission(&input, &state.pastes))
+            .unwrap_or(PasteSubmission::Ready(input));
+        match submission {
+            PasteSubmission::Ready(expanded) => return Ok(expanded),
+            PasteSubmission::NeedsReview(expanded) => {
+                if let Ok(mut state) = paste_state.write() {
+                    state.pastes.clear();
+                }
+                prefill = Some(expanded);
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -424,7 +453,7 @@ mod tests {
     }
 
     #[test]
-    fn test_paste_marker_keeps_slash_commands_visible() {
+    fn test_paste_marker_keeps_direct_and_split_slash_commands_visible() {
         assert_eq!(marker("/extension example\nignored", 4), None);
 
         let long = format!("/mode auto {}", "x".repeat(PASTE_CHIP_MIN_CHARS));
@@ -532,6 +561,42 @@ mod tests {
             },
         ];
         assert_eq!(expand_pastes("[Pasted 2 lines #2]", &pastes), "CURRENT");
+    }
+
+    #[test]
+    fn test_prepare_paste_submission_reviews_hidden_slash_after_edit() {
+        let pasted_slash = vec![Paste {
+            marker: "[Pasted 2 lines #1]".to_string(),
+            content: "/extension example\ncontinued".to_string(),
+        }];
+        assert!(matches!(
+            prepare_paste_submission("[Pasted 2 lines #1]", &pasted_slash),
+            PasteSubmission::NeedsReview(input)
+                if input == "/extension example\ncontinued"
+        ));
+
+        let pasted_command = vec![Paste {
+            marker: "[Pasted 2 lines #2]".to_string(),
+            content: "extension example\ncontinued".to_string(),
+        }];
+        assert!(matches!(
+            prepare_paste_submission("/[Pasted 2 lines #2]", &pasted_command),
+            PasteSubmission::NeedsReview(input)
+                if input == "/extension example\ncontinued"
+        ));
+    }
+
+    #[test]
+    fn test_prepare_paste_submission_preserves_legitimate_chips() {
+        let pastes = vec![Paste {
+            marker: "[Pasted 2 lines #1]".to_string(),
+            content: "/extension example\ncontinued".to_string(),
+        }];
+        assert!(matches!(
+            prepare_paste_submission("explain [Pasted 2 lines #1]", &pastes),
+            PasteSubmission::Ready(input)
+                if input == "explain /extension example\ncontinued"
+        ));
     }
 
     #[test]

--- a/crates/goose-cli/src/session/paste.rs
+++ b/crates/goose-cli/src/session/paste.rs
@@ -232,6 +232,8 @@ fn console_has_pending_char() -> bool {
 fn capture_paste(
     state: &Arc<std::sync::RwLock<PasteState>>,
     first: char,
+    editor_line: &str,
+    cursor_position: usize,
 ) -> Option<rustyline::Cmd> {
     if console_pending_events() < PASTE_QUEUE_THRESHOLD {
         return None;
@@ -248,15 +250,17 @@ fn capture_paste(
     let content = drain_console_paste(first);
     let mut state = state.write().ok()?;
     let id = state.next_id + 1;
-    Some(match paste_marker(&content, id) {
-        Some(marker) => {
-            state.next_id = id;
-            let cmd = rustyline::Cmd::Insert(1, marker.clone());
-            state.pastes.push(Paste { marker, content });
-            cmd
-        }
-        None => rustyline::Cmd::Insert(1, content),
-    })
+    Some(
+        match paste_marker(&content, id, editor_line, cursor_position) {
+            Some(marker) => {
+                state.next_id = id;
+                let cmd = rustyline::Cmd::Insert(1, marker.clone());
+                state.pastes.push(Paste { marker, content });
+                cmd
+            }
+            None => rustyline::Cmd::Insert(1, content),
+        },
+    )
 }
 
 /// Intercepts printable characters so a pasted burst is captured into
@@ -277,7 +281,7 @@ impl rustyline::ConditionalEventHandler for PasteCaptureHandler {
         event: &rustyline::Event,
         _n: u16,
         _positive: bool,
-        _ctx: &rustyline::EventContext,
+        ctx: &rustyline::EventContext,
     ) -> Option<rustyline::Cmd> {
         let ch = match event.get(0)? {
             rustyline::KeyEvent(rustyline::KeyCode::Char(c), m)
@@ -288,7 +292,7 @@ impl rustyline::ConditionalEventHandler for PasteCaptureHandler {
             rustyline::KeyEvent(rustyline::KeyCode::Tab, rustyline::Modifiers::NONE) => '\t',
             _ => return None,
         };
-        capture_paste(&self.paste_state, ch)
+        capture_paste(&self.paste_state, ch, ctx.line(), ctx.pos())
     }
 }
 
@@ -310,9 +314,12 @@ impl rustyline::ConditionalEventHandler for PasteAwareEnterHandler {
         _event: &rustyline::Event,
         _n: u16,
         _positive: bool,
-        _ctx: &rustyline::EventContext,
+        ctx: &rustyline::EventContext,
     ) -> Option<rustyline::Cmd> {
-        Some(capture_paste(&self.paste_state, '\n').unwrap_or(rustyline::Cmd::AcceptLine))
+        Some(
+            capture_paste(&self.paste_state, '\n', ctx.line(), ctx.pos())
+                .unwrap_or(rustyline::Cmd::AcceptLine),
+        )
     }
 }
 
@@ -321,12 +328,23 @@ fn normalize_paste_text(text: &str) -> String {
     text.replace("\r\n", "\n").replace('\r', "\n")
 }
 
-/// Build the chip shown in place of a pasted block, or `None` when the paste must
-/// remain visible. `id` makes the marker unique to this paste instance so a
-/// cleared chip can never be expanded into a later, identical-looking one (see
-/// [`expand_pastes`]).
-fn paste_marker(content: &str, id: usize) -> Option<String> {
-    if content.starts_with('/') {
+/// Build the chip shown in place of a pasted block, or `None` when inserting the
+/// paste would make the full editor buffer a slash command. `id` makes the
+/// marker unique to this paste instance so a cleared chip can never be expanded
+/// into a later, identical-looking one (see [`expand_pastes`]).
+fn paste_marker(
+    content: &str,
+    id: usize,
+    editor_line: &str,
+    cursor_position: usize,
+) -> Option<String> {
+    let (before, after) = editor_line.split_at(cursor_position);
+    let first_after_insert = before
+        .chars()
+        .next()
+        .or_else(|| content.chars().next())
+        .or_else(|| after.chars().next());
+    if first_after_insert == Some('/') {
         return None;
     }
 
@@ -382,35 +400,61 @@ pub(super) fn read_paste_aware_input(
 mod tests {
     use super::*;
 
+    fn marker(content: &str, id: usize) -> Option<String> {
+        paste_marker(content, id, "", 0)
+    }
+
     #[test]
     fn test_paste_marker() {
-        assert_eq!(paste_marker("single line", 1), None);
+        assert_eq!(marker("single line", 1), None);
         assert_eq!(
-            paste_marker("line one\nline two", 1),
+            marker("line one\nline two", 1),
             Some("[Pasted 2 lines #1]".to_string())
         );
         // Trailing newline is not counted as an extra line.
         assert_eq!(
-            paste_marker("line one\nline two\n", 2),
+            marker("line one\nline two\n", 2),
             Some("[Pasted 2 lines #2]".to_string())
         );
         let long = "x".repeat(PASTE_CHIP_MIN_CHARS);
         assert_eq!(
-            paste_marker(&long, 3),
+            marker(&long, 3),
             Some(format!("[Pasted {PASTE_CHIP_MIN_CHARS} chars #3]"))
         );
     }
 
     #[test]
     fn test_paste_marker_keeps_slash_commands_visible() {
-        assert_eq!(paste_marker("/extension example\nignored", 4), None);
+        assert_eq!(marker("/extension example\nignored", 4), None);
 
         let long = format!("/mode auto {}", "x".repeat(PASTE_CHIP_MIN_CHARS));
-        assert_eq!(paste_marker(&long, 5), None);
+        assert_eq!(marker(&long, 5), None);
 
+        assert_eq!(paste_marker("extension example\nignored", 6, "/", 1), None);
         assert_eq!(
-            paste_marker("explain /extension\ncontinued", 6),
-            Some("[Pasted 2 lines #6]".to_string())
+            paste_marker(
+                &format!("mode auto {}", "x".repeat(PASTE_CHIP_MIN_CHARS)),
+                7,
+                "/",
+                1,
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn test_paste_marker_preserves_non_command_chips() {
+        assert_eq!(
+            marker("explain /extension\ncontinued", 8),
+            Some("[Pasted 2 lines #8]".to_string())
+        );
+        assert_eq!(
+            paste_marker("/extension example\ncontinued", 9, "explain ", 8),
+            Some("[Pasted 2 lines #9]".to_string())
+        );
+        assert_eq!(
+            paste_marker("extension example\ncontinued", 10, "explain /", 9),
+            Some("[Pasted 2 lines #10]".to_string())
         );
     }
 
@@ -495,7 +539,7 @@ mod tests {
         // Off Windows (and on Windows with no queued burst) there is nothing to
         // drain, so ordinary keystrokes are never captured as a paste.
         let state = Arc::new(std::sync::RwLock::new(PasteState::default()));
-        assert!(capture_paste(&state, 'a').is_none());
+        assert!(capture_paste(&state, 'a', "", 0).is_none());
         assert!(state.read().unwrap().pastes.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

- keep pasted CLI slash commands visible instead of collapsing them into an opaque paste chip
- preserve paste chips for ordinary multiline and long text
- cover multiline, long, and non-leading-slash cases

## Verification

- `cargo test -p goose-cli test_paste_marker_keeps_slash_commands_visible`
- `cargo build`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt`

*This finding was discovered by [Project Loupe](https://github.com/project-loupe/loupe)*