### PR TITLE
feat(agents): freeze the system prompt per conversation and deliver changes as system messages

### DIFF
--- a/crates/goose-agent/src/inference.rs
+++ b/crates/goose-agent/src/inference.rs
@@ -75,7 +75,8 @@ fn is_thinking(content: &MessageContent) -> bool {
     )
 }
 
-fn normalize_tool_call_thinking(accumulator: &mut Conversation, chunk: &mut Message) {
+/// Some providers repeat already streamed reasoning on the tool-call chunk.
+fn drop_repeated_tool_call_thinking(accumulator: &Conversation, chunk: &mut Message) {
     if !chunk
         .content
         .iter()
@@ -83,42 +84,15 @@ fn normalize_tool_call_thinking(accumulator: &mut Conversation, chunk: &mut Mess
     {
         return;
     }
-
-    let has_direct_thinking = chunk.content.iter().any(is_thinking);
-    let mut prior_thinking = Vec::new();
-    for message in accumulator.messages_mut() {
-        if message.role != chunk.role
-            || message
-                .content
-                .iter()
-                .any(|content| matches!(content, MessageContent::ToolRequest(_)))
-        {
-            continue;
-        }
-        prior_thinking.extend(
-            message
-                .content
-                .iter()
-                .filter(|content| is_thinking(content))
-                .cloned(),
-        );
-        message.content.retain(|content| !is_thinking(content));
-    }
-    accumulator
-        .messages_mut()
-        .retain(|message| !message.content.is_empty());
-
-    if !has_direct_thinking && !prior_thinking.is_empty() {
-        if let Some(tool_request) = chunk
-            .content
-            .iter()
-            .position(|content| matches!(content, MessageContent::ToolRequest(_)))
-        {
-            chunk
-                .content
-                .splice(tool_request..tool_request, prior_thinking);
-        }
-    }
+    let prior: Vec<&MessageContent> = accumulator
+        .iter()
+        .filter(|message| message.role == chunk.role)
+        .flat_map(|message| message.content.iter())
+        .filter(|content| is_thinking(content))
+        .collect();
+    chunk
+        .content
+        .retain(|content| !(is_thinking(content) && prior.contains(&content)));
 }
 
 pub fn chat_span(
@@ -469,7 +443,7 @@ impl<S: Sync, E: InferenceEffect> Inference<S, E> for InferenceRunner<'_, S, E> 
                                 }
                                 _ => true,
                             });
