### PR TITLE
Treat truncated SSE as complete after tokens

### DIFF
--- a/crates/goose-provider-types/src/errors.rs
+++ b/crates/goose-provider-types/src/errors.rs
@@ -96,6 +96,40 @@ impl ProviderError {
             .downcast()
             .unwrap_or_else(ProviderError::stream_decode_error)
     }
+
+    /// True when the HTTP body ended without a complete frame — a dropped
+    /// chunked connection, an incomplete gzip stream, a reset. Distinct from a
+    /// JSON parse failure on a well-formed frame.
+    pub fn is_truncated_http_stream(error: &anyhow::Error) -> bool {
+        error.chain().any(|cause| {
+            if let Some(io_error) = cause.downcast_ref::<std::io::Error>() {
+                if matches!(
+                    io_error.kind(),
+                    std::io::ErrorKind::UnexpectedEof
+                        | std::io::ErrorKind::BrokenPipe
+                        | std::io::ErrorKind::ConnectionReset
+                        | std::io::ErrorKind::ConnectionAborted
+                ) {
+                    return true;
+                }
+            }
+            if let Some(reqwest_error) = cause.downcast_ref::<reqwest::Error>() {
+                if reqwest_error.is_decode() || reqwest_error.is_body() {
+                    return true;
+                }
+            }
+            is_truncated_http_stream_message(&cause.to_string())
+        })
+    }
+}
+
+fn is_truncated_http_stream_message(message: &str) -> bool {
+    let message = message.to_ascii_lowercase();
+    message.contains("error decoding response body")
+        || message.contains("incomplete message")
+        || message.contains("unexpected eof")
+        || message.contains("connection reset")
+        || message.contains("broken pipe")
 }
 
 fn is_network_error(err: &reqwest::Error) -> bool {
@@ -267,6 +301,24 @@ mod tests {
         assert!(!message.contains("url-password"));
         assert!(message.contains("status: 401 Unauthorized"));
         assert!(message.contains(&format!("http://{address}/chat")));
+    }
+
+    #[test]
+    fn truncated_http_stream_matches_reqwest_decode_message() {
+        let error = anyhow::anyhow!("error decoding response body");
+        assert!(ProviderError::is_truncated_http_stream(&error));
+        assert!(!ProviderError::is_truncated_http_stream(&anyhow::anyhow!(
+            "Failed to parse streaming chunk: missing field `choices`"
+        )));
+    }
+
+    #[test]
+    fn truncated_http_stream_matches_unexpected_eof() {
+        let error = anyhow::Error::from(std::io::Error::new(
+            std::io::ErrorKind::UnexpectedEof,
+            "end of file",
+        ));
+        assert!(ProviderError::is_truncated_http_stream(&error));
     }
 }
 

--- a/crates/goose-provider-types/src/formats/openai.rs
+++ b/crates/goose-provider-types/src/formats/openai.rs
@@ -1255,9 +1255,22 @@ where
         let mut output_token_limit_reached = false;
         let mut output_token_limit_metadata_emitted = false;
         let mut usage_emitted = false;
+        let mut received_payload = false;
 
         'outer: while let Some(response) = stream.next().await {
-            let response_str = response?;
+            let response_str = match response {
+                Ok(s) => s,
+                Err(error)
+                    if received_payload && ProviderError::is_truncated_http_stream(&error) =>
+                {
+                    tracing::warn!(
+                        error = %error,
+                        "Provider stream truncated after tokens; treating as complete"
+                    );
+                    break 'outer;
+                }
+                Err(error) => Err(error)?,
+            };
             let line = strip_data_prefix(&response_str);
 
             if line.is_some_and(|l| l == "[DONE]") {
@@ -1273,6 +1286,7 @@ where
             )? else {
                 continue  // metadata-only frame
             };
+            received_payload = true;
             if let Some(model) = &chunk.model {
                 last_seen_model = Some(model.clone());
             }
