### PR TITLE
Support GPT-6 Astra models

### DIFF
--- a/crates/goose-provider-types/src/canonical/data/canonical_models.json
+++ b/crates/goose-provider-types/src/canonical/data/canonical_models.json
@@ -16114,6 +16114,39 @@
     }
   },
   {
+    "id": "amazon-bedrock/anthropic.claude-fable-5.1",
+    "name": "Claude Fable 5.1",
+    "family": "claude-fable",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-06",
+    "release_date": "2026-09-01",
+    "last_updated": "2026-09-01",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 10.0,
+      "output": 50.0,
+      "cache_read": 0.25,
+      "cache_write": 12.5
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
     "id": "amazon-bedrock/anthropic.claude-haiku-4.5-20251001-v1:0",
     "name": "Claude Haiku 4.5",
     "family": "claude-haiku",
@@ -17117,6 +17150,39 @@
       "input": 10.0,
       "output": 50.0,
       "cache_read": 1.0,
+      "cache_write": 12.5
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "amazon-bedrock/global.anthropic.claude-fable-5.1",
+    "name": "Claude Fable 5.1 (Global)",
+    "family": "claude-fable",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-06",
+    "release_date": "2026-09-01",
+    "last_updated": "2026-09-01",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 10.0,
+      "output": 50.0,
+      "cache_read": 0.25,
       "cache_write": 12.5
     },
     "limit": {
@@ -19065,6 +19131,39 @@
     }
   },
   {
+    "id": "amazon-bedrock/us.anthropic.claude-fable-5.1",
+    "name": "Claude Fable 5.1 (US)",
+    "family": "claude-fable",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-06",
+    "release_date": "2026-09-01",
+    "last_updated": "2026-09-01",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 11.0,
+      "output": 55.0,
+      "cache_read": 0.275,
+      "cache_write": 13.75
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
     "id": "amazon-bedrock/us.anthropic.claude-haiku-4.5-20251001-v1:0",
     "name": "Claude Haiku 4.5 (US)",
     "family": "claude-haiku",
@@ -19999,10 +20098,68 @@
     }
   },
   {
+    "id": "amd/DeepSeek-V4-Flash-Vision-Exp",
+    "name": "DeepSeek V4 Flash Vision Exp",
+    "family": "deepseek-flash",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-08-21",
+    "last_updated": "2026-08-21",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.14,
+      "output": 0.28,
+      "cache_read": 0.0028
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 384000
+    }
+  },
+  {
+    "id": "amd/MiniCPM5-1B",
+    "name": "MiniCPM5-1B",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-05-19",
+    "last_updated": "2026-05-19",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.124,
+      "output": 0.7425,
+      "cache_read": 0.124
+    },
+    "limit": {
+      "context": 131072,
+      "output": 131072
+    }
+  },
+  {
     "id": "amd/Qwen3.8-Flash-Next",
     "name": "Qwen3.8 Flash Next",
     "family": "qwen",
-    "attachment": false,
+    "attachment": true,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
@@ -20010,7 +20167,8 @@
     "last_updated": "2026-08-27",
     "modalities": {
       "input": [
-        "text"
+        "text",
+        "image"
       ],
       "output": [
         "text"
@@ -20053,6 +20211,39 @@
       "input": 10.0,
       "output": 50.0,
       "cache_read": 1.0,
+      "cache_write": 12.5
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "anthropic/claude-fable-5.1",
+    "name": "Claude Fable 5.1",
+    "family": "claude-fable",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-06",
+    "release_date": "2026-09-01",
+    "last_updated": "2026-09-01",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 10.0,
+      "output": 50.0,
+      "cache_read": 0.25,
       "cache_write": 12.5
     },
     "limit": {
@@ -22008,6 +22199,39 @@
       "input": 10.0,
       "output": 50.0,
       "cache_read": 1.0,
+      "cache_write": 12.5
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "azure-cognitive-services/claude-fable-5.1",
+    "name": "Claude Fable 5.1",
+    "family": "claude-fable",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-06",
+    "release_date": "2026-09-01",
+    "last_updated": "2026-09-01",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 10.0,
+      "output": 50.0,
+      "cache_read": 0.25,
       "cache_write": 12.5
     },
     "limit": {
@@ -24224,6 +24448,39 @@
     }
   },
   {
+    "id": "azure/claude-fable-5.1",
+    "name": "Claude Fable 5.1",
+    "family": "claude-fable",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-06",
+    "release_date": "2026-09-01",
+    "last_updated": "2026-09-01",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 10.0,
+      "output": 50.0,
+      "cache_read": 0.25,
+      "cache_write": 12.5
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
     "id": "azure/claude-haiku-4.5",
     "name": "Claude Haiku 4.5",
     "family": "claude-haiku",
@@ -25768,8 +26025,8 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 5.0,
-      "output": 30.0,
+      "input": 4.0,
+      "output": 20.0,
       "cache_read": 0.5,
       "cache_write": 6.25
     },
@@ -26049,6 +26306,33 @@
     "limit": {
       "context": 128000,
       "output": 8192
+    }
+  },
+  {
+    "id": "azure/grok-4.6",
+    "name": "Grok 4.6",
+    "family": "grok",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2026-02-01",
+    "release_date": "2026-08-12",
+    "last_updated": "2026-08-12",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {},
+    "limit": {
+      "context": 200000,
+      "output": 128000
     }
   },
   {
@@ -27351,6 +27635,35 @@
     }
   },
   {
+    "id": "baseten/zai-org/GLM-5.3-Fast",
+    "name": "GLM 5.3 Fast",
+    "family": "glm",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-08-14",
+    "last_updated": "2026-08-14",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 2.1,
+      "output": 6.6
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 262144
+    }
+  },
+  {
     "id": "baseten/zai-org/GLM-5.3-Flash",
     "name": "GLM 5.3 Flash",
     "family": "glm",
@@ -27377,6 +27690,35 @@
     "limit": {
       "context": 1048576,
       "output": 131072
+    }
+  },
+  {
+    "id": "berget/Qwen/Qwen3.8-27B-FP8",
+    "name": "Qwen3.8 27B",
+    "family": "qwen",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-08-14",
+    "last_updated": "2026-09-01",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.46,
+      "output": 3.48
+    },
+    "limit": {
+      "context": 262144,
+      "output": 65536
     }
   },
   {
@@ -27412,65 +27754,6 @@
     }
   },
   {
-    "id": "berget/meta-llama/Llama-3.3-70B-Instruct",
-    "name": "Llama 3.3 70B Instruct",
-    "family": "llama",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2023-12",
-    "release_date": "2025-04-27",
-    "last_updated": "2025-04-27",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.99,
-      "output": 0.99
-    },
-    "limit": {
-      "context": 128000,
-      "output": 8192
-    }
-  },
-  {
-    "id": "berget/mistralai/Mistral-Medium-3.5-128B",
-    "name": "Mistral Medium 3.5 128B",
-    "family": "mistral-medium",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2026-04",
-    "release_date": "2026-04-29",
-    "last_updated": "2026-04-29",
-    "modalities": {
-      "input": [
-        "image",
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 1.65,
-      "output": 5.5
-    },
-    "limit": {
-      "context": 262144,
-      "output": 131072
-    }
-  },
-  {
     "id": "berget/mistralai/Mistral-Small-3.2-24B-Instruct",
     "name": "Mistral Small 3.2 24B Instruct 2506",
     "family": "mistral-small",
@@ -27497,38 +27780,6 @@
     "limit": {
       "context": 32000,
       "output": 8192
-    }
-  },
-  {
-    "id": "berget/moonshotai/Kimi-K2.6",
-    "name": "Kimi K2.6",
-    "family": "kimi-k2",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-01",
-    "release_date": "2026-05-07",
-    "last_updated": "2026-05-07",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "video"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.83,
-      "output": 3.85,
-      "cache_read": 0.16
-    },
-    "limit": {
-      "context": 262144,
-      "output": 262144
     }
   },
   {
@@ -27561,64 +27812,6 @@
     }
   },
   {
-    "id": "berget/openai/gpt-oss-120b",
-    "name": "GPT-OSS-120B",
-    "family": "gpt-oss",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-08",
-    "release_date": "2025-08-05",
-    "last_updated": "2025-08-05",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.22,
-      "output": 0.83
-    },
-    "limit": {
-      "context": 128000,
-      "output": 8192
-    }
-  },
-  {
-    "id": "berget/zai-org/GLM-4.7",
-    "name": "GLM 4.7",
-    "family": "glm",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-12",
-    "release_date": "2026-01-19",
-    "last_updated": "2026-01-19",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.77,
-      "output": 2.75
-    },
-    "limit": {
-      "context": 128000,
-      "output": 8192
-    }
-  },
-  {
     "id": "berget/zai-org/GLM-5.2",
     "name": "GLM-5.2",
     "family": "glm",
@@ -27647,34 +27840,6 @@
     }
   },
   {
-    "id": "berget/zai-org/GLM-5.3",
-    "name": "GLM-5.3",
-    "family": "glm",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2026-08-14",
-    "last_updated": "2026-08-29",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 1.75,
-      "output": 5.82
-    },
-    "limit": {
-      "context": 327680,
-      "output": 32768
-    }
-  },
-  {
     "id": "berget/zai-org/GLM-5.3-Flash",
     "name": "GLM-5.3-Flash",
     "family": "glm",
@@ -27683,7 +27848,7 @@
     "tool_call": true,
     "temperature": true,
     "release_date": "2026-08-26",
-    "last_updated": "2026-08-29",
+    "last_updated": "2026-09-01",
     "modalities": {
       "input": [
         "text",
@@ -27700,7 +27865,7 @@
       "output": 0.58
     },
     "limit": {
-      "context": 327680,
+      "context": 524288,
       "output": 16384
     }
   },
@@ -28038,9 +28203,9 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.35,
-      "output": 2.75,
-      "cache_read": 0.03499999999999999
+      "input": 0.32,
+      "output": 2.5,
+      "cache_read": 0.031999999999999994
     },
     "limit": {
       "context": 262144,
@@ -29420,6 +29585,39 @@
       "input": 10.0,
       "output": 50.0,
       "cache_read": 1.0,
+      "cache_write": 12.5
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "cloudflare-ai-gateway/anthropic/claude-fable-5.1",
+    "name": "Claude Fable 5.1",
+    "family": "claude-fable",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-06",
+    "release_date": "2026-09-01",
+    "last_updated": "2026-09-01",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 10.0,
+      "output": 50.0,
+      "cache_read": 0.25,
       "cache_write": 12.5
     },
     "limit": {
@@ -31888,7 +32086,7 @@
     },
     "limit": {
       "context": 65536,
-      "output": 65536
+      "output": 16384
     }
   },
   {
@@ -31921,7 +32119,7 @@
     },
     "limit": {
       "context": 200000,
-      "output": 200000
+      "output": 64000
     }
   },
   {
@@ -31954,7 +32152,7 @@
     },
     "limit": {
       "context": 1000000,
-      "output": 1000000
+      "output": 128000
     }
   },
   {
@@ -31987,7 +32185,7 @@
     },
     "limit": {
       "context": 200000,
-      "output": 200000
+      "output": 64000
     }
   },
   {
@@ -32020,7 +32218,7 @@
     },
     "limit": {
       "context": 1000000,
-      "output": 1000000
+      "output": 128000
     }
   },
   {
@@ -32053,7 +32251,7 @@
     },
     "limit": {
       "context": 200000,
-      "output": 200000
+      "output": 64000
     }
   },
   {
@@ -32086,7 +32284,7 @@
     },
     "limit": {
       "context": 1000000,
-      "output": 1000000
+      "output": 128000
     }
   },
   {
@@ -32119,7 +32317,7 @@
     },
     "limit": {
       "context": 1000000,
-      "output": 1000000
+      "output": 128000
     }
   },
   {
@@ -32152,7 +32350,7 @@
     },
     "limit": {
       "context": 1000000,
-      "output": 1000000
+      "output": 128000
     }
   },
   {
@@ -32185,7 +32383,7 @@
     },
     "limit": {
       "context": 200000,
-      "output": 200000
+      "output": 65000
     }
   },
   {
@@ -32218,7 +32416,7 @@
     },
     "limit": {
       "context": 1000000,
-      "output": 1000000
+      "output": 128000
     }
   },
   {
@@ -32419,13 +32617,13 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.446,
-      "output": 2.228,
+      "input": 0.478,
+      "output": 2.392,
       "cache_read": 0.045
     },
     "limit": {
-      "context": 262000,
-      "output": 262000
+      "context": 256000,
+      "output": 256000
     }
   },
   {
@@ -32459,7 +32657,7 @@
     },
     "limit": {
       "context": 1048576,
-      "output": 1048576
+      "output": 65535
     }
   },
   {
@@ -32526,7 +32724,7 @@
     },
     "limit": {
       "context": 1048576,
-      "output": 1048576
+      "output": 65535
     }
   },
   {
@@ -32559,7 +32757,7 @@
     },
     "limit": {
       "context": 1048576,
-      "output": 1048576
+      "output": 65535
     }
   },
   {
@@ -32592,7 +32790,7 @@
     },
     "limit": {
       "context": 1048576,
-      "output": 1048576
+      "output": 65535
     }
   },
   {
@@ -32625,7 +32823,7 @@
     },
     "limit": {
       "context": 1048576,
-      "output": 1048576
+      "output": 65535
     }
   },
   {
@@ -32659,7 +32857,7 @@
     },
     "limit": {
       "context": 1048576,
-      "output": 1048576
+      "output": 65535
     }
   },
   {
@@ -32687,7 +32885,7 @@
     },
     "limit": {
       "context": 131000,
-      "output": 131000
+      "output": 110000
     }
   },
   {
@@ -32716,7 +32914,7 @@
     },
     "limit": {
       "context": 262000,
-      "output": 262000
+      "output": 81920
     }
   },
   {
@@ -32746,35 +32944,6 @@
     "limit": {
       "context": 262000,
       "output": 262000
-    }
-  },
-  {
-    "id": "cortecs/glm-4.7",
-    "name": "GLM-4.7",
-    "family": "glm",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-04",
-    "release_date": "2025-12-22",
-    "last_updated": "2025-12-22",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.78,
-      "output": 2.785
-    },
-    "limit": {
-      "context": 202752,
-      "output": 198000
     }
   },
   {
@@ -32920,7 +33089,7 @@
     },
     "limit": {
       "context": 1048576,
-      "output": 1048576
+      "output": 1000000
     }
   },
   {
@@ -32943,9 +33112,9 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 1.75,
-      "output": 4.499,
-      "cache_read": 0.438
+      "input": 1.4,
+      "output": 4.399,
+      "cache_read": 0.26
     },
     "limit": {
       "context": 1048576,
@@ -32979,7 +33148,7 @@
     },
     "limit": {
       "context": 1048576,
-      "output": 64000
+      "output": 1048576
     }
   },
   {
@@ -33042,7 +33211,7 @@
     },
     "limit": {
       "context": 1047576,
-      "output": 1047576
+      "output": 32768
     }
   },
   {
@@ -33074,7 +33243,7 @@
     },
     "limit": {
       "context": 1047576,
-      "output": 1047576
+      "output": 32768
     }
   },
   {
@@ -33106,7 +33275,7 @@
     },
     "limit": {
       "context": 1047576,
-      "output": 1047576
+      "output": 32768
     }
   },
   {
@@ -33138,7 +33307,7 @@
     },
     "limit": {
       "context": 128000,
-      "output": 128000
+      "output": 16000
     }
   },
   {
@@ -33170,7 +33339,7 @@
     },
     "limit": {
       "context": 128000,
-      "output": 128000
+      "output": 16000
     }
   },
   {
@@ -33201,7 +33370,7 @@
     },
     "limit": {
       "context": 400000,
-      "output": 400000
+      "output": 128000
     }
   },
   {
@@ -33232,7 +33401,7 @@
     },
     "limit": {
       "context": 400000,
-      "output": 400000
+      "output": 128000
     }
   },
   {
@@ -33263,7 +33432,7 @@
     },
     "limit": {
       "context": 400000,
-      "output": 400000
+      "output": 128000
     }
   },
   {
@@ -33295,7 +33464,7 @@
     },
     "limit": {
       "context": 400000,
-      "output": 400000
+      "output": 128000
     }
   },
   {
@@ -33327,7 +33496,7 @@
     },
     "limit": {
       "context": 1050000,
-      "output": 1050000
+      "output": 128000
     }
   },
   {
@@ -33360,7 +33529,7 @@
     },
     "limit": {
       "context": 1050000,
-      "output": 1050000
+      "output": 128000
     }
   },
   {
@@ -33393,7 +33562,7 @@
     },
     "limit": {
       "context": 1050000,
-      "output": 1050000
+      "output": 128000
     }
   },
   {
@@ -33426,7 +33595,7 @@
     },
     "limit": {
       "context": 1050000,
-      "output": 1050000
+      "output": 128000
     }
   },
   {
@@ -33455,7 +33624,7 @@
     },
     "limit": {
       "context": 131000,
-      "output": 128000
+      "output": 131000
     }
   },
   {
@@ -33542,34 +33711,6 @@
     }
   },
   {
-    "id": "cortecs/hermes-4-70b",
-    "name": "Hermes 4 70B",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2023-12",
-    "release_date": "2025-08-26",
-    "last_updated": "2025-08-26",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.129,
-      "output": 0.399
-    },
-    "limit": {
-      "context": 128000,
-      "output": 128000
-    }
-  },
-  {
     "id": "cortecs/kimi-k2.5",
     "name": "Kimi K2.5",
     "family": "kimi-k2",
@@ -33597,7 +33738,7 @@
     },
     "limit": {
       "context": 262144,
-      "output": 256000
+      "output": 262144
     }
   },
   {
@@ -33629,7 +33770,7 @@
     },
     "limit": {
       "context": 262144,
-      "output": 256000
+      "output": 262144
     }
   },
   {
@@ -33859,7 +34000,7 @@
     },
     "limit": {
       "context": 400000,
-      "output": 400000
+      "output": 196000
     }
   },
   {
@@ -33915,8 +34056,8 @@
       "cache_read": 0.075
     },
     "limit": {
-      "context": 196680,
-      "output": 196608
+      "context": 196000,
+      "output": 196000
     }
   },
   {
@@ -33944,7 +34085,7 @@
     },
     "limit": {
       "context": 196608,
-      "output": 196072
+      "output": 196608
     }
   },
   {
@@ -34089,7 +34230,7 @@
     },
     "limit": {
       "context": 32000,
-      "output": 32000
+      "output": 8192
     }
   },
   {
@@ -34151,35 +34292,6 @@
     }
   },
   {
-    "id": "cortecs/mistral-medium",
-    "name": "mistral-medium-2508",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": false,
-    "release_date": "2024-08-07",
-    "last_updated": "2024-08-07",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.446,
-      "output": 2.228,
-      "cache_read": 0.045
-    },
-    "limit": {
-      "context": 128000,
-      "output": 128000
-    }
-  },
-  {
     "id": "cortecs/mistral-medium-3.5",
     "name": "mistral-medium-3.5",
     "attachment": true,
@@ -34233,7 +34345,7 @@
     },
     "limit": {
       "context": 128000,
-      "output": 131072
+      "output": 128000
     }
   },
   {
@@ -34264,7 +34376,7 @@
     },
     "limit": {
       "context": 262144,
-      "output": 262144
+      "output": 256000
     }
   },
   {
@@ -34321,7 +34433,7 @@
     },
     "limit": {
       "context": 32000,
-      "output": 32000
+      "output": 4096
     }
   },
   {
@@ -34378,7 +34490,7 @@
     },
     "limit": {
       "context": 1000000,
-      "output": 1000000
+      "output": 65535
     }
   },
   {
@@ -34407,7 +34519,7 @@
     },
     "limit": {
       "context": 300000,
-      "output": 300000
+      "output": 10000
     }
   },
   {
@@ -34435,7 +34547,7 @@
     },
     "limit": {
       "context": 128000,
-      "output": 128000
+      "output": 10000
     }
   },
   {
@@ -34466,7 +34578,7 @@
     },
     "limit": {
       "context": 300000,
-      "output": 5000
+      "output": 10000
     }
   },
   {
@@ -34520,7 +34632,7 @@
     },
     "limit": {
       "context": 300000,
-      "output": 300000
+      "output": 65536
     }
   },
   {
@@ -34548,7 +34660,7 @@
     },
     "limit": {
       "context": 128000,
-      "output": 128000
+      "output": 4096
     }
   },
   {
@@ -34600,8 +34712,8 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.25,
-      "output": 0.747
+      "input": 1.014,
+      "output": 1.014
     },
     "limit": {
       "context": 32000,
@@ -34634,7 +34746,7 @@
     },
     "limit": {
       "context": 262000,
-      "output": 131000
+      "output": 262000
     }
   },
   {
@@ -34685,12 +34797,12 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.099,
-      "output": 0.299
+      "input": 0.089,
+      "output": 0.312
     },
     "limit": {
-      "context": 40000,
-      "output": 40000
+      "context": 32000,
+      "output": 32000
     }
   },
   {
@@ -34720,7 +34832,7 @@
     },
     "limit": {
       "context": 262144,
-      "output": 262000
+      "output": 262144
     }
   },
   {
@@ -34864,7 +34976,7 @@
     },
     "limit": {
       "context": 262000,
-      "output": 250000
+      "output": 262000
     }
   },
   {
@@ -34951,7 +35063,7 @@
     },
     "limit": {
       "context": 262000,
-      "output": 262000
+      "output": 32768
     }
   },
   {
@@ -35794,6 +35906,38 @@
     }
   },
   {
+    "id": "crossmodel/anthropic/claude-fable-5.1",
+    "name": "Claude Fable 5.1",
+    "family": "claude-fable",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-06",
+    "release_date": "2026-09-01",
+    "last_updated": "2026-09-01",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 10.0,
+      "output": 50.0,
+      "cache_read": 0.25,
+      "cache_write": 12.5
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
     "id": "crossmodel/anthropic/claude-haiku-4.5",
     "name": "Claude Haiku 4.5 (latest)",
     "family": "claude-haiku",
@@ -36340,10 +36484,10 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 1.5,
-      "output": 7.5,
-      "cache_read": 0.15,
-      "cache_write": 1.5
+      "input": 0.75,
+      "output": 3.75,
+      "cache_read": 0.075,
+      "cache_write": 0.75
     },
     "limit": {
       "context": 1048576,
@@ -36361,6 +36505,39 @@
     "knowledge": "2026-03",
     "release_date": "2026-08-13",
     "last_updated": "2026-08-13",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.75,
+      "output": 3.75,
+      "cache_read": 0.075,
+      "cache_write": 0.75
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    }
+  },
+  {
+    "id": "crossmodel/gemini/gemini-3.8-flash",
+    "name": "Gemini 3.8 Flash",
+    "family": "gemini-flash",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-09-02",
+    "last_updated": "2026-09-02",
     "modalities": {
       "input": [
         "text",
@@ -39971,6 +40148,36 @@
     }
   },
   {
+    "id": "deepinfra/deepseek-ai/DeepSeek-V4-Flash-Vision-Exp",
+    "name": "DeepSeek V4 Flash Vision Exp",
+    "family": "deepseek-flash",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-08-21",
+    "last_updated": "2026-08-21",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.44,
+      "output": 1.32,
+      "cache_read": 0.14
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 384000
+    }
+  },
+  {
     "id": "deepinfra/deepseek-ai/DeepSeek-V4-Pro",
     "name": "DeepSeek V4 Pro",
     "family": "deepseek-thinking",
@@ -40499,7 +40706,7 @@
     },
     "limit": {
       "context": 262144,
-      "output": 64000
+      "output": 128000
     }
   },
   {
@@ -41259,6 +41466,38 @@
       "input": 10.0,
       "output": 50.0,
       "cache_read": 1.0,
+      "cache_write": 12.5
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "digitalocean/anthropic-claude-fable-5.1",
+    "name": "Anthropic Claude Fable 5.1",
+    "family": "claude-fable",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-06",
+    "release_date": "2026-09-01",
+    "last_updated": "2026-09-01",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 10.0,
+      "output": 50.0,
+      "cache_read": 0.25,
       "cache_write": 12.5
     },
     "limit": {
@@ -44172,15 +44411,15 @@
   },
   {
     "id": "edenai/anthropic/claude-fable",
-    "name": "Claude Fable 5",
+    "name": "Claude Fable 5.1",
     "family": "claude-fable",
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
     "temperature": false,
-    "knowledge": "2026-01-31",
-    "release_date": "2026-06-09",
-    "last_updated": "2026-06-09",
+    "knowledge": "2026-06",
+    "release_date": "2026-09-01",
+    "last_updated": "2026-09-01",
     "modalities": {
       "input": [
         "text",
@@ -44195,7 +44434,7 @@
     "cost": {
       "input": 10.0,
       "output": 50.0,
-      "cache_read": 1.0,
+      "cache_read": 0.25,
       "cache_write": 12.5
     },
     "limit": {
@@ -44229,6 +44468,39 @@
       "input": 10.0,
       "output": 50.0,
       "cache_read": 1.0,
+      "cache_write": 12.5
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "edenai/anthropic/claude-fable-5.1",
+    "name": "Claude Fable 5.1",
+    "family": "claude-fable",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-06",
+    "release_date": "2026-09-01",
+    "last_updated": "2026-09-01",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 10.0,
+      "output": 50.0,
+      "cache_read": 0.25,
       "cache_write": 12.5
     },
     "limit": {
@@ -45036,6 +45308,67 @@
     }
   },
   {
+    "id": "edenai/databricks/databricks-deepseek-v4-flash",
+    "name": "DeepSeek V4 Flash 0731",
+    "family": "deepseek-flash",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-05",
+    "release_date": "2026-07-31",
+    "last_updated": "2026-07-31",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.14,
+      "output": 0.28,
+      "cache_read": 0.028,
+      "cache_write": 0.14
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 384000
+    }
+  },
+  {
+    "id": "edenai/databricks/databricks-deepseek-v4-pro",
+    "name": "DeepSeek V4 Pro 0813",
+    "family": "deepseek-thinking",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-08-12",
+    "last_updated": "2026-08-22",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 1.31999,
+      "output": 3.95997,
+      "cache_read": 0.13202,
+      "cache_write": 1.31999
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 384000
+    }
+  },
+  {
     "id": "edenai/databricks/databricks-gpt-oss-120b",
     "name": "GPT OSS 120B",
     "family": "gpt-oss",
@@ -45057,7 +45390,7 @@
     "cost": {
       "input": 0.15001,
       "output": 0.59997,
-      "cache_read": 0.15001,
+      "cache_read": 0.015001,
       "cache_write": 0.15001
     },
     "limit": {
@@ -45087,7 +45420,7 @@
     "cost": {
       "input": 0.15001,
       "output": 0.59997,
-      "cache_read": 0.15001,
+      "cache_read": 0.015001,
       "cache_write": 0.15001
     },
     "limit": {
@@ -45117,7 +45450,7 @@
     "cost": {
       "input": 0.07,
       "output": 0.30002,
-      "cache_read": 0.07,
+      "cache_read": 0.007,
       "cache_write": 0.07
     },
     "limit": {
@@ -45147,7 +45480,7 @@
     "cost": {
       "input": 0.07,
       "output": 0.30002,
-      "cache_read": 0.07,
+      "cache_read": 0.007,
       "cache_write": 0.07
     },
     "limit": {
@@ -45709,7 +46042,7 @@
     },
     "limit": {
       "context": 262144,
-      "output": 64000
+      "output": 128000
     }
   },
   {
@@ -45984,18 +46317,19 @@
     }
   },
   {
-    "id": "edenai/fireworks_ai/accounts/fireworks/models/gpt-oss-120b",
-    "name": "GPT OSS 120B",
-    "family": "gpt-oss",
-    "attachment": false,
+    "id": "edenai/fireworks_ai/accounts/fireworks/models/inkling",
+    "name": "Inkling",
+    "family": "ling",
+    "attachment": true,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "release_date": "2025-08-05",
-    "last_updated": "2025-08-05",
+    "release_date": "2026-07-15",
+    "last_updated": "2026-07-15",
     "modalities": {
       "input": [
-        "text"
+        "text",
+        "image"
       ],
       "output": [
         "text"
@@ -46003,13 +46337,13 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.15,
-      "output": 0.6,
-      "cache_read": 0.015
+      "input": 1.0,
+      "output": 4.05,
+      "cache_read": 0.17
     },
     "limit": {
-      "context": 131072,
-      "output": 32768
+      "context": 1048576,
+      "output": 1048576
     }
   },
   {
@@ -46128,6 +46462,35 @@
     "limit": {
       "context": 262144,
       "output": 262144
+    }
+  },
+  {
+    "id": "edenai/flexai/Step-3.7-Flash",
+    "name": "Step 3.7 Flash",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "temperature": true,
+    "knowledge": "2026-03-01",
+    "release_date": "2026-05-29",
+    "last_updated": "2026-05-29",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.2,
+      "output": 1.15
+    },
+    "limit": {
+      "context": 262144,
+      "output": 256000
     }
   },
   {
@@ -46714,10 +47077,44 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 1.5,
-      "output": 7.5,
-      "cache_read": 0.15,
-      "cache_write": 0.083333
+      "input": 0.75,
+      "output": 3.75,
+      "cache_read": 0.075,
+      "cache_write": 0.041667
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    }
+  },
+  {
+    "id": "edenai/google/gemini-3.8-flash",
+    "name": "Gemini 3.8 Flash",
+    "family": "gemini-flash",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-09-02",
+    "last_updated": "2026-09-02",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.75,
+      "output": 3.75,
+      "cache_read": 0.075,
+      "cache_write": 0.041667
     },
     "limit": {
       "context": 1048576,
@@ -46749,10 +47146,10 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 1.5,
-      "output": 7.5,
-      "cache_read": 0.15,
-      "cache_write": 0.083333
+      "input": 0.75,
+      "output": 3.75,
+      "cache_read": 0.075,
+      "cache_write": 0.041667
     },
     "limit": {
       "context": 1048576,
@@ -46873,8 +47270,8 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.75374,
-      "output": 0.75374
+      "input": 0.75543,
+      "output": 0.75543
     },
     "limit": {
       "context": 128000,
@@ -46901,8 +47298,8 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.17394,
-      "output": 0.75374
+      "input": 0.17433,
+      "output": 0.75543
     },
     "limit": {
       "context": 131072,
@@ -49444,7 +49841,7 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.16,
+      "input": 0.15,
       "output": 0.47,
       "cache_read": 0.016,
       "cache_write": 0.2
@@ -49536,8 +49933,8 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.46384,
-      "output": 0.92768
+      "input": 0.46488,
+      "output": 0.92976
     },
     "limit": {
       "context": 256000,
@@ -49564,8 +49961,8 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.17394,
-      "output": 0.69576
+      "input": 0.17433,
+      "output": 0.69732
     },
     "limit": {
       "context": 128000,
@@ -49593,8 +49990,8 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 1.04364,
-      "output": 1.04364
+      "input": 1.04598,
+      "output": 1.04598
     },
     "limit": {
       "context": 128000,
@@ -50542,10 +50939,10 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 1.5,
-      "output": 7.5,
-      "cache_read": 0.15,
-      "cache_write": 0.083333
+      "input": 0.75,
+      "output": 3.75,
+      "cache_read": 0.075,
+      "cache_write": 0.041667
     },
     "limit": {
       "context": 1048576,
@@ -50577,10 +50974,10 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 1.5,
-      "output": 7.5,
-      "cache_read": 0.15,
-      "cache_write": 0.083333
+      "input": 0.75,
+      "output": 3.75,
+      "cache_read": 0.075,
+      "cache_write": 0.041667
     },
     "limit": {
       "context": 1048576,
@@ -50612,10 +51009,112 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 1.5,
-      "output": 7.5,
-      "cache_read": 0.15,
-      "cache_write": 0.083333
+      "input": 0.75,
+      "output": 3.75,
+      "cache_read": 0.075,
+      "cache_write": 0.041667
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    }
+  },
+  {
+    "id": "edenai/vertex/gemini-3.8-flash",
+    "name": "Gemini 3.8 Flash",
+    "family": "gemini-flash",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-09-02",
+    "last_updated": "2026-09-02",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.75,
+      "output": 3.75,
+      "cache_read": 0.075,
+      "cache_write": 0.041667
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    }
+  },
+  {
+    "id": "edenai/vertex/gemini-3.8-flash@eu",
+    "name": "Gemini 3.8 Flash (EU)",
+    "family": "gemini-flash",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-09-02",
+    "last_updated": "2026-09-02",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.75,
+      "output": 3.75,
+      "cache_read": 0.075,
+      "cache_write": 0.041667
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    }
+  },
+  {
+    "id": "edenai/vertex/gemini-3.8-flash@us",
+    "name": "Gemini 3.8 Flash (US)",
+    "family": "gemini-flash",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-09-02",
+    "last_updated": "2026-09-02",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.75,
+      "output": 3.75,
+      "cache_read": 0.075,
+      "cache_write": 0.041667
     },
     "limit": {
       "context": 1048576,
@@ -50647,10 +51146,10 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 1.5,
-      "output": 7.5,
-      "cache_read": 0.15,
-      "cache_write": 0.083333
+      "input": 0.75,
+      "output": 3.75,
+      "cache_read": 0.075,
+      "cache_write": 0.041667
     },
     "limit": {
       "context": 1048576,
@@ -51986,6 +52485,37 @@
         "image",
         "video",
         "audio"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.25,
+      "output": 4.25,
+      "cache_read": 1.0
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 131072
+    }
+  },
+  {
+    "id": "empiriolabs/muse-spark-1.3",
+    "name": "Muse Spark 1.3",
+    "family": "muse",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-09-02",
+    "last_updated": "2026-09-02",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
       ],
       "output": [
         "text"
@@ -54684,9 +55214,39 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.14,
-      "output": 0.28,
-      "cache_read": 0.028
+      "input": 0.22,
+      "output": 0.66,
+      "cache_read": 0.007
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 384000
+    }
+  },
+  {
+    "id": "fireworks-ai/accounts/fireworks/models/deepseek-v4-flash-vision-exp",
+    "name": "DeepSeek V4 Flash Vision Exp",
+    "family": "deepseek-flash",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-08-21",
+    "last_updated": "2026-08-21",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.22,
+      "output": 0.66,
+      "cache_read": 0.007
     },
     "limit": {
       "context": 1000000,
@@ -54760,7 +55320,7 @@
     "tool_call": true,
     "temperature": true,
     "release_date": "2026-08-14",
-    "last_updated": "2026-08-28",
+    "last_updated": "2026-09-04",
     "modalities": {
       "input": [
         "text"
@@ -54789,7 +55349,7 @@
     "tool_call": true,
     "temperature": true,
     "release_date": "2026-08-26",
-    "last_updated": "2026-08-26",
+    "last_updated": "2026-09-04",
     "modalities": {
       "input": [
         "text",
@@ -54805,7 +55365,7 @@
     "cost": {
       "input": 0.15,
       "output": 0.5,
-      "cache_read": 0.029
+      "cache_read": 0.03
     },
     "limit": {
       "context": 1000000,
@@ -56549,6 +57109,39 @@
     }
   },
   {
+    "id": "github-copilot/claude-fable-5.1",
+    "name": "Claude Fable 5.1",
+    "family": "claude-fable",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-06",
+    "release_date": "2026-09-01",
+    "last_updated": "2026-09-01",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 10.0,
+      "output": 50.0,
+      "cache_read": 0.25,
+      "cache_write": 12.5
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
     "id": "github-copilot/claude-haiku-4.5",
     "name": "Claude Haiku 4.5 (latest)",
     "family": "claude-haiku",
@@ -56579,72 +57172,6 @@
     "limit": {
       "context": 200000,
       "output": 64000
-    }
-  },
-  {
-    "id": "github-copilot/claude-opus-4.5",
-    "name": "Claude Opus 4.5 (latest)",
-    "family": "claude-opus",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-05",
-    "release_date": "2025-11-24",
-    "last_updated": "2025-11-24",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "pdf"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 5.0,
-      "output": 25.0,
-      "cache_read": 0.5,
-      "cache_write": 6.25
-    },
-    "limit": {
-      "context": 200000,
-      "output": 32000
-    }
-  },
-  {
-    "id": "github-copilot/claude-opus-4.6",
-    "name": "Claude Opus 4.6",
-    "family": "claude-opus",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-05-31",
-    "release_date": "2026-02-05",
-    "last_updated": "2026-03-13",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "pdf"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 5.0,
-      "output": 25.0,
-      "cache_read": 0.5,
-      "cache_write": 6.25
-    },
-    "limit": {
-      "context": 200000,
-      "output": 32000
     }
   },
   {
@@ -56747,72 +57274,6 @@
     }
   },
   {
-    "id": "github-copilot/claude-sonnet-4",
-    "name": "Claude Sonnet 4 (latest)",
-    "family": "claude-sonnet",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-03-31",
-    "release_date": "2025-05-22",
-    "last_updated": "2025-05-22",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "pdf"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 3.0,
-      "output": 15.0,
-      "cache_read": 0.3,
-      "cache_write": 3.75
-    },
-    "limit": {
-      "context": 216000,
-      "output": 16000
-    }
-  },
-  {
-    "id": "github-copilot/claude-sonnet-4.5",
-    "name": "Claude Sonnet 4.5 (latest)",
-    "family": "claude-sonnet",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-07-31",
-    "release_date": "2025-09-29",
-    "last_updated": "2025-09-29",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "pdf"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 3.0,
-      "output": 15.0,
-      "cache_read": 0.3,
-      "cache_write": 3.75
-    },
-    "limit": {
-      "context": 200000,
-      "output": 32000
-    }
-  },
-  {
     "id": "github-copilot/claude-sonnet-4.6",
     "name": "Claude Sonnet 4.6",
     "family": "claude-sonnet",
@@ -56876,40 +57337,6 @@
     "limit": {
       "context": 1000000,
       "output": 128000
-    }
-  },
-  {
-    "id": "github-copilot/gemini-3.1-pro-preview",
-    "name": "Gemini 3.1 Pro Preview",
-    "family": "gemini-pro",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-01",
-    "release_date": "2026-02-19",
-    "last_updated": "2026-02-19",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "video",
-        "audio",
-        "pdf"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 2.0,
-      "output": 12.0,
-      "cache_read": 0.2
-    },
-    "limit": {
-      "context": 1000000,
-      "output": 64000
     }
   },
   {
@@ -57010,21 +57437,19 @@
     }
   },
   {
-    "id": "github-copilot/gpt-4.1",
-    "name": "GPT-4.1",
-    "family": "gpt",
+    "id": "github-copilot/gemini-3.8-flash",
+    "name": "Gemini 3.8 Flash",
+    "family": "gemini-flash",
     "attachment": true,
-    "reasoning": false,
+    "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2024-04",
-    "release_date": "2025-04-14",
-    "last_updated": "2025-04-14",
+    "release_date": "2026-09-02",
+    "last_updated": "2026-09-02",
     "modalities": {
       "input": [
         "text",
-        "image",
-        "pdf"
+        "image"
       ],
       "output": [
         "text"
@@ -57032,13 +57457,13 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 2.0,
-      "output": 8.0,
-      "cache_read": 0.5
+      "input": 0.75,
+      "output": 3.75,
+      "cache_read": 0.075
     },
     "limit": {
-      "context": 128000,
-      "output": 16384
+      "context": 1000000,
+      "output": 64000
     }
   },
   {
@@ -57070,69 +57495,6 @@
     "limit": {
       "context": 264000,
       "output": 64000
-    }
-  },
-  {
-    "id": "github-copilot/gpt-5.2",
-    "name": "GPT-5.2",
-    "family": "gpt",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-08-31",
-    "release_date": "2025-12-11",
-    "last_updated": "2025-12-11",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 1.75,
-      "output": 14.0,
-      "cache_read": 0.175
-    },
-    "limit": {
-      "context": 400000,
-      "output": 128000
-    }
-  },
-  {
-    "id": "github-copilot/gpt-5.2-codex",
-    "name": "GPT-5.2 Codex",
-    "family": "gpt-codex",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": false,
-    "knowledge": "2025-08-31",
-    "release_date": "2025-12-11",
-    "last_updated": "2025-12-11",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "pdf"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 1.75,
-      "output": 14.0,
-      "cache_read": 0.175
-    },
-    "limit": {
-      "context": 400000,
-      "output": 128000
     }
   },
   {
@@ -57349,10 +57711,10 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 2.0,
-      "output": 10.0,
-      "cache_read": 0.2,
-      "cache_write": 2.5
+      "input": 4.0,
+      "output": 20.0,
+      "cache_read": 0.4,
+      "cache_write": 5.0
     },
     "limit": {
       "context": 1050000,
@@ -57585,6 +57947,39 @@
     "knowledge": "2026-01-31",
     "release_date": "2026-06-09",
     "last_updated": "2026-06-09",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0,
+      "cache_read": 0.0,
+      "cache_write": 0.0
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "gitlab/duo-chat-fable-5.1",
+    "name": "Agentic Chat (Claude Fable 5.1)",
+    "family": "claude-fable",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-06",
+    "release_date": "2026-09-01",
+    "last_updated": "2026-09-01",
     "modalities": {
       "input": [
         "text",
@@ -58759,6 +59154,39 @@
     }
   },
   {
+    "id": "google-vertex-anthropic/claude-fable-5.1@default",
+    "name": "Claude Fable 5.1",
+    "family": "claude-fable",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-06",
+    "release_date": "2026-09-01",
+    "last_updated": "2026-09-01",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 10.0,
+      "output": 50.0,
+      "cache_read": 0.25,
+      "cache_write": 12.5
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
     "id": "google-vertex-anthropic/claude-fable-5@default",
     "name": "Claude Fable 5",
     "family": "claude-fable",
@@ -59181,6 +59609,39 @@
       "output": 10.0,
       "cache_read": 0.2,
       "cache_write": 2.5
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "google-vertex/claude-fable-5.1@default",
+    "name": "Claude Fable 5.1",
+    "family": "claude-fable",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-06",
+    "release_date": "2026-09-01",
+    "last_updated": "2026-09-01",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 10.0,
+      "output": 50.0,
+      "cache_read": 0.25,
+      "cache_write": 12.5
     },
     "limit": {
       "context": 1000000,
@@ -60216,6 +60677,39 @@
     "knowledge": "2026-03",
     "release_date": "2026-08-13",
     "last_updated": "2026-08-13",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.75,
+      "output": 3.75,
+      "cache_read": 0.075
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    }
+  },
+  {
+    "id": "google-vertex/gemini-3.8-flash",
+    "name": "Gemini 3.8 Flash",
+    "family": "gemini-flash",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-09-02",
+    "last_updated": "2026-09-02",
     "modalities": {
       "input": [
         "text",
@@ -61395,6 +61889,39 @@
     "knowledge": "2026-03",
     "release_date": "2026-08-13",
     "last_updated": "2026-08-13",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.75,
+      "output": 3.75,
+      "cache_read": 0.075
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    }
+  },
+  {
+    "id": "google/gemini-3.8-flash",
+    "name": "Gemini 3.8 Flash",
+    "family": "gemini-flash",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-09-02",
+    "last_updated": "2026-09-02",
     "modalities": {
       "input": [
         "text",
@@ -67331,6 +67858,35 @@
     }
   },
   {
+    "id": "huggingface/deepseek-ai/DeepSeek-V4-Flash-Vision-Exp",
+    "name": "DeepSeek V4 Flash Vision Exp",
+    "family": "deepseek-flash",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-08-21",
+    "last_updated": "2026-08-21",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.44,
+      "output": 1.32
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 384000
+    }
+  },
+  {
     "id": "huggingface/deepseek-ai/DeepSeek-V4-Pro",
     "name": "DeepSeek V4 Pro",
     "family": "deepseek-thinking",
@@ -67797,7 +68353,7 @@
     },
     "limit": {
       "context": 262144,
-      "output": 64000
+      "output": 128000
     }
   },
   {
@@ -68286,9 +68842,9 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.12,
-      "output": 0.42,
-      "cache_write": 0.06
+      "input": 0.106,
+      "output": 0.368,
+      "cache_write": 0.053
     },
     "limit": {
       "context": 256000,
@@ -68315,9 +68871,9 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.91,
-      "output": 2.934,
-      "cache_write": 0.455
+      "input": 0.86,
+      "output": 2.784,
+      "cache_write": 0.43
     },
     "limit": {
       "context": 202752,
@@ -68344,9 +68900,9 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 1.332,
-      "output": 4.312,
-      "cache_write": 0.666
+      "input": 1.262,
+      "output": 4.132,
+      "cache_write": 0.631
     },
     "limit": {
       "context": 202750,
@@ -68471,6 +69027,36 @@
     }
   },
   {
+    "id": "hyper/kimi-k2-thinking",
+    "name": "Kimi K2 Thinking",
+    "family": "kimi-thinking",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-08",
+    "release_date": "2026-09-02",
+    "last_updated": "2026-09-02",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.6,
+      "output": 2.5,
+      "cache_write": 0.3
+    },
+    "limit": {
+      "context": 262144,
+      "output": 26214
+    }
+  },
+  {
     "id": "hyper/kimi-k2.5",
     "name": "Kimi K2.5",
     "family": "kimi-k2",
@@ -68491,9 +69077,9 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.5444,
-      "output": 2.855,
-      "cache_write": 0.2722
+      "input": 0.5144,
+      "output": 2.755,
+      "cache_write": 0.2572
     },
     "limit": {
       "context": 262144,
@@ -68672,9 +69258,9 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.424,
-      "output": 1.612,
-      "cache_write": 0.212
+      "input": 0.484,
+      "output": 1.852,
+      "cache_write": 0.242
     },
     "limit": {
       "context": 262100,
@@ -73453,6 +74039,34 @@
     }
   },
   {
+    "id": "iteracompute/iteracompute/ornith-1.5-35b-a3b",
+    "name": "Ornith 1.5 35B A3B",
+    "family": "ornith",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-08-18",
+    "last_updated": "2026-08-23",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.3,
+      "output": 3.0
+    },
+    "limit": {
+      "context": 327680,
+      "output": 65536
+    }
+  },
+  {
     "id": "iteracompute/iteracompute/qwen3.8-27b",
     "name": "Qwen3.8 27B",
     "family": "qwen",
@@ -73465,8 +74079,7 @@
     "modalities": {
       "input": [
         "text",
-        "image",
-        "video"
+        "image"
       ],
       "output": [
         "text"
@@ -73474,13 +74087,12 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.35,
-      "output": 3.0,
-      "cache_read": 0.1
+      "input": 0.3,
+      "output": 2.5
     },
     "limit": {
-      "context": 262144,
-      "output": 32768
+      "context": 327680,
+      "output": 65536
     }
   },
   {
@@ -73622,7 +74234,7 @@
     },
     "limit": {
       "context": 202752,
-      "output": 64000
+      "output": 128000
     }
   },
   {
@@ -76844,7 +77456,7 @@
     },
     "limit": {
       "context": 256000,
-      "output": 64000
+      "output": 128000
     }
   },
   {
@@ -76872,7 +77484,7 @@
     },
     "limit": {
       "context": 256000,
-      "output": 64000
+      "output": 128000
     }
   },
   {
@@ -77806,7 +78418,7 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 3.0,
+      "input": 2.5,
       "output": 5.0
     },
     "limit": {
@@ -77872,6 +78484,39 @@
       "input": 10.0,
       "output": 50.0,
       "cache_read": 1.0,
+      "cache_write": 12.5
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "kilo/anthropic/claude-fable-5.1",
+    "name": "Claude Fable 5.1",
+    "family": "claude-fable",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-06",
+    "release_date": "2026-09-01",
+    "last_updated": "2026-09-01",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 10.0,
+      "output": 50.0,
+      "cache_read": 0.25,
       "cache_write": 12.5
     },
     "limit": {
@@ -78077,39 +78722,6 @@
     }
   },
   {
-    "id": "kilo/anthropic/claude-opus-4.7-fast",
-    "name": "Claude Opus 4.7",
-    "family": "claude-opus",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": false,
-    "knowledge": "2026-01-31",
-    "release_date": "2026-04-16",
-    "last_updated": "2026-04-16",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "pdf"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 30.0,
-      "output": 150.0,
-      "cache_read": 3.0,
-      "cache_write": 37.5
-    },
-    "limit": {
-      "context": 1000000,
-      "output": 128000
-    }
-  },
-  {
     "id": "kilo/anthropic/claude-opus-4.8",
     "name": "Claude Opus 4.8",
     "family": "claude-opus",
@@ -78143,39 +78755,6 @@
     }
   },
   {
-    "id": "kilo/anthropic/claude-opus-4.8-fast",
-    "name": "Claude Opus 4.8",
-    "family": "claude-opus",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": false,
-    "knowledge": "2026-01",
-    "release_date": "2026-05-28",
-    "last_updated": "2026-05-28",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "pdf"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 10.0,
-      "output": 50.0,
-      "cache_read": 1.0,
-      "cache_write": 12.5
-    },
-    "limit": {
-      "context": 1000000,
-      "output": 128000
-    }
-  },
-  {
     "id": "kilo/anthropic/claude-opus-5",
     "name": "Claude Opus 5",
     "family": "claude-opus",
@@ -78202,39 +78781,6 @@
       "output": 25.0,
       "cache_read": 0.5,
       "cache_write": 6.25
-    },
-    "limit": {
-      "context": 1000000,
-      "output": 128000
-    }
-  },
-  {
-    "id": "kilo/anthropic/claude-opus-5-fast",
-    "name": "Claude Opus 5",
-    "family": "claude-opus",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": false,
-    "knowledge": "2026-05",
-    "release_date": "2026-07-24",
-    "last_updated": "2026-07-24",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "pdf"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 10.0,
-      "output": 50.0,
-      "cache_read": 1.0,
-      "cache_write": 12.5
     },
     "limit": {
       "context": 1000000,
@@ -78831,12 +79377,12 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.2574,
-      "output": 1.0287
+      "input": 0.32,
+      "output": 0.89
     },
     "limit": {
-      "context": 128000,
-      "output": 16000
+      "context": 163840,
+      "output": 16384
     }
   },
   {
@@ -79429,7 +79975,7 @@
       "cache_write": 0.375
     },
     "limit": {
-      "context": 131072,
+      "context": 65536,
       "output": 32768
     }
   },
