### PR TITLE
docs: add QVeris MCP extension

### DIFF
--- a/documentation/docs/mcp/qveris-mcp.md
+++ b/documentation/docs/mcp/qveris-mcp.md
@@ -1,0 +1,88 @@
+---
+title: QVeris Extension
+description: Add QVeris MCP Server as a goose Extension
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import GooseDesktopInstaller from '@site/src/components/GooseDesktopInstaller';
+import CLIExtensionInstructions from '@site/src/components/CLIExtensionInstructions';
+
+This tutorial covers how to add the [QVeris MCP Server](https://github.com/QVerisAI/qveris-agent-toolkit) as a goose extension. QVeris lets goose discover, inspect, and call real-world API capabilities through one MCP connection.
+
+:::tip Quick Install
+<Tabs groupId="interface">
+  <TabItem value="ui" label="goose Desktop" default>
+  [Launch the installer](goose://extension?type=streamable_http&url=https%3A%2F%2Fmcp.qveris.ai%2Fmcp&id=qveris&name=QVeris&description=Discover%2C%20inspect%2C%20and%20call%2010%2C000%2B%20real-world%20API%20capabilities&header=Authorization%3DBearer%20YOUR_QVERIS_API_KEY)
+  </TabItem>
+  <TabItem value="cli" label="goose CLI">
+  Add a `Remote Extension (Streamable HTTP)` extension with:
+
+  **Endpoint URL**
+  ```text
+  https://mcp.qveris.ai/mcp
+  ```
+  </TabItem>
+</Tabs>
+
+  **Custom Request Header**
+  ```text
+  Authorization: Bearer <YOUR_QVERIS_API_KEY>
+  ```
+:::
+
+## Configuration
+
+Create a QVeris API key on the [API Keys page](https://qveris.ai/account?page=api-keys). Keep the key private and enter it only in goose's extension configuration.
+
+<Tabs groupId="interface">
+  <TabItem value="ui" label="goose Desktop" default>
+    <GooseDesktopInstaller
+      extensionId="qveris"
+      extensionName="QVeris"
+      description="Discover, inspect, and call real-world API capabilities through one MCP server"
+      type="http"
+      url="https://mcp.qveris.ai/mcp"
+      envVars={[
+        { name: "Authorization", label: "Bearer YOUR_QVERIS_API_KEY" }
+      ]}
+      apiKeyLink="https://qveris.ai/account?page=api-keys"
+      apiKeyLinkText="QVeris API key"
+    />
+  </TabItem>
+  <TabItem value="cli" label="goose CLI">
+    <CLIExtensionInstructions
+      name="QVeris"
+      description="Discover, inspect, and call real-world API capabilities through one MCP server"
+      type="http"
+      url="https://mcp.qveris.ai/mcp"
+      timeout={300}
+      envVars={[
+        { key: "Authorization", value: "Bearer qveris_your_api_key" }
+      ]}
+      infoNote={
+        <>
+          Create a <a href="https://qveris.ai/account?page=api-keys" target="_blank" rel="noopener noreferrer">QVeris API key</a> and paste it after <code>Bearer</code>.
+        </>
+      }
+    />
+  </TabItem>
+</Tabs>
+
+## Example Usage
+
+Ask goose for the outcome you need. QVeris first discovers matching capabilities, then lets goose inspect a candidate before making a call.
+
+### goose Prompt
+
+> Find a weather capability and get the current weather in Shanghai. Inspect the selected capability before calling it.
+
+### goose Output
+
+:::note Example
+
+goose searches QVeris for a suitable weather capability, inspects its parameters and service metadata, calls it with Shanghai as the location, and summarizes the returned conditions.
+
+:::
+
+Capability discovery is free. Calling a capability can consume QVeris credits; use the extension's usage and credits tools when you need to audit a call.

--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -606,6 +606,26 @@
     ]
   },
   {
+    "id": "qveris",
+    "name": "QVeris",
+    "description": "Discover, inspect, and call 10,000+ real-world API capabilities through one MCP server",
+    "url": "https://mcp.qveris.ai/mcp",
+    "link": "https://github.com/QVerisAI/qveris-agent-toolkit",
+    "installation_notes": "Hosted Streamable HTTP extension. Requires a QVeris API key from https://qveris.ai/account?page=api-keys sent as an Authorization header: Bearer <YOUR_QVERIS_API_KEY>.",
+    "is_builtin": false,
+    "endorsed": false,
+    "environmentVariables": [],
+    "headers": [
+      {
+        "name": "Authorization",
+        "description": "Bearer <YOUR_QVERIS_API_KEY>",
+        "required": true
+      }
+    ],
+    "show_install_command": false,
+    "type": "streamable-http"
+  },
+  {
     "id": "reddit-mcp",
     "name": "Reddit",
     "description": "Reddit API integration for posts and comments",


### PR DESCRIPTION
## Summary

- add QVeris to the community extensions directory
- document hosted Streamable HTTP setup for Goose Desktop and CLI
- keep the API key in the `Authorization` request header

### Testing

- validated `documentation/static/servers.json` parses successfully and has unique IDs
- verified `https://mcp.qveris.ai/mcp` completes MCP initialization and `tools/list`
- checked the extension ID, URL, and authentication header match in the directory entry and tutorial
- ran `git diff --check`

### Related Issues

N/A — this documentation/catalog addition follows the maintainer-authored [Add MCP Server recipe](https://goose-docs.ai/recipes/detail?id=add-mcp-server).

### Screenshots/Demos

Not applicable; documentation and extension catalog metadata only.