### PR TITLE
fix(docs): preserve cookbook recipe source paths

### DIFF
--- a/documentation/scripts/recipes.test.js
+++ b/documentation/scripts/recipes.test.js
@@ -1,0 +1,106 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+const vm = require("node:vm");
+const ts = require("typescript");
+
+function loadTypeScriptModule(relativePath, configureRequire = () => {}) {
+  const sourcePath = path.join(__dirname, "..", relativePath);
+  const source = fs.readFileSync(sourcePath, "utf8");
+  const javascript = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2020,
+    },
+  }).outputText;
+  const moduleObject = { exports: {} };
+  const fakeRequire = (id) => {
+    throw new Error(`unexpected runtime require: ${id}`);
+  };
+
+  configureRequire(fakeRequire);
+  vm.runInNewContext(javascript, {
+    module: moduleObject,
+    exports: moduleObject.exports,
+    require: fakeRequire,
+    Buffer,
+  });
+  return moduleObject.exports;
+}
+
+function loadRecipesModule(recipeMap) {
+  return loadTypeScriptModule("src/utils/recipes.ts", (fakeRequire) => {
+    fakeRequire.context = () => {
+      const context = (key) => recipeMap[key];
+      context.keys = () => Object.keys(recipeMap);
+      return context;
+    };
+  });
+}
+
+test("preserves the discovered path for a .yml-only recipe", async () => {
+  const recipes = loadRecipesModule({
+    "./reviewed.yml": {
+      default: {
+        title: "Reviewed recipe",
+        description: "Uses the discovered source path",
+      },
+    },
+  });
+
+  const [recipe] = await recipes.searchRecipes("");
+
+  assert.equal(recipe.id, "reviewed");
+  assert.equal(
+    recipe.localPath,
+    "documentation/src/pages/recipes/data/recipes/reviewed.yml",
+  );
+});
+
+test("preserves the normal .yaml recipe path", () => {
+  const recipes = loadRecipesModule({
+    "./standard.yaml": {
+      default: {
+        title: "Standard recipe",
+        description: "Uses the standard extension",
+      },
+    },
+  });
+
+  assert.equal(
+    recipes.getRecipeById("standard").localPath,
+    "documentation/src/pages/recipes/data/recipes/standard.yaml",
+  );
+});
+
+test("rejects same-stem .yml and .yaml recipes", () => {
+  assert.throws(
+    () =>
+      loadRecipesModule({
+        "./ambiguous.yml": {
+          default: { title: "First recipe", description: "First source" },
+        },
+        "./ambiguous.yaml": {
+          default: { title: "Second recipe", description: "Second source" },
+        },
+      }),
+    /Ambiguous recipe ID "ambiguous" from "ambiguous\.yml" and "ambiguous\.yaml"/,
+  );
+});
+
+test("card and detail command variants use the supplied source path", () => {
+  const { buildRecipeCliCommand } = loadTypeScriptModule(
+    "src/utils/recipe-command.ts",
+  );
+  const localPath = "documentation/src/pages/recipes/data/recipes/reviewed.yml";
+
+  assert.equal(
+    buildRecipeCliCommand(localPath),
+    `goose run --recipe ${localPath}`,
+  );
+  assert.equal(
+    buildRecipeCliCommand(localPath, "topic=security"),
+    `goose run --recipe ${localPath} --params topic=security`,
+  );
+});

--- a/documentation/src/components/recipe-card.tsx
+++ b/documentation/src/components/recipe-card.tsx
@@ -2,6 +2,7 @@
 import React, { useState } from "react";
 import toast from "react-hot-toast";
 import Link from "@docusaurus/Link";