@@ -79844,6 +80390,40 @@
     }
   },
   {
+    "id": "kilo/google/gemini-3.8-flash",
+    "name": "Gemini 3.8 Flash",
+    "family": "gemini-flash",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-09-02",
+    "last_updated": "2026-09-02",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.75,
+      "output": 3.75,
+      "cache_read": 0.075,
+      "cache_write": 0.041667
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    }
+  },
+  {
     "id": "kilo/google/gemma-2-27b-it",
     "name": "Google: Gemma 2 27B",
     "family": "gemma",
@@ -80135,35 +80715,6 @@
     }
   },
   {
-    "id": "kilo/ibm-granite/granite-4.1-8b",
-    "name": "IBM: Granite 4.1 8B",
-    "family": "granite",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2026-04-30",
-    "last_updated": "2026-04-30",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.05,
-      "output": 0.1,
-      "cache_read": 0.05
-    },
-    "limit": {
-      "context": 131072,
-      "output": 117964
-    }
-  },
-  {
     "id": "kilo/ibm-granite/granite-4.2-8b",
     "name": "IBM: Granite 4.2 8B",
     "family": "granite",
@@ -80183,9 +80734,9 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.1,
-      "output": 0.15,
-      "cache_read": 0.05
+      "input": 0.06,
+      "output": 0.25,
+      "cache_read": 0.015
     },
     "limit": {
       "context": 131072,
@@ -80222,8 +80773,37 @@
     }
   },
   {
+    "id": "kilo/inception/mercury-2.5-preview",
+    "name": "Inception: Mercury 2.5 Preview",
+    "family": "mercury",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-08-31",
+    "last_updated": "2026-08-31",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.2,
+      "output": 0.75,
+      "cache_read": 0.02
+    },
+    "limit": {
+      "context": 260000,
+      "output": 65536
+    }
+  },
+  {
     "id": "kilo/inclusionai/ling-3.0-flash",
-    "name": "Ling-3.0-flash",
+    "name": "inclusionAI: Ling 3.0 Flash",
     "family": "ling",
     "attachment": false,
     "reasoning": true,
@@ -80251,8 +80831,8 @@
     }
   },
   {
-    "id": "kilo/inclusionai/ling-3.0-flash-fin:free",
-    "name": "Ling 3.0 Flash Fin (free)",
+    "id": "kilo/inclusionai/ling-3.0-flash-fin",
+    "name": "inclusionAI: Ling 3.0 Flash Fin",
     "family": "ling",
     "attachment": false,
     "reasoning": true,
@@ -80260,6 +80840,63 @@
     "temperature": true,
     "release_date": "2026-08-27",
     "last_updated": "2026-08-27",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.06,
+      "output": 0.18,
+      "cache_read": 0.012
+    },
+    "limit": {
+      "context": 262144,
+      "output": 235929
+    }
+  },
+  {
+    "id": "kilo/inclusionai/ling-3.0-flash-fin:free",
+    "name": "inclusionAI: Ling 3.0 Flash Fin (free)",
+    "family": "ling",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-08-27",
+    "last_updated": "2026-08-27",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 262144,
+      "output": 32768
+    }
+  },
+  {
+    "id": "kilo/inclusionai/ling-3.0-flash-sante:free",
+    "name": "inclusionAI: Ling 3.0 Flash Sante (free)",
+    "family": "ling",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-09-04",
+    "last_updated": "2026-09-04",
     "modalities": {
       "input": [
         "text"
@@ -80538,7 +81175,7 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.5,
+      "input": 0.4,
       "output": 0.75
     },
     "limit": {
@@ -80573,35 +81210,6 @@
     "limit": {
       "context": 1048756,
       "output": 262144
-    }
-  },
-  {
-    "id": "kilo/meituan/longcat-2.0-free",
-    "name": "Meituan: LongCat 2.0 (free)",
-    "family": "longcat",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2025-08-26",
-    "last_updated": "2025-08-26",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.0,
-      "output": 0.0,
-      "cache_read": 0.0
-    },
-    "limit": {
-      "context": 1048756,
-      "output": 131072
     }
   },
   {
@@ -80742,8 +81350,8 @@
       "output": 0.32
     },
     "limit": {
-      "context": 128000,
-      "output": 115200
+      "context": 131072,
+      "output": 16384
     }
   },
   {
@@ -80800,8 +81408,8 @@
       "output": 0.3
     },
     "limit": {
-      "context": 131072,
-      "output": 8192
+      "context": 327680,
+      "output": 16384
     }
   },
   {
@@ -80862,7 +81470,7 @@
     },
     "limit": {
       "context": 131072,
-      "output": 16384
+      "output": 117964
     }
   },
   {
@@ -80941,6 +81549,72 @@
     "temperature": true,
     "release_date": "2026-08-21",
     "last_updated": "2026-08-21",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "pdf",
+        "audio"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.1,
+      "output": 0.2,
+      "cache_read": 0.002
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 943718
+    }
+  },
+  {
+    "id": "kilo/meta/muse-spark-1.3",
+    "name": "Muse Spark 1.3",
+    "family": "muse",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-09-02",
+    "last_updated": "2026-09-02",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "pdf",
+        "audio"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.25,
+      "output": 4.25,
+      "cache_read": 0.15
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 943718
+    }
+  },
+  {
+    "id": "kilo/meta/muse-spark-1.3-contributor",
+    "name": "Meta: Muse Spark 1.3 Contributor",
+    "family": "muse",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-09-02",
+    "last_updated": "2026-09-02",
     "modalities": {
       "input": [
         "text",
@@ -81241,12 +81915,11 @@
     "open_weights": true,
     "cost": {
       "input": 0.0,
-      "output": 0.0,
-      "cache_read": 0.0
+      "output": 0.0
     },
     "limit": {
       "context": 196608,
-      "output": 196608
+      "output": 176947
     }
   },
   {
@@ -81293,7 +81966,8 @@
     "modalities": {
       "input": [
         "text",
-        "image"
+        "image",
+        "video"
       ],
       "output": [
         "text"
@@ -81302,12 +81976,11 @@
     "open_weights": true,
     "cost": {
       "input": 0.0,
-      "output": 0.0,
-      "cache_read": 0.0
+      "output": 0.0
     },
     "limit": {
       "context": 1048576,
-      "output": 1048576
+      "output": 943718
     }
   },
   {
@@ -82060,7 +82733,7 @@
   },
   {
     "id": "kilo/nex-agi/nex-n2-mini",
-    "name": "Nex AGI: Nex-N2-Mini",
+    "name": "Nex AGI: Nex-N2-Mini (retires Sep 8)",
     "family": "agi",
     "attachment": true,
     "reasoning": true,
@@ -82090,7 +82763,7 @@
   },
   {
     "id": "kilo/nex-agi/nex-n2-pro",
-    "name": "Nex AGI: Nex-N2-Pro",
+    "name": "Nex AGI: Nex-N2-Pro (retires Sep 8)",
     "family": "agi",
     "attachment": true,
     "reasoning": true,
@@ -82252,11 +82925,11 @@
     "cost": {
       "input": 0.05,
       "output": 0.2,
-      "cache_read": 0.025
+      "cache_read": 0.03
     },
     "limit": {
       "context": 262144,
-      "output": 228000
+      "output": 235929
     }
   },
   {
@@ -82371,8 +83044,8 @@
       "cache_read": 0.1
     },
     "limit": {
-      "context": 262144,
-      "output": 16384
+      "context": 256000,
+      "output": 32768
     }
   },
   {
@@ -82401,6 +83074,35 @@
     "limit": {
       "context": 1000000,
       "output": 65536
+    }
+  },
+  {
+    "id": "kilo/nvidia/nemotron-3.5-content-safety",
+    "name": "Nemotron 3.5 Content Safety",
+    "family": "nemotron",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2026-06-04",
+    "last_updated": "2026-06-04",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.2,
+      "output": 0.2
+    },
+    "limit": {
+      "context": 131072,
+      "output": 117964
     }
   },
   {
@@ -83757,6 +84459,70 @@
     }
   },
   {
+    "id": "kilo/openai/gpt-6-astra",
+    "name": "GPT-6 Astra",
+    "family": "gpt-astra",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "release_date": "2026-09-04",
+    "last_updated": "2026-09-04",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 10.0,
+      "output": 50.0,
+      "cache_read": 1.0,
+      "cache_write": 12.5
+    },
+    "limit": {
+      "context": 1050000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "kilo/openai/gpt-6-astra-pro",
+    "name": "OpenAI: GPT-6 Astra Pro ($$$$)",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "release_date": "2026-09-04",
+    "last_updated": "2026-09-04",
+    "modalities": {
+      "input": [
+        "pdf",
+        "image",
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 10.0,
+      "output": 50.0,
+      "cache_read": 1.0,
+      "cache_write": 12.5
+    },
+    "limit": {
+      "context": 1050000,
+      "output": 128000
+    }
+  },
+  {
     "id": "kilo/openai/gpt-audio",
     "name": "OpenAI: GPT Audio",
     "family": "gpt",
@@ -84721,12 +85487,13 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.25,
-      "output": 0.75
+      "input": 0.8,
+      "output": 1.0,
+      "cache_read": 0.4
     },
     "limit": {
-      "context": 32000,
-      "output": 28800
+      "context": 128000,
+      "output": 115200
     }
   },
   {
@@ -85512,7 +86279,7 @@
     },
     "limit": {
       "context": 262144,
-      "output": 235929
+      "output": 16384
     }
   },
   {
@@ -85542,7 +86309,7 @@
     },
     "limit": {
       "context": 262144,
-      "output": 65536
+      "output": 235929
     }
   },
   {
@@ -85693,7 +86460,7 @@
     },
     "limit": {
       "context": 262144,
-      "output": 235929
+      "output": 65536
     }
   },
   {
@@ -86968,12 +87735,12 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.45,
+      "input": 0.35,
       "output": 0.65
     },
     "limit": {
       "context": 6144,
-      "output": 4096
+      "output": 5529
     }
   },
   {
@@ -87424,13 +88191,13 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.43,
-      "output": 1.75,
-      "cache_read": 0.08
+      "input": 0.55,
+      "output": 2.2,
+      "cache_read": 0.11
     },
     "limit": {
-      "context": 198000,
-      "output": 16384
+      "context": 204800,
+      "output": 131072
     }
   },
   {
@@ -87638,7 +88405,7 @@
     },
     "limit": {
       "context": 1048576,
-      "output": 262144
+      "output": 131072
     }
   },
   {
@@ -87667,7 +88434,7 @@
     },
     "limit": {
       "context": 1048576,
-      "output": 131072
+      "output": 262144
     }
   },
   {
@@ -87756,7 +88523,7 @@
     "cost": {
       "input": 10.0,
       "output": 50.0,
-      "cache_read": 1.0,
+      "cache_read": 0.25,
       "cache_write": 12.5
     },
     "limit": {
@@ -87881,13 +88648,13 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.05,
-      "output": 0.16,
-      "cache_read": 0.013
+      "input": 0.04998,
+      "output": 0.09996,
+      "cache_read": 0.009996
     },
     "limit": {
       "context": 1048576,
-      "output": 393216
+      "output": 131072
     }
   },
   {
@@ -87980,9 +88747,9 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 2.55,
-      "output": 12.75,
-      "cache_read": 0.256
+      "input": 2.5,
+      "output": 14.0,
+      "cache_read": 0.29
     },
     "limit": {
       "context": 1048576,
@@ -88103,9 +88870,40 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 1.17,
-      "output": 3.96,
-      "cache_read": 0.234
+      "input": 1.15,
+      "output": 3.5,
+      "cache_read": 0.1
+    },
+    "limit": {
+      "context": 262144,
+      "output": 235929
+    }
+  },
+  {
+    "id": "kilo/~z-ai/glm-flash",
+    "name": "Z.ai: GLM Flash Latest",
+    "family": "glm-flash",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-08-27",
+    "last_updated": "2026-08-27",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.075,
+      "output": 0.25,
+      "cache_read": 0.015
     },
     "limit": {
       "context": 1048576,
@@ -89299,6 +90097,39 @@
       "input": 10.0,
       "output": 50.0,
       "cache_read": 1.0,
+      "cache_write": 12.5
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "llmgateway-providers/anthropic/claude-fable-5.1",
+    "name": "Claude Fable 5.1 (Anthropic)",
+    "family": "claude-fable",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-06",
+    "release_date": "2026-09-01",
+    "last_updated": "2026-09-01",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 10.0,
+      "output": 50.0,
+      "cache_read": 0.25,
       "cache_write": 12.5
     },
     "limit": {
@@ -92233,6 +93064,34 @@
     }
   },
   {
+    "id": "llmgateway-providers/consensusprotocol/Qwen3.8-27B",
+    "name": "Qwen3.8 27B (Consensus Protocol)",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-09-02",
+    "last_updated": "2026-09-02",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.41,
+      "output": 2.5,
+      "cache_read": 0.08
+    },
+    "limit": {
+      "context": 32768,
+      "output": 32768
+    }
+  },
+  {
     "id": "llmgateway-providers/consensusprotocol/deepseek-v4-flash",
     "name": "DeepSeek V4 Flash (Consensus Protocol)",
     "family": "deepseek-flash",
@@ -92253,13 +93112,71 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.13,
-      "output": 0.27,
+      "input": 0.08,
+      "output": 0.16,
       "cache_read": 0.02
     },
     "limit": {
       "context": 524288,
       "output": 393216
+    }
+  },
+  {
+    "id": "llmgateway-providers/consensusprotocol/glm-5.3-flash",
+    "name": "GLM-5.3 Flash (Consensus Protocol)",
+    "family": "glm",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-08-26",
+    "last_updated": "2026-08-26",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.1,
+      "output": 0.25,
+      "cache_read": 0.02
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 131072
+    }
+  },
+  {
+    "id": "llmgateway-providers/consensusprotocol/gpt-oss-20b",
+    "name": "GPT OSS 20B (Consensus Protocol)",
+    "family": "gpt-oss",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2025-08-05",
+    "last_updated": "2025-08-05",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.04,
+      "output": 0.19,
+      "cache_read": 0.01
+    },
+    "limit": {
+      "context": 65536,
+      "output": 32768
     }
   },
   {
@@ -93621,6 +94538,40 @@
     }
   },
   {
+    "id": "llmgateway-providers/google-ai-studio/gemini-3.8-flash",
+    "name": "Gemini 3.8 Flash (Google AI Studio)",
+    "family": "gemini-flash",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-09-02",
+    "last_updated": "2026-09-02",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.75,
+      "output": 3.75,
+      "cache_read": 0.075,
+      "cache_write": 0.08333
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    }
+  },
+  {
     "id": "llmgateway-providers/google-ai-studio/gemini-pro",
     "name": "Gemini Pro Latest (Google AI Studio)",
     "family": "gemini-pro",
@@ -93997,6 +94948,38 @@
     }
   },
   {
+    "id": "llmgateway-providers/google-vertex/gemini-3.8-flash",
+    "name": "Gemini 3.8 Flash (Google Vertex AI)",
+    "family": "gemini",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-09-02",
+    "last_updated": "2026-09-02",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.75,
+      "output": 3.75,
+      "cache_read": 0.075,
+      "cache_write": 0.08333
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    }
+  },
+  {
     "id": "llmgateway-providers/groq/gpt-oss-120b",
     "name": "GPT OSS 120B (Groq)",
     "family": "gpt-oss",
@@ -94081,6 +95064,66 @@
     }
   },
   {
+    "id": "llmgateway-providers/meta-contributor/muse-spark-1.2-contributor",
+    "name": "Muse Spark 1.2 Contributor (Meta Contributor)",
+    "family": "muse",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-08-06",
+    "last_updated": "2026-08-06",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.1,
+      "output": 0.2,
+      "cache_read": 0.002
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 131072
+    }
+  },
+  {
+    "id": "llmgateway-providers/meta-contributor/muse-spark-1.3-contributor",
+    "name": "Muse Spark 1.3 Contributor (Meta Contributor)",
+    "family": "muse",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-09-02",
+    "last_updated": "2026-09-02",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.1,
+      "output": 0.2,
+      "cache_read": 0.002
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 1048576
+    }
+  },
+  {
     "id": "llmgateway-providers/meta/muse-spark-1.1",
     "name": "Muse Spark 1.1 (Meta)",
     "family": "muse",
@@ -94143,6 +95186,39 @@
     "limit": {
       "context": 1048576,
       "output": 131072
+    }
+  },
+  {
+    "id": "llmgateway-providers/meta/muse-spark-1.3",
+    "name": "Muse Spark 1.3 (Meta)",
+    "family": "muse",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-09-02",
+    "last_updated": "2026-09-02",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "pdf",
+        "audio"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.25,
+      "output": 4.25,
+      "cache_read": 0.15
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 1048576
     }
   },
   {
@@ -95147,6 +96223,38 @@
       "input": 1.4,
       "output": 4.4,
       "cache_read": 0.26
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 131072
+    }
+  },
+  {
+    "id": "llmgateway-providers/novita/glm-5.3-flash",
+    "name": "GLM-5.3 Flash (NovitaAI)",
+    "family": "glm",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-08-26",
+    "last_updated": "2026-08-26",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.075,
+      "output": 0.25,
+      "cache_read": 0.015
     },
     "limit": {
       "context": 1048576,
@@ -96931,6 +98039,37 @@
     }
   },
   {
+    "id": "llmgateway-providers/openai/gpt-6-astra",
+    "name": "GPT-6 Astra (OpenAI)",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "release_date": "2026-09-03",
+    "last_updated": "2026-09-03",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 10.0,
+      "output": 50.0,
+      "cache_read": 1.0,
+      "cache_write": 12.5
+    },
+    "limit": {
+      "context": 1050000,
+      "output": 128000
+    }
+  },
+  {
     "id": "llmgateway-providers/openai/o1",
     "name": "o1 (OpenAI)",
     "family": "o",
@@ -97326,6 +98465,35 @@
     }
   },
   {
+    "id": "llmgateway-providers/runware/glm-5.3",
+    "name": "GLM-5.3 (Runware)",
+    "family": "glm",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-08-14",
+    "last_updated": "2026-08-14",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 1.2,
+      "output": 4.0,
+      "cache_read": 0.2
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 131072
+    }
+  },
+  {
     "id": "llmgateway-providers/runware/glm-5.3-flash",
     "name": "GLM-5.3 Flash (Runware)",
     "family": "glm",
@@ -97539,7 +98707,7 @@
     "id": "llmgateway-providers/scx-ai-gp/glm-5.3-flash",
     "name": "GLM-5.3 Flash (SCX.ai)",
     "family": "glm",
-    "attachment": false,
+    "attachment": true,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
@@ -97547,7 +98715,10 @@
     "last_updated": "2026-08-26",
     "modalities": {
       "input": [
-        "text"
+        "text",
+        "image",
+        "video",
+        "pdf"
       ],
       "output": [
         "text"
@@ -99339,6 +100510,34 @@
     }
   },
   {
+    "id": "llmgateway/Qwen3.8-27B",
+    "name": "Qwen3.8 27B",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-09-02",
+    "last_updated": "2026-09-02",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.41,
+      "output": 2.5,
+      "cache_read": 0.08
+    },
+    "limit": {
+      "context": 32768,
+      "output": 32768
+    }
+  },
+  {
     "id": "llmgateway/auto",
     "name": "Auto Route",
     "family": "auto",
@@ -99393,6 +100592,39 @@
       "input": 10.0,
       "output": 50.0,
       "cache_read": 1.0,
+      "cache_write": 12.5
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "llmgateway/claude-fable-5.1",
+    "name": "Claude Fable 5.1",
+    "family": "claude-fable",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-06",
+    "release_date": "2026-09-01",
+    "last_updated": "2026-09-01",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 10.0,
+      "output": 50.0,
+      "cache_read": 0.25,
       "cache_write": 12.5
     },
     "limit": {
@@ -100339,6 +101571,38 @@
     }
   },
   {
+    "id": "llmgateway/gemini-3.8-flash",
+    "name": "Gemini 3.8 Flash",
+    "family": "gemini",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-09-02",
+    "last_updated": "2026-09-02",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.75,
+      "output": 3.75,
+      "cache_read": 0.075,
+      "cache_write": 0.08333
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 1048576
+    }
+  },
+  {
     "id": "llmgateway/gemini-pro",
     "name": "Gemini Pro Latest",
     "family": "gemini",
@@ -100932,9 +102196,9 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 1.3,
+      "input": 1.2,
       "output": 4.0,
-      "cache_read": 0.25
+      "cache_read": 0.2
     },
     "limit": {
       "context": 1048576,
@@ -100964,9 +102228,9 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.13,
-      "output": 0.4,
-      "cache_read": 0.024
+      "input": 0.075,
+      "output": 0.25,
+      "cache_read": 0.015
     },
     "limit": {
       "context": 1048576,
@@ -101907,6 +103171,37 @@
     }
   },
   {
+    "id": "llmgateway/gpt-6-astra",
+    "name": "GPT-6 Astra",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "release_date": "2026-09-03",
+    "last_updated": "2026-09-03",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 10.0,
+      "output": 50.0,
+      "cache_read": 1.0,
+      "cache_write": 12.5
+    },
+    "limit": {
+      "context": 1050000,
+      "output": 1050000
+    }
+  },
+  {
     "id": "llmgateway/gpt-oss-120b",
     "name": "GPT OSS 120B",
     "family": "gpt-oss",
@@ -101955,8 +103250,9 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.05,
-      "output": 0.2
+      "input": 0.04,
+      "output": 0.19,
+      "cache_read": 0.01
     },
     "limit": {
       "context": 131072,
@@ -102326,7 +103622,7 @@
     },
     "limit": {
       "context": 262144,
-      "output": 64000
+      "output": 128000
     }
   },
   {
@@ -103309,7 +104605,7 @@
     },
     "limit": {
       "context": 1048576,
-      "output": 32000
+      "output": 131072
     }
   },
   {
@@ -103343,6 +104639,99 @@
     "limit": {
       "context": 1048576,
       "output": 131072
+    }
+  },
+  {
+    "id": "llmgateway/muse-spark-1.2-contributor",
+    "name": "Muse Spark 1.2 Contributor",
+    "family": "muse",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-08-06",
+    "last_updated": "2026-08-06",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.1,
+      "output": 0.2,
+      "cache_read": 0.002
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 1048576
+    }
+  },
+  {
+    "id": "llmgateway/muse-spark-1.3",
+    "name": "Muse Spark 1.3",
+    "family": "muse",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-09-02",
+    "last_updated": "2026-09-02",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "pdf",
+        "audio"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.25,
+      "output": 4.25,
+      "cache_read": 0.15
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 131072
+    }
+  },
+  {
+    "id": "llmgateway/muse-spark-1.3-contributor",
+    "name": "Muse Spark 1.3 Contributor",
+    "family": "muse",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-09-02",
+    "last_updated": "2026-09-02",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.1,
+      "output": 0.2,
+      "cache_read": 0.002
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 1048576
     }
   },
   {
@@ -104400,37 +105789,6 @@
     "limit": {
       "context": 1000000,
       "output": 64000
-    }
-  },
-  {
-    "id": "llmgateway/qwen3.8-27b",
-    "name": "Qwen3.8 27B",
-    "family": "qwen",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2026-08-14",
-    "last_updated": "2026-08-14",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "video"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.42,
-      "output": 3.0,
-      "cache_read": 0.085
-    },
-    "limit": {
-      "context": 1000000,
-      "output": 32768
     }
   },
   {
@@ -106587,6 +107945,39 @@
     }
   },
   {
+    "id": "merge-gateway/anthropic/claude-fable-5.1",
+    "name": "Claude Fable 5.1",
+    "family": "claude-fable",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-06",
+    "release_date": "2026-09-01",
+    "last_updated": "2026-09-01",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 10.0,
+      "output": 50.0,
+      "cache_read": 0.25,
+      "cache_write": 12.5
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
     "id": "merge-gateway/anthropic/claude-haiku-4.5",
     "name": "Claude Haiku 4.5 (20251001)",
     "family": "claude-haiku",
@@ -107976,6 +109367,39 @@
     "knowledge": "2026-03",
     "release_date": "2026-08-13",
     "last_updated": "2026-08-13",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.75,
+      "output": 3.75,
+      "cache_read": 0.075
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    }
+  },
+  {
+    "id": "merge-gateway/google/gemini-3.8-flash",
+    "name": "Gemini 3.8 Flash",
+    "family": "gemini-flash",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-09-02",
+    "last_updated": "2026-09-02",
     "modalities": {
       "input": [
         "text",
@@ -109753,6 +111177,36 @@
     }
   },
   {
+    "id": "merge-gateway/openai/gpt-6-astra",
+    "name": "GPT-6 Astra",
+    "family": "gpt-astra",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "release_date": "2026-09-04",
+    "last_updated": "2026-09-04",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 10.0,
+      "output": 50.0,
+      "cache_read": 1.0
+    },
+    "limit": {
+      "context": 1050000,
+      "output": 128000
+    }
+  },
+  {
     "id": "merge-gateway/openai/gpt-oss-120b",
     "name": "GPT-OSS 120B",
     "family": "gpt-oss",
@@ -110445,35 +111899,6 @@
     "id": "merge-gateway/qwen/qwen3.5-122b-a10b",
     "name": "Qwen3.5 122B A10B",
     "family": "qwen",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2026-02-23",
-    "last_updated": "2026-02-23",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.115,
-      "output": 0.917,
-      "cache_read": 0.023
-    },
-    "limit": {
-      "context": 131072,
-      "output": 32768
-    }
-  },
-  {
-    "id": "merge-gateway/qwen/qwen3.5-27b",
-    "name": "Qwen3.5 27B",
-    "family": "qwen",
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
@@ -110491,13 +111916,42 @@
     },
     "open_weights": true,
     "cost": {
+      "input": 0.115,
+      "output": 0.917,
+      "cache_read": 0.023
+    },
+    "limit": {
+      "context": 256000,
+      "output": 64000
+    }
+  },
+  {
+    "id": "merge-gateway/qwen/qwen3.5-27b",
+    "name": "Qwen3.5 27B",
+    "family": "qwen",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-02-23",
+    "last_updated": "2026-02-23",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
       "input": 0.086,
       "output": 0.688,
       "cache_read": 0.0172
     },
     "limit": {
-      "context": 256000,
-      "output": 64000
+      "context": 131072,
+      "output": 32768
     }
   },
   {
@@ -110534,7 +111988,7 @@
     "id": "merge-gateway/qwen/qwen3.5-397b-a17b",
     "name": "Qwen3.5 397B A17B",
     "family": "qwen",
-    "attachment": true,
+    "attachment": false,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
@@ -110542,8 +111996,7 @@
     "last_updated": "2026-02-15",
     "modalities": {
       "input": [
-        "text",
-        "image"
+        "text"
       ],
       "output": [
         "text"
@@ -110556,8 +112009,8 @@
       "cache_read": 0.0344
     },
     "limit": {
-      "context": 256000,
-      "output": 64000
+      "context": 131072,
+      "output": 32768
     }
   },
   {
@@ -111624,9 +113077,9 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.015,
-      "output": 0.05,
-      "cache_read": 0.003
+      "input": 0.075,
+      "output": 0.25,
+      "cache_read": 0.015
     },
     "limit": {
       "context": 1000000,
@@ -111866,8 +113319,8 @@
       "cache_read": 0.15
     },
     "limit": {
-      "context": 1000000,
-      "output": 32000
+      "context": 1048576,
+      "output": 131072
     }
   },
   {
@@ -111913,6 +113366,72 @@
     "temperature": true,
     "release_date": "2026-08-05",
     "last_updated": "2026-08-05",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "pdf",
+        "audio"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.1,
+      "output": 0.2,
+      "cache_read": 0.002
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 131072
+    }
+  },
+  {
+    "id": "meta/muse-spark-1.3",
+    "name": "Muse Spark 1.3",
+    "family": "muse",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-09-02",
+    "last_updated": "2026-09-02",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "pdf",
+        "audio"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.25,
+      "output": 4.25,
+      "cache_read": 0.15
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 131072
+    }
+  },
+  {
+    "id": "meta/muse-spark-1.3-contributor",
+    "name": "Muse Spark 1.3 Contributor",
+    "family": "muse",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-09-02",
+    "last_updated": "2026-09-02",
     "modalities": {
       "input": [
         "text",
@@ -115377,14 +116896,16 @@
     }
   },
   {
-    "id": "nano-gpt/Baichuan4-Air",
-    "name": "Baichuan 4 Air",
-    "family": "baichuan",
+    "id": "nan/deepseek-v4-flash",
+    "name": "DeepSeek V4 Flash",
+    "family": "deepseek-flash",
     "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2025-08-19",
-    "last_updated": "2025-08-19",
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-05",
+    "release_date": "2026-04-24",
+    "last_updated": "2026-04-24",
     "modalities": {
       "input": [
         "text"
@@ -115393,26 +116914,55 @@
         "text"
       ]
     },
-    "open_weights": false,
+    "open_weights": true,
     "cost": {
-      "input": 0.157,
-      "output": 0.157,
-      "cache_read": 0.0785
+      "input": 0.0,
+      "output": 0.0
     },
     "limit": {
-      "context": 32768,
+      "context": 1000000,
+      "output": 384000
+    }
+  },
+  {
+    "id": "nan/gemma4",
+    "name": "Gemma 4 26B A4B IT",
+    "family": "gemma",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-02",
+    "last_updated": "2026-04-02",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 262144,
       "output": 32768
     }
   },
   {
-    "id": "nano-gpt/Baichuan4-Turbo",
-    "name": "Baichuan 4 Turbo",
-    "family": "baichuan",
+    "id": "nan/glm5.2",
+    "name": "GLM-5.2",
+    "family": "glm",
     "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2025-08-19",
-    "last_updated": "2025-08-19",
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-06-13",
+    "last_updated": "2026-06-13",
     "modalities": {
       "input": [
         "text"
@@ -115421,15 +116971,131 @@
         "text"
       ]
     },
-    "open_weights": false,
+    "open_weights": true,
     "cost": {
-      "input": 2.42,
-      "output": 2.42,
-      "cache_read": 1.21
+      "input": 0.0,
+      "output": 0.0
     },
     "limit": {
-      "context": 128000,
-      "output": 32768
+      "context": 500000,
+      "output": 131072
+    }
+  },
+  {
+    "id": "nan/glm5.3-flash",
+    "name": "GLM-5.3-Flash",
+    "family": "glm",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-08-26",
+    "last_updated": "2026-08-26",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 131072
+    }
+  },
+  {
+    "id": "nan/mimo-v2.5",
+    "name": "MiMo-V2.5",
+    "family": "mimo",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-12",
+    "release_date": "2026-04-22",
+    "last_updated": "2026-04-22",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 131072
+    }
+  },
+  {
+    "id": "nan/qwen3.6",
+    "name": "Qwen3.6 35B-A3B",
+    "family": "qwen",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-04-17",
+    "last_updated": "2026-04-17",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 262144,
+      "output": 65536
+    }
+  },
+  {
+    "id": "nan/qwen3.8-flash",
+    "name": "Qwen3.8 Flash",
+    "family": "qwen",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-08-26",
+    "last_updated": "2026-08-26",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 262144,
+      "output": 131072
     }
   },
   {
@@ -115456,7 +117122,7 @@
       "cache_read": 0.2465
     },
     "limit": {
-      "context": 16384,
+      "context": 32768,
       "output": 32768
     }
   },
