### PR TITLE
Add ToolRouter to the extension directory

### DIFF
--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -831,7 +831,7 @@
   {
     "id": "toolrouter",
     "name": "ToolRouter",
-    "description": "One connection to 250+ hosted specialist tools for web search, scraping, image and video generation, SEO, finance and more",
+    "description": "The OpenRouter for tools. One connection to 250+ hosted specialist tools for web search, scraping, image and video generation, SEO, finance and more",
     "url": "https://api.toolrouter.com/mcp",
     "link": "https://github.com/Humanleap/toolrouter-mcp",
     "installation_notes": "Hosted remote server. No credentials are needed to connect — free tools run immediately and a free account is provisioned on first use. Paid tools are pay per call.",

--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -827,6 +827,17 @@
       "required": false
     }
   ]
-}
-
+},
+  {
+    "id": "toolrouter",
+    "name": "ToolRouter",
+    "description": "One connection to 250+ hosted specialist tools for web search, scraping, image and video generation, SEO, finance and more",
+    "url": "https://api.toolrouter.com/mcp",
+    "link": "https://github.com/Humanleap/toolrouter-mcp",
+    "installation_notes": "Hosted remote server. No credentials are needed to connect — free tools run immediately and a free account is provisioned on first use. Paid tools are pay per call.",
+    "is_builtin": false,
+    "endorsed": false,
+    "environmentVariables": [],
+    "type": "streamable-http"
+  }
 ]


### PR DESCRIPTION
Adds ToolRouter to the extension directory (`documentation/static/servers.json`), following the same pattern as the other `type: streamable-http` entries (excalidraw, glif, neon).

**ToolRouter** is the OpenRouter for tools: one MCP connection gives an agent a hosted catalog of 250+ specialist tools — web search, scraping, image and video generation, SEO, finance, property, compliance and more. The agent finds what it needs with `discover` and runs it with `use_tool`, so the whole catalog costs roughly 9,000 tokens of context instead of one tool definition per skill.

- Endpoint: `https://api.toolrouter.com/mcp` (streamable-http)
- Source (MIT): https://github.com/Humanleap/toolrouter-mcp
- Website: https://toolrouter.com · Docs: https://toolrouter.com/docs
- Official MCP Registry: `io.github.Humanleap/toolrouter` (active)

**No credentials required** — the endpoint needs no auth for the first connection, provisions a free account, and free tools run immediately, so there are no `environmentVariables` or `headers` to configure and reviewers can call it as-is. Paid tools are pay per call.

Verified today with a live `initialize` at protocol version `2025-06-18`. The JSON change is one appended entry; the file parses and the rest of it is byte-identical.
