### PR TITLE
fix gdk kotlin example

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,17 @@ jobs:
         env:
           RUST_MIN_STACK: 8388608
 
+  kotlin-gdk-smoke-test:
+    name: Test Kotlin GDK package
+    needs: changes
+    if: needs.changes.outputs.code == 'true' || github.event_name != 'pull_request'
+    permissions:
+      contents: read
+    uses: ./.github/workflows/maven-sdk.yml
+    with:
+      publish: false
+      smoke-test: true
+
   rust-build-and-test-tls:
     name: Build and Test TLS Backend (${{ matrix.tls-feature }})
     runs-on: ubuntu-latest

--- a/.github/workflows/gdk-release.yml
+++ b/.github/workflows/gdk-release.yml
@@ -80,6 +80,7 @@ jobs:
     uses: ./.github/workflows/maven-sdk.yml
     with:
       publish: true
+      smoke-test: false
     secrets: inherit
 
   python-wheels:

--- a/.github/workflows/maven-sdk.yml
+++ b/.github/workflows/maven-sdk.yml
@@ -8,12 +8,22 @@ on:
         required: false
         default: false
         type: boolean
+      smoke-test:
+        description: "Run the Kotlin GDK smoke test"
+        required: false
+        default: true
+        type: boolean
   workflow_dispatch:
     inputs:
       publish:
         description: "Publish gdk to Maven Central after building"
         required: true
         default: false
+        type: boolean
+      smoke-test:
+        description: "Run the Kotlin GDK smoke test"
+        required: true
+        default: true
         type: boolean
 
 permissions:
@@ -146,6 +156,7 @@ jobs:
   smoke-test-linux-aarch64:
     name: Smoke test Kotlin GDK (linux-aarch64)
     needs: package
+    if: inputs.smoke-test
     runs-on: ubuntu-22.04-arm
     steps:
       - name: Checkout code
@@ -192,7 +203,7 @@ jobs:
     name: Publish to Maven Central
     needs: [package, smoke-test-linux-aarch64]
     runs-on: ubuntu-latest
-    if: inputs.publish
+    if: inputs.publish && always() && needs.package.result == 'success' && (!inputs.smoke-test || needs.smoke-test-linux-aarch64.result == 'success')
     environment: maven-central
     concurrency:
       group: gdk-maven-release-${{ needs.package.outputs.version }}

--- a/.github/workflows/maven-sdk.yml
+++ b/.github/workflows/maven-sdk.yml
@@ -203,7 +203,7 @@ jobs:
     name: Publish to Maven Central
     needs: [package, smoke-test-linux-aarch64]
     runs-on: ubuntu-latest
-    if: inputs.publish && always() && needs.package.result == 'success' && (!inputs.smoke-test || needs.smoke-test-linux-aarch64.result == 'success')
+    if: inputs.publish && !cancelled() && needs.package.result == 'success' && (!inputs.smoke-test || needs.smoke-test-linux-aarch64.result == 'success')
     environment: maven-central
     concurrency:
       group: gdk-maven-release-${{ needs.package.outputs.version }}

--- a/crates/goose-sdk/examples/uniffi/kotlin/src/main/kotlin/Main.kt
+++ b/crates/goose-sdk/examples/uniffi/kotlin/src/main/kotlin/Main.kt
@@ -39,6 +39,8 @@ fun main() = runBlocking {
                 is StreamChunk.EndChunk -> chunk.usage?.let { println("\nusage: $it") }
                 is StreamChunk.ErrorChunk -> System.err.println("\nerror: ${chunk.error.message}")
                 is StreamChunk.ToolChunk -> Unit
+                is StreamChunk.ThinkingChunk -> Unit
+                is StreamChunk.RedactedThinkingChunk -> Unit
             }
         }
     println()


### PR DESCRIPTION
The example wasn't compiled anywhere other than a release check, so we didn't catch it before. This moves that release check into normal CI, and fixes the error