### PR TITLE
Add deja-vu to the extension directory

### DIFF
--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -233,6 +233,17 @@
     "environmentVariables": []
   },
   {
+    "id": "deja",
+    "name": "deja-vu",
+    "description": "Memory from the coding sessions already on this machine \u2014 Goose, Claude Code, Codex, Cursor and 18 more \u2014 searchable and recalled before a turn; no model, no API key",
+    "command": "deja mcp",
+    "link": "https://vshulcz.github.io/deja-vu/guide/memory-for-goose.html",
+    "installation_notes": "Install the deja binary first: brew install deja-vu (or go install github.com/vshulcz/deja-vu/cmd/deja@latest). The first call indexes the session history already on the machine.",
+    "is_builtin": false,
+    "endorsed": false,
+    "environmentVariables": []
+  },
+  {
     "id": "developer",
     "name": "Developer",
     "description": "Built-in developer tools for file editing and shell command execution",


### PR DESCRIPTION
## Summary

Adds deja-vu to the goose extension directory (servers.json) so it appears in the Extension Manager's discoverable list.

## About deja-vu

deja indexes the session history the coding agents on a machine already write to disk — Goose's own sessions plus Claude Code, Codex, Cursor and 18 others — and gives the agent a `deja` MCP tool to recall it: what was tried, what failed, what finally worked, including months from before it was installed. One Go binary; no model, no API key, no background service.

- Source: https://github.com/vshulcz/deja-vu (MIT)
- Goose guide: https://vshulcz.github.io/deja-vu/guide/memory-for-goose.html
- Install: `brew install deja-vu` (or `go install github.com/vshulcz/deja-vu/cmd/deja@latest`), then the extension command is `deja mcp`
- No API key required (reads local session files; keys and tokens are stripped as the index is built)
- One MCP tool with modes: recall, fix (what was run after this error before), blame (a file's session history), how, context, remember

## Changes

- 1 file changed, 11 insertions to `documentation/static/servers.json`
- Inserted alphabetically (before `developer`)
- No other entries modified