### PR TITLE
fix: only report providers as configured when the user set them up

### DIFF
--- a/crates/goose/src/providers/githubcopilot.rs
+++ b/crates/goose/src/providers/githubcopilot.rs
@@ -185,6 +185,13 @@ impl DiskCache {
         Self { cache_path }
     }
 
+    fn has_state(&self) -> bool {
+        std::fs::read_to_string(&self.cache_path)
+            .ok()
+            .and_then(|contents| serde_json::from_str::<CopilotState>(&contents).ok())
+            .is_some()
+    }
+
     async fn load(&self) -> Option<CopilotState> {
         if let Ok(contents) = tokio::fs::read_to_string(&self.cache_path).await {
             if let Ok(info) = serde_json::from_str::<CopilotState>(&contents) {
@@ -229,6 +236,15 @@ pub struct GithubCopilotProvider {
 }
 
 impl GithubCopilotProvider {
+    pub(crate) fn has_oauth_state() -> bool {
+        let host = normalize_host(
+            &Config::global()
+                .get_param::<String>("GITHUB_COPILOT_HOST")
+                .unwrap_or_else(|_| DEFAULT_GITHUB_HOST.to_string()),
+        );
+        DiskCache::new(&host).has_state()
+    }
+
     pub async fn cleanup() -> Result<()> {
         let config = Config::global();
         let host = normalize_host(

--- a/crates/goose/src/providers/init.rs
+++ b/crates/goose/src/providers/init.rs
@@ -87,7 +87,18 @@ async fn init_registry() -> RwLock<ProviderRegistry> {
             false,
             Some(registrations::claude_acp_inventory()),
         );
-        registry.register::<ClaudeCodeProvider>(true);
+        registry.register_with_inventory::<ClaudeCodeProvider>(
+            true,
+            Some(registrations::cli_agent_inventory(
+                || {
+                    crate::config::Config::global()
+                        .get_claude_code_command()
+                        .unwrap_or_default()
+                        .into()
+                },
+                false,
+            )),
+        );
         registry.register_with_inventory::<CodexAcpProvider>(
             false,
             Some(registrations::codex_acp_inventory()),
@@ -96,10 +107,29 @@ async fn init_registry() -> RwLock<ProviderRegistry> {
             false,
             Some(registrations::copilot_acp_inventory()),
         );
-        registry.register::<CodexProvider>(true);
+        registry.register_with_inventory::<CodexProvider>(
+            true,
+            Some(registrations::cli_agent_inventory(
+                || {
+                    crate::config::Config::global()
+                        .get_codex_command()
+                        .unwrap_or_default()
+                        .into()
+                },
+                false,
+            )),
+        );
         registry.register_with_inventory::<CursorAgentProvider>(
             false,
-            Some(registrations::refresh_only()),
+            Some(registrations::cli_agent_inventory(
+                || {
+                    crate::config::Config::global()
+                        .get_cursor_agent_command()
+                        .unwrap_or_default()
+                        .into()
+                },
+                true,
+            )),
         );
         registry.register_with_inventory::<DatabricksProviderDef>(
             true,
@@ -113,14 +143,25 @@ async fn init_registry() -> RwLock<ProviderRegistry> {
             false,
             Some(registrations::refresh_only()),
         );
-        registry.register::<GeminiCliProvider>(false);
+        registry.register_with_inventory::<GeminiCliProvider>(
+            false,
+            Some(registrations::cli_agent_inventory(
+                || {
+                    crate::config::Config::global()
+                        .get_gemini_cli_command()
+                        .unwrap_or_default()
+                        .into()
+                },
+                false,
+            )),
+        );
         registry.register_with_inventory::<GeminiOAuthProvider>(
             false,
             Some(registrations::gemini_oauth_inventory()),
         );
         registry.register_with_inventory::<GithubCopilotProvider>(
             false,
-            Some(registrations::refresh_only()),
+            Some(registrations::github_copilot_inventory()),
         );
         registry.register::<GondolaProvider>(false);
         registry.register_with_inventory::<GoogleProviderDef>(

--- a/crates/goose/src/providers/inventory/mod.rs
+++ b/crates/goose/src/providers/inventory/mod.rs
@@ -899,20 +899,37 @@ pub fn default_inventory_identity(
     identity
 }
 
-pub fn default_inventory_configured(config_keys: &[ConfigKey], config: &Config) -> bool {
-    config_keys.iter().all(|key| {
-        if !key.required {
-            return true;
-        }
-        if key.default.is_some() {
-            return true;
-        }
+/// A provider is configured when the user supplied its configuration, not merely
+/// when its declared defaults would let it construct. `declaration_is_configuration`
+/// is set for authless custom providers, whose declaration carries the base URL and
+/// models and so is itself the user-supplied configuration.
+pub fn default_inventory_configured(
+    provider_id: &str,
+    config_keys: &[ConfigKey],
+    config: &Config,
+    declaration_is_configuration: bool,
+) -> bool {
+    let has_value = |key: &ConfigKey| {
         if key.secret {
             config.get_secret::<serde_json::Value>(&key.name).is_ok()
         } else {
             config.get_param::<serde_json::Value>(&key.name).is_ok()
         }
-    })
+    };
+
+    let required_keys_satisfied = config_keys
+        .iter()
+        .all(|key| !key.required || key.default.is_some() || has_value(key));
+    if !required_keys_satisfied {
+        return false;
+    }
+
+    if crate::config::get_provider_entry(config, provider_id).is_some_and(|entry| entry.configured)
+    {
+        return true;
+    }
+
+    declaration_is_configuration || config_keys.iter().any(has_value)
 }
 
 pub fn declarative_inventory_identity(
@@ -1443,5 +1460,133 @@ mod tests {
 
         assert_eq!(models.len(), 1);
         assert_eq!(models[0].id, "gpt-5.6");
+    }
+
+    struct TestConfig {
+        config: Config,
+        _config_file: tempfile::NamedTempFile,
+        _secrets_file: tempfile::NamedTempFile,
+    }
+
+    impl std::ops::Deref for TestConfig {
+        type Target = Config;
+
+        fn deref(&self) -> &Config {
+            &self.config
+        }
+    }
+
+    fn test_config() -> TestConfig {
+        let config_file = tempfile::NamedTempFile::new().unwrap();
+        let secrets_file = tempfile::NamedTempFile::new().unwrap();
+        let config =
+            Config::new_with_file_secrets(config_file.path(), secrets_file.path()).unwrap();
+        TestConfig {
+            config,
+            _config_file: config_file,
+            _secrets_file: secrets_file,
+        }
+    }
+
+    #[test]
+    fn defaulted_and_keyless_providers_are_not_configured() {
+        let config = test_config();
+        let defaulted = vec![ConfigKey::new(
+            "GOOSE_TEST_COMMAND",
+            true,
+            false,
+            Some("some-binary"),
+            true,
+        )];
+
+        assert!(!default_inventory_configured(
+            "defaulted",
+            &defaulted,
+            &config,
+            false
+        ));
+        assert!(!default_inventory_configured(
+            "no_keys",
+            &[],
+            &config,
+            false
+        ));
+    }
+
+    #[test]
+    fn authless_declaration_counts_as_configuration() {
+        let config = test_config();
+
+        assert!(default_inventory_configured("authless", &[], &config, true));
+    }
+
+    #[test]
+    fn a_stored_value_makes_a_provider_configured() {
+        let config = test_config();
+        let api_key = vec![ConfigKey::new("GOOSE_TEST_API_KEY", true, true, None, true)];
+
+        assert!(!default_inventory_configured(
+            "secret", &api_key, &config, false
+        ));
+
+        config
+            .set_secret("GOOSE_TEST_API_KEY", &"sk-test".to_string())
+            .unwrap();
+
+        assert!(default_inventory_configured(
+            "secret", &api_key, &config, false
+        ));
+    }
+
+    #[test]
+    fn missing_required_keys_outrank_the_configured_marker() {
+        let config = test_config();
+        let api_key = vec![ConfigKey::new("GOOSE_TEST_API_KEY", true, true, None, true)];
+        crate::config::set_provider_entry(
+            &config,
+            "secret",
+            &crate::config::ProviderEntry {
+                enabled: true,
+                model: "some-model".to_string(),
+                configured: true,
+            },
+        )
+        .unwrap();
+
+        assert!(!default_inventory_configured(
+            "secret", &api_key, &config, false
+        ));
+        assert!(!default_inventory_configured(
+            "secret", &api_key, &config, true
+        ));
+    }
+
+    #[test]
+    fn an_explicit_selection_configures_a_defaulted_provider() {
+        let config = test_config();
+        let defaulted = vec![ConfigKey::new(
+            "GOOSE_TEST_COMMAND",
+            true,
+            false,
+            Some("some-binary"),
+            true,
+        )];
+        crate::config::set_provider_entry(
+            &config,
+            "defaulted",
+            &crate::config::ProviderEntry {
+                enabled: true,
+                model: "some-model".to_string(),
+                configured: true,
+            },
+        )
+        .unwrap();
+
+        assert!(default_inventory_configured(
+            "defaulted",
+            &defaulted,
+            &config,
+            false
+        ));
     }
 }

--- a/crates/goose/src/providers/inventory/registrations.rs
+++ b/crates/goose/src/providers/inventory/registrations.rs
@@ -12,6 +12,7 @@ use crate::providers::codex_acp::CODEX_ACP_PROVIDER_NAME;
 use crate::providers::copilot_acp::{COPILOT_ACP_BINARY, COPILOT_ACP_PROVIDER_NAME};
 use crate::providers::formats::anthropic::ANTHROPIC_PROVIDER_NAME;
 use crate::providers::gemini_oauth::TokenCache as GeminiOAuthTokenCache;
+use crate::providers::githubcopilot::GithubCopilotProvider;
 use crate::providers::google::{GOOGLE_API_HOST, GOOGLE_PROVIDER_NAME};
 use crate::providers::huggingface::HuggingFaceProvider;
 use crate::providers::huggingface_auth;
@@ -187,6 +188,10 @@ pub fn huggingface_inventory() -> InventoryRegistration {
     .with_configured(|| huggingface_auth::has_configured_token().unwrap_or(false))
 }
 
+pub fn github_copilot_inventory() -> InventoryRegistration {
+    refresh_only().with_configured(GithubCopilotProvider::has_oauth_state)
+}
+
 pub fn refresh_only() -> InventoryRegistration {
     InventoryRegistration {
         supports_refresh: true,
@@ -239,6 +244,21 @@ pub fn acp_inventory(
     .with_configured(move || acp_adapter_installed(command))
 }
 
+/// CLI agent providers declare a required command key with a default, so the command
+/// resolves without any stored config. Having that command installed is what makes the
+/// provider usable, so it stands in for user-supplied configuration.
+pub fn cli_agent_inventory(
+    command: impl Fn() -> String + Send + Sync + 'static,
+    supports_refresh: bool,
+) -> InventoryRegistration {
+    InventoryRegistration {
+        supports_refresh,
+        identity: default_inventory_identity_resolver(),
+        configured: None,
+    }
+    .with_configured(move || acp_adapter_installed(&command()))
+}
+
 pub fn amp_acp_inventory() -> InventoryRegistration {
     acp_inventory(AMP_ACP_PROVIDER_NAME, AMP_ACP_BINARY, false)
 }
@@ -287,6 +307,55 @@ mod tests {
             Some("https://hub.services.ai.azure.com"),
             None,
         ));
+    }
+
+    #[test]
+    fn cli_agent_inventory_configured_tracks_command_installation() {
+        let missing = cli_agent_inventory(|| "goose-cli-agent-not-installed".to_string(), false);
+        let configured = missing
+            .configured
+            .expect("CLI agent should define configured resolver");
+        assert!(!configured());
+
+        let installed = cli_agent_inventory(|| "sh".to_string(), false);
+        let configured = installed
+            .configured
+            .expect("CLI agent should define configured resolver");
+        assert!(configured());
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn github_copilot_inventory_configured_uses_oauth_state() {
+        let root = tempfile::tempdir().unwrap();
+        let root_path = root.path().to_string_lossy().to_string();
+        let _guard = env_lock::lock_env([("GOOSE_PATH_ROOT", Some(root_path.as_str()))]);
+
+        let registration = github_copilot_inventory();
+        let configured = registration
+            .configured
+            .expect("GitHub Copilot should define configured resolver");
+
+        assert!(!configured());
+
+        let cache_path = Paths::in_config_dir("githubcopilot/info.json");
+        std::fs::create_dir_all(cache_path.parent().unwrap()).unwrap();
+        std::fs::write(
+            cache_path,
+            serde_json::to_string(&serde_json::json!({
+                "expires_at": (Utc::now() + chrono::Duration::hours(1)).to_rfc3339(),
+                "info": {
+                    "token": "copilot-token",
+                    "expires_at": (Utc::now() + chrono::Duration::hours(1)).timestamp(),
+                    "refresh_in": 1500,
+                    "endpoints": { "api": "https://api.githubcopilot.com" },
+                },
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        assert!(configured());
     }
 
     #[test]

--- a/crates/goose/src/providers/inventory/resolver.rs
+++ b/crates/goose/src/providers/inventory/resolver.rs
@@ -66,8 +66,10 @@ impl InventoryResolvers {
         });
 
         let config_keys = metadata.config_keys.clone();
-        let default_configured =
-            Arc::new(move || default_inventory_configured(&config_keys, Config::global()));
+        let provider_id = metadata.name.clone();
+        let default_configured = Arc::new(move || {
+            default_inventory_configured(&provider_id, &config_keys, Config::global(), false)
+        });
 
         match registration {
             Some(registration) => Self {

--- a/crates/goose/src/providers/provider_registry.rs
+++ b/crates/goose/src/providers/provider_registry.rs
@@ -285,10 +285,14 @@ impl ProviderRegistry {
             deprecated: None,
         };
         let inventory_config_keys = custom_metadata.config_keys.clone();
+        let inventory_provider_id = custom_metadata.name.clone();
+        let declaration_is_configuration = !config.requires_auth || config.auth.is_some();
         let default_inventory_configured = Arc::new(move || {
             super::inventory::default_inventory_configured(
+                &inventory_provider_id,
                 &inventory_config_keys,
                 crate::config::Config::global(),
+                declaration_is_configuration,
             )
         });
 


### PR DESCRIPTION
Fixes: https://github.com/aaif-goose/goose/issues/11331

## Summary
* Before, we had some false positives on providers looking configured if every config key had a default value
* This makes it so we check `ProviderEntry.configured`
* Things appear configured if the user supplied at least one key
 
### Testing
Local desktop run

### Related Issues
https://github.com/aaif-goose/goose/issues/11331

### Screenshots/Demos (for UX changes)
N/A - It just shows the correct ones configured now 