### PR TITLE
feat(desktop): minimal in-place auto-update (cached zip + Restart-now)

### DIFF
--- a/docs/plans/2026-09-02-desktop-autoupdate-inplace-restart.md
+++ b/docs/plans/2026-09-02-desktop-autoupdate-inplace-restart.md
@@ -1,0 +1,59 @@
+# Plan: Desktop Auto-Update In-Place Restart (macOS + Windows)
+
+**Source:** `docs/brainstorms/2026-09-02-desktop-autoupdate-inplace-restart.md` (Approach A)
+**Goal:** In-place, restart-and-replace auto-update — no new zip/duplicate app, overwrite same install, keep zip cached for rollback, "Restart now" notification.
+
+## Context
+- Current: `ui/desktop/src/utils/autoUpdater.ts` (845 LOC) uses `electron-updater` + `quitAndInstall(false, true)` + fallback to `githubUpdater.ts` (746 LOC) which already does `extractArchive`/`resolvePayloadPath`/`SwapCommand` but leaves artifacts.
+- Forge: `ui/desktop/forge.config.ts` maker-zip + publisher-github.
+- Decisions: macOS+Windows only, graceful-fail permissions (no elevation v1), keep cached zip in `userData/update-cache`, Restart-now UX.
+
+## Implementation Steps
+
+### Step 1: Extend githubUpdater.ts — cached zip, prune, writability pre-check
+**Files:** `ui/desktop/src/utils/githubUpdater.ts`
+- Add `getUpdateCacheDir()`, `ensureCacheDir()`, `pruneCache(keep=2)` helpers using `app.getPath('userData')/update-cache`.
+- Add `isTargetWritable(targetPath)` via `fs.access(targetPath, constants.W_OK)` with macOS `.app` bundle check (check parent + bundle).
+- Change download path from `os.tmpdir()`/random to `cacheDir/<version>.zip` — keep after install.
+- After successful swap, delete only `extractDir`, not zip; call `pruneCache`.
+- Export helpers for testing.
+
+### Step 2: Make swap use app.relaunch + graceful failure + Notification
+**Files:** `ui/desktop/src/utils/githubUpdater.ts`, `ui/desktop/src/utils/autoUpdater.ts`
+- In `githubUpdater.installUpdate()`: pre-flight writability check; if fails, return `{ success:false, needsPermission:true }` instead of swapping; caller shows error Notification.
+- On success: spawn detached? Prefer `app.relaunch()` + `app.quit()` (preserves args). Only use detached shell if file lock detected (Windows).
+- Ensure `autoUpdater.ts` fallback path calls `githubUpdater.installUpdate` and handles `needsPermission` case.
+- Add code-sign verification log: `codesign --verify --deep` on macOS (non-blocking, log only).
+
+### Step 3: Update autoUpdater.ts — unify Restart-now flow, cleanup
+**Files:** `ui/desktop/src/utils/autoUpdater.ts`
+- On `update-downloaded`: show `Notification` with "Restart now" button (existing handler at ~641). Click → call `installUpdate` (either `quitAndInstall` or `githubUpdater` swap). Ensure zip not duplicated in Downloads.
+- For `isUsingGitHubFallback` branch, use `githubUpdater` swap helper instead of direct `quitAndInstall`.
+- Ensure `autoDownloadDisabled` handling still works.
+- Clean up staging dir after electron-updater success (delete temp zip if any).
+- Keep analytics hooks `trackUpdateInstallInitiated` etc.
+
+### Step 4: Main.ts wiring + IPC
+**Files:** `ui/desktop/src/main.ts`
+- No major change; ensure `setupAutoUpdater` still called at 2542 after window creation; verify IPC `check-for-updates` returns updated info.
+- Optionally add IPC `install-cached-update` for manual rollback (stretch).
+
+### Step 5: Tests & verification
+- Unit test: `ui/desktop/src/utils/__tests__/githubUpdater.test.ts` (new) — mock `fs.access`, test `isTargetWritable`, `pruneCache`, cache path.
+- Manual smoke: `pnpm --prefix ui/desktop test` or `vitest` ; `cargo fmt` / `cargo clippy` not needed (desktop only) but run `pnpm run typecheck` and `pnpm run lint` if available.
+- Runtime smoke: build dev `pnpm --prefix ui/desktop start` and trigger fake update via `forceDevUpdateConfig`.
+
+## Effort
+S (1-2 weeks). This plan implements Approach A minimal.
+
+## Risks
+- Windows file lock during swap → fallback to `setTimeout` retry or `Update.exe` style.
+- Gatekeeper: `ditto` preserves xattrs, verify with `codesign --verify`.
+
+## Verification Plan
+- [ ] `ui/desktop/src/utils/githubUpdater.ts` has cache + prune + writability helpers
+- [ ] No zip left in Downloads/parent after update; cache has ≤2 zips
+- [ ] Notification "Restart now" triggers relaunch and version bumps
+- [ ] Typecheck passes: `pnpm --prefix ui/desktop run typecheck`
+- [ ] Existing updater tests pass
+

