### PR TITLE
fix(openai): update stored tool call name when later delta carries non-empty name

### DIFF
--- a/crates/goose-provider-types/src/formats/openai.rs
+++ b/crates/goose-provider-types/src/formats/openai.rs
@@ -1361,7 +1361,12 @@ where
                                     if let Some(delta_tool_calls) = &tool_chunk.choices[0].delta.tool_calls {
                                         for delta_call in delta_tool_calls {
                                             if let Some(index) = delta_call.index {
-                                                if let Some((_, _, ref mut args, ref mut extra)) = tool_call_data.get_mut(&index) {
+                                                if let Some((_, ref mut stored_name, ref mut args, ref mut extra)) = tool_call_data.get_mut(&index) {
+                                                    if let Some(new_name) = &delta_call.function.name {
+                                                        if !new_name.is_empty() {
+                                                            *stored_name = new_name.clone();
+                                                        }
+                                                    }
                                                     args.push_str(&delta_call.function.arguments);
                                                     if extra.is_none() && delta_call.extra.is_some() {
                                                         *extra = delta_call.extra.clone();


### PR DESCRIPTION
Fixes: #11686

## Summary

Some OpenAI-compatible providers (e.g. vMLX/DeepSeek) send streamed tool calls where the first delta carries the call
ID with an empty function name, and a later delta carries the real name. The accumulation loop in openai.rs was ignoring the name field on subsequent deltas (_), so the stored name stayed "" even after the real name arrived. 
  
### Testing

  - Traced the exact SSE sequence from the bug report through the code manually, confirmed the empty name was inserted
    on delta 1, and the fix correctly overwrites it on delta 2.
  - cargo build -p goose-provider-types — compiled clean.
  - cargo test -p goose-provider-types — all 8 tests pass.