-                            normalize_tool_call_thinking(&mut accumulator, &mut chunk);
+                            drop_repeated_tool_call_thinking(&accumulator, &mut chunk);
                             if chunk.content.is_empty() {
                                 if chunk.metadata.output_token_limit_reached {
                                     chunk = emit.message(chunk).await;

--- a/crates/goose-cli/src/session/output.rs
+++ b/crates/goose-cli/src/session/output.rs
@@ -561,7 +561,7 @@ fn should_show_thinking() -> bool {
 }
 
 fn render_thinking(text: &str, theme: Theme) {
-    if should_show_thinking() {
+    if should_show_thinking() && !text.is_empty() {
         println!("\n{}", style("Thinking:").dim().italic());
         print_markdown(text, theme);
     }
@@ -573,7 +573,7 @@ fn render_thinking_streaming(
     header_shown: &mut bool,
     theme: Theme,
 ) {
-    if should_show_thinking() {
+    if should_show_thinking() && !text.is_empty() {
         flush_markdown_buffer(buffer, theme);
         if !*header_shown {
             println!("\n{}", style("Thinking:").dim().italic());

--- a/crates/goose-provider-types/src/canonical/data/canonical_models.json
+++ b/crates/goose-provider-types/src/canonical/data/canonical_models.json
@@ -20061,6 +20061,39 @@
     }
   },
   {
+    "id": "anthropic/claude-fable-5.1",
+    "name": "Claude Fable 5.1",
+    "family": "claude-fable",
+    "attachment": true,
+    "reasoning": true,
+    "thinking_mode": "always_on_adaptive",
+    "tool_call": true,
+    "temperature": false,
+    "release_date": "2026-08-31",
+    "last_updated": "2026-08-31",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 10.0,
+      "output": 50.0,
+      "cache_read": 1.0,
+      "cache_write": 12.5
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
     "id": "anthropic/claude-haiku-4.5",
     "name": "Claude Haiku 4.5 (latest)",
     "family": "claude-haiku",

--- a/crates/goose-provider-types/src/canonical/name_builder.rs
+++ b/crates/goose-provider-types/src/canonical/name_builder.rs
@@ -16,7 +16,7 @@ static STRIP_PATTERNS: Lazy<Vec<Regex>> = Lazy::new(|| {
 });
 
 static CLAUDE_PATTERNS: Lazy<Vec<(Regex, Regex, &'static str)>> = Lazy::new(|| {
-    ["sonnet", "opus", "haiku"]
+    ["sonnet", "opus", "haiku", "fable"]
         .iter()
         .map(|&size| {
             (

--- a/crates/goose-provider-types/src/conversation.rs
+++ b/crates/goose-provider-types/src/conversation.rs
@@ -523,6 +523,29 @@ pub fn merge_consecutive_messages_for_request(messages: Vec<Message>) -> Vec<Mes
     merge_consecutive(messages, true).0
 }
 
+/// For formatters that send system updates as plain user text: folds each
+/// update into the surrounding user messages so role alternation survives.
+pub fn merge_system_updates_for_request(messages: &[Message]) -> Vec<Message> {
+    let mut merged: Vec<Message> = Vec::new();
+    let mut folding = false;
+    for message in messages.iter().cloned() {
+        if let Some(last) = merged.last_mut() {
+            if message.role == Role::User
+                && last.role == Role::User
+                && (folding || message.is_system_update() || last.is_system_update())
+            {
+                last.content.extend(message.content);
+                last.metadata.system_update = false;
+                folding = true;
+                continue;
+            }
+        }
+        folding = false;
+        merged.push(message);
+    }
+    merged
+}
+
 fn merge_consecutive(
     messages: Vec<Message>,
     across_visibility: bool,
@@ -534,6 +557,8 @@ fn merge_consecutive(
         if let Some(last) = merged_messages.last_mut() {
             let effective = effective_role(&message);
             if effective_role(last) == effective
+                && !last.is_system_update()
+                && !message.is_system_update()
                 && (across_visibility
                     || (last.metadata.user_visible == message.metadata.user_visible
                         && last.metadata.turn_context == message.metadata.turn_context))
@@ -722,7 +747,10 @@ mod tests {
     use crate::conversation::message::{
         InferenceMetadata, Message, MessageContentBlock, MessageMetadata,
     };
-    use crate::conversation::{debug_conversation_fix, fix_conversation, Conversation};
+    use crate::conversation::{
+        debug_conversation_fix, fix_conversation, merge_consecutive_messages_for_request,
+        merge_system_updates_for_request, Conversation,
+    };
     use rmcp::model::{CallToolRequestParams, Role};
     use rmcp::object;
 
@@ -878,6 +906,32 @@ mod tests {
             "the request form merges to satisfy role alternation"
         );
         assert_eq!(merged[0].content.len(), 2);
+    }
+
+    #[test]
+    fn system_updates_are_never_merged_into_neighbours() {
+        let messages = vec![
+            Message::user().with_text("prompt"),
+            Message::user()
+                .with_text("update")
+                .with_metadata(MessageMetadata::agent_only().with_system_update()),
+            Message::user()
+                .with_text("<turn-context/>")
+                .with_metadata(MessageMetadata::agent_only().with_turn_context()),
+        ];
+
+        let (fixed, _) = fix_conversation(Conversation::new_unvalidated(messages.clone()));
+        assert_eq!(fixed.messages().len(), 3);
+        assert!(fixed.messages()[1].is_system_update());
+
+        let merged = merge_consecutive_messages_for_request(messages);
+        assert_eq!(merged.len(), 3);
+        assert!(merged[1].is_system_update());
+        assert_eq!(merged[1].as_concat_text(), "update");
+
+        let folded = merge_system_updates_for_request(&merged);
+        assert_eq!(folded.len(), 1);
+        assert_eq!(folded[0].content.len(), 3);
     }
 
     #[test]

--- a/crates/goose-provider-types/src/conversation/message.rs
+++ b/crates/goose-provider-types/src/conversation/message.rs
@@ -844,6 +844,8 @@ pub struct MessageMetadata {
     /// Whether this message is a per-turn context event appended by the agent.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub turn_context: bool,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub system_update: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub usage: Option<Box<MessageUsage>>,
     /// What an operation did to this message, keyed by operation name. Read back
@@ -862,6 +864,7 @@ impl Default for MessageMetadata {
             output_token_limit_reached: false,
             steer: false,
             turn_context: false,
+            system_update: false,
             usage: None,
             operations: None,
         }
@@ -952,6 +955,11 @@ impl MessageMetadata {
 
     pub fn with_turn_context(mut self) -> Self {
         self.turn_context = true;
+        self
+    }
+
+    pub fn with_system_update(mut self) -> Self {
+        self.system_update = true;
         self
     }
 }
@@ -1340,6 +1348,10 @@ impl Message {
 
     pub fn is_turn_context(&self) -> bool {
         self.metadata.turn_context
+    }
+
+    pub fn is_system_update(&self) -> bool {
+        self.metadata.system_update
     }
 }
 

--- a/crates/goose-provider-types/src/formats/anthropic.rs
+++ b/crates/goose-provider-types/src/formats/anthropic.rs
@@ -51,15 +51,21 @@ macro_rules! string_enum {
 string_enum!(ThinkingType { Adaptive => "adaptive", Enabled => "enabled", Disabled => "disabled" });
 string_enum!(CacheTtl { FiveMinutes => "5m", OneHour => "1h" });
 
+string_enum!(PrefixMismatchBehavior { DropBlock => "drop_block", Error => "error" });
+
+pub const THINKING_BINDING_CONTROLS_BETA: &str = "thinking-binding-controls-2026-08-01";
+pub const INPUT_TRANSFORMATIONS_FIELD: &str = "input_transformations";
+
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct AnthropicFormatOptions {
     pub preserve_unsigned_thinking: bool,
     pub preserve_thinking_context: bool,
     pub thinking_disabled: bool,
     pub emit_clear_thinking: bool,
-    pub current_model: Option<String>,
     pub prompt_cache_disabled: bool,
     pub cache_ttl: Option<CacheTtl>,
+    pub prefix_mismatch_behavior: Option<PrefixMismatchBehavior>,
+    pub strip_thinking_history: bool,
 }
 
 impl AnthropicFormatOptions {
@@ -80,17 +86,24 @@ impl AnthropicFormatOptions {
             .cache_ttl()
             .and_then(|ttl| ttl.parse::<CacheTtl>().ok())
             .or(self.cache_ttl);
+        let prefix_mismatch_behavior = match model_config
+            .request_param::<String>("prefix_mismatch_behavior")
+            .as_deref()
+        {
+            None => self.prefix_mismatch_behavior,
+            Some("off") => None,
+            Some(value) => value.parse::<PrefixMismatchBehavior>().ok(),
+        };
 
         Self {
             preserve_unsigned_thinking,
             preserve_thinking_context,
             thinking_disabled,
             emit_clear_thinking,
-            current_model: self
-                .current_model
-                .or_else(|| Some(model_config.model_name.clone())),
             prompt_cache_disabled: model_config.prompt_cache_disabled(),
             cache_ttl,
+            prefix_mismatch_behavior,
+            strip_thinking_history: self.strip_thinking_history,
         }
     }
 
@@ -247,7 +260,7 @@ fn format_messages_with_options(
             Role::Assistant => ASSISTANT_ROLE,
         };
 
-        let thinking_is_stale = thinking_block_is_stale(message, options.current_model.as_deref());
+        let replay_thinking = !options.thinking_disabled && !options.strip_thinking_history;
 
         let mut content = Vec::new();
         for msg_content in &message.content {
@@ -401,15 +414,13 @@ fn format_messages_with_options(
                 }
                 MessageContentBlock::Thinking(thinking) => {
                     // Anthropic rejects thinking blocks sent without a matching thinking config.
-                    if !options.thinking_disabled {
+                    if replay_thinking {
                         if !thinking.signature.is_empty() {
-                            if !thinking_is_stale {
-                                content.push(json!({
-                                    TYPE_FIELD: THINKING_TYPE,
-                                    THINKING_TYPE: thinking.thinking,
-                                    SIGNATURE_FIELD: thinking.signature
-                                }));
-                            }
+                            content.push(json!({
+                                TYPE_FIELD: THINKING_TYPE,
+                                THINKING_TYPE: thinking.thinking,
+                                SIGNATURE_FIELD: thinking.signature
+                            }));
                         } else if options.preserve_unsigned_thinking
                             && !thinking.thinking.is_empty()
                         {
@@ -421,7 +432,7 @@ fn format_messages_with_options(
                     }
                 }
                 MessageContentBlock::RedactedThinking(redacted) => {
-                    if !options.thinking_disabled && !thinking_is_stale {
+                    if replay_thinking {
                         content.push(json!({
                             TYPE_FIELD: REDACTED_THINKING_TYPE,
                             DATA_FIELD: redacted.data
@@ -688,6 +699,33 @@ pub fn get_usage(data: &Value) -> Result<Usage> {
 /// Anthropic response fields that have no canonical `ProviderUsage` equivalent.
 const ADDITIONAL_USAGE_FIELDS: [&str; 1] = ["service_tier"];
 
+/// Thinking blocks the API dropped from this request. A `prefix_binding_mismatch`
+/// means the replayed conversation changed ahead of the block.
+pub fn input_transformations(message_data: &Value) -> Option<Value> {
+    let transformations = message_data
+        .get(INPUT_TRANSFORMATIONS_FIELD)?
+        .as_array()
+        .filter(|entries| !entries.is_empty())?;
+    let prefix_mismatches: Vec<&str> = transformations
+        .iter()
+        .filter(|t| t.get("reason").and_then(|r| r.as_str()) == Some("prefix_binding_mismatch"))
+        .filter_map(|t| t.get("path").and_then(|p| p.as_str()))
+        .collect();
+    let transformations = Value::Array(transformations.clone());
+    if prefix_mismatches.is_empty() {
+        tracing::info!(
+            %transformations,
+            "API dropped thinking blocks the current model cannot read"
+        );
+    } else {
+        tracing::warn!(
+            paths = ?prefix_mismatches,
+            "API dropped thinking blocks because the conversation prefix changed since they were produced"
+        );
+    }
+    Some(transformations)
+}
+
 pub fn get_additional_data(data: &Value) -> Option<Map<String, Value>> {
     let usage = data.get("usage")?.as_object()?;
     let additional: Map<String, Value> = ADDITIONAL_USAGE_FIELDS
@@ -809,6 +847,38 @@ fn apply_thinking_config(
     {
         obj.insert("thinking".to_string(), json!({"type": "disabled"}));
     }
+
+    // `block_binding` is only accepted alongside adaptive or enabled thinking.
+    if let Some(behavior) = options.prefix_mismatch_behavior {
+        if let Some(thinking) = obj.get_mut("thinking").and_then(|t| t.as_object_mut()) {
+            if thinking.get("type").and_then(|t| t.as_str()) != Some("disabled") {
+                thinking.insert(
+                    "block_binding".to_string(),
+                    json!({"prefix_mismatch_behavior": behavior.to_string()}),
+                );
+            }
+        }
+    }
+}
+
+pub fn required_beta_features(payload: &Value) -> Vec<&'static str> {
+    let mut features = Vec::new();
+    if payload
+        .get("thinking")
+        .and_then(|t| t.get("block_binding"))
+        .is_some()
+    {
+        features.push(THINKING_BINDING_CONTROLS_BETA);
+    }
+    features
+}
+
+pub fn is_thinking_signature_error(message: &str) -> bool {
+    let lower = message.to_lowercase();
+    lower.contains("thinking")
+        && (lower.contains("signature")
+            || lower.contains("cannot be modified")
+            || lower.contains("block_binding"))
 }
 
 pub fn create_request(
@@ -973,6 +1043,11 @@ where
                 EVENT_MESSAGE_START => {
                     if let Some(message_data) = event.data.get("message") {
                         additional_data = get_additional_data(message_data);
+                        if let Some(transformations) = input_transformations(message_data) {
+                            additional_data
+                                .get_or_insert_with(Map::new)
+                                .insert(INPUT_TRANSFORMATIONS_FIELD.to_string(), transformations);
+                        }
                         if let Some(id) = message_data.get("id").and_then(|v| v.as_str()) {
                             message_id = Some(id.to_string());
                         }
@@ -1067,7 +1142,9 @@ where
                 }
                 EVENT_CONTENT_BLOCK_STOP => {
                     if let Some(state) = thinking.take() {
-                        if !state.text.is_empty() {
+                        // Omitted thinking display yields an empty `thinking` string
+                        // with a signature; the block must still be replayed.
+                        if !state.text.is_empty() || !state.signature.is_empty() {
                             let mut message = Message::assistant()
                                 .with_thinking(state.text, state.signature);
                             message.id = message_id.clone();
@@ -1540,48 +1617,94 @@ mod tests {
     }
 
     #[test]
-    fn drops_signed_thinking_from_a_different_model() {
-        let messages = vec![signed_thinking_from_model("claude-opus-4-1")];
-        let opts = AnthropicFormatOptions {
-            current_model: Some("claude-sonnet-4-5".to_string()),
-            ..Default::default()
-        };
-        let spec = format_messages_with_options(&messages, &opts);
-        let types: Vec<&str> = spec[0]["content"]
-            .as_array()
-            .unwrap()
-            .iter()
-            .map(|c| c["type"].as_str().unwrap())
-            .collect();
-        assert!(
-            !types.contains(&"thinking"),
-            "stale thinking must be dropped"
-        );
-        assert!(types.contains(&"text"), "text content must be preserved");
-    }
-
-    #[test]
-    fn keeps_signed_thinking_from_the_same_model() {
-        let messages = vec![signed_thinking_from_model("claude-sonnet-4-5")];
-        let opts = AnthropicFormatOptions {
-            current_model: Some("claude-sonnet-4-5".to_string()),
-            ..Default::default()
-        };
+    fn keeps_signed_thinking_from_a_different_model() {
+        let messages = vec![signed_thinking_from_model("claude-opus-4-8")];
+        let opts = AnthropicFormatOptions::default().for_model(&ModelConfig::new("claude-opus-5"));
         let spec = format_messages_with_options(&messages, &opts);
         assert_eq!(spec[0]["content"][0]["type"], "thinking");
         assert_eq!(spec[0]["content"][0]["signature"], "sig-abc");
+        assert_eq!(spec[0]["content"][1]["type"], "text");
     }
 
     #[test]
-    fn keeps_signed_thinking_when_provenance_unknown() {
-        let messages =
-            vec![Message::assistant().with_content(MessageContent::thinking("internal", "sig"))];
+    fn replays_signed_thinking_with_empty_text() {
+        let messages = vec![Message::assistant()
+            .with_content(MessageContent::thinking("", "sig-omitted"))
+            .with_text("answer")];
+        let spec = format_messages_with_options(&messages, &AnthropicFormatOptions::default());
+        assert_eq!(
+            spec[0]["content"][0],
+            json!({"type": "thinking", "thinking": "", "signature": "sig-omitted"})
+        );
+    }
+
+    #[test]
+    fn strip_thinking_history_removes_signed_and_redacted_blocks() {
+        let messages = vec![Message::assistant()
+            .with_content(MessageContent::thinking("internal", "sig"))
+            .with_redacted_thinking("opaque")
+            .with_text("answer")];
         let opts = AnthropicFormatOptions {
-            current_model: Some("claude-sonnet-4-5".to_string()),
+            strip_thinking_history: true,
             ..Default::default()
         };
         let spec = format_messages_with_options(&messages, &opts);
-        assert_eq!(spec[0]["content"][0]["type"], "thinking");
+        assert_eq!(
+            spec[0]["content"],
+            json!([{"type": "text", "text": "answer"}])
+        );
+    }
+
+    fn request_with_options(model: &ModelConfig, opts: AnthropicFormatOptions) -> Result<Value> {
+        create_request(
+            ANTHROPIC_PROVIDER_NAME,
+            model,
+            "system",
+            &[Message::user().with_text("hi")],
+            &[],
+            opts,
+        )
+    }
+
+    fn opus_5_with_params(params: &[(&str, Value)]) -> ModelConfig {
+        let params: std::collections::HashMap<String, Value> = params
+            .iter()
+            .map(|(key, value)| (key.to_string(), value.clone()))
+            .collect();
+        ModelConfig::new("claude-opus-5").with_merged_request_params(params)
+    }
+
+    #[test]
+    fn block_binding_sent_with_adaptive_thinking() -> Result<()> {
+        let model = opus_5_with_params(&[("thinking_effort", json!("high"))]);
+        let opts = AnthropicFormatOptions {
+            prefix_mismatch_behavior: Some(PrefixMismatchBehavior::DropBlock),
+            ..Default::default()
+        };
+        let payload = request_with_options(&model, opts)?;
+        assert_eq!(payload["thinking"]["type"], "adaptive");
+        assert_eq!(
+            payload["thinking"]["block_binding"]["prefix_mismatch_behavior"],
+            "drop_block"
+        );
+        assert_eq!(
+            required_beta_features(&payload),
+            vec![THINKING_BINDING_CONTROLS_BETA]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn block_binding_not_sent_with_disabled_thinking() -> Result<()> {
+        let model = opus_5_with_params(&[("thinking_effort", json!("off"))]);
+        let opts = AnthropicFormatOptions {
+            prefix_mismatch_behavior: Some(PrefixMismatchBehavior::Error),
+            ..Default::default()
+        };
+        let payload = request_with_options(&model, opts)?;
+        assert_eq!(payload["thinking"], json!({"type": "disabled"}));
+        assert!(required_beta_features(&payload).is_empty());
+        Ok(())
     }
 
     #[test]
@@ -2453,6 +2576,36 @@ mod tests {
         assert_eq!(parts.thinking.len(), 1);
         assert_eq!(parts.thinking[0].0, "Initial reasoning continues.");
         assert_eq!(parts.thinking[0].1, "");
+    }
+
+    #[tokio::test]
+    async fn test_streaming_keeps_signed_thinking_with_omitted_display() {
+        let events = concat!(
+            r#"data: {"type":"message_start","message":{"id":"msg_1","role":"assistant","content":[],"model":"claude-opus-5","usage":{"input_tokens":10,"output_tokens":0}}}"#,
+            "\n",
+            r#"data: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}"#,
+            "\n",
+            r#"data: {"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"sig_omitted"}}"#,
+            "\n",
+            r#"data: {"type":"content_block_stop","index":0}"#,
+            "\n",
+            r#"data: {"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}"#,
+            "\n",
+            r#"data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"Done."}}"#,
+            "\n",
+            r#"data: {"type":"content_block_stop","index":1}"#,
+            "\n",
+            r#"data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":5}}"#,
+            "\n",
+            r#"data: {"type":"message_stop"}"#,
+        );
+
+        let parts = collect_stream(events).await;
+        assert_eq!(
+            parts.thinking,
+            vec![(String::new(), "sig_omitted".to_string())]
+        );
+        assert_eq!(parts.text, vec!["Done."]);
     }
 
     #[tokio::test]

--- a/crates/goose-provider-types/src/formats/anthropic.rs
+++ b/crates/goose-provider-types/src/formats/anthropic.rs
@@ -1,5 +1,6 @@
 use crate::canonical::maybe_get_canonical_model;
 use crate::canonical::ThinkingMode;
+use crate::conversation::merge_system_updates_for_request;
 use crate::conversation::message::{Message, MessageContentBlock};
 use crate::conversation::token_usage::{CostSource, ProviderUsage, Usage};
 use crate::documents::{
@@ -66,6 +67,8 @@ pub struct AnthropicFormatOptions {
     pub cache_ttl: Option<CacheTtl>,
     pub prefix_mismatch_behavior: Option<PrefixMismatchBehavior>,
     pub strip_thinking_history: bool,
+    /// Only the native Anthropic API is known to accept `role: "system"` mid-conversation.
+    pub system_messages: bool,
 }
 
 impl AnthropicFormatOptions {
@@ -94,6 +97,8 @@ impl AnthropicFormatOptions {
             Some("off") => None,
             Some(value) => value.parse::<PrefixMismatchBehavior>().ok(),
         };
+        let system_messages =
+            self.system_messages && model_supports_system_messages(&model_config.model_name);
 
         Self {
             preserve_unsigned_thinking,
@@ -104,6 +109,7 @@ impl AnthropicFormatOptions {
             cache_ttl,
             prefix_mismatch_behavior,
             strip_thinking_history: self.strip_thinking_history,
+            system_messages,
         }
     }
 
@@ -197,6 +203,15 @@ const TEXT_TYPE: &str = "text";
 const ROLE_FIELD: &str = "role";
 const USER_ROLE: &str = "user";
 const ASSISTANT_ROLE: &str = "assistant";
+const SYSTEM_ROLE: &str = "system";
+
+/// Older models reject mid-conversation system messages with a 400.
+fn model_supports_system_messages(model_name: &str) -> bool {
+    let name = model_name.to_ascii_lowercase().replace('.', "-");
+    ["opus-5", "sonnet-5", "fable-5", "mythos-5", "opus-4-8"]
+        .iter()
+        .any(|family| name.contains(family))
+}
 const TOOL_USE_TYPE: &str = "tool_use";
 const TOOL_RESULT_TYPE: &str = "tool_result";
 const THINKING_TYPE: &str = "thinking";
@@ -252,10 +267,30 @@ fn format_messages_with_options(
     messages: &[Message],
     options: &AnthropicFormatOptions,
 ) -> Vec<Value> {
+    let folded;
+    let messages = if options.system_messages {
+        messages
+    } else {
+        folded = merge_system_updates_for_request(messages);
+        folded.as_slice()
+    };
     let mut anthropic_messages = Vec::new();
 
-    for message in messages {
+    for (index, message) in messages.iter().enumerate() {
+        // The API only accepts a system message between a user message and the
+        // next assistant turn (or at the end); anywhere else it goes as user text.
+        let next_is_assistant = messages
+            .get(index + 1)
+            .is_none_or(|next| next.role == Role::Assistant);
         let role = match message.role {
+            Role::User
+                if options.system_messages
+                    && message.is_system_update()
+                    && !anthropic_messages.is_empty()
+                    && next_is_assistant =>
+            {
+                SYSTEM_ROLE
+            }
             Role::User => USER_ROLE,
             Role::Assistant => ASSISTANT_ROLE,
         };
@@ -1672,6 +1707,87 @@ mod tests {
             .map(|(key, value)| (key.to_string(), value.clone()))
             .collect();
         ModelConfig::new("claude-opus-5").with_merged_request_params(params)
+    }
+
+    fn system_update(text: &str) -> Message {
+        Message::user().with_text(text).with_metadata(
+            crate::conversation::message::MessageMetadata::agent_only().with_system_update(),
+        )
+    }
+
+    fn system_message_options() -> AnthropicFormatOptions {
+        AnthropicFormatOptions {
+            system_messages: true,
+            ..Default::default()
+        }
+        .for_model(&ModelConfig::new("claude-opus-5"))
+    }
+
+    fn roles(messages: &[Value]) -> Vec<&str> {
+        messages
+            .iter()
+            .map(|message| message["role"].as_str().unwrap())
+            .collect()
+    }
+
+    #[test]
+    fn system_update_after_a_tool_result_is_sent_with_the_system_role() {
+        let tool_call = CallToolRequestParams::new("shell").with_arguments(object!({"cmd": "ls"}));
+        let messages = vec![
+            Message::user().with_text("run it"),
+            Message::assistant().with_tool_request("t1", Ok(tool_call)),
+            Message::user().with_tool_response(
+                "t1",
+                Ok(rmcp::model::CallToolResult::success(vec![
+                    rmcp::model::ContentBlock::text("ok"),
+                ])),
+            ),
+            system_update("New additional instructions: end with PINEAPPLE."),
+        ];
+        let formatted = format_messages_with_options(&messages, &system_message_options());
+        assert_eq!(
+            roles(&formatted),
+            vec!["user", "assistant", "user", "system"]
+        );
+        assert_eq!(
+            formatted[3]["content"],
+            json!([{"type": "text", "text": "New additional instructions: end with PINEAPPLE."}])
+        );
+    }
+
+    #[test]
+    fn system_update_followed_by_a_user_message_falls_back_to_user_text() {
+        let messages = vec![
+            Message::user().with_text("hi"),
+            system_update("update"),
+            Message::user().with_text("<turn-context/>"),
+        ];
+        let formatted = format_messages_with_options(&messages, &system_message_options());
+        assert_eq!(roles(&formatted), vec!["user", "user", "user"]);
+    }
+
+    #[test]
+    fn system_updates_fold_into_user_text_when_unsupported() {
+        let messages = vec![Message::user().with_text("hi"), system_update("update")];
+
+        let older_model = AnthropicFormatOptions {
+            system_messages: true,
+            ..Default::default()
+        }
+        .for_model(&ModelConfig::new("claude-opus-4-7"));
+        let formatted = format_messages_with_options(&messages, &older_model);
+        assert_eq!(roles(&formatted), vec!["user"]);
+        assert_eq!(formatted[0]["content"].as_array().unwrap().len(), 2);
+
+        let compatible_endpoint =
+            AnthropicFormatOptions::default().for_model(&ModelConfig::new("claude-opus-5"));
+        assert_eq!(
+            roles(&format_messages_with_options(
+                &messages,
+                &compatible_endpoint
+            )),
+            vec!["user"]
+        );
     }
 
     #[test]

--- a/crates/goose-provider-types/src/formats/databricks.rs
+++ b/crates/goose-provider-types/src/formats/databricks.rs
@@ -1,4 +1,5 @@
 use crate::cache_semantics::{apply_chat_payload_breakpoints, CacheSemantics};
+use crate::conversation::merge_system_updates_for_request;
 use crate::conversation::message::{Message, MessageContentBlock};
 use crate::formats::anthropic::{
     adaptive_output_effort, model_supports_temperature, requires_explicit_thinking_disable,
@@ -130,7 +131,7 @@ fn format_messages(
     supports_vision: bool,
 ) -> Vec<DatabricksMessage> {
     let mut result = Vec::new();
-    for message in messages {
+    for message in &merge_system_updates_for_request(messages) {
         let thinking_is_stale = thinking_block_is_stale(message, current_model);
         let mut converted = DatabricksMessage {
             content: Value::Null,

--- a/crates/goose-provider-types/src/formats/google.rs
+++ b/crates/goose-provider-types/src/formats/google.rs
@@ -38,6 +38,7 @@ pub fn get_thought_signature(metadata: &Option<ProviderMetadata>) -> Option<&str
 
 fn is_user_loop_boundary(message: &Message) -> bool {
     message.role == Role::User
+        && !message.is_system_update()
         && message
             .content
             .iter()
@@ -1326,6 +1327,41 @@ mod tests {
 
     fn tool_result(text: &str) -> CallToolResult {
         CallToolResult::success(vec![ContentBlock::text(text)])
+    }
+
+    #[test]
+    fn system_update_does_not_start_a_new_tool_loop() {
+        const SIG: &str = "thought_sig_update";
+        let assistant = response_to_message(google_response(vec![json!({
+            "functionCall": {"name": "shell", "args": {"cmd": "ls"}},
+            "thoughtSignature": SIG
+        })]))
+        .unwrap();
+        let request = assistant.content[0].as_tool_request().unwrap();
+        let mut tool_response = Message::user();
+        tool_response.add_tool_response_with_metadata(
+            request.id.clone(),
+            Ok(tool_result("output")),
+            request.metadata.as_ref(),
+        );
+        let update = Message::user()
+            .with_text("System prompt update.")
+            .with_metadata(
+                crate::conversation::message::MessageMetadata::agent_only().with_system_update(),
+            );
+
+        let out = format_messages(
+            &[
+                set_up_text_message("List files", Role::User),
+                assistant.clone(),
+                tool_response,
+                update,
+            ],
+            false,
+        );
+
+        assert_eq!(out[1]["parts"][0]["thoughtSignature"], SIG);
+        assert_eq!(out[2]["parts"][0]["thoughtSignature"], SIG);
     }
 
     #[test]

--- a/crates/goose-provider-types/src/formats/openai.rs
+++ b/crates/goose-provider-types/src/formats/openai.rs
@@ -1,4 +1,5 @@
 use crate::base::ThinkingPreservationFormat;
+use crate::conversation::merge_system_updates_for_request;
 use crate::conversation::message::{Message, MessageContentBlock, ProviderMetadata};
 use crate::conversation::token_usage::{CostSource, ProviderUsage, Usage};
 use crate::documents::{
@@ -72,6 +73,9 @@ pub struct OpenAiFormatOptions {
     pub preserve_thinking_context: bool,
     pub supports_vision: bool,
     pub thinking_preservation_format: Option<ThinkingPreservationFormat>,
+    /// Chat templates behind OpenAI-compatible endpoints often accept a system
+    /// message only at the start, so only the native API lowers updates to it.
+    pub system_messages: bool,
 }
 
 fn merge_reasoning_text(prefix: &str, suffix: &str) -> String {
@@ -214,6 +218,13 @@ pub fn format_messages_with_options(
     image_format: &ImageFormat,
     options: OpenAiFormatOptions,
 ) -> Vec<Value> {
+    let folded;
+    let messages = if options.system_messages {
+        messages
+    } else {
+        folded = merge_system_updates_for_request(messages);
+        folded.as_slice()
+    };
     let mut messages_spec = Vec::new();
     let mut pending_assistant_reasoning = String::new();
     // Reasoning to propagate across consecutive tool-call messages in the same turn.
@@ -247,9 +258,12 @@ pub fn format_messages_with_options(
             saw_tool_response = false;
         }
 
-        let mut converted = json!({
-            "role": message.role
-        });
+        let role = if options.system_messages && message.is_system_update() {
+            json!("system")
+        } else {
+            json!(message.role)
+        };
+        let mut converted = json!({ "role": role });
 
         let mut output = Vec::new();
         let mut content_array = Vec::new();
@@ -2234,6 +2248,37 @@ mod tests {
         assert_eq!(spec[0]["role"], "user");
         assert_eq!(spec[0]["content"], "Hello");
         Ok(())
+    }
+
+    #[test]
+    fn system_updates_carry_the_system_role_only_when_enabled() {
+        let messages = [
+            Message::user().with_text("Hello"),
+            Message::user()
+                .with_text("System prompt update.")
+                .with_metadata(
+                    crate::conversation::message::MessageMetadata::agent_only()
+                        .with_system_update(),
+                ),
+        ];
+
+        let native = format_messages_with_options(
+            &messages,
+            &ImageFormat::OpenAi,
+            OpenAiFormatOptions {
+                system_messages: true,
+                ..Default::default()
+            },
+        );
+        assert_eq!(native[1]["role"], "system");
+        assert_eq!(native[1]["content"], "System prompt update.");
+
+        let compatible = format_messages(&messages, &ImageFormat::OpenAi);
+        assert_eq!(compatible.len(), 1);
+        assert_eq!(compatible[0]["role"], "user");
+        assert!(compatible[0]["content"]
+            .to_string()
+            .contains("System prompt update."));
     }
 
     #[test]
@@ -5548,6 +5593,7 @@ data: [DONE]"#;
                 preserve_thinking_context: true,
                 supports_vision: false,
                 thinking_preservation_format: Some(format),
+                ..Default::default()
             },
         )
     }

--- a/crates/goose-provider-types/src/formats/openai_responses.rs
+++ b/crates/goose-provider-types/src/formats/openai_responses.rs
@@ -406,6 +406,7 @@ pub enum ContentBlockPart {
 fn add_message_items(input_items: &mut Vec<Value>, messages: &[Message], supports_vision: bool) {
     for message in messages.iter().filter(|m| m.is_agent_visible()) {
         let role = match message.role {
+            Role::User if message.is_system_update() => "system",
             Role::User => "user",
             Role::Assistant => "assistant",
         };
@@ -1225,6 +1226,23 @@ mod document_tests {
         let mut items = Vec::new();
         add_message_items(&mut items, messages, true);
         items
+    }
+
+    #[test]
+    fn system_updates_carry_the_system_role() {
+        let items = format(&[
+            Message::user().with_text("Hello"),
+            Message::user()
+                .with_text("System prompt update.")
+                .with_metadata(
+                    crate::conversation::message::MessageMetadata::agent_only()
+                        .with_system_update(),
+                ),
+        ]);
+
+        assert_eq!(items[0]["role"], "user");
+        assert_eq!(items[1]["role"], "system");
+        assert_eq!(items[1]["content"][0]["type"], "input_text");
     }
 
     #[test]

--- a/crates/goose-provider-types/src/formats/snowflake.rs
+++ b/crates/goose-provider-types/src/formats/snowflake.rs
@@ -1,3 +1,4 @@
+use crate::conversation::merge_system_updates_for_request;
 use crate::conversation::message::{Message, MessageContentBlock};
 use crate::conversation::token_usage::Usage;
 use crate::documents::{unsupported_document_text, UNSUPPORTED_PROVIDER_REASON};
@@ -14,7 +15,7 @@ use std::collections::HashSet;
 pub fn format_messages(messages: &[Message]) -> Vec<Value> {
     let mut snowflake_messages = Vec::new();
 
-    for message in messages {
+    for message in &merge_system_updates_for_request(messages) {
         let role = match message.role {
             Role::User => "user",
             Role::Assistant => "assistant",

--- a/crates/goose-provider-types/src/retry.rs
+++ b/crates/goose-provider-types/src/retry.rs
@@ -88,6 +88,8 @@ impl RetryConfig {
 const PERMANENT_REQUEST_FAILURE_MARKERS: &[&str] = &[
     "blocks in the latest assistant message cannot be modified",
     "must remain as they were in the original response",
+    "Invalid `signature` in `thinking` block",
+    "bound to a different conversation",
     "Reasoning is mandatory for this endpoint",
 ];
 

--- a/crates/goose-providers/src/anthropic.rs
+++ b/crates/goose-providers/src/anthropic.rs
@@ -16,8 +16,8 @@ use tokio_util::io::StreamReader;
 use super::api_client::ApiClient;
 use super::base::{ConfigKey, MessageStream, ModelInfo, Provider, ProviderMetadata};
 use super::formats::anthropic::{
-    create_request_for_model, response_to_streaming_message, AnthropicFormatOptions,
-    ANTHROPIC_PROVIDER_NAME,
+    create_request_for_model, is_thinking_signature_error, required_beta_features,
+    response_to_streaming_message, AnthropicFormatOptions, ANTHROPIC_PROVIDER_NAME,
 };
 use super::openai_compatible::handle_status;
 use super::retry::ProviderRetry;
@@ -27,6 +27,7 @@ use rmcp::model::Tool;
 
 pub const ANTHROPIC_DEFAULT_MODEL: &str = "claude-sonnet-4-5";
 const ANTHROPIC_KNOWN_MODELS: &[&str] = &[
+    "claude-fable-5-1",
     "claude-opus-5",
     "claude-sonnet-5",
     "claude-fable-5",
@@ -162,6 +163,47 @@ impl AnthropicProviderBuilder {
 }
 
 impl AnthropicProvider {
+    fn streaming_payload(
+        &self,
+        model_config: &ModelConfig,
+        wire_model: &str,
+        system: &str,
+        messages: &[Message],
+        tools: &[Tool],
+        format_options: AnthropicFormatOptions,
+    ) -> Result<Value, ProviderError> {
+        let mut payload = create_request_for_model(
+            ANTHROPIC_PROVIDER_NAME,
+            model_config,
+            wire_model,
+            system,
+            messages,
+            tools,
+            format_options,
+        )?;
+        payload["stream"] = Value::Bool(true);
+        Ok(payload)
+    }
+
+    async fn post_messages(
+        &self,
+        model_config: &ModelConfig,
+        payload: &Value,
+    ) -> Result<reqwest::Response, ProviderError> {
+        let beta_header = beta_header_value(model_config, payload);
+        self.with_retry(|| async {
+            let mut request = self
+                .api_client
+                .request("v1/messages")
+                .model_headers(model_config)?;
+            if let Some(beta) = &beta_header {
+                request = request.header("anthropic-beta", beta)?;
+            }
+            handle_status(request.streaming(true).response_post(payload).await?).await
+        })
+        .await
+    }
+
     pub async fn stream_for_model(
         &self,
         model_config: &ModelConfig,
@@ -170,8 +212,7 @@ impl AnthropicProvider {
         messages: &[Message],
         tools: &[Tool],
     ) -> Result<MessageStream, ProviderError> {
-        let mut payload = create_request_for_model(
-            ANTHROPIC_PROVIDER_NAME,
+        let payload = self.streaming_payload(
             model_config,
             wire_model,
             system,
@@ -179,24 +220,31 @@ impl AnthropicProvider {
             tools,
             self.format_options.clone(),
         )?;
-        payload["stream"] = Value::Bool(true);
         let mut log = start_log(model_config, &payload)?;
-        let response = self
-            .with_retry(|| async {
-                handle_status(
-                    self.api_client
-                        .request("v1/messages")
-                        .model_headers(model_config)?
-                        .streaming(true)
-                        .response_post(&payload)
-                        .await?,
-                )
-                .await
-            })
-            .await
-            .inspect_err(|e| {
-                let _ = log.error(e);
-            })?;
+        let response = match self.post_messages(model_config, &payload).await {
+            Err(ProviderError::RequestFailed(message))
+                if is_thinking_signature_error(&message)
+                    && !self.format_options.strip_thinking_history =>
+            {
+                tracing::warn!(
+                    error = %message,
+                    "API rejected replayed thinking blocks; retrying once with thinking history stripped"
+                );
+                let _ = log.error(&message);
+                let stripped = AnthropicFormatOptions {
+                    strip_thinking_history: true,
+                    ..self.format_options.clone()
+                };
+                let payload =
+                    self.streaming_payload(model_config, wire_model, system, messages, tools, stripped)?;
+                log = start_log(model_config, &payload)?;
+                self.post_messages(model_config, &payload).await
+            }
+            other => other,
+        }
+        .inspect_err(|e| {
+            let _ = log.error(e);
+        })?;
         let stream = response.bytes_stream().map_err(io::Error::other);
         Ok(Box::pin(try_stream! {
             let reader = StreamReader::new(stream);
@@ -385,6 +433,33 @@ impl Provider for AnthropicProvider {
         )
         .await
     }
+}
+
+fn beta_header_value(model_config: &ModelConfig, payload: &Value) -> Option<String> {
+    let mut features: Vec<String> = model_config
+        .request_headers
+        .as_ref()
+        .and_then(|headers| {
+            headers
+                .iter()
+                .find(|(key, _)| key.eq_ignore_ascii_case("anthropic-beta"))
+                .map(|(_, value)| value.as_str())
+        })
+        .map(|value| {
+            value
+                .split(',')
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default();
+    for feature in required_beta_features(payload) {
+        if !features.iter().any(|f| f == feature) {
+            features.push(feature.to_string());
+        }
+    }
+    (!features.is_empty()).then(|| features.join(","))
 }
 
 fn format_options_for_provider(
@@ -753,6 +828,147 @@ mod tests {
             matches!(err, ProviderError::Authentication(_)),
             "expected Authentication error, got: {:?}",
             err
+        );
+    }
+
+    fn provider_for(host: &str, format_options: AnthropicFormatOptions) -> AnthropicProvider {
+        AnthropicProvider {
+            api_client: ApiClient::new_with_tls(host.to_string(), AuthMethod::NoAuth, None)
+                .unwrap(),
+            supports_streaming: true,
+            name: ANTHROPIC_PROVIDER_NAME.to_string(),
+            custom_models: None,
+            dynamic_models: None,
+            skip_canonical_filtering: false,
+            format_options,
+        }
+    }
+
+    fn thinking_model(name: &str) -> ModelConfig {
+        ModelConfig::new(name).with_merged_request_params(std::collections::HashMap::from([(
+            "thinking_effort".to_string(),
+            json!("high"),
+        )]))
+    }
+
+    const SSE_OK: &str = concat!(
+        "data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"role\":\"assistant\",\"content\":[],\"model\":\"claude-opus-5\",\"usage\":{\"input_tokens\":3,\"output_tokens\":0}}}\n\n",
+        "data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n",
+        "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"ok\"}}\n\n",
+        "data: {\"type\":\"content_block_stop\",\"index\":0}\n\n",
+        "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":1}}\n\n",
+        "data: {\"type\":\"message_stop\"}\n\n",
+    );
+
+    async fn drain(stream: MessageStream) -> Vec<Message> {
+        use futures::StreamExt;
+        let mut messages = Vec::new();
+        let mut stream = stream;
+        while let Some(item) = stream.next().await {
+            if let Some(message) = item.expect("stream item").0 {
+                messages.push(message);
+            }
+        }
+        messages
+    }
+
+    #[tokio::test]
+    async fn stream_sends_binding_controls_beta_header_with_block_binding() {
+        use wiremock::matchers::{body_partial_json, header, method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/messages"))
+            .and(header(
+                "anthropic-beta",
+                super::super::formats::anthropic::THINKING_BINDING_CONTROLS_BETA,
+            ))
+            .and(body_partial_json(json!({
+                "thinking": {"type": "adaptive", "block_binding": {"prefix_mismatch_behavior": "drop_block"}}
+            })))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(SSE_OK),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let provider = provider_for(
+            &server.uri(),
+            AnthropicFormatOptions {
+                prefix_mismatch_behavior: Some(
+                    super::super::formats::anthropic::PrefixMismatchBehavior::DropBlock,
+                ),
+                ..Default::default()
+            },
+        );
+        let stream = provider
+            .stream(
+                &thinking_model("claude-opus-5"),
+                "system",
+                &[Message::user().with_text("hi")],
+                &[],
+            )
+            .await
+            .expect("request accepted");
+        let messages = drain(stream).await;
+        assert_eq!(messages[0].as_concat_text(), "ok");
+    }
+
+    #[tokio::test]
+    async fn stream_retries_once_without_thinking_after_signature_rejection() {
+        use wiremock::matchers::{body_string_contains, method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/messages"))
+            .and(body_string_contains("\"signature\""))
+            .respond_with(ResponseTemplate::new(400).set_body_json(json!({
+                "type": "error",
+                "error": {
+                    "type": "invalid_request_error",
+                    "message": "messages.1.content.0: Invalid `signature` in `thinking` block. The block is bound to a different conversation."
+                }
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/v1/messages"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(SSE_OK),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let provider = provider_for(&server.uri(), AnthropicFormatOptions::default());
+        let history = vec![
+            Message::user().with_text("hi"),
+            Message::assistant()
+                .with_content(MessageContent::thinking("", "sig-from-elsewhere"))
+                .with_text("hello"),
+            Message::user().with_text("again"),
+        ];
+        let stream = provider
+            .stream(&thinking_model("claude-opus-5"), "system", &history, &[])
+            .await
+            .expect("second attempt accepted");
+        let messages = drain(stream).await;
+        assert_eq!(messages[0].as_concat_text(), "ok");
+
+        let requests = server.received_requests().await.unwrap();
+        assert_eq!(requests.len(), 2);
+        let retry: Value = serde_json::from_slice(&requests[1].body).unwrap();
+        assert_eq!(
+            retry["messages"][1]["content"],
+            json!([{"type": "text", "text": "hello"}])
         );
     }
 }

--- a/crates/goose-providers/src/openai.rs
+++ b/crates/goose-providers/src/openai.rs
@@ -820,6 +820,7 @@ impl Provider for OpenAiProvider {
                         || thinking_preservation_format.is_some(),
                     supports_vision: model_config.supports_vision.unwrap_or_default(),
                     thinking_preservation_format,
+                    system_messages: true,
                 },
             )?;
 

--- a/crates/goose/src/acp/handoff.rs
+++ b/crates/goose/src/acp/handoff.rs
@@ -59,7 +59,7 @@ pub(crate) fn build_handoff_context_memo(
     let visible: Vec<Message> = Conversation::new_unvalidated(prior_messages.iter().cloned())
         .agent_visible_messages()
         .iter()
-        .filter(|message| !message.is_turn_context())
+        .filter(|message| !message.is_turn_context() && !message.is_system_update())
         .map(|message| message.agent_visible_content())
         .collect();
 

--- a/crates/goose/src/acp/provider.rs
+++ b/crates/goose/src/acp/provider.rs
@@ -1931,7 +1931,6 @@ fn messages_to_prompt(messages: &[Message], handoff_memo: Option<String>) -> Vec
             _ => {}
         }
     }
-
     let Some(memo) = handoff_memo else {
         return current_prompt_blocks;
     };
@@ -1945,9 +1944,12 @@ fn messages_to_prompt(messages: &[Message], handoff_memo: Option<String>) -> Vec
 }
 
 fn last_user_message_index(messages: &[Message]) -> Option<usize> {
-    messages
-        .iter()
-        .rposition(|m| m.role == Role::User && m.is_agent_visible() && !m.is_turn_context())
+    messages.iter().rposition(|m| {
+        m.role == Role::User
+            && m.is_agent_visible()
+            && !m.is_turn_context()
+            && !m.is_system_update()
+    })
 }
 
 fn has_handoff_context(messages: &[Message]) -> bool {
@@ -2529,6 +2531,22 @@ mod tests {
     #[tokio::test]
     async fn messages_to_prompt_without_prior_history_preserves_current_prompt() {
         let messages = vec![Message::user().with_text("current request")];
+
+        let blocks = prompt_with_handoff(&messages).await;
+
+        assert_eq!(blocks.len(), 1);
+        assert_eq!(prompt_text(&blocks[0]), "current request");
+    }
+
+    #[tokio::test]
+    async fn trailing_system_update_is_not_the_prompt() {
+        use crate::conversation::message::MessageMetadata;
+        let messages = vec![
+            Message::user().with_text("current request"),
+            Message::user()
+                .with_text("System prompt update.")
+                .with_metadata(MessageMetadata::agent_only().with_system_update()),
+        ];
 
         let blocks = prompt_with_handoff(&messages).await;
 

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -187,6 +187,7 @@ pub struct ReplyContext {
     pub tools: Vec<Tool>,
     pub toolshim_tools: Vec<Tool>,
     pub system_prompt: String,
+    pub system_update: Option<super::system_prompt_state::PendingSystemUpdate>,
     pub goose_mode: GooseMode,
     pub tool_call_cut_off: usize,
     pub model_config: goose_providers::model::ModelConfig,
@@ -838,25 +839,10 @@ impl Agent {
         }
         Ok(result)
     }
-    async fn load_project_instructions(&self, session: &Session) -> Option<String> {
-        let project_id = session.project_id.as_deref()?;
-        let entry = crate::sources::read_project(project_id).ok()?;
-        let mut parts = Vec::new();
-        parts.push(format!("# Project: {}", entry.name));
-        if !entry.description.is_empty() {
-            parts.push(entry.description.clone());
-        }
-        if !entry.content.is_empty() {
-            parts.push(entry.content.clone());
-        }
-        Some(parts.join("\n\n"))
-    }
-
     async fn prepare_reply_context(
         &self,
-        session_id: &str,
+        session: &Session,
         unfixed_conversation: Conversation,
-        working_dir: &std::path::Path,
     ) -> Result<ReplyContext> {
         let unfixed_messages = unfixed_conversation.messages().clone();
         let (conversation, issues) = fix_conversation(unfixed_conversation.clone());
@@ -870,8 +856,30 @@ impl Agent {
                 )
             );
         }
-        let (tools, toolshim_tools, system_prompt, model_config) = self
-            .prepare_tools_and_prompt(session_id, working_dir)
+        // A resumed session has to rediscover subdirectory hints from its earlier tool calls.
+        {
+            let mut prompt_manager = self.prompt_manager.lock().await;
+            for message in conversation.messages() {
+                for content in &message.content {
+                    if let MessageContent::ToolRequest(request) = content {
+                        if let Ok(tool_call) = &request.tool_call {
+                            prompt_manager
+                                .record_tool_arguments(&tool_call.arguments, &session.working_dir);
+                        }
+                    }
+                }
+            }
+            prompt_manager.load_subdirectory_hints(&session.working_dir);
+        }
+
+        let super::reply_parts::PreparedPrompt {
+            tools,
+            toolshim_tools,
+            system_prompt,
+            system_update,
+            model_config,
+        } = self
+            .prepare_tools_and_prompt(session, &conversation)
             .await?;
 
         let goose_mode = *self.current_goose_mode.lock().await;
@@ -901,6 +909,7 @@ impl Agent {
             tools,
             toolshim_tools,
             system_prompt,
+            system_update,
             goose_mode,
             tool_call_cut_off,
             model_config,
@@ -1715,6 +1724,9 @@ impl Agent {
             prompt_manager: &self.prompt_manager,
             tool_inspection_manager: &self.tool_inspection_manager,
             context_limit,
+            session_manager: self.config.session_manager.clone(),
+            provider_manages_own_context: manages_own_context,
+            toolshim: model_config.toolshim,
         };
         let status_operation =
             Arc::new(StatusOperation::new(provider.clone(), model_config.clone()));
@@ -2393,22 +2405,17 @@ impl Agent {
         cancel_token: Option<CancellationToken>,
         reply_span: tracing::Span,
     ) -> Result<BoxStream<'_, Result<AgentEvent>>> {
-        let context = self
-            .prepare_reply_context(&session.id, conversation, session.working_dir.as_path())
-            .await?;
+        let context = self.prepare_reply_context(&session, conversation).await?;
         let ReplyContext {
             mut conversation,
             mut tools,
             mut toolshim_tools,
             mut system_prompt,
+            mut system_update,
             tool_call_cut_off,
             goose_mode,
             model_config,
         } = context;
-
-        if let Some(project_addendum) = self.load_project_instructions(&session).await {
-            system_prompt = format!("{system_prompt}\n\n{project_addendum}");
-        }
 
         self.reset_retry_attempts().await;
 
@@ -2552,8 +2559,22 @@ impl Agent {
                 )
                 .await?;
             }
+
+            // A system update has to be the last message before the assistant turn.
+            if let Some(pending) = system_update.take() {
+                let message = pending.message.clone();
+                pending.commit(&session_manager, &session_config.id).await?;
+                persist_and_push_message_with_id(
+                    &session_manager,
+                    &session_config.id,
+                    &mut conversation,
+                    message,
+                )
+                .await?;
+            }
             // Snapshot after the turn-context append so a retry keeps the sent prefix.
             let initial_messages = conversation.messages().clone();
+            let mut rebuild_prompt = false;
 
             loop {
                 if is_token_cancelled(&cancel_token) {
@@ -2646,6 +2667,26 @@ impl Agent {
                     last_assistant_text = MAX_TURNS_MESSAGE.to_string();
                     yield AgentEvent::Message(Message::assistant().with_text(last_assistant_text.clone()));
                     break;
+                }
+
+                if rebuild_prompt {
+                    let prepared = self
+                        .prepare_tools_and_prompt(&session, &conversation)
+                        .await?;
+                    tools = prepared.tools;
+                    toolshim_tools = prepared.toolshim_tools;
+                    system_prompt = prepared.system_prompt;
+                    if let Some(pending) = prepared.system_update {
+                        let message = pending.message.clone();
+                        pending.commit(&session_manager, &session_config.id).await?;
+                        persist_and_push_message_with_id(
+                            &session_manager,
+                            &session_config.id,
+                            &mut conversation,
+                            message,
+                        )
+                        .await?;
+                    }
                 }
 
                 let mut stream = crate::agents::reply_parts::stream_response_from_provider(
@@ -3241,22 +3282,12 @@ impl Agent {
                 }
                 can_drain_pending_steers = true;
 
-                if tools_updated {
-                    (tools, toolshim_tools, system_prompt, _) =
-                        self.prepare_tools_and_prompt(&session_config.id, &session.working_dir).await?;
-                }
-
-                {
-                    let has_new_hints = self
-                        .prompt_manager
-                        .lock()
-                        .await
-                        .load_subdirectory_hints(&working_dir);
-                    if has_new_hints && !tools_updated {
-                        (tools, toolshim_tools, system_prompt, _) =
-                            self.prepare_tools_and_prompt(&session_config.id, &session.working_dir).await?;
-                    }
-                }
+                let has_new_hints = self
+                    .prompt_manager
+                    .lock()
+                    .await
+                    .load_subdirectory_hints(&working_dir);
+                rebuild_prompt = tools_updated || has_new_hints || did_recovery_compact_this_iteration;
 
                 // An empty provider response — no tool calls, no text, and no error
                 // or recovery compaction that legitimately produces no assistant
@@ -3352,6 +3383,7 @@ impl Agent {
                                 Ok(RetryResult::Retried) => {
                                     info!("Retry logic triggered, restarting agent loop");
                                     messages_to_add = Conversation::default();
+                                    rebuild_prompt = true;
                                     session_manager.replace_conversation(&session_config.id, &conversation).await?;
                                     yield AgentEvent::HistoryReplaced(conversation.clone());
                                 }
@@ -4136,7 +4168,7 @@ fn recipe_conversation_history(messages: &Conversation) -> Vec<Message> {
     messages
         .agent_visible_messages()
         .into_iter()
-        .filter(|message| !message.is_turn_context())
+        .filter(|message| !message.is_turn_context() && !message.is_system_update())
         .collect()
 }
 

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -2967,117 +2967,33 @@ impl Agent {
                                     }
                                 }
 
-                                // Thinking/reasoning belongs on the tool-call messages, not also
-                                // as a separate standalone message: Gemini and Kimi/DeepSeek
-                                // require it echoed on each assistant tool-call message, and the
-                                // provider formatters reconstruct per-provider shape from there.
-                                // Storing it both standalone AND on the tool-call message
-                                // duplicates it; once merge_consecutive_messages glues the adjacent
-                                // standalone and tool-call messages together, the duplicate signed
-                                // blocks make Anthropic reject the turn with a 400. So the thinking
-                                // is carried onto the split request messages below and never kept
-                                // as a redundant standalone message.
+                                // Thinking stays where the model produced it: moving it onto the
+                                // tool-call message reorders the turn and breaks Anthropic's
+                                // prefix-bound signatures. Split messages after the first repeat
+                                // the turn's thinking for DeepSeek and Kimi; fix_conversation
+                                // dedupes the signed copies.
+                                let is_thinking = |c: &MessageContent| {
+                                    matches!(
+                                        c,
+                                        MessageContent::Thinking(_)
+                                            | MessageContent::RedactedThinking(_)
+                                    )
+                                };
+                                let prior_thinking: Vec<MessageContent> = messages_to_add
+                                    .iter()
+                                    .filter(|m| m.role == response.role)
+                                    .flat_map(|m| m.content.iter())
+                                    .filter(|c| is_thinking(c))
+                                    .cloned()
+                                    .collect();
                                 let direct_thinking: Vec<MessageContent> = response
                                     .content
                                     .iter()
-                                    .filter(|c| {
-                                        matches!(
-                                            c,
-                                            MessageContent::Thinking(_)
-                                                | MessageContent::RedactedThinking(_)
-                                        )
-                                    })
+                                    .filter(|c| is_thinking(c) && !prior_thinking.contains(c))
                                     .cloned()
                                     .collect();
-                                // When thinking arrived in earlier stream chunks it was stored as
-                                // standalone thinking-only messages; reuse that thinking on the
-                                // tool-call messages and drop the standalone messages so the
-                                // thinking isn't duplicated.
-                                // Always accumulate ALL prior thinking — even when
-                                // direct_thinking is non-empty (reasoning arrived on the same
-                                // chunk as tool_calls) — because otherwise only the last chunk's
-                                // reasoning ends up on split tool-call messages.
-                                // Also extract thinking from mixed (thinking+text) messages,
-                                // not just pure-thinking-only ones.
-                                let mut accumulated_prior: Vec<MessageContent> = Vec::new();
-                                let mut indices_to_remove: Vec<usize> = Vec::new();
-                                for (idx, m) in messages_to_add.messages_mut().iter_mut().enumerate()
-                                {
-                                    if m.role != response.role || m.content.is_empty() {
-                                        continue;
-                                    }
-                                    let thinking_only = m.content.iter().all(|c| {
-                                        matches!(
-                                            c,
-                                            MessageContent::Thinking(_)
-                                                | MessageContent::RedactedThinking(_)
-                                        )
-                                    });
-                                    let has_thinking = m.content.iter().any(|c| {
-                                        matches!(
-                                            c,
-                                            MessageContent::Thinking(_)
-                                                | MessageContent::RedactedThinking(_)
-                                        )
-                                    });
-                                    if has_thinking {
-                                        // Only accumulate thinking from messages that
-                                        // have not already been split into tool-call
-                                        // request_msg items — prior-split messages
-                                        // already carry their own thinking copy.
-                                        if !m.content.iter().any(|c| {
-                                            matches!(c, MessageContent::ToolRequest(_))
-                                        }) {
-                                            for c in &m.content {
-                                                if matches!(
-                                                    c,
-                                                    MessageContent::Thinking(_)
-                                                        | MessageContent::RedactedThinking(_)
-                                                ) {
-                                                    accumulated_prior.push(c.clone());
-                                                }
-                                            }
-                                        }
-                                    }
-                                    if thinking_only {
-                                        indices_to_remove.push(idx);
-                                    } else if has_thinking
-                                        && !m.content.iter().any(|c| {
-                                            matches!(c, MessageContent::ToolRequest(_))
-                                        })
-                                    {
-                                        // Strip thinking blocks from mixed text+thinking
-                                        // messages so the same signed/unsigned thinking is not
-                                        // duplicated when carried onto the tool-call request
-                                        // messages below. Messages that already contain tool
-                                        // requests are prior-split request_msg items whose
-                                        // thinking was already attached — stripping their
-                                        // thinking would leave only the last split message
-                                        // with reasoning, violating the signed-thinking
-                                        // dedup expectation that the first split message
-                                        // retains it.
-                                        m.content.retain(|c| {
-                                            !matches!(
-                                                c,
-                                                MessageContent::Thinking(_)
-                                                    | MessageContent::RedactedThinking(_)
-                                            )
-                                        });
-                                    }
-                                }
-                                // Remove in reverse order to preserve indices
-                                for idx in indices_to_remove.into_iter().rev() {
-                                    messages_to_add.remove(idx);
-                                }
-                                let response_thinking = if direct_thinking.is_empty() {
-                                    accumulated_prior
-                                } else if accumulated_prior.is_empty() {
-                                    direct_thinking
-                                } else {
-                                    let mut merged = accumulated_prior;
-                                    merged.extend(direct_thinking);
-                                    merged
-                                };
+                                let mut turn_thinking = prior_thinking;
+                                turn_thinking.extend(direct_thinking.iter().cloned());
 
                                 let response_message_id = response
                                     .id
@@ -3098,7 +3014,7 @@ impl Agent {
                                 preferred_turn_usage_message_id =
                                     Some(response_message_id.to_owned());
 
-                                for request in &tool_requests {
+                                for (index, request) in tool_requests.iter().enumerate() {
                                     let mut request_msg =
                                         if carrier_tool_call_id == Some(request.id.as_str()) {
                                             Message::assistant().with_id(response_message_id)
@@ -3106,7 +3022,12 @@ impl Agent {
                                             Message::assistant().with_generated_id()
                                         };
 
-                                    for thinking in &response_thinking {
+                                    let thinking = if index == 0 {
+                                        &direct_thinking
+                                    } else {
+                                        &turn_thinking
+                                    };
+                                    for thinking in thinking {
                                         request_msg = request_msg.with_content(thinking.clone());
                                     }
 

--- a/crates/goose/src/agents/mod.rs
+++ b/crates/goose/src/agents/mod.rs
@@ -19,6 +19,7 @@ pub mod state_machine;
 pub mod subagent_execution_tool;
 pub(crate) mod subagent_handler;
 pub(crate) mod subagent_task_config;
+pub mod system_prompt_state;
 mod tool_confirmation_coordinator;
 mod tool_confirmation_router;
 pub mod tool_execution;

--- a/crates/goose/src/agents/prompt_manager.rs
+++ b/crates/goose/src/agents/prompt_manager.rs
@@ -6,6 +6,7 @@ use serde::Serialize;
 use serde_json::Value;
 use std::collections::HashMap;
 
+use crate::agents::system_prompt_state::SystemPromptSections;
 use crate::agents::{extension::ExtensionInfo, moim};
 use crate::hints::load_hints::build_gitignore;
 use crate::hints::{get_context_filenames, load_hint_files, SubdirectoryHintTracker};
@@ -108,6 +109,10 @@ impl<'a> SystemPromptBuilder<'a, PromptManager> {
     }
 
     pub fn build(self) -> String {
+        self.build_sections().render()
+    }
+
+    pub fn build_sections(self) -> SystemPromptSections {
         let mut extensions_info = self.extensions_info;
 
         // Stable tool ordering is important for multi session prompt caching.
@@ -162,19 +167,12 @@ impl<'a> SystemPromptBuilder<'a, PromptManager> {
             );
         }
 
-        if system_prompt_extras.is_empty() {
-            base_prompt
-        } else {
-            let sanitized_system_prompt_extras: Vec<String> = system_prompt_extras
-                .into_values()
-                .map(|extra| sanitize_unicode_tags(&extra))
-                .collect();
-
-            format!(
-                "{}\n\n# Additional Instructions:\n\n{}",
-                base_prompt,
-                sanitized_system_prompt_extras.join("\n\n")
-            )
+        SystemPromptSections {
+            base: base_prompt,
+            extras: system_prompt_extras
+                .into_iter()
+                .map(|(key, extra)| (key, sanitize_unicode_tags(&extra)))
+                .collect(),
         }
     }
 }
@@ -235,13 +233,23 @@ impl PromptManager {
         prompt_parts: Vec<(String, String)>,
         goose_mode: GooseMode,
     ) -> String {
+        self.build_system_prompt_sections(working_dir, prompt_parts, goose_mode)
+            .render()
+    }
+
+    pub fn build_system_prompt_sections(
+        &mut self,
+        working_dir: &Path,
+        prompt_parts: Vec<(String, String)>,
+        goose_mode: GooseMode,
+    ) -> SystemPromptSections {
         self.load_subdirectory_hints(working_dir);
         self.builder()
             .with_prompt_extras(prompt_parts)
             .with_hints(working_dir)
             .with_goose_mode(goose_mode)
             .without_extensions()
-            .build()
+            .build_sections()
     }
 
     /// Override the system prompt with custom text

--- a/crates/goose/src/agents/reply_parts.rs
+++ b/crates/goose/src/agents/reply_parts.rs
@@ -13,6 +13,7 @@ use super::gen_ai_telemetry;
 use crate::agents::extension_manager::{get_tool_owner, recover_mangled_tool_name};
 #[cfg(feature = "code-mode")]
 use crate::agents::platform_extensions::code_execution;
+use crate::agents::system_prompt_state::{self, PendingSystemUpdate};
 use crate::config::{Config, GooseMode};
 use crate::conversation::message::{Message, MessageContent, MessageUsage, ToolRequest};
 use crate::conversation::{fix_conversation, merge_consecutive_messages_for_request, Conversation};
@@ -21,8 +22,9 @@ use crate::providers::base::stream_from_single_message;
 use crate::providers::base::{MessageStream, Provider};
 use crate::providers::toolshim::{
     augment_message_with_selected_tool_interpreter, convert_tool_messages_to_text,
-    modify_system_prompt_for_tool_json, sanitize_residual_markers,
+    sanitize_residual_markers, tool_json_instructions,
 };
+use crate::session::Session;
 use goose_providers::conversation::token_usage::{CostSource, ProviderStats, ProviderUsage, Usage};
 use goose_providers::model::ModelConfig;
 use rmcp::model::{ErrorData, Tool};
@@ -193,12 +195,35 @@ fn ensure_unique_tool_names(tools: &[Tool]) -> Result<()> {
     Ok(())
 }
 
+pub struct PreparedPrompt {
+    pub tools: Vec<Tool>,
+    pub toolshim_tools: Vec<Tool>,
+    pub system_prompt: String,
+    pub system_update: Option<PendingSystemUpdate>,
+    pub model_config: ModelConfig,
+}
+
+fn project_instructions(session: &Session) -> Option<String> {
+    let project_id = session.project_id.as_deref()?;
+    let entry = crate::sources::read_project(project_id).ok()?;
+    let mut parts = vec![format!("# Project: {}", entry.name)];
+    if !entry.description.is_empty() {
+        parts.push(entry.description.clone());
+    }
+    if !entry.content.is_empty() {
+        parts.push(entry.content.clone());
+    }
+    Some(parts.join("\n\n"))
+}
+
 impl Agent {
     pub async fn prepare_tools_and_prompt(
         &self,
-        session_id: &str,
-        working_dir: &std::path::Path,
-    ) -> Result<(Vec<Tool>, Vec<Tool>, String, ModelConfig)> {
+        session: &Session,
+        conversation: &Conversation,
+    ) -> Result<PreparedPrompt> {
+        let session_id = session.id.as_str();
+        let working_dir = session.working_dir.as_path();
         let tools = self.list_tools(session_id, None).await;
         ensure_unique_tool_names(&tools)?;
 
@@ -225,19 +250,46 @@ impl Agent {
             self.tool_inspection_manager.apply_tool_annotations(&tools);
         }
 
-        let prompt_manager = self.prompt_manager.lock().await;
-        let system_prompt = prompt_manager
-            .builder()
-            .with_extensions(extensions_info.into_iter())
-            .with_code_execution_mode(code_execution_active)
-            .with_hints(working_dir)
-            .with_goose_mode(goose_mode)
-            .build();
+        let sections = {
+            let prompt_manager = self.prompt_manager.lock().await;
+            prompt_manager
+                .builder()
+                .with_extensions(extensions_info.into_iter())
+                .with_code_execution_mode(code_execution_active)
+                .with_prompt_extras(
+                    project_instructions(session).map(|text| ("project".to_string(), text)),
+                )
+                .with_prompt_extras(toolshim_instructions(&tools, &model_config))
+                .with_hints(working_dir)
+                .with_goose_mode(goose_mode)
+                .build_sections()
+        };
 
-        let (tools, toolshim_tools, system_prompt) =
-            prepare_tools_for_provider(tools, system_prompt, &model_config);
+        let provider = self.provider().await?;
+        // A provider that owns the conversation context replays nothing, so there
+        // is no prefix to keep stable and a fresh CLI context needs the live prompt.
+        let (system_prompt, system_update) = if provider.manages_own_context() {
+            (sections.render(), None)
+        } else {
+            let frozen = system_prompt_state::freeze(
+                &self.config.session_manager,
+                session_id,
+                sections,
+                conversation,
+            )
+            .await?;
+            (frozen.system, frozen.update)
+        };
 
-        Ok((tools, toolshim_tools, system_prompt, model_config))
+        let (tools, toolshim_tools) = split_toolshim_tools(tools, &model_config);
+
+        Ok(PreparedPrompt {
+            tools,
+            toolshim_tools,
+            system_prompt,
+            system_update,
+            model_config,
+        })
     }
 }
 
@@ -303,16 +355,23 @@ pub(crate) fn prepare_inference_tools(
     tools
 }
 
-pub(crate) fn prepare_tools_for_provider(
-    tools: Vec<Tool>,
-    system_prompt: String,
+pub(crate) fn toolshim_instructions(
+    tools: &[Tool],
     model_config: &ModelConfig,
-) -> (Vec<Tool>, Vec<Tool>, String) {
+) -> Option<(String, String)> {
+    model_config
+        .toolshim
+        .then(|| ("tools".to_string(), tool_json_instructions(tools)))
+}
+
+pub(crate) fn split_toolshim_tools(
+    tools: Vec<Tool>,
+    model_config: &ModelConfig,
+) -> (Vec<Tool>, Vec<Tool>) {
     if model_config.toolshim {
-        let system_prompt = modify_system_prompt_for_tool_json(&system_prompt, &tools);
-        (Vec::new(), tools, system_prompt)
+        (Vec::new(), tools)
     } else {
-        (tools, Vec::new(), system_prompt)
+        (tools, Vec::new())
     }
 }
 

--- a/crates/goose/src/agents/state_machine/inference_preparation.rs
+++ b/crates/goose/src/agents/state_machine/inference_preparation.rs
@@ -1,10 +1,11 @@
 //! Goose-specific inference request preparation.
 
+use crate::agents::system_prompt_state;
 #[cfg(feature = "code-mode")]
 use crate::agents::ExtensionManager;
 use crate::agents::PromptManager;
 use crate::config::GooseMode;
-use crate::session::Session;
+use crate::session::{Session, SessionManager};
 use crate::tool_inspection::ToolInspectionManager;
 use anyhow::Result;
 use async_trait::async_trait;
@@ -12,7 +13,6 @@ use goose_agent::inference::{InferenceRequestPreparer, PreparedInferenceRequest}
 use goose_agent::operation::{messages_since_kickoff, InferenceInput};
 use goose_providers::conversation::message::Message;
 use goose_providers::conversation::Conversation;
-#[cfg(feature = "code-mode")]
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
@@ -23,6 +23,9 @@ pub struct GooseInferenceRequestPreparer<'a> {
     pub(crate) prompt_manager: &'a Mutex<PromptManager>,
     pub(crate) tool_inspection_manager: &'a ToolInspectionManager,
     pub(crate) context_limit: usize,
+    pub(crate) session_manager: Arc<SessionManager>,
+    pub(crate) provider_manages_own_context: bool,
+    pub(crate) toolshim: bool,
 }
 
 #[async_trait]
@@ -50,11 +53,32 @@ impl InferenceRequestPreparer<Session> for GooseInferenceRequestPreparer<'_> {
         }
         let tools =
             crate::agents::reply_parts::prepare_inference_tools(input.tools, code_execution_mode);
-        let system_prompt = self.prompt_manager.lock().await.build_system_prompt(
-            &session.working_dir,
-            input.prompt_parts,
-            goose_mode,
-        );
+        let mut prompt_parts = input.prompt_parts;
+        if self.toolshim {
+            prompt_parts.push((
+                "tools".to_string(),
+                crate::providers::toolshim::tool_json_instructions(&tools),
+            ));
+        }
+        let sections = self
+            .prompt_manager
+            .lock()
+            .await
+            .build_system_prompt_sections(&session.working_dir, prompt_parts, goose_mode);
+        // A provider that owns the conversation context replays nothing, so there
+        // is no prefix to keep stable and a fresh CLI context needs the live prompt.
+        let (system_prompt, system_update) = if self.provider_manages_own_context {
+            (sections.render(), None)
+        } else {
+            let frozen = system_prompt_state::freeze(
+                &self.session_manager,
+                &session.id,
+                sections,
+                conversation,
+            )
+            .await?;
+            (frozen.system, frozen.update)
+        };
         let turn = messages_since_kickoff(conversation)?;
         let turn_start = turn
             .first()
@@ -67,7 +91,7 @@ impl InferenceRequestPreparer<Session> for GooseInferenceRequestPreparer<'_> {
             .find(|message| message.is_turn_context())
             .map(Message::as_concat_text);
         let context_limit = Some(self.context_limit);
-        let additional_messages = crate::agents::moim::turn_context_event(
+        let mut additional_messages: Vec<Message> = crate::agents::moim::turn_context_event(
             &session.working_dir,
             context_limit,
             input.moim_parts,
@@ -76,6 +100,11 @@ impl InferenceRequestPreparer<Session> for GooseInferenceRequestPreparer<'_> {
         .filter(|event| Some(event.as_concat_text()) != last)
         .into_iter()
         .collect();
+        // A system update has to be the last message before the assistant turn.
+        if let Some(pending) = system_update {
+            additional_messages.push(pending.message.clone());
+            pending.commit(&self.session_manager, &session.id).await?;
+        }
         Ok(PreparedInferenceRequest {
             system_prompt,
             tools,

--- a/crates/goose/src/agents/state_machine/ops_llm.rs
+++ b/crates/goose/src/agents/state_machine/ops_llm.rs
@@ -118,12 +118,8 @@ impl Provider for GooseInferenceProvider {
         tools: &[rmcp::model::Tool],
     ) -> Result<MessageStream, ProviderError> {
         let messages = enrich_unclaimed_tool_errors(messages, tools);
-        let (tools, toolshim_tools, system_prompt) =
-            crate::agents::reply_parts::prepare_tools_for_provider(
-                tools.to_vec(),
-                system.to_string(),
-                model_config,
-            );
+        let (tools, toolshim_tools) =
+            crate::agents::reply_parts::split_toolshim_tools(tools.to_vec(), model_config);
         let advertised_tool_descriptors = tools
             .iter()
             .chain(toolshim_tools.iter())
@@ -146,7 +142,7 @@ impl Provider for GooseInferenceProvider {
             self.inner.clone(),
             model_config.clone(),
             &session_id,
-            &system_prompt,
+            system,
             &messages,
             &tools,
             &toolshim_tools,

--- a/crates/goose/src/agents/state_machine/tests/agent_reply.rs
+++ b/crates/goose/src/agents/state_machine/tests/agent_reply.rs
@@ -528,3 +528,78 @@ async fn bang_shell_visibility_is_enforced_when_state_machine_is_enabled() -> Re
     let _guard = env_lock::lock_env([("GOOSE_STATE_MACHINE", Some("1"))]);
     assert_bang_shell_uses_only_user_visible_content().await
 }
+
+async fn assert_prompt_freezes_after_the_first_assistant_turn() -> Result<()> {
+    let (agent, api, session_id, _temp_dir) = agent_with_dummy_api().await?;
+    api.on("hello").reply("hi");
+
+    reply_messages(
+        &agent,
+        session_id.clone(),
+        Message::user().with_text("hello"),
+    )
+    .await?;
+    agent
+        .extend_system_prompt(
+            "fruit".to_string(),
+            "Always end with PINEAPPLE.".to_string(),
+        )
+        .await;
+    reply_messages(
+        &agent,
+        session_id.clone(),
+        Message::user().with_text("hello"),
+    )
+    .await?;
+    reply_messages(
+        &agent,
+        session_id.clone(),
+        Message::user().with_text("hello"),
+    )
+    .await?;
+
+    let calls = api.calls();
+    assert_eq!(calls.len(), 3);
+    let frozen = &calls[0].system_messages()[0];
+    assert!(!frozen.contains("PINEAPPLE"));
+    for call in &calls[1..] {
+        let system_messages = call.system_messages();
+        assert_eq!(
+            &system_messages[0], frozen,
+            "system prompt must stay frozen"
+        );
+        assert_eq!(system_messages.len(), 2, "exactly one update is replayed");
+        assert!(system_messages[1].contains("PINEAPPLE"));
+    }
+    assert_eq!(calls[1].last_role().as_deref(), Some("system"));
+    assert_eq!(calls[2].last_role().as_deref(), Some("user"));
+
+    let session = agent
+        .config
+        .session_manager
+        .get_session(&session_id, true)
+        .await?;
+    let persisted_updates = session
+        .conversation
+        .expect("session conversation")
+        .messages()
+        .iter()
+        .filter(|message| message.is_system_update())
+        .count();
+    assert_eq!(persisted_updates, 1);
+    Ok(())
+}
+
+#[tokio::test]
+async fn prompt_freezes_after_the_first_assistant_turn_when_state_machine_is_disabled() -> Result<()>
+{
+    let _guard = env_lock::lock_env([("GOOSE_STATE_MACHINE", None::<&str>)]);
+    assert_prompt_freezes_after_the_first_assistant_turn().await
+}
+
+#[tokio::test]
+async fn prompt_freezes_after_the_first_assistant_turn_when_state_machine_is_enabled() -> Result<()>
+{
+    let _guard = env_lock::lock_env([("GOOSE_STATE_MACHINE", Some("1"))]);
+    assert_prompt_freezes_after_the_first_assistant_turn().await
+}

--- a/crates/goose/src/agents/state_machine/tests/dummy_api.rs
+++ b/crates/goose/src/agents/state_machine/tests/dummy_api.rs
@@ -158,6 +158,22 @@ impl ApiCall {
         request_system(&self.body).contains(needle)
     }
 
+    pub(super) fn system_messages(&self) -> Vec<String> {
+        self.body["messages"]
+            .as_array()
+            .into_iter()
+            .flatten()
+            .filter(|message| message["role"] == "system")
+            .filter_map(|message| message["content"].as_str().map(str::to_string))
+            .collect()
+    }
+
+    pub(super) fn last_role(&self) -> Option<String> {
+        self.body["messages"].as_array()?.last()?["role"]
+            .as_str()
+            .map(str::to_string)
+    }
+
     pub(super) fn advertises_tool(&self, name: &str) -> bool {
         self.body["tools"]
             .as_array()

--- a/crates/goose/src/agents/state_machine/tests/pipeline.rs
+++ b/crates/goose/src/agents/state_machine/tests/pipeline.rs
@@ -177,6 +177,9 @@ impl TestPipeline {
             prompt_manager: &self.prompt_manager,
             tool_inspection_manager: &self.tool_inspection_manager,
             context_limit: self.model_config.context_limit(),
+            session_manager: self.session_manager.clone(),
+            provider_manages_own_context: self.provider.manages_own_context(),
+            toolshim: self.model_config.toolshim,
         };
         let status_operation = Arc::new(StatusOperation::new(
             provider.clone(),

--- a/crates/goose/src/agents/state_machine/tests/provider_lifecycle.rs
+++ b/crates/goose/src/agents/state_machine/tests/provider_lifecycle.rs
@@ -36,12 +36,12 @@ async fn provider_lifecycle() -> Result<()> {
                 .with_image(image_data, "image/png"),
         )
         .await?;
-    result.assert_message(2, Agent, "The image is suitable. I will add one.");
     result.assert_message(
-        3,
+        2,
         Thinking,
         "I should inspect the image before calculating.",
     );
+    result.assert_message(3, Agent, "The image is suitable. I will add one.");
     result.assert_message(4, ToolCall, ADD);
     result.assert_message(5, ToolResponse, "result: 1");
     result.assert_message(-1, Agent, "The total is 1.");

--- a/crates/goose/src/agents/system_prompt_state.rs
+++ b/crates/goose/src/agents/system_prompt_state.rs
@@ -1,0 +1,336 @@
+//! Keeps the request `system` frozen for the life of a conversation so the
+//! cached prefix and any thinking bound to it stay valid. Later changes are
+//! appended to the conversation as system-update messages instead.
+
+use anyhow::Result;
+use indexmap::IndexMap;
+use serde::{Deserialize, Serialize};
+
+use crate::conversation::message::{Message, MessageMetadata};
+use crate::conversation::Conversation;
+use crate::session::extension_data::ExtensionData;
+use crate::session::SessionManager;
+use rmcp::model::Role;
+
+const STATE_NAME: &str = "system_prompt";
+const STATE_VERSION: &str = "v1";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SystemPromptSections {
+    pub base: String,
+    pub extras: IndexMap<String, String>,
+}
+
+impl SystemPromptSections {
+    pub fn render(&self) -> String {
+        if self.extras.is_empty() {
+            self.base.clone()
+        } else {
+            let extras: Vec<&str> = self.extras.values().map(String::as_str).collect();
+            format!(
+                "{}\n\n# Additional Instructions:\n\n{}",
+                self.base,
+                extras.join("\n\n")
+            )
+        }
+    }
+}
+
+/// `sections` is what `system` renders. An update counts as told to the model
+/// only while its message is still visible in the conversation, so history
+/// rewrites (retry, cancel) re-emit whatever they removed.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SystemPromptSnapshot {
+    pub system: String,
+    pub sections: SystemPromptSections,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub updates: Vec<DeliveredUpdate>,
+}
+
+impl SystemPromptSnapshot {
+    fn told(&self) -> SystemPromptSections {
+        let mut sections = self.sections.clone();
+        for update in &self.updates {
+            update.delta.apply(&mut sections);
+        }
+        sections
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DeliveredUpdate {
+    pub message_id: String,
+    pub delta: SectionsDelta,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SectionsDelta {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub base: Option<String>,
+    #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
+    pub extras: IndexMap<String, String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub removed: Vec<String>,
+}
+
+impl SectionsDelta {
+    fn between(previous: &SystemPromptSections, live: &SystemPromptSections) -> Option<Self> {
+        let delta = Self {
+            base: (previous.base != live.base).then(|| live.base.clone()),
+            extras: live
+                .extras
+                .iter()
+                .filter(|(key, text)| previous.extras.get(*key) != Some(text))
+                .map(|(key, text)| (key.clone(), text.clone()))
+                .collect(),
+            removed: previous
+                .extras
+                .keys()
+                .filter(|key| !live.extras.contains_key(*key))
+                .cloned()
+                .collect(),
+        };
+        let empty = delta.base.is_none() && delta.extras.is_empty() && delta.removed.is_empty();
+        (!empty).then_some(delta)
+    }
+
+    fn apply(&self, sections: &mut SystemPromptSections) {
+        if let Some(base) = &self.base {
+            sections.base = base.clone();
+        }
+        for (key, text) in &self.extras {
+            sections.extras.insert(key.clone(), text.clone());
+        }
+        for key in &self.removed {
+            sections.extras.shift_remove(key);
+        }
+    }
+
+    fn describe(&self, previous: &SystemPromptSections) -> String {
+        let mut parts = vec![
+            "System prompt update. The following applies from this point on, in addition to your \
+             original instructions."
+                .to_string(),
+        ];
+        if let Some(base) = &self.base {
+            parts.push(format!(
+                "The main system instructions have been replaced with the following:\n\n{base}"
+            ));
+        }
+        for (key, text) in &self.extras {
+            if previous.extras.contains_key(key) {
+                parts.push(format!(
+                    "The additional instructions \"{key}\" have changed to:\n\n{text}"
+                ));
+            } else {
+                parts.push(format!("New additional instructions \"{key}\":\n\n{text}"));
+            }
+        }
+        for key in &self.removed {
+            parts.push(format!(
+                "The additional instructions \"{key}\" no longer apply."
+            ));
+        }
+        parts.join("\n\n")
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PendingSystemUpdate {
+    pub message: Message,
+    snapshot: SystemPromptSnapshot,
+}
+
+impl PendingSystemUpdate {
+    pub async fn commit(self, session_manager: &SessionManager, session_id: &str) -> Result<()> {
+        store_snapshot(session_manager, session_id, &self.snapshot).await
+    }
+}
+
+pub struct FrozenSystemPrompt {
+    pub system: String,
+    pub update: Option<PendingSystemUpdate>,
+}
+
+fn system_update_message(text: String) -> Message {
+    Message::user()
+        .with_text(text)
+        .with_metadata(MessageMetadata::agent_only().with_system_update())
+        .with_generated_id()
+}
+
+fn load_snapshot(data: &ExtensionData) -> Option<SystemPromptSnapshot> {
+    data.get_extension_state(STATE_NAME, STATE_VERSION)
+        .and_then(|value| serde_json::from_value(value.clone()).ok())
+}
+
+async fn store_snapshot(
+    session_manager: &SessionManager,
+    session_id: &str,
+    snapshot: &SystemPromptSnapshot,
+) -> Result<()> {
+    let mut data = session_manager
+        .get_session(session_id, false)
+        .await?
+        .extension_data;
+    data.set_extension_state(STATE_NAME, STATE_VERSION, serde_json::to_value(snapshot)?);
+    session_manager
+        .update(session_id)
+        .extension_data(data)
+        .apply()
+        .await
+}
+
+pub async fn freeze(
+    session_manager: &SessionManager,
+    session_id: &str,
+    live: SystemPromptSections,
+    conversation: &Conversation,
+) -> Result<FrozenSystemPrompt> {
+    let session = session_manager.get_session(session_id, false).await?;
+    let stored = load_snapshot(&session.extension_data);
+    let (snapshot, frozen) = resolve(stored.clone(), live, conversation);
+    if stored.as_ref() != Some(&snapshot) {
+        store_snapshot(session_manager, session_id, &snapshot).await?;
+    }
+    Ok(frozen)
+}
+
+fn resolve(
+    stored: Option<SystemPromptSnapshot>,
+    live: SystemPromptSections,
+    conversation: &Conversation,
+) -> (SystemPromptSnapshot, FrozenSystemPrompt) {
+    let previous = stored
+        .filter(|_| has_assistant_turn(conversation))
+        .map(|snapshot| settle(snapshot, conversation));
+    let Some(previous) = previous else {
+        let snapshot = SystemPromptSnapshot {
+            system: live.render(),
+            sections: live,
+            updates: Vec::new(),
+        };
+        let frozen = FrozenSystemPrompt {
+            system: snapshot.system.clone(),
+            update: None,
+        };
+        return (snapshot, frozen);
+    };
+    let told = previous.told();
+    let update = SectionsDelta::between(&told, &live).map(|delta| {
+        let message = system_update_message(delta.describe(&told));
+        let mut snapshot = previous.clone();
+        snapshot.updates.push(DeliveredUpdate {
+            message_id: message.id.clone().expect("generated id"),
+            delta,
+        });
+        PendingSystemUpdate { message, snapshot }
+    });
+    let frozen = FrozenSystemPrompt {
+        system: previous.system.clone(),
+        update,
+    };
+    (previous, frozen)
+}
+
+fn settle(mut snapshot: SystemPromptSnapshot, conversation: &Conversation) -> SystemPromptSnapshot {
+    snapshot.updates.retain(|update| {
+        conversation.iter().any(|message| {
+            message.is_agent_visible() && message.id.as_deref() == Some(update.message_id.as_str())
+        })
+    });
+    snapshot
+}
+
+fn has_assistant_turn(conversation: &Conversation) -> bool {
+    conversation
+        .iter()
+        .any(|message| message.is_agent_visible() && message.role == Role::Assistant)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sections(base: &str, extras: &[(&str, &str)]) -> SystemPromptSections {
+        SystemPromptSections {
+            base: base.to_string(),
+            extras: extras
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect(),
+        }
+    }
+
+    fn answered() -> Conversation {
+        Conversation::new_unvalidated(vec![
+            Message::user().with_text("hi"),
+            Message::assistant().with_text("hello"),
+        ])
+    }
+
+    fn frozen(base: &str) -> SystemPromptSnapshot {
+        SystemPromptSnapshot {
+            system: base.to_string(),
+            sections: sections(base, &[]),
+            updates: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn delta_describes_and_applies_added_changed_and_removed_extras() {
+        let previous = sections("base", &[("hints", "h"), ("gone", "g"), ("same", "s")]);
+        let live = sections("base", &[("hints", "h2"), ("same", "s"), ("new", "n")]);
+        let delta = SectionsDelta::between(&previous, &live).unwrap();
+
+        let text = delta.describe(&previous);
+        assert!(text.contains("\"hints\" have changed to:\n\nh2"));
+        assert!(text.contains("New additional instructions \"new\":\n\nn"));
+        assert!(text.contains("\"gone\" no longer apply."));
+        assert!(!text.contains("\"same\""));
+
+        let mut rebuilt = previous.clone();
+        delta.apply(&mut rebuilt);
+        assert_eq!(rebuilt.render(), live.render());
+    }
+
+    #[test]
+    fn prompt_is_live_until_the_first_assistant_turn() {
+        let unanswered = Conversation::new_unvalidated(vec![Message::user().with_text("hi")]);
+        let (snapshot, result) = resolve(Some(frozen("old")), sections("new", &[]), &unanswered);
+        assert_eq!(result.system, "new");
+        assert!(result.update.is_none());
+        assert_eq!(snapshot.sections, sections("new", &[]));
+
+        let (_, result) = resolve(Some(frozen("old")), sections("new", &[]), &answered());
+        assert_eq!(result.system, "old");
+        assert!(result.update.is_some());
+    }
+
+    #[test]
+    fn an_update_counts_only_while_its_message_is_in_the_conversation() {
+        let live = sections("base", &[("hints", "h")]);
+        let (_, result) = resolve(Some(frozen("base")), live.clone(), &answered());
+        let update = result.update.unwrap();
+        let committed = update.snapshot;
+
+        let (_, lost) = resolve(Some(committed.clone()), live.clone(), &answered());
+        assert!(
+            lost.update.is_some(),
+            "a message that never landed is re-sent"
+        );
+
+        let mut delivered = answered();
+        delivered.push(update.message);
+        delivered.push(Message::assistant().with_text("ok"));
+        let (settled, told) = resolve(Some(committed), live.clone(), &delivered);
+        assert!(told.update.is_none());
+        assert_eq!(settled.told(), live);
+
+        let (_, rolled_back) = resolve(Some(settled), live, &answered());
+        assert!(
+            rolled_back.update.is_some(),
+            "a retry that removed the message re-sends the update"
+        );
+    }
+}

--- a/crates/goose/src/bin/build_canonical_models.rs
+++ b/crates/goose/src/bin/build_canonical_models.rs
@@ -357,6 +357,7 @@ fn get_thinking_mode(canonical_id: &str, value: &Value) -> Option<ThinkingMode> 
 fn inferred_thinking_mode(canonical_id: &str) -> Option<ThinkingMode> {
     match canonical_id {
         "anthropic/claude-fable-5" => Some(ThinkingMode::AlwaysOnAdaptive),
+        "anthropic/claude-fable-5.1" => Some(ThinkingMode::AlwaysOnAdaptive),
         "anthropic/claude-opus-5" => Some(ThinkingMode::Adaptive),
         "anthropic/claude-opus-4.6" => Some(ThinkingMode::Adaptive),
         "anthropic/claude-opus-4.7" => Some(ThinkingMode::Adaptive),

--- a/crates/goose/src/context_mgmt/mod.rs
+++ b/crates/goose/src/context_mgmt/mod.rs
@@ -97,6 +97,7 @@ pub async fn compact_messages(
         let found_msg = messages.iter().enumerate().rev().find_map(|(idx, msg)| {
             if !msg.is_agent_visible()
                 || msg.is_turn_context()
+                || msg.is_system_update()
                 || !matches!(msg.role, rmcp::model::Role::User)
             {
                 return None;
@@ -119,7 +120,9 @@ pub async fn compact_messages(
         });
 
         if let Some((idx, msg)) = found_msg {
-            let is_last = messages[idx + 1..].iter().all(Message::is_turn_context);
+            let is_last = messages[idx + 1..]
+                .iter()
+                .all(|message| message.is_turn_context() || message.is_system_update());
             (Some(msg), Some(idx), is_last)
         } else {
             (None, None, false)
@@ -955,6 +958,38 @@ mod tests {
             continuation.contains(CONVERSATION_CONTINUATION_TEXT),
             "a trailing turn-context event must not demote the compaction to a tool-loop continuation"
         );
+    }
+
+    #[tokio::test]
+    async fn preserved_user_message_skips_system_updates() {
+        let conversation = Conversation::new_unvalidated([
+            Message::user().with_text("the real current request"),
+            Message::user()
+                .with_text("System prompt update: end with PINEAPPLE.")
+                .with_metadata(MessageMetadata::agent_only().with_system_update()),
+        ]);
+        let provider = MockProvider::new(Message::assistant().with_text("summary"), 1000);
+
+        let compacted = compact_messages(
+            &provider,
+            &provider.config,
+            "test-session-id",
+            &conversation,
+            false,
+        )
+        .await
+        .unwrap()
+        .conversation;
+
+        let user_prompt = compacted
+            .messages()
+            .iter()
+            .rfind(|message| message.is_agent_visible() && message.role == Role::User)
+            .unwrap();
+        assert!(user_prompt
+            .as_concat_text()
+            .contains("the real current request"));
+        assert!(!user_prompt.is_system_update());
     }
 
     #[tokio::test]

--- a/crates/goose/src/providers/anthropic_def.rs
+++ b/crates/goose/src/providers/anthropic_def.rs
@@ -12,6 +12,7 @@ use goose_providers::{
     anthropic::{self, AnthropicProvider, AnthropicProviderBuilder, ANTHROPIC_API_VERSION},
     api_client::{ApiClient, AuthMethod, TlsConfig},
     base::ProviderDescriptor,
+    formats::anthropic::{AnthropicFormatOptions, PrefixMismatchBehavior},
 };
 
 pub struct AnthropicProviderDef;
@@ -51,6 +52,20 @@ async fn from_env(
         .get_param("ANTHROPIC_TIMEOUT")
         .unwrap_or(crate::providers::base::DEFAULT_PROVIDER_TIMEOUT_SECS);
 
+    let prefix_mismatch_behavior = match config
+        .get_param::<String>("ANTHROPIC_PREFIX_MISMATCH_BEHAVIOR")
+        .ok()
+        .as_deref()
+    {
+        None => Some(PrefixMismatchBehavior::DropBlock),
+        Some("off") => None,
+        Some(value) => Some(
+            value
+                .parse::<PrefixMismatchBehavior>()
+                .map_err(|e| anyhow::anyhow!("invalid ANTHROPIC_PREFIX_MISMATCH_BEHAVIOR: {e}"))?,
+        ),
+    };
+
     let auth = AuthMethod::ApiKey {
         header_name: "x-api-key".to_string(),
         key: api_key,
@@ -65,7 +80,12 @@ async fn from_env(
     .with_request_builder(crate::session_context::session_id_request_builder())
     .with_header("anthropic-version", ANTHROPIC_API_VERSION)?;
 
-    Ok(AnthropicProviderBuilder::new(api_client).build())
+    Ok(AnthropicProviderBuilder::new(api_client)
+        .format_options(AnthropicFormatOptions {
+            prefix_mismatch_behavior,
+            ..Default::default()
+        })
+        .build())
 }
 
 pub fn from_custom_config(

--- a/crates/goose/src/providers/anthropic_def.rs
+++ b/crates/goose/src/providers/anthropic_def.rs
@@ -83,6 +83,7 @@ async fn from_env(
     Ok(AnthropicProviderBuilder::new(api_client)
         .format_options(AnthropicFormatOptions {
             prefix_mismatch_behavior,
+            system_messages: true,
             ..Default::default()
         })
         .build())

--- a/crates/goose/src/providers/bedrock.rs
+++ b/crates/goose/src/providers/bedrock.rs
@@ -774,7 +774,7 @@ fn process_stream_event(
         bedrock::ConverseStreamOutput::ContentBlockStop(ev) => {
             let idx = ev.content_block_index;
             if let Some((text, signature)) = state.reasoning_blocks.remove(&idx) {
-                if !text.is_empty() {
+                if !text.is_empty() || !signature.is_empty() {
                     messages.push(
                         Message::assistant()
                             .with_thinking(text, signature)

--- a/crates/goose/src/providers/claude_code.rs
+++ b/crates/goose/src/providers/claude_code.rs
@@ -278,7 +278,11 @@ impl ClaudeCodeProvider {
     /// Build content blocks from the last user message only. The CLI maintains
     /// conversation context internally per session_id.
     fn last_user_content_blocks(&self, messages: &[Message]) -> Vec<Value> {
-        let msgs = match messages.iter().rev().find(|m| m.role == Role::User) {
+        let msgs = match messages
+            .iter()
+            .rev()
+            .find(|m| m.role == Role::User && !m.is_system_update())
+        {
             Some(msg) => std::slice::from_ref(msg),
             None => messages,
         };
@@ -1180,6 +1184,15 @@ mod tests {
         vec![Message::new(Role::User, 0, vec![MessageContent::text("hidden input")]).user_only()],
         &[json!({"type":"text","text":"Human: hidden input"})]
         ; "user_only_message_not_dropped"
+    )]
+    #[test_case(
+        vec![
+            Message::new(Role::User, 0, vec![MessageContent::text("What changed?")]),
+            Message::new(Role::User, 0, vec![MessageContent::text("System prompt update.")])
+                .with_metadata(crate::conversation::message::MessageMetadata::agent_only().with_system_update()),
+        ],
+        &[json!({"type":"text","text":"Human: What changed?"})]
+        ; "trailing_system_update_is_not_the_prompt"
     )]
     fn test_last_user_content_blocks(messages: Vec<Message>, expected: &[Value]) {
         let provider = make_provider();

--- a/crates/goose/src/providers/gemini_cli.rs
+++ b/crates/goose/src/providers/gemini_cli.rs
@@ -71,7 +71,7 @@ impl GeminiCliProvider {
         messages
             .iter()
             .rev()
-            .find(|m| m.role == Role::User)
+            .find(|m| m.role == Role::User && !m.is_system_update())
             .map(|m| m.as_concat_text())
             .unwrap_or_default()
     }
@@ -380,6 +380,27 @@ mod tests {
         ];
         let prompt = provider.build_prompt("You are helpful.", &messages);
         assert_eq!(prompt, "Follow up question");
+    }
+
+    #[test]
+    fn trailing_system_update_is_not_the_prompt() {
+        let provider = make_provider();
+        let _ = provider.cli_session_id.set("session-123".to_string());
+        let messages = vec![
+            Message::new(Role::User, 0, vec![MessageContent::text("Hello")]),
+            Message::new(Role::Assistant, 0, vec![MessageContent::text("Hi!")]),
+            Message::new(Role::User, 0, vec![MessageContent::text("What changed?")]),
+            Message::new(
+                Role::User,
+                0,
+                vec![MessageContent::text("System prompt update.")],
+            )
+            .with_metadata(
+                crate::conversation::message::MessageMetadata::agent_only().with_system_update(),
+            ),
+        ];
+        let prompt = provider.build_prompt("You are helpful.", &messages);
+        assert_eq!(prompt, "What changed?");
     }
 
     #[cfg(unix)]

--- a/crates/goose/src/providers/toolshim.rs
+++ b/crates/goose/src/providers/toolshim.rs
@@ -1268,13 +1268,11 @@ pub fn convert_tool_messages_to_text(messages: &[Message]) -> Conversation {
     Conversation::new_unvalidated(converted_messages)
 }
 
-/// Modifies the system prompt to include tool usage instructions when tool interpretation is enabled
-pub fn modify_system_prompt_for_tool_json(system_prompt: &str, tools: &[Tool]) -> String {
-    let tool_info = format_tool_info(tools);
-
+/// System prompt instructions for models that emit tool calls as JSON text.
+pub fn tool_json_instructions(tools: &[Tool]) -> String {
     format!(
-        "{}\n\n{}\n\nBreak down your task into smaller steps and do one step and tool call at a time. Do not try to use multiple tools at once. If you want to use a tool, tell the user what tool to use by specifying the tool in this JSON format\n{{\n  \"name\": \"tool_name\",\n  \"arguments\": {{\n    \"parameter1\": \"value1\",\n    \"parameter2\": \"value2\"\n }}\n}}. After you get the tool result back, consider the result and then proceed to do the next step and tool call if required.",
-        system_prompt, tool_info
+        "{}\n\nBreak down your task into smaller steps and do one step and tool call at a time. Do not try to use multiple tools at once. If you want to use a tool, tell the user what tool to use by specifying the tool in this JSON format\n{{\n  \"name\": \"tool_name\",\n  \"arguments\": {{\n    \"parameter1\": \"value1\",\n    \"parameter2\": \"value2\"\n }}\n}}. After you get the tool result back, consider the result and then proceed to do the next step and tool call if required.",
+        format_tool_info(tools)
     )
 }
 

--- a/crates/goose/src/security/adversary_inspector.rs
+++ b/crates/goose/src/security/adversary_inspector.rs
@@ -224,7 +224,9 @@ impl AdversaryInspector {
         messages
             .iter()
             .rev()
-            .filter(|m| m.role == rmcp::model::Role::User && !m.is_turn_context())
+            .filter(|m| {
+                m.role == rmcp::model::Role::User && !m.is_turn_context() && !m.is_system_update()
+            })
             .filter_map(|m| {
                 let text: String = m
                     .content
@@ -250,7 +252,10 @@ impl AdversaryInspector {
 
     fn extract_original_task(messages: &[Message]) -> String {
         for msg in messages {
-            if msg.role == rmcp::model::Role::User && !msg.is_turn_context() {
+            if msg.role == rmcp::model::Role::User
+                && !msg.is_turn_context()
+                && !msg.is_system_update()
+            {
                 let text: String = msg
                     .content
                     .iter()
@@ -711,7 +716,7 @@ mod tests {
     }
 
     #[test]
-    fn user_context_extraction_skips_turn_context_events() {
+    fn user_context_extraction_skips_agent_only_events() {
         use crate::conversation::message::MessageMetadata;
 
         let turn_context = |text: &str| {
@@ -719,6 +724,9 @@ mod tests {
                 .with_text(text)
                 .with_metadata(MessageMetadata::agent_only().with_turn_context())
         };
+        let system_update = Message::user()
+            .with_text("System prompt update: new hints.")
+            .with_metadata(MessageMetadata::agent_only().with_system_update());
         let messages = vec![
             turn_context("turn context before any prompt"),
             Message::user().with_text("never delete files outside the repo"),
@@ -726,6 +734,7 @@ mod tests {
             Message::assistant().with_text("understood"),
             Message::user().with_text("first task"),
             turn_context("turn context for turn two"),
+            system_update,
             Message::assistant().with_text("done"),
             Message::user().with_text("second task"),
             turn_context("turn context for turn three"),

--- a/crates/goose/src/security/scanner.rs
+++ b/crates/goose/src/security/scanner.rs
@@ -379,6 +379,7 @@ impl PromptInjectionScanner {
             .filter(|m| {
                 crate::conversation::effective_role(m) == crate::conversation::EffectiveRole::User
                     && !m.is_turn_context()
+                    && !m.is_system_update()
             })
             .take(limit)
             .map(|m| {
@@ -688,7 +689,7 @@ mod tests {
     }
 
     #[test]
-    fn extract_user_messages_skips_turn_context_events() {
+    fn extract_user_messages_skips_agent_only_events() {
         use crate::conversation::message::MessageMetadata;
 
         let scanner = PromptInjectionScanner::new();
@@ -697,12 +698,16 @@ mod tests {
                 .with_text(text)
                 .with_metadata(MessageMetadata::agent_only().with_turn_context())
         };
+        let system_update = Message::user()
+            .with_text("System prompt update: new hints.")
+            .with_metadata(MessageMetadata::agent_only().with_system_update());
         let messages = vec![
             Message::user().with_text("oldest prompt"),
             turn_context("turn context one"),
             Message::assistant().with_text("ok"),
             Message::user().with_text("middle prompt"),
             turn_context("turn context two"),
+            system_update,
             Message::assistant().with_text("done"),
             Message::user().with_text("newest prompt"),
             turn_context("turn context three"),

--- a/crates/goose/tests/agent.rs
+++ b/crates/goose/tests/agent.rs
@@ -2096,14 +2096,13 @@ mod tests {
             Ok(())
         }
 
-        /// Regression for the Anthropic 400: signed thinking arriving in a
-        /// separate chunk before the tool calls must be stored once per
-        /// tool-call message and never as an extra standalone message. When the
-        /// Anthropic formatter serializes the persisted history, each assistant
-        /// turn must carry exactly one thinking block — a duplicate signed block
-        /// is rejected with `thinking blocks ... cannot be modified`.
+        /// Signed thinking streamed before the tool calls must reach Anthropic
+        /// once, ahead of the tool calls it produced.
         #[tokio::test]
         async fn test_signed_thinking_not_duplicated_for_anthropic() -> Result<()> {
+            use goose::conversation::{
+                fix_conversation, merge_consecutive_messages_for_request, Conversation,
+            };
             use goose_providers::formats::anthropic::format_messages as anthropic_format;
 
             let temp_dir = tempfile::tempdir()?;
@@ -2159,38 +2158,44 @@ mod tests {
                 .messages()
                 .to_vec();
 
-            // No standalone thinking-only assistant message should be persisted —
-            // thinking lives on the tool-call messages.
-            let standalone_thinking = messages.iter().any(|m| {
-                m.role == rmcp::model::Role::Assistant
-                    && !m.content.is_empty()
-                    && m.content
-                        .iter()
-                        .all(|c| matches!(c, MessageContent::Thinking(_)))
-            });
-            assert!(
-                !standalone_thinking,
-                "thinking must not be persisted as a standalone message: {messages:#?}"
+            let (fixed, _) = fix_conversation(Conversation::new_unvalidated(messages));
+            let spec = anthropic_format(&merge_consecutive_messages_for_request(
+                fixed.messages().to_vec(),
+            ));
+            let thinking_blocks = |msg: &serde_json::Value| {
+                msg["content"]
+                    .as_array()
+                    .into_iter()
+                    .flatten()
+                    .filter(|c| c["type"] == "thinking")
+                    .count()
+            };
+            let total_thinking: usize = spec.iter().map(thinking_blocks).sum();
+            assert_eq!(
+                total_thinking, 1,
+                "signed thinking must be replayed exactly once: {spec:#?}"
             );
 
-            // Every serialized Anthropic assistant message must contain at most
-            // one thinking block; a duplicate is what triggers the 400.
-            let spec = anthropic_format(&messages);
-            for msg in &spec {
-                if msg.get("role") == Some(&serde_json::json!("assistant")) {
-                    if let Some(content) = msg.get("content").and_then(|c| c.as_array()) {
-                        let thinking_blocks = content
-                            .iter()
-                            .filter(|c| c.get("type") == Some(&serde_json::json!("thinking")))
-                            .count();
-                        assert!(
-                            thinking_blocks <= 1,
-                            "assistant message has {thinking_blocks} thinking blocks, \
-                             Anthropic rejects duplicates: {msg}"
-                        );
-                    }
-                }
-            }
+            let tool_turn = spec
+                .iter()
+                .find(|msg| {
+                    msg["role"] == "assistant"
+                        && msg["content"]
+                            .as_array()
+                            .is_some_and(|c| c.iter().any(|b| b["type"] == "tool_use"))
+                })
+                .expect("a tool-call assistant message is sent");
+            let block_types: Vec<&str> = tool_turn["content"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .filter_map(|b| b["type"].as_str())
+                .collect();
+            assert_eq!(
+                block_types.first().copied(),
+                Some("thinking"),
+                "thinking must precede the tool calls it produced: {block_types:?}"
+            );
 
             Ok(())
         }


### PR DESCRIPTION
Fixes: #11839
Fixes part of #11800

## Summary

Goose rewrites the request `system` prompt mid-session when a subdirectory hint file is discovered, an extension is enabled or disabled, or the approval mode changes. Every rewrite busts the prompt cache, and on Anthropic it also drops all preserved thinking, which is bound to the exact `system` it was produced under.

Design B from #11839: after the first assistant turn, the rendered system prompt is frozen for the life of the conversation, and later changes are appended as agent-only system-update messages. Each provider lowers the update at request time: `role: "system"` on the native Anthropic API for models that accept it and on the native OpenAI API (chat and Responses), plain user text folded into the neighbouring user message everywhere else, including OpenAI-compatible endpoints. Providers that own their own conversation context (claude-code, gemini-cli, ACP) replay nothing, so they keep the live prompt. Both agent loops.

- The snapshot lives in the session's extension data. An update counts as delivered only while its message is still in the conversation, so a cancelled request, retry, or compaction re-sends what was lost.
- A conversation with no assistant turn yet (new session, `/clear`) re-anchors to the live prompt.
- The toolshim tool disclosure is one of the frozen sections, so a tool change on a JSON-tool-call model also arrives as an update instead of rewriting `system`.

### Testing

Both agent loops have an end-to-end test that changes the prompt after the first assistant turn and checks the frozen `system` plus exactly one persisted update on the next requests. Unit tests cover section diffing, re-anchoring, delivery tracking, each formatter's lowering, and compaction and the context-owning providers ignoring a trailing update when picking the user's request. Wire-verified in both loops: Fable 5.1 sees a byte-identical `system` across a tool round and a resume, receives the hint as `role: "system"`, and with #11837 reports empty `input_transformations`; `gpt-5.6` on the Responses API sees a byte-identical first system item and accepts the mid-conversation one.

### Stack

1. #11836 provider layer: block binding, signature-aware history
2. #11837 agent loops: keep streamed thinking ahead of text and tool calls
3. #11864 agent loops: freeze the system prompt, deliver changes as system messages (this PR)