--- a/ui/desktop/src/utils/autoUpdater.ts
+++ b/ui/desktop/src/utils/autoUpdater.ts
@@ -292,13 +292,21 @@ export function registerUpdateIpcHandlers() {
       const result = await githubUpdater.installUpdate(downloadPath);
       if (!result.success) {
         log.error('Error installing GitHub update:', result.error);
+        if ((result as { needsPermission?: boolean }).needsPermission) {
+          const notif = new Notification({
+            title: 'Update needs permission',
+            body: result.error || 'Please move Goose to /Applications or check write permission and try again.',
+          });
+          notif.show();
+        }
         throw new Error(result.error || 'Failed to install update');
       }
 
+      // Keep cached zip for rollback (githubUpdater keeps it), swap script cleans staging
       log.info('Quitting app so the update swap can complete...');
       setTimeout(() => app.quit(), 0);
     } else {
-      // Use electron-updater's built-in install
+      // Use electron-updater's built-in install (in-place Squirrel replacement)
       trackUpdateInstallInitiated(
         lastUpdateState?.latestVersion || 'unknown',
         'electron-updater',
@@ -643,16 +651,16 @@ export function setupAutoUpdater(tray?: Tray) {
     trackUpdateDownloadCompleted(true, info.version, 'electron-updater');
     sendStatusToWindow('update-downloaded', info);
 
-    // Show native notification
+    // Show Restart now notification (user-confirmed in-place restart)
     const notification = new Notification({
       title: 'Update Ready',
-      body: `Version ${info.version} will be installed when you quit Goose. Click to install now.`,
+      body: `Version ${info.version} is ready. Click "Restart now" to replace the app and relaunch.`,
     });
     notification.show();
 
-    // Optional: Add click handler to install immediately
     notification.on('click', () => {
       trackUpdateInstallInitiated(info.version, 'electron-updater', 'quit_and_install');
+      // electron-updater's quitAndInstall does in-place Squirrel replacement on macOS/Windows
       autoUpdater.quitAndInstall(false, true);
     });
   });
@@ -699,6 +707,32 @@ async function githubAutoDownload(
       githubUpdateInfo.extractedPath = downloadResult.extractedPath;
       trackUpdateDownloadCompleted(true, latestVersion, 'github-fallback');
       sendStatusToWindow('update-downloaded', { version: latestVersion });
+      // Show Restart now notification for GitHub-fallback path as well
+      try {
+        const notif = new Notification({
+          title: 'Update Ready',
+          body: `Version ${latestVersion} is ready. Click to restart and install now.`,
+        });
+        notif.show();
+        notif.on('click', async () => {
+          try {
+            const res = await githubUpdater.installUpdate(downloadResult.downloadPath!);
+            if (!res.success) {
+              if ((res as { needsPermission?: boolean }).needsPermission) {
+                const permNotif = new Notification({
+                  title: 'Update needs permission',
+                  body: res.error || 'Check write permission and try again.',
+                });
+                permNotif.show();
+              }
+              throw new Error(res.error);
+            }
+            setTimeout(() => app.quit(), 0);
+          } catch (e) {
+            log.error('Failed to install on notification click:', e);
+          }
+        });
+      } catch {}
     } else {
       trackUpdateDownloadCompleted(false, latestVersion, 'github-fallback', downloadResult.error);
       log.error(

--- a/ui/desktop/src/utils/githubUpdater.ts
+++ b/ui/desktop/src/utils/githubUpdater.ts
@@ -1,4 +1,5 @@
 import { app } from 'electron';
+import { constants as fsConstants } from 'fs';
 import { compareVersions } from 'compare-versions';
 import { spawn } from 'child_process';
 import * as fs from 'fs/promises';
@@ -55,6 +56,69 @@ function runCommand(command: string, args: string[]): Promise<void> {
 
 function powershellQuote(value: string): string {
   return `'${value.replace(/'/g, "''")}'`;
+}
+
+
+export function getUpdateCacheDir(): string {
+  return path.join(app.getPath('userData'), 'update-cache');
+}
+
+export async function ensureCacheDir(): Promise<string> {
+  const dir = getUpdateCacheDir();
+  await fs.mkdir(dir, { recursive: true });
+  return dir;
+}
+
+export async function pruneCache(keep = 2): Promise<void> {
+  try {
+    const dir = getUpdateCacheDir();
+    const entries = await fs.readdir(dir);
+    const zipEntries = entries.filter((e) => e.toLowerCase().endsWith('.zip'));
+    if (zipEntries.length <= keep) return;
+    const withStats = await Promise.all(
+      zipEntries.map(async (name) => {
+        const full = path.join(dir, name);
+        try {
+          const stat = await fs.stat(full);
+          return { name, full, mtime: stat.mtimeMs };
+        } catch {
+          return { name, full, mtime: 0 };
+        }
+      })
+    );
+    withStats.sort((a, b) => b.mtime - a.mtime);
+    const toDelete = withStats.slice(keep);
+    for (const entry of toDelete) {
+      try {
+        await fs.unlink(entry.full);
+        log.info(`pruneCache: removed old cached update ${entry.name}`);
+      } catch {}
+    }
+  } catch {}
+}
+
+export async function isTargetWritable(targetPath: string): Promise<boolean> {
+  try {
+    await fs.access(targetPath, fsConstants.W_OK);
+    return true;
+  } catch {
+    try {
+      await fs.access(path.dirname(targetPath), fsConstants.W_OK);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}
+
+async function verifyCodeSign(targetPath: string): Promise<void> {
+  if (process.platform !== 'darwin') return;
+  try {
+    await runCommand('codesign', ['--verify', '--deep', '--strict', targetPath]);
+    log.info(`codesign verify passed for ${targetPath}`);
+  } catch (e) {
+    log.warn(`codesign verify failed for ${targetPath}: ${errorMessage(e, 'unknown')}`);
+  }
 }
 
 function shellQuote(value: string): string {
@@ -679,10 +743,12 @@ export class GitHubUpdater {
       const buffer = Buffer.concat(chunks.map((chunk) => Buffer.from(chunk)));
       log.info(`GitHubUpdater: Buffer created - ${buffer.length} bytes`);
 
+      const cacheDir = await ensureCacheDir();
+      const fileName = `${this.bundleName}-${latestVersion}.zip`;
+      const downloadPath = path.join(cacheDir, fileName);
+      // Staging dir is still needed for extraction, keep it in tmp
       const stagingDir = path.join(os.tmpdir(), `goose-update-${latestVersion}-${Date.now()}`);
       await fs.mkdir(stagingDir, { recursive: true });
-      const fileName = `${this.bundleName}-${latestVersion}.zip`;
-      const downloadPath = path.join(stagingDir, fileName);
 
       log.info(`GitHubUpdater: Writing file to ${downloadPath}...`);
       await fs.writeFile(downloadPath, buffer);
@@ -708,7 +774,9 @@ export class GitHubUpdater {
     }
   }
 
-  async installUpdate(downloadPath: string): Promise<{ success: boolean; error?: string }> {
+  async installUpdate(
+    downloadPath: string
+  ): Promise<{ success: boolean; error?: string; needsPermission?: boolean }> {
     try {
       log.info('=== GitHubUpdater: STARTING AUTOMATIC INSTALL ===');
       log.info(`GitHubUpdater: Download path: ${downloadPath}`);
@@ -719,6 +787,17 @@ export class GitHubUpdater {
         app.getPath('exe')
       );
       log.info(`GitHubUpdater: Install target: ${targetPath}`);
+
+      if (!(await isTargetWritable(targetPath))) {
+        log.warn(`GitHubUpdater: target not writable: ${targetPath}`);
+        return {
+          success: false,
+          error: `Update location is not writable: ${targetPath}. Please move Goose to /Applications (macOS) or ensure you have write permission, then try again.`,
+          needsPermission: true,
+        };
+      }
+
+      await verifyCodeSign(targetPath).catch(() => {});
 
       const swap = await prepareUpdateInstall({
         archivePath: downloadPath,
@@ -731,6 +810,8 @@ export class GitHubUpdater {
       launchSwapScript(swap);
 
       log.info('=== GitHubUpdater: SWAP SCRIPT LAUNCHED, app will quit ===');
+      // Keep cached zip for rollback, prune old ones, but swap script will clean stagingDir
+      await pruneCache(2).catch(() => {});
       return { success: true };
     } catch (error) {
       log.error('GitHubUpdater: Error installing update:', error);


### PR DESCRIPTION
## What problem would this solve?

The desktop app's current auto-update leaves a new zip/duplicate bundle and doesn't reliably replace the running app in its existing location. Users on macOS (`/Applications`) and Windows (`Program Files`) see extra artifacts, manual steps, and confusing restart. Inspired by https://github.com/pingdotgg/t3code, we want a restart-and-replace flow that overwrites the same `.app`/install dir and relaunches.

Affects all desktop users on macOS + Windows (Linux deb/rpm/flatpak delegated to package manager).

## What would a good outcome look like?

- "Check for updates" downloads once to `userData/update-cache/<version>.zip` (pruned to last 2 for rollback), extracts to `os.tmpdir()`, then swaps in-place over the existing install and relaunches the same `Goose.app`/`Goose.exe` path.
- No zip/duplicate left in `~/Downloads` or install parent after update; cache holds <=2 zips.
- Update shows a **"Restart now" Notification** (user-confirmed) on `update-downloaded` for both `electron-updater` and GitHub-fallback paths -- click triggers the swap + `app.quit()`/`quitAndInstall`.
- If the install location is not writable, fail gracefully with a permission Notification ("move to /Applications or check write permission") -- no UAC/osascript elevation in v1.
- `codesign --verify --deep` logged on macOS (non-blocking) to preserve Gatekeeper.
- Existing `autoUpdater` events (`checking-for-update`, `update-available`, `download-progress`, `update-downloaded`, `error`) still fire.

## Possible approaches

**Source:** `docs/brainstorms/2026-09-02-desktop-autoupdate-inplace-restart.md` + `docs/plans/2026-09-02-desktop-autoupdate-inplace-restart.md` (Approach A -- minimal, t3code-inspired)

- **Approach A (recommended, S effort):** Keep `electron-updater` as primary (`quitAndInstall(false,true)` already does Squirrel in-place). Make `githubUpdater.ts` the canonical zip-free path: `ensureCacheDir()`/`pruneCache()`/`isTargetWritable()`, `ditto -x -k` (macOS) / `Expand-Archive` (Windows), swap via detached script + `app.relaunch`, keep zip cached. ~120 lines in 2 files.
- **Approach B:** Vendor t3code's helper verbatim (`rsync`/`ditto` detached script) -- more faithful but `rsync` doesn't preserve xattrs/signing, larger surface.
- **Approach C:** Go full `electron-updater` differential and drop GitHub fallback -- cleanest long-term but loses fallback.

Implementation touches `ui/desktop/src/utils/githubUpdater.ts` and `ui/desktop/src/utils/autoUpdater.ts` only (Forge and `main.ts` unchanged).

## Additional context

- Decision log: macOS + Windows in scope, Restart-now UX, keep cached zip for rollback, graceful-fail permissions.
- Minimal PR (code-only): https://github.com/aaif-goose/goose/pull/11775 (replaces earlier #11774, rebased on `main` @ f9176266e, MERGEABLE)
- Full PR with docs: `feat/desktop-inplace-update-restart-v2` branch tracks docs/brainstorms + docs/plans
- Verification: `npx tsc --noEmit` OK, `cargo fmt`/`clippy` OK; manual smoke needed (install vN -> vN+1 -> Restart now -> version bump).

Checklist for Ready:
- [x] Problem / outcome described
- [x] Approaches with tradeoffs listed
- [ ] Team agrees on Approach A vs B vs C and v1 scope (permissions escalation follow-up, codesign verification handling)

Do not begin implementation until the issue reaches Ready on the Goose Issues board (https://github.com/orgs/aaif-goose/projects/1).
