### PR TITLE
release(gdk): cut 0.1.0-alpha.9 and unblock the Kotlin smoke test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5330,7 +5330,7 @@ dependencies = [
 
 [[package]]
 name = "goose-agent"
-version = "0.1.0-alpha.8"
+version = "0.1.0-alpha.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5412,7 +5412,7 @@ dependencies = [
 
 [[package]]
 name = "goose-context-management"
-version = "0.1.0-alpha.8"
+version = "0.1.0-alpha.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5428,7 +5428,7 @@ dependencies = [
 
 [[package]]
 name = "goose-download-manager"
-version = "0.1.0-alpha.8"
+version = "0.1.0-alpha.9"
 dependencies = [
  "anyhow",
  "once_cell",
@@ -5440,7 +5440,7 @@ dependencies = [
 
 [[package]]
 name = "goose-local-inference"
-version = "0.1.0-alpha.8"
+version = "0.1.0-alpha.9"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -5502,7 +5502,7 @@ dependencies = [
 
 [[package]]
 name = "goose-provider-types"
-version = "0.1.0-alpha.8"
+version = "0.1.0-alpha.9"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -5531,7 +5531,7 @@ dependencies = [
 
 [[package]]
 name = "goose-providers"
-version = "0.1.0-alpha.8"
+version = "0.1.0-alpha.9"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -5583,7 +5583,7 @@ dependencies = [
 
 [[package]]
 name = "goose-sdk"
-version = "0.1.0-alpha.8"
+version = "0.1.0-alpha.9"
 dependencies = [
  "agent-client-protocol",
  "agent-client-protocol-schema",
@@ -5603,7 +5603,7 @@ dependencies = [
 
 [[package]]
 name = "goose-sdk-types"
-version = "0.1.0-alpha.8"
+version = "0.1.0-alpha.9"
 dependencies = [
  "agent-client-protocol",
  "agent-client-protocol-schema",

--- a/crates/goose-agent/Cargo.toml
+++ b/crates/goose-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goose-agent"
-version = "0.1.0-alpha.8"
+version = "0.1.0-alpha.9"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -16,7 +16,7 @@ anyhow = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "sync", "time", "fs", "process", "net", "signal", "io-std", "io-util"] }
 tokio-util = { workspace = true, features = ["compat"] }
 async-trait = { workspace = true }
-goose-provider-types = { version = "0.1.0-alpha.8", path = "../goose-provider-types", default-features = false }
+goose-provider-types = { version = "0.1.0-alpha.9", path = "../goose-provider-types", default-features = false }
 rmcp = { workspace = true, features = ["server"] }
 uuid = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/goose-context-management/Cargo.toml
+++ b/crates/goose-context-management/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goose-context-management"
-version = "0.1.0-alpha.8"
+version = "0.1.0-alpha.9"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -12,7 +12,7 @@ description = "Conversation compaction for Goose"
 workspace = true
 
 [dependencies]
-goose-providers = { version = "0.1.0-alpha.8", path = "../goose-providers", features = ["rustls-tls"] }
+goose-providers = { version = "0.1.0-alpha.9", path = "../goose-providers", features = ["rustls-tls"] }
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 include_dir = { workspace = true }

--- a/crates/goose-download-manager/Cargo.toml
+++ b/crates/goose-download-manager/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goose-download-manager"
-version = "0.1.0-alpha.8"
+version = "0.1.0-alpha.9"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/goose-local-inference/Cargo.toml
+++ b/crates/goose-local-inference/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goose-local-inference"
-version = "0.1.0-alpha.8"
+version = "0.1.0-alpha.9"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -32,9 +32,9 @@ chrono = { workspace = true }
 etcetera = { workspace = true }
 encoding_rs = { version = "0.8.35", default-features = false }
 futures = { workspace = true, optional = true }
-goose-download-manager = { version = "0.1.0-alpha.8", path = "../goose-download-manager", optional = true }
-goose-provider-types = { version = "0.1.0-alpha.8", path = "../goose-provider-types", default-features = false }
-goose-sdk-types = { version = "0.1.0-alpha.8", path = "../goose-sdk-types", default-features = false, optional = true }
+goose-download-manager = { version = "0.1.0-alpha.9", path = "../goose-download-manager", optional = true }
+goose-provider-types = { version = "0.1.0-alpha.9", path = "../goose-provider-types", default-features = false }
+goose-sdk-types = { version = "0.1.0-alpha.9", path = "../goose-sdk-types", default-features = false, optional = true }
 hf-hub = { version = "1.0.0", default-features = false, optional = true }
 include_dir = { workspace = true }
 llama-cpp-2 = { workspace = true }

--- a/crates/goose-provider-types/Cargo.toml
+++ b/crates/goose-provider-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goose-provider-types"
-version = "0.1.0-alpha.8"
+version = "0.1.0-alpha.9"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/goose-providers/Cargo.toml
+++ b/crates/goose-providers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goose-providers"
-version = "0.1.0-alpha.8"
+version = "0.1.0-alpha.9"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -35,8 +35,8 @@ anyhow = { workspace = true }
 async-stream = { workspace = true }
 chrono = { workspace = true }
 futures = { workspace = true }
-goose-provider-types = { version = "0.1.0-alpha.8", path = "../goose-provider-types", default-features = false }
-goose-local-inference = { version = "0.1.0-alpha.8", path = "../goose-local-inference", default-features = false, optional = true }
+goose-provider-types = { version = "0.1.0-alpha.9", path = "../goose-provider-types", default-features = false }
+goose-local-inference = { version = "0.1.0-alpha.9", path = "../goose-local-inference", default-features = false, optional = true }
 reqwest = { workspace = true }
 rmcp = { workspace = true, features = ["server", "macros"] }
 serde = { workspace = true }

--- a/crates/goose-sdk-types/Cargo.toml
+++ b/crates/goose-sdk-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goose-sdk-types"
-version = "0.1.0-alpha.8"
+version = "0.1.0-alpha.9"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/goose-sdk/Cargo.toml
+++ b/crates/goose-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goose-sdk"
-version = "0.1.0-alpha.8"
+version = "0.1.0-alpha.9"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -33,14 +33,14 @@ uniffi = [
 ]
 
 [dependencies]
-goose-sdk-types = { version = "0.1.0-alpha.8", path = "../goose-sdk-types" }
+goose-sdk-types = { version = "0.1.0-alpha.9", path = "../goose-sdk-types" }
 agent-client-protocol = { workspace = true }
 agent-client-protocol-schema = { workspace = true }
 
 uniffi = { version = "0.32", features = ["cli"], optional = true }
 thiserror = { version = "2", optional = true }
-goose-providers = { version = "0.1.0-alpha.8", path = "../goose-providers", features = ["rustls-tls"], optional = true }
-goose-context-management = { version = "0.1.0-alpha.8", path = "../goose-context-management", optional = true }
+goose-providers = { version = "0.1.0-alpha.9", path = "../goose-providers", features = ["rustls-tls"], optional = true }
+goose-context-management = { version = "0.1.0-alpha.9", path = "../goose-context-management", optional = true }
 futures = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "sync"], optional = true }

--- a/crates/goose-sdk/examples/uniffi/kotlin/src/main/kotlin/Main.kt
+++ b/crates/goose-sdk/examples/uniffi/kotlin/src/main/kotlin/Main.kt
@@ -39,6 +39,8 @@ fun main() = runBlocking {
                 is StreamChunk.EndChunk -> chunk.usage?.let { println("\nusage: $it") }
                 is StreamChunk.ErrorChunk -> System.err.println("\nerror: ${chunk.error.message}")
                 is StreamChunk.ToolChunk -> Unit
+                is StreamChunk.ThinkingChunk -> Unit
+                is StreamChunk.RedactedThinkingChunk -> Unit
             }
         }
     println()

--- a/crates/goose-sdk/python/pyproject.toml
+++ b/crates/goose-sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "goose-sdk"
-version = "0.1.0a8"
+version = "0.1.0a9"
 description = "Python bindings for the goose Development Kit (GDK)"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/documentation/src/data/gdk-api.json
+++ b/documentation/src/data/gdk-api.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "version": "0.1.0-alpha.8",
+      "version": "0.1.0-alpha.9",
       "docVersion": "0.1",
       "source": "crates/goose-sdk/src/bindings.rs",
       "functions": [


### PR DESCRIPTION
## Why

The `0.1.0-alpha.8` Maven publish never happened. [Its release run](https://github.com/aaif-goose/goose/actions/runs/33787829826) reached `Smoke test Kotlin GDK (linux-aarch64)`, failed there, and because `publish` declares `needs: [package, smoke-test-linux-aarch64]`, `Publish to Maven Central` was **skipped**:

```
[success] Publish Maven package / Package Maven artifact
[failure] Publish Maven package / Smoke test Kotlin GDK (linux-aarch64)
[skipped] Publish Maven package / Publish to Maven Central
```

The `gdk-v0.1.0-alpha.8` tag exists and the crates.io/PyPI artifacts published fine, but `io.github.aaif-goose:gdk` on Maven Central still stops at `0.1.0-alpha.7`. **No JVM consumer can pick up anything merged since alpha.7** — that includes #11628, #11629, #11630, #11631, #11632, #11634, #11636, #11637 and #11721.

## What broke

The smoke test failed to *compile*, not to load a native library:

```
e: Main.kt:37:13 'when' expression must be exhaustive.
   Add the 'is RedactedThinkingChunk', 'is ThinkingChunk' branches or an 'else' branch.
```

#11636 added `ThinkingChunk` and `RedactedThinkingChunk` to `StreamChunk` without updating the example that the release workflow compiles. The `when` is deliberately written without an `else` — a new chunk variant *should* break this loudly rather than be silently swallowed — so both variants are now handled explicitly.

## Why a new version instead of re-tagging alpha.8

alpha.8 is already on crates.io and PyPI, and `crates-publish` skips crates that are already up (HTTP `200` → skip). Re-tagging `alpha.8` would republish nothing and leave Maven Central empty. Cutting alpha.9 is what actually ships the alpha.7..alpha.8 Kotlin work.

## Verification

Run on ARM64 — the platform that failed — against a locally published `0.1.0-alpha.9`:

- `gradle installDist` on the example: **succeeds** (was the failing step)
- The workflow's native-load check prints `gpt-4o`
- `just check-version 0.1.0-alpha.9`: passes
- Generated Kotlin API surface is **identical** to alpha.8 (diffed top-level declarations), so for JVM consumers this is a publish-only change

Also compiled a real downstream consumer (`cash-server`'s `goosellm`/`kgoose`) against the local alpha.9 — compiles and tests green.

## After merge

The release still needs `Publish GDK` to run for the new tag, since tagging is what triggers publication.
