### PR TITLE
fix(desktop): unfreeze the window after closing a dialog opened from a menu

### DIFF
--- a/ui/desktop/src/components/ui/RecipeWarningModal.tsx
+++ b/ui/desktop/src/components/ui/RecipeWarningModal.tsx
@@ -6,6 +6,7 @@ import {
   DialogTitle,
   DialogPortal,
   DialogOverlay,
+  DialogPointerEventsRecovery,
 } from './dialog';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
 import { Button } from './button';
@@ -93,6 +94,7 @@ export function RecipeWarningModal({
           onPointerDownOutside={(e) => e.preventDefault()}
           onEscapeKeyDown={(e) => e.preventDefault()}
         >
+          <DialogPointerEventsRecovery />
           <DialogHeader className="flex-shrink-0 p-6 pb-0">
             <DialogTitle>
               {hasSecurityWarnings

--- a/ui/desktop/src/components/ui/dialog.pointerEvents.test.tsx
+++ b/ui/desktop/src/components/ui/dialog.pointerEvents.test.tsx
@@ -1,0 +1,85 @@
+/**
+ * Regression test for a dialog opened from a dropdown menu leaving the whole window
+ * unclickable after it closes.
+ *
+ * Radix's `DismissableLayer` sets `pointer-events: none` on `<body>` while a modal layer is
+ * open, and restores the value it snapshotted when the last layer of its own copy unmounts.
+ * That snapshot is a module-level variable, so it is only correct while one copy of
+ * `@radix-ui/react-dismissable-layer` is loaded. Two are: `@radix-ui/react-dialog` resolves
+ * 1.1.19 under `ui/desktop`, while the dropdown menu that arrives with `@radix-ui/themes`
+ * resolves 1.1.11, hoisted into `ui/node_modules`.
+ *
+ * A dropdown menu's close animation keeps its layer mounted for a beat after the item that
+ * opened the dialog was selected, so the dialog mounts while the menu's `none` is still on
+ * the body, snapshots it as the "original", and writes it back on close. Every click in the
+ * window is then dead — the sidebar, the session title, the header links.
+ *
+ * The menu half of that is stood in for here (set the lock, later drop it) rather than
+ * rendered: two modal Radix layers mounted at once put jsdom's focus scopes into an
+ * infinite focus loop, and the menu's contribution is only ever "set none, restore what was
+ * there before". The dialog half is the real component and the real 1.1.19 copy.
+ */
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+
+import { Dialog, DialogContent, DialogTitle } from './dialog';
+import { IntlTestWrapper } from '../../i18n/test-utils';
+
+function JsonDialog({ open }: { open: boolean }) {
+  return (
+    <IntlTestWrapper>
+      <Dialog open={open}>
+        <DialogContent>
+          <DialogTitle>Session JSON</DialogTitle>
+        </DialogContent>
+      </Dialog>
+    </IntlTestWrapper>
+  );
+}
+
+async function nextFrames(): Promise<void> {
+  await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+}
+
+describe('a dialog opened while a dropdown menu still holds the body lock', () => {
+  beforeEach(() => {
+    document.body.style.removeProperty('pointer-events');
+  });
+
+  afterEach(() => {
+    cleanup();
+    document.body.style.removeProperty('pointer-events');
+  });
+
+  it('leaves the body clickable after the dialog closes', async () => {
+    // The menu that was clicked is still animating out, so its copy of the layer still
+    // holds the lock.
+    document.body.style.pointerEvents = 'none';
+
+    const { rerender } = render(<JsonDialog open />);
+
+    // The menu finishes closing and its own copy restores what it found: an unlocked body.
+    document.body.style.removeProperty('pointer-events');
+
+    rerender(<JsonDialog open={false} />);
+    await nextFrames();
+
+    expect(document.body.style.pointerEvents).not.toBe('none');
+  });
+
+  it('still locks the body while the dialog is open', () => {
+    render(<JsonDialog open />);
+
+    expect(document.body.style.pointerEvents).toBe('none');
+  });
+
+  it('leaves the body clickable after a dialog opened on its own closes', async () => {
+    const { rerender } = render(<JsonDialog open />);
+    expect(document.body.style.pointerEvents).toBe('none');
+
+    rerender(<JsonDialog open={false} />);
+    await nextFrames();
+
+    expect(document.body.style.pointerEvents).not.toBe('none');
+  });
+});

--- a/ui/desktop/src/components/ui/dialog.pointerEvents.test.tsx
+++ b/ui/desktop/src/components/ui/dialog.pointerEvents.test.tsx
@@ -22,7 +22,16 @@
 import { describe, expect, it, beforeEach, afterEach } from 'vitest';
 import { render, cleanup } from '@testing-library/react';
 
-import { Dialog, DialogContent, DialogTitle } from './dialog';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+
+import {
+  Dialog,
+  DialogContent,
+  DialogOverlay,
+  DialogPointerEventsRecovery,
+  DialogPortal,
+  DialogTitle,
+} from './dialog';
 import { IntlTestWrapper } from '../../i18n/test-utils';
 
 function JsonDialog({ open }: { open: boolean }) {
@@ -32,6 +41,30 @@ function JsonDialog({ open }: { open: boolean }) {
         <DialogContent>
           <DialogTitle>Session JSON</DialogTitle>
         </DialogContent>
+      </Dialog>
+    </IntlTestWrapper>
+  );
+}
+
+/**
+ * Overlay and content have separate presence lifecycles, and the content's exit animation
+ * (`duration-200`) outlasts the overlay's (150ms by default). `forceMount` on the portal and
+ * the content stands in for that here: closing the dialog unmounts only the overlay, and the
+ * content is taken down in a later step, the way the real exit animations order it.
+ */
+function SplitExitDialog({ open, contentMounted }: { open: boolean; contentMounted: boolean }) {
+  return (
+    <IntlTestWrapper>
+      <Dialog open={open}>
+        <DialogPortal forceMount>
+          <DialogOverlay />
+          {contentMounted && (
+            <DialogPrimitive.Content forceMount>
+              <DialogPointerEventsRecovery />
+              <DialogTitle>Session JSON</DialogTitle>
+            </DialogPrimitive.Content>
+          )}
+        </DialogPortal>
       </Dialog>
     </IntlTestWrapper>
   );
@@ -78,6 +111,23 @@ describe('a dialog opened while a dropdown menu still holds the body lock', () =
     expect(document.body.style.pointerEvents).toBe('none');
 
     rerender(<JsonDialog open={false} />);
+    await nextFrames();
+
+    expect(document.body.style.pointerEvents).not.toBe('none');
+  });
+
+  it('leaves the body clickable when the content outlives the overlay', async () => {
+    document.body.style.pointerEvents = 'none';
+
+    const { rerender } = render(<SplitExitDialog open contentMounted />);
+    document.body.style.removeProperty('pointer-events');
+
+    // The overlay's exit animation ends first: only the overlay unmounts.
+    rerender(<SplitExitDialog open={false} contentMounted />);
+    await nextFrames();
+
+    // Then the content's does, and its layer restores the stale `none` it snapshotted.
+    rerender(<SplitExitDialog open={false} contentMounted={false} />);
     await nextFrames();
 
     expect(document.body.style.pointerEvents).not.toBe('none');

--- a/ui/desktop/src/components/ui/dialog.tsx
+++ b/ui/desktop/src/components/ui/dialog.tsx
@@ -30,27 +30,40 @@ function DialogPortal({ ...props }: React.ComponentProps<typeof DialogPrimitive.
 const DialogOverlay = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Overlay>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
->(({ className, ...props }, ref) => {
-  // The overlay lives inside the portal, so it unmounts when the dialog closes - unlike
-  // `DialogContent`, which stays mounted for the life of the `Dialog`. Two copies of
-  // Radix's dismissable layer are installed, so a dialog opened from a dropdown menu can
-  // otherwise leave `pointer-events: none` on the body and freeze every click in the
-  // window. See `releaseStuckBodyPointerEvents`.
-  React.useEffect(() => () => scheduleBodyPointerEventsRelease(), []);
-
-  return (
-    <DialogPrimitive.Overlay
-      ref={ref}
-      data-slot="dialog-overlay"
-      className={cn(
-        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-40 bg-black/50',
-        className
-      )}
-      {...props}
-    />
-  );
-});
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    data-slot="dialog-overlay"
+    className={cn(
+      'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-40 bg-black/50',
+      className
+    )}
+    {...props}
+  />
+));
 DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+/**
+ * Renders nothing. Place it inside `DialogPrimitive.Content` so that it unmounts together
+ * with the content's dismissable layer, and schedules the body pointer-events recovery
+ * from there.
+ *
+ * Two copies of Radix's dismissable layer are installed, so a dialog opened from a
+ * dropdown menu can leave `pointer-events: none` on the body and freeze every click in
+ * the window - see `releaseStuckBodyPointerEvents`. The recovery has to run after the
+ * content's layer has done its own restore, which is what keeps writing the stale value
+ * back. Hanging it off the overlay is not enough: overlay and content have separate
+ * presence lifecycles and exit animations (the overlay's default 150ms against the
+ * content's `duration-200`), so the overlay unmounts first and a check scheduled from
+ * there runs while the closing content is still mounted, only for the content's later
+ * cleanup to re-apply `none` with nothing left to clear it. `DialogContent` itself is no
+ * home for the effect either: it stays mounted for the life of the `Dialog`, and only the
+ * portal's children unmount on close.
+ */
+function DialogPointerEventsRecovery() {
+  React.useEffect(() => () => scheduleBodyPointerEventsRelease(), []);
+  return null;
+}
 
 function DialogContent({
   className,
@@ -69,6 +82,7 @@ function DialogContent({
         )}
         {...props}
       >
+        <DialogPointerEventsRecovery />
         {children}
         <DialogPrimitive.Close className="ring-offset-background p-1 hover:bg-background-secondary rounded-full focus:ring-ring data-[state=open]:bg-background-secondary transition-all duration-200 data-[state=open]:text-text-secondary absolute top-4 right-4 opacity-70 hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4">
           <XIcon />
@@ -129,6 +143,7 @@ export {
   DialogFooter,
   DialogHeader,
   DialogOverlay,
+  DialogPointerEventsRecovery,
   DialogPortal,
   DialogTitle,
   DialogTrigger,

--- a/ui/desktop/src/components/ui/dialog.tsx
+++ b/ui/desktop/src/components/ui/dialog.tsx
@@ -6,6 +6,7 @@ import { XIcon } from 'lucide-react';
 
 import { cn } from '../../utils';
 import { defineMessages, useIntl } from '../../i18n';
+import { scheduleBodyPointerEventsRelease } from '../../utils/radixPointerEvents';
 
 const i18n = defineMessages({
   close: {
@@ -29,17 +30,26 @@ function DialogPortal({ ...props }: React.ComponentProps<typeof DialogPrimitive.
 const DialogOverlay = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Overlay>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
->(({ className, ...props }, ref) => (
-  <DialogPrimitive.Overlay
-    ref={ref}
-    data-slot="dialog-overlay"
-    className={cn(
-      'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-40 bg-black/50',
-      className
-    )}
-    {...props}
-  />
-));
+>(({ className, ...props }, ref) => {
+  // The overlay lives inside the portal, so it unmounts when the dialog closes - unlike
+  // `DialogContent`, which stays mounted for the life of the `Dialog`. Two copies of
+  // Radix's dismissable layer are installed, so a dialog opened from a dropdown menu can
+  // otherwise leave `pointer-events: none` on the body and freeze every click in the
+  // window. See `releaseStuckBodyPointerEvents`.
+  React.useEffect(() => () => scheduleBodyPointerEventsRelease(), []);
+
+  return (
+    <DialogPrimitive.Overlay
+      ref={ref}
+      data-slot="dialog-overlay"
+      className={cn(
+        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-40 bg-black/50',
+        className
+      )}
+      {...props}
+    />
+  );
+});
 DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
 function DialogContent({

--- a/ui/desktop/src/utils/radixPointerEvents.test.ts
+++ b/ui/desktop/src/utils/radixPointerEvents.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import {
+  releaseStuckBodyPointerEvents,
+  scheduleBodyPointerEventsRelease,
+} from './radixPointerEvents';
+
+describe('releaseStuckBodyPointerEvents', () => {
+  beforeEach(() => {
+    document.body.style.removeProperty('pointer-events');
+    document.body.innerHTML = '';
+  });
+
+  afterEach(() => {
+    document.body.style.removeProperty('pointer-events');
+    document.body.innerHTML = '';
+  });
+
+  it('clears a leftover lock once the last layer is gone', () => {
+    document.body.style.pointerEvents = 'none';
+
+    releaseStuckBodyPointerEvents(document);
+
+    expect(document.body.style.pointerEvents).toBe('');
+  });
+
+  it('leaves the lock alone while a dialog is still open', () => {
+    document.body.style.pointerEvents = 'none';
+    document.body.innerHTML = '<div role="dialog" data-state="open"></div>';
+
+    releaseStuckBodyPointerEvents(document);
+
+    expect(document.body.style.pointerEvents).toBe('none');
+  });
+
+  it('leaves the lock alone while a popper-backed menu is still open', () => {
+    document.body.style.pointerEvents = 'none';
+    document.body.innerHTML = '<div data-radix-popper-content-wrapper></div>';
+
+    releaseStuckBodyPointerEvents(document);
+
+    expect(document.body.style.pointerEvents).toBe('none');
+  });
+
+  it('ignores a closed dialog left in the tree', () => {
+    document.body.style.pointerEvents = 'none';
+    document.body.innerHTML = '<div role="dialog" data-state="closed"></div>';
+
+    releaseStuckBodyPointerEvents(document);
+
+    expect(document.body.style.pointerEvents).toBe('');
+  });
+
+  it('does not touch a body that was never locked', () => {
+    document.body.style.pointerEvents = 'auto';
+
+    releaseStuckBodyPointerEvents(document);
+
+    expect(document.body.style.pointerEvents).toBe('auto');
+  });
+
+  it('defers the check to the next frame', async () => {
+    document.body.style.pointerEvents = 'none';
+
+    scheduleBodyPointerEventsRelease(document);
+    expect(document.body.style.pointerEvents).toBe('none');
+
+    await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+    expect(document.body.style.pointerEvents).toBe('');
+  });
+});

--- a/ui/desktop/src/utils/radixPointerEvents.test.ts
+++ b/ui/desktop/src/utils/radixPointerEvents.test.ts
@@ -34,11 +34,46 @@ describe('releaseStuckBodyPointerEvents', () => {
 
   it('leaves the lock alone while a popper-backed menu is still open', () => {
     document.body.style.pointerEvents = 'none';
-    document.body.innerHTML = '<div data-radix-popper-content-wrapper></div>';
+    document.body.innerHTML =
+      '<div data-radix-popper-content-wrapper><div role="menu" data-state="open"></div></div>';
 
     releaseStuckBodyPointerEvents(document);
 
     expect(document.body.style.pointerEvents).toBe('none');
+  });
+
+  it('leaves the lock alone while a select listbox is still open', () => {
+    document.body.style.pointerEvents = 'none';
+    document.body.innerHTML =
+      '<div data-radix-popper-content-wrapper><div role="listbox" data-state="open"></div></div>';
+
+    releaseStuckBodyPointerEvents(document);
+
+    expect(document.body.style.pointerEvents).toBe('none');
+  });
+
+  it('is not blocked by a tooltip that is still showing', () => {
+    // Tooltips ride the same popper wrapper as menus but never take the body lock, and
+    // nothing re-runs the check when they hide.
+    document.body.style.pointerEvents = 'none';
+    document.body.innerHTML =
+      '<div data-radix-popper-content-wrapper>' +
+      '<div data-slot="tooltip-content" data-state="delayed-open"><span role="tooltip">Copy</span></div>' +
+      '</div>';
+
+    releaseStuckBodyPointerEvents(document);
+
+    expect(document.body.style.pointerEvents).toBe('');
+  });
+
+  it('ignores a menu that is animating closed', () => {
+    document.body.style.pointerEvents = 'none';
+    document.body.innerHTML =
+      '<div data-radix-popper-content-wrapper><div role="menu" data-state="closed"></div></div>';
+
+    releaseStuckBodyPointerEvents(document);
+
+    expect(document.body.style.pointerEvents).toBe('');
   });
 
   it('ignores a closed dialog left in the tree', () => {

--- a/ui/desktop/src/utils/radixPointerEvents.ts
+++ b/ui/desktop/src/utils/radixPointerEvents.ts
@@ -1,0 +1,48 @@
+/**
+ * Recover from a leftover `pointer-events: none` on `<body>`.
+ *
+ * Radix's `DismissableLayer` disables pointer events on the body while a modal layer is
+ * open, and restores the value it snapshotted when the last layer of that copy unmounts.
+ * The snapshot lives in a module-level variable, so it is only correct while a single copy
+ * of `@radix-ui/react-dismissable-layer` is loaded. Two are: `@radix-ui/react-dialog`
+ * resolves 1.1.19 under `ui/desktop`, and the dropdown menu that arrives with
+ * `@radix-ui/themes` resolves 1.1.11, hoisted into `ui/node_modules`. A dialog opened from
+ * a menu that is still animating out therefore snapshots the menu's own
+ * `none`, and writes that back when the dialog closes - after which the window takes no
+ * clicks at all: the sidebar, the session title and the header links all look frozen.
+ *
+ * Clearing the property is safe only once no modal layer is left, which is what the
+ * selector below checks. Any still-open dialog, menu, select or popover keeps its own
+ * lock and re-applies it on its own unmount.
+ */
+const OPEN_LAYER_SELECTOR = [
+  '[data-radix-popper-content-wrapper]',
+  '[role="dialog"][data-state="open"]',
+  '[role="alertdialog"][data-state="open"]',
+  '[role="menu"][data-state="open"]',
+  '[role="listbox"][data-state="open"]',
+].join(', ');
+
+export function releaseStuckBodyPointerEvents(doc: typeof document = document): void {
+  if (doc.body.style.pointerEvents !== 'none') {
+    return;
+  }
+  if (doc.querySelector(OPEN_LAYER_SELECTOR)) {
+    return;
+  }
+  doc.body.style.removeProperty('pointer-events');
+}
+
+/**
+ * Schedule the check for after the next paint, so a dialog that is being replaced by
+ * another one - closing one modal to open the next - is not cleared out from under the
+ * incoming layer.
+ */
+export function scheduleBodyPointerEventsRelease(doc: typeof document = document): void {
+  const view = doc.defaultView;
+  if (view?.requestAnimationFrame) {
+    view.requestAnimationFrame(() => releaseStuckBodyPointerEvents(doc));
+    return;
+  }
+  setTimeout(() => releaseStuckBodyPointerEvents(doc), 0);
+}

--- a/ui/desktop/src/utils/radixPointerEvents.ts
+++ b/ui/desktop/src/utils/radixPointerEvents.ts
@@ -14,9 +14,14 @@
  * Clearing the property is safe only once no modal layer is left, which is what the
  * selector below checks. Any still-open dialog, menu, select or popover keeps its own
  * lock and re-applies it on its own unmount.
+ *
+ * The check goes by role and open state, not by Radix's `[data-radix-popper-content-wrapper]`.
+ * Tooltips ride the same popper wrapper without ever taking the body lock, and a tooltip can
+ * still be showing while the dialog closes - its trigger keeps focus after keyboard
+ * navigation, say. Nothing reschedules the release when that tooltip later goes away, so
+ * letting it block the check would leave the body locked for good.
  */
 const OPEN_LAYER_SELECTOR = [
-  '[data-radix-popper-content-wrapper]',
   '[role="dialog"][data-state="open"]',
   '[role="alertdialog"][data-state="open"]',
   '[role="menu"][data-state="open"]',


### PR DESCRIPTION
Relates to #11762 — that issue diagnoses the root cause (two copies of `@radix-ui/react-dismissable-layer` writing one `document.body`), which I hit independently before finding it.

This PR does **not** close #11762. #11792 does: it removes the duplicate tree at the dependency level. This one is the runtime recovery that #11792's author deliberately left out of scope ("Possible follow-up, not included here: a runtime safety net that clears a stranded `pointer-events: none`..."). The two are complementary and land in different files — #11792 touches only `package.json` / lockfile / workspace, this one only `ui/desktop/src`.

#11762 is not on the Issues board yet, so it has not reached **Ready**; #11792 is parked as a draft for the same reason. Happy for this to wait alongside it.

---

## The bug

Open the session-title dropdown, choose **View session JSON**, close the dialog. The whole window stops taking clicks — sidebar, session title, header links. The keyboard still works, which is why it reads as "some parts of the UI froze" rather than "the app hung".

It reproduces for any dialog opened from a `DropdownMenuItem`, not just this one.

## Why

`DismissableLayer` sets `pointer-events: none` on `<body>` while a modal layer is open, and restores the value it snapshotted when the last layer of **its own copy** unmounts:

```js
if (context.layersWithOutsidePointerEventsDisabled.size === 0) {
  originalBodyPointerEvents = ownerDocument.body.style.pointerEvents;
  ownerDocument.body.style.pointerEvents = 'none';
}
```

`originalBodyPointerEvents` is a module-level variable, so it is only correct while one copy of `@radix-ui/react-dismissable-layer` is loaded. Two are:

| copy | resolved for | on disk |
|---|---|---|
| 1.1.19 | `@radix-ui/react-dialog@1.1.23` (direct dep) | `ui/desktop/node_modules` |
| 1.1.11 | `@radix-ui/themes` -> `react-dropdown-menu@2.1.16` -> `react-menu` | `ui/node_modules` (hoisted) |

The menu's close animation keeps its layer mounted for a beat after `onSelect` fires, so the sequence is:

1. menu opens - copy A snapshots `''`, sets `none`
2. dialog opens while the menu animates out - copy B snapshots **`none`**, sets `none`
3. menu finishes closing - copy A restores `''`
4. dialog closes - copy B restores its snapshot, **`none`**, and nothing ever clears it

## The fix

Clear the leftover on the next frame, but only once no modal layer is left (any still-open dialog, menu, select or popover keeps its own lock and re-applies it on its own unmount).

The check hangs off `DialogOverlay`, not `DialogContent`: only the portal's children unmount when a dialog closes — `DialogContent` itself stays mounted for the life of the `Dialog`, so a cleanup there never runs. `RecipeWarningModal` builds its own content but renders this same `DialogOverlay`, so it is covered too.

This is a recovery, not the root fix. The root fix is to stop resolving two copies of `react-dismissable-layer` — declaring `@radix-ui/react-dropdown-menu` directly (it is imported by `src/components/ui/dropdown-menu.tsx` but is not in `package.json`, so it resolves through `@radix-ui/themes` today), or a `pnpm.overrides` pin. I kept that out of this PR because it moves the lockfile and touches every Radix primitive `themes` brings in; happy to add it if you would rather fix it there.

## Tests

`dialog.pointerEvents.test.tsx` drives the real `Dialog` against the real 1.1.19 copy and stands in for the menu's half of the lock. Mounting two modal Radix layers at once was the faithful version, but it puts jsdom's focus scopes into an infinite focus loop (~80k errors, worker dies), and the menu's only contribution is "set `none`, restore what was there before". Confirmed the new test fails on `main` and passes with the fix.

`radixPointerEvents.test.ts` covers the guard itself: it clears a stuck lock, leaves it alone while a dialog / popper-backed menu is still open, ignores a closed dialog left in the tree, and never touches a body that was not locked.

`tsc --noEmit` and `eslint` clean; 9/9 tests pass.

