### PR TITLE
Add Zovo Time Tracker to the extensions directory

### DIFF
--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -783,6 +783,26 @@
     "environmentVariables": []
   },
   {
+    "id": "zovo-time-tracker",
+    "name": "Zovo Time Tracker",
+    "description": "Track billable time from chat: start and stop timers, log entries, run reports and export CSV or invoice lines",
+    "url": "https://mcp.zovo.one/mcp/time-tracker",
+    "link": "https://github.com/theluckystrike/mcp-time-tracker",
+    "installation_notes": "This is a remote extension. It needs an Authorization header. Get a free anonymous token with `curl https://mcp.zovo.one/mcp/token` (no account, no card, no email) and pass it as `Authorization: Bearer <token>`.",
+    "is_builtin": false,
+    "endorsed": false,
+    "environmentVariables": [],
+    "headers": [
+      {
+        "name": "Authorization",
+        "description": "Bearer <free token from https://mcp.zovo.one/mcp/token>",
+        "required": true
+      }
+    ],
+    "show_install_command": false,
+    "type": "streamable-http"
+  },
+  {
     "id": "neighborhood",
     "name": "Neighborhood",
     "description": "Discover nearby restaurants, browse menus, and place takeout orders through natural conversation. Sellers are US-based.",

--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -788,7 +788,7 @@
     "description": "Track billable time from chat: start and stop timers, log entries, run reports and export CSV or invoice lines",
     "url": "https://mcp.zovo.one/mcp/time-tracker",
     "link": "https://github.com/theluckystrike/mcp-time-tracker",
-    "installation_notes": "This is a remote extension. It needs an Authorization header. Get a free anonymous token with `curl https://mcp.zovo.one/mcp/token` (no account, no card, no email) and pass it as `Authorization: Bearer <token>`.",
+    "installation_notes": "This is a remote extension. It needs an Authorization header. Open https://mcp.zovo.one/mcp/connect in a browser to mint a free anonymous token, or run `curl https://mcp.zovo.one/mcp/token` — no account, no card, no email either way. Pass it as `Authorization: Bearer <token>`.",
     "is_builtin": false,
     "endorsed": false,
     "environmentVariables": [],


### PR DESCRIPTION
Adds one MCP server to `documentation/static/servers.json`: **Zovo Time Tracker**.

- Endpoint: `https://mcp.zovo.one/mcp/time-tracker` (streamable-http, MCP protocol 2025-06-18)
- Source: https://github.com/theluckystrike/mcp-time-tracker (MIT)

It follows the shape of the existing `rendex-mcp` entry: a remote extension with an
`Authorization` header. The difference is that the token is free and needs no account
and no card — `curl https://mcp.zovo.one/mcp/token` returns an anonymous bearer token
immediately.

Verified before opening this PR:

```
$ curl -s https://mcp.zovo.one/mcp/token | jq -r .token
anon_...
$ curl -s -X POST https://mcp.zovo.one/mcp/time-tracker \
    -H "Authorization: Bearer $TOKEN" \
    -H "Content-Type: application/json" \
    -H "Accept: application/json, text/event-stream" \
    -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"probe","version":"1"}}}'
{"result":{"protocolVersion":"2025-06-18","capabilities":{"tools":{"listChanged":true},...},
  "serverInfo":{"name":"mcp-time-tracker","version":"0.21.0"}},"jsonrpc":"2.0","id":1}
```

`python3 -c "import json;json.load(open('documentation/static/servers.json'))"` parses
clean, and the entry is inserted in the existing alphabetical position.

One server per PR — I have two sibling servers and opened them separately rather than
batching them into this one. Happy to close any of them if you would rather the
directory took just one.