@@ -115484,7 +117150,7 @@
       "cache_read": 1.003
     },
     "limit": {
-      "context": 16384,
+      "context": 32768,
       "output": 16384
     }
   },
@@ -115512,7 +117178,7 @@
       "cache_read": 1.003
     },
     "limit": {
-      "context": 16384,
+      "context": 32768,
       "output": 16384
     }
   },
@@ -115969,8 +117635,8 @@
       "cache_read": 0.05015
     },
     "limit": {
-      "context": 4000,
-      "output": 4096
+      "context": 4096,
+      "output": 3686
     }
   },
   {
@@ -116025,7 +117691,7 @@
       "cache_read": 0.35
     },
     "limit": {
-      "context": 16384,
+      "context": 32768,
       "output": 16384
     }
   },
@@ -116311,34 +117977,6 @@
     }
   },
   {
-    "id": "nano-gpt/NousResearch/hermes-4-70b",
-    "name": "Hermes 4 Medium",
-    "family": "nousresearch",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2025-07-03",
-    "last_updated": "2025-07-03",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.2006,
-      "output": 0.3995,
-      "cache_read": 0.1003
-    },
-    "limit": {
-      "context": 128000,
-      "output": 8192
-    }
-  },
-  {
     "id": "nano-gpt/Qwen3.5-27B-BlueStar-v3-Derestricted",
     "name": "Qwen3.5 27B BlueStar v3 Derestricted",
     "family": "qwen3.5",
@@ -116420,7 +118058,7 @@
       "cache_read": 0.25
     },
     "limit": {
-      "context": 16384,
+      "context": 32768,
       "output": 32768
     }
   },
