### PR TITLE
fix(anthropic): preserved-thinking compliance for the provider layer

### DIFF
--- a/crates/goose-agent/src/inference.rs
+++ b/crates/goose-agent/src/inference.rs
@@ -148,6 +148,16 @@ pub fn chat_span(
     span
 }
 
+fn is_empty_response(message: &Message) -> bool {
+    message.content.iter().all(|content| match content {
+        MessageContent::Text(text) => text.text.trim().is_empty(),
+        MessageContent::Thinking(thinking) => {
+            thinking.thinking.trim().is_empty() && thinking.signature.is_empty()
+        }
+        _ => false,
+    })
+}
+
 fn record_request_params(span: &tracing::Span, model_config: &ModelConfig) {
     if let Some(temperature) = model_config.temperature {
         span.record("gen_ai.request.temperature", temperature as f64);
@@ -499,13 +509,7 @@ impl<S: Sync, E: InferenceEffect> Inference<S, E> for InferenceRunner<'_, S, E> 
                 && !accumulator
                     .iter()
                     .any(|message| message.metadata.output_token_limit_reached)
-                && accumulator.iter().all(|message| {
-                    message.content.iter().all(|content| match content {
-                        MessageContent::Text(text) => text.text.trim().is_empty(),
-                        MessageContent::Thinking(thinking) => thinking.thinking.trim().is_empty(),
-                        _ => false,
-                    })
-                });
+                && accumulator.iter().all(is_empty_response);
             if empty_response {
                 let message = Message::assistant().with_text(EMPTY_RESPONSE_MESSAGE);
                 let message = emit.message(message).await;
@@ -596,5 +600,15 @@ mod tests {
         );
 
         assert!(cancellation_response(&[request, response], &[]).is_none());
+    }
+
+    #[test]
+    fn signed_thinking_without_text_is_not_an_empty_response() {
+        assert!(is_empty_response(
+            &Message::assistant().with_content(MessageContent::thinking("", ""))
+        ));
+        assert!(!is_empty_response(
+            &Message::assistant().with_content(MessageContent::thinking("", "sig-omitted"))
+        ));
     }
 }

--- a/crates/goose-cli/src/session/output.rs
+++ b/crates/goose-cli/src/session/output.rs
@@ -561,7 +561,7 @@ fn should_show_thinking() -> bool {
 }
 
 fn render_thinking(text: &str, theme: Theme) {
-    if should_show_thinking() {
+    if should_show_thinking() && !text.is_empty() {
         println!("\n{}", style("Thinking:").dim().italic());
         print_markdown(text, theme);
     }
@@ -573,7 +573,7 @@ fn render_thinking_streaming(
     header_shown: &mut bool,
     theme: Theme,
 ) {
-    if should_show_thinking() {
+    if should_show_thinking() && !text.is_empty() {
         flush_markdown_buffer(buffer, theme);
         if !*header_shown {
             println!("\n{}", style("Thinking:").dim().italic());

--- a/crates/goose-provider-types/src/canonical/data/canonical_models.json
+++ b/crates/goose-provider-types/src/canonical/data/canonical_models.json
@@ -20224,6 +20224,7 @@
     "family": "claude-fable",
     "attachment": true,
     "reasoning": true,
+    "thinking_mode": "always_on_adaptive",
     "tool_call": true,
     "temperature": false,
     "knowledge": "2026-06",

--- a/crates/goose-provider-types/src/canonical/name_builder.rs
+++ b/crates/goose-provider-types/src/canonical/name_builder.rs
@@ -16,7 +16,7 @@ static STRIP_PATTERNS: Lazy<Vec<Regex>> = Lazy::new(|| {
 });
 
 static CLAUDE_PATTERNS: Lazy<Vec<(Regex, Regex, &'static str)>> = Lazy::new(|| {
-    ["sonnet", "opus", "haiku"]
+    ["sonnet", "opus", "haiku", "fable"]
         .iter()
         .map(|&size| {
             (

--- a/crates/goose-provider-types/src/formats/anthropic.rs
+++ b/crates/goose-provider-types/src/formats/anthropic.rs
@@ -51,6 +51,11 @@ macro_rules! string_enum {
 string_enum!(ThinkingType { Adaptive => "adaptive", Enabled => "enabled", Disabled => "disabled" });
 string_enum!(CacheTtl { FiveMinutes => "5m", OneHour => "1h" });
 
+string_enum!(PrefixMismatchBehavior { DropBlock => "drop_block", Error => "error" });
+
+pub const THINKING_BINDING_CONTROLS_BETA: &str = "thinking-binding-controls-2026-08-01";
+pub const INPUT_TRANSFORMATIONS_FIELD: &str = "input_transformations";
+
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct AnthropicFormatOptions {
     pub preserve_unsigned_thinking: bool,
@@ -60,9 +65,19 @@ pub struct AnthropicFormatOptions {
     pub current_model: Option<String>,
     pub prompt_cache_disabled: bool,
     pub cache_ttl: Option<CacheTtl>,
+    pub prefix_mismatch_behavior: Option<PrefixMismatchBehavior>,
+    pub strip_thinking_history: bool,
 }
 
 impl AnthropicFormatOptions {
+    /// Anthropic-compatible providers keep `Default`, which does not request block binding.
+    pub fn native() -> Self {
+        Self {
+            prefix_mismatch_behavior: Some(PrefixMismatchBehavior::DropBlock),
+            ..Self::default()
+        }
+    }
+
     fn for_model(self, model_config: &ModelConfig) -> Self {
         let preserve_thinking_context = model_config
             .request_param::<bool>("preserve_thinking_context")
@@ -80,6 +95,14 @@ impl AnthropicFormatOptions {
             .cache_ttl()
             .and_then(|ttl| ttl.parse::<CacheTtl>().ok())
             .or(self.cache_ttl);
+        let prefix_mismatch_behavior = match model_config
+            .request_param::<String>("prefix_mismatch_behavior")
+            .as_deref()
+        {
+            None => self.prefix_mismatch_behavior,
+            Some("off") => None,
+            Some(value) => value.parse().ok().or(self.prefix_mismatch_behavior),
+        };
 
         Self {
             preserve_unsigned_thinking,
@@ -91,6 +114,8 @@ impl AnthropicFormatOptions {
                 .or_else(|| Some(model_config.model_name.clone())),
             prompt_cache_disabled: model_config.prompt_cache_disabled(),
             cache_ttl,
+            prefix_mismatch_behavior,
+            strip_thinking_history: self.strip_thinking_history,
         }
     }
 
@@ -248,6 +273,8 @@ fn format_messages_with_options(
         };
 
         let thinking_is_stale = thinking_block_is_stale(message, options.current_model.as_deref());
+        let replay_thinking =
+            !options.thinking_disabled && !options.strip_thinking_history && !thinking_is_stale;
 
         let mut content = Vec::new();
         for msg_content in &message.content {
@@ -401,15 +428,13 @@ fn format_messages_with_options(
                 }
                 MessageContentBlock::Thinking(thinking) => {
                     // Anthropic rejects thinking blocks sent without a matching thinking config.
-                    if !options.thinking_disabled {
+                    if replay_thinking {
                         if !thinking.signature.is_empty() {
-                            if !thinking_is_stale {
-                                content.push(json!({
-                                    TYPE_FIELD: THINKING_TYPE,
-                                    THINKING_TYPE: thinking.thinking,
-                                    SIGNATURE_FIELD: thinking.signature
-                                }));
-                            }
+                            content.push(json!({
+                                TYPE_FIELD: THINKING_TYPE,
+                                THINKING_TYPE: thinking.thinking,
+                                SIGNATURE_FIELD: thinking.signature
+                            }));
                         } else if options.preserve_unsigned_thinking
                             && !thinking.thinking.is_empty()
                         {
@@ -421,7 +446,7 @@ fn format_messages_with_options(
                     }
                 }
                 MessageContentBlock::RedactedThinking(redacted) => {
-                    if !options.thinking_disabled && !thinking_is_stale {
+                    if replay_thinking {
                         content.push(json!({
                             TYPE_FIELD: REDACTED_THINKING_TYPE,
                             DATA_FIELD: redacted.data
@@ -688,6 +713,24 @@ pub fn get_usage(data: &Value) -> Result<Usage> {
 /// Anthropic response fields that have no canonical `ProviderUsage` equivalent.
 const ADDITIONAL_USAGE_FIELDS: [&str; 1] = ["service_tier"];
 
+pub fn input_transformations(message_data: &Value) -> Option<Value> {
+    let transformations = message_data.get(INPUT_TRANSFORMATIONS_FIELD)?.as_array()?;
+    let dropped: Vec<(&str, &str)> = transformations
+        .iter()
+        .filter(|t| t.get("type").and_then(|v| v.as_str()) == Some("thinking_dropped"))
+        .map(|t| {
+            (
+                t.get("path").and_then(Value::as_str).unwrap_or(""),
+                t.get("reason").and_then(Value::as_str).unwrap_or(""),
+            )
+        })
+        .collect();
+    if !dropped.is_empty() {
+        tracing::warn!(?dropped, "API dropped thinking blocks from the request");
+    }
+    Some(Value::Array(transformations.clone()))
+}
+
 pub fn get_additional_data(data: &Value) -> Option<Map<String, Value>> {
     let usage = data.get("usage")?.as_object()?;
     let additional: Map<String, Value> = ADDITIONAL_USAGE_FIELDS
@@ -809,6 +852,33 @@ fn apply_thinking_config(
     {
         obj.insert("thinking".to_string(), json!({"type": "disabled"}));
     }
+
+    // `block_binding` is only accepted alongside adaptive or enabled thinking.
+    if let Some(behavior) = options.prefix_mismatch_behavior {
+        if let Some(thinking) = obj.get_mut("thinking").and_then(|t| t.as_object_mut()) {
+            if thinking.get("type").and_then(|t| t.as_str()) != Some("disabled") {
+                thinking.insert(
+                    "block_binding".to_string(),
+                    json!({"prefix_mismatch_behavior": behavior.to_string()}),
+                );
+            }
+        }
+    }
+}
+
+pub fn block_binding_behavior(payload: &Value) -> Option<PrefixMismatchBehavior> {
+    payload
+        .pointer("/thinking/block_binding/prefix_mismatch_behavior")
+        .and_then(Value::as_str)
+        .and_then(|behavior| behavior.parse().ok())
+}
+
+pub fn is_thinking_signature_error(message: &str) -> bool {
+    let lower = message.to_lowercase();
+    lower.contains("thinking")
+        && (lower.contains("signature")
+            || lower.contains("cannot be modified")
+            || lower.contains("block_binding"))
 }
 
 pub fn create_request(
@@ -973,6 +1043,11 @@ where
                 EVENT_MESSAGE_START => {
                     if let Some(message_data) = event.data.get("message") {
                         additional_data = get_additional_data(message_data);
+                        if let Some(transformations) = input_transformations(message_data) {
+                            additional_data
+                                .get_or_insert_with(Map::new)
+                                .insert(INPUT_TRANSFORMATIONS_FIELD.to_string(), transformations);
+                        }
                         if let Some(id) = message_data.get("id").and_then(|v| v.as_str()) {
                             message_id = Some(id.to_string());
                         }
@@ -1067,7 +1142,8 @@ where
                 }
                 EVENT_CONTENT_BLOCK_STOP => {
                     if let Some(state) = thinking.take() {
-                        if !state.text.is_empty() {
+                        // Omitted thinking arrives as an empty string with a signature and must still be replayed.
+                        if !state.text.is_empty() || !state.signature.is_empty() {
                             let mut message = Message::assistant()
                                 .with_thinking(state.text, state.signature);
                             message.id = message_id.clone();
@@ -1537,6 +1613,22 @@ mod tests {
                 resolved_model: None,
                 provider_session_id: None,
             })
+    }
+
+    #[test]
+    fn strip_thinking_history_removes_signed_blocks() {
+        let messages = vec![Message::assistant()
+            .with_content(MessageContent::thinking("", "sig"))
+            .with_text("answer")];
+        let opts = AnthropicFormatOptions {
+            strip_thinking_history: true,
+            ..Default::default()
+        };
+        let spec = format_messages_with_options(&messages, &opts);
+        assert_eq!(
+            spec[0]["content"],
+            json!([{"type": "text", "text": "answer"}])
+        );
     }
 
     #[test]

--- a/crates/goose-provider-types/src/retry.rs
+++ b/crates/goose-provider-types/src/retry.rs
@@ -95,6 +95,7 @@ fn is_permanent_request_failure(message: &str) -> bool {
     PERMANENT_REQUEST_FAILURE_MARKERS
         .iter()
         .any(|marker| message.contains(marker))
+        || crate::formats::anthropic::is_thinking_signature_error(message)
 }
 
 pub fn should_retry(error: &ProviderError, config: &RetryConfig) -> bool {
@@ -292,6 +293,9 @@ mod tests {
         ));
         assert!(is_permanent_request_failure(
             "These blocks must remain as they were in the original response."
+        ));
+        assert!(is_permanent_request_failure(
+            "messages.1.content.0: Invalid `signature` in `thinking` block."
         ));
         assert!(!is_permanent_request_failure(
             "Bad request (400): model not found"

--- a/crates/goose-providers/src/anthropic.rs
+++ b/crates/goose-providers/src/anthropic.rs
@@ -8,7 +8,7 @@ use async_stream::try_stream;
 use async_trait::async_trait;
 use futures::TryStreamExt;
 use reqwest::StatusCode;
-use serde_json::Value;
+use serde_json::{json, Value};
 use std::io;
 use tokio::pin;
 use tokio_util::io::StreamReader;
@@ -16,8 +16,9 @@ use tokio_util::io::StreamReader;
 use super::api_client::ApiClient;
 use super::base::{ConfigKey, MessageStream, ModelInfo, Provider, ProviderMetadata};
 use super::formats::anthropic::{
-    create_request_for_model, response_to_streaming_message, AnthropicFormatOptions,
-    ANTHROPIC_PROVIDER_NAME,
+    block_binding_behavior, create_request_for_model, is_thinking_signature_error,
+    response_to_streaming_message, AnthropicFormatOptions, PrefixMismatchBehavior,
+    ANTHROPIC_PROVIDER_NAME, INPUT_TRANSFORMATIONS_FIELD, THINKING_BINDING_CONTROLS_BETA,
 };
 use super::openai_compatible::handle_status;
 use super::retry::ProviderRetry;
@@ -27,6 +28,7 @@ use rmcp::model::Tool;
 
 pub const ANTHROPIC_DEFAULT_MODEL: &str = "claude-sonnet-4-5";
 const ANTHROPIC_KNOWN_MODELS: &[&str] = &[
+    "claude-fable-5-1",
     "claude-opus-5",
     "claude-sonnet-5",
     "claude-fable-5",
@@ -162,6 +164,47 @@ impl AnthropicProviderBuilder {
 }
 
 impl AnthropicProvider {
+    fn streaming_payload(
+        &self,
+        model_config: &ModelConfig,
+        wire_model: &str,
+        system: &str,
+        messages: &[Message],
+        tools: &[Tool],
+        format_options: AnthropicFormatOptions,
+    ) -> Result<Value, ProviderError> {
+        let mut payload = create_request_for_model(
+            ANTHROPIC_PROVIDER_NAME,
+            model_config,
+            wire_model,
+            system,
+            messages,
+            tools,
+            format_options,
+        )?;
+        payload["stream"] = Value::Bool(true);
+        Ok(payload)
+    }
+
+    async fn post_messages(
+        &self,
+        model_config: &ModelConfig,
+        payload: &Value,
+    ) -> Result<reqwest::Response, ProviderError> {
+        let beta_header = beta_header_value(&self.api_client, model_config, payload);
+        self.with_retry(|| async {
+            let mut request = self
+                .api_client
+                .request("v1/messages")
+                .model_headers(model_config)?;
+            if let Some(beta) = &beta_header {
+                request = request.header("anthropic-beta", beta)?;
+            }
+            handle_status(request.streaming(true).response_post(payload).await?).await
+        })
+        .await
+    }
+
     pub async fn stream_for_model(
         &self,
         model_config: &ModelConfig,
@@ -170,8 +213,7 @@ impl AnthropicProvider {
         messages: &[Message],
         tools: &[Tool],
     ) -> Result<MessageStream, ProviderError> {
-        let mut payload = create_request_for_model(
-            ANTHROPIC_PROVIDER_NAME,
+        let payload = self.streaming_payload(
             model_config,
             wire_model,
             system,
@@ -179,24 +221,33 @@ impl AnthropicProvider {
             tools,
             self.format_options.clone(),
         )?;
-        payload["stream"] = Value::Bool(true);
         let mut log = start_log(model_config, &payload)?;
-        let response = self
-            .with_retry(|| async {
-                handle_status(
-                    self.api_client
-                        .request("v1/messages")
-                        .model_headers(model_config)?
-                        .streaming(true)
-                        .response_post(&payload)
-                        .await?,
-                )
-                .await
-            })
-            .await
-            .inspect_err(|e| {
-                let _ = log.error(e);
-            })?;
+        let response = match self.post_messages(model_config, &payload).await {
+            Err(ProviderError::RequestFailed(message))
+                if is_thinking_signature_error(&message)
+                    && !self.format_options.strip_thinking_history
+                    && block_binding_behavior(&payload) != Some(PrefixMismatchBehavior::Error) =>
+            {
+                tracing::warn!(
+                    error = %message,
+                    "API rejected replayed thinking blocks; retrying once with thinking history stripped. \
+                     The rejected blocks stay in the session, so later requests may repeat this retry"
+                );
+                let _ = log.error(&message);
+                let stripped = AnthropicFormatOptions {
+                    strip_thinking_history: true,
+                    ..self.format_options.clone()
+                };
+                let payload =
+                    self.streaming_payload(model_config, wire_model, system, messages, tools, stripped)?;
+                log = start_log(model_config, &payload)?;
+                self.post_messages(model_config, &payload).await
+            }
+            other => other,
+        }
+        .inspect_err(|e| {
+            let _ = log.error(e);
+        })?;
         let stream = response.bytes_stream().map_err(io::Error::other);
         Ok(Box::pin(try_stream! {
             let reader = StreamReader::new(stream);
@@ -205,6 +256,13 @@ impl AnthropicProvider {
             pin!(messages);
             while let Some(message) = futures::StreamExt::next(&mut messages).await {
                 let (message, usage) = message.map_err(ProviderError::from_stream_error)?;
+                if let Some(transformations) = usage
+                    .as_ref()
+                    .and_then(|usage| usage.additional_data.as_ref())
+                    .and_then(|data| data.get(INPUT_TRANSFORMATIONS_FIELD))
+                {
+                    log.write(&json!({ INPUT_TRANSFORMATIONS_FIELD: transformations }), None)?;
+                }
                 log.write(&message, usage.as_ref().map(|f| f.usage).as_ref())?;
                 yield (message, usage);
             }
@@ -385,6 +443,38 @@ impl Provider for AnthropicProvider {
         )
         .await
     }
+}
+
+fn beta_header_value(
+    api_client: &ApiClient,
+    model_config: &ModelConfig,
+    payload: &Value,
+) -> Option<String> {
+    let mut features: Vec<String> = model_config
+        .request_headers
+        .as_ref()
+        .and_then(|headers| {
+            headers
+                .iter()
+                .find(|(key, _)| key.eq_ignore_ascii_case("anthropic-beta"))
+                .map(|(_, value)| value.as_str())
+        })
+        .or_else(|| api_client.default_header("anthropic-beta"))
+        .map(|value| {
+            value
+                .split(',')
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default();
+    if block_binding_behavior(payload).is_some()
+        && !features.iter().any(|f| f == THINKING_BINDING_CONTROLS_BETA)
+    {
+        features.push(THINKING_BINDING_CONTROLS_BETA.to_string());
+    }
+    (!features.is_empty()).then(|| features.join(","))
 }
 
 fn format_options_for_provider(
@@ -753,6 +843,22 @@ mod tests {
             matches!(err, ProviderError::Authentication(_)),
             "expected Authentication error, got: {:?}",
             err
+        );
+    }
+
+    #[test]
+    fn beta_header_merges_client_default_with_binding_beta() {
+        let client =
+            ApiClient::new_with_tls("http://localhost".to_string(), AuthMethod::NoAuth, None)
+                .unwrap()
+                .with_header("anthropic-beta", "context-1m-2025-08-07")
+                .unwrap();
+        let payload = json!({
+            "thinking": {"type": "adaptive", "block_binding": {"prefix_mismatch_behavior": "drop_block"}}
+        });
+        assert_eq!(
+            beta_header_value(&client, &ModelConfig::new("claude-opus-5"), &payload).as_deref(),
+            Some("context-1m-2025-08-07,thinking-binding-controls-2026-08-01")
         );
     }
 }

--- a/crates/goose-providers/src/api_client.rs
+++ b/crates/goose-providers/src/api_client.rs
@@ -305,6 +305,12 @@ impl ApiClient {
         self.timeout
     }
 
+    pub fn default_header(&self, name: &str) -> Option<&str> {
+        self.default_headers
+            .get(name)
+            .and_then(|value| value.to_str().ok())
+    }
+
     fn client_builder(timeout: Duration) -> reqwest::ClientBuilder {
         Client::builder()
             .connect_timeout(Duration::from_secs(DEFAULT_CONNECT_TIMEOUT_SECS))

--- a/crates/goose-sdk/src/bindings.rs
+++ b/crates/goose-sdk/src/bindings.rs
@@ -1074,7 +1074,9 @@ pub fn anthropic_provider(
         api_client = api_client.with_header("anthropic-beta", &beta_headers.join(","))?;
     }
 
-    let provider = AnthropicProviderBuilder::new(api_client).build();
+    let provider = AnthropicProviderBuilder::new(api_client)
+        .format_options(goose_providers::formats::anthropic::AnthropicFormatOptions::native())
+        .build();
     Ok(Provider::new(Box::new(provider)))
 }
 

--- a/crates/goose/src/bin/build_canonical_models.rs
+++ b/crates/goose/src/bin/build_canonical_models.rs
@@ -357,6 +357,7 @@ fn get_thinking_mode(canonical_id: &str, value: &Value) -> Option<ThinkingMode> 
 fn inferred_thinking_mode(canonical_id: &str) -> Option<ThinkingMode> {
     match canonical_id {
         "anthropic/claude-fable-5" => Some(ThinkingMode::AlwaysOnAdaptive),
+        "anthropic/claude-fable-5.1" => Some(ThinkingMode::AlwaysOnAdaptive),
         "anthropic/claude-opus-5" => Some(ThinkingMode::Adaptive),
         "anthropic/claude-opus-4.6" => Some(ThinkingMode::Adaptive),
         "anthropic/claude-opus-4.7" => Some(ThinkingMode::Adaptive),

--- a/crates/goose/src/providers/anthropic_def.rs
+++ b/crates/goose/src/providers/anthropic_def.rs
@@ -12,6 +12,7 @@ use goose_providers::{
     anthropic::{self, AnthropicProvider, AnthropicProviderBuilder, ANTHROPIC_API_VERSION},
     api_client::{ApiClient, AuthMethod, TlsConfig},
     base::ProviderDescriptor,
+    formats::anthropic::{AnthropicFormatOptions, PrefixMismatchBehavior},
 };
 
 pub struct AnthropicProviderDef;
@@ -51,6 +52,17 @@ async fn from_env(
         .get_param("ANTHROPIC_TIMEOUT")
         .unwrap_or(crate::providers::base::DEFAULT_PROVIDER_TIMEOUT_SECS);
 
+    let mut format_options = AnthropicFormatOptions::native();
+    if let Ok(value) = config.get_param::<String>("ANTHROPIC_PREFIX_MISMATCH_BEHAVIOR") {
+        format_options.prefix_mismatch_behavior =
+            match value.as_str() {
+                "off" => None,
+                value => Some(value.parse::<PrefixMismatchBehavior>().map_err(|e| {
+                    anyhow::anyhow!("invalid ANTHROPIC_PREFIX_MISMATCH_BEHAVIOR: {e}")
+                })?),
+            };
+    }
+
     let auth = AuthMethod::ApiKey {
         header_name: "x-api-key".to_string(),
         key: api_key,
@@ -65,7 +77,9 @@ async fn from_env(
     .with_request_builder(crate::session_context::session_id_request_builder())
     .with_header("anthropic-version", ANTHROPIC_API_VERSION)?;
 
-    Ok(AnthropicProviderBuilder::new(api_client).build())
+    Ok(AnthropicProviderBuilder::new(api_client)
+        .format_options(format_options)
+        .build())
 }
 
 pub fn from_custom_config(

--- a/crates/goose/src/providers/bedrock.rs
+++ b/crates/goose/src/providers/bedrock.rs
@@ -774,7 +774,7 @@ fn process_stream_event(
         bedrock::ConverseStreamOutput::ContentBlockStop(ev) => {
             let idx = ev.content_block_index;
             if let Some((text, signature)) = state.reasoning_blocks.remove(&idx) {
-                if !text.is_empty() {
+                if !text.is_empty() || !signature.is_empty() {
                     messages.push(
                         Message::assistant()
                             .with_thinking(text, signature)


### PR DESCRIPTION
Fixes part of #11800

Claude Opus 4.7 and later omit thinking text by default, so thinking blocks arrive as an empty string plus a signature. Goose dropped those blocks on parse and replayed the next request without them. Anthropic now binds each signature to the request prefix and enforces it on Claude Fable 5.1, which turns that silent loss into dropped blocks or a 400 on every tool round.

Provider-layer fixes:

- Keep signed thinking blocks with empty text in the streaming parser and in Bedrock.
- Request `block_binding` with `drop_block` by default and send the beta header, merged with any `anthropic-beta` value already configured. `ANTHROPIC_PREFIX_MISMATCH_BEHAVIOR` accepts `drop_block`, `error`, or `off`.
- Log `input_transformations` so dropped blocks are visible in the request log.
- Treat signature rejections as permanent and retry once with thinking history stripped, unless `error` behavior was requested explicitly.
- Count a signed thinking block with empty text as content in the unrolled agent loop, matching the legacy loop.
- Mark Claude Fable 5.1 as always-on adaptive thinking in the model catalog.

Only the native Anthropic provider opts into block binding. Bedrock, Vertex, Databricks, and Kimi Code are unaffected beyond replaying empty-text thinking.
