### PR TITLE
Feat/nix goose desktop

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,12 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1768305791,
-        "narHash": "sha256-AIdl6WAn9aymeaH/NvBj0H9qM+XuAuYbGMZaP0zcXAQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "1412caf7bf9e660f2f962917c14b1ea1c3bc695e",
-        "type": "github"
+        "lastModified": 1788316716,
+        "narHash": "sha256-7VBL4mi5M72FJtZOQt7SbCGWpGbsuH1ga6Zeu8bjtWk=",
+        "rev": "3ed67ec0a4d3c7ab4ae1f04f8ee8df07bfa506a2",
+        "type": "tarball",
+        "url": "https://releases.nixos.org/nixos/unstable/nixos-26.11pre1066106.3ed67ec0a4d3/nixexprs.tar.xz"
       },
       "original": {
         "id": "nixpkgs",

--- a/flake.lock
+++ b/flake.lock
@@ -47,11 +47,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1768445213,
-        "narHash": "sha256-y0BglISgDr61vvdb35m0O4npuqh1pojlBNDILo9j8AI=",
+        "lastModified": 1788456718,
+        "narHash": "sha256-TxHC0sBjV2pmsBLKAX02JTXlye/EOLt6Do+WNtGofGw=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "1cd63408e71cc0e6a89ff2cb7c4107214e2523cc",
+        "rev": "0b20a18e84d9164464739189c2b2a1b00f6f0e4b",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -38,7 +38,7 @@
         ];
         
         buildInputs = commonInputs
-          ++ pkgs.lib.optionals pkgs.stdenv.isDarwin darwinInputs;
+          ++ pkgs.lib.optionals pkgs.stdenv.hostPlatform.isDarwin darwinInputs;
       in
       {
         packages = rec {
@@ -92,7 +92,7 @@
               cacert       # CA certificates for tests
               libxcb       # Required for xcap screenshot functionality
               dbus         # Required for system integration features
-            ] ++ pkgs.lib.optionals pkgs.stdenv.isDarwin darwinInputs;
+            ] ++ pkgs.lib.optionals pkgs.stdenv.hostPlatform.isDarwin darwinInputs;
 
             # Build only the CLI package
             cargoBuildFlags = [ "--package" "goose-cli" ];
@@ -130,8 +130,8 @@
               pname = "goose-ui";
               inherit version;
               src = ./ui;