@@ -3489,6 +3503,63 @@ data: [DONE]
         );
         assert_usage_yielded_once(&result, 10, 5, 15);
 
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_streaming_truncated_http_body_after_tokens_is_complete() -> anyhow::Result<()> {
+        let response_lines = [
+            Ok(
+                r#"data: {"id":"chatcmpl-cut","model":"auto","choices":[{"index":0,"delta":{"role":"assistant","content":"Hello from auto"},"finish_reason":null}]}"#
+                    .to_string(),
+            ),
+            Err(anyhow::anyhow!("error decoding response body")),
+        ];
+        let response_stream = tokio_stream::iter(response_lines);
+        let messages = response_to_streaming_message(response_stream);
+        pin!(messages);
+
+        let mut text = String::new();
+        let mut errors = Vec::new();
+        while let Some(item) = messages.next().await {
+            match item {
+                Ok((Some(msg), _)) => {
+                    for content in &msg.content {
+                        if let MessageContentBlock::Text(t) = content {
+                            text.push_str(&t.text);
+                        }
+                    }
+                }
+                Ok(_) => {}
+                Err(error) => errors.push(error.to_string()),
+            }
+        }
+
+        assert_eq!(text, "Hello from auto");
+        assert!(
+            errors.is_empty(),
+            "truncated HTTP body after tokens must not fail the turn: {errors:?}"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_streaming_truncated_http_body_before_tokens_is_error() -> anyhow::Result<()> {
+        let response_stream = tokio_stream::iter(vec![Err(anyhow::anyhow!(
+            "error decoding response body"
+        ))]);
+        let messages = response_to_streaming_message(response_stream);
+        pin!(messages);
+
+        let first = messages
+            .next()
+            .await
+            .expect("empty-stream truncation should surface as an error");
+        assert!(first.is_err());
+        assert!(first
+            .expect_err("expected decode error")
+            .to_string()
+            .contains("error decoding response body"));
         Ok(())
     }
 

--- a/crates/goose-provider-types/src/formats/openai.rs
+++ b/crates/goose-provider-types/src/formats/openai.rs
@@ -3545,9 +3545,8 @@ data: [DONE]
 
     #[tokio::test]
     async fn test_streaming_truncated_http_body_before_tokens_is_error() -> anyhow::Result<()> {
-        let response_stream = tokio_stream::iter(vec![Err(anyhow::anyhow!(
-            "error decoding response body"
-        ))]);
+        let response_stream =
+            tokio_stream::iter(vec![Err(anyhow::anyhow!("error decoding response body"))]);
         let messages = response_to_streaming_message(response_stream);
         pin!(messages);
 

--- a/crates/goose-provider-types/src/formats/openai_responses.rs
+++ b/crates/goose-provider-types/src/formats/openai_responses.rs
@@ -1722,8 +1722,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_responses_stream_truncated_http_body_after_tokens_is_complete()
-    -> anyhow::Result<()> {
+    async fn test_responses_stream_truncated_http_body_after_tokens_is_complete(
+    ) -> anyhow::Result<()> {
         let lines = vec![
             Ok(
                 r#"data: {"type":"response.created","sequence_number":1,"response":{"id":"resp_cut","object":"response","created_at":1737368310,"status":"in_progress","model":"auto","output":[]}}"#

--- a/crates/goose-provider-types/src/formats/openai_responses.rs
+++ b/crates/goose-provider-types/src/formats/openai_responses.rs
@@ -1017,9 +1017,22 @@ where
         let mut output_items: Vec<ResponseOutputItemInfo> = Vec::new();
         let mut is_text_response = false;
         let mut output_token_limit_reached = false;
+        let mut received_payload = false;
 
         'outer: while let Some(response) = stream.next().await {
-            let response_str = response?;
+            let response_str = match response {
+                Ok(s) => s,
+                Err(error)
+                    if received_payload && ProviderError::is_truncated_http_stream(&error) =>
+                {
+                    tracing::warn!(
+                        error = %error,
+                        "Provider stream truncated after tokens; treating as complete"
+                    );
+                    break 'outer;
+                }
+                Err(error) => Err(error)?,
+            };
 
             // Skip empty lines
             if response_str.trim().is_empty() {
@@ -1053,6 +1066,7 @@ where
             let Some(event) = parse_responses_stream_event(data_line)? else {
                 continue;
             };
+            received_payload = true;
 
             match event {
                 ResponsesStreamEvent::ResponseCreated { response, .. } |
@@ -1704,6 +1718,51 @@ mod tests {
             .to_string()
             .contains("Responses API error"));
 
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_responses_stream_truncated_http_body_after_tokens_is_complete()
+    -> anyhow::Result<()> {
+        let lines = vec![
+            Ok(
+                r#"data: {"type":"response.created","sequence_number":1,"response":{"id":"resp_cut","object":"response","created_at":1737368310,"status":"in_progress","model":"auto","output":[]}}"#
+                    .to_string(),
+            ),
+            Ok(
+                r#"data: {"type":"response.output_text.delta","sequence_number":2,"item_id":"msg_1","output_index":0,"content_index":0,"delta":"Hello from auto"}"#
+                    .to_string(),
+            ),
+            Err(anyhow::anyhow!("error decoding response body")),
+        ];
+        let response_stream = tokio_stream::iter(lines);
+        let messages = responses_api_to_streaming_message(response_stream);
+        futures::pin_mut!(messages);
+
+        let mut text = String::new();
+        let mut errors = Vec::new();
+        while let Some(item) = messages.next().await {
+            match item {
+                Ok((Some(msg), _)) => {
+                    for content in &msg.content {
+                        if let MessageContentBlock::Text(t) = content {
+                            text.push_str(&t.text);
+                        }
+                    }
+                }
+                Ok(_) => {}
+                Err(error) => errors.push(error.to_string()),
+            }
+        }
+
+        assert!(
+            text.contains("Hello from auto"),
+            "expected yielded text, got {text:?}"
+        );
+        assert!(
+            errors.is_empty(),
+            "truncated HTTP body after tokens must not fail the turn: {errors:?}"
+        );
         Ok(())
     }
 

--- a/crates/goose-providers/src/api_client.rs
+++ b/crates/goose-providers/src/api_client.rs
@@ -583,7 +583,16 @@ impl<'a> ApiRequestBuilder<'a> {
         let mut request = request_builder(url, &self.client.client);
         request = request.headers(headers);
 
-        if !self.streaming {
+        if self.streaming {
+            // Compressed SSE is a common source of "error decoding response body"
+            // when a proxy or router drops the connection mid-frame: gzip then
+            // fails the whole stream even though tokens already arrived. Ask for
+            // identity so a truncated body is still line-readable.
+            request = request.header(
+                reqwest::header::ACCEPT_ENCODING,
+                HeaderValue::from_static("identity"),
+            );
+        } else {
             request = request.timeout(self.client.timeout);
         }
 
@@ -746,6 +755,25 @@ mod tests {
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpListener;
 
+    async fn spawn_header_echo_server() -> (SocketAddr, tokio::sync::oneshot::Receiver<String>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        tokio::spawn(async move {
+            let Ok((mut sock, _)) = listener.accept().await else {
+                return;
+            };
+            let mut buf = [0u8; 8192];
+            let n = sock.read(&mut buf).await.unwrap_or(0);
+            let request = String::from_utf8_lossy(&buf[..n]).to_string();
+            let _ = tx.send(request);
+            let _ = sock
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\n{}")
+                .await;
+        });
+        (addr, rx)
+    }
+
     async fn spawn_chunked_server(gap_ms: u64, chunks: usize) -> SocketAddr {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
@@ -886,6 +914,45 @@ mod tests {
 
         let count = drain_counting_data_lines(response).await.unwrap();
         assert_eq!(count, 12);
+    }
+
+    #[tokio::test]
+    async fn streaming_request_asks_for_identity_encoding() {
+        let (addr, headers) = spawn_header_echo_server().await;
+        let client = client_with_timeout(addr, 400);
+
+        let _ = client
+            .request("v1/messages")
+            .streaming(true)
+            .response_post(&serde_json::json!({}))
+            .await;
+
+        let request = headers.await.expect("server should capture request");
+        assert!(
+            request
+                .to_ascii_lowercase()
+                .contains("accept-encoding: identity"),
+            "streaming requests must disable compression, got:\n{request}"
+        );
+    }
+
+    #[tokio::test]
+    async fn non_streaming_request_does_not_force_identity_encoding() {
+        let (addr, headers) = spawn_header_echo_server().await;
+        let client = client_with_timeout(addr, 400);
+
+        let _ = client
+            .request("v1/messages")
+            .response_post(&serde_json::json!({}))
+            .await;
+
+        let request = headers.await.expect("server should capture request");
+        assert!(
+            !request
+                .to_ascii_lowercase()
+                .contains("accept-encoding: identity"),
+            "non-streaming requests should keep default compression, got:\n{request}"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Local OpenAI-compatible routers (minirouter `auto` on Spark) can drop a chunked SSE body mid-stream. reqwest then reports `error decoding response body`, and goose fails the turn even after tokens already arrived.
- Treat that transport truncation as a clean stream end once payload has been received, on both the chat-completions and Responses stream parsers.
- Streaming requests now send `Accept-Encoding: identity` so gzip cannot poison a truncated body.

## Test plan
- [ ] `cargo test -p goose-provider-types --lib truncated_http`
- [ ] `cargo test -p goose-providers --lib identity_encoding`
- [ ] `cargo clippy -p goose-provider-types -p goose-providers --all-targets -- -D warnings`
- [ ] Reproduce against minirouter `auto`: a mid-stream drop after tokens should keep the reply instead of showing `Network error: Stream decode error: error decoding response body`