### PR TITLE
feat(desktop): in-place auto-update with cached zip and Restart-now

### DIFF
--- a/docs/brainstorms/2026-09-02-desktop-autoupdate-inplace-restart.md
+++ b/docs/brainstorms/2026-09-02-desktop-autoupdate-inplace-restart.md
@@ -1,0 +1,59 @@
+## Clarified Problem Statement
+
+**Goal:** Replace the desktop app's auto-update flow with an in-place, restart-and-replace mechanism (like pingdotgg/t3code) so updating does not leave a new zip/duplicate app bundle but overwrites the running app and restarts it.
+
+**Constraints:**
+- Must preserve macOS code-signing / notarization and Windows signing; cannot break Gatekeeper / SmartScreen.
+- Must work when app is in `/Applications` (macOS), `Program Files` (Windows), `/opt` (Linux deb/rpm) with appropriate permissions (prompt/fail gracefully if not writable).
+- Must not break existing Electron Forge + `electron-updater` release pipeline (GitHub Releases via `@electron-forge/publisher-github`).
+- Must handle **macOS and Windows only** (Linux deb/rpm/flatpak out of scope, delegated to package manager).
+- Restart via **"Restart now" Notification** (not silent auto-restart): on `update-downloaded` show Notification, click triggers swap + `app.relaunch`/`app.quit`.
+
+**Non-goals:**
+- Changing release channels / feed URL logic or adding delta/differential download optimization (unless required for in-place).
+- Reworking Linux package-manager updates (apt/dnf/flatpak) beyond the existing deb/rpm/flatpak makers — those stay as-is.
+- Background silent update scheduling / rollout % / telemetry redesign (keep existing analytics hooks).
+- CLI (`goose-cli`) update mechanism.
+
+**Success criteria:**
+- Triggering "Check for updates" downloads once, **keeps zip cached for rollback** in `app.getPath('userData')/update-cache` (not `~/Downloads`), replaces files at the current install path, and relaunches the same `Goose.app` / `Goose.exe` / `/opt/Goose` binary on next launch (verified by `app.getVersion()` bump).
+- No duplicate `.app` / `.zip` left in `~/Downloads` or install parent dir after update; cache dir holds last 1-2 zips for rollback, auto-pruned.
+- Manual test on macOS (Apple Silicon + Intel) and Windows shows: install vN, update to vN+1 via in-app updater, app restarts automatically, `ps` shows new PID, old version not present.
+- Existing `autoUpdater` events (`checking-for-update`, `update-available`, `download-progress`, `update-downloaded`, `error`) still fire and UI reflects them.
+
+## Approaches Considered
+
+### Approach A: Fix the GitHub-fallback in-place swap (minimal, t3code-inspired)
+- Sketch: Keep `electron-updater` as primary. Make `ui/desktop/src/utils/githubUpdater.ts` the canonical "zip-free" path: download to `os.tmpdir()`, `extractArchive` with `ditto`/`Expand-Archive`/`unzip`, resolve payload via `resolvePayloadPath`, validate with `REQUIRED_INSTALL_DIRECTORIES` allowlist, then atomic swap via temp `SwapCommand` script + `app.relaunch`/`app.quit`. Delete archive + extract dir on success. Patch `autoUpdater.ts:quitAndInstall` branch to also clean up and use same swap helper when `isUsingGitHubFallback`.
+- Affected files: `ui/desktop/src/utils/autoUpdater.ts` (~845 LOC, IPC + event handlers), `ui/desktop/src/utils/githubUpdater.ts` (~746 LOC, `extractArchive`, `runCommand`, `SwapCommand`), `ui/desktop/src/main.ts` (setup at line 2542), `ui/desktop/forge.config.ts` (keep `maker-zip` but no change).
+- Tradeoffs: Smallest change; reuses existing safety checks (shared-directory guard, runtime allowlist). Still two codepaths (`electron-updater` vs fallback) — risk of drift. Does not remove zip maker; just cleans up after. Fastest to ship.
+- Effort: S (1-2 weeks, mostly testing permissions/signing)
+
+### Approach B: Vendor t3code's updater verbatim (faithful port)
+- Sketch: Clone t3code's updater module (shell-script `rsync`/`ditto` over existing bundle while app is quitting, spawned detached). Replace both update paths with a single `inplaceUpdater.ts` that: downloads asset to temp, verifies signature/checksum, spawns a detached helper (`sh -c "sleep 0.5; rsync -a --delete payload/ target/; open -n target/Goose.app"` on macOS, equivalent PowerShell on Windows), then `app.quit()`. `autoUpdater.ts` becomes thin wrapper that only checks version, delegating install to helper. Delete `githubUpdater.ts` or keep as legacy.
+- Affected files: new `ui/desktop/src/utils/inplaceUpdater.ts`, `ui/desktop/src/utils/autoUpdater.ts` (shrink to check-only), `ui/desktop/src/utils/githubUpdater.ts` (deprecate/remove), `ui/desktop/forge.config.ts`/`package.json` (add helper scripts, maybe `extraResource` for shell helper), `ui/desktop/src/main.ts`.
+- Tradeoffs: Most faithful to t3code UX — true "replace same app, restart". Single install path. Requires vendoring + maintaining foreign shell logic, careful code-sign handling (macOS `ditto` preserves xattrs/signing, `rsync` may not). More risk on Windows (file locks). Larger review surface.
+- Effort: M (2-4 weeks, cross-platform QA + signing verification)
+
+### Approach C: Go full electron-updater differential + autoInstallOnAppQuit=false (upstream-aligned)
+- Sketch: Remove GitHub-fallback zip path entirely. Configure `electron-updater` for differential updates (`autoUpdater.autoDownload`, `autoInstallOnAppQuit=false`, `forceDevUpdateConfig` handling) and rely on `app-update.yml` + GitHub Releases feed. `quitAndInstall(false, true)` already does in-place Squirrel replacement on macOS/Windows; fix is to ensure it does not stage a zip side-by-side and to clean staging dir. For Linux, keep deb/rpm makers but disable in-app updater (delegate to package manager). Add explicit `before-quit-for-update` hook that deletes staging zip.
+- Affected files: `ui/desktop/src/utils/autoUpdater.ts` (remove fallback branching, simplify to ~300 LOC), `ui/desktop/forge.config.ts` (tune `packagerConfig.extraResource`, makers), `ui/desktop/src/utils/githubUpdater.ts` (delete), `ui/desktop/package.json` (`electron-updater` config, `build.publish`), `ui/desktop/src/updates.ts`.
+- Tradeoffs: Cleanest long-term, least custom code, leverages Squirrel.Mac/Windows tested path. Loses the GitHub fallback that helps when `electron-updater` feed fails. Requires confidence that `electron-updater` quitAndInstall is truly in-place on all platforms (it is on macOS/Win, but Linux is no-op). Not a t3code clone — violates literal request but achieves same UX with less shell.
+- Effort: M (2-3 weeks, but risky if feed/Squirrel edge cases regress)
+
+## Recommendation
+
+**Approach A** — fix the existing `githubUpdater` swap to be the zip-free, restart-in-place path and make `autoUpdater` delegate to it when fallback is used. It is the smallest change that literally satisfies "no new zip, replace same app, restart" while preserving the current Forge pipeline and safety guards (`REQUIRED_INSTALL_DIRECTORIES`, `SHARED_DIRECTORY_NAMES`). It can be evolved into B later if you want to fully vendor t3code's helper. If you are willing to drop the fallback, C is the cleaner second choice.
+
+## Decisions (from brainstorm Q&A 2026-09-02)
+
+- **Q1 Platform:** macOS + Windows in-scope; Linux explicitly out.
+- **Q2 t3code reference:** **My take:** don't vendor t3code verbatim. Use hybrid: `electron-updater.quitAndInstall(false,true)` for primary path (Squirrel already in-place), and for `githubUpdater` fallback use `ditto -x -k` (macOS) / `Expand-Archive` (Windows) + `app.relaunch` + `app.quit` with detached helper only if file lock. `ditto` preserves code-signing xattrs; `rsync -a --delete` does not. If you want literal t3code, that's Approach B — but adds maintenance for no UX gain.
+- **Q3 Restart:** "Restart now" Notification (user-confirmed), not silent. Matches `autoUpdater.ts:641` `update-downloaded` handler.
+- **Q4 Permissions:** **Default to graceful fail** (no UAC/osascript escalation in v1). Pre-flight `fs.access(target, W_OK)`; if not writable, show error Notification + log, keep cached zip, don't swap. Escalation can be added later if needed — keeps v1 small.
+- **Q5 Cache:** Keep zip cached for rollback in `userData/update-cache/<version>.zip` (or `app.getPath('temp')` staging), prune to last 2. Delete extract dir after swap.
+
+## Open questions
+
+- **Permission escalation follow-up:** If graceful-fail (Q4) causes support tickets for non-writable `/Applications` / `Program Files`, should v2 add `osascript with administrator privileges` (macOS) / UAC elevation (Windows) helper? Defer until data.
+- **Codesign verification:** Log `codesign --verify --deep` after swap but don't block relaunch — ok, or should failure block restart and rollback to cached zip?

