### PR TITLE
(Bug) Fix desktop updater for Linux and populate OS-latest release artifacts

### DIFF
--- a/.github/workflows/build-cli-linux.yml
+++ b/.github/workflows/build-cli-linux.yml
@@ -372,7 +372,28 @@ jobs:
         run: |
           source ./bin/activate-hermit
           cd ui/desktop
-          pnpm run make --platform=linux --arch="${ELECTRON_ARCH}"
+          pnpm run package --platform=linux --arch="${ELECTRON_ARCH}"
+
+          # electron-updater picks DebUpdater/RpmUpdater from resources/package-type;
+          # resources/update-channel is read by our autoUpdater.ts to select the
+          # manifest channel. Each package type is made from the same packaged app
+          # with its own markers. Flatpak has no updater and gets none.
+          resources="out/Goose-linux-${ELECTRON_ARCH}/resources"
+          make_target() {
+            local maker="$1" package_type="$2"
+            rm -f "${resources}/package-type" "${resources}/update-channel"
+            if [ -n "${package_type}" ]; then
+              printf '%s\n' "${package_type}" > "${resources}/package-type"
+              if [ "${GOOSE_DESKTOP_LINUX_VARIANT}" = "vulkan" ]; then
+                printf 'vulkan\n' > "${resources}/update-channel"
+              fi
+            fi
+            pnpm exec electron-forge make --skip-package --platform=linux \
+              --arch="${ELECTRON_ARCH}" --targets "@electron-forge/maker-${maker}"
+          }
+          make_target deb deb
+          make_target rpm rpm
+          make_target flatpak ""
 
           if [ "${GOOSE_DESKTOP_LINUX_VARIANT}" = "vulkan" ]; then
             for package in \
@@ -395,6 +416,29 @@ jobs:
           done
 
           find out/ -type f \( -name "*.deb" -o -name "*.rpm" -o -name "*.flatpak" \) -exec ls -lh {} \;
+
+      - name: Verify updater markers
+        env:
+          ELECTRON_ARCH: ${{ matrix.electron_arch }}
+          GOOSE_DESKTOP_LINUX_VARIANT: ${{ matrix.variant }}
+        run: |
+          cd ui/desktop
+          markers=(package-type)
+          if [ "${GOOSE_DESKTOP_LINUX_VARIANT}" = "vulkan" ]; then
+            markers+=(update-channel)
+          fi
+          for package in "out/make/deb/${ELECTRON_ARCH}/"*.deb; do
+            for marker in "${markers[@]}"; do
+              dpkg-deb -c "${package}" | grep -qE "/resources/${marker}( |\$)" \
+                || { echo "::error file=${package}::missing /resources/${marker}"; exit 1; }
+            done
+          done
+          for package in "out/make/rpm/${ELECTRON_ARCH}/"*.rpm; do
+            for marker in "${markers[@]}"; do
+              rpm -qlp "${package}" | grep -qE "/resources/${marker}\$" \
+                || { echo "::error file=${package}::missing /resources/${marker}"; exit 1; }
+            done
+          done
 
       - name: Upload .deb package
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,10 @@ env:
   # Set this repository Actions variable to "true" in GitHub Settings > Secrets and variables
   # > Actions > Variables after a release containing desktop app-update.yml has shipped.
   ENABLE_MAC_NATIVE_AUTO_UPDATE: ${{ vars.ENABLE_MAC_NATIVE_AUTO_UPDATE || 'false' }}
+  # Publishes the Linux deb/rpm update manifests (latest-linux*.yml, vulkan-linux*.yml).
+  # Until enabled, deb/rpm installs fall back to a GitHub API check that can report
+  # a newer version but not install it.
+  ENABLE_LINUX_NATIVE_AUTO_UPDATE: ${{ vars.ENABLE_LINUX_NATIVE_AUTO_UPDATE || 'false' }}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -140,6 +144,42 @@ jobs:
         with:
           subject-path: latest-mac.yml
 