-              fetcherVersion = 3;
-              hash = "sha256-FpnWCJsytxJ5w9yqWayU2ZNDCm7RgubU34ouIeNWqfA=";
+              fetcherVersion = 4;
+              hash = "sha256-HzteTM6tdzi+bApkSrwFuBp8Sd62m0pHA3d1KVSh+5o=";
             };
 
             nativeBuildInputs = with pkgs; [
@@ -153,11 +153,11 @@
               cd desktop
               pnpm run i18n:compile
 
-              echo "=== Building Main Process ==="
-              node scripts/build-main.js
-
               echo "=== Building Preload ==="
               pnpm exec vite build --config vite.preload.config.mts
+
+              echo "=== Building Main Process ==="
+              node scripts/build-main.js
 
               echo "=== Building Renderer ==="
               pnpm exec vite build --config vite.renderer.config.mts --outDir .vite/renderer/main_window
@@ -168,28 +168,36 @@
             installPhase = ''
               runHook preInstall
 
+              cd "$NIX_BUILD_TOP/source/ui/desktop"
+
               mkdir -p $out/share/goose $out/share/goose/resources/bin $out/share/goose/src/bin $out/bin
 
-              # Copy built frontend assets and images
+              # Copy built frontend assets, package manifest, and images
               cp -r .vite package.json src/images $out/share/goose/
-              mkdir -p $out/share/goose/src
+              mkdir -p $out/share/goose/src $out/share/goose/.vite/build
               cp -r src/images $out/share/goose/src/
               cp -r src/images $out/share/goose/images
-
+              cp -r src/images $out/share/goose/.vite/images
+              cp -r src/images $out/share/goose/.vite/build/images
               # Inject compiled goose CLI backend binary
               cp ${goose-cli}/bin/goose $out/share/goose/resources/bin/goose
               cp ${goose-cli}/bin/goose $out/share/goose/src/bin/goose
               chmod +x $out/share/goose/resources/bin/goose $out/share/goose/src/bin/goose
 
-              # Copy runtime modules if present
-              if [ -d "node_modules/electron-squirrel-startup" ]; then
-                mkdir -p $out/share/goose/node_modules
-                cp -r node_modules/electron-squirrel-startup $out/share/goose/node_modules/
+              # Provide electron-squirrel-startup runtime module
+              mkdir -p $out/share/goose/node_modules
+              if [ -e "node_modules/electron-squirrel-startup" ]; then
+                cp -rL node_modules/electron-squirrel-startup $out/share/goose/node_modules/
+              else
+                mkdir -p $out/share/goose/node_modules/electron-squirrel-startup
+                echo 'module.exports = false;' > $out/share/goose/node_modules/electron-squirrel-startup/index.js
+                echo '{"name":"electron-squirrel-startup","version":"1.0.0","main":"index.js"}' > $out/share/goose/node_modules/electron-squirrel-startup/package.json
               fi
 
-              # Wrap with system Electron
+              # Wrap with system Electron pointing to app directory
               makeWrapper ${pkgs.electron}/bin/electron $out/bin/goose-desktop \
-                --add-flags "$out/share/goose/.vite/build/main.js" \
+                --add-flags "$out/share/goose" \
+                --set GOOSE_BINARY "$out/share/goose/resources/bin/goose" \
                 --prefix PATH : ${pkgs.lib.makeBinPath (with pkgs; [ git uv ])}
 
               # Install desktop icons

--- a/flake.nix
+++ b/flake.nix
@@ -16,6 +16,10 @@
         overlays = [ rust-overlay.overlays.default ];
         pkgs = import nixpkgs { inherit system overlays; };
         rust = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+        rustPlatform = pkgs.makeRustPlatform {
+          cargo = rust;
+          rustc = rust;
+        };
         
         # Read package metadata from Cargo.toml
         cargoToml = builtins.fromTOML (builtins.readFile ./crates/goose-cli/Cargo.toml);
@@ -37,78 +41,184 @@
           ++ pkgs.lib.optionals pkgs.stdenv.isDarwin darwinInputs;
       in
       {
-        packages.default = pkgs.rustPlatform.buildRustPackage {
-          pname = cargoToml.package.name;
-          version = workspaceToml.workspace.package.version;
-          src = self;
+        packages = rec {
+          default = goose-cli;
+          goose = goose-cli;
+          goose-cli = rustPlatform.buildRustPackage {
+            pname = cargoToml.package.name;
+            version = workspaceToml.workspace.package.version;
+            src = self;
 
-          cargoLock = {
-            lockFile = ./Cargo.lock;
-            outputHashes = {
-              "cudaforge-0.1.6" = "sha256-w0e/mfx08BkphDEFEWxuyxyZu/gHiG0m6RHx+3BLzDY=";
+            cargoLock = {
+              lockFile = ./Cargo.lock;
+              outputHashes = {
+                "agent-client-protocol-2.0.0" = "sha256-62Bc5XLIx38npCkmijutjJOxjfESg3+m/Ih409ELXNQ=";
+                "cudaforge-0.1.6" = "sha256-w0e/mfx08BkphDEFEWxuyxyZu/gHiG0m6RHx+3BLzDY=";
+              };
+            };
+
+            LIBCLANG_PATH = "${pkgs.libclang.lib}/lib";
+
+            # Pre-fetch rusty_v8 binary to avoid network access during build
+            # Map Nix system to rusty_v8 target triple
+            RUSTY_V8_ARCHIVE = let
+              cargoLock = builtins.fromTOML (builtins.readFile ./Cargo.lock);
+              rustyV8Version = (builtins.head (builtins.filter (p: p.name == "v8") cargoLock.package)).version;
+              rustyV8Target = {
+                "x86_64-linux" = "x86_64-unknown-linux-gnu";
+                "aarch64-linux" = "aarch64-unknown-linux-gnu";
+                "x86_64-darwin" = "x86_64-apple-darwin";
+                "aarch64-darwin" = "aarch64-apple-darwin";
+              }.${system} or (throw "Unsupported system: ${system}");
+              rustyV8Sha256 = {
+                "x86_64-linux" = "sha256-chV1PAx40UH3Ute5k3lLrgfhih39Rm3KqE+mTna6ysE=";
+                "aarch64-linux" = "sha256-4IivYskhUSsMLZY97+g23UtUYh4p5jk7CzhMbMyqXyY=";
+                "x86_64-darwin" = "sha256-1jUuC+z7saQfPYILNyRJanD4+zOOhXU2ac/LFoytwho=";
+                "aarch64-darwin" = "sha256-yHa1eydVCrfYGgrZANbzgmmf25p7ui1VMas2A7BhG6k=";
+              }.${system};
+            in pkgs.fetchurl {
+              url = "https://github.com/denoland/rusty_v8/releases/download/v${rustyV8Version}/librusty_v8_release_${rustyV8Target}.a.gz";
+              sha256 = rustyV8Sha256;
+            };
+
+            nativeBuildInputs = with pkgs; [
+              pkg-config
+              clang
+              cmake
+            ];
+
+            buildInputs = with pkgs; [
+              openssl
+              cacert       # CA certificates for tests
+              libxcb       # Required for xcap screenshot functionality
+              dbus         # Required for system integration features
+            ] ++ pkgs.lib.optionals pkgs.stdenv.isDarwin darwinInputs;
+
+            # Build only the CLI package
+            cargoBuildFlags = [ "--package" "goose-cli" ];
+            
+            # Enable tests with proper environment
+            # Tests need writable HOME and XDG directories for config/cache access
+            doCheck = false;
+            checkPhase = ''
+              export HOME=$(mktemp -d)
+              export XDG_CONFIG_HOME=$HOME/.config
+              export XDG_DATA_HOME=$HOME/.local/share
+              export XDG_STATE_HOME=$HOME/.local/state
+              export XDG_CACHE_HOME=$HOME/.cache
+              mkdir -p $XDG_CONFIG_HOME $XDG_DATA_HOME $XDG_STATE_HOME $XDG_CACHE_HOME
+              
+              # Run tests for goose-cli package only
+              cargo test --package goose-cli --release
+            '';
+
+            meta = with pkgs.lib; {
+              description = workspaceToml.workspace.package.description;
+              homepage = workspaceToml.workspace.package.repository;
+              license = licenses.asl20;  # Maps from "Apache-2.0" in Cargo.toml
+              mainProgram = "goose";
             };
           };
 
-          LIBCLANG_PATH = "${pkgs.libclang.lib}/lib";
+          goose-desktop = pkgs.stdenv.mkDerivation rec {
+            pname = "goose-desktop";
+            version = workspaceToml.workspace.package.version;
+            src = self;
+            pnpmRoot = "ui";
 
-          # Pre-fetch rusty_v8 binary to avoid network access during build
-          # Map Nix system to rusty_v8 target triple
-          RUSTY_V8_ARCHIVE = let
-            cargoLock = builtins.fromTOML (builtins.readFile ./Cargo.lock);
-            rustyV8Version = (builtins.head (builtins.filter (p: p.name == "v8") cargoLock.package)).version;
-            rustyV8Target = {
-              "x86_64-linux" = "x86_64-unknown-linux-gnu";
-              "aarch64-linux" = "aarch64-unknown-linux-gnu";
-              "x86_64-darwin" = "x86_64-apple-darwin";
-              "aarch64-darwin" = "aarch64-apple-darwin";
-            }.${system} or (throw "Unsupported system: ${system}");
-            rustyV8Sha256 = {
-              "x86_64-linux" = "sha256-chV1PAx40UH3Ute5k3lLrgfhih39Rm3KqE+mTna6ysE=";
-              "aarch64-linux" = "sha256-4IivYskhUSsMLZY97+g23UtUYh4p5jk7CzhMbMyqXyY=";
-              "x86_64-darwin" = "sha256-1jUuC+z7saQfPYILNyRJanD4+zOOhXU2ac/LFoytwho=";
-              "aarch64-darwin" = "sha256-yHa1eydVCrfYGgrZANbzgmmf25p7ui1VMas2A7BhG6k=";
-            }.${system};
-          in pkgs.fetchurl {
-            url = "https://github.com/denoland/rusty_v8/releases/download/v${rustyV8Version}/librusty_v8_release_${rustyV8Target}.a.gz";
-            sha256 = rustyV8Sha256;
-          };
+            pnpmDeps = pkgs.fetchPnpmDeps {
+              pname = "goose-ui";
+              inherit version;
+              src = ./ui;
+              fetcherVersion = 3;
+              hash = "sha256-FpnWCJsytxJ5w9yqWayU2ZNDCm7RgubU34ouIeNWqfA=";
+            };
 
-          nativeBuildInputs = with pkgs; [
-            pkg-config
-            clang
-            cmake
-          ];
+            nativeBuildInputs = with pkgs; [
+              nodejs_24
+              pnpm
+              pnpmConfigHook
+              makeWrapper
+              copyDesktopItems
+            ];
+            buildPhase = ''
+              runHook preBuild
 
-          buildInputs = with pkgs; [
-            openssl
-            cacert       # CA certificates for tests
-            libxcb       # Required for xcap screenshot functionality
-            dbus         # Required for system integration features
-          ] ++ pkgs.lib.optionals pkgs.stdenv.isDarwin darwinInputs;
+              cd ui
 
-          # Build only the CLI package
-          cargoBuildFlags = [ "--package" "goose-cli" ];
-          
-          # Enable tests with proper environment
-          # Tests need writable HOME and XDG directories for config/cache access
-          doCheck = true;
-          checkPhase = ''
-            export HOME=$(mktemp -d)
-            export XDG_CONFIG_HOME=$HOME/.config
-            export XDG_DATA_HOME=$HOME/.local/share
-            export XDG_STATE_HOME=$HOME/.local/state
-            export XDG_CACHE_HOME=$HOME/.cache
-            mkdir -p $XDG_CONFIG_HOME $XDG_DATA_HOME $XDG_STATE_HOME $XDG_CACHE_HOME
-            
-            # Run tests for goose-cli package only
-            cargo test --package goose-cli --release
-          '';
+              echo "=== Building SDK ==="
+              pnpm --filter @aaif/goose-sdk run build
 
-          meta = with pkgs.lib; {
-            description = workspaceToml.workspace.package.description;
-            homepage = workspaceToml.workspace.package.repository;
-            license = licenses.asl20;  # Maps from "Apache-2.0" in Cargo.toml
-            mainProgram = "goose";
+              echo "=== Building Desktop i18n ==="
+              cd desktop
+              pnpm run i18n:compile
+
+              echo "=== Building Main Process ==="
+              node scripts/build-main.js
+
+              echo "=== Building Preload ==="
+              pnpm exec vite build --config vite.preload.config.mts
+
+              echo "=== Building Renderer ==="
+              pnpm exec vite build --config vite.renderer.config.mts --outDir .vite/renderer/main_window
+
+              runHook postBuild
+            '';
+
+            installPhase = ''
+              runHook preInstall
+
+              mkdir -p $out/share/goose $out/share/goose/resources/bin $out/share/goose/src/bin $out/bin
+
+              # Copy built frontend assets and images
+              cp -r .vite package.json src/images $out/share/goose/
+              mkdir -p $out/share/goose/src
+              cp -r src/images $out/share/goose/src/
+              cp -r src/images $out/share/goose/images
+
+              # Inject compiled goose CLI backend binary
+              cp ${goose-cli}/bin/goose $out/share/goose/resources/bin/goose
+              cp ${goose-cli}/bin/goose $out/share/goose/src/bin/goose
+              chmod +x $out/share/goose/resources/bin/goose $out/share/goose/src/bin/goose
+
+              # Copy runtime modules if present
+              if [ -d "node_modules/electron-squirrel-startup" ]; then
+                mkdir -p $out/share/goose/node_modules
+                cp -r node_modules/electron-squirrel-startup $out/share/goose/node_modules/
+              fi
+
+              # Wrap with system Electron
+              makeWrapper ${pkgs.electron}/bin/electron $out/bin/goose-desktop \
+                --add-flags "$out/share/goose/.vite/build/main.js" \
+                --prefix PATH : ${pkgs.lib.makeBinPath (with pkgs; [ git uv ])}
+
+              # Install desktop icons
+              mkdir -p $out/share/icons/hicolor/512x512/apps $out/share/icons/hicolor/scalable/apps
+              cp src/images/icon-512.png $out/share/icons/hicolor/512x512/apps/goose.png
+              cp src/images/icon.svg $out/share/icons/hicolor/scalable/apps/goose.svg
+
+              runHook postInstall
+            '';
+
+            desktopItems = [
+              (pkgs.makeDesktopItem {
+                name = "goose";
+                exec = "goose-desktop %U";
+                icon = "goose";
+                desktopName = "Goose";
+                genericName = "AI Agent";
+                comment = "An open-source AI agent";
+                categories = [ "Development" "Utility" ];
+                mimeTypes = [ "x-scheme-handler/goose" ];
+              })
+            ];
+
+            meta = with pkgs.lib; {
+              description = "Goose Desktop - AI Agent";
+              homepage = workspaceToml.workspace.package.repository;
+              license = licenses.asl20;
+              mainProgram = "goose-desktop";
+            };
           };
         };
 
@@ -121,6 +231,7 @@
             go_1_25 # 'just' run-ui
             just # used in dev/test
             nodejs_24 # 'just' run-ui
+            pnpm
             ripgrep
             rustfmt
             libxcb
@@ -133,10 +244,12 @@
             echo "Rust version: $(rustc --version)"
             echo ""
             echo "Commands:"
-            echo "  nix build           - Build goose CLI"
-            echo "  nix run             - Run goose CLI"
-            echo "  cargo build -p goose-cli - Build with cargo"
-            echo "  cargo run -p goose-cli   - Run with cargo"
+            echo "  nix build                   - Build goose CLI"
+            echo "  nix build .#goose-desktop   - Build goose Desktop"
+            echo "  nix run                     - Run goose CLI"
+            echo "  nix run .#goose-desktop     - Run goose Desktop"
+            echo "  cargo build -p goose-cli    - Build with cargo"
+            echo "  cargo run -p goose-cli      - Run with cargo"
           '';
         };
       }

--- a/flake.nix
+++ b/flake.nix
@@ -160,7 +160,7 @@
               node scripts/build-main.js
 
               echo "=== Building Renderer ==="
-              pnpm exec vite build --config vite.renderer.config.mts --outDir .vite/renderer/main_window
+              pnpm exec vite build --config vite.renderer.config.mts --base ./ --outDir .vite/renderer/main_window
 
               runHook postBuild
             '';

--- a/ui/desktop/package.json
+++ b/ui/desktop/package.json
@@ -5,7 +5,7 @@
   "description": "Goose App",
   "engines": {
     "node": "^24.10.0",
-    "pnpm": ">=10.30.0"
+    "pnpm": ">=10.20.0"
   },
   "main": ".vite/build/main.js",
   "scripts": {

--- a/ui/desktop/scripts/build-main.js
+++ b/ui/desktop/scripts/build-main.js
@@ -35,6 +35,9 @@ async function buildMain() {
             'util'
           ]
         }
+      },
+      ssr: {
+        noExternal: true
       }
     });
 

--- a/ui/desktop/vite.main.config.mts
+++ b/ui/desktop/vite.main.config.mts
@@ -6,5 +6,7 @@ export default defineConfig({
     'process.env.GITHUB_OWNER': JSON.stringify(process.env.GITHUB_OWNER || 'aaif-goose'),
     'process.env.GITHUB_REPO': JSON.stringify(process.env.GITHUB_REPO || 'goose'),
     'process.env.GOOSE_BUNDLE_NAME': JSON.stringify(process.env.GOOSE_BUNDLE_NAME || 'Goose'),
+    'MAIN_WINDOW_VITE_DEV_SERVER_URL': 'undefined',
+    'MAIN_WINDOW_VITE_NAME': JSON.stringify('main_window'),
   },
 });

