### PR TITLE
feat(providers): add DaoXE as a declarative OpenAI-compatible provider

### DIFF
--- a/crates/goose-providers/src/declarative.rs
+++ b/crates/goose-providers/src/declarative.rs
@@ -17,6 +17,7 @@ pub(crate) mod declarative_providers {
         alibaba,
         atomic_chat,
         cerebras,
+        daoxe,
         deepseek,
         empiriolabs,
         fireworks,

--- a/crates/goose-providers/src/declarative/definitions/daoxe.json
+++ b/crates/goose-providers/src/declarative/definitions/daoxe.json
@@ -1,0 +1,55 @@
+{
+  "name": "daoxe",
+  "engine": "openai",
+  "display_name": "DaoXE",
+  "description": "Hundreds of models from roughly 25 providers behind one OpenAI-compatible API key, plus a native Anthropic Messages surface for Claude-native tools. The live catalog is account-scoped and drifts as providers ship, so the model list here is only a fallback — goose pulls the current one from GET /models when you first connect. Not available in mainland China.",
+  "api_key_env": "DAOXE_API_KEY",
+  "base_url": "https://daoxe.com/v1",
+  "catalog_provider_id": "daoxe",
+  "dynamic_models": true,
+  "models": [
+    {
+      "name": "gpt-5.4",
+      "context_limit": 1050000
+    },
+    {
+      "name": "gpt-5.5",
+      "context_limit": 1050000
+    },
+    {
+      "name": "claude-opus-4-8",
+      "context_limit": 1000000
+    },
+    {
+      "name": "claude-sonnet-4-6",
+      "context_limit": 1000000
+    },
+    {
+      "name": "claude-haiku-4-5-20251001",
+      "context_limit": 200000
+    },
+    {
+      "name": "gemini-3.1-pro-preview",
+      "context_limit": 1048576
+    },
+    {
+      "name": "grok-4.3",
+      "context_limit": 1000000
+    },
+    {
+      "name": "grok-4.5",
+      "context_limit": 500000
+    },
+    {
+      "name": "kimi-k2.5",
+      "context_limit": 262144
+    }
+  ],
+  "supports_streaming": true,
+  "model_doc_link": "https://daoxe.com/pricing",
+  "setup_steps": [
+    "Sign up at https://daoxe.com (GitHub, Telegram or Passkey)",
+    "Create an API key in the console",
+    "Paste the key above as DAOXE_API_KEY — run /models in goose to list what your account carries"
+  ]
+}


### PR DESCRIPTION
# feat(providers): add DaoXE as a declarative OpenAI-compatible provider

## What this adds

A new declarative provider definition at
`crates/goose-providers/src/declarative/definitions/daoxe.json`, following the same
schema as the existing 46 definitions (modeled on `aimlapi.json` and `celeris.json`).

## Disclosure

I maintain DaoXE, the OpenAI-compatible gateway this definition adds — same disclosure
shape as the AIML API integration (#11758) and "I operate this endpoint" in #11891.

## Provider shape

- **Engine**: `openai` — the gateway is OpenAI-wire-compatible at `https://daoxe.com/v1`.
- **`dynamic_models: true`**: the live catalog is account-scoped and drifts as upstream
  providers ship, so goose pulls the current list via `GET /models` on connect. The
  static `models` array exists only as a fallback (9 entries sourced from the
  [models.dev public catalog](https://models.dev/api.json), which already indexes the
  gateway) — not as an authoritative list.
- **`supports_streaming: true`**, standard Bearer auth via `DAOXE_API_KEY`.
- `model_doc_link` points at the provider's pricing page, where per-model rates live
  (rates are account-scoped and change, so no figures are embedded here).

## Scope note

The gateway also exposes a native Anthropic Messages surface (`/v1/messages`) for
Claude-native clients. That is a separate wire protocol from the OpenAI engine this
schema covers, so it is deliberately **not** claimed in this definition — if a native
Anthropic engine provider slot makes sense later, that would be its own change.

## Verification

- All 9 fallback model ids and context limits cross-checked against the live
  [models.dev api.json](https://models.dev/api.json) `daoxe` entry (name + context
  limit match exactly; models.dev is the same registry that generates this repo's
  `provider_metadata.json`).
- The JSON parses against `DeclarativeProviderConfig` / `ModelInfo` field names
  (`context_limit` only — no `max_output_tokens`, which is not a `ModelInfo` field);
  provider id `daoxe` is in both the definitions dir and the `expose_declarative_providers!`
  macro list, so `expose_declarative_providers_enumerates_all_bundled_json_files` and
  `all_bundled_providers_are_valid` pass (CI green on this PR).
- The `dynamic_models: true` path needs a live key, so the `/models` fetch was not
  exercised in CI; the fallback list guarantees non-empty model results if the fetch
  fails.

### Related Issues
None — the recently merged provider additions (#11589, #11422, #10939, #11758) set the
precedent for direct declarative-definition PRs.
