### PR TITLE
feat(providers): add LLM Tech as a declarative OpenAI-compatible provider

### DIFF
--- a/crates/goose-providers/src/declarative.rs
+++ b/crates/goose-providers/src/declarative.rs
@@ -28,6 +28,7 @@ pub(crate) mod declarative_providers {
         iflytek_astron,
         inception,
         llama_swap,
+        llmtech,
         lmstudio,
         lynkr,
         meta,

--- a/crates/goose-providers/src/declarative/definitions/llmtech.json
+++ b/crates/goose-providers/src/declarative/definitions/llmtech.json
@@ -1,0 +1,25 @@
+{
+  "name": "llmtech",
+  "engine": "openai",
+  "display_name": "LLM Tech",
+  "description": "EU-hosted endpoint for open-weight models: Qwen3.8-27B on dedicated hardware in Helsinki, 262,144 context, tool calling, structured outputs and image input, no prompt retention.",
+  "api_key_env": "LLMTECH_API_KEY",
+  "base_url": "https://api.llmtech.eu/v1/chat/completions",
+  "catalog_provider_id": "llmtech",
+  "models": [
+    {
+      "name": "unsloth/Qwen3.8-27B-NVFP4",
+      "context_limit": 262144,
+      "input_token_cost": 0.00000025,
+      "output_token_cost": 0.00000209,
+      "currency": "USD"
+    }
+  ],
+  "dynamic_models": true,
+  "supports_streaming": true,
+  "model_doc_link": "https://llmtech.eu/models/qwen3.8-27b/",
+  "setup_steps": [
+    "Get a key at https://llmtech.eu/docs/",
+    "Paste the key above as LLMTECH_API_KEY"
+  ]
+}


### PR DESCRIPTION
Closes #11854

@michaelneale asked for it to be one specific provider with a description that makes the EU hosting clear, not a new category, and okayed it in the issue ("go for it"). That is what this is.

LLM Tech speaks the OpenAI wire format and serves an OpenAI-shaped models endpoint, so this is a definition plus one line of registration, no engine code. Same shape as Opper in #11589.

### Changes
- New `crates/goose-providers/src/declarative/definitions/llmtech.json`
- Registered `llmtech` in the `expose_declarative_providers!` macro in `declarative.rs`

### Notes on the definition
- The canonical catalogue already carries `llmtech` with `LLMTECH_API_KEY` in `crates/goose-provider-types/src/canonical/data/provider_metadata.json` (from models.dev), so `catalog_provider_id` points at it and that file is unchanged.
- `base_url` is the full `https://api.llmtech.eu/v1/chat/completions`, as in #11589; `map_base_path` derives the models endpoint as `v1/models`, which returns the OpenAI-shaped list.
- `dynamic_models: true`, so the picker fetches the live list; the static entry is the one model served today, `nvidia/Qwen3.8-27B-NVFP4`, 262,144 context.
- Costs are the public list price, USD per token.
- Disclosure: I operate this endpoint.

### Testing
- `/v1/models` against the live endpoint returns the OpenAI-shaped list with `context_length: 262144`.
- Both links in the definition return 200.
- The JSON parses; the macro entry name matches the file name, which is what `expose_declarative_providers_enumerates_all_bundled_json_files` checks.
