### PR TITLE
Add Zetesis extension (remote, streamable-http, no auth)

### DIFF
--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -827,6 +827,17 @@
       "required": false
     }
   ]
-}
-
+},
+  {
+    "id": "zetesis",
+    "name": "Zetesis",
+    "description": "Check whether a scientific claim holds up against the published record. Returns the questions a domain reviewer would ask, the failure patterns that caught comparable claims before, and evidence from Europe PMC, ClinicalTrials.gov, openFDA, NIH RePORTER and SEC EDGAR with an identifier on every source. Retrieval can be fenced to a year, so a claim is judged on what was knowable at the time.",
+    "url": "https://api.zetesis.science/mcp",
+    "link": "https://github.com/reutavidan/zetesis",
+    "installation_notes": "No account, key or token. The two retrieval tools call no language model and send nothing to any model provider.",
+    "is_builtin": false,
+    "endorsed": false,
+    "environmentVariables": [],
+    "type": "streamable-http"
+  }
 ]


### PR DESCRIPTION
Adds Zetesis to the extensions directory.

**What it does.** Given a scientific claim, a paper, an abstract or a deck, it returns the questions a domain reviewer would ask, the failure patterns that have caught comparable claims before, and the public evidence bearing on it, with a PMID, DOI, NCT number, grant number or filing reference on every source. Every identifier is retrieved from a public register rather than generated.

**Why it might be useful in Goose.** The two retrieval tools call no language model at all. They return in about a second and send nothing to any model provider, so the agent does the reading and grading in its own context with real sources in front of it.

Retrieval can also be fenced to a year, which restricts evidence to what existed by then. That is useful beyond honesty in retrospect: on a control claim, an unfenced search missed the pivotal publication entirely and reached 35% evidence coverage, while fencing to the claim's own year retrieved it and coverage rose to 79%.

**Entry details**

- `type`: `streamable-http`, `url`: `https://api.zetesis.science/mcp`
- No account, key or token, so `environmentVariables` is empty
- Four tools, all read-only, all carrying `readOnlyHint` and `destructiveHint` annotations
- Listed in the official MCP Registry as `io.github.reutavidan/zetesis`

**Try it after installing**

> What did the published evidence support about aducanumab and cognitive decline at the end of 2019, using only sources available by then?

Then ask the same question without the year.

The diff is a single entry appended to `documentation/static/servers.json`. I used a text insertion rather than re-serialising the file, because `json.dumps` normalises indentation and unicode escaping elsewhere in it and would have buried this in a couple of dozen unrelated lines.
