### PR TITLE
Fix/gdk pypi direct publish

### DIFF
--- a/.github/workflows/gdk-release.yml
+++ b/.github/workflows/gdk-release.yml
@@ -82,12 +82,31 @@ jobs:
       publish: true
     secrets: inherit
 
-  pypi:
-    name: Publish Python wheels
+  python-wheels:
+    name: Build Python wheels
     needs: validate-version
     permissions:
       contents: read
-      id-token: write
     uses: ./.github/workflows/python-sdk-wheels.yml
-    with:
-      publish: true
+
+  pypi:
+    name: Publish Python wheels to PyPI
+    needs: python-wheels
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Download wheel artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          pattern: goose-sdk-wheel-*
+          path: dist
+          merge-multiple: true
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
+        with:
+          packages-dir: dist
+          skip-existing: true

--- a/.github/workflows/python-sdk-wheels.yml
+++ b/.github/workflows/python-sdk-wheels.yml
@@ -2,23 +2,10 @@ name: Python GDK Wheels
 
 on:
   workflow_call:
-    inputs:
-      publish:
-        description: "Publish wheels to PyPI after building"
-        required: false
-        default: false
-        type: boolean
   workflow_dispatch:
-    inputs:
-      publish:
-        description: "Publish wheels to PyPI after building"
-        required: true
-        default: false
-        type: boolean
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   build-wheels:
@@ -106,23 +93,3 @@ jobs:
           name: goose-sdk-wheel-${{ matrix.name }}
           path: crates/goose-sdk/python/dist/*.whl
           if-no-files-found: error
-
-  publish:
-    name: Publish wheels to PyPI
-    needs: build-wheels
-    runs-on: ubuntu-latest
-    if: inputs.publish
-    environment: pypi
-    steps:
-      - name: Download wheel artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          pattern: goose-sdk-wheel-*
-          path: dist
-          merge-multiple: true
-
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
-        with:
-          packages-dir: dist
-          skip-existing: true


### PR DESCRIPTION
don't publish from a reusable workflow, as that doesn't work properly with the trusted publishing in pypi