+import { buildRecipeCliCommand } from "@site/src/utils/recipe-command";
 
 export type Recipe = {
   id: string;
@@ -10,6 +11,7 @@ export type Recipe = {
   extensions: string[];
   activities: string[];
   recipeUrl: string;
+  localPath: string;
   action?: string;
   author?: {
     contact?: string;
@@ -33,7 +35,7 @@ export function RecipeCard({ recipe }: { recipe: Recipe }) {
       setShowParamPrompt(true);
       return;
     }
-    const command = `goose run --recipe documentation/src/pages/recipes/data/recipes/${recipe.id}.yaml`;
+    const command = buildRecipeCliCommand(recipe.localPath);
     navigator.clipboard.writeText(command);
     toast.success("CLI command copied!");
   };
@@ -42,7 +44,7 @@ export function RecipeCard({ recipe }: { recipe: Recipe }) {
     const filledParams = Object.entries(paramValues)
       .map(([key, val]) => `${key}=${val}`)
       .join(" ");
-    const command = `goose run --recipe documentation/src/pages/recipes/data/recipes/${recipe.id}.yaml --params ${filledParams}`;
+    const command = buildRecipeCliCommand(recipe.localPath, filledParams);
     navigator.clipboard.writeText(command);
     setShowParamPrompt(false);
     toast.success("CLI command copied with params!");

--- a/documentation/src/pages/recipes/detail.tsx
+++ b/documentation/src/pages/recipes/detail.tsx
@@ -10,6 +10,7 @@ import { getRecipeById } from "@site/src/utils/recipes";
 import type { Recipe } from "@site/src/components/recipe-card";
 import toast from "react-hot-toast";
 import ReactMarkdown from "react-markdown";
+import { buildRecipeCliCommand } from "@site/src/utils/recipe-command";
 
 const colorMap: { [key: string]: string } = {
   "GitHub MCP": "bg-yellow-100 text-yellow-800 border-yellow-200",
@@ -61,26 +62,28 @@ export default function RecipeDetailPage(): JSX.Element {
   const requiredParams = allParams.filter((p) => p.requirement === "required");
 
   const handleCopyCLI = () => {
+    if (!recipe) return;
+
     if (allParams.length > 0) {
       setParamValues({});
       setShowParamsPrompt(true);
       return;
     }
 
-    const command = `goose run --recipe ${recipe?.localPath}`;
+    const command = buildRecipeCliCommand(recipe.localPath);
     navigator.clipboard.writeText(command);
     toast.success("CLI command copied!");
   };
 
   const handleSubmitParams = () => {
+    if (!recipe) return;
+
     const filledParams = Object.entries(paramValues)
       .filter(([, val]) => val !== "")
       .map(([key, val]) => `${key}=${val}`)
       .join(" ");
 
-    const command = `goose run --recipe ${recipe?.localPath}${
-      filledParams ? ` --params ${filledParams}` : ""
-    }`;
+    const command = buildRecipeCliCommand(recipe.localPath, filledParams);
 
     navigator.clipboard.writeText(command);
     toast.success("CLI command copied with params!");

--- a/documentation/src/utils/recipe-command.ts
+++ b/documentation/src/utils/recipe-command.ts
@@ -1,0 +1,6 @@
+export function buildRecipeCliCommand(
+  localPath: string,
+  filledParams = "",
+): string {
+  return `goose run --recipe ${localPath}${filledParams ? ` --params ${filledParams}` : ""}`;
+}

--- a/documentation/src/utils/recipes.ts
+++ b/documentation/src/utils/recipes.ts
@@ -7,14 +7,13 @@ const recipeFiles = require.context(
   /\.ya?ml$/
 );
 
+const allRecipes = loadAllRecipes();
+
 export function getRecipeById(id: string): Recipe | null {
-  const allRecipes = loadAllRecipes();
   return allRecipes.find((recipe) => recipe.id === id) || null;
 }
 
 export async function searchRecipes(query: string): Promise<Recipe[]> {
-  const allRecipes = loadAllRecipes();
-
   if (!query) return allRecipes;
 
   return allRecipes.filter((r) =>
@@ -26,14 +25,29 @@ export async function searchRecipes(query: string): Promise<Recipe[]> {
 }
 
 function loadAllRecipes(): Recipe[] {
+  const sourceById = new Map<string, string>();
+
   return recipeFiles.keys().map((key: string) => {
     const parsed = recipeFiles(key).default || recipeFiles(key);
-    const id = key.replace(/^.*[\\/]/, "").replace(/\.(yaml|yml)$/, "");
-    return normalizeRecipe({ ...parsed, id });
+    const sourceFile = key.replace(/^.*[\\/]/, "");
+    const id = sourceFile.replace(/\.(yaml|yml)$/, "");
+    const existingSource = sourceById.get(id);
+
+    if (existingSource) {
+      throw new Error(
+        `Ambiguous recipe ID "${id}" from "${existingSource}" and "${sourceFile}"`
+      );
+    }
+
+    sourceById.set(id, sourceFile);
+    return normalizeRecipe(
+      { ...parsed, id },
+      `documentation/src/pages/recipes/data/recipes/${sourceFile}`
+    );
   });
 }
 
-function normalizeRecipe(recipe: any): Recipe {
+function normalizeRecipe(recipe: any, localPath: string): Recipe {
   const cleaned: Recipe = {
     id: recipe.id || recipe.title?.toLowerCase().replace(/\s+/g, "-") || "untitled-recipe",
     title: recipe.title || "Untitled Recipe",
@@ -55,7 +69,7 @@ function normalizeRecipe(recipe: any): Recipe {
     persona: recipe.persona || undefined,
     tags: recipe.tags || [],
     recipeUrl: "",
-    localPath: `documentation/src/pages/recipes/data/recipes/${recipe.id}.yaml`,
+    localPath,
   };
 
   // Add parameters and populate missing required values


### PR DESCRIPTION
## Summary

- preserve each cookbook recipe's discovered `.yml` or `.yaml` source path in copied CLI commands
- reject same-stem recipe collisions when cookbook data loads
- share path-based command generation across the card and detail views

## Testing

- `npm test`
- `npm run typecheck` *(blocked by existing Docusaurus config, React JSX namespace, and recipe model errors)*
- `npm run build` *(client and server bundles compile; the final link check is blocked by the existing `/docs/gdk/acp/reference` broken link)*

*This finding was discovered by [Project Loupe](https://github.com/project-loupe/loupe)*