### PR TITLE
Add x402-list MCP server to extensions directory

### DIFF
--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -827,6 +827,18 @@
       "required": false
     }
   ]
-}
+},
+  {
+    "id": "x402-list",
+    "name": "x402-list",
+    "description": "Directory of x402-payable APIs and services: find and verify x402 endpoints before an agent pays",
+    "type": "streamable-http",
+    "url": "https://mcp.x402-list.com/mcp",
+    "link": "https://x402-list.com",
+    "installation_notes": "Streamable HTTP extension. No API key or environment variables required.",
+    "is_builtin": false,
+    "endorsed": false,
+    "environmentVariables": []
+  }
 
 ]


### PR DESCRIPTION
Adds x402-list to documentation/static/servers.json.

x402-list is a directory of x402-payable APIs and services. Its MCP server lets
an agent find and verify x402 endpoints before paying.

- Transport: Streamable HTTP
- URL: https://mcp.x402-list.com/mcp
- No API key / environment variables required
- Homepage: https://x402-list.com

Appended to the array following the existing streamable-http entry format
(e.g. Ophis). endorsed:false, is_builtin:false.
