### PR TITLE
fix(desktop): start a chat with no extensions when the user selects none

### DIFF
--- a/ui/desktop/src/__tests__/createSession.test.ts
+++ b/ui/desktop/src/__tests__/createSession.test.ts
@@ -104,23 +104,10 @@ describe('createSession ACP session extensions', () => {
     });
   });
 
-  it('falls back to enabled configured extensions when extension configs are empty', async () => {
+  it('sends an explicitly empty selection as an empty list, not as "unspecified"', async () => {
     await createSession('/tmp', {
       extensionConfigs: [],
       allExtensions: [configuredExtension('developer', true), configuredExtension('memory', false)],
-    });
-
-    expect(mockedGetConfiguredGooseExtensions).toHaveBeenCalledOnce();
-    expect(mockedCreateAcpSession).toHaveBeenCalledWith('/tmp', [gooseExtension('developer')], {
-      recipeDeeplink: undefined,
-      recipeId: undefined,
-      recipeParameterScopeId: undefined,
-    });
-  });
-
-  it('omits ACP session extensions when no configured extensions are enabled', async () => {
-    await createSession('/tmp', {
-      allExtensions: [configuredExtension('developer', false)],
     });
 
     expect(mockedGetConfiguredGooseExtensions).not.toHaveBeenCalled();
@@ -131,11 +118,34 @@ describe('createSession ACP session extensions', () => {
     });
   });
 
+  it('leaves the set unspecified when no configured extensions are enabled', async () => {
+    await createSession('/tmp', {
+      allExtensions: [configuredExtension('developer', false)],
+    });
+
+    expect(mockedGetConfiguredGooseExtensions).not.toHaveBeenCalled();
+    expect(mockedCreateAcpSession).toHaveBeenCalledWith('/tmp', undefined, {
+      recipeDeeplink: undefined,
+      recipeId: undefined,
+      recipeParameterScopeId: undefined,
+    });
+  });
+
+  it('leaves the set unspecified while the configured extensions are still loading', async () => {
+    await createSession('/tmp', { allExtensions: [] });
+
+    expect(mockedCreateAcpSession).toHaveBeenCalledWith('/tmp', undefined, {
+      recipeDeeplink: undefined,
+      recipeId: undefined,
+      recipeParameterScopeId: undefined,
+    });
+  });
+
   it('scopes startup parameters to recipe deeplink session creation', async () => {
     await createSession('/tmp', { recipeDeeplink: 'goose://recipe?url=example' });
 
     expect(mockedBeginConfiguredRecipeParameterScope).toHaveBeenCalledOnce();
-    expect(mockedCreateAcpSession).toHaveBeenCalledWith('/tmp', [], {
+    expect(mockedCreateAcpSession).toHaveBeenCalledWith('/tmp', undefined, {
       recipeDeeplink: 'goose://recipe?url=example',
       recipeId: undefined,
       recipeParameterScopeId: 'scope-1',

--- a/ui/desktop/src/acp/__tests__/sessions.test.ts
+++ b/ui/desktop/src/acp/__tests__/sessions.test.ts
@@ -28,6 +28,23 @@ function sessionInfo(overrides: Partial<SessionInfo> = {}): SessionInfo {
   } as unknown as SessionInfo;
 }
 
+function newSessionClient() {
+  const client = {
+    connection: {
+      agent: {
+        request: vi.fn().mockResolvedValue({ sessionId: 'session-1' }),
+      },
+    },
+    goose: {
+      sessionInfo_unstable: vi.fn().mockResolvedValue({ session: sessionInfo() }),
+    },
+  };
+  vi.mocked(getAcpClient).mockResolvedValue(
+    client as unknown as Awaited<ReturnType<typeof getAcpClient>>
+  );
+  return client;
+}
+
 describe('ACP sessions', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -109,6 +126,33 @@ describe('ACP sessions', () => {
     );
   });
 
+  it('sends an explicitly empty extension set as an empty list', async () => {
+    const client = newSessionClient();
+
+    await acpNewSession('/tmp', []);
+
+    expect(client.connection.agent.request).toHaveBeenCalledWith(methods.agent.session.new, {
+      cwd: '/tmp',
+      mcpServers: [],
+      _meta: {
+        client: 'goose-desktop',
+        enabledExtensions: [],
+      },
+    });
+  });
+
+  it('omits the extension key when the caller names no set', async () => {
+    const client = newSessionClient();
+
+    await acpNewSession('/tmp', undefined);
+
+    expect(client.connection.agent.request).toHaveBeenCalledWith(methods.agent.session.new, {
+      cwd: '/tmp',
+      mcpServers: [],
+      _meta: { client: 'goose-desktop' },
+    });
+  });
+
   it('carries the recipe parameter scope id in new-session metadata', async () => {
     const createdSessionInfo = sessionInfo();
     const client = {
@@ -125,7 +169,7 @@ describe('ACP sessions', () => {
       client as unknown as Awaited<ReturnType<typeof getAcpClient>>
     );
 
-    await acpNewSession('/tmp', [], {
+    await acpNewSession('/tmp', undefined, {
       recipeDeeplink: 'goose://recipe?url=example',
       recipeParameterScopeId: 'scope-1',
     });

--- a/ui/desktop/src/acp/chatSessionController.ts
+++ b/ui/desktop/src/acp/chatSessionController.ts
@@ -48,7 +48,7 @@ export interface AcpSubmitMessageOptions extends AcpSnapshotOptions {
 export interface AcpChatSessionController {
   createSession(
     cwd: string,
-    gooseExtensions: GooseExtension[],
+    gooseExtensions: GooseExtension[] | undefined,
     recipe?: AcpRecipeOptions
   ): Promise<Session>;
   loadSession(sessionId: string, options?: AcpLoadSessionOptions): Promise<void>;
@@ -114,7 +114,7 @@ async function forkSessionWithEditedMessage(
 
 async function createSession(
   cwd: string,
-  gooseExtensions: GooseExtension[],
+  gooseExtensions: GooseExtension[] | undefined,
   recipe?: AcpRecipeOptions
 ): Promise<Session> {
   const { sessionId, sessionInfo, meta } = await acpNewSession(cwd, gooseExtensions, recipe);

--- a/ui/desktop/src/acp/sessions.ts
+++ b/ui/desktop/src/acp/sessions.ts
@@ -235,14 +235,19 @@ export interface AcpRecipeOptions {
   recipeParameterScopeId?: string;
 }
 
+/**
+ * `gooseExtensions` is three-valued: `undefined` leaves the key out so the backend
+ * uses the configured set, while `[]` asks for a session with no extensions. The
+ * backend already distinguishes the two, so the client has to as well.
+ */
 export async function acpNewSession(
   cwd: string,
-  gooseExtensions: GooseExtension[],
+  gooseExtensions: GooseExtension[] | undefined,
   recipe?: AcpRecipeOptions
 ): Promise<AcpNewSessionResult> {
   const client = await getAcpClient();
   const meta: Record<string, unknown> = { client: 'goose-desktop' };
-  if (gooseExtensions.length > 0) {
+  if (gooseExtensions !== undefined) {
     meta.enabledExtensions = gooseExtensions;
   }
   if (recipe?.recipeId) {

--- a/ui/desktop/src/components/Hub.test.tsx
+++ b/ui/desktop/src/components/Hub.test.tsx
@@ -11,6 +11,7 @@ import { UserInput } from '../types/message';
 type ChatInputCapture = {
   draftRef?: { current: string };
   handleSubmit: (input: UserInput) => void;
+  onNextChatExtensionDraftChange?: (draft: { selectedNames: Set<string> }) => void;
 };
 
 type Session = Awaited<ReturnType<typeof createSession>>;
@@ -80,6 +81,29 @@ describe('Hub', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     captured.chatInput = null;
+  });
+
+  it('starts a chat with no extensions when the user cleared the picker', async () => {
+    vi.mocked(createSession).mockResolvedValue({ id: 'session-1' } as Session);
+    renderHub({ current: '' });
+
+    // Touching the picker is what turns "not specified" into a real choice, and
+    // clearing it is the case the composer already promises in a toast.
+    await act(async () => {
+      captured.chatInput?.onNextChatExtensionDraftChange?.({ selectedNames: new Set() });
+    });
+    await submit();
+
+    expect(createSession).toHaveBeenCalledWith('/tmp/goose', { extensionConfigs: [] });
+  });
+
+  it('leaves the set unspecified when the picker was never touched', async () => {
+    vi.mocked(createSession).mockResolvedValue({ id: 'session-1' } as Session);
+    renderHub({ current: '' });
+
+    await submit();
+
+    expect(createSession).toHaveBeenCalledWith('/tmp/goose', { allExtensions: [] });
   });
 
   it('hands the draft to the input', () => {

--- a/ui/desktop/src/components/Hub.tsx
+++ b/ui/desktop/src/components/Hub.tsx
@@ -111,13 +111,13 @@ export default function Hub({
     setIsCreatingSession(true);
 
     try {
-      const selectedExtensions = nextChatExtensionDraft
-        ? selectNextChatExtensions(extensionsList, nextChatExtensionDraft)
-        : [];
-      const sessionOptions =
-        selectedExtensions.length > 0
-          ? { extensionConfigs: selectedExtensions }
-          : { allExtensions: extensionsList };
+      // A draft exists only once the user has opened the picker, so its absence is
+      // "not specified" while an empty draft is "start with no extensions".
+      const sessionOptions = nextChatExtensionDraft
+        ? {
+            extensionConfigs: selectNextChatExtensions(extensionsList, nextChatExtensionDraft),
+          }
+        : { allExtensions: extensionsList };
 
       // Resolve the effective directory at submit time: the IPC lookup may still
       // be pending when the user submits, and an explicit pick must win.

--- a/ui/desktop/src/components/apps/StandaloneAppView.tsx
+++ b/ui/desktop/src/components/apps/StandaloneAppView.tsx
@@ -73,7 +73,8 @@ export default function StandaloneAppView() {
       }
 
       try {
-        const { sessionId: sid } = await acpNewSession(workingDir, []);
+        // This view names no extension set, so the backend uses the configured one.
+        const { sessionId: sid } = await acpNewSession(workingDir, undefined);
         setSessionId(sid);
         setLoading(false);
       } catch (err) {

--- a/ui/desktop/src/sessions.ts
+++ b/ui/desktop/src/sessions.ts
@@ -1,5 +1,6 @@
 import type { Session } from './types/session';
 import type { ExtensionConfig } from './types/extensions';
+import type { GooseExtension } from '@aaif/goose-acp-client';
 import type { setViewType } from './hooks/useNavigation';
 import type { FixedExtensionEntry } from './components/ConfigContext';
 import { AppEvents } from './constants/events';
@@ -26,19 +27,44 @@ interface CreateSessionOptions {
   allExtensions?: FixedExtensionEntry[];
 }
 
-function selectedExtensionConfigs(options?: CreateSessionOptions): ExtensionConfig[] {
-  if (options?.extensionConfigs && options.extensionConfigs.length > 0) {
+/**
+ * Three-valued on purpose. `undefined` means the caller is not naming a set and the
+ * backend should use the configured one; `[]` means the user asked for a session with
+ * no extensions at all. Collapsing the two is what made an all-off selection come back
+ * with the default extensions.
+ */
+function selectedExtensionConfigs(options?: CreateSessionOptions): ExtensionConfig[] | undefined {
+  if (options?.extensionConfigs) {
     return options.extensionConfigs;
   }
   if (options?.allExtensions) {
-    return options.allExtensions
+    const enabled = options.allExtensions
       .filter((extension) => extension.enabled)
       .map((extension) => {
         const { enabled: _enabled, ...config } = extension;
         return config as ExtensionConfig;
       });
+    // An empty configured list is also what this looks like before the config
+    // finishes loading, so it stays "not specified" rather than becoming an
+    // explicit empty selection. Only `extensionConfigs` can express that.
+    return enabled.length > 0 ? enabled : undefined;
   }
-  return [];
+  return undefined;
+}
+
+async function resolveGooseExtensions(
+  selected: ExtensionConfig[] | undefined
+): Promise<GooseExtension[] | undefined> {
+  if (selected === undefined) {
+    return undefined;
+  }
+  if (selected.length === 0) {
+    return [];
+  }
+  const selectedNames = new Set(selected.map((config) => config.name));
+  return (await getConfiguredGooseExtensions())
+    .filter((entry) => selectedNames.has(gooseExtensionName(entry.extension)))
+    .map((entry) => entry.extension);
 }
 
 async function createAcpSession(
@@ -55,13 +81,7 @@ async function createAcpSession(
         throw new RecipeParameterScopesUnsupportedError();
       }
     }
-    const selectedNames = new Set(selectedExtensionConfigs(options).map((config) => config.name));
-    const gooseExtensions =
-      selectedNames.size > 0
-        ? (await getConfiguredGooseExtensions())
-            .filter((entry) => selectedNames.has(gooseExtensionName(entry.extension)))
-            .map((entry) => entry.extension)
-        : [];
+    const gooseExtensions = await resolveGooseExtensions(selectedExtensionConfigs(options));
     return await acpChatSessionController.createSession(workingDir, gooseExtensions, {
       recipeId: options?.recipeId,
       recipeDeeplink: options?.recipeDeeplink,


### PR DESCRIPTION
## Description

The composer already lets a user turn every extension off, and each toggle confirms it with a toast that says the extension "will be disabled in new chats". The choice was then discarded on the way to the request, so the new chat came up with the configured extensions anyway - and, with none of them visible, with the hidden Scheduler platform extension.

An empty selection was collapsed into "not specified" in three places:

- `Hub.tsx:117` sent `{ allExtensions }` whenever the selection was empty, which is also what it sends when the picker was never opened
- `selectedExtensionConfigs` in `sessions.ts:30` ignored `extensionConfigs` unless it was non-empty
- `acpNewSession` in `acp/sessions.ts:245` only wrote `enabledExtensions` for a non-empty list

The backend already distinguishes the two: an absent key falls back to the configured set, and an empty array is an explicit selection. This carries the same distinction on the client, as `ExtensionConfig[] | undefined`, from the composer to the request.

Two details worth calling out:

- an empty **configured** list stays "not specified" rather than becoming an explicit empty selection, because that is also what the list looks like before `ConfigContext` finishes loading, and an early submit should not silently start a session with no extensions
- `StandaloneAppView` passed `[]` literally. It names no set of its own, so it now passes `undefined` and keeps its current behaviour

## Related Issue

Part of #11573

## Verification

`pnpm lint:check` and `pnpm test:run` in `ui/desktop`. The one failure in the suite is `githubUpdater.target.test.ts`, which fails on Windows regardless of this change: it sets `process.platform` to `darwin` but compares against POSIX path literals while `path` stays win32.

New tests, each red before the corresponding change and green after:

- `Hub.test.tsx` - a cleared picker starts the chat with `extensionConfigs: []`, and an untouched picker leaves the set unspecified
- `acp/__tests__/sessions.test.ts` - `[]` writes `enabledExtensions: []` into `_meta`, `undefined` omits the key
- `__tests__/createSession.test.ts` - an explicitly empty selection survives as `[]`; an empty or still-loading configured list stays unspecified

Three existing tests changed, because they pinned the behaviour this fixes:

- "falls back to enabled configured extensions when extension configs are empty" asserted that an explicitly empty selection falls back. That is the bug, one layer up, so it is now "sends an explicitly empty selection as an empty list".
- "omits ACP session extensions when no configured extensions are enabled" and the recipe-deeplink test both expected `[]` to reach the controller for the unspecified case; they now expect `undefined`.

## What this does not change

Per the discussion on the issue, the server precedence stays as it is: `enabledExtensions` is an explicit selection, so the request's `mcpServers` are ignored when it is present. No server-side change is included here.

## Checklist

- [x] Tests added/updated
- [x] Linter passes
- [x] Commits signed off (DCO)