--- a/docs/plans/2026-09-02-desktop-autoupdate-inplace-restart.md
+++ b/docs/plans/2026-09-02-desktop-autoupdate-inplace-restart.md
@@ -1,0 +1,59 @@
+# Plan: Desktop Auto-Update In-Place Restart (macOS + Windows)
+
+**Source:** `docs/brainstorms/2026-09-02-desktop-autoupdate-inplace-restart.md` (Approach A)
+**Goal:** In-place, restart-and-replace auto-update — no new zip/duplicate app, overwrite same install, keep zip cached for rollback, "Restart now" notification.
+
+## Context
+- Current: `ui/desktop/src/utils/autoUpdater.ts` (845 LOC) uses `electron-updater` + `quitAndInstall(false, true)` + fallback to `githubUpdater.ts` (746 LOC) which already does `extractArchive`/`resolvePayloadPath`/`SwapCommand` but leaves artifacts.
+- Forge: `ui/desktop/forge.config.ts` maker-zip + publisher-github.
+- Decisions: macOS+Windows only, graceful-fail permissions (no elevation v1), keep cached zip in `userData/update-cache`, Restart-now UX.
+
+## Implementation Steps
+
+### Step 1: Extend githubUpdater.ts — cached zip, prune, writability pre-check
+**Files:** `ui/desktop/src/utils/githubUpdater.ts`
+- Add `getUpdateCacheDir()`, `ensureCacheDir()`, `pruneCache(keep=2)` helpers using `app.getPath('userData')/update-cache`.
+- Add `isTargetWritable(targetPath)` via `fs.access(targetPath, constants.W_OK)` with macOS `.app` bundle check (check parent + bundle).
+- Change download path from `os.tmpdir()`/random to `cacheDir/<version>.zip` — keep after install.
+- After successful swap, delete only `extractDir`, not zip; call `pruneCache`.
+- Export helpers for testing.
+
+### Step 2: Make swap use app.relaunch + graceful failure + Notification
+**Files:** `ui/desktop/src/utils/githubUpdater.ts`, `ui/desktop/src/utils/autoUpdater.ts`
+- In `githubUpdater.installUpdate()`: pre-flight writability check; if fails, return `{ success:false, needsPermission:true }` instead of swapping; caller shows error Notification.
+- On success: spawn detached? Prefer `app.relaunch()` + `app.quit()` (preserves args). Only use detached shell if file lock detected (Windows).
+- Ensure `autoUpdater.ts` fallback path calls `githubUpdater.installUpdate` and handles `needsPermission` case.
+- Add code-sign verification log: `codesign --verify --deep` on macOS (non-blocking, log only).
+
+### Step 3: Update autoUpdater.ts — unify Restart-now flow, cleanup
+**Files:** `ui/desktop/src/utils/autoUpdater.ts`
+- On `update-downloaded`: show `Notification` with "Restart now" button (existing handler at ~641). Click → call `installUpdate` (either `quitAndInstall` or `githubUpdater` swap). Ensure zip not duplicated in Downloads.
+- For `isUsingGitHubFallback` branch, use `githubUpdater` swap helper instead of direct `quitAndInstall`.
+- Ensure `autoDownloadDisabled` handling still works.
+- Clean up staging dir after electron-updater success (delete temp zip if any).
+- Keep analytics hooks `trackUpdateInstallInitiated` etc.
+
+### Step 4: Main.ts wiring + IPC
+**Files:** `ui/desktop/src/main.ts`
+- No major change; ensure `setupAutoUpdater` still called at 2542 after window creation; verify IPC `check-for-updates` returns updated info.
+- Optionally add IPC `install-cached-update` for manual rollback (stretch).
+
+### Step 5: Tests & verification
+- Unit test: `ui/desktop/src/utils/__tests__/githubUpdater.test.ts` (new) — mock `fs.access`, test `isTargetWritable`, `pruneCache`, cache path.
+- Manual smoke: `pnpm --prefix ui/desktop test` or `vitest` ; `cargo fmt` / `cargo clippy` not needed (desktop only) but run `pnpm run typecheck` and `pnpm run lint` if available.
+- Runtime smoke: build dev `pnpm --prefix ui/desktop start` and trigger fake update via `forceDevUpdateConfig`.
+
+## Effort
+S (1-2 weeks). This plan implements Approach A minimal.
+
+## Risks
+- Windows file lock during swap → fallback to `setTimeout` retry or `Update.exe` style.
+- Gatekeeper: `ditto` preserves xattrs, verify with `codesign --verify`.
+
+## Verification Plan
+- [ ] `ui/desktop/src/utils/githubUpdater.ts` has cache + prune + writability helpers
+- [ ] No zip left in Downloads/parent after update; cache has ≤2 zips
+- [ ] Notification "Restart now" triggers relaunch and version bumps
+- [ ] Typecheck passes: `pnpm --prefix ui/desktop run typecheck`
+- [ ] Existing updater tests pass
+