+      - name: Generate Linux (deb + rpm) update manifests
+        if: ${{ env.ENABLE_LINUX_NATIVE_AUTO_UPDATE == 'true' }}
+        # One manifest per arch and per variant; each lists both the .deb and the
+        # .rpm, and each updater picks its own extension. The vulkan variant shares
+        # the package name with the standard build, so it gets its own channel.
+        run: |
+          generate() {
+            local channel="$1" arch="$2" deb_glob="$3" rpm_glob="$4" out="$5"
+            local deb rpm
+            deb=$(ls -1 $deb_glob 2>/dev/null | head -n1 || true)
+            rpm=$(ls -1 $rpm_glob 2>/dev/null | head -n1 || true)
+            if [ -z "$deb" ] && [ -z "$rpm" ]; then
+              echo "No ${channel} .deb/.rpm asset for ${arch} found; skipping ${out}."
+              return 0
+            fi
+            local args=(--version "${GITHUB_REF_NAME}" --channel "$channel" --arch "$arch" --out "$out")
+            if [ -n "$deb" ]; then args+=(--deb "$deb"); fi
+            if [ -n "$rpm" ]; then args+=(--rpm "$rpm"); fi
+            node ui/desktop/scripts/generate-linux-update-manifest.js "${args[@]}"
+          }
+
+          generate latest x64   'goose_*_amd64.deb'        'Goose-*.x86_64.rpm'        latest-linux.yml
+          generate latest arm64 'goose_*_arm64.deb'        'Goose-*.arm64.rpm'         latest-linux-arm64.yml
+          generate vulkan x64   'goose_*_amd64-vulkan.deb' 'Goose-*.x86_64-vulkan.rpm' vulkan-linux.yml
+          generate vulkan arm64 'goose_*_arm64-vulkan.deb' 'Goose-*.arm64-vulkan.rpm'  vulkan-linux-arm64.yml
+
+      - name: Attest Linux (deb + rpm) update manifests
+        if: ${{ env.ENABLE_LINUX_NATIVE_AUTO_UPDATE == 'true' }}
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8  # v4.2.2
+        with:
+          subject-path: |
+            latest-linux.yml
+            latest-linux-arm64.yml
+            vulkan-linux.yml
+            vulkan-linux-arm64.yml
+
       - name: Attest build provenance
         uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8  # v4.2.2
         with:
@@ -198,3 +238,18 @@ jobs:
         run: |
           gh release upload "${GITHUB_REF_NAME}" latest-mac.yml --clobber
           gh release upload stable latest-mac.yml --clobber
+
+      - name: Upload Linux (deb + rpm) update manifests
+        if: ${{ env.ENABLE_LINUX_NATIVE_AUTO_UPDATE == 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # A manifest is only uploaded if its packages were built this run.
+          for f in latest-linux.yml latest-linux-arm64.yml vulkan-linux.yml vulkan-linux-arm64.yml; do
+            if [ -f "$f" ]; then
+              gh release upload "${GITHUB_REF_NAME}" "$f" --clobber
+              gh release upload stable "$f" --clobber
+            else
+              echo "::warning file=release.yml::$f was not generated; skipping upload"
+            fi
+          done

--- a/ui/desktop/scripts/generate-linux-update-manifest.js
+++ b/ui/desktop/scripts/generate-linux-update-manifest.js
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+
+// Generates an electron-updater Linux manifest listing the .deb and .rpm for
+// one architecture. DebUpdater and RpmUpdater read the same file and each pick
+// the entry with their own extension (Provider.js#findFile).
+//
+// Output name follows Provider.js#getChannelFilePrefix:
+//   <channel>-linux.yml (x64) or <channel>-linux-arm64.yml (arm64)
+// The channel defaults to "latest"; package variants that share a package name
+// (vulkan) get their own channel so they are never updated across variants.
+//
+// Usage:
+//   node scripts/generate-linux-update-manifest.js --version 1.49.0 --arch x64 \
+//     --deb goose_1.49.0_amd64.deb --rpm Goose-1.49.0-1.x86_64.rpm
+
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const SUPPORTED_ARCHES = ['x64', 'arm64'];
+
+function manifestName(channel, arch) {
+  const archSuffix = arch === 'x64' ? '' : `-${arch}`;
+  return `${channel}-linux${archSuffix}.yml`;
+}
+
+function usage() {
+  console.error(
+    [
+      'Usage: node scripts/generate-linux-update-manifest.js',
+      '  --version <semver>',
+      '  [--arch x64|arm64]        (defaults to "x64")',
+      '  [--channel <name>]        (defaults to "latest")',
+      '  [--deb <path>]...         (one or more .deb assets to include)',
+      '  [--rpm <path>]...         (one or more .rpm assets to include)',
+      '  [--out <manifest.yml>]    (defaults to <channel>-linux[-arm64].yml in cwd)',
+    ].join('\n')
+  );
+}
+
+function parseArgs(argv) {
+  const args = {
+    version: '',
+    arch: 'x64',
+    channel: 'latest',
+    debs: [],
+    rpms: [],
+    out: '',
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = argv[i];
+    if (a === '--version') args.version = argv[++i] || '';
+    else if (a === '--arch') args.arch = argv[++i] || 'x64';
+    else if (a === '--channel') args.channel = argv[++i] || 'latest';
+    else if (a === '--deb' || a === '--rpm') {
+      const value = argv[++i];
+      if (!value) throw new Error(`${a} requires a file path`);
+      (a === '--deb' ? args.debs : args.rpms).push(value);
+    } else if (a === '--out') args.out = argv[++i] || '';
+    else {
+      usage();
+      process.exit(1);
+    }
+  }
+  if (!args.version) {
+    usage();
+    process.exit(1);
+  }
+  args.version = args.version.replace(/^v/, '');
+  if (!SUPPORTED_ARCHES.includes(args.arch)) {
+    throw new Error(
+      `Unsupported arch "${args.arch}" — expected one of: ${SUPPORTED_ARCHES.join(', ')}`
+    );
+  }
+  if (!/^[a-z0-9]+$/.test(args.channel)) {
+    throw new Error(`Invalid channel "${args.channel}" — use lowercase letters and digits only`);
+  }
+  return args;
+}
+
+function sha512B64(filePath) {
+  return crypto.createHash('sha512').update(fs.readFileSync(filePath)).digest('base64');
+}
+
+function yamlString(value) {
+  return JSON.stringify(value);
+}
+
+function entryFor(filePath) {
+  const p = path.resolve(filePath);
+  if (!fs.existsSync(p)) throw new Error(`Missing artifact: ${p}`);
+  const ext = path.extname(p).slice(1).toLowerCase();
+  if (ext !== 'deb' && ext !== 'rpm') {
+    throw new Error(`Expected a .deb or .rpm artifact, got: ${path.basename(p)}`);
+  }
+  const stats = fs.statSync(p);
+  return {
+    url: path.basename(p),
+    sha512: sha512B64(p),
+    size: stats.size,
+  };
+}
+
+function writeManifest({ version, arch, channel, debs, rpms, out }) {
+  if (debs.length === 0 && rpms.length === 0) {
+    throw new Error('Provide at least one --deb or --rpm artifact');
+  }
+  const files = [...debs.map(entryFor), ...rpms.map(entryFor)];
+  const primary = files[0];
+
+  const lines = [
+    `version: ${yamlString(version)}`,
+    'files:',
+    ...files.flatMap((f) => [
+      `  - url: ${yamlString(f.url)}`,
+      `    sha512: ${yamlString(f.sha512)}`,
+      `    size: ${f.size}`,
+    ]),
+    // Legacy top-level path/sha512, kept for parity with the mac manifest.
+    `path: ${yamlString(primary.url)}`,
+    `sha512: ${yamlString(primary.sha512)}`,
+    `releaseDate: ${yamlString(new Date().toISOString())}`,
+    '',
+  ];
+  const text = lines.join('\n');
+
+  const outPath = path.resolve(out || manifestName(channel, arch));
+  fs.mkdirSync(path.dirname(outPath), { recursive: true });
+  fs.writeFileSync(outPath, text);
+  console.log(`Wrote ${outPath} for version ${version} (${files.length} artifact(s))`);
+  for (const f of files) console.log(`  - ${f.url}  ${f.size} bytes`);
+}
+
+try {
+  const args = parseArgs(process.argv.slice(2));
+  writeManifest(args);
+} catch (err) {
+  console.error(err instanceof Error ? err.message : err);
+  process.exit(1);
+}

--- a/ui/desktop/src/utils/autoUpdater.ts
+++ b/ui/desktop/src/utils/autoUpdater.ts
@@ -11,6 +11,7 @@ import {
 } from 'electron';
 import * as path from 'path';
 import * as fs from 'fs/promises';
+import { existsSync, readFileSync } from 'fs';
 import log from './logger';
 import { githubUpdater } from './githubUpdater';
 import { loadRecentDirs } from './recentDirs';
@@ -65,9 +66,7 @@ export function registerUpdateIpcHandlers() {
   log.info('Registering update IPC handlers...');
   ipcUpdateHandlersRegistered = true;
 
-  // Fall back to the GitHub API updater. Returns the handler result so the
-  // caller can propagate the GitHub outcome (error / available / not-available)
-  // instead of leaving the UI in a stuck 'checking' state.
+  // Returns the handler result so the renderer always leaves the 'checking' state.
   const runGitHubFallback = async (
     currentVersion: string,
     reason: 'inactive' | 'error',
@@ -186,13 +185,16 @@ export function registerUpdateIpcHandlers() {
       log.info(`=== MANUAL UPDATE CHECK COMPLETED in ${duration}ms ===`);
       log.info('Auto-updater checkForUpdates result:', result);
 
-      // null means electron-updater has no active updater for this install type
-      // (e.g. a deb/rpm install without a usable AppImage). That is NOT "no
-      // update available" — it means the native path is not wired up. Route to
-      // the GitHub fallback so the UI still gets a definitive answer instead
-      // of an unresolved {updateInfo: null, error: null} that leaves the
-      // spinner spinning.
-      if (result === null || result.updateInfo === null) {
+      // null means no updater is active for this install type (no package-type
+      // marker, no APPIMAGE env), not "up to date".
+      if (result === null) {
+        if (!app.isPackaged && !autoUpdater.forceDevUpdateConfig) {
+          log.info('Skipping GitHub fallback: updates are disabled in development builds');
+          return {
+            updateInfo: null,
+            error: 'Updates are disabled in development builds',
+          };
+        }
         log.warn('electron-updater returned null; falling back to GitHub API updater');
         return runGitHubFallback(currentVersion, 'inactive');
       }
@@ -366,15 +368,34 @@ export function setupAutoUpdater(tray?: Tray) {
   log.info(`Resources path: ${process.resourcesPath}`);
 
   // Set the feed URL for GitHub releases
+  // Inlined at build time by vite.main.config.mts, like githubUpdater's, so a build
+  // made with GITHUB_OWNER=<fork> points both updater paths at that fork's releases.
   const feedConfig = {
     provider: 'github' as const,
-    owner: 'aaif-goose',
-    repo: 'goose',
+    owner: process.env.GITHUB_OWNER || 'aaif-goose',
+    repo: process.env.GITHUB_REPO || 'goose',
     releaseType: 'release' as const,
   };
 
   log.info('Setting feed URL with config:', feedConfig);
   autoUpdater.setFeedURL(feedConfig);
+
+  // Package variants (e.g. vulkan) share a package name, so each follows its own manifest.
+  if (process.platform === 'linux') {
+    const channelFile = path.join(process.resourcesPath, 'update-channel');
+    if (existsSync(channelFile)) {
+      const channel = readFileSync(channelFile, 'utf8').trim();
+      // The channel becomes a manifest URL path segment; match the generator's rule.
+      if (channel && /^[a-z0-9]+$/.test(channel)) {
+        autoUpdater.channel = channel;
+        // The channel setter turns allowDowngrade on as a side effect.
+        autoUpdater.allowDowngrade = false;
+        log.info(`Update channel set from package marker: ${channel}`);
+      } else if (channel) {
+        log.warn(`Ignoring invalid update channel marker: ${JSON.stringify(channel)}`);
+      }
+    }
+  }
 
   // Log the feed URL after setting it
   try {
@@ -458,6 +479,9 @@ export function setupAutoUpdater(tray?: Tray) {
         const duration = Date.now() - checkStartTime;
         log.info(`=== STARTUP UPDATE CHECK COMPLETED in ${duration}ms ===`);
         log.info('Update check result:', result);
+        // A null result means no updater is active for this install type (no
+        // package-type marker). We intentionally do nothing on startup; the manual
+        // check surfaces the GitHub fallback when the user asks.
       })
       .catch((err) => {
         clearTimeout(timeoutWarning);
@@ -512,7 +536,11 @@ export function setupAutoUpdater(tray?: Tray) {
 
                 if (!autoDownloadDisabled) {
                   log.info('Auto-downloading update via GitHub fallback on startup...');
-                  await githubAutoDownload(result.downloadUrl!, result.latestVersion!, 'on startup');
+                  await githubAutoDownload(
+                    result.downloadUrl!,
+                    result.latestVersion!,
+                    'on startup'
+                  );
                 } else {
                   log.info('Auto-download disabled — skipping GitHub fallback download on startup');
                 }

--- a/ui/desktop/src/utils/autoUpdater.ts
+++ b/ui/desktop/src/utils/autoUpdater.ts
@@ -65,6 +65,91 @@ export function registerUpdateIpcHandlers() {
   log.info('Registering update IPC handlers...');
   ipcUpdateHandlersRegistered = true;
 
+  // Fall back to the GitHub API updater. Returns the handler result so the
+  // caller can propagate the GitHub outcome (error / available / not-available)
+  // instead of leaving the UI in a stuck 'checking' state.
+  const runGitHubFallback = async (
+    currentVersion: string,
+    reason: 'inactive' | 'error',
+    error?: unknown
+  ) => {
+    if (reason === 'error') {
+      log.info('Manual fallback triggered by error:', errorMessage(error, 'unknown'));
+    } else {
+      log.info('Manual fallback triggered: electron-updater returned null (no active updater)');
+    }
+    log.info('Using GitHub API fallback in check-for-updates...');
+    isUsingGitHubFallback = true;
+
+    try {
+      const result = await githubUpdater.checkForUpdates();
+
+      if (result.error) {
+        trackUpdateCheckCompleted('error', currentVersion, {
+          usingFallback: true,
+          errorType: result.error,
+        });
+        return {
+          updateInfo: null,
+          error: result.error,
+        };
+      }
+
+      // Store GitHub update info
+      if (result.updateAvailable) {
+        githubUpdateInfo = {
+          latestVersion: result.latestVersion,
+          downloadUrl: result.downloadUrl,
+          releaseUrl: result.releaseUrl,
+        };
+
+        trackUpdateCheckCompleted('available', currentVersion, {
+          latestVersion: result.latestVersion,
+          usingFallback: true,
+        });
+
+        updateAvailable = true;
+        lastUpdateState = { updateAvailable: true, latestVersion: result.latestVersion };
+        updateTrayIcon(true);
+        sendStatusToWindow('update-available', { version: result.latestVersion });
+
+        if (!autoDownloadDisabled) {
+          log.info('Auto-downloading update via GitHub fallback...');
+          await githubAutoDownload(result.downloadUrl!, result.latestVersion!, 'manual check');
+        } else {
+          log.info('Auto-download disabled — skipping GitHub fallback download');
+        }
+      } else {
+        trackUpdateCheckCompleted('not_available', currentVersion, {
+          latestVersion: result.latestVersion,
+          usingFallback: true,
+        });
+
+        updateAvailable = false;
+        lastUpdateState = { updateAvailable: false };
+        updateTrayIcon(false);
+        sendStatusToWindow('update-not-available', {
+          version: autoUpdater.currentVersion?.version ?? currentVersion,
+        });
+      }
+
+      return {
+        updateInfo: null,
+        error: null,
+      };
+    } catch (fallbackError) {
+      log.error('GitHub fallback also failed:', fallbackError);
+      trackUpdateCheckCompleted('error', currentVersion, {
+        usingFallback: true,
+        errorType: 'github_fallback_failed',
+      });
+      return {
+        updateInfo: null,
+        error: 'Unable to check for updates. Please check your internet connection.',
+      };
+    }
+  };
+
   // IPC handlers for renderer process
   ipcMain.handle('check-for-updates', async () => {
     const currentVersion = autoUpdater.currentVersion?.version || app.getVersion();
@@ -101,6 +186,17 @@ export function registerUpdateIpcHandlers() {
       log.info(`=== MANUAL UPDATE CHECK COMPLETED in ${duration}ms ===`);
       log.info('Auto-updater checkForUpdates result:', result);
 
+      // null means electron-updater has no active updater for this install type
+      // (e.g. a deb/rpm install without a usable AppImage). That is NOT "no
+      // update available" — it means the native path is not wired up. Route to
+      // the GitHub fallback so the UI still gets a definitive answer instead
+      // of an unresolved {updateInfo: null, error: null} that leaves the
+      // spinner spinning.
+      if (result === null || result.updateInfo === null) {
+        log.warn('electron-updater returned null; falling back to GitHub API updater');
+        return runGitHubFallback(currentVersion, 'inactive');
+      }
+
       return {
         updateInfo: result?.updateInfo,
         error: null,
@@ -128,77 +224,7 @@ export function registerUpdateIpcHandlers() {
           error.message.includes('ENOTFOUND') ||
           error.message.includes('No published versions'))
       ) {
-        log.info('Using GitHub API fallback in check-for-updates...');
-        log.info('Manual fallback triggered by error:', error.message);
-        isUsingGitHubFallback = true;
-
-        try {
-          const result = await githubUpdater.checkForUpdates();
-
-          if (result.error) {
-            trackUpdateCheckCompleted('error', currentVersion, {
-              usingFallback: true,
-              errorType: result.error,
-            });
-            return {
-              updateInfo: null,
-              error: result.error,
-            };
-          }
-
-          // Store GitHub update info
-          if (result.updateAvailable) {
-            githubUpdateInfo = {
-              latestVersion: result.latestVersion,
-              downloadUrl: result.downloadUrl,
-              releaseUrl: result.releaseUrl,
-            };
-
-            trackUpdateCheckCompleted('available', currentVersion, {
-              latestVersion: result.latestVersion,
-              usingFallback: true,
-            });
-
-            updateAvailable = true;
-            lastUpdateState = { updateAvailable: true, latestVersion: result.latestVersion };
-            updateTrayIcon(true);
-            sendStatusToWindow('update-available', { version: result.latestVersion });
-
-            if (!autoDownloadDisabled) {
-              log.info('Auto-downloading update via GitHub fallback...');
-              await githubAutoDownload(result.downloadUrl!, result.latestVersion!, 'manual check');
-            } else {
-              log.info('Auto-download disabled — skipping GitHub fallback download');
-            }
-          } else {
-            trackUpdateCheckCompleted('not_available', currentVersion, {
-              latestVersion: result.latestVersion,
-              usingFallback: true,
-            });
-
-            updateAvailable = false;
-            lastUpdateState = { updateAvailable: false };
-            updateTrayIcon(false);
-            sendStatusToWindow('update-not-available', {
-              version: autoUpdater.currentVersion.version,
-            });
-          }
-
-          return {
-            updateInfo: null,
-            error: null,
-          };
-        } catch (fallbackError) {
-          log.error('GitHub fallback also failed:', fallbackError);
-          trackUpdateCheckCompleted('error', currentVersion, {
-            usingFallback: true,
-            errorType: 'github_fallback_failed',
-          });
-          return {
-            updateInfo: null,
-            error: 'Unable to check for updates. Please check your internet connection.',
-          };
-        }
+        return runGitHubFallback(currentVersion, 'error', error);
       }
 
       trackUpdateCheckCompleted('error', currentVersion, {

--- a/ui/desktop/src/utils/githubUpdater.ts
+++ b/ui/desktop/src/utils/githubUpdater.ts
@@ -556,6 +556,16 @@ export class GitHubUpdater {
       }
 
       if (!downloadUrl) {
+        if (platform === 'linux' && process.env.FLATPAK_ID) {
+          throw new Error(
+            `Version ${latestVersion} is available. Flatpak installs update with "flatpak install --bundle"; download the new bundle from ${release.html_url}`
+          );
+        }
+        if (platform === 'linux') {
+          throw new Error(
+            `Version ${latestVersion} is available, but this Linux package cannot update itself. Download it from ${release.html_url}`
+          );
+        }
         throw new Error(
           `Update Available but no download URL found for platform: ${platform}, arch: ${arch}`
         );


### PR DESCRIPTION
Fixes: #11672

## Summary
The issue is clearly broken down here: https://github.com/aaif-goose/goose/issues/11672#issuecomment-5466280766

934b59a fixes the UX issue where the update spinner goes on forever. The root cause was missing null handling which prevented an updater-event from firing. This left the UI in limbo and nothing stopped the spinner.

95841fe is a release-side fix to ensure that (a) Linux builds have a resources/package-type defined and (b) <OS>-latest.yml files are populated for each platform Goose supports. **a** is important because it allows electron-updater to select the appropriate installer type. **b** is important because it guarantees that each supported platform has an explicit release asset that points to the appropriate package. This is more reliably set at release time than guessed at runtime (which is how it works today).

### Testing
- [x] Rebuild .deb and .rpm packages on these changes and confirmed that resources/package-type is the only new addition.
- [x] Install affected packages in a fresh container and check for updates to ensure it works off my machine. (.deb, .rpm, .app, windows .zip)
- [x] CI dry run

### Related Issues
NA

### Screenshots/Demos (for UX changes)
Before:  

After:
