### PR TITLE
fix(desktop): resolve UI freeze after renaming session

### DIFF
--- a/ui/desktop/src/components/SessionActionsHeader.tsx
+++ b/ui/desktop/src/components/SessionActionsHeader.tsx
@@ -556,7 +556,7 @@ export default function SessionActionsHeader({
               <ChevronDown className="size-3.5 text-text-secondary" />
             </button>
           </DropdownMenuTrigger>
-          <DropdownMenuContent align="center" className="w-56" onCloseAutoFocus={(e) => e.preventDefault()}>
+          <DropdownMenuContent align="center" className="w-56">
             <DropdownMenuItem onSelect={() => setTimeout(() => setIsRenameOpen(true), 0)}>
               <Edit2 className="size-4" />
               {intl.formatMessage(i18n.renameSession)}

--- a/ui/desktop/src/components/SessionActionsHeader.tsx
+++ b/ui/desktop/src/components/SessionActionsHeader.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type KeyboardEvent } from 'react';
+import { flushSync } from 'react-dom';
 import {
   Activity,
   ChevronDown,
@@ -385,13 +386,14 @@ export default function SessionActionsHeader({
     setIsRenaming(true);
     try {
       await acpRenameSession(session.id, trimmedName);
+      flushSync(() => setIsRenameOpen(false));
+      document.body.style.removeProperty('pointer-events');
       onSessionChange((current) => ({ ...current, name: trimmedName, user_set_name: true }));
       window.dispatchEvent(
         new CustomEvent(AppEvents.SESSION_RENAMED, {
           detail: { sessionId: session.id, newName: trimmedName, userInitiated: true },
         })
       );
-      setIsRenameOpen(false);
       toast.success(intl.formatMessage(i18n.renamed));
     } catch (error) {
       toast.error(
@@ -554,8 +556,8 @@ export default function SessionActionsHeader({
               <ChevronDown className="size-3.5 text-text-secondary" />
             </button>
           </DropdownMenuTrigger>
-          <DropdownMenuContent align="center" className="w-56">
-            <DropdownMenuItem onSelect={() => setIsRenameOpen(true)}>
+          <DropdownMenuContent align="center" className="w-56" onCloseAutoFocus={(e) => e.preventDefault()}>
+            <DropdownMenuItem onSelect={() => setTimeout(() => setIsRenameOpen(true), 0)}>
               <Edit2 className="size-4" />
               {intl.formatMessage(i18n.renameSession)}
             </DropdownMenuItem>


### PR DESCRIPTION
Fixes: #11748

## Summary

When "Rename session" is selected from the dropdown, Radix's DismissableLayer for both the dropdown and the dialog
were active at the same time, causing the layersWithOutsidePointerEventsDisabled size check to fail and leaving body.pointer-events: none stuck permanently. The fix delays opening the dialog by one tick (setTimeout 0) so the
dropdown fully unmounts before the dialog mounts, and force-clears pointer-events after close as a safety net

### Testing
Manual testing