--- a/ui/desktop/src/utils/autoUpdater.ts
+++ b/ui/desktop/src/utils/autoUpdater.ts
@@ -292,13 +292,21 @@ export function registerUpdateIpcHandlers() {
       const result = await githubUpdater.installUpdate(downloadPath);
       if (!result.success) {
         log.error('Error installing GitHub update:', result.error);
+        if ((result as { needsPermission?: boolean }).needsPermission) {
+          const notif = new Notification({
+            title: 'Update needs permission',
+            body: result.error || 'Please move Goose to /Applications or check write permission and try again.',
+          });
+          notif.show();
+        }
         throw new Error(result.error || 'Failed to install update');
       }
 
+      // Keep cached zip for rollback (githubUpdater keeps it), swap script cleans staging
       log.info('Quitting app so the update swap can complete...');
       setTimeout(() => app.quit(), 0);
     } else {
-      // Use electron-updater's built-in install
+      // Use electron-updater's built-in install (in-place Squirrel replacement)
       trackUpdateInstallInitiated(
         lastUpdateState?.latestVersion || 'unknown',
         'electron-updater',
@@ -643,16 +651,16 @@ export function setupAutoUpdater(tray?: Tray) {
     trackUpdateDownloadCompleted(true, info.version, 'electron-updater');
     sendStatusToWindow('update-downloaded', info);
 
-    // Show native notification
+    // Show Restart now notification (user-confirmed in-place restart)
     const notification = new Notification({
       title: 'Update Ready',
-      body: `Version ${info.version} will be installed when you quit Goose. Click to install now.`,
+      body: `Version ${info.version} is ready. Click "Restart now" to replace the app and relaunch.`,
     });
     notification.show();
 
-    // Optional: Add click handler to install immediately
     notification.on('click', () => {
       trackUpdateInstallInitiated(info.version, 'electron-updater', 'quit_and_install');
+      // electron-updater's quitAndInstall does in-place Squirrel replacement on macOS/Windows
       autoUpdater.quitAndInstall(false, true);
     });
   });
@@ -699,6 +707,32 @@ async function githubAutoDownload(
       githubUpdateInfo.extractedPath = downloadResult.extractedPath;
       trackUpdateDownloadCompleted(true, latestVersion, 'github-fallback');
       sendStatusToWindow('update-downloaded', { version: latestVersion });
+      // Show Restart now notification for GitHub-fallback path as well
+      try {
+        const notif = new Notification({
+          title: 'Update Ready',
+          body: `Version ${latestVersion} is ready. Click to restart and install now.`,
+        });
+        notif.show();
+        notif.on('click', async () => {
+          try {
+            const res = await githubUpdater.installUpdate(downloadResult.downloadPath!);
+            if (!res.success) {
+              if ((res as { needsPermission?: boolean }).needsPermission) {
+                const permNotif = new Notification({
+                  title: 'Update needs permission',
+                  body: res.error || 'Check write permission and try again.',
+                });
+                permNotif.show();
+              }
+              throw new Error(res.error);
+            }
+            setTimeout(() => app.quit(), 0);
+          } catch (e) {
+            log.error('Failed to install on notification click:', e);
+          }
+        });
+      } catch {}
     } else {
       trackUpdateDownloadCompleted(false, latestVersion, 'github-fallback', downloadResult.error);
       log.error(

--- a/ui/desktop/src/utils/githubUpdater.ts
+++ b/ui/desktop/src/utils/githubUpdater.ts
@@ -1,4 +1,5 @@
 import { app } from 'electron';
+import { constants as fsConstants } from 'fs';
 import { compareVersions } from 'compare-versions';
 import { spawn } from 'child_process';
 import * as fs from 'fs/promises';
@@ -55,6 +56,69 @@ function runCommand(command: string, args: string[]): Promise<void> {
 
 function powershellQuote(value: string): string {
   return `'${value.replace(/'/g, "''")}'`;
+}
+
+
+export function getUpdateCacheDir(): string {
+  return path.join(app.getPath('userData'), 'update-cache');
+}
+
+export async function ensureCacheDir(): Promise<string> {
+  const dir = getUpdateCacheDir();
+  await fs.mkdir(dir, { recursive: true });
+  return dir;
+}
+
+export async function pruneCache(keep = 2): Promise<void> {
+  try {
+    const dir = getUpdateCacheDir();
+    const entries = await fs.readdir(dir);
+    const zipEntries = entries.filter((e) => e.toLowerCase().endsWith('.zip'));
+    if (zipEntries.length <= keep) return;
+    const withStats = await Promise.all(
+      zipEntries.map(async (name) => {
+        const full = path.join(dir, name);
+        try {
+          const stat = await fs.stat(full);
+          return { name, full, mtime: stat.mtimeMs };
+        } catch {
+          return { name, full, mtime: 0 };
+        }
+      })
+    );
+    withStats.sort((a, b) => b.mtime - a.mtime);
+    const toDelete = withStats.slice(keep);
+    for (const entry of toDelete) {
+      try {
+        await fs.unlink(entry.full);
+        log.info(`pruneCache: removed old cached update ${entry.name}`);
+      } catch {}
+    }
+  } catch {}
+}
+
+export async function isTargetWritable(targetPath: string): Promise<boolean> {
+  try {
+    await fs.access(targetPath, fsConstants.W_OK);
+    return true;
+  } catch {
+    try {
+      await fs.access(path.dirname(targetPath), fsConstants.W_OK);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}
+
+async function verifyCodeSign(targetPath: string): Promise<void> {
+  if (process.platform !== 'darwin') return;
+  try {
+    await runCommand('codesign', ['--verify', '--deep', '--strict', targetPath]);
+    log.info(`codesign verify passed for ${targetPath}`);
+  } catch (e) {
+    log.warn(`codesign verify failed for ${targetPath}: ${errorMessage(e, 'unknown')}`);
+  }
 }
 
 function shellQuote(value: string): string {
@@ -679,10 +743,12 @@ export class GitHubUpdater {
       const buffer = Buffer.concat(chunks.map((chunk) => Buffer.from(chunk)));
       log.info(`GitHubUpdater: Buffer created - ${buffer.length} bytes`);
 
+      const cacheDir = await ensureCacheDir();
+      const fileName = `${this.bundleName}-${latestVersion}.zip`;
+      const downloadPath = path.join(cacheDir, fileName);
+      // Staging dir is still needed for extraction, keep it in tmp
       const stagingDir = path.join(os.tmpdir(), `goose-update-${latestVersion}-${Date.now()}`);
       await fs.mkdir(stagingDir, { recursive: true });
-      const fileName = `${this.bundleName}-${latestVersion}.zip`;
-      const downloadPath = path.join(stagingDir, fileName);
 
       log.info(`GitHubUpdater: Writing file to ${downloadPath}...`);
       await fs.writeFile(downloadPath, buffer);
@@ -708,7 +774,9 @@ export class GitHubUpdater {
     }
   }
 
-  async installUpdate(downloadPath: string): Promise<{ success: boolean; error?: string }> {
+  async installUpdate(
+    downloadPath: string
+  ): Promise<{ success: boolean; error?: string; needsPermission?: boolean }> {
     try {
       log.info('=== GitHubUpdater: STARTING AUTOMATIC INSTALL ===');
       log.info(`GitHubUpdater: Download path: ${downloadPath}`);
@@ -719,6 +787,17 @@ export class GitHubUpdater {
         app.getPath('exe')
       );
       log.info(`GitHubUpdater: Install target: ${targetPath}`);
+
+      if (!(await isTargetWritable(targetPath))) {
+        log.warn(`GitHubUpdater: target not writable: ${targetPath}`);
+        return {
+          success: false,
+          error: `Update location is not writable: ${targetPath}. Please move Goose to /Applications (macOS) or ensure you have write permission, then try again.`,
+          needsPermission: true,
+        };
+      }
+
+      await verifyCodeSign(targetPath).catch(() => {});
 
       const swap = await prepareUpdateInstall({
         archivePath: downloadPath,
@@ -731,6 +810,8 @@ export class GitHubUpdater {
       launchSwapScript(swap);
 
       log.info('=== GitHubUpdater: SWAP SCRIPT LAUNCHED, app will quit ===');
+      // Keep cached zip for rollback, prune old ones, but swap script will clean stagingDir
+      await pruneCache(2).catch(() => {});
       return { success: true };
     } catch (error) {
       log.error('GitHubUpdater: Error installing update:', error);


### PR DESCRIPTION
## Summary
- Implements Approach A from `docs/brainstorms/2026-09-02-desktop-autoupdate-inplace-restart.md`: in-place restart-and-replace (t3code-style) for macOS + Windows, no duplicate zip/bundle.
- `githubUpdater.ts`: adds `getUpdateCacheDir`/`ensureCacheDir`/`pruneCache(keep=2)`/`isTargetWritable`, moves download to `userData/update-cache/<version>.zip`, keeps zip for rollback (prune to last 2), deletes only extract dir, pre-flight writability check with `needsPermission` graceful error, `codesign --verify` logging on macOS.
- `autoUpdater.ts`: unified **Restart now** Notification (user-confirmed) for both `electron-updater` (`quitAndInstall`) and GitHub-fallback paths.

## Test plan
- [x] `npx tsc --noEmit` passes (ui/desktop)
- [x] `cargo fmt` + `cargo clippy --all-targets -- -D warnings` passes
- [ ] Manual smoke: install vN, trigger update to vN+1 via `check-for-updates`, verify Notification "Restart now" → quit → relaunch same path, `app.getVersion()` bumps, no zip in `~/Downloads`, cache ≤2 zips

Source: `docs/brainstorms/2026-09-02-desktop-autoupdate-inplace-restart.md` + `docs/plans/2026-09-02-desktop-autoupdate-inplace-restart.md`

Fixes: in-place auto-update (t3code-style).

## Replaces
Closes #11774 via rebased branch (previous branch was behind main and showed merge conflicts). This branch is cleanly rebased on `aaif-goose/main` @ f9176266e.