### PR TITLE
fix(security): show authoritative tool approval details

### DIFF
--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -2413,13 +2413,16 @@ fn emit_stream_event(event: &StreamEvent) {
 fn prompt_tool_confirmation(request: &ToolConfirmationRequest) -> Result<Permission> {
     output::hide_thinking();
 
-    let prompt = if let Some(security_message) = &request.prompt {
-        println!("\n{}", security_message);
+    output::render_tool_confirmation(
+        &request.tool_name,
+        &request.arguments,
+        request.prompt.as_deref(),
+    );
+    let prompt = if request.prompt.is_some() {
         "Do you allow this tool call?".to_string()
     } else {
         "Goose would like to call the above tool, do you allow?".to_string()
     };
-    output::render_tool_confirmation(&request.tool_name, &request.arguments);
 
     let permission_result = if request.prompt.is_none() {
         cliclack::select(prompt)

--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -48,7 +48,9 @@ use strum::VariantNames;
 
 use goose::config::paths::Paths;
 use goose::config::providers;
-use goose::conversation::message::{ActionRequiredData, Message, MessageContent};
+use goose::conversation::message::{
+    ActionRequiredData, Message, MessageContent, ToolConfirmationRequest,
+};
 use goose::providers::inventory::ProviderInventoryService;
 use goose::session::SessionManager;
 use rustyline::EditMode;
@@ -1586,9 +1588,9 @@ impl CliSession {
                             if first_token_at.is_none() && message_has_text(&message) {
                                 first_token_at = Some(Instant::now());
                             }
-                            if let Some((id, security_prompt)) = find_tool_confirmation(&message) {
+                            if let Some(confirmation_request) = find_tool_confirmation(&message) {
                                 let selected_permission = if interactive {
-                                    prompt_tool_confirmation(&security_prompt)?
+                                    prompt_tool_confirmation(&confirmation_request)?
                                 } else {
                                     // Non-interactive/headless mode: refuse to run in
                                     // Approve/SmartApprove modes since auto-allowing would
@@ -1617,14 +1619,14 @@ impl CliSession {
                                 self.agent
                                     .submit_tool_confirmation(
                                         &self.session_id,
-                                        &id,
+                                        &confirmation_request.id,
                                         selected_permission,
                                     )
                                     .await?;
                                 if cancelled_by_user {
                                     let mut response_message = Message::user();
                                     response_message.content.push(MessageContent::tool_response(
-                                        id,
+                                        confirmation_request.id,
                                         Err(ErrorData {
                                             code: ErrorCode::INVALID_REQUEST,
                                             message: std::borrow::Cow::from(
@@ -2408,17 +2410,18 @@ fn emit_stream_event(event: &StreamEvent) {
 }
 
 /// Prompt user for tool call confirmation, returns the Permission selected
-fn prompt_tool_confirmation(security_prompt: &Option<String>) -> Result<Permission> {
+fn prompt_tool_confirmation(request: &ToolConfirmationRequest) -> Result<Permission> {
     output::hide_thinking();
 
-    let prompt = if let Some(security_message) = security_prompt {
+    let prompt = if let Some(security_message) = &request.prompt {
         println!("\n{}", security_message);
         "Do you allow this tool call?".to_string()
     } else {
         "Goose would like to call the above tool, do you allow?".to_string()
     };
+    output::render_tool_confirmation(&request.tool_name, &request.arguments);
 
-    let permission_result = if security_prompt.is_none() {
+    let permission_result = if request.prompt.is_none() {
         cliclack::select(prompt)
             .item(Permission::AllowOnce, "Allow", "Allow the tool call once")
             .item(
@@ -2458,11 +2461,22 @@ fn prompt_tool_confirmation(security_prompt: &Option<String>) -> Result<Permissi
 }
 
 /// Extract tool confirmation request from a message
-fn find_tool_confirmation(message: &Message) -> Option<(String, Option<String>)> {
+fn find_tool_confirmation(message: &Message) -> Option<ToolConfirmationRequest> {
     message.content.iter().find_map(|content| {
         if let MessageContent::ActionRequired(action) = content {
-            if let ActionRequiredData::ToolConfirmation { id, prompt, .. } = &action.data {
-                return Some((id.clone(), prompt.clone()));
+            if let ActionRequiredData::ToolConfirmation {
+                id,
+                tool_name,
+                arguments,
+                prompt,
+            } = &action.data
+            {
+                return Some(ToolConfirmationRequest {
+                    id: id.clone(),
+                    tool_name: tool_name.clone(),
+                    arguments: arguments.clone(),
+                    prompt: prompt.clone(),
+                });
             }
         }
         None
@@ -2905,9 +2919,31 @@ mod tests {
     use super::*;
     use goose::agents::extension::Envs;
     use goose::config::ExtensionConfig;
+    use serde_json::json;
     use std::collections::HashMap;
     use std::time::Duration;
     use test_case::test_case;
+
+    #[test]
+    fn provider_only_confirmation_preserves_authoritative_request() {
+        let arguments = json!({"command": "cat ~/.ssh/id_rsa"})
+            .as_object()
+            .unwrap()
+            .clone();
+        let message = Message::assistant().with_action_required(
+            "provider-request",
+            "Bash".to_string(),
+            arguments.clone(),
+            Some("Review this request".to_string()),
+        );
+
+        let request = find_tool_confirmation(&message).unwrap();
+
+        assert_eq!(request.id, "provider-request");
+        assert_eq!(request.tool_name, "Bash");
+        assert_eq!(request.arguments, arguments);
+        assert_eq!(request.prompt.as_deref(), Some("Review this request"));
+    }
 
     #[test]
     fn planner_classification_excludes_user_only_content() {

--- a/crates/goose-cli/src/session/output.rs
+++ b/crates/goose-cli/src/session/output.rs
@@ -652,6 +652,25 @@ pub(super) fn sanitize_terminal_line(line: &str) -> String {
         .collect()
 }
 
+fn sanitize_tool_confirmation_line(line: &str) -> String {
+    let mut sanitized = String::with_capacity(line.len());
+    for character in sanitize_terminal_line(line).chars() {
+        if matches!(
+            character,
+            '\u{061c}'
+                | '\u{200e}'
+                | '\u{200f}'
+                | '\u{202a}'..='\u{202e}'
+                | '\u{2066}'..='\u{2069}'
+        ) {
+            sanitized.push_str(&format!("\\u{:04x}", character as u32));
+        } else {
+            sanitized.push(character);
+        }
+    }
+    sanitized
+}
+
 pub(super) fn format_tool_confirmation(tool_name: &str, arguments: &JsonObject) -> String {
     let mut request = JsonObject::new();
     request.insert(
@@ -663,7 +682,7 @@ pub(super) fn format_tool_confirmation(tool_name: &str, arguments: &JsonObject) 
     serde_json::to_string_pretty(&Value::Object(request))
         .expect("tool confirmation request must serialize")
         .lines()
-        .map(sanitize_terminal_line)
+        .map(sanitize_tool_confirmation_line)
         .collect::<Vec<_>>()
         .join("\n")
 }
@@ -1799,6 +1818,39 @@ mod tests {
         assert!(rendered.contains("title\\u0007"));
         assert!(!rendered.contains('\u{1b}'));
         assert!(!rendered.contains('\u{7}'));
+    }
+
+    #[test]
+    fn tool_confirmation_escapes_bidi_controls() {
+        let controls = [
+            '\u{061c}', '\u{200e}', '\u{200f}', '\u{202a}', '\u{202b}', '\u{202c}', '\u{202d}',
+            '\u{202e}', '\u{2066}', '\u{2067}', '\u{2068}', '\u{2069}',
+        ];
+        let untrusted = controls.iter().collect::<String>();
+        let arguments = json!({"command": format!("before{untrusted}after")})
+            .as_object()
+            .unwrap()
+            .clone();
+
+        let rendered = format_tool_confirmation(&format!("tool{untrusted}"), &arguments);
+
+        for control in controls {
+            assert!(!rendered.contains(control));
+            assert!(rendered.contains(&format!("\\u{:04x}", control as u32)));
+        }
+    }
+
+    #[test]
+    fn tool_confirmation_preserves_plain_unicode_text() {
+        let arguments = json!({"query": "שלום مرحبا 日本語 🪿"})
+            .as_object()
+            .unwrap()
+            .clone();
+
+        let rendered = format_tool_confirmation("検索", &arguments);
+
+        assert!(rendered.contains("שלום مرحبا 日本語 🪿"));
+        assert!(rendered.contains("検索"));
     }
 
     #[test]

--- a/crates/goose-cli/src/session/output.rs
+++ b/crates/goose-cli/src/session/output.rs
@@ -652,6 +652,31 @@ pub(super) fn sanitize_terminal_line(line: &str) -> String {
         .collect()
 }
 
+pub(super) fn format_tool_confirmation(tool_name: &str, arguments: &JsonObject) -> String {
+    let mut request = JsonObject::new();
+    request.insert(
+        "tool_name".to_string(),
+        Value::String(tool_name.to_string()),
+    );
+    request.insert("arguments".to_string(), Value::Object(arguments.clone()));
+
+    serde_json::to_string_pretty(&Value::Object(request))
+        .expect("tool confirmation request must serialize")
+        .lines()
+        .map(sanitize_terminal_line)
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+pub(super) fn render_tool_confirmation(tool_name: &str, arguments: &JsonObject) {
+    println!();
+    println!("  {}", style("Tool approval request").bold());
+    for line in format_tool_confirmation(tool_name, arguments).lines() {
+        println!("    {}", style(line).dim());
+    }
+    println!();
+}
+
 fn print_tool_output_line(line: &str) {
     println!("    {}", style(sanitize_terminal_line(line)).dim());
 }
@@ -1707,6 +1732,73 @@ mod tests {
             sanitize_terminal_line("goose 🪿\t日本語"),
             "goose 🪿\t日本語"
         );
+    }
+
+    #[test]
+    fn tool_confirmation_shows_execute_code_and_graph() {
+        let arguments = json!({
+            "code": "await developer.shell({ command: \"cat ~/.ssh/id_rsa\" });",
+            "tool_graph": [{
+                "tool": "developer/read",
+                "description": "read package manifest",
+                "depends_on": []
+            }]
+        })
+        .as_object()
+        .unwrap()
+        .clone();
+
+        let rendered = format_tool_confirmation("execute_typescript", &arguments);
+
+        assert!(rendered.contains("execute_typescript"));
+        assert!(rendered.contains("read package manifest"));
+        assert!(rendered.contains("cat ~/.ssh/id_rsa"));
+    }
+
+    #[test]
+    fn tool_confirmation_shows_load_arguments() {
+        let arguments = json!({"source": "private-recipe", "cancel": true})
+            .as_object()
+            .unwrap()
+            .clone();
+
+        let rendered = format_tool_confirmation("load", &arguments);
+
+        assert!(rendered.contains("\"tool_name\": \"load\""));
+        assert!(rendered.contains("\"source\": \"private-recipe\""));
+        assert!(rendered.contains("\"cancel\": true"));
+    }
+
+    #[test]
+    fn tool_confirmation_does_not_truncate_delegate_instructions() {
+        let instructions = format!("{} then run the final delegated command", "A".repeat(120));
+        let arguments = json!({"instructions": instructions.clone()})
+            .as_object()
+            .unwrap()
+            .clone();
+
+        let rendered = format_tool_confirmation("delegate", &arguments);
+
+        assert!(rendered.contains(&instructions));
+        assert!(!rendered.contains('…'));
+    }
+
+    #[test]
+    fn tool_confirmation_escapes_terminal_controls() {
+        let arguments = json!({
+            "command": "echo safe\u{1b}[2J\u{1b}]0;spoofed title\u{7}"
+        })
+        .as_object()
+        .unwrap()
+        .clone();
+
+        let rendered = format_tool_confirmation("Bash\u{1b}[31m", &arguments);
+
+        assert!(rendered.contains("Bash\\u001b[31m"));
+        assert!(rendered.contains("safe\\u001b[2J"));
+        assert!(rendered.contains("title\\u0007"));
+        assert!(!rendered.contains('\u{1b}'));
+        assert!(!rendered.contains('\u{7}'));
     }
 
     #[test]

--- a/crates/goose-cli/src/session/output.rs
+++ b/crates/goose-cli/src/session/output.rs
@@ -671,6 +671,13 @@ fn sanitize_tool_confirmation_line(line: &str) -> String {
     sanitized
 }
 
+fn sanitize_tool_confirmation_text(text: &str) -> String {
+    text.split('\n')
+        .map(sanitize_tool_confirmation_line)
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
 pub(super) fn format_tool_confirmation(tool_name: &str, arguments: &JsonObject) -> String {
     let mut request = JsonObject::new();
     request.insert(
@@ -687,13 +694,21 @@ pub(super) fn format_tool_confirmation(tool_name: &str, arguments: &JsonObject) 
         .join("\n")
 }
 
-pub(super) fn render_tool_confirmation(tool_name: &str, arguments: &JsonObject) {
+pub(super) fn render_tool_confirmation(
+    tool_name: &str,
+    arguments: &JsonObject,
+    security_prompt: Option<&str>,
+) {
     eprintln!();
     eprintln!("  {}", style("Tool approval request").bold());
     for line in format_tool_confirmation(tool_name, arguments).lines() {
         eprintln!("    {}", style(line).dim());
     }
     eprintln!();
+    if let Some(security_prompt) = security_prompt {
+        eprintln!("{}", sanitize_tool_confirmation_text(security_prompt));
+        eprintln!();
+    }
 }
 
 fn print_tool_output_line(line: &str) {
@@ -1854,16 +1869,36 @@ mod tests {
     }
 
     #[test]
+    fn tool_confirmation_sanitizes_unterminated_control_strings() {
+        let rendered = sanitize_tool_confirmation_text(
+            "visible bidi\u{202e}\nvisible OSC\u{1b}]unterminated\nvisible DCS\u{1b}Punterminated",
+        );
+
+        assert!(rendered.contains("visible OSC"));
+        assert!(rendered.contains("visible DCS"));
+        assert!(!rendered.contains('\u{1b}'));
+        assert!(!rendered.contains('\u{202e}'));
+        assert!(rendered.contains("\\u202e"));
+    }
+
+    #[test]
     fn tool_confirmation_renders_authoritative_details_on_stderr() {
         const CHILD_ENV: &str = "GOOSE_TEST_TOOL_CONFIRMATION_STDERR_CHILD";
         const AUTHORITATIVE_TOKEN: &str = "authoritative-redirect-token";
+        const PROVIDER_TOKEN: &str = "provider-prompt-token";
 
         if env::var_os(CHILD_ENV).is_some() {
             let arguments = json!({"command": AUTHORITATIVE_TOKEN})
                 .as_object()
                 .unwrap()
                 .clone();
-            render_tool_confirmation("shell", &arguments);
+            render_tool_confirmation(
+                "shell",
+                &arguments,
+                Some(&format!(
+                    "{PROVIDER_TOKEN} OSC\u{1b}]unterminated\nDCS\u{1b}Punterminated"
+                )),
+            );
             return;
         }
 
@@ -1881,7 +1916,12 @@ mod tests {
         let stdout = String::from_utf8_lossy(&output.stdout);
         let stderr = String::from_utf8_lossy(&output.stderr);
         assert!(!stdout.contains(AUTHORITATIVE_TOKEN));
+        assert!(!stdout.contains(PROVIDER_TOKEN));
         assert!(stderr.contains(AUTHORITATIVE_TOKEN));
+        assert!(stderr.contains(PROVIDER_TOKEN));
+        assert!(stderr.find(AUTHORITATIVE_TOKEN) < stderr.find(PROVIDER_TOKEN));
+        assert!(!stderr.contains("\u{1b}]"));
+        assert!(!stderr.contains("\u{1b}P"));
     }
 
     #[test]

--- a/crates/goose-cli/src/session/output.rs
+++ b/crates/goose-cli/src/session/output.rs
@@ -700,15 +700,18 @@ pub(super) fn render_tool_confirmation(
     security_prompt: Option<&str>,
 ) {
     eprintln!();
+    if let Some(security_prompt) = security_prompt {
+        eprintln!("  {}", style("Provider-provided approval notice").bold());
+        for line in sanitize_tool_confirmation_text(security_prompt).split('\n') {
+            eprintln!("    {}", style(line).dim());
+        }
+        eprintln!();
+    }
     eprintln!("  {}", style("Tool approval request").bold());
     for line in format_tool_confirmation(tool_name, arguments).lines() {
         eprintln!("    {}", style(line).dim());
     }
     eprintln!();
-    if let Some(security_prompt) = security_prompt {
-        eprintln!("{}", sanitize_tool_confirmation_text(security_prompt));
-        eprintln!();
-    }
 }
 
 fn print_tool_output_line(line: &str) {
@@ -1888,17 +1891,18 @@ mod tests {
         const PROVIDER_TOKEN: &str = "provider-prompt-token";
 
         if env::var_os(CHILD_ENV).is_some() {
+            let forged_request = (0..80)
+                .map(|line| format!("forged safe request line {line}"))
+                .collect::<Vec<_>>()
+                .join("\n");
+            let provider_prompt = format!(
+                "{forged_request}\n{PROVIDER_TOKEN} OSC\u{1b}]unterminated\nDCS\u{1b}Punterminated"
+            );
             let arguments = json!({"command": AUTHORITATIVE_TOKEN})
                 .as_object()
                 .unwrap()
                 .clone();
-            render_tool_confirmation(
-                "shell",
-                &arguments,
-                Some(&format!(
-                    "{PROVIDER_TOKEN} OSC\u{1b}]unterminated\nDCS\u{1b}Punterminated"
-                )),
-            );
+            render_tool_confirmation("shell", &arguments, Some(&provider_prompt));
             return;
         }
 
@@ -1919,7 +1923,15 @@ mod tests {
         assert!(!stdout.contains(PROVIDER_TOKEN));
         assert!(stderr.contains(AUTHORITATIVE_TOKEN));
         assert!(stderr.contains(PROVIDER_TOKEN));
-        assert!(stderr.find(AUTHORITATIVE_TOKEN) < stderr.find(PROVIDER_TOKEN));
+        assert!(stderr.contains("forged safe request line 79"));
+        let provider_notice = stderr.find("Provider-provided approval notice").unwrap();
+        let provider_content = stderr.find(PROVIDER_TOKEN).unwrap();
+        let authoritative_block = stderr.find("Tool approval request").unwrap();
+        assert!(provider_notice < provider_content);
+        assert!(provider_content < authoritative_block);
+        let authoritative_tail = stderr.get(authoritative_block..).unwrap();
+        assert!(authoritative_tail.contains(AUTHORITATIVE_TOKEN));
+        assert!(!authoritative_tail.contains(PROVIDER_TOKEN));
         assert!(!stderr.contains("\u{1b}]"));
         assert!(!stderr.contains("\u{1b}P"));
     }

--- a/crates/goose-cli/src/session/output.rs
+++ b/crates/goose-cli/src/session/output.rs
@@ -1,5 +1,5 @@
 use crate::session::builder::ExtensionFailure;
-use anstream::{adapter::strip_str, println};
+use anstream::{adapter::strip_str, eprintln, println};
 use bat::WrappingMode;
 use console::{measure_text_width, style, Color, StyledObject, Term};
 use goose::config::Config;
@@ -688,12 +688,12 @@ pub(super) fn format_tool_confirmation(tool_name: &str, arguments: &JsonObject) 
 }
 
 pub(super) fn render_tool_confirmation(tool_name: &str, arguments: &JsonObject) {
-    println!();
-    println!("  {}", style("Tool approval request").bold());
+    eprintln!();
+    eprintln!("  {}", style("Tool approval request").bold());
     for line in format_tool_confirmation(tool_name, arguments).lines() {
-        println!("    {}", style(line).dim());
+        eprintln!("    {}", style(line).dim());
     }
-    println!();
+    eprintln!();
 }
 
 fn print_tool_output_line(line: &str) {
@@ -1851,6 +1851,37 @@ mod tests {
 
         assert!(rendered.contains("שלום مرحبا 日本語 🪿"));
         assert!(rendered.contains("検索"));
+    }
+
+    #[test]
+    fn tool_confirmation_renders_authoritative_details_on_stderr() {
+        const CHILD_ENV: &str = "GOOSE_TEST_TOOL_CONFIRMATION_STDERR_CHILD";
+        const AUTHORITATIVE_TOKEN: &str = "authoritative-redirect-token";
+
+        if env::var_os(CHILD_ENV).is_some() {
+            let arguments = json!({"command": AUTHORITATIVE_TOKEN})
+                .as_object()
+                .unwrap()
+                .clone();
+            render_tool_confirmation("shell", &arguments);
+            return;
+        }
+
+        let output = std::process::Command::new(env::current_exe().unwrap())
+            .args([
+                "--exact",
+                "session::output::tests::tool_confirmation_renders_authoritative_details_on_stderr",
+                "--nocapture",
+            ])
+            .env(CHILD_ENV, "1")
+            .output()
+            .unwrap();
+        assert!(output.status.success());
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(!stdout.contains(AUTHORITATIVE_TOKEN));
+        assert!(stderr.contains(AUTHORITATIVE_TOKEN));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- carry the complete authoritative tool confirmation request into the interactive CLI approval boundary
- show terminal-safe, untruncated tool names and arguments immediately before every Allow decision
- cover execute code with a tool graph, load arguments, long delegated commands, provider-origin requests, and terminal controls

## Verification

- `cargo test -p goose-cli tool_confirmation -- --nocapture`
- `cargo test -p goose-cli provider_only_confirmation_preserves_authoritative_request -- --nocapture`
- `cargo build`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt`

*This finding was discovered by [Project Loupe](https://github.com/project-loupe/loupe)*
