### PR TITLE
Add RTL support to chat content (#11400)

### DIFF
--- a/ui/desktop/src/components/ChatInput.tsx
+++ b/ui/desktop/src/components/ChatInput.tsx
@@ -37,6 +37,7 @@ import { getNavigationShortcutText } from '../utils/keyboardShortcuts';
 import { UserInput, ImageData } from '../types/message';
 import { compressImageDataUrl } from '../utils/conversionUtils';
 import { fetchCanonicalModelInfo } from '../utils/canonical';
+import { getTextDirection } from '../utils/textDirection';
 import { defineMessages, useIntl } from '../i18n';
 import TurndownService from 'turndown';
 import type { NextChatExtensionDraft } from '../utils/nextChatExtensions';
@@ -258,6 +259,8 @@ export default function ChatInput({
   // Derived state - chatState != Idle means we're in some form of loading state
   const isLoading = chatState !== ChatState.Idle;
   const isLoadingRef = useRef(isLoading);
+
+  const composerDir = useMemo(() => getTextDirection(displayValue) ?? undefined, [displayValue]);
   const queueProcessingBlockedRef = useRef(queueProcessingBlocked);
   const wasLoadingRef = useRef(isLoading);
   const wasQueueProcessingBlockedRef = useRef(queueProcessingBlocked);
@@ -1542,6 +1545,7 @@ export default function ChatInput({
             data-testid="chat-input"
             autoFocus
             id="dynamic-textarea"
+            dir={composerDir}
             placeholder={isRecording ? '' : getNavigationShortcutText(intl)}
             value={displayValue}
             onChange={handleChange}

--- a/ui/desktop/src/components/GooseMessage.tsx
+++ b/ui/desktop/src/components/GooseMessage.tsx
@@ -18,6 +18,7 @@ import ToolCallConfirmation from './ToolCallConfirmation';
 import ElicitationRequest from './ElicitationRequest';
 import MessageCopyLink from './MessageCopyLink';
 import MessageUsageStats from './MessageUsageStats';
+import { getTextDirection } from '../utils/textDirection';
 import { cn } from '../utils';
 import type { ToolRenderState } from './messageRowContext';
 import {
@@ -78,6 +79,7 @@ function GooseMessage({
     streamingRenderCooldownMs
   );
   const toolConfirmationContent = getToolConfirmationContent(message);
+  const messageDir = useMemo(() => getTextDirection(displayText) ?? undefined, [displayText]);
   const elicitationContent = getElicitationContent(message);
   const hasToolConfirmation = toolConfirmationContent !== undefined;
   const hasElicitation = elicitationContent !== undefined;
@@ -110,7 +112,7 @@ function GooseMessage({
         {(displayText.trim() || imagePaths.length > 0) && (
           <div className="flex flex-col group">
             {displayText.trim() && (
-              <div ref={contentRef} className="agent-message-bubble w-full">
+              <div ref={contentRef} className="agent-message-bubble w-full" dir={messageDir}>
                 <MarkdownContent content={markdownText} />
               </div>
             )}

--- a/ui/desktop/src/components/MarkdownContent.tsx
+++ b/ui/desktop/src/components/MarkdownContent.tsx
@@ -29,6 +29,7 @@ const customOneDarkTheme = {
 import { Check, Copy } from './icons';
 import { wrapHTMLInCodeBlock } from '../utils/htmlSecurity';
 import { BLOCKED_PROTOCOLS } from '../utils/urlSecurity';
+import { getTextDirection } from '../utils/textDirection';
 import { defineMessages, useIntl } from '../i18n';
 
 const i18n = defineMessages({
@@ -53,6 +54,63 @@ interface CodeProps extends React.ClassAttributes<HTMLElement>, React.HTMLAttrib
 interface MarkdownContentProps {
   content: string;
   className?: string;
+}
+
+// Minimal hast node shape; avoids importing @types/hast just for this plugin.
+interface HastNode {
+  type?: string;
+  tagName?: string;
+  value?: string;
+  properties?: Record<string, unknown> | null;
+  children?: HastNode[];
+}
+
+// Block-level elements that get their own computed dir so mixed-direction
+// markdown (e.g. an English paragraph inside an Arabic message) resolves
+// punctuation placement per block instead of inheriting the message direction.
+const DIRECTIONAL_BLOCK_TAGS = new Set([
+  'p',
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  'h5',
+  'h6',
+  'li',
+  'blockquote',
+  'dd',
+  'dt',
+  'td',
+  'th',
+  'figcaption',
+  'caption',
+  'summary',
+]);
+
+function collectText(node: HastNode): string {
+  let text = node.type === 'text' ? (node.value ?? '') : '';
+  for (const child of node.children ?? []) {
+    text += collectText(child);
+  }
+  return text;
+}
+
+function applyPerBlockDirection(node: HastNode): void {
+  if (node.type === 'element' && node.tagName && DIRECTIONAL_BLOCK_TAGS.has(node.tagName)) {
+    const direction = getTextDirection(collectText(node));
+    if (direction) {
+      node.properties = { ...node.properties, dir: direction };
+    }
+  }
+  for (const child of node.children ?? []) {
+    applyPerBlockDirection(child);
+  }
+}
+
+function rehypePerBlockDirection(): (tree: HastNode) => void {
+  return (tree) => {
+    if (tree) applyPerBlockDirection(tree);
+  };
 }
 
 // Memoized CodeBlock component to prevent re-rendering when props haven't changed
@@ -131,7 +189,7 @@ const CodeBlock = memo(function CodeBlock({
   }, [language, children]);
 
   return (
-    <div className="relative group w-full">
+    <div className="relative group w-full" dir="ltr">
       <button
         onClick={handleCopy}
         className="absolute right-2 bottom-2 p-1.5 rounded-lg bg-gray-700/50 text-gray-300 font-sans text-sm
@@ -162,7 +220,12 @@ const MarkdownCode = memo(
     return isBlockLevelCode ? (
       <CodeBlock language={match ? match[1] : 'text'}>{codeContent.replace(/\n$/, '')}</CodeBlock>
     ) : (
-      <code ref={ref} {...props} className="break-all bg-inline-code whitespace-pre-wrap font-mono">
+      <code
+        ref={ref}
+        {...props}
+        dir="ltr"
+        className="break-all bg-inline-code whitespace-pre-wrap font-mono"
+      >
         {children}
       </code>
     );
@@ -217,7 +280,7 @@ const MarkdownContent = memo(function MarkdownContent({
 
   return (
     <div
-      className={`w-full overflow-x-hidden prose prose-sm text-text-primary dark:prose-invert max-w-full word-break font-sans
+      className={`w-full overflow-x-hidden prose prose-sm text-start text-text-primary dark:prose-invert max-w-full word-break font-sans
         prose-pre:p-0 prose-pre:m-0 !p-0
         prose-code:break-all prose-code:whitespace-pre-wrap prose-code:font-mono
         prose-a:break-all prose-a:overflow-wrap-anywhere
@@ -246,6 +309,7 @@ const MarkdownContent = memo(function MarkdownContent({
               strict: false,
             },
           ],
+          rehypePerBlockDirection,
         ]}
         components={{
           a: (props) => {

--- a/ui/desktop/src/components/MarkdownContent.tsx
+++ b/ui/desktop/src/components/MarkdownContent.tsx
@@ -88,6 +88,11 @@ const DIRECTIONAL_BLOCK_TAGS = new Set([
 ]);
 
 function collectText(node: HastNode): string {
+  // Code is language-neutral and always rendered LTR, so it doesn't vote on
+  // the direction of the prose block containing it.
+  if (node.type === 'element' && (node.tagName === 'code' || node.tagName === 'pre')) {
+    return '';
+  }
   let text = node.type === 'text' ? (node.value ?? '') : '';
   for (const child of node.children ?? []) {
     text += collectText(child);

--- a/ui/desktop/src/components/MarkdownContent.tsx
+++ b/ui/desktop/src/components/MarkdownContent.tsx
@@ -97,9 +97,17 @@ function collectText(node: HastNode): string {
   }
   let text = node.type === 'text' ? (node.value ?? '') : '';
   for (const child of node.children ?? []) {
-    // Nested blocks compute their own direction and don't vote on the parent,
-    // so a long sublist can't flip the list item containing it.
-    if (child.type === 'element' && child.tagName && DIRECTIONAL_BLOCK_TAGS.has(child.tagName)) {
+    // Nested blocks other than paragraphs compute their own direction and
+    // don't vote on the parent, so a long sublist can't flip the list item
+    // containing it. Prose <p> children still count: loose list items and
+    // blockquotes hold their own text in direct <p> children, and their
+    // marker/indent side follows the parent's own direction.
+    if (
+      child.type === 'element' &&
+      child.tagName &&
+      child.tagName !== 'p' &&
+      DIRECTIONAL_BLOCK_TAGS.has(child.tagName)
+    ) {
       continue;
     }
     text += collectText(child);

--- a/ui/desktop/src/components/MarkdownContent.tsx
+++ b/ui/desktop/src/components/MarkdownContent.tsx
@@ -88,10 +88,12 @@ const DIRECTIONAL_BLOCK_TAGS = new Set([
 ]);
 
 function collectText(node: HastNode): string {
-  // Code is language-neutral and always rendered LTR, so it doesn't vote on
-  // the direction of the prose block containing it.
-  if (node.type === 'element' && (node.tagName === 'code' || node.tagName === 'pre')) {
-    return '';
+  // Code and KaTeX output are language-neutral (both render LTR internally),
+  // so they don't vote on the direction of the prose block containing them.
+  if (node.type === 'element') {
+    if (node.tagName === 'code' || node.tagName === 'pre') return '';
+    const classNames = node.properties?.className;
+    if (Array.isArray(classNames) && classNames.includes('katex')) return '';
   }
   let text = node.type === 'text' ? (node.value ?? '') : '';
   for (const child of node.children ?? []) {

--- a/ui/desktop/src/components/MarkdownContent.tsx
+++ b/ui/desktop/src/components/MarkdownContent.tsx
@@ -97,6 +97,11 @@ function collectText(node: HastNode): string {
   }
   let text = node.type === 'text' ? (node.value ?? '') : '';
   for (const child of node.children ?? []) {
+    // Nested blocks compute their own direction and don't vote on the parent,
+    // so a long sublist can't flip the list item containing it.
+    if (child.type === 'element' && child.tagName && DIRECTIONAL_BLOCK_TAGS.has(child.tagName)) {
+      continue;
+    }
     text += collectText(child);
   }
   return text;

--- a/ui/desktop/src/components/MessageQueue.tsx
+++ b/ui/desktop/src/components/MessageQueue.tsx
@@ -226,7 +226,11 @@ export const MessageQueue: React.FC<MessageQueueProps> = ({
 
             {/* Next message preview */}
             <div className="flex-1 min-w-0">
-              <p className="text-sm text-muted-foreground truncate" title={nextMessage.content}>
+              <p
+                dir={getTextDirection(nextMessage.content) ?? undefined}
+                className="text-sm text-muted-foreground truncate"
+                title={nextMessage.content}
+              >
                 {nextMessage.content.length > 40
                   ? `${nextMessage.content.substring(0, 40)}...`
                   : nextMessage.content}

--- a/ui/desktop/src/components/MessageQueue.tsx
+++ b/ui/desktop/src/components/MessageQueue.tsx
@@ -2,6 +2,7 @@ import React, { useRef, useState } from 'react';
 import { X, Clock, Send, GripVertical, Zap, Sparkles, ChevronDown, ChevronUp } from 'lucide-react';
 import { Button } from './ui/button';
 import { ImageData } from '../types/message';
+import { getTextDirection } from '../utils/textDirection';
 import { defineMessages, useIntl } from '../i18n';
 
 const i18n = defineMessages({
@@ -418,6 +419,7 @@ export const MessageQueue: React.FC<MessageQueueProps> = ({
                         value={editContent}
                         onChange={(e) => setEditContent(e.target.value)}
                         disabled={isSending}
+                        dir={getTextDirection(editContent) ?? undefined}
                         className="w-full text-sm bg-background border border-border rounded-md px-2 py-1 resize-none focus:outline-none focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500"
                         rows={Math.min(Math.ceil(editContent.length / 60), 4)}
                         autoFocus
@@ -464,6 +466,7 @@ export const MessageQueue: React.FC<MessageQueueProps> = ({
                     </div>
                   ) : (
                     <p
+                      dir={getTextDirection(message.content) ?? undefined}
                       className={`text-sm text-foreground leading-relaxed rounded px-1 py-0.5 transition-colors ${
                         isSending ? 'cursor-not-allowed' : 'cursor-pointer hover:bg-muted/30'
                       }`}

--- a/ui/desktop/src/components/UserMessage.tsx
+++ b/ui/desktop/src/components/UserMessage.tsx
@@ -9,6 +9,7 @@ import {
 } from '../types/message';
 import MessageCopyLink from './MessageCopyLink';
 import { formatMessageTimestamp } from '../utils/timeUtils';
+import { getTextDirection } from '../utils/textDirection';
 import Close from './icons/Close';
 import Edit from './icons/Edit';
 import { Button } from './ui/button';
@@ -106,6 +107,8 @@ function UserMessage({ message, onMessageUpdate }: UserMessageProps) {
 
   const { textContent, imagePaths } = getTextAndImageContent(message);
   const timestamp = formatMessageTimestamp(message.created);
+  const messageDir = getTextDirection(textContent) ?? undefined;
+  const editDir = getTextDirection(editContent) ?? undefined;
 
   const messageImages: ImageData[] = imageDataFromMessage(message);
 
@@ -234,6 +237,7 @@ function UserMessage({ message, onMessageUpdate }: UserMessageProps) {
           <div className="w-full max-w-4xl mx-auto text-text-primary rounded-xl border border-border-primary shadow-lg py-4 px-4 my-2 transition-all duration-200 ease-in-out">
             <textarea
               ref={textareaRef}
+              dir={editDir}
               value={editContent}
               onChange={handleContentChange}
               onKeyDown={handleKeyDown}
@@ -323,7 +327,10 @@ function UserMessage({ message, onMessageUpdate }: UserMessageProps) {
             <div className="flex-col max-w-[85%] w-fit">
               <div className="flex flex-col group">
                 {textContent.trim() && (
-                  <div className="user-message-bubble flex bg-text-primary text-background-primary rounded-xl py-2.5 px-4">
+                  <div
+                    className="user-message-bubble flex bg-text-primary text-background-primary rounded-xl py-2.5 px-4"
+                    dir={messageDir}
+                  >
                     <div ref={contentRef}>
                       <MarkdownContent
                         content={textContent}

--- a/ui/desktop/src/components/rtlChatDirection.test.tsx
+++ b/ui/desktop/src/components/rtlChatDirection.test.tsx
@@ -79,10 +79,21 @@ describe('RTL chat direction', () => {
       await waitFor(() => {
         expect(container.querySelector('li')).toBeInTheDocument();
       });
-      // Loose list: the item's prose lives in a <p> with its own direction;
-      // the outer li carries no dir and inherits the message direction.
-      expect(container.querySelector('li')?.getAttribute('dir')).toBe(null);
+      // Loose list: the item's prose lives in a <p>, and the li's own vote
+      // counts it, so the marker side follows the prose direction.
+      expect(container.querySelector('li')?.getAttribute('dir')).toBe('rtl');
       expect(container.querySelector('li p')?.getAttribute('dir')).toBe('rtl');
+    });
+
+    it('tags loose list items even when the message-level vote is LTR', async () => {
+      const content =
+        'A fairly long English intro paragraph that tips the raw message text towards LTR.\n\n- عنصر عربي\n\n- عنصر آخر';
+      const { container } = renderWithIntl(<MarkdownContent content={content} />);
+
+      await waitFor(() => {
+        expect(container.querySelector('li')).toBeInTheDocument();
+      });
+      expect(container.querySelector('li')?.getAttribute('dir')).toBe('rtl');
     });
 
     it('does not let a nested sublist flip a list item direction', async () => {

--- a/ui/desktop/src/components/rtlChatDirection.test.tsx
+++ b/ui/desktop/src/components/rtlChatDirection.test.tsx
@@ -79,6 +79,20 @@ describe('RTL chat direction', () => {
       await waitFor(() => {
         expect(container.querySelector('li')).toBeInTheDocument();
       });
+      // Loose list: the item's prose lives in a <p> with its own direction;
+      // the outer li carries no dir and inherits the message direction.
+      expect(container.querySelector('li')?.getAttribute('dir')).toBe(null);
+      expect(container.querySelector('li p')?.getAttribute('dir')).toBe('rtl');
+    });
+
+    it('does not let a nested sublist flip a list item direction', async () => {
+      const content =
+        '- هذه قائمة عربية قصيرة\n  - a fairly long english nested sublist entry here';
+      const { container } = renderWithIntl(<MarkdownContent content={content} />);
+
+      await waitFor(() => {
+        expect(container.querySelector('li')).toBeInTheDocument();
+      });
       expect(container.querySelector('li')?.getAttribute('dir')).toBe('rtl');
     });
 
@@ -150,6 +164,13 @@ describe('RTL chat direction', () => {
     it('sets dir on the queued message preview', () => {
       renderQueueWith(arabicText);
       expect(screen.getByText(arabicText).getAttribute('dir')).toBe('rtl');
+    });
+
+    it('applies direction to the collapsed queue preview', () => {
+      renderQueueWith(arabicText);
+      fireEvent.click(screen.getByTitle('Collapse queue'));
+
+      expect(screen.getByTitle(arabicText).getAttribute('dir')).toBe('rtl');
     });
 
     it('follows the direction while editing a queued message', () => {

--- a/ui/desktop/src/components/rtlChatDirection.test.tsx
+++ b/ui/desktop/src/components/rtlChatDirection.test.tsx
@@ -1,0 +1,130 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import MarkdownContent from './MarkdownContent';
+import MessageQueue, { type QueuedMessage } from './MessageQueue';
+import UserMessage from './UserMessage';
+import { IntlTestWrapper } from '../i18n/test-utils';
+import type { Message } from '../types/message';
+
+vi.mock('./icons', () => ({
+  Check: () => <div data-testid="check-icon">ok</div>,
+  Copy: () => <div data-testid="copy-icon">copy</div>,
+  Edit: () => <div data-testid="edit-icon">edit</div>,
+  Close: () => <div data-testid="close-icon">close</div>,
+}));
+
+const arabicText = 'هذه رسالة تجريبية باللغة العربية';
+const hebrewText = 'זו הודעת בדיקה בעברית';
+
+function renderWithIntl(ui: React.ReactElement) {
+  return render(ui, { wrapper: IntlTestWrapper });
+}
+
+function makeUserMessage(text: string): Message {
+  return {
+    content: [{ type: 'text', text }],
+    created: Date.now(),
+    id: 'msg-1',
+    metadata: { agentVisible: true, userVisible: true },
+    role: 'user',
+  };
+}
+
+describe('RTL chat direction', () => {
+  describe('MarkdownContent per-block direction', () => {
+    it('tags each block with its own direction in a mixed message', async () => {
+      const { container } = renderWithIntl(
+        <MarkdownContent content={`${arabicText}\n\nThis is an English paragraph.`} />
+      );
+
+      await waitFor(() => {
+        const paragraphs = container.querySelectorAll('p');
+        expect(paragraphs).toHaveLength(2);
+      });
+
+      const paragraphs = container.querySelectorAll('p');
+      expect(paragraphs[0].getAttribute('dir')).toBe('rtl');
+      expect(paragraphs[1].getAttribute('dir')).toBe('ltr');
+    });
+
+    it('keeps paragraphs without strong characters undirected', async () => {
+      const { container } = renderWithIntl(<MarkdownContent content="12345" />);
+
+      await waitFor(() => {
+        expect(container.querySelector('p')).toBeInTheDocument();
+      });
+      expect(container.querySelector('p')?.getAttribute('dir')).toBe(null);
+    });
+
+    it('renders inline code LTR inside an RTL paragraph', async () => {
+      const { container } = renderWithIntl(
+        <MarkdownContent content={`${arabicText} مع \`some code\``} />
+      );
+
+      await waitFor(() => {
+        expect(container.querySelector('code')).toBeInTheDocument();
+      });
+      expect(container.querySelector('code')?.getAttribute('dir')).toBe('ltr');
+      expect(container.querySelector('p')?.getAttribute('dir')).toBe('rtl');
+    });
+
+    it('renders fenced code blocks LTR', async () => {
+      const { container } = renderWithIntl(
+        <MarkdownContent content={`${arabicText}\n\n\`\`\`js\nconst x = 1;\n\`\`\``} />
+      );
+
+      await waitFor(() => {
+        expect(container.querySelector('div[dir="ltr"]')).toBeInTheDocument();
+      });
+      expect(container.querySelector('p')?.getAttribute('dir')).toBe('rtl');
+    });
+  });
+
+  describe('UserMessage', () => {
+    it('sets dir on the message bubble', () => {
+      const { container } = renderWithIntl(<UserMessage message={makeUserMessage(arabicText)} />);
+      expect(container.querySelector('.user-message-bubble')?.getAttribute('dir')).toBe('rtl');
+    });
+
+    it('leaves the dir attribute off non-directional messages', () => {
+      const { container } = renderWithIntl(<UserMessage message={makeUserMessage('123')} />);
+      expect(container.querySelector('.user-message-bubble')?.getAttribute('dir')).toBe(null);
+    });
+
+    it('updates the edit textarea direction as the content changes', () => {
+      renderWithIntl(<UserMessage message={makeUserMessage('hello')} />);
+
+      fireEvent.click(screen.getByRole('button', { name: /Edit message/ }));
+      const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+
+      expect(textarea.getAttribute('dir')).toBe('ltr');
+      fireEvent.change(textarea, { target: { value: hebrewText } });
+      expect(textarea.getAttribute('dir')).toBe('rtl');
+    });
+  });
+
+  describe('MessageQueue', () => {
+    function renderQueueWith(content: string) {
+      const queued: QueuedMessage[] = [{ id: 'q1', content, timestamp: Date.now(), images: [] }];
+      renderWithIntl(
+        <MessageQueue queuedMessages={queued} onRemoveMessage={() => {}} onClearQueue={() => {}} />
+      );
+    }
+
+    it('sets dir on the queued message preview', () => {
+      renderQueueWith(arabicText);
+      expect(screen.getByText(arabicText).getAttribute('dir')).toBe('rtl');
+    });
+
+    it('follows the direction while editing a queued message', () => {
+      renderQueueWith(arabicText);
+      fireEvent.click(screen.getByText(arabicText));
+
+      const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+      expect(textarea.getAttribute('dir')).toBe('rtl');
+
+      fireEvent.change(textarea, { target: { value: 'hello again' } });
+      expect(textarea.getAttribute('dir')).toBe('ltr');
+    });
+  });
+});

--- a/ui/desktop/src/components/rtlChatDirection.test.tsx
+++ b/ui/desktop/src/components/rtlChatDirection.test.tsx
@@ -82,6 +82,16 @@ describe('RTL chat direction', () => {
       expect(container.querySelector('li')?.getAttribute('dir')).toBe('rtl');
     });
 
+    it('does not let a long KaTeX formula flip an RTL paragraph', async () => {
+      const content = 'القيمة المحسوبة $$\\text{calculateTotalSumOfAllItems}$$ في القائمة';
+      const { container } = renderWithIntl(<MarkdownContent content={content} />);
+
+      await waitFor(() => {
+        expect(container.querySelector('p')).toBeInTheDocument();
+      });
+      expect(container.querySelector('p')?.getAttribute('dir')).toBe('rtl');
+    });
+
     it('renders inline code LTR inside an RTL paragraph', async () => {
       const { container } = renderWithIntl(
         <MarkdownContent content={`${arabicText} مع \`some code\``} />

--- a/ui/desktop/src/components/rtlChatDirection.test.tsx
+++ b/ui/desktop/src/components/rtlChatDirection.test.tsx
@@ -56,6 +56,32 @@ describe('RTL chat direction', () => {
       expect(container.querySelector('p')?.getAttribute('dir')).toBe(null);
     });
 
+    it('does not let a long inline identifier flip an RTL paragraph', async () => {
+      const { container } = renderWithIntl(
+        <MarkdownContent content="شغّل `getPredefinedModelsFromEnv` في المجلد" />
+      );
+
+      await waitFor(() => {
+        expect(container.querySelector('p')).toBeInTheDocument();
+      });
+      expect(container.querySelector('p')?.getAttribute('dir')).toBe('rtl');
+    });
+
+    it('does not let a fenced code block flip a list item direction', async () => {
+      const content = `- هذه قائمة بالعربية
+
+  \`\`\`js
+  const veryLongEnglishCode = 1;
+  \`\`\`
+`;
+      const { container } = renderWithIntl(<MarkdownContent content={content} />);
+
+      await waitFor(() => {
+        expect(container.querySelector('li')).toBeInTheDocument();
+      });
+      expect(container.querySelector('li')?.getAttribute('dir')).toBe('rtl');
+    });
+
     it('renders inline code LTR inside an RTL paragraph', async () => {
       const { container } = renderWithIntl(
         <MarkdownContent content={`${arabicText} مع \`some code\``} />

--- a/ui/desktop/src/test/setup.ts
+++ b/ui/desktop/src/test/setup.ts
@@ -86,6 +86,8 @@ Object.defineProperty(window, 'electron', {
     reloadApp: vi.fn(),
     showMessageBox: vi.fn(() => Promise.resolve({ response: 0 })),
     getIsFullScreen: vi.fn(() => Promise.resolve(false)),
+    logInfo: vi.fn(),
+    logError: vi.fn(),
     on: vi.fn(),
     off: vi.fn(),
   },

--- a/ui/desktop/src/utils/textDirection.test.ts
+++ b/ui/desktop/src/utils/textDirection.test.ts
@@ -43,6 +43,15 @@ describe('getTextDirection', () => {
     expect(getTextDirection('٣٤٥٦ مرحبا')).toBe('rtl');
   });
 
+  it('treats Arabic separators as neutral', () => {
+    expect(getTextDirection('٣٬٤٥٦')).toBe(null);
+    expect(getTextDirection('٣٬٤٥٦ مرحبا')).toBe('rtl');
+  });
+
+  it('counts strong Arabic punctuation as RTL', () => {
+    expect(getTextDirection('ما هذا؟')).toBe('rtl');
+  });
+
   it('returns null for text without strong directional characters', () => {
     expect(getTextDirection('')).toBe(null);
     expect(getTextDirection('12345 !!! ...')).toBe(null);

--- a/ui/desktop/src/utils/textDirection.test.ts
+++ b/ui/desktop/src/utils/textDirection.test.ts
@@ -14,6 +14,10 @@ describe('getTextDirection', () => {
     expect(getTextDirection('این یک پیام آزمایشی است.')).toBe('rtl');
   });
 
+  it('detects RTL for Arabic Extended-B letters', () => {
+    expect(getTextDirection(String.fromCodePoint(0x0870, 0x0871, 0x0872))).toBe('rtl');
+  });
+
   it('detects LTR for English text', () => {
     expect(getTextDirection('Hello, world!')).toBe('ltr');
   });

--- a/ui/desktop/src/utils/textDirection.test.ts
+++ b/ui/desktop/src/utils/textDirection.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { getTextDirection } from './textDirection';
+
+describe('getTextDirection', () => {
+  it('detects RTL for Arabic text with punctuation', () => {
+    expect(getTextDirection('مرحبا، هذا اختبار.')).toBe('rtl');
+  });
+
+  it('detects RTL for Hebrew text', () => {
+    expect(getTextDirection('שלום, עולם!')).toBe('rtl');
+  });
+
+  it('detects RTL for Persian text', () => {
+    expect(getTextDirection('این یک پیام آزمایشی است.')).toBe('rtl');
+  });
+
+  it('detects LTR for English text', () => {
+    expect(getTextDirection('Hello, world!')).toBe('ltr');
+  });
+
+  it('stays RTL when an English word leads the message', () => {
+    expect(getTextDirection('Note: هذه رسالة تجريبية')).toBe('rtl');
+  });
+
+  it('stays RTL when a number leads the message', () => {
+    expect(getTextDirection('123 سلام عليكم')).toBe('rtl');
+  });
+
+  it('stays RTL when an English word trails the message', () => {
+    expect(getTextDirection('هذه رسالة تجريبية for testing')).toBe('rtl');
+  });
+
+  it('stays LTR when a single Arabic word sits in English text', () => {
+    expect(getTextDirection('This is mostly English with سلام as one word')).toBe('ltr');
+  });
+
+  it('treats Arabic-Indic digits as neutral', () => {
+    expect(getTextDirection('٣٤٥٦')).toBe(null);
+    expect(getTextDirection('٣٤٥٦ مرحبا')).toBe('rtl');
+  });
+
+  it('returns null for text without strong directional characters', () => {
+    expect(getTextDirection('')).toBe(null);
+    expect(getTextDirection('12345 !!! ...')).toBe(null);
+    expect(getTextDirection('🎉 👍 100%')).toBe(null);
+  });
+
+  it('breaks ties towards LTR', () => {
+    expect(getTextDirection('abcd שלום')).toBe('ltr');
+  });
+
+  it('does not count surrogate pairs as directional characters', () => {
+    expect(getTextDirection('😀 שלום')).toBe('rtl');
+  });
+});

--- a/ui/desktop/src/utils/textDirection.ts
+++ b/ui/desktop/src/utils/textDirection.ts
@@ -11,7 +11,8 @@ const RTL_RANGES: readonly Range[] = [
   [0x0780, 0x07bf], // Thaana
   [0x07c0, 0x082f], // NKo, Samaritan
   [0x0840, 0x085f], // Mandaic
-  [0x08a0, 0x08ff], // Arabic extended-B
+  [0x0870, 0x089f], // Arabic extended-B
+  [0x08a0, 0x08ff], // Arabic extended-A
   [0xfb1d, 0xfdff], // Hebrew and Arabic presentation forms
   [0xfe70, 0xfeff], // Arabic presentation forms-B
 ];

--- a/ui/desktop/src/utils/textDirection.ts
+++ b/ui/desktop/src/utils/textDirection.ts
@@ -1,0 +1,81 @@
+export type TextDirection = 'rtl' | 'ltr';
+
+type Range = readonly [start: number, end: number];
+
+// Blocks whose characters have strong RTL direction (bidi class R or AL).
+const RTL_RANGES: readonly Range[] = [
+  [0x0590, 0x05ff], // Hebrew
+  [0x0600, 0x06ff], // Arabic
+  [0x0700, 0x074f], // Syriac
+  [0x0750, 0x077f], // Arabic supplement
+  [0x0780, 0x07bf], // Thaana
+  [0x07c0, 0x082f], // NKo, Samaritan
+  [0x0840, 0x085f], // Mandaic
+  [0x08a0, 0x08ff], // Arabic extended-B
+  [0xfb1d, 0xfdff], // Hebrew and Arabic presentation forms
+  [0xfe70, 0xfeff], // Arabic presentation forms-B
+];
+
+// Digits inside RTL blocks are weak (bidi class AN/EN), not strong RTL, so a
+// message made only of digits must not flip direction.
+const WEAK_RTL_RANGES: readonly Range[] = [
+  [0x0660, 0x0669], // Arabic-Indic digits
+  [0x06f0, 0x06f9], // Extended Arabic-Indic digits
+];
+
+// Blocks with strong LTR direction. Checked after RTL_RANGES, so overlaps with
+// RTL blocks are impossible. Digits, punctuation, whitespace, emoji and scripts
+// not listed here count as neutral and don't influence the result.
+const LTR_RANGES: readonly Range[] = [
+  [0x0041, 0x005a], // A-Z
+  [0x0061, 0x007a], // a-z
+  [0x00c0, 0x024f], // Latin-1 letters, Latin extended-A/B, IPA
+  [0x0370, 0x03ff], // Greek
+  [0x0400, 0x052f], // Cyrillic and supplement
+  [0x0530, 0x058f], // Armenian
+  [0x0900, 0x0dff], // Indic scripts
+  [0x0e00, 0x0eff], // Thai, Lao
+  [0x10a0, 0x10ff], // Georgian
+  [0x1e00, 0x1eff], // Latin extended additional
+  [0x1f00, 0x1fff], // Greek extended
+  [0x3040, 0x30ff], // Hiragana, Katakana
+  [0x3400, 0x4dbf], // CJK ext-A
+  [0x4e00, 0x9fff], // CJK unified
+  [0xac00, 0xd7af], // Hangul syllables
+  [0xf900, 0xfaff], // CJK compatibility ideographs
+];
+
+function inRanges(code: number, ranges: readonly Range[]): boolean {
+  for (const [start, end] of ranges) {
+    if (code >= start && code <= end) return true;
+  }
+  return false;
+}
+
+/**
+ * Heuristic direction for a block of text: counts strong RTL characters
+ * against strong LTR characters, so a leading English word or number doesn't
+ * force an Arabic/Hebrew message to render LTR.
+ *
+ * Returns null when the text has no strong directional characters at all
+ * (digits, punctuation, whitespace, emoji); callers should treat that as
+ * "inherit from the surrounding context".
+ */
+export function getTextDirection(text: string): TextDirection | null {
+  if (!text) return null;
+
+  let rtlCount = 0;
+  let ltrCount = 0;
+  for (let i = 0; i < text.length; i++) {
+    const code = text.charCodeAt(i);
+    if (inRanges(code, WEAK_RTL_RANGES)) continue;
+    if (inRanges(code, RTL_RANGES)) {
+      rtlCount++;
+    } else if (inRanges(code, LTR_RANGES)) {
+      ltrCount++;
+    }
+  }
+
+  if (rtlCount === 0 && ltrCount === 0) return null;
+  return rtlCount > ltrCount ? 'rtl' : 'ltr';
+}

--- a/ui/desktop/src/utils/textDirection.ts
+++ b/ui/desktop/src/utils/textDirection.ts
@@ -3,9 +3,21 @@ export type TextDirection = 'rtl' | 'ltr';
 type Range = readonly [start: number, end: number];
 
 // Blocks whose characters have strong RTL direction (bidi class R or AL).
+// The Arabic block is enumerated as strong sub-ranges only: digits,
+// separators (066B-066C, 06DD), the Arabic comma (060C, bidi CS) and
+// combining marks are weak/neutral, so text made only of them (e.g.
+// "٣٬٤٥٦") must not flip direction.
 const RTL_RANGES: readonly Range[] = [
   [0x0590, 0x05ff], // Hebrew
-  [0x0600, 0x06ff], // Arabic
+  [0x061b, 0x061b], // Arabic semicolon
+  [0x061c, 0x061c], // Arabic letter mark
+  [0x061f, 0x061f], // Arabic question mark
+  [0x0620, 0x064a], // Arabic letters (incl. tatweel)
+  [0x066e, 0x066f], // Arabic letters (dotless forms)
+  [0x0671, 0x06d3], // Arabic letters
+  [0x06e5, 0x06e6], // Arabic small waw, small ya
+  [0x06fa, 0x06fc], // Arabic letters
+  [0x06ff, 0x06ff], // Arabic letter heh with inverted v
   [0x0700, 0x074f], // Syriac
   [0x0750, 0x077f], // Arabic supplement
   [0x0780, 0x07bf], // Thaana
@@ -15,13 +27,6 @@ const RTL_RANGES: readonly Range[] = [
   [0x08a0, 0x08ff], // Arabic extended-A
   [0xfb1d, 0xfdff], // Hebrew and Arabic presentation forms
   [0xfe70, 0xfeff], // Arabic presentation forms-B
-];
-
-// Digits inside RTL blocks are weak (bidi class AN/EN), not strong RTL, so a
-// message made only of digits must not flip direction.
-const WEAK_RTL_RANGES: readonly Range[] = [
-  [0x0660, 0x0669], // Arabic-Indic digits
-  [0x06f0, 0x06f9], // Extended Arabic-Indic digits
 ];
 
 // Blocks with strong LTR direction. Checked after RTL_RANGES, so overlaps with
@@ -69,7 +74,6 @@ export function getTextDirection(text: string): TextDirection | null {
   let ltrCount = 0;
   for (let i = 0; i < text.length; i++) {
     const code = text.charCodeAt(i);
-    if (inRanges(code, WEAK_RTL_RANGES)) continue;
     if (inRanges(code, RTL_RANGES)) {
       rtlCount++;
     } else if (inRanges(code, LTR_RANGES)) {


### PR DESCRIPTION
Fixes #11400

## What

RTL text in chat now renders with the correct direction and alignment automatically, with no toggle. LTR behavior is unchanged.

## Implementation

Follows the plan from https://github.com/aaif-goose/goose/issues/11400#issuecomment-5413599064:

- New `getTextDirection(text)` helper (`ui/desktop/src/utils/textDirection.ts`) that counts strong RTL characters (Arabic, Hebrew, Syriac, Thaana, NKo, presentation forms) against strong LTR characters (Latin, Cyrillic, Greek, CJK, Indic). A leading English word or number doesn't force an Arabic message LTR, and text with no strong directional characters returns `null` so callers inherit the surrounding context.
- Composer textarea gets a `dir` attribute recomputed from the input value on every keystroke, so cursor, punctuation, and placeholder behave naturally while typing or deleting.
- Message bubbles (user + assistant) get `dir` computed from their text content.
- A small rehype plugin tags each markdown block element (`p`, headings, `li`, `blockquote`, table cells) with its own computed direction, so multi-paragraph mixed content resolves punctuation placement per block. Per-block counting is used instead of `unicode-bidi: plaintext` because plaintext keys off the first strong character, which breaks on messages starting with an English word.
- Fenced code blocks and inline code are pinned to `dir="ltr"` regardless of surrounding direction.
- `text-align: start` on the markdown root so alignment follows direction; list indents already use logical properties via the typography plugin.
- Same rules applied to message editing (edit-in-place textarea) and queued-message previews + queue edit textarea.

Out of scope, matching the issue: mirroring the wider app shell (navigation, buttons, panels).

## Testing

- [ ] Arabic, Hebrew, and Persian sample messages render right-aligned with correct punctuation
- [ ] Mixed LTR/RTL text: leading English word or number keeps the message RTL
- [ ] Multi-paragraph markdown, lists, and tables render per-block
- [ ] Composer typing, editing, cursor behavior
- [ ] Message editing and queued-message editing flip direction as you type
- [ ] Code blocks and inline code stay LTR
- [ ] Existing LTR chats unchanged

`pnpm run test:run` passes (828 tests), `tsc --noEmit` clean, eslint/prettier clean on touched files. Manual RTL spot-checks done in the desktop app.

## Credits

Implemented with the GLM agent (glm-5.3-flash) in Zed, working from the plan above, directed by @omidamraei.
