### PR TITLE
fix(desktop): preserve cwd and child status in node launchers

### DIFF
--- a/ui/desktop/src/bin/node
+++ b/ui/desktop/src/bin/node
@@ -3,14 +3,15 @@
 # Enable strict mode to exit on errors and unset variables
 set -euo pipefail
 
+ORIGINAL_CWD="$(pwd -P)"
+
 # Get the directory where this script is located
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Source the common setup script
 source "${SCRIPT_DIR}/node-setup-common.sh"
+cd -- "${ORIGINAL_CWD}"
 
 # Final step: Execute node with passed arguments
 log "Executing 'node' command with arguments: ${*}"
-node "${@}" || log "Failed to execute 'node' with arguments: ${*}"
-
-log "node script completed successfully."
+exec node "${@}"

--- a/ui/desktop/src/bin/node-launchers.test.ts
+++ b/ui/desktop/src/bin/node-launchers.test.ts
@@ -1,0 +1,83 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const launcherSourceDir = path.dirname(fileURLToPath(import.meta.url));
+const tempDirs: string[] = [];
+
+function makeLauncherHarness(launcherName: 'node' | 'npx') {
+  const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'goose node launchers '));
+  tempDirs.push(rootDir);
+
+  const launcherDir = path.join(rootDir, 'launcher');
+  const callerDir = path.join(rootDir, 'caller directory');
+  const setupDir = path.join(rootDir, 'setup directory');
+  const fakeBinDir = path.join(rootDir, 'fake bin');
+  fs.mkdirSync(launcherDir);
+  fs.mkdirSync(callerDir);
+  fs.mkdirSync(setupDir);
+  fs.mkdirSync(fakeBinDir);
+
+  const launcherPath = path.join(launcherDir, launcherName);
+  fs.copyFileSync(path.join(launcherSourceDir, launcherName), launcherPath);
+  fs.chmodSync(launcherPath, 0o755);
+
+  fs.writeFileSync(
+    path.join(launcherDir, 'node-setup-common.sh'),
+    ['cd -- "$FAKE_SETUP_DIR"', 'export PATH="$FAKE_BIN_DIR:$PATH"', 'log() { :; }', ''].join('\n')
+  );
+
+  const childPath = path.join(fakeBinDir, launcherName);
+  fs.writeFileSync(
+    childPath,
+    ['#!/bin/bash', 'printf "%s\\n" "$PWD"', 'exit "$FAKE_CHILD_EXIT_CODE"', ''].join('\n')
+  );
+  fs.chmodSync(childPath, 0o755);
+
+  return { callerDir, fakeBinDir, launcherPath, setupDir };
+}
+
+function runLauncher(launcherName: 'node' | 'npx', exitCode: number) {
+  const harness = makeLauncherHarness(launcherName);
+  const result = spawnSync(harness.launcherPath, ['--fixture'], {
+    cwd: harness.callerDir,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      FAKE_BIN_DIR: harness.fakeBinDir,
+      FAKE_CHILD_EXIT_CODE: String(exitCode),
+      FAKE_SETUP_DIR: harness.setupDir,
+    },
+  });
+
+  expect(result.error).toBeUndefined();
+  return { ...harness, callerDir: fs.realpathSync(harness.callerDir), result };
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    fs.rmSync(tempDirs.pop()!, { recursive: true, force: true });
+  }
+});
+
+describe.skipIf(process.platform === 'win32').each(['node', 'npx'] as const)(
+  '%s desktop launcher',
+  (launcherName) => {
+    it('runs the child from the caller working directory', () => {
+      const { callerDir, result } = runLauncher(launcherName, 0);
+
+      expect(result.status).toBe(0);
+      expect(result.stdout.trim()).toBe(callerDir);
+    });
+
+    it('propagates a nonzero child exit status', () => {
+      const { callerDir, result } = runLauncher(launcherName, 37);
+
+      expect(result.status).toBe(37);
+      expect(result.stdout.trim()).toBe(callerDir);
+    });
+  }
+);

--- a/ui/desktop/src/bin/npx
+++ b/ui/desktop/src/bin/npx
@@ -3,14 +3,15 @@
 # Enable strict mode to exit on errors and unset variables
 set -euo pipefail
 
+ORIGINAL_CWD="$(pwd -P)"
+
 # Get the directory where this script is located
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Source the common setup script
 source "${SCRIPT_DIR}/node-setup-common.sh"
+cd -- "${ORIGINAL_CWD}"
 
 # Final step: Execute npx with passed arguments
 log "Executing 'npx' command with arguments: ${*}"
-npx "${@}" || log "Failed to execute 'npx' with arguments: ${*}"
-
-log "npx script completed successfully."
+exec npx "${@}"


### PR DESCRIPTION
Fixes: #11586

## Summary

- Restore the caller's working directory after the shared Hermit setup completes.
- Use `exec` for the final `node` and `npx` invocation so child exit codes and signals reach the caller unchanged.
- Add hermetic regression coverage for successful and failing child processes in both launchers.

The shared setup script and the other desktop launchers are intentionally unchanged.

### Testing

- Confirmed the new regression test fails all four cases before the launcher change.
- `cd ui/desktop && ../node_modules/.bin/vitest run src/bin/node-launchers.test.ts` (4 passed)
- `cd ui/desktop && ../node_modules/.bin/vitest run` (807 passed)
- `pnpm --dir ui/desktop run lint:check`
- `bash -n ui/desktop/src/bin/node ui/desktop/src/bin/npx ui/desktop/src/bin/node-setup-common.sh`
- `prettier --check ui/desktop/src/bin/node-launchers.test.ts`

The regression harness substitutes the setup script and child executables, so it does not download Hermit or access the network.

### Related Issues

Discussion: #11586

### Screenshots/Demos (for UX changes)

Not applicable.