@@ -116532,7 +118170,7 @@
       "cache_read": 0.2465
     },
     "limit": {
-      "context": 16384,
+      "context": 32768,
       "output": 16384
     }
   },
@@ -116588,7 +118226,7 @@
       "cache_read": 0.2465
     },
     "limit": {
-      "context": 16384,
+      "context": 32768,
       "output": 16384
     }
   },
@@ -116616,35 +118254,7 @@
       "cache_read": 0.349945
     },
     "limit": {
-      "context": 16384,
-      "output": 16384
-    }
-  },
-  {
-    "id": "nano-gpt/Steelskull/L3.3-MS-Evayale-70B",
-    "name": "Evayale 70b ",
-    "family": "llama",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2024-01-01",
-    "last_updated": "2024-12-06",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.493,
-      "output": 0.493,
-      "cache_read": 0.2465
-    },
-    "limit": {
-      "context": 16384,
+      "context": 32768,
       "output": 16384
     }
   },
@@ -116672,7 +118282,7 @@
       "cache_read": 0.2465
     },
     "limit": {
-      "context": 16384,
+      "context": 32768,
       "output": 16384
     }
   },
@@ -116700,7 +118310,7 @@
       "cache_read": 0.2465
     },
     "limit": {
-      "context": 16384,
+      "context": 32768,
       "output": 16384
     }
   },
@@ -116761,7 +118371,7 @@
     },
     "limit": {
       "context": 1048576,
-      "output": 1048576
+      "output": 393216
     }
   },
   {
@@ -116877,36 +118487,6 @@
     "limit": {
       "context": 262144,
       "output": 131072
-    }
-  },
-  {
-    "id": "nano-gpt/TEE/glm-4.7",
-    "name": "GLM 4.7 TEE",
-    "family": "glm",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "temperature": true,
-    "knowledge": "2025-04",
-    "release_date": "2025-12-22",
-    "last_updated": "2025-12-22",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.85,
-      "output": 3.3,
-      "cache_read": 0.425
-    },
-    "limit": {
-      "context": 131000,
-      "output": 65535
     }
   },
   {
@@ -117231,7 +118811,7 @@
     },
     "limit": {
       "context": 1048576,
-      "output": 1048576
+      "output": 65535
     }
   },
   {
@@ -117319,6 +118899,33 @@
     },
     "limit": {
       "context": 65536,
+      "output": 8192
+    }
+  },
+  {
+    "id": "nano-gpt/TEE/qwen3-8b",
+    "name": "Qwen3 8B TEE",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-09-04",
+    "last_updated": "2026-09-04",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.11,
+      "output": 0.45,
+      "cache_read": 0.11
+    },
+    "limit": {
+      "context": 40960,
       "output": 8192
     }
   },
@@ -117662,7 +119269,7 @@
       "cache_read": 0.05015
     },
     "limit": {
-      "context": 16384,
+      "context": 32768,
       "output": 32768
     }
   },
@@ -117689,7 +119296,7 @@
       "cache_read": 0.1003
     },
     "limit": {
-      "context": 16384,
+      "context": 32768,
       "output": 32768
     }
   },
@@ -117717,7 +119324,7 @@
     },
     "limit": {
       "context": 131072,
-      "output": 131072
+      "output": 117964
     }
   },
   {
@@ -117826,7 +119433,7 @@
     },
     "limit": {
       "context": 8192,
-      "output": 8192
+      "output": 26214
     }
   },
   {
@@ -117853,36 +119460,8 @@
       "cache_read": 0.25
     },
     "limit": {
-      "context": 32000,
-      "output": 32768
-    }
-  },
-  {
-    "id": "nano-gpt/Tongyi-Zhiwen/QwenLong-L1-32B",
-    "name": "QwenLong L1 32B",
-    "family": "qwen",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2024-01-01",
-    "last_updated": "2025-01-25",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.14,
-      "output": 0.6,
-      "cache_read": 0.07
-    },
-    "limit": {
-      "context": 128000,
-      "output": 40960
+      "context": 32768,
+      "output": 29491
     }
   },
   {
@@ -118001,7 +119580,7 @@
     "name": "Abliterated Model Large V2",
     "attachment": false,
     "reasoning": true,
-    "tool_call": false,
+    "tool_call": true,
     "release_date": "2026-08-31",
     "last_updated": "2026-08-31",
     "modalities": {
@@ -118258,6 +119837,39 @@
     }
   },
   {
+    "id": "nano-gpt/alibaba/qwen3.8-max",
+    "name": "Qwen3.8 Max 0902",
+    "family": "qwen",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-09-02",
+    "last_updated": "2026-09-02",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 2.0,
+      "output": 6.0,
+      "cache_read": 0.17,
+      "cache_write": 2.5
+    },
+    "limit": {
+      "context": 991808,
+      "output": 131072
+    }
+  },
+  {
     "id": "nano-gpt/amazon/nova-2-lite-v1",
     "name": "Amazon Nova 2 Lite",
     "family": "nova",
@@ -118421,7 +120033,7 @@
     "cost": {
       "input": 10.0,
       "output": 50.0,
-      "cache_read": 1.0,
+      "cache_read": 0.25,
       "cache_write": 12.5
     },
     "limit": {
@@ -118455,6 +120067,39 @@
       "input": 10.0,
       "output": 50.0,
       "cache_read": 1.0,
+      "cache_write": 12.5
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "nano-gpt/anthropic/claude-fable-5.1",
+    "name": "Claude Fable 5.1",
+    "family": "claude-fable",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-06",
+    "release_date": "2026-09-01",
+    "last_updated": "2026-09-01",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 10.0,
+      "output": 50.0,
+      "cache_read": 0.25,
       "cache_write": 12.5
     },
     "limit": {
@@ -119338,7 +120983,7 @@
       "cache_read": 0.2
     },
     "limit": {
-      "context": 128000,
+      "context": 131072,
       "output": 131072
     }
   },