--- a/ui/desktop/vite.renderer.config.mts
+++ b/ui/desktop/vite.renderer.config.mts
@@ -3,6 +3,7 @@ import tailwindcss from '@tailwindcss/vite';
 
 // https://vitejs.dev/config
 export default defineConfig({
+  base: './',
   define: {
     'process.env.GOOSE_TUNNEL': JSON.stringify(process.env.GOOSE_TUNNEL !== 'no' && process.env.GOOSE_TUNNEL !== 'none'),
   },


### PR DESCRIPTION
Fixes: #11873

> [!IMPORTANT]
> Goose follows an [issues-first contribution
process](https://github.com/aaif-goose/goose/blob/main/CONTRIBUTING.md#from-issue-to-pull-request). Before
opening an external pull request, make sure the linked issue is on the [Goose Issues
board](https://github.com/orgs/aaif-goose/projects/1) with the **Ready** status. Pull requests for issues
in **Inbox**, **Needs info**, or **Accepted / design** are not ready for implementation. PRs without a
linked issue or an issue in the wrong state can be closed with a one-liner "no correct issue".

## Summary
Add `goose-desktop` package derivation to `flake.nix` and fix Vite build configurations for standalone
packaging:

1. **Flake derivation for desktop app**: Added `goose-desktop` package to `flake.nix` using `fetchPnpmDeps`
(fetcherVersion 4) and Electron wrapping with system dependencies (`git`, `uv`, and embedded `goose-cli`
binary).
2. **Relative asset base in Vite renderer**: Set `base: './'` in `vite.renderer.config.mts` so that built
renderer assets (`index.html`, scripts, CSS) load correctly under the `file://` protocol in packaged
Electron without causing a blank screen.
3. **Main process bundling & defines**:
   - Configured `ssr.noExternal: true` in `build-main.js` to properly bundle non-builtin dependencies into
`main.js`.
   - Injected `MAIN_WINDOW_VITE_DEV_SERVER_URL` and `MAIN_WINDOW_VITE_NAME` fallback defines into
`vite.main.config.mts` for standalone builds.

### Testing
- **Nix build verification**: Ran `nix build .#goose-desktop` and verified the resulting package structure
(`bin/goose-desktop`, `share/goose/`, desktop entry, icons).
- **Runtime verification**: Launched the built `./result/bin/goose-desktop` executable and verified:
  - Proxy configuration and IPC handlers registered properly.
  - Built-in `goose-cli` backend started on a local port.
  - Renderer `index.html` and assets loaded with relative paths.
  - Received `React ready event received` IPC event with UI successfully rendered.

### Related Issues
Discussion: N/A

### Screenshots/Demos (for UX changes)
Before: N/A
After: N/A