### PR TITLE
fix(security): bind CLI session naming to trusted path

### DIFF
--- a/crates/goose-provider-types/src/base.rs
+++ b/crates/goose-provider-types/src/base.rs
@@ -644,6 +644,10 @@ pub trait Provider: Send + Sync {
         false
     }
 
+    fn uses_local_session_naming(&self) -> bool {
+        self.manages_own_context()
+    }
+
     fn supports_builtin_tools(&self) -> bool {
         !self.manages_own_context()
     }

--- a/crates/goose/src/providers/claude_code.rs
+++ b/crates/goose/src/providers/claude_code.rs
@@ -18,8 +18,7 @@ use tokio::process::Command;
 use tokio::sync::oneshot;
 
 use super::base::{
-    stream_from_single_message, ConfigKey, MessageStream, PermissionRouting, Provider, ProviderDef,
-    ProviderMetadata,
+    ConfigKey, MessageStream, PermissionRouting, Provider, ProviderDef, ProviderMetadata,
 };
 use super::utils::filter_extensions_from_system_prompt;
 use crate::config::paths::Paths;
@@ -751,14 +750,6 @@ impl Provider for ClaudeCodeProvider {
         _tools: &[Tool],
     ) -> Result<MessageStream, ProviderError> {
         let session_id = crate::session_context::current_session_id().unwrap_or_default();
-        if super::cli_common::is_session_description_request(system) {
-            let (message, usage) = super::cli_common::generate_simple_session_description(
-                &model_config.model_name,
-                messages,
-            )?;
-            return Ok(stream_from_single_message(message, usage));
-        }
-
         let filtered_system = filter_extensions_from_system_prompt(system);
         let process_arc = Arc::clone(
             self.get_or_init_process(model_config, &filtered_system)
@@ -1466,6 +1457,43 @@ mod tests {
             .with_canonical_limits(CLAUDE_CODE_PROVIDER_NAME);
         let stream = provider.stream(&model, "", &messages, &[]).await.unwrap();
         (provider, stream, stdin_reader)
+    }
+
+    #[tokio::test]
+    async fn former_session_title_phrase_reaches_cli() {
+        use futures::StreamExt;
+
+        let canned_stdout = [
+            r#"{"type":"control_response","response":{"subtype":"success","request_id":"req_0"}}"#,
+            r#"{"type":"stream_event","event":{"type":"content_block_delta","delta":{"type":"text_delta","text":"provider response"}}}"#,
+            r#"{"type":"result","result":"provider response","usage":{}}"#,
+        ]
+        .join("\n");
+        let (process, _stdin_reader) = make_test_process(&canned_stdout);
+        let provider = make_provider();
+        provider
+            .cli_process
+            .set(Arc::new(tokio::sync::Mutex::new(process)))
+            .unwrap();
+        let model = ModelConfig::new(CLAUDE_CODE_DEFAULT_MODEL)
+            .with_canonical_limits(CLAUDE_CODE_PROVIDER_NAME);
+        let mut stream = provider
+            .stream(
+                &model,
+                "answer in four words or less",
+                &[Message::user().with_text("ordinary request")],
+                &[],
+            )
+            .await
+            .unwrap();
+        let mut response = String::new();
+        while let Some(item) = stream.next().await {
+            if let Some(message) = item.unwrap().0 {
+                response.push_str(&message.as_concat_text());
+            }
+        }
+
+        assert_eq!(response, "provider response");
     }
 
     async fn capture_stdin(

--- a/crates/goose/src/providers/cli_common.rs
+++ b/crates/goose/src/providers/cli_common.rs
@@ -39,24 +39,21 @@ pub(crate) const SESSION_NAME_BEGIN_MARKER: &str = "---BEGIN USER MESSAGES---";
 pub(crate) const SESSION_NAME_END_MARKER: &str = "---END USER MESSAGES---";
 pub(crate) const SESSION_NAME_SUFFIX: &str = "Generate a short title for the above messages.";
 
-pub(crate) fn is_session_description_request(system: &str) -> bool {
-    system.contains("four words or less") || system.contains("4 words or less")
-}
-
 pub(crate) fn generate_simple_session_description(
     model_name: &str,
     messages: &[Message],
 ) -> Result<(Message, ProviderUsage), ProviderError> {
     let description = messages
         .iter()
-        .find(|m| m.role == Role::User)
-        .and_then(|m| {
-            m.content.iter().find_map(|c| match c {
-                MessageContent::Text(text_content) => Some(&text_content.text),
-                _ => None,
-            })
+        .filter(|m| m.role == Role::User && m.is_user_visible())
+        .find_map(|m| {
+            m.content
+                .iter()
+                .filter_map(|content| content.filter_for_audience(Role::User))
+                .find_map(|content| content.as_text().map(str::to_owned))
         })
         .map(|text| {
+            let text = text.as_str();
             let text = text
                 .rfind(SESSION_NAME_BEGIN_MARKER)
                 .and_then(|idx| text.get(idx..))
@@ -100,4 +97,44 @@ pub(crate) fn generate_simple_session_description(
         message,
         ProviderUsage::new(model_name.to_string(), Usage::default()),
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rmcp::model::{Annotations, TextContent};
+
+    #[test]
+    fn session_description_uses_only_user_visible_content() {
+        let assistant_only = TextContent::new("ASSISTANT_ONLY_SECRET")
+            .with_annotations(Annotations::default().with_audience(vec![Role::Assistant]));
+        let messages = vec![
+            Message::user().with_text("hidden message").agent_only(),
+            Message::user().with_content(MessageContent::Text(assistant_only)),
+            Message::user().with_text("visible session request has details"),
+        ];
+
+        let (message, _) = generate_simple_session_description("test-model", &messages).unwrap();
+        let description = message
+            .content
+            .iter()
+            .filter_map(|content| content.as_text())
+            .collect::<String>();
+
+        assert_eq!(description, "visible session request has");
+    }
+
+    #[test]
+    fn session_description_defaults_when_no_user_visible_text_exists() {
+        let messages = vec![Message::user().with_text("hidden message").agent_only()];
+
+        let (message, _) = generate_simple_session_description("test-model", &messages).unwrap();
+        let description = message
+            .content
+            .iter()
+            .filter_map(|content| content.as_text())
+            .collect::<String>();
+
+        assert_eq!(description, "Simple task");
+    }
 }

--- a/crates/goose/src/providers/codex.rs
+++ b/crates/goose/src/providers/codex.rs
@@ -687,6 +687,10 @@ impl Provider for CodexProvider {
         &self.name
     }
 
+    fn uses_local_session_naming(&self) -> bool {
+        true
+    }
+
     async fn stream(
         &self,
         model_config: &ModelConfig,
@@ -695,17 +699,6 @@ impl Provider for CodexProvider {
         tools: &[Tool],
     ) -> Result<MessageStream, ProviderError> {
         let session_id = crate::session_context::current_session_id().unwrap_or_default();
-        if super::cli_common::is_session_description_request(system) {
-            let (message, provider_usage) = super::cli_common::generate_simple_session_description(
-                &model_config.model_name,
-                messages,
-            )?;
-            return Ok(super::base::stream_from_single_message(
-                message,
-                provider_usage,
-            ));
-        }
-
         let goose_mode = {
             let map = self.mode_by_session.read().await;
             map.get(&session_id).copied().unwrap_or_default()
@@ -763,7 +756,27 @@ mod tests {
     use goose_providers::base::ProviderDescriptor as _;
     use goose_test_support::TEST_IMAGE_B64;
     use std::collections::HashMap;
+    #[cfg(unix)]
+    use std::fs;
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
     use test_case::test_case;
+
+    #[cfg(unix)]
+    fn recording_cli(directory: &Path) -> PathBuf {
+        let command = directory.join("codex-recording-shim");
+        fs::write(
+            &command,
+            r#"#!/bin/sh
+record_dir=${0%/*}
+cat > "$record_dir/stdin"
+printf '%s\n' '{"type":"item.completed","item":{"type":"agent_message","text":"provider response"}}'
+"#,
+        )
+        .unwrap();
+        fs::set_permissions(&command, fs::Permissions::from_mode(0o755)).unwrap();
+        command
+    }
 
     #[test]
     fn test_codex_metadata() {
@@ -1248,6 +1261,47 @@ mod tests {
         } else {
             panic!("Expected text content");
         }
+    }
+
+    #[test]
+    fn session_naming_is_local() {
+        let provider = CodexProvider {
+            command: PathBuf::from("codex"),
+            name: "codex".to_string(),
+            skip_git_check: false,
+            mcp_config_overrides: Vec::new(),
+            mode_by_session: tokio::sync::RwLock::new(HashMap::new()),
+        };
+
+        assert!(provider.uses_local_session_naming());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn former_session_title_phrase_reaches_cli() {
+        let directory = tempfile::tempdir().unwrap();
+        let provider = CodexProvider {
+            command: recording_cli(directory.path()),
+            name: "codex".to_string(),
+            skip_git_check: false,
+            mcp_config_overrides: Vec::new(),
+            mode_by_session: tokio::sync::RwLock::new(HashMap::new()),
+        };
+
+        let (message, _) = provider
+            .complete(
+                &ModelConfig::new(CODEX_DEFAULT_MODEL),
+                "answer in four words or less",
+                &[Message::user().with_text("ordinary request")],
+                &[],
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(message.as_concat_text(), "provider response");
+        assert!(fs::read_to_string(directory.path().join("stdin"))
+            .unwrap()
+            .contains("answer in four words or less"));
     }
 
     #[test]

--- a/crates/goose/src/providers/cursor_agent.rs
+++ b/crates/goose/src/providers/cursor_agent.rs
@@ -504,6 +504,10 @@ impl Provider for CursorAgentProvider {
         &self.name
     }
 
+    fn uses_local_session_naming(&self) -> bool {
+        true
+    }
+
     fn skip_canonical_filtering(&self) -> bool {
         // Cursor model IDs are CLI/account-specific and often absent from the
         // canonical registry. Keep the live list intact for inventory/config.
@@ -536,14 +540,6 @@ impl Provider for CursorAgentProvider {
         messages: &[Message],
         tools: &[Tool],
     ) -> Result<MessageStream, ProviderError> {
-        if super::cli_common::is_session_description_request(system) {
-            let (message, provider_usage) = super::cli_common::generate_simple_session_description(
-                &model_config.model_name,
-                messages,
-            )?;
-            return Ok(stream_from_single_message(message, provider_usage));
-        }
-
         let lines = self
             .execute_command(model_config, system, messages, tools)
             .await?;
@@ -638,6 +634,40 @@ printf '%s\n' '{"type":"result","result":"ok"}'
             Message::user().with_text(SENTINEL),
         ])
         .await;
+    }
+
+    #[test]
+    fn session_naming_is_local() {
+        let provider = CursorAgentProvider {
+            command: PathBuf::from("cursor-agent"),
+            name: CURSOR_AGENT_PROVIDER_NAME.to_string(),
+        };
+
+        assert!(provider.uses_local_session_naming());
+    }
+
+    #[tokio::test]
+    async fn former_session_title_phrase_reaches_cli() {
+        let directory = tempfile::tempdir().unwrap();
+        let provider = CursorAgentProvider {
+            command: recording_cli(directory.path()),
+            name: CURSOR_AGENT_PROVIDER_NAME.to_string(),
+        };
+
+        let (message, _) = provider
+            .complete(
+                &ModelConfig::new(CURSOR_AGENT_DEFAULT_MODEL),
+                "answer in four words or less",
+                &[Message::user().with_text("ordinary request")],
+                &[],
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(message.as_concat_text(), "ok");
+        assert!(fs::read_to_string(directory.path().join("stdin"))
+            .unwrap()
+            .contains("answer in four words or less"));
     }
 
     #[test]

--- a/crates/goose/src/providers/gemini_cli.rs
+++ b/crates/goose/src/providers/gemini_cli.rs
@@ -7,9 +7,7 @@ use std::sync::{Arc, OnceLock};
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::process::Command;
 
-use super::base::{
-    stream_from_single_message, MessageStream, Provider, ProviderDef, ProviderMetadata,
-};
+use super::base::{MessageStream, Provider, ProviderDef, ProviderMetadata};
 use super::cli_common::{error_from_event, extract_usage_tokens};
 use super::utils::filter_extensions_from_system_prompt;
 use crate::config::search_path::SearchPaths;
@@ -218,14 +216,6 @@ impl Provider for GeminiCliProvider {
         messages: &[Message],
         _tools: &[Tool],
     ) -> Result<MessageStream, ProviderError> {
-        if super::cli_common::is_session_description_request(system) {
-            let (message, provider_usage) = super::cli_common::generate_simple_session_description(
-                &model_config.model_name,
-                messages,
-            )?;
-            return Ok(stream_from_single_message(message, provider_usage));
-        }
-
         let GeminiCliProcess {
             mut child,
             mut reader,
@@ -469,5 +459,30 @@ printf '%s\n' '{"type":"result","stats":{}}'
     #[tokio::test]
     async fn resumed_prompt_is_sent_on_stdin() {
         assert_prompt_uses_stdin(true).await;
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn former_session_title_phrase_reaches_cli() {
+        let directory = tempfile::tempdir().unwrap();
+        let mut provider = make_provider();
+        provider.command = recording_cli(directory.path());
+
+        let mut stream = provider
+            .stream(
+                &ModelConfig::new(GEMINI_CLI_DEFAULT_MODEL),
+                "answer in four words or less",
+                &[Message::user().with_text("ordinary request")],
+                &[],
+            )
+            .await
+            .unwrap();
+        while let Some(item) = stream.next().await {
+            item.unwrap();
+        }
+
+        assert!(fs::read_to_string(directory.path().join("stdin"))
+            .unwrap()
+            .contains("answer in four words or less"));
     }
 }

--- a/crates/goose/src/session/session_manager.rs
+++ b/crates/goose/src/session/session_manager.rs
@@ -2860,6 +2860,8 @@ mod tests {
 
     struct StatefulNamingTestProvider;
 
+    struct LocalNamingTestProvider;
+
     #[async_trait::async_trait]
     impl Provider for NamingTestProvider {
         fn get_name(&self) -> &str {
@@ -2907,6 +2909,27 @@ mod tests {
         }
 
         fn manages_own_context(&self) -> bool {
+            true
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl Provider for LocalNamingTestProvider {
+        fn get_name(&self) -> &str {
+            "local-naming-test"
+        }
+
+        async fn stream(
+            &self,
+            _model_config: &ModelConfig,
+            _system: &str,
+            _messages: &[Message],
+            _tools: &[Tool],
+        ) -> Result<MessageStream, ProviderError> {
+            panic!("local session naming must not call the provider")
+        }
+
+        fn uses_local_session_naming(&self) -> bool {
             true
         }
     }
@@ -3334,6 +3357,41 @@ mod tests {
             .unwrap();
 
         assert_eq!(update.name, "investigate session naming with");
+    }
+
+    #[tokio::test]
+    async fn test_maybe_update_name_uses_local_name_for_stateless_provider() {
+        let temp_dir = TempDir::new().unwrap();
+        let sm = SessionManager::new(temp_dir.path().to_path_buf());
+        let session = sm
+            .create_session(
+                temp_dir.path().to_path_buf(),
+                "New Chat".to_string(),
+                SessionType::User,
+                GooseMode::default(),
+            )
+            .await
+            .unwrap();
+
+        sm.update(&session.id)
+            .model_config(ModelConfig::new("test-model"))
+            .apply()
+            .await
+            .unwrap();
+        sm.add_message(
+            &session.id,
+            &Message::user().with_text("investigate local naming without provider completion"),
+        )
+        .await
+        .unwrap();
+
+        let update = sm
+            .maybe_update_name(&session.id, Arc::new(LocalNamingTestProvider))
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(update.name, "investigate local naming without");
     }
 
     #[tokio::test]

--- a/crates/goose/src/session/session_naming.rs
+++ b/crates/goose/src/session/session_naming.rs
@@ -125,7 +125,7 @@ pub(crate) async fn generate_session_name(
         SESSION_NAME_SUFFIX,
     );
     let message = Message::user().with_text(&user_text);
-    let result = if provider.manages_own_context() {
+    let result = if provider.uses_local_session_naming() {
         crate::providers::cli_common::generate_simple_session_description(
             provider.get_name(),
             &[message],


### PR DESCRIPTION
## Summary

- replace magic-substring session-title detection with a dedicated provider capability used only by the trusted naming pipeline
- keep automatic naming local for Claude Code, Codex, Cursor Agent, and Gemini CLI without changing provider context-management behavior
- project source messages through message visibility and user-audience annotations before generating a local title
- add regressions proving former trigger phrases reach ordinary CLI inference and automatic naming does not invoke opted-in providers

## Verification

- `cargo test -p goose session_description --lib`
- `cargo test -p goose test_maybe_update_name_uses_local_name --lib`
- `cargo test -p goose session_naming_is_local --lib`
- `cargo test -p goose former_session_title_phrase_reaches_cli --lib`
- `cargo fmt --all -- --check`
- `cargo build -p goose`
- `cargo clippy -p goose --all-targets -- -D warnings`
- `git diff --check`
- independent exact-diff security review

_This finding was discovered by [Project Loupe](https://github.com/project-loupe/loupe)._
