### PR TITLE
Add Melaya remote extension (Android phone + browser control)

### DIFF
--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -827,6 +827,18 @@
       "required": false
     }
   ]
+},
+{
+  "id": "melaya",
+  "name": "Melaya",
+  "description": "Operate a paired Android phone and browser, and run agent pipelines reaching 6k+ tools",
+  "url": "https://api.melaya.org/mcp",
+  "link": "https://melaya.org/en/product/mcp",
+  "installation_notes": "Hosted remote server. Sign in with your Melaya account via OAuth on first connect; the client registers itself, so there is no API key and no environment variables to set. The agent can only touch phone apps and browser origins you have allow-listed in Melaya.",
+  "is_builtin": false,
+  "endorsed": false,
+  "environmentVariables": [],
+  "type": "streamable-http"
 }
 
 ]


### PR DESCRIPTION
Adds Melaya to `documentation/static/servers.json` as a `streamable-http` extension.

I followed the shape of the existing hosted entries rather than inventing one. The closest analogue already in the file is **Glif**: a remote URL, OAuth on first connect, and an empty `environmentVariables`. Melaya is the same pattern.

### What it is

A remote MCP server that operates a paired Android phone and a paired browser. On the phone it reads the screen through Android's accessibility tree and then taps, types and swipes, so it works inside any app without a per-app integration or a vendor API. It also runs agent pipelines that reach 6k+ tools through connectors.

Endpoint: `https://api.melaya.org/mcp`

Auth is OAuth 2.1 with PKCE and dynamic client registration, so `environmentVariables` is genuinely empty rather than incomplete. There is no API key for a user to paste.

### Why it belongs on the hosted side of this list

I saw the note in discussion #2075 asking for remote extensions. This one cannot be anything else: there is no npm package, no binary and no stdio mode. 12 of the 59 current entries are already `streamable-http`, so the schema handles it.

### Safety

Since this drives a physical device, worth stating plainly: the agent only touches phone apps and browser origins the user has allow-listed, that list can only be narrowed from the agent side and never widened, and anything publishing under the user's own identity stages an approval on the device before it sends. I set `endorsed: false`, which is yours to decide, not ours.

Repo: https://github.com/melaya-labs/melaya-mcp (Apache-2.0)
Product page: https://melaya.org/en/product/mcp
