### PR TITLE
feat: add AIgateway provider

### DIFF
--- a/crates/goose-providers/src/declarative.rs
+++ b/crates/goose-providers/src/declarative.rs
@@ -13,6 +13,7 @@ pub(crate) mod declarative_providers {
     use super::*;
 
     expose_declarative_providers!(
+        aigateway,
         aimlapi,
         alibaba,
         atomic_chat,

--- a/crates/goose-providers/src/declarative/definitions/aigateway.json
+++ b/crates/goose-providers/src/declarative/definitions/aigateway.json
@@ -1,0 +1,117 @@
+{
+  "name": "aigateway",
+  "engine": "openai",
+  "display_name": "AIgateway",
+  "description": "1,000+ models from 85+ labs behind one OpenAI-compatible endpoint at pass-through pricing",
+  "api_key_env": "AIGATEWAY_API_KEY",
+  "base_url": "https://api.aigateway.sh/v1/chat/completions",
+  "catalog_provider_id": "aigateway",
+  "models": [
+    {
+      "name": "zai-org/glm-5.3-flash",
+      "context_limit": 1310720,
+      "max_tokens": 131072,
+      "input_token_cost": 0.00000015,
+      "output_token_cost": 0.0000005,
+      "currency": "USD"
+    },
+    {
+      "name": "anthropic/claude-opus-4.7",
+      "context_limit": 200000,
+      "max_tokens": 64000,
+      "input_token_cost": 0.000005,
+      "output_token_cost": 0.000025,
+      "currency": "USD"
+    },
+    {
+      "name": "anthropic/claude-sonnet-4.6",
+      "context_limit": 200000,
+      "max_tokens": 64000,
+      "input_token_cost": 0.000003,
+      "output_token_cost": 0.000015,
+      "currency": "USD"
+    },
+    {
+      "name": "anthropic/claude-haiku-4.5",
+      "context_limit": 200000,
+      "max_tokens": 64000,
+      "input_token_cost": 0.000001,
+      "output_token_cost": 0.000005,
+      "currency": "USD"
+    },
+    {
+      "name": "openai/gpt-5.4",
+      "context_limit": 1050000,
+      "max_tokens": 128000,
+      "input_token_cost": 0.0000025,
+      "output_token_cost": 0.000015,
+      "currency": "USD"
+    },
+    {
+      "name": "openai/gpt-5.4-mini",
+      "context_limit": 400000,
+      "max_tokens": 128000,
+      "input_token_cost": 0.00000075,
+      "output_token_cost": 0.0000045,
+      "currency": "USD"
+    },
+    {
+      "name": "google/gemini-3.7-flash",
+      "context_limit": 1048576,
+      "max_tokens": 65536,
+      "input_token_cost": 0.00000075,
+      "output_token_cost": 0.00000375,
+      "currency": "USD"
+    },
+    {
+      "name": "xai/grok-4.6",
+      "context_limit": 200000,
+      "max_tokens": 128000,
+      "input_token_cost": 0.000002,
+      "output_token_cost": 0.000006,
+      "currency": "USD"
+    },
+    {
+      "name": "moonshot/kimi-k3",
+      "context_limit": 1048576,
+      "max_tokens": 1048576,
+      "input_token_cost": 0.000003,
+      "output_token_cost": 0.000015,
+      "currency": "USD"
+    },
+    {
+      "name": "moonshot/kimi-k2.7-code",
+      "context_limit": 262144,
+      "max_tokens": 262144,
+      "input_token_cost": 0.00000095,
+      "output_token_cost": 0.000004,
+      "currency": "USD"
+    },
+    {
+      "name": "alibaba/qwen3.8-max",
+      "context_limit": 1000000,
+      "max_tokens": 65536,
+      "input_token_cost": 0.000002,
+      "output_token_cost": 0.000006,
+      "currency": "USD"
+    },
+    {
+      "name": "deepseek/deepseek-v4-pro-0813",
+      "context_limit": 1048576,
+      "max_tokens": 393216,
+      "input_token_cost": 0.00000132,
+      "output_token_cost": 0.00000396,
+      "currency": "USD"
+    },
+    {
+      "name": "meta/llama-4-scout-17b-16e-instruct",
+      "context_limit": 10485760,
+      "max_tokens": 32768,
+      "input_token_cost": 0.00000027,
+      "output_token_cost": 0.00000085,
+      "currency": "USD"
+    }
+  ],
+  "preserves_thinking": true,
+  "supports_streaming": true
+}

--- a/crates/goose/src/providers/init.rs
+++ b/crates/goose/src/providers/init.rs
@@ -362,6 +362,21 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_aigateway_provider_registry_wiring() {
+        let aigateway = get_from_registry("aigateway")
+            .await
+            .expect("aigateway provider should be registered");
+        let meta = aigateway.metadata();
+
+        assert_eq!(meta.name, "aigateway");
+        assert_eq!(meta.default_model, "zai-org/glm-5.3-flash");
+        assert!(meta
+            .config_keys
+            .iter()
+            .any(|key| key.name == "AIGATEWAY_API_KEY" && key.secret));
+    }
+
+    #[tokio::test]
     async fn test_openai_compatible_providers_config_keys() {
         let providers_list = providers().await;
         let required_api_key_cases = vec![

--- a/goose-self-test.yaml
+++ b/goose-self-test.yaml
@@ -176,6 +176,12 @@ prompt: |
   1. Run `cargo test -p goose test_gondola_provider_registry_wiring` to verify Gondola is registered with the correct name, default model (`deepseek-v4-flash`), and a secret `GONDOLA_API_KEY` config key.
   If the source checkout or Rust toolchain is unavailable, mark this validation as skipped rather than failed.
 
+  ### AIgateway Provider Validation
+  When running from a goose source checkout:
+  1. Run `cargo test -p goose test_aigateway_provider_registry_wiring` to verify AIgateway is registered with the correct name, default model (`zai-org/glm-5.3-flash`), and a secret `AIGATEWAY_API_KEY` config key.
+  2. Verify the declarative definition (`crates/goose-providers/src/declarative/definitions/aigateway.json`) parses, its engine resolves to OpenAI-compatible, and its base URL is `https://api.aigateway.sh/v1/chat/completions`.
+  If the source checkout or Rust toolchain is unavailable, mark this validation as skipped rather than failed.
+
   ### Databricks AI Gateway Path Validation
   When running from a goose source checkout:
   1. Run `cargo test -p goose-providers databricks_v2::tests::gateway_path` to verify the configurable gateway path.


### PR DESCRIPTION
## What

Adds a declarative provider definition for [AIgateway](https://aigateway.sh) — a model aggregator with 1,000+ models from 85+ labs behind one OpenAI-compatible endpoint at pass-through provider pricing.

- `crates/goose-providers/src/declarative/definitions/aigateway.json` — engine `openai`, `base_url: https://api.aigateway.sh/v1/chat/completions`, `AIGATEWAY_API_KEY`, 13 curated models with context limits + per-token costs, `catalog_provider_id: aigateway` (our models.dev provider entry; PR open upstream at anomalyco/models.dev#6361, CI-green)
- Registered in the `expose_declarative_providers!` macro list

Validated: `cargo check -p goose-providers` passes; `cargo test -p goose-providers --lib` — 217 passed, 0 failed.

I'm the founder of AIgateway — happy to adjust anything to fit conventions.