@@ -119507,7 +121152,7 @@
     },
     "limit": {
       "context": 262144,
-      "output": 262144
+      "output": 235929
     }
   },
   {
@@ -119648,7 +121293,7 @@
     },
     "limit": {
       "context": 128000,
-      "output": 131072
+      "output": 16384
     }
   },
   {
@@ -120468,67 +122113,6 @@
     }
   },
   {
-    "id": "nano-gpt/cohere/north-mini-code",
-    "name": "Cohere North Mini Code 1.0",
-    "family": "north",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": false,
-    "temperature": true,
-    "knowledge": "2025-09-23",
-    "release_date": "2026-06-09",
-    "last_updated": "2026-06-09",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.2,
-      "output": 0.8,
-      "cache_read": 0.1
-    },
-    "limit": {
-      "context": 256000,
-      "output": 64000
-    }
-  },
-  {
-    "id": "nano-gpt/command-a-plus-05",
-    "name": "Cohere Command A+ (05/2026)",
-    "family": "command-a",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": false,
-    "temperature": true,
-    "knowledge": "2025-04-01",
-    "release_date": "2026-05-20",
-    "last_updated": "2026-06-09",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 2.5,
-      "output": 10.0,
-      "cache_read": 1.25
-    },
-    "limit": {
-      "context": 128000,
-      "output": 64000
-    }
-  },
-  {
     "id": "nano-gpt/command-a-reasoning-08",
     "name": "Cohere Command A (08/2025)",
     "family": "command-a",
@@ -120692,8 +122276,8 @@
       "cache_read": 0.2
     },
     "limit": {
-      "context": 128000,
-      "output": 163840
+      "context": 163840,
+      "output": 32768
     }
   },
   {
@@ -121099,34 +122683,6 @@
     }
   },
   {
-    "id": "nano-gpt/deepseek/deepseek-prover-v2-671b",
-    "name": "DeepSeek Prover v2 671B",
-    "family": "deepseek",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2025-11-15",
-    "last_updated": "2025-04-30",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 1.0,
-      "output": 2.5,
-      "cache_read": 0.5
-    },
-    "limit": {
-      "context": 160000,
-      "output": 16384
-    }
-  },
-  {
     "id": "nano-gpt/deepseek/deepseek-v3.2",
     "name": "DeepSeek V3.2",
     "family": "deepseek",
@@ -121395,34 +122951,6 @@
     "limit": {
       "context": 1048576,
       "output": 384000
-    }
-  },
-  {
-    "id": "nano-gpt/dots-studio/dots-3-note-preview",
-    "name": "Dots3-Note Preview",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "release_date": "2026-08-15",
-    "last_updated": "2026-08-15",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.1,
-      "output": 0.2,
-      "cache_read": 0.05
-    },
-    "limit": {
-      "context": 393216,
-      "output": 393216
     }
   },
   {
@@ -123240,34 +124768,6 @@
     }
   },
   {
-    "id": "nano-gpt/glm-z1-air",
-    "name": "GLM Z1 Air",
-    "family": "glm",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "release_date": "2025-04-15",
-    "last_updated": "2025-04-15",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.07,
-      "output": 0.07,
-      "cache_read": 0.035
-    },
-    "limit": {
-      "context": 32000,
-      "output": 16384
-    }
-  },
-  {
     "id": "nano-gpt/glm-z1-airx",
     "name": "GLM Z1 AirX",
     "family": "glm",
@@ -123683,10 +125183,44 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.375,
-      "output": 1.875,
-      "cache_read": 0.0375,
-      "cache_write": 0.020833
+      "input": 0.75,
+      "output": 3.75,
+      "cache_read": 0.075,
+      "cache_write": 0.075
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    }
+  },
+  {
+    "id": "nano-gpt/google/gemini-3.8-flash",
+    "name": "Gemini 3.8 Flash",
+    "family": "gemini-flash",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-09-02",
+    "last_updated": "2026-09-02",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.75,
+      "output": 3.75,
+      "cache_read": 0.075,
+      "cache_write": 0.075
     },
     "limit": {
       "context": 1048576,
@@ -123718,10 +125252,10 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.375,
-      "output": 1.875,
-      "cache_read": 0.0375,
-      "cache_write": 0.020833
+      "input": 0.75,
+      "output": 3.75,
+      "cache_read": 0.075,
+      "cache_write": 0.075
     },
     "limit": {
       "context": 1048576,
@@ -124024,7 +125558,7 @@
     },
     "limit": {
       "context": 65536,
-      "output": 65536
+      "output": 8192
     }
   },
   {
@@ -124052,7 +125586,7 @@
     },
     "limit": {
       "context": 65536,
-      "output": 65536
+      "output": 8192
     }
   },
   {
@@ -124135,7 +125669,7 @@
       "cache_read": 0.35
     },
     "limit": {
-      "context": 16384,
+      "context": 32768,
       "output": 16384
     }
   },
@@ -124168,34 +125702,6 @@
     }
   },
   {
-    "id": "nano-gpt/ibm-granite/granite-4.1-8b",
-    "name": "Granite 4.1 8B",
-    "family": "granite",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "release_date": "2026-04-29",
-    "last_updated": "2026-04-29",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.05,
-      "output": 0.1,
-      "cache_read": 0.05
-    },
-    "limit": {
-      "context": 131072,
-      "output": 131072
-    }
-  },
-  {
     "id": "nano-gpt/ibm-granite/granite-4.2-8b",
     "name": "Granite 4.2 8B",
     "family": "granite",
@@ -124221,6 +125727,34 @@
     "limit": {
       "context": 131072,
       "output": 117964
+    }
+  },
+  {
+    "id": "nano-gpt/inception/mercury-2.5-preview",
+    "name": "Mercury 2.5 Preview",
+    "family": "mercury",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-09-01",
+    "last_updated": "2026-09-01",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.04,
+      "output": 0.15,
+      "cache_read": 0.004
+    },
+    "limit": {
+      "context": 260000,
+      "output": 65536
     }
   },
   {
@@ -124334,90 +125868,6 @@
     "limit": {
       "context": 131072,
       "output": 16384
-    }
-  },
-  {
-    "id": "nano-gpt/kwaipilot/kat-coder-air-v2.5",
-    "name": "KAT Coder Air V2.5",
-    "family": "kat-coder",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "release_date": "2026-07-14",
-    "last_updated": "2026-07-14",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.15,
-      "output": 0.6,
-      "cache_read": 0.03
-    },
-    "limit": {
-      "context": 256000,
-      "output": 80000
-    }
-  },
-  {
-    "id": "nano-gpt/kwaipilot/kat-coder-pro-v2",
-    "name": "KAT Coder Pro V2",
-    "family": "kat-coder",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2026-03-28",
-    "last_updated": "2026-03-28",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.3,
-      "output": 1.2,
-      "cache_read": 0.15
-    },
-    "limit": {
-      "context": 256000,
-      "output": 80000
-    }
-  },
-  {
-    "id": "nano-gpt/kwaipilot/kat-coder-pro-v2.5",
-    "name": "KAT Coder Pro V2.5",
-    "family": "kat-coder",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "release_date": "2026-07-14",
-    "last_updated": "2026-07-14",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.74,
-      "output": 2.96,
-      "cache_read": 0.15
-    },
-    "limit": {
-      "context": 256000,
-      "output": 80000
     }
   },
   {
@@ -124586,7 +126036,7 @@
       "cache_read": 0.03
     },
     "limit": {
-      "context": 32768,
+      "context": 65536,
       "output": 32768
     }
   },
@@ -124821,7 +126271,7 @@
     },
     "limit": {
       "context": 131072,
-      "output": 131072
+      "output": 117964
     }
   },
   {
@@ -124917,6 +126367,71 @@
     "limit": {
       "context": 1000000,
       "output": 65536
+    }
+  },
+  {
+    "id": "nano-gpt/meta/muse-spark-1.3",
+    "name": "Muse Spark 1.3",
+    "family": "muse",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-09-02",
+    "last_updated": "2026-09-02",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "pdf",
+        "audio"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.25,
+      "output": 4.25,
+      "cache_read": 0.15
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 943718
+    }
+  },
+  {
+    "id": "nano-gpt/meta/muse-spark-1.3-contributor",
+    "name": "Muse Spark 1.3 Contributor",
+    "family": "muse",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-09-02",
+    "last_updated": "2026-09-02",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.1,
+      "output": 0.2,
+      "cache_read": 0.002
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 943718
     }
   },
   {
@@ -125292,7 +126807,7 @@
     },
     "limit": {
       "context": 128000,
-      "output": 131072
+      "output": 102400
     }
   },
   {
@@ -125603,7 +127118,7 @@
     },
     "limit": {
       "context": 128000,
-      "output": 256000
+      "output": 102400
     }
   },
   {
@@ -125716,8 +127231,8 @@
       "cache_read": 0.09945
     },
     "limit": {
-      "context": 32000,
-      "output": 32768
+      "context": 32768,
+      "output": 26214
     }
   },
   {
@@ -125803,7 +127318,7 @@
     },
     "limit": {
       "context": 65536,
-      "output": 65536
+      "output": 52428
     }
   },
   {
@@ -125858,8 +127373,8 @@
       "cache_read": 0.2
     },
     "limit": {
-      "context": 256000,
-      "output": 262144
+      "context": 262144,
+      "output": 100352
     }
   },
   {
@@ -125889,7 +127404,7 @@
     },
     "limit": {
       "context": 1048576,
-      "output": 1048576
+      "output": 943718
     }
   },
   {
@@ -126164,7 +127679,7 @@
     },
     "limit": {
       "context": 1048576,
-      "output": 1048576
+      "output": 943718
     }
   },
   {
@@ -126355,7 +127870,7 @@
     },
     "limit": {
       "context": 262144,
-      "output": 262144
+      "output": 235929
     }
   },
   {
@@ -126384,7 +127899,7 @@
     },
     "limit": {
       "context": 262144,
-      "output": 262144
+      "output": 235929
     }
   },
   {
@@ -126411,7 +127926,7 @@
       "cache_read": 0.2465
     },
     "limit": {
-      "context": 16384,
+      "context": 32768,
       "output": 16384
     }
   },
@@ -126498,8 +128013,8 @@
       "cache_read": 0.085
     },
     "limit": {
-      "context": 256000,
-      "output": 262144
+      "context": 262144,
+      "output": 235929
     }
   },
   {
@@ -126797,33 +128312,6 @@
     }
   },
   {
-    "id": "nano-gpt/openai/gpt-4-turbo-preview",
-    "name": "GPT-4 Turbo Preview",
-    "family": "gpt",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2024-01-01",
-    "last_updated": "2024-01-01",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 10.0,
-      "output": 30.0
-    },
-    "limit": {
-      "context": 128000,
-      "output": 4096
-    }
-  },
-  {
     "id": "nano-gpt/openai/gpt-4.1",
     "name": "GPT 4.1",
     "family": "gpt",
@@ -126981,63 +128469,6 @@
     }
   },
   {
-    "id": "nano-gpt/openai/gpt-4o-mini-search-preview",
-    "name": "GPT-4o mini Search Preview",
-    "family": "gpt-mini",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2026-03-10",
-    "last_updated": "2024-07-18",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.15,
-      "output": 0.6,
-      "cache_read": 0.075
-    },
-    "limit": {
-      "context": 128000,
-      "output": 16384
-    }
-  },
-  {
-    "id": "nano-gpt/openai/gpt-4o-search-preview",
-    "name": "GPT-4o Search Preview",
-    "family": "gpt",
-    "attachment": true,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2026-03-10",
-    "last_updated": "2024-05-13",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 2.5,
-      "output": 10.0,
-      "cache_read": 1.25
-    },
-    "limit": {
-      "context": 128000,
-      "output": 16384
-    }
-  },
-  {
     "id": "nano-gpt/openai/gpt-5",
     "name": "GPT 5",
     "family": "gpt",
@@ -127067,36 +128498,6 @@
     "limit": {
       "context": 400000,
       "output": 128000
-    }
-  },
-  {
-    "id": "nano-gpt/openai/gpt-5-codex",
-    "name": "GPT-5 Codex",
-    "family": "gpt-codex",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": false,
-    "knowledge": "2024-09-30",
-    "release_date": "2025-09-15",
-    "last_updated": "2025-09-15",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 1.25,
-      "output": 10.0,
-      "cache_read": 0.125
-    },
-    "limit": {
-      "context": 256000,
-      "output": 32768
     }
   },
   {
@@ -127741,6 +129142,69 @@
     }
   },
   {
+    "id": "nano-gpt/openai/gpt-6-astra",
+    "name": "GPT 6 Astra",
+    "family": "gpt-astra",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "release_date": "2026-09-04",
+    "last_updated": "2026-09-04",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 10.0,
+      "output": 50.0,
+      "cache_read": 1.0,
+      "cache_write": 12.5
+    },
+    "limit": {
+      "context": 1050000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "nano-gpt/openai/gpt-6-astra-pro",
+    "name": "GPT 6 Astra Pro",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-09-04",
+    "last_updated": "2026-09-04",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 10.0,
+      "output": 50.0,
+      "cache_read": 1.0,
+      "cache_write": 12.5
+    },
+    "limit": {
+      "context": 1050000,
+      "output": 128000
+    }
+  },
+  {
     "id": "nano-gpt/openai/gpt-chat",
     "name": "GPT Chat Latest",
     "family": "gpt",
@@ -127885,34 +129349,6 @@
     }
   },
   {
-    "id": "nano-gpt/openai/o1-preview",
-    "name": "OpenAI o1-preview",
-    "family": "o",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": false,
-    "release_date": "2024-01-01",
-    "last_updated": "2024-09-12",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 15.0,
-      "output": 60.0,
-      "cache_read": 7.5
-    },
-    "limit": {
-      "context": 128000,
-      "output": 32768
-    }
-  },
-  {
     "id": "nano-gpt/openai/o1-pro",
     "name": "OpenAI o1 Pro",
     "family": "o-pro",
@@ -127968,36 +129404,6 @@
       "input": 2.0,
       "output": 8.0,
       "cache_read": 1.0
-    },
-    "limit": {
-      "context": 200000,
-      "output": 100000
-    }
-  },
-  {
-    "id": "nano-gpt/openai/o3-deep-research",
-    "name": "OpenAI o3 Deep Research",
-    "family": "o",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": false,
-    "temperature": false,
-    "knowledge": "2024-05",
-    "release_date": "2024-06-26",
-    "last_updated": "2024-06-26",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 11.0,
-      "output": 44.0,
-      "cache_read": 5.5
     },
     "limit": {
       "context": 200000,
@@ -128149,36 +129555,6 @@
     }
   },
   {
-    "id": "nano-gpt/openai/o4-mini-deep-research",
-    "name": "OpenAI o4-mini Deep Research",
-    "family": "o-mini",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": false,
-    "temperature": false,
-    "knowledge": "2024-05",
-    "release_date": "2024-06-26",
-    "last_updated": "2024-06-26",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 2.2,
-      "output": 8.8,
-      "cache_read": 1.1
-    },
-    "limit": {
-      "context": 200000,
-      "output": 100000
-    }
-  },
-  {
     "id": "nano-gpt/openai/o4-mini-high",
     "name": "OpenAI o4-mini high",
     "family": "o-mini",
@@ -128272,7 +129648,7 @@
     "reasoning": true,
     "tool_call": true,
     "release_date": "2026-07-29",
-    "last_updated": "2026-08-23",
+    "last_updated": "2026-07-29",
     "modalities": {
       "input": [
         "text",
@@ -128301,7 +129677,7 @@
     "reasoning": true,
     "tool_call": true,
     "release_date": "2026-07-29",
-    "last_updated": "2026-08-24",
+    "last_updated": "2026-07-29",
     "modalities": {
       "input": [
         "text",
@@ -128402,8 +129778,8 @@
       "cache_read": 1.0
     },
     "limit": {
-      "context": 127000,
-      "output": 128000
+      "context": 128000,
+      "output": 115200
     }
   },
   {
@@ -128780,8 +130156,8 @@
       "cache_read": 0.065
     },
     "limit": {
-      "context": 256000,
-      "output": 262144
+      "context": 262144,
+      "output": 235929
     }
   },
   {
@@ -128808,8 +130184,8 @@
       "cache_read": 0.15
     },
     "limit": {
-      "context": 256000,
-      "output": 262144
+      "context": 131072,
+      "output": 117964
     }
   },
   {
@@ -128866,8 +130242,8 @@
       "cache_read": 0.075
     },
     "limit": {
-      "context": 256000,
-      "output": 262144
+      "context": 262144,
+      "output": 235929
     }
   },
   {
@@ -128897,8 +130273,8 @@
       "cache_read": 0.15
     },
     "limit": {
-      "context": 128000,
-      "output": 262144
+      "context": 131072,
+      "output": 32768
     }
   },
   {
@@ -129046,8 +130422,8 @@
       "cache_read": 0.15
     },
     "limit": {
-      "context": 41000,
-      "output": 32768
+      "context": 262144,
+      "output": 16384
     }
   },
   {
@@ -129452,7 +130828,7 @@
     "reasoning": true,
     "tool_call": true,
     "release_date": "2026-07-29",
-    "last_updated": "2026-08-21",
+    "last_updated": "2026-07-29",
     "modalities": {
       "input": [
         "text",
@@ -129481,7 +130857,7 @@
     "reasoning": true,
     "tool_call": true,
     "release_date": "2026-07-29",
-    "last_updated": "2026-08-24",
+    "last_updated": "2026-07-29",
     "modalities": {
       "input": [
         "text",
@@ -129705,7 +131081,7 @@
     },
     "limit": {
       "context": 32000,
-      "output": 32768
+      "output": 115200
     }
   },
   {
@@ -130677,35 +132053,6 @@
     }
   },
   {
-    "id": "nano-gpt/sarvam-30b",
-    "name": "Sarvam 30B",
-    "family": "sarvam",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2026-02-18",
-    "last_updated": "2026-02-18",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.028,
-      "output": 0.111,
-      "cache_read": 0.017
-    },
-    "limit": {
-      "context": 65536,
-      "output": 4096
-    }
-  },
-  {
     "id": "nano-gpt/shisa-ai/shisa-v2-llama3.3-70b",
     "name": "Shisa V2 Llama 3.3 70B",
     "family": "llama",
@@ -130787,8 +132134,8 @@
       "cache_read": 0.5
     },
     "limit": {
-      "context": 127000,
-      "output": 128000
+      "context": 127072,
+      "output": 114364
     }
   },
   {
@@ -130817,8 +132164,8 @@
       "cache_read": 1.7
     },
     "limit": {
-      "context": 60000,
-      "output": 128000
+      "context": 128000,
+      "output": 115200
     }
   },
   {
@@ -130877,8 +132224,8 @@
       "cache_read": 1.0
     },
     "limit": {
-      "context": 127000,
-      "output": 128000
+      "context": 128000,
+      "output": 115200
     }
   },
   {
@@ -130905,7 +132252,7 @@
       "cache_read": 0.15
     },
     "limit": {
-      "context": 16384,
+      "context": 32768,
       "output": 32768
     }
   },
@@ -130990,8 +132337,8 @@
       "cache_read": 0.05
     },
     "limit": {
-      "context": 256000,
-      "output": 256000
+      "context": 262144,
+      "output": 65536
     }
   },
   {
@@ -131026,34 +132373,6 @@
     }
   },
   {
-    "id": "nano-gpt/tencent/Hunyuan-MT-7B",
-    "name": "Hunyuan MT 7B",
-    "family": "hunyuan",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2025-08-15",
-    "last_updated": "2025-09-18",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 10.0,
-      "output": 20.0,
-      "cache_read": 5.0
-    },
-    "limit": {
-      "context": 8192,
-      "output": 8192
-    }
-  },
-  {
     "id": "nano-gpt/tencent/hy3",
     "name": "Tencent Hy3",
     "family": "Hy",
@@ -131079,7 +132398,7 @@
     },
     "limit": {
       "context": 262144,
-      "output": 262144
+      "output": 128000
     }
   },
   {
@@ -131313,8 +132632,8 @@
       "cache_read": 0.136
     },
     "limit": {
-      "context": 128000,
-      "output": 131072
+      "context": 131072,
+      "output": 16384
     }
   },
   {
@@ -131399,8 +132718,8 @@
       "cache_read": 0.015
     },
     "limit": {
-      "context": 128000,
-      "output": 128000
+      "context": 131072,
+      "output": 117964
     }
   },
   {
@@ -131517,7 +132836,7 @@
     },
     "limit": {
       "context": 500000,
-      "output": 500000
+      "output": 450000
     }
   },
   {
@@ -131605,7 +132924,7 @@
     },
     "limit": {
       "context": 1000000,
-      "output": 1000000
+      "output": 900000
     }
   },
   {
@@ -131635,7 +132954,7 @@
     },
     "limit": {
       "context": 500000,
-      "output": 500000
+      "output": 450000
     }
   },
   {
@@ -131666,7 +132985,7 @@
     },
     "limit": {
       "context": 500000,
-      "output": 500000
+      "output": 450000
     }
   },
   {
@@ -131696,7 +133015,7 @@
     },
     "limit": {
       "context": 256000,
-      "output": 256000
+      "output": 230400
     }
   },
   {
@@ -132053,8 +133372,8 @@
       "cache_read": 0.5
     },
     "limit": {
-      "context": 200000,
-      "output": 204800
+      "context": 204800,
+      "output": 131072
     }
   },
   {
@@ -132081,8 +133400,8 @@
       "cache_read": 0.5
     },
     "limit": {
-      "context": 200000,
-      "output": 204800
+      "context": 204800,
+      "output": 131072
     }
   },
   {
@@ -132170,8 +133489,8 @@
       "cache_read": 0.3
     },
     "limit": {
-      "context": 64000,
-      "output": 96000
+      "context": 65536,
+      "output": 16384
     }
   },
   {
@@ -132201,8 +133520,8 @@
       "cache_read": 0.3
     },
     "limit": {
-      "context": 64000,
-      "output": 96000
+      "context": 65536,
+      "output": 16384
     }
   },
   {
@@ -132318,35 +133637,6 @@
       "input": 0.3,
       "output": 0.9,
       "cache_read": 0.15
-    },
-    "limit": {
-      "context": 128000,
-      "output": 24000
-    }
-  },
-  {
-    "id": "nano-gpt/z-ai/glm-4.6v-flash-original",
-    "name": "GLM 4.6V Flash",
-    "family": "glm",
-    "attachment": true,
-    "reasoning": false,
-    "tool_call": false,
-    "release_date": "2025-12-08",
-    "last_updated": "2025-12-08",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.1,
-      "output": 0.4,
-      "cache_read": 0.05
     },
     "limit": {
       "context": 128000,
@@ -132929,7 +134219,7 @@
       "cache_read": 0.175
     },
     "limit": {
-      "context": 262144,
+      "context": 1048576,
       "output": 32768
     }
   },
@@ -134202,66 +135492,6 @@
     }
   },
   {
-    "id": "nebius/MiniMaxAI/MiniMax-M2.5",
-    "name": "MiniMax-M2.5",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-01",
-    "release_date": "2025-01-20",
-    "last_updated": "2026-05-07",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.3,
-      "output": 1.2,
-      "cache_read": 0.03,
-      "cache_write": 0.375
-    },
-    "limit": {
-      "context": 196608,
-      "output": 8192
-    }
-  },
-  {
-    "id": "nebius/MiniMaxAI/MiniMax-M2.5-fast",
-    "name": "MiniMax-M2.5-fast",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-01",
-    "release_date": "2025-01-20",
-    "last_updated": "2026-05-07",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.3,
-      "output": 1.2,
-      "cache_read": 0.03,
-      "cache_write": 0.375
-    },
-    "limit": {
-      "context": 8000,
-      "output": 8192
-    }
-  },
-  {
     "id": "nebius/MiniMaxAI/MiniMax-M3",
     "name": "MiniMax-M3",
     "family": "minimax",
@@ -134315,98 +135545,7 @@
       "cache_write": 1.25
     },
     "limit": {
-      "context": 128000,
-      "output": 8192
-    }
-  },
-  {
-    "id": "nebius/NousResearch/Hermes-4-70B",
-    "name": "Hermes-4-70B",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-11",
-    "release_date": "2026-01-30",
-    "last_updated": "2026-02-04",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.13,
-      "output": 0.4,
-      "cache_read": 0.013,
-      "cache_write": 0.16
-    },
-    "limit": {
-      "context": 128000,
-      "output": 8192
-    }
-  },
-  {
-    "id": "nebius/PrimeIntellect/INTELLECT-3",
-    "name": "INTELLECT-3",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-10",
-    "release_date": "2026-01-25",
-    "last_updated": "2026-02-04",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.2,
-      "output": 1.1,
-      "cache_read": 0.02,
-      "cache_write": 0.25
-    },
-    "limit": {
-      "context": 128000,
-      "output": 8192
-    }
-  },
-  {
-    "id": "nebius/Qwen/Qwen2.5-VL-72B-Instruct",
-    "name": "Qwen2.5-VL-72B-Instruct",
-    "attachment": true,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-12",
-    "release_date": "2025-01-20",
-    "last_updated": "2026-02-04",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.25,
-      "output": 0.75,
-      "cache_read": 0.025,
-      "cache_write": 0.31
-    },
-    "limit": {
-      "context": 128000,
+      "context": 131072,
       "output": 8192
     }
   },
@@ -134440,36 +135579,6 @@
     }
   },
   {
-    "id": "nebius/Qwen/Qwen3-235B-A22B-Thinking-2507-fast",
-    "name": "Qwen3-235B-A22B-Thinking-2507-fast",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-07",
-    "release_date": "2025-07-25",
-    "last_updated": "2026-05-07",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.5,
-      "output": 2.0,
-      "cache_read": 0.05,
-      "cache_write": 0.625
-    },
-    "limit": {
-      "context": 8000,
-      "output": 8192
-    }
-  },
-  {
     "id": "nebius/Qwen/Qwen3-30B-A3B-Instruct",
     "name": "Qwen3-30B-A3B-Instruct-2507",
     "attachment": false,
@@ -134495,37 +135604,7 @@
       "cache_write": 0.125
     },
     "limit": {
-      "context": 128000,
-      "output": 8192
-    }
-  },
-  {
-    "id": "nebius/Qwen/Qwen3-32B",
-    "name": "Qwen3-32B",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-12",
-    "release_date": "2026-01-28",
-    "last_updated": "2026-02-04",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.1,
-      "output": 0.3,
-      "cache_read": 0.01,
-      "cache_write": 0.125
-    },
-    "limit": {
-      "context": 128000,
+      "context": 262144,
       "output": 8192
     }
   },
@@ -134554,68 +135633,8 @@
       "output": 0.0
     },
     "limit": {
-      "context": 32768,
+      "context": 40960,
       "output": 0
-    }
-  },
-  {
-    "id": "nebius/Qwen/Qwen3-Next-80B-A3B-Thinking",
-    "name": "Qwen3-Next-80B-A3B-Thinking",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-12",
-    "release_date": "2026-01-28",
-    "last_updated": "2026-02-04",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.15,
-      "output": 1.2,
-      "cache_read": 0.015,
-      "cache_write": 0.18
-    },
-    "limit": {
-      "context": 128000,
-      "output": 16384
-    }
-  },
-  {
-    "id": "nebius/Qwen/Qwen3-Next-80B-A3B-Thinking-fast",
-    "name": "Qwen3-Next-80B-A3B-Thinking-fast",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-07",
-    "release_date": "2025-07-25",
-    "last_updated": "2026-05-07",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.15,
-      "output": 1.2,
-      "cache_read": 0.015,
-      "cache_write": 0.1875
-    },
-    "limit": {
-      "context": 8000,
-      "output": 8192
     }
   },
   {
@@ -134649,106 +135668,16 @@
     }
   },
   {
-    "id": "nebius/Qwen/Qwen3.5-397B-A17B-fast",
-    "name": "Qwen3.5-397B-A17B-fast",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-07",
-    "release_date": "2025-07-15",
-    "last_updated": "2026-05-07",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.6,
-      "output": 3.6,
-      "cache_read": 0.06,
-      "cache_write": 0.75
-    },
-    "limit": {
-      "context": 8000,
-      "output": 8192
-    }
-  },
-  {
-    "id": "nebius/deepseek-ai/DeepSeek-V3.2",
-    "name": "DeepSeek-V3.2",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-11",
-    "release_date": "2026-01-20",
-    "last_updated": "2026-02-04",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.3,
-      "output": 0.45,
-      "cache_read": 0.03,
-      "cache_write": 0.375
-    },
-    "limit": {
-      "context": 163000,
-      "output": 16384
-    }
-  },
-  {
-    "id": "nebius/deepseek-ai/DeepSeek-V3.2-fast",
-    "name": "DeepSeek-V3.2-fast",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-01",
-    "release_date": "2025-01-27",
-    "last_updated": "2026-05-07",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.4,
-      "output": 2.0,
-      "cache_read": 0.04,
-      "cache_write": 0.5
-    },
-    "limit": {
-      "context": 8000,
-      "output": 8192
-    }
-  },
-  {
     "id": "nebius/deepseek-ai/DeepSeek-V4-Flash",
-    "name": "DeepSeek V4 Flash",
+    "name": "DeepSeek V4 Flash 0731",
     "family": "deepseek-flash",
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
     "knowledge": "2025-05",
-    "release_date": "2026-04-24",
-    "last_updated": "2026-04-24",
+    "release_date": "2026-07-31",
+    "last_updated": "2026-07-31",
     "modalities": {
       "input": [
         "text"
@@ -134764,8 +135693,8 @@
       "cache_read": 0.14
     },
     "limit": {
-      "context": 131072,
-      "output": 131072
+      "context": 1024000,
+      "output": 1024000
     }
   },
   {
@@ -134794,8 +135723,8 @@
       "cache_read": 0.15
     },
     "limit": {
-      "context": 1000000,
-      "output": 384000
+      "context": 1048576,
+      "output": 1048576
     }
   },
   {
@@ -134826,100 +135755,6 @@
     },
     "limit": {
       "context": 110000,
-      "output": 8192
-    }
-  },
-  {
-    "id": "nebius/meta-llama/Llama-3.3-70B-Instruct",
-    "name": "Llama-3.3-70B-Instruct",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-08",
-    "release_date": "2025-12-05",
-    "last_updated": "2026-02-04",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.13,
-      "output": 0.4,
-      "cache_read": 0.013,
-      "cache_write": 0.16
-    },
-    "limit": {
-      "context": 128000,
-      "output": 8192
-    }
-  },
-  {
-    "id": "nebius/moonshotai/Kimi-K2.5",
-    "name": "Kimi-K2.5",
-    "family": "kimi-k2",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-06",
-    "release_date": "2025-12-15",
-    "last_updated": "2026-02-04",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.5,
-      "output": 2.5,
-      "cache_read": 0.05,
-      "cache_write": 0.625
-    },
-    "limit": {
-      "context": 256000,
-      "output": 8192
-    }
-  },
-  {
-    "id": "nebius/moonshotai/Kimi-K2.5-fast",
-    "name": "Kimi-K2.5-fast",
-    "family": "kimi-k2",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-06",
-    "release_date": "2025-12-15",
-    "last_updated": "2026-02-04",
-    "modalities": {
-      "input": [
-        "text",
-        "image"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.5,
-      "output": 2.5,
-      "cache_read": 0.05,
-      "cache_write": 0.625
-    },
-    "limit": {
-      "context": 256000,
       "output": 8192
     }
   },
@@ -134982,78 +135817,44 @@
     }
   },
   {
-    "id": "nebius/nvidia/Llama-3_1-Nemotron-Ultra-253B-v1",
-    "name": "Llama-3.1-Nemotron-Ultra-253B-v1",
-    "family": "nemotron",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-12",
-    "release_date": "2025-01-15",
-    "last_updated": "2026-02-04",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.6,
-      "output": 1.8,
-      "cache_read": 0.06,
-      "cache_write": 0.75
-    },
-    "limit": {
-      "context": 128000,
-      "output": 4096
-    }
-  },
-  {
-    "id": "nebius/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B",
-    "name": "Nemotron-3-Nano-30B-A3B",
-    "family": "nemotron",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-05",
-    "release_date": "2025-08-10",
-    "last_updated": "2026-02-04",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.06,
-      "output": 0.24,
-      "cache_read": 0.006,
-      "cache_write": 0.075
-    },
-    "limit": {
-      "context": 32000,
-      "output": 4096
-    }
-  },
-  {
-    "id": "nebius/nvidia/Nemotron-3-Nano-Omni",
-    "name": "Nemotron-3-Nano-Omni",
+    "id": "nebius/nvidia/Nemotron-3-Ultra-550b-a55b",
+    "name": "Nemotron 3 Ultra 550B A55B",
     "family": "nemotron",
     "attachment": false,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "knowledge": "2025-01",
-    "release_date": "2025-01-20",
-    "last_updated": "2026-05-07",
+    "release_date": "2026-06-04",
+    "last_updated": "2026-06-04",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 1.0,
+      "output": 3.0,
+      "cache_read": 1.0
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 1048576
+    }
+  },
+  {
+    "id": "nebius/nvidia/Nemotron-3_5-Lightning",
+    "name": "Nemotron 3.5 Lightning 30B A3B",
+    "family": "nemotron",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-08-11",
+    "last_updated": "2026-08-11",
     "modalities": {
       "input": [
         "text"
@@ -135066,12 +135867,11 @@
     "cost": {
       "input": 0.06,
       "output": 0.24,
-      "cache_read": 0.006,
-      "cache_write": 0.075
+      "cache_read": 0.06
     },
     "limit": {
-      "context": 65536,
-      "output": 8192
+      "context": 1048576,
+      "output": 1048576
     }
   },
   {
@@ -135099,7 +135899,7 @@
       "output": 0.9
     },
     "limit": {
-      "context": 256000,
+      "context": 262144,
       "output": 32768
     }
   },
@@ -135129,68 +135929,8 @@
       "cache_write": 0.18
     },
     "limit": {
-      "context": 128000,
+      "context": 131072,
       "output": 8192
-    }
-  },
-  {
-    "id": "nebius/openai/gpt-oss-120b-fast",
-    "name": "gpt-oss-120b-fast",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2025-06",
-    "release_date": "2025-06-10",
-    "last_updated": "2026-05-07",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.1,
-      "output": 0.5,
-      "cache_read": 0.01,
-      "cache_write": 0.125
-    },
-    "limit": {
-      "context": 8000,
-      "output": 8192
-    }
-  },
-  {
-    "id": "nebius/zai-org/GLM-5",
-    "name": "GLM-5",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2026-01",
-    "release_date": "2026-03-01",
-    "last_updated": "2026-03-10",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 1.0,
-      "output": 3.2,
-      "cache_read": 0.1,
-      "cache_write": 1.0
-    },
-    "limit": {
-      "context": 200000,
-      "output": 16384
     }
   },
   {
@@ -135217,8 +135957,37 @@
       "output": 4.4
     },
     "limit": {
-      "context": 432000,
-      "output": 432000
+      "context": 1048576,
+      "output": 1048576
+    }
+  },
+  {
+    "id": "nebius/zai-org/GLM-5.3-Flash",
+    "name": "GLM-5.3-Flash",
+    "family": "glm",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-08-26",
+    "last_updated": "2026-08-26",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.15,
+      "output": 0.5,
+      "cache_read": 0.15
+    },
+    "limit": {
+      "context": 1024000,
+      "output": 1024000
     }
   },
   {
@@ -136226,9 +136995,10 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 1.0,
-      "output": 6.0,
-      "cache_read": 0.1
+      "input": 0.2,
+      "output": 1.2,
+      "cache_read": 0.02,
+      "cache_write": 0.25
     },
     "limit": {
       "context": 1050000,
@@ -136261,7 +137031,8 @@
     "cost": {
       "input": 5.0,
       "output": 30.0,
-      "cache_read": 0.5
+      "cache_read": 0.5,
+      "cache_write": 6.25
     },
     "limit": {
       "context": 1050000,
@@ -136292,9 +137063,10 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 2.5,
-      "output": 15.0,
-      "cache_read": 0.25
+      "input": 2.0,
+      "output": 12.0,
+      "cache_read": 0.2,
+      "cache_write": 2.5
     },
     "limit": {
       "context": 1050000,
@@ -136321,8 +137093,8 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.072,
-      "output": 0.28
+      "input": 0.15,
+      "output": 0.6
     },
     "limit": {
       "context": 131072,
@@ -136349,8 +137121,8 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.05,
-      "output": 0.2
+      "input": 0.07,
+      "output": 0.3
     },
     "limit": {
       "context": 131072,
@@ -136378,7 +137150,11 @@
       ]
     },
     "open_weights": true,
-    "cost": {},
+    "cost": {
+      "input": 1.0,
+      "output": 4.05,
+      "cache_read": 0.17
+    },
     "limit": {
       "context": 1048576,
       "output": 65536
@@ -143335,6 +144111,39 @@
     }
   },
   {
+    "id": "ofox/anthropic/claude-fable-5.1",
+    "name": "Claude Fable 5.1",
+    "family": "claude-fable",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-06",
+    "release_date": "2026-09-01",
+    "last_updated": "2026-09-01",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 10.0,
+      "output": 50.0,
+      "cache_read": 0.25,
+      "cache_write": 12.5
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
     "id": "ofox/anthropic/claude-haiku-4.5",
     "name": "Claude Haiku 4.5 (latest)",
     "family": "claude-haiku",
@@ -148228,6 +149037,38 @@
     }
   },
   {
+    "id": "openai/gpt-6-astra",
+    "name": "GPT-6 Astra",
+    "family": "gpt-astra",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "release_date": "2026-09-04",
+    "last_updated": "2026-09-04",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 10.0,
+      "output": 50.0,
+      "cache_read": 1.0,
+      "cache_write": 12.5
+    },
+    "limit": {
+      "context": 1050000,
+      "output": 128000
+    }
+  },
+  {
     "id": "openai/gpt-image-1",
     "name": "gpt-image-1",
     "family": "gpt-image",
@@ -149002,7 +149843,7 @@
     },
     "limit": {
       "context": 256000,
-      "output": 64000
+      "output": 128000
     }
   },
   {
@@ -149442,6 +150283,68 @@
     }
   },
   {
+    "id": "opencode-go/muse-spark-1.3-contributor",
+    "name": "Muse Spark 1.3 Contributor",
+    "family": "muse",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-09-02",
+    "last_updated": "2026-09-02",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "pdf",
+        "audio"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.1,
+      "output": 0.2,
+      "cache_read": 0.002
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 131072
+    }
+  },
+  {
+    "id": "opencode-go/omen-alpha",
+    "name": "Omen Alpha",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-09-04",
+    "last_updated": "2026-09-04",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.2,
+      "output": 0.66,
+      "cache_read": 0.04
+    },
+    "limit": {
+      "context": 500000,
+      "output": 128000
+    }
+  },
+  {
     "id": "opencode-go/ox-alpha-free",
     "name": "Ox Alpha Free (Unlimited)",
     "attachment": true,
@@ -149753,6 +150656,39 @@
       "input": 10.0,
       "output": 50.0,
       "cache_read": 1.0,
+      "cache_write": 12.5
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "opencode/claude-fable-5.1",
+    "name": "Claude Fable 5.1",
+    "family": "claude-fable",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-06",
+    "release_date": "2026-09-01",
+    "last_updated": "2026-09-01",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 10.0,
+      "output": 50.0,
+      "cache_read": 0.25,
       "cache_write": 12.5
     },
     "limit": {
@@ -150428,6 +151364,39 @@
     "knowledge": "2026-03",
     "release_date": "2026-08-13",
     "last_updated": "2026-08-13",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.5,
+      "output": 7.5,
+      "cache_read": 0.15
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    }
+  },
+  {
+    "id": "opencode/gemini-3.8-flash",
+    "name": "Gemini 3.8 Flash",
+    "family": "gemini-flash",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-09-02",
+    "last_updated": "2026-09-02",
     "modalities": {
       "input": [
         "text",
@@ -152272,6 +153241,39 @@
     }
   },
   {
+    "id": "opencode/muse-spark-1.3-contributor-free",
+    "name": "Muse Spark 1.3 Free",
+    "family": "muse-free",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-09-02",
+    "last_updated": "2026-09-02",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "pdf",
+        "audio"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0,
+      "cache_read": 0.0
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 131072
+    }
+  },
+  {
     "id": "opencode/nemotron-3-super-free",
     "name": "Nemotron 3 Super Free",
     "family": "nemotron-free",
@@ -152974,7 +153976,7 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 3.0,
+      "input": 2.5,
       "output": 5.0
     },
     "limit": {
@@ -153040,6 +154042,39 @@
       "input": 10.0,
       "output": 50.0,
       "cache_read": 1.0,
+      "cache_write": 12.5
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "openrouter/anthropic/claude-fable-5.1",
+    "name": "Claude Fable 5.1",
+    "family": "claude-fable",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-06",
+    "release_date": "2026-09-01",
+    "last_updated": "2026-09-01",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 10.0,
+      "output": 50.0,
+      "cache_read": 0.25,
       "cache_write": 12.5
     },
     "limit": {
@@ -153246,39 +154281,6 @@
     }
   },
   {
-    "id": "openrouter/anthropic/claude-opus-4.7-fast",
-    "name": "Claude Opus 4.7 (Fast)",
-    "family": "claude-opus",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": false,
-    "knowledge": "2026-01-31",
-    "release_date": "2026-04-16",
-    "last_updated": "2026-04-16",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "pdf"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 30.0,
-      "output": 150.0,
-      "cache_read": 3.0,
-      "cache_write": 37.5
-    },
-    "limit": {
-      "context": 1000000,
-      "output": 128000
-    }
-  },
-  {
     "id": "openrouter/anthropic/claude-opus-4.8",
     "name": "Claude Opus 4.8",
     "family": "claude-opus",
@@ -153312,39 +154314,6 @@
     }
   },
   {
-    "id": "openrouter/anthropic/claude-opus-4.8-fast",
-    "name": "Claude Opus 4.8 (Fast)",
-    "family": "claude-opus",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": false,
-    "knowledge": "2026-01",
-    "release_date": "2026-05-28",
-    "last_updated": "2026-05-28",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "pdf"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 10.0,
-      "output": 50.0,
-      "cache_read": 1.0,
-      "cache_write": 12.5
-    },
-    "limit": {
-      "context": 1000000,
-      "output": 128000
-    }
-  },
-  {
     "id": "openrouter/anthropic/claude-opus-5",
     "name": "Claude Opus 5",
     "family": "claude-opus",
@@ -153371,39 +154340,6 @@
       "output": 25.0,
       "cache_read": 0.5,
       "cache_write": 6.25
-    },
-    "limit": {
-      "context": 1000000,
-      "output": 128000
-    }
-  },
-  {
-    "id": "openrouter/anthropic/claude-opus-5-fast",
-    "name": "Claude Opus 5 (Fast)",
-    "family": "claude-opus",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": false,
-    "knowledge": "2026-05",
-    "release_date": "2026-07-24",
-    "last_updated": "2026-07-24",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "pdf"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 10.0,
-      "output": 50.0,
-      "cache_read": 1.0,
-      "cache_write": 12.5
     },
     "limit": {
       "context": 1000000,
@@ -154005,12 +154941,12 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.2574,
-      "output": 1.0287
+      "input": 0.32,
+      "output": 0.89
     },
     "limit": {
       "context": 163840,
-      "output": 16000
+      "output": 16384
     }
   },
   {
@@ -154240,9 +155176,9 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.08092,
-      "output": 0.16184,
-      "cache_read": 0.016184
+      "input": 0.0875,
+      "output": 0.175,
+      "cache_read": 0.0175
     },
     "limit": {
       "context": 1048576,
@@ -154300,9 +155236,9 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.87,
-      "output": 1.74,
-      "cache_read": 0.0725
+      "input": 0.971442,
+      "output": 1.942884,
+      "cache_read": 0.080954
     },
     "limit": {
       "context": 1048576,
@@ -155019,6 +155955,40 @@
     }
   },
   {
+    "id": "openrouter/google/gemini-3.8-flash",
+    "name": "Gemini 3.8 Flash",
+    "family": "gemini-flash",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-09-02",
+    "last_updated": "2026-09-02",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.75,
+      "output": 3.75,
+      "cache_read": 0.075,
+      "cache_write": 0.041667
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65536
+    }
+  },
+  {
     "id": "openrouter/google/gemma-2-27b-it",
     "name": "Gemma 2 27B",
     "family": "gemma",
@@ -155376,35 +156346,6 @@
     }
   },
   {
-    "id": "openrouter/ibm-granite/granite-4.1-8b",
-    "name": "Granite 4.1 8B",
-    "family": "granite",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2026-04-30",
-    "last_updated": "2026-04-30",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.05,
-      "output": 0.1,
-      "cache_read": 0.05
-    },
-    "limit": {
-      "context": 131072,
-      "output": 117964
-    }
-  },
-  {
     "id": "openrouter/ibm-granite/granite-4.2-8b",
     "name": "Granite 4.2 8B",
     "family": "granite",
@@ -155463,8 +156404,37 @@
     }
   },
   {
+    "id": "openrouter/inception/mercury-2.5-preview",
+    "name": "Mercury 2.5 Preview",
+    "family": "mercury",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-08-31",
+    "last_updated": "2026-08-31",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.04,
+      "output": 0.15,
+      "cache_read": 0.004
+    },
+    "limit": {
+      "context": 260000,
+      "output": 65536
+    }
+  },
+  {
     "id": "openrouter/inclusionai/ling-3.0-flash",
-    "name": "Ling-3.0-flash",
+    "name": "Ling 3.0 Flash",
     "family": "ling",
     "attachment": false,
     "reasoning": true,
@@ -155492,6 +156462,35 @@
     }
   },
   {
+    "id": "openrouter/inclusionai/ling-3.0-flash-fin",
+    "name": "Ling 3.0 Flash Fin",
+    "family": "ling",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-08-27",
+    "last_updated": "2026-08-27",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.06,
+      "output": 0.18,
+      "cache_read": 0.012
+    },
+    "limit": {
+      "context": 262144,
+      "output": 235929
+    }
+  },
+  {
     "id": "openrouter/inclusionai/ling-3.0-flash-fin:free",
     "name": "Ling 3.0 Flash Fin (free)",
     "family": "ling",
@@ -155501,6 +156500,34 @@
     "temperature": true,
     "release_date": "2026-08-27",
     "last_updated": "2026-08-27",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 262144,
+      "output": 32768
+    }
+  },
+  {
+    "id": "openrouter/inclusionai/ling-3.0-flash-sante:free",
+    "name": "Ling 3.0 Flash Sante (free)",
+    "family": "ling",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-09-04",
+    "last_updated": "2026-09-04",
     "modalities": {
       "input": [
         "text"
@@ -155626,7 +156653,7 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.5,
+      "input": 0.4,
       "output": 0.75
     },
     "limit": {
@@ -155801,13 +156828,12 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.71,
-      "output": 0.71,
-      "cache_read": 0.71
+      "input": 0.1,
+      "output": 0.32
     },
     "limit": {
       "context": 131072,
-      "output": 115200
+      "output": 16384
     }
   },
   {
@@ -155862,13 +156888,12 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.11,
-      "output": 0.34,
-      "cache_read": 0.055
+      "input": 0.1,
+      "output": 0.3
     },
     "limit": {
       "context": 1310720,
-      "output": 8192
+      "output": 16384
     }
   },
   {
@@ -155924,12 +156949,12 @@
     "open_weights": true,
     "cost": {
       "input": 0.3,
-      "output": 1.2,
+      "output": 1.1,
       "cache_read": 0.04
     },
     "limit": {
       "context": 131072,
-      "output": 16384
+      "output": 117964
     }
   },
   {
@@ -156008,6 +157033,72 @@
     "temperature": true,
     "release_date": "2026-08-21",
     "last_updated": "2026-08-21",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "pdf",
+        "audio"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.1,
+      "output": 0.2,
+      "cache_read": 0.002
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 943718
+    }
+  },
+  {
+    "id": "openrouter/meta/muse-spark-1.3",
+    "name": "Muse Spark 1.3",
+    "family": "muse",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-09-02",
+    "last_updated": "2026-09-02",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "pdf",
+        "audio"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.25,
+      "output": 4.25,
+      "cache_read": 0.15
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 943718
+    }
+  },
+  {
+    "id": "openrouter/meta/muse-spark-1.3-contributor",
+    "name": "Muse Spark 1.3 Contributor",
+    "family": "muse",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-09-02",
+    "last_updated": "2026-09-02",
     "modalities": {
       "input": [
         "text",
@@ -157336,11 +158427,11 @@
     "cost": {
       "input": 0.05,
       "output": 0.2,
-      "cache_read": 0.025
+      "cache_read": 0.03
     },
     "limit": {
       "context": 262144,
-      "output": 228000
+      "output": 235929
     }
   },
   {
@@ -157450,13 +158541,13 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.5,
-      "output": 2.2,
-      "cache_read": 0.1
+      "input": 0.625,
+      "output": 3.125,
+      "cache_read": 0.1875
     },
     "limit": {
       "context": 262144,
-      "output": 16384
+      "output": 32768
     }
   },
   {
@@ -157485,6 +158576,35 @@
     "limit": {
       "context": 1000000,
       "output": 65536
+    }
+  },
+  {
+    "id": "openrouter/nvidia/nemotron-3.5-content-safety",
+    "name": "Nemotron 3.5 Content Safety",
+    "family": "nemotron",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": false,
+    "temperature": true,
+    "release_date": "2026-06-04",
+    "last_updated": "2026-06-04",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.2,
+      "output": 0.2
+    },
+    "limit": {
+      "context": 131072,
+      "output": 117964
     }
   },
   {
@@ -158804,6 +159924,70 @@
     }
   },
   {
+    "id": "openrouter/openai/gpt-6-astra",
+    "name": "GPT-6 Astra",
+    "family": "gpt-astra",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "release_date": "2026-09-04",
+    "last_updated": "2026-09-04",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 10.0,
+      "output": 50.0,
+      "cache_read": 1.0,
+      "cache_write": 12.5
+    },
+    "limit": {
+      "context": 1050000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "openrouter/openai/gpt-6-astra-pro",
+    "name": "GPT-6 Astra Pro",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "release_date": "2026-09-04",
+    "last_updated": "2026-09-04",
+    "modalities": {
+      "input": [
+        "pdf",
+        "image",
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 10.0,
+      "output": 50.0,
+      "cache_read": 1.0,
+      "cache_write": 12.5
+    },
+    "limit": {
+      "context": 1050000,
+      "output": 128000
+    }
+  },
+  {
     "id": "openrouter/openai/gpt-audio",
     "name": "GPT Audio",
     "family": "gpt",
@@ -159789,12 +160973,13 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.25,
-      "output": 0.75
+      "input": 0.8,
+      "output": 1.0,
+      "cache_read": 0.4
     },
     "limit": {
       "context": 128000,
-      "output": 28800
+      "output": 115200
     }
   },
   {
@@ -160587,13 +161772,12 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.25,
-      "output": 1.25,
-      "cache_read": 0.25
+      "input": 0.08,
+      "output": 0.75
     },
     "limit": {
       "context": 262144,
-      "output": 235929
+      "output": 16384
     }
   },
   {
@@ -160618,12 +161802,13 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.39,
-      "output": 2.34
+      "input": 0.55,
+      "output": 3.5,
+      "cache_read": 0.225
     },
     "limit": {
       "context": 262144,
-      "output": 65536
+      "output": 235929
     }
   },
   {
@@ -160770,13 +161955,13 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.6,
-      "output": 3.6,
-      "cache_read": 0.12
+      "input": 0.3,
+      "output": 2.0,
+      "cache_read": 0.03
     },
     "limit": {
       "context": 262144,
-      "output": 235929
+      "output": 65536
     }
   },
   {
@@ -161048,10 +162233,9 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.425,
-      "output": 2.55,
-      "cache_read": 0.085,
-      "cache_write": 0.53125
+      "input": 0.42,
+      "output": 3.0,
+      "cache_read": 0.085
     },
     "limit": {
       "context": 1000000,
@@ -161870,12 +163054,12 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.45,
+      "input": 0.35,
       "output": 0.65
     },
     "limit": {
       "context": 6144,
-      "output": 4096
+      "output": 5529
     }
   },
   {
@@ -162328,13 +163512,13 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.43,
-      "output": 1.75,
-      "cache_read": 0.08
+      "input": 0.55,
+      "output": 2.2,
+      "cache_read": 0.11
     },
     "limit": {
       "context": 204800,
-      "output": 16384
+      "output": 131072
     }
   },
   {
@@ -162536,13 +163720,13 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 1.19,
-      "output": 3.74,
-      "cache_read": 0.221
+      "input": 0.966,
+      "output": 3.036,
+      "cache_read": 0.1932
     },
     "limit": {
       "context": 1048576,
-      "output": 262144
+      "output": 131072
     }
   },
   {
@@ -162595,11 +163779,11 @@
     "cost": {
       "input": 1.4,
       "output": 4.4,
-      "cache_read": 0.26
+      "cache_read": 0.14
     },
     "limit": {
       "context": 1310720,
-      "output": 131072
+      "output": 262144
     }
   },
   {
@@ -162688,7 +163872,7 @@
     "cost": {
       "input": 10.0,
       "output": 50.0,
-      "cache_read": 1.0,
+      "cache_read": 0.25,
       "cache_write": 12.5
     },
     "limit": {
@@ -162813,13 +163997,13 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.05,
-      "output": 0.16,
-      "cache_read": 0.013
+      "input": 0.04998,
+      "output": 0.09996,
+      "cache_read": 0.009996
     },
     "limit": {
       "context": 1310720,
-      "output": 393216
+      "output": 131072
     }
   },
   {
@@ -162914,9 +164098,9 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 2.55,
-      "output": 12.75,
-      "cache_read": 0.256
+      "input": 2.5,
+      "output": 14.0,
+      "cache_read": 0.29
     },
     "limit": {
       "context": 1048576,
@@ -163039,9 +164223,40 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 1.17,
-      "output": 3.96,
-      "cache_read": 0.234
+      "input": 1.15,
+      "output": 3.5,
+      "cache_read": 0.1
+    },
+    "limit": {
+      "context": 1310720,
+      "output": 235929
+    }
+  },
+  {
+    "id": "openrouter/~z-ai/glm-flash",
+    "name": "GLM Flash Latest",
+    "family": "glm-flash",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-08-27",
+    "last_updated": "2026-08-27",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.075,
+      "output": 0.25,
+      "cache_read": 0.015
     },
     "limit": {
       "context": 1310720,
@@ -165619,8 +166834,8 @@
       "cache_read": 0.15
     },
     "limit": {
-      "context": 1000000,
-      "output": 32000
+      "context": 1048576,
+      "output": 131072
     }
   },
   {
@@ -167520,7 +168735,7 @@
     },
     "limit": {
       "context": 256000,
-      "output": 64000
+      "output": 128000
     }
   },
   {
@@ -167548,7 +168763,7 @@
     },
     "limit": {
       "context": 256000,
-      "output": 64000
+      "output": 128000
     }
   },
   {
@@ -168152,6 +169367,35 @@
     }
   },
   {
+    "id": "ovhcloud/qwen3.8-27b",
+    "name": "Qwen3.8-27B",
+    "family": "qwen",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-09-02",
+    "last_updated": "2026-09-02",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 262144,
+      "output": 262144
+    }
+  },
+  {
     "id": "ovhcloud/qwen3guard-gen-0.6b",
     "name": "Qwen3Guard-Gen-0.6B",
     "attachment": false,
@@ -168169,7 +169413,10 @@
       ]
     },
     "open_weights": true,
-    "cost": {},
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
     "limit": {
       "context": 32768,
       "output": 16384
@@ -168193,7 +169440,10 @@
       ]
     },
     "open_weights": true,
-    "cost": {},
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
     "limit": {
       "context": 32768,
       "output": 16384
@@ -179887,6 +181137,72 @@
     }
   },
   {
+    "id": "requesty/claude-fable-5.1",
+    "name": "Claude Fable 5.1",
+    "family": "claude-fable",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-06",
+    "release_date": "2026-09-01",
+    "last_updated": "2026-09-01",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 10.0,
+      "output": 50.0,
+      "cache_read": 0.25,
+      "cache_write": 12.5
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "requesty/claude-fable-5.1@eu",
+    "name": "Claude Fable 5.1 (EU)",
+    "family": "claude-fable",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-06",
+    "release_date": "2026-09-01",
+    "last_updated": "2026-09-01",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 11.0,
+      "output": 55.0,
+      "cache_read": 0.275,
+      "cache_write": 13.75
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
     "id": "requesty/claude-fable-5@eu",
     "name": "Claude Fable 5 (EU)",
     "family": "claude-fable",
@@ -180584,7 +181900,7 @@
     "name": "DeepSeek V4 Flash",
     "family": "deepseek-flash",
     "attachment": false,
-    "reasoning": false,
+    "reasoning": true,
     "tool_call": true,
     "temperature": true,
     "knowledge": "2025-05",
@@ -180600,13 +181916,13 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 0.44,
-      "output": 1.32,
-      "cache_read": 0.014
+      "input": 0.14,
+      "output": 0.28,
+      "cache_read": 0.07
     },
     "limit": {
-      "context": 1000000,
-      "output": 384000
+      "context": 1048576,
+      "output": 131072
     }
   },
   {
@@ -180666,7 +181982,36 @@
     },
     "limit": {
       "context": 1000000,
-      "output": 384000
+      "output": 131072
+    }
+  },
+  {
+    "id": "requesty/deepseek-v4-pro-0813@eu",
+    "name": "DeepSeek V4 Pro 0813 (EU)",
+    "family": "deepseek-thinking",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-08-12",
+    "last_updated": "2026-08-22",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 1.75,
+      "output": 3.5,
+      "cache_read": 0.44
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 1048576
     }
   },
   {
@@ -180760,7 +182105,7 @@
     "name": "Fugu Ultra",
     "family": "fugu",
     "attachment": true,
-    "reasoning": false,
+    "reasoning": true,
     "tool_call": true,
     "temperature": false,
     "release_date": "2026-06-15",
@@ -180783,6 +182128,41 @@
     "limit": {
       "context": 1048576,
       "output": 131072
+    }
+  },
+  {
+    "id": "requesty/gemini-2.5-flash-lite@eu",
+    "name": "Gemini 2.5 Flash-Lite (EU)",
+    "family": "gemini-flash-lite",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2025-06-17",
+    "last_updated": "2025-06-17",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.1,
+      "output": 0.4,
+      "cache_read": 0.01,
+      "cache_write": 0.18333
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65535
     }
   },
   {
@@ -180814,6 +182194,41 @@
       "output": 2.5,
       "cache_read": 0.075,
       "cache_write": 0.55
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65535
+    }
+  },
+  {
+    "id": "requesty/gemini-2.5-pro@eu",
+    "name": "Gemini 2.5 Pro (EU)",
+    "family": "gemini-pro",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2025-01",
+    "release_date": "2025-06-17",
+    "last_updated": "2025-06-17",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.25,
+      "output": 10.0,
+      "cache_read": 0.31,
+      "cache_write": 2.375
     },
     "limit": {
       "context": 1048576,
@@ -181232,6 +182647,72 @@
     }
   },
   {
+    "id": "requesty/gemini-3.8-flash",
+    "name": "Gemini 3.8 Flash",
+    "family": "gemini-flash",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-09-02",
+    "last_updated": "2026-09-02",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.75,
+      "output": 3.75,
+      "cache_read": 0.075
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65535
+    }
+  },
+  {
+    "id": "requesty/gemini-3.8-flash@eu",
+    "name": "Gemini 3.8 Flash (EU)",
+    "family": "gemini-flash",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-09-02",
+    "last_updated": "2026-09-02",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "audio",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.825,
+      "output": 4.125,
+      "cache_read": 0.0825
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 65535
+    }
+  },
+  {
     "id": "requesty/gemma-4-26b-a4b-it",
     "name": "Gemma 4 26B A4B IT",
     "family": "gemma",
@@ -181486,13 +182967,45 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 0.075,
-      "output": 0.25,
-      "cache_read": 0.015
+      "input": 0.2,
+      "output": 0.5,
+      "cache_read": 0.07
     },
     "limit": {
-      "context": 131072,
-      "output": 131072
+      "context": 1000000,
+      "output": 262144
+    }
+  },
+  {
+    "id": "requesty/glm-5.3-flash@eu",
+    "name": "GLM-5.3-Flash (EU)",
+    "family": "glm",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-08-26",
+    "last_updated": "2026-08-26",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.2,
+      "output": 0.5,
+      "cache_read": 0.07
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 262144
     }
   },
   {
@@ -182907,7 +184420,7 @@
     "name": "MiMo-V2.5",
     "family": "mimo",
     "attachment": true,
-    "reasoning": false,
+    "reasoning": true,
     "tool_call": true,
     "temperature": true,
     "knowledge": "2024-12",
@@ -182940,7 +184453,7 @@
     "name": "MiMo-V2.5-Pro",
     "family": "mimo",
     "attachment": false,
-    "reasoning": false,
+    "reasoning": true,
     "tool_call": true,
     "temperature": true,
     "knowledge": "2024-12",
@@ -183847,6 +185360,128 @@
       "input": 2.0,
       "output": 6.0,
       "cache_read": 0.2
+    },
+    "limit": {
+      "context": 262144,
+      "output": 262144
+    }
+  },
+  {
+    "id": "requesty/qwen3.8-2.4T-A95B@eu",
+    "name": "Qwen3.8 2.4T A95B (EU)",
+    "family": "qwen",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-08-12",
+    "last_updated": "2026-08-12",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 2.5,
+      "output": 6.0,
+      "cache_read": 0.63
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 262144
+    }
+  },
+  {
+    "id": "requesty/qwen3.8-flash",
+    "name": "Qwen3.8 Flash",
+    "family": "qwen",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-08-26",
+    "last_updated": "2026-08-26",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.16,
+      "output": 0.47,
+      "cache_read": 0.016,
+      "cache_write": 0.2
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 131072
+    }
+  },
+  {
+    "id": "requesty/qwen3.8-flash-next",
+    "name": "Qwen3.8 Flash Next",
+    "family": "qwen",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-08-27",
+    "last_updated": "2026-08-27",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.2,
+      "output": 0.5,
+      "cache_read": 0.05
+    },
+    "limit": {
+      "context": 262144,
+      "output": 262144
+    }
+  },
+  {
+    "id": "requesty/qwen3.8-flash-next@eu",
+    "name": "Qwen3.8 Flash Next (EU)",
+    "family": "qwen",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-08-27",
+    "last_updated": "2026-08-27",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.2,
+      "output": 0.5,
+      "cache_read": 0.05
     },
     "limit": {
       "context": 262144,
@@ -187054,6 +188689,67 @@
     }
   },
   {
+    "id": "scnet-token-plan/GLM-5.3",
+    "name": "GLM-5.3",
+    "family": "glm",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-08-14",
+    "last_updated": "2026-08-14",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0,
+      "cache_read": 0.0
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 131072
+    }
+  },
+  {
+    "id": "scnet-token-plan/GLM-5.3-Flash",
+    "name": "GLM-5.3-Flash",
+    "family": "glm",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-08-26",
+    "last_updated": "2026-08-26",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0,
+      "cache_read": 0.0
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 131072
+    }
+  },
+  {
     "id": "scnet-token-plan/Kimi-K2.5",
     "name": "Kimi K2.5",
     "family": "kimi-k2",
@@ -187289,6 +188985,36 @@
     "limit": {
       "context": 1048576,
       "output": 512000
+    }
+  },
+  {
+    "id": "scnet-token-plan/Qwen3.8-Flash",
+    "name": "Qwen3.8 Flash",
+    "family": "qwen",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-08-26",
+    "last_updated": "2026-08-26",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0,
+      "cache_read": 0.0
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 131072
     }
   },
   {
@@ -192591,7 +194317,7 @@
     },
     "limit": {
       "context": 256000,
-      "output": 64000
+      "output": 128000
     }
   },
   {
@@ -192650,7 +194376,7 @@
     },
     "limit": {
       "context": 256000,
-      "output": 64000
+      "output": 128000
     }
   },
   {
@@ -193800,31 +195526,34 @@
     }
   },
   {
-    "id": "tinfoil/glm-5.2",
-    "name": "GLM-5.2",
+    "id": "tinfoil/glm-5.3-flash",
+    "name": "GLM-5.3-Flash",
     "family": "glm",
-    "attachment": false,
+    "attachment": true,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
-    "release_date": "2026-06-13",
-    "last_updated": "2026-06-13",
+    "release_date": "2026-08-26",
+    "last_updated": "2026-08-26",
     "modalities": {
       "input": [
-        "text"
+        "text",
+        "image",
+        "video",
+        "pdf"
       ],
       "output": [
         "text"
       ]
     },
-    "open_weights": true,
+    "open_weights": false,
     "cost": {
-      "input": 1.5,
-      "output": 5.25,
-      "cache_read": 0.375
+      "input": 0.4,
+      "output": 1.25,
+      "cache_read": 0.1
     },
     "limit": {
-      "context": 393216,
+      "context": 1048576,
       "output": 131072
     }
   },
@@ -197005,35 +198734,6 @@
     }
   },
   {
-    "id": "vancine/LongCat-2.0",
-    "name": "LongCat-2.0",
-    "family": "longcat",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2026-06-30",
-    "last_updated": "2026-06-30",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "cost": {
-      "input": 0.24,
-      "output": 0.96,
-      "cache_read": 0.0048
-    },
-    "limit": {
-      "context": 1000000,
-      "output": 131072
-    }
-  },
-  {
     "id": "vancine/MiniMax-M3",
     "name": "MiniMax-M3",
     "family": "minimax",
@@ -197276,36 +198976,6 @@
     }
   },
   {
-    "id": "vancine/mimo-v2.5-pro",
-    "name": "MiMo-V2.5-Pro",
-    "family": "mimo",
-    "attachment": false,
-    "reasoning": true,
-    "tool_call": true,
-    "temperature": true,
-    "knowledge": "2024-12",
-    "release_date": "2026-04-22",
-    "last_updated": "2026-04-22",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.348,
-      "output": 0.696,
-      "cache_read": 0.00288
-    },
-    "limit": {
-      "context": 1048576,
-      "output": 131072
-    }
-  },
-  {
     "id": "vancine/qwen3.8-flash",
     "name": "Qwen3.8 Flash",
     "family": "qwen",
@@ -197446,6 +199116,38 @@
       "input": 12.0,
       "output": 60.0,
       "cache_read": 1.2,
+      "cache_write": 15.0
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "venice/claude-fable-5.1",
+    "name": "Claude Fable 5.1",
+    "family": "claude-fable",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-06",
+    "release_date": "2026-08-29",
+    "last_updated": "2026-09-01",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 12.0,
+      "output": 60.0,
+      "cache_read": 0.3,
       "cache_write": 15.0
     },
     "limit": {
@@ -197763,10 +199465,10 @@
     },
     "open_weights": false,
     "cost": {
-      "input": 2.0,
-      "output": 10.000000000000002,
-      "cache_read": 0.2,
-      "cache_write": 2.5000000000000004
+      "input": 3.0,
+      "output": 15.0,
+      "cache_read": 0.3,
+      "cache_write": 3.75
     },
     "limit": {
       "context": 1000000,
@@ -198072,6 +199774,38 @@
     "knowledge": "2026-03",
     "release_date": "2026-08-14",
     "last_updated": "2026-08-14",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "audio",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.9375,
+      "output": 4.6875,
+      "cache_read": 0.09375
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 65536
+    }
+  },
+  {
+    "id": "venice/gemini-3.8-flash",
+    "name": "Gemini 3.8 Flash",
+    "family": "gemini-flash",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-09-02",
+    "last_updated": "2026-09-02",
     "modalities": {
       "input": [
         "text",
@@ -199411,6 +201145,37 @@
     },
     "limit": {
       "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "venice/openai-gpt-6-astra",
+    "name": "GPT-6 Astra",
+    "family": "gpt",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "release_date": "2026-09-04",
+    "last_updated": "2026-09-04",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 12.5,
+      "output": 62.5,
+      "cache_read": 1.25,
+      "cache_write": 15.625
+    },
+    "limit": {
+      "context": 1050000,
       "output": 128000
     }
   },
@@ -201787,6 +203552,39 @@
     }
   },
   {
+    "id": "vercel/anthropic/claude-fable-5.1",
+    "name": "Claude Fable 5.1",
+    "family": "claude-fable",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "knowledge": "2026-06",
+    "release_date": "2026-09-01",
+    "last_updated": "2026-09-01",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 10.0,
+      "output": 50.0,
+      "cache_read": 0.25,
+      "cache_write": 12.5
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    }
+  },
+  {
     "id": "vercel/anthropic/claude-haiku-4.5",
     "name": "Claude Haiku 4.5",
     "family": "claude-haiku",
@@ -203014,35 +204812,6 @@
     }
   },
   {
-    "id": "vercel/deepseek/deepseek-v3",
-    "name": "DeepSeek V3 0324",
-    "family": "deepseek",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": true,
-    "temperature": true,
-    "release_date": "2024-12-26",
-    "last_updated": "2024-12-26",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "cost": {
-      "input": 0.27,
-      "output": 1.12,
-      "cache_read": 0.135
-    },
-    "limit": {
-      "context": 163840,
-      "output": 163840
-    }
-  },
-  {
     "id": "vercel/deepseek/deepseek-v3.1",
     "name": "DeepSeek-V3.1",
     "family": "deepseek",
@@ -203216,8 +204985,8 @@
       "cache_read": 0.007
     },
     "limit": {
-      "context": 1000000,
-      "output": 384000
+      "context": 1048576,
+      "output": 1048576
     }
   },
   {
@@ -203978,6 +205747,37 @@
     }
   },
   {
+    "id": "vercel/google/gemini-3.8-flash",
+    "name": "Gemini 3.8 Flash",
+    "family": "gemini-flash",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-09-02",
+    "last_updated": "2026-09-02",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.75,
+      "output": 3.75,
+      "cache_read": 0.075
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 65536
+    }
+  },
+  {
     "id": "vercel/google/gemini-embedding-001",
     "name": "Gemini Embedding 001",
     "family": "gemini",
@@ -204415,6 +206215,60 @@
     "tool_call": true,
     "release_date": "2026-08-27",
     "last_updated": "2026-08-27",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 256000,
+      "output": 32000
+    }
+  },
+  {
+    "id": "vercel/inclusionai/ling-3.0-flash-sante",
+    "name": "Ling 3.0 Flash Sante",
+    "family": "ling",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-09-04",
+    "last_updated": "2026-09-04",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.0,
+      "output": 0.0
+    },
+    "limit": {
+      "context": 256000,
+      "output": 32000
+    }
+  },
+  {
+    "id": "vercel/inclusionai/ling-3.0-flash-sante-free",
+    "name": "Ling 3.0 Flash Sante (Free)",
+    "family": "ling",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-09-04",
+    "last_updated": "2026-09-04",
     "modalities": {
       "input": [
         "text"
@@ -205055,6 +206909,67 @@
     "tool_call": true,
     "release_date": "2026-08-05",
     "last_updated": "2026-08-05",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.1,
+      "output": 0.2,
+      "cache_read": 0.002
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 1048576
+    }
+  },
+  {
+    "id": "vercel/meta/muse-spark-1.3",
+    "name": "Muse Spark 1.3",
+    "family": "muse",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-09-02",
+    "last_updated": "2026-09-02",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 1.25,
+      "output": 4.25,
+      "cache_read": 0.15
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 1048576
+    }
+  },
+  {
+    "id": "vercel/meta/muse-spark-1.3-contributor",
+    "name": "Muse Spark 1.3 Contributor",
+    "family": "muse",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-09-02",
+    "last_updated": "2026-09-02",
     "modalities": {
       "input": [
         "text",
@@ -207795,6 +209710,70 @@
     }
   },
   {
+    "id": "vercel/openai/gpt-6-astra",
+    "name": "GPT-6 Astra",
+    "family": "gpt-astra",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "release_date": "2026-09-04",
+    "last_updated": "2026-09-04",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 10.0,
+      "output": 50.0,
+      "cache_read": 1.0,
+      "cache_write": 12.5
+    },
+    "limit": {
+      "context": 1050000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "vercel/openai/gpt-6-astra-fast",
+    "name": "GPT-6 Astra (Fast)",
+    "family": "gpt-astra",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": false,
+    "release_date": "2026-09-04",
+    "last_updated": "2026-09-04",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 20.0,
+      "output": 100.0,
+      "cache_read": 2.0,
+      "cache_write": 12.5
+    },
+    "limit": {
+      "context": 1050000,
+      "output": 128000
+    }
+  },
+  {
     "id": "vercel/openai/gpt-image-1",
     "name": "GPT Image 1",
     "family": "gpt-image",
@@ -210247,6 +212226,36 @@
     }
   },
   {
+    "id": "vercel/xiaomi/mimo-v2.5-pro-ultraspeed",
+    "name": "MiMo V2.5 Pro UltraSpeed",
+    "family": "mimo",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "knowledge": "2024-12",
+    "release_date": "2026-06-08",
+    "last_updated": "2026-06-09",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 1.305,
+      "output": 2.61,
+      "cache_read": 0.0108
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 131072
+    }
+  },
+  {
     "id": "vercel/zai/glm-4.5",
     "name": "GLM 4.5",
     "family": "glm",
@@ -210620,13 +212629,42 @@
     },
     "open_weights": true,
     "cost": {
-      "input": 1.4,
-      "output": 4.4,
-      "cache_read": 0.14
+      "input": 0.7,
+      "output": 2.2,
+      "cache_read": 0.13
     },
     "limit": {
       "context": 1000000,
       "output": 1000000
+    }
+  },
+  {
+    "id": "vercel/zai/glm-5.3-fast",
+    "name": "GLM 5.3 Fast",
+    "family": "glm",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2026-08-14",
+    "last_updated": "2026-08-14",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "cost": {
+      "input": 2.1,
+      "output": 6.6,
+      "cache_read": 0.21
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 262144
     }
   },
   {
@@ -210657,6 +212695,34 @@
     "limit": {
       "context": 1000000,
       "output": 131000
+    }
+  },
+  {
+    "id": "vercel/zai/glm-5.3-promo-50",
+    "name": "GLM 5.3 (50% off)",
+    "family": "glm",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "release_date": "2026-08-18",
+    "last_updated": "2026-08-18",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "cost": {
+      "input": 0.7,
+      "output": 2.2,
+      "cache_read": 0.13
+    },
+    "limit": {
+      "context": 1048576,
+      "output": 1048576
     }
   },
   {
@@ -213628,7 +215694,7 @@
     "open_weights": false,
     "cost": {},
     "limit": {
-      "context": 8000,
+      "context": 16000,
       "output": 0
     }
   },
@@ -213656,7 +215722,7 @@
     "open_weights": false,
     "cost": {},
     "limit": {
-      "context": 8000,
+      "context": 64000,
       "output": 0
     }
   },
@@ -213684,7 +215750,7 @@
     "open_weights": false,
     "cost": {},
     "limit": {
-      "context": 8000,
+      "context": 16000,
       "output": 0
     }
   },

--- a/crates/goose-provider-types/src/canonical/data/provider_metadata.json
+++ b/crates/goose-provider-types/src/canonical/data/provider_metadata.json
@@ -195,7 +195,7 @@
     "env": [
       "AMD_API_KEY"
     ],
-    "model_count": 2
+    "model_count": 4
   },
   {
     "id": "anyapi",
@@ -261,7 +261,7 @@
     "env": [
       "BASETEN_API_KEY"
     ],
-    "model_count": 21
+    "model_count": 22
   },
   {
     "id": "berget",
@@ -272,7 +272,7 @@
     "env": [
       "BERGET_API_KEY"
     ],
-    "model_count": 11
+    "model_count": 6
   },
   {
     "id": "blueclaw",
@@ -383,7 +383,7 @@
     "env": [
       "CORTECS_API_KEY"
     ],
-    "model_count": 112
+    "model_count": 109
   },
   {
     "id": "crof",
@@ -405,7 +405,7 @@
     "env": [
       "CROSSMODEL_API_KEY"
     ],
-    "model_count": 56
+    "model_count": 58
   },
   {
     "id": "crusoe",
@@ -461,7 +461,7 @@
     "env": [
       "DIGITALOCEAN_ACCESS_TOKEN"
     ],
-    "model_count": 94
+    "model_count": 95
   },
   {
     "id": "dinference",
@@ -516,7 +516,7 @@
     "env": [
       "EDENAI_API_KEY"
     ],
-    "model_count": 239
+    "model_count": 247
   },
   {
     "id": "empiriolabs",
@@ -527,7 +527,7 @@
     "env": [
       "EMPIRIOLABS_API_KEY"
     ],
-    "model_count": 56
+    "model_count": 58
   },
   {
     "id": "evroc",
@@ -560,7 +560,7 @@
     "env": [
       "FIREWORKS_API_KEY"
     ],
-    "model_count": 18
+    "model_count": 19
   },
   {
     "id": "freemodel",
@@ -604,7 +604,7 @@
     "env": [
       "GITHUB_TOKEN"
     ],
-    "model_count": 33
+    "model_count": 27
   },
   {
     "id": "gmicloud",
@@ -670,7 +670,7 @@
     "env": [
       "HF_TOKEN"
     ],
-    "model_count": 72
+    "model_count": 73
   },
   {
     "id": "hyper",
@@ -681,7 +681,7 @@
     "env": [
       "HYPER_API_KEY"
     ],
-    "model_count": 31
+    "model_count": 32
   },
   {
     "id": "iflowcn",
@@ -781,7 +781,7 @@
     "env": [
       "ITERACOMPUTE_API_KEY"
     ],
-    "model_count": 1
+    "model_count": 2
   },
   {
     "id": "jalapeno",
@@ -825,14 +825,14 @@
     "env": [
       "KILO_API_KEY"
     ],
-    "model_count": 363
+    "model_count": 369
   },
   {
     "id": "kimi-for-coding",
     "display_name": "Kimi For Coding",
     "npm": "@ai-sdk/anthropic",
     "api": "https://api.kimi.com/coding/v1",
-    "doc": "https://www.kimi.com/code/docs/en/third-party-tools/other-coding-agents.html",
+    "doc": "https://www.kimi.com/code/docs/en/kimi-code/models.html",
     "env": [
       "KIMI_API_KEY"
     ],
@@ -891,7 +891,7 @@
     "env": [
       "LLMGATEWAY_API_KEY"
     ],
-    "model_count": 180
+    "model_count": 186
   },
   {
     "id": "llmgateway-providers",
@@ -902,7 +902,7 @@
     "env": [
       "LLMGATEWAY_API_KEY"
     ],
-    "model_count": 360
+    "model_count": 372
   },
   {
     "id": "llmtech",
@@ -990,7 +990,7 @@
     "env": [
       "META_MODEL_API_KEY"
     ],
-    "model_count": 3
+    "model_count": 5
   },
   {
     "id": "meta-llama",
@@ -1147,6 +1147,17 @@
     "model_count": 3
   },
   {
+    "id": "nan",
+    "display_name": "NaN",
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.nan.builders/v1",
+    "doc": "https://nan.builders/docs/models",
+    "env": [
+      "NAN_API_KEY"
+    ],
+    "model_count": 7
+  },
+  {
     "id": "nano-gpt",
     "display_name": "NanoGPT",
     "npm": "@ai-sdk/openai-compatible",
@@ -1155,7 +1166,7 @@
     "env": [
       "NANO_GPT_API_KEY"
     ],
-    "model_count": 608
+    "model_count": 592
   },
   {
     "id": "nearai",
@@ -1177,7 +1188,7 @@
     "env": [
       "NEBIUS_API_KEY"
     ],
-    "model_count": 34
+    "model_count": 17
   },
   {
     "id": "neon",
@@ -1255,7 +1266,7 @@
     "env": [
       "OFOX_API_KEY"
     ],
-    "model_count": 112
+    "model_count": 114
   },
   {
     "id": "ollama-cloud",
@@ -1277,7 +1288,7 @@
     "env": [
       "OPENCODE_API_KEY"
     ],
-    "model_count": 94
+    "model_count": 97
   },
   {
     "id": "opencode-go",
@@ -1288,7 +1299,7 @@
     "env": [
       "OPENCODE_API_KEY"
     ],
-    "model_count": 33
+    "model_count": 35
   },
   {
     "id": "openreason",
@@ -1332,7 +1343,7 @@
     "env": [
       "OVHCLOUD_API_KEY"
     ],
-    "model_count": 14
+    "model_count": 15
   },
   {
     "id": "pendra",
@@ -1443,7 +1454,7 @@
     "env": [
       "REQUESTY_API_KEY"
     ],
-    "model_count": 140
+    "model_count": 152
   },
   {
     "id": "routing-run",
@@ -1509,7 +1520,7 @@
     "env": [
       "SCNET_API_KEY"
     ],
-    "model_count": 17
+    "model_count": 20
   },
   {
     "id": "scx-ai",
@@ -1829,7 +1840,7 @@
     "env": [
       "VANCINE_API_KEY"
     ],
-    "model_count": 12
+    "model_count": 10
   },
   {
     "id": "vivgrid",

--- a/crates/goose-provider-types/src/formats/openai.rs
+++ b/crates/goose-provider-types/src/formats/openai.rs
@@ -1841,14 +1841,15 @@ pub fn extract_reasoning_effort(model_name: &str) -> (String, Option<String>) {
 /// True when the model should use the OpenAI Responses API.
 ///
 /// The Responses API is backwards-compatible with all OpenAI reasoning
-/// models, so every `o`-series (`o1`, `o3`, `o4`, …) and `gpt-5` variant
+/// models, so every `o`-series (`o1`, `o3`, `o4`, …), `gpt-5`, and `gpt-6` variant
 /// routes here. The matcher intentionally scans the full model identifier so
 /// hosted aliases like `databricks-gpt-5.4`, `goose-o3-mini`, or
 /// `headless-goose-o3-mini` work without provider-specific normalization.
 pub fn is_openai_responses_model(model_name: &str) -> bool {
     static RE: OnceLock<Regex> = OnceLock::new();
-    let re =
-        RE.get_or_init(|| Regex::new(r"(?i)(?:^|[-/])(?:o\d+(?:$|-)|gpt-5(?:$|[-.]))").unwrap());
+    let re = RE.get_or_init(|| {
+        Regex::new(r"(?i)(?:^|[-/])(?:o\d+(?:$|-)|gpt-(?:5|6)(?:$|[-.]))").unwrap()
+    });
     re.is_match(model_name)
 }
 
@@ -1919,7 +1920,7 @@ pub fn openai_reasoning_effort_for_thinking(
 pub(crate) fn openai_reasoning_efforts_for_model(model_name: &str) -> &'static [&'static str] {
     let normalized = model_name.to_ascii_lowercase();
 
-    if normalized.contains("gpt-5") {
+    if normalized.contains("gpt-5") || normalized.contains("gpt-6") {
         if normalized.contains("-pro") || normalized.contains("/pro") {
             &["high"]
         } else if normalized.contains("gpt-5.4")
@@ -1928,6 +1929,7 @@ pub(crate) fn openai_reasoning_efforts_for_model(model_name: &str) -> &'static [
             || normalized.contains("gpt-5-5")
             || normalized.contains("gpt-5.6")
             || normalized.contains("gpt-5-6")
+            || normalized.contains("gpt-6")
         {
             &["none", "low", "medium", "high", "xhigh"]
         } else {
@@ -5292,7 +5294,7 @@ data: [DONE]"#;
     }
 
     #[test]
-    fn test_is_openai_responses_model_matches_o_and_gpt5_families() {
+    fn test_is_openai_responses_model_matches_openai_reasoning_families() {
         for model in [
             "o3",
             "o3-mini",
@@ -5305,6 +5307,8 @@ data: [DONE]"#;
             "gpt-5-2-pro",
             "databricks-gpt-5.4",
             "goose-gpt-5.4-high",
+            "gpt-6-astra",
+            "data_workflow_tools.goose.goose-gpt-6-astra",
             "headless-goose-o3-mini",
         ] {
             assert!(is_openai_responses_model(model), "{model} should match");

--- a/crates/goose-provider-types/src/model.rs
+++ b/crates/goose-provider-types/src/model.rs
@@ -856,6 +856,27 @@ mod tests {
         }
 
         #[test]
+        fn resolves_gpt_6_astra_limits_for_databricks_model_service() {
+            let _guard = env_lock::lock_env([
+                ("GOOSE_MAX_TOKENS", None::<&str>),
+                ("GOOSE_CONTEXT_LIMIT", None::<&str>),
+            ]);
+            let config = ModelConfig::new("data_workflow_tools.goose.goose-gpt-6-astra")
+                .with_canonical_limits("databricks_v2");
+
+            let canonical = crate::canonical::maybe_get_canonical_model(
+                "databricks_v2",
+                "data_workflow_tools.goose.goose-gpt-6-astra",
+            )
+            .expect("GPT-6 Astra should have canonical metadata");
+            assert_eq!(canonical.limit.context, 1_050_000);
+            assert_eq!(canonical.limit.output, Some(128_000));
+            assert_eq!(config.max_tokens, Some(128_000));
+            assert_eq!(config.reasoning, Some(true));
+            assert_eq!(config.supports_vision, Some(true));
+        }
+
+        #[test]
         fn fills_supports_vision_from_canonical_model() {
             let _guard = env_lock::lock_env([
                 ("GOOSE_MAX_TOKENS", None::<&str>),

--- a/crates/goose-providers/src/databricks_v2.rs
+++ b/crates/goose-providers/src/databricks_v2.rs
@@ -216,15 +216,19 @@ impl DatabricksV2Provider {
     }
 
     fn route_for_model(model_name: &str) -> DatabricksV2Route {
-        if Self::is_model_service_fqn(model_name) {
-            // UC namespaces are user-defined and cannot select a native API.
-            return DatabricksV2Route::MlflowChatCompletions;
-        }
-        let (clean_name, _) = extract_reasoning_effort(model_name);
+        let is_model_service = Self::is_model_service_fqn(model_name);
+        let routing_name = if is_model_service {
+            model_name.rsplit('.').next().unwrap_or(model_name)
+        } else {
+            model_name
+        };
+        let (clean_name, _) = extract_reasoning_effort(routing_name);
         let lower = clean_name.to_lowercase();
 
         if is_openai_responses_model(&clean_name) || Self::looks_like_gpt5(&lower) {
             DatabricksV2Route::OpenAiResponses
+        } else if is_model_service {
+            DatabricksV2Route::MlflowChatCompletions
         } else if Self::is_claude_model(&lower) {
             DatabricksV2Route::AnthropicMessages
         } else {
@@ -613,7 +617,11 @@ mod tests {
 
     #[test]
     fn routes_known_model_families() {
-        for model in ["databricks-gpt-5-5", "databricks-gpt5"] {
+        for model in [
+            "databricks-gpt-5-5",
+            "databricks-gpt5",
+            "data_workflow_tools.goose.goose-gpt-6-astra",
+        ] {
             assert_eq!(
                 DatabricksV2Provider::route_for_model(model),
                 DatabricksV2Route::OpenAiResponses,
@@ -631,6 +639,10 @@ mod tests {
 
         assert_eq!(
             DatabricksV2Provider::route_for_model("custom-model"),
+            DatabricksV2Route::MlflowChatCompletions
+        );
+        assert_eq!(
+            DatabricksV2Provider::route_for_model("catalog.schema.claude-alias"),
             DatabricksV2Route::MlflowChatCompletions
         );
     }
@@ -743,7 +755,7 @@ mod tests {
     mod gateway_path {
         use super::*;
         use serde_json::json;
-        use wiremock::matchers::{method, path};
+        use wiremock::matchers::{body_partial_json, method, path};
         use wiremock::{Mock, MockServer, ResponseTemplate};
 
         fn provider(host: String) -> DatabricksV2Provider {
@@ -830,6 +842,33 @@ mod tests {
                     "error for {input:?} should mention {expected:?}, got: {err}"
                 );
             }
+        }
+
+        #[tokio::test]
+        async fn model_service_gpt_6_uses_responses_route_and_preserves_fqn() {
+            let model = "data_workflow_tools.goose.goose-gpt-6-astra";
+            let completed = format!(
+                r#"data: {{"type":"response.completed","sequence_number":1,"response":{{"id":"resp_1","object":"response","created_at":0,"status":"completed","model":"{model}","output":[],"usage":{{"input_tokens":1,"output_tokens":1,"total_tokens":2}}}}}}"#
+            );
+            let body = format!("{completed}\n\ndata: [DONE]\n\n");
+
+            let server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .and(path("/ai-gateway/openai/v1/responses"))
+                .and(body_partial_json(json!({"model": model})))
+                .respond_with(
+                    ResponseTemplate::new(200)
+                        .set_body_string(body)
+                        .append_header("content-type", "text/event-stream"),
+                )
+                .expect(1)
+                .mount(&server)
+                .await;
+
+            provider(server.uri())
+                .complete(&ModelConfig::new(model), "system", &[], &[])
+                .await
+                .expect("GPT-6 model service should use the Responses API");
         }
 
         #[tokio::test]

--- a/crates/goose-providers/src/openai.rs
+++ b/crates/goose-providers/src/openai.rs
@@ -90,6 +90,7 @@ pub const OPEN_AI_KNOWN_MODELS: &[(&str, usize)] = &[
     ("gpt-5.6-sol", 1_050_000),
     ("gpt-5.6-terra", 1_050_000),
     ("gpt-5.6-luna", 1_050_000),
+    ("gpt-6-astra", 1_050_000),
 ];
 
 pub const OPEN_AI_DOC_URL: &str = "https://platform.openai.com/docs/models";


### PR DESCRIPTION
## Summary

GPT-6 Astra requests through a Databricks model-service fully qualified name went to Chat Completions. That endpoint rejects tools when `reasoning_effort` is set.

This change recognizes GPT-6 as an OpenAI Responses model and routes a GPT-6 model-service leaf through `openai/v1/responses`. Other Unity Catalog model services keep the MLflow Chat Completions route.

It also refreshes the canonical model registry. GPT-6 Astra now has a 1,050,000-token context window and a 128,000-token output limit.

### Testing

No manual testing. CI covers the routing, request-path, model-name, registry, and lint checks.

### Related Issues

Maintainer-directed support for the GPT-6 Astra launch; no issue.

### Screenshots/Demos

Not applicable.

Generated with Goose
