### PR TITLE
feat(desktop): external backend improvements (combined stack #11828-#11832)

### DIFF
--- a/ui/desktop/src/App.tsx
+++ b/ui/desktop/src/App.tsx
@@ -12,6 +12,7 @@ import TelemetryConsentPrompt from './components/TelemetryConsentPrompt';
 import OnboardingGuard from './components/onboarding/OnboardingGuard';
 import { createSession } from './sessions';
 import { acpListSessions, acpDeleteSession } from './acp/sessions';
+import { acpChatSessionActions } from './acp/chatSessionStore';
 
 import { ChatType } from './types/chat';
 import Hub from './components/Hub';
@@ -46,7 +47,7 @@ import { View, ViewOptions } from './utils/navigationUtils';
 
 import { useNavigation } from './hooks/useNavigation';
 import { errorMessage } from './utils/conversionUtils';
-import { getInitialWorkingDir } from './utils/workingDir';
+import { getInitialWorkingDir, refreshWorkingDir } from './utils/workingDir';
 import { usePageViewTracking } from './hooks/useAnalytics';
 import { trackErrorWithContext } from './utils/analytics';
 import { AppEvents } from './constants/events';
@@ -111,7 +112,7 @@ export const PairRouteWrapper = ({
 
       (async () => {
         try {
-          const newSession = await createSession(getInitialWorkingDir(), {
+          const newSession = await createSession(await refreshWorkingDir(), {
             recipeDeeplink: recipeDeeplinkFromConfig,
             recipeId: recipeIdFromConfig,
             allExtensions: extensionsList,
@@ -380,13 +381,24 @@ export function AppInner() {
       });
     };
 
+    const handleBackendSwitched = () => {
+      setActiveSessions((prev) => {
+        for (const session of prev) {
+          acpChatSessionActions.deleteSnapshot(session.sessionId);
+        }
+        return [];
+      });
+    };
+
     window.addEventListener(AppEvents.ADD_ACTIVE_SESSION, handleAddActiveSession);
     window.addEventListener(AppEvents.CLEAR_INITIAL_MESSAGE, handleClearInitialMessage);
     window.addEventListener(AppEvents.SESSION_DELETED, handleSessionDeleted);
+    window.addEventListener(AppEvents.BACKEND_SWITCHED, handleBackendSwitched);
     return () => {
       window.removeEventListener(AppEvents.ADD_ACTIVE_SESSION, handleAddActiveSession);
       window.removeEventListener(AppEvents.CLEAR_INITIAL_MESSAGE, handleClearInitialMessage);
       window.removeEventListener(AppEvents.SESSION_DELETED, handleSessionDeleted);
+      window.removeEventListener(AppEvents.BACKEND_SWITCHED, handleBackendSwitched);
     };
   }, []);
 

--- a/ui/desktop/src/acp/acpConnection.ts
+++ b/ui/desktop/src/acp/acpConnection.ts
@@ -16,6 +16,7 @@ import {
 } from './gooseAcpClient';
 import { requestAcpPermission } from './permissionRequests';
 import { requestAcpRecipeParams } from './recipeParamRequests';
+import { AppEvents } from '../constants/events';
 
 type AcpConnection = {
   client: GooseAcpClient;
@@ -45,6 +46,16 @@ export async function getAcpInitializeResponse(): Promise<InitializeResponse> {
 
 export function reconnectAcpAfterSystemResume(): void {
   recoverConnection(true);
+}
+
+export function reconnectAcpToNewBackend(): void {
+  connectionGeneration += 1;
+  const previousConnection = currentConnection;
+  currentConnection = null;
+  pendingConnection = null;
+  setRecovering(false);
+  previousConnection?.client.connection.close();
+  window.dispatchEvent(new CustomEvent(AppEvents.BACKEND_SWITCHED));
 }
 
 export function isAcpRecovering(): boolean {

--- a/ui/desktop/src/backendProbe.ts
+++ b/ui/desktop/src/backendProbe.ts
@@ -1,0 +1,81 @@
+import { WebContentsView } from 'electron';
+
+// Chromium only runs client certificate selection for WebContents-originated
+// requests, so mTLS backends are unreachable from main-process net.fetch. Probes
+// go through an offscreen view on the renderer partition to share the network
+// path the ACP WebSocket uses. A WebContentsView is not a window, so it does not
+// affect the window-all-closed lifecycle.
+const PROBE_PARTITION = 'persist:goose';
+
+type ProbeResult =
+  | { ok: true; status: number; statusText: string; url: string; headers: [string, string][] }
+  | { ok: false; message: string };
+
+let probeView: WebContentsView | null = null;
+
+const getProbeView = async (): Promise<WebContentsView> => {
+  if (probeView && !probeView.webContents.isDestroyed()) {
+    return probeView;
+  }
+
+  probeView = new WebContentsView({
+    webPreferences: { partition: PROBE_PARTITION, nodeIntegration: false, contextIsolation: true },
+  });
+  await probeView.webContents.loadURL('data:text/html,<title>goose backend probe</title>');
+  return probeView;
+};
+
+type FetchInit = NonNullable<Parameters<typeof globalThis.fetch>[1]>;
+
+const rejectOnAbort = (signal: NonNullable<FetchInit['signal']>): Promise<never> =>
+  new Promise((_resolve, reject) => {
+    signal.addEventListener('abort', () => reject(new Error('Probe request timed out.')), {
+      once: true,
+    });
+  });
+
+export const probeFetch: typeof globalThis.fetch = async (input, init) => {
+  const view = await getProbeView();
+  const request = JSON.stringify({
+    url: String(input),
+    headers: (init?.headers as Record<string, string> | undefined) ?? {},
+  });
+
+  const probe = view.webContents.executeJavaScript(`
+    (async () => {
+      const request = ${request};
+      try {
+        const response = await fetch(request.url, { headers: request.headers });
+        return {
+          ok: true,
+          status: response.status,
+          statusText: response.statusText,
+          url: response.url,
+          headers: [...response.headers.entries()],
+        };
+      } catch (error) {
+        return { ok: false, message: String((error && error.message) || error) };
+      }
+    })()
+  `) as Promise<ProbeResult>;
+
+  const result: ProbeResult = await (init?.signal
+    ? Promise.race([probe, rejectOnAbort(init.signal)])
+    : probe);
+  if (result.ok !== true) {
+    throw new Error(result.message);
+  }
+
+  return {
+    ok: result.status >= 200 && result.status < 300,
+    status: result.status,
+    statusText: result.statusText,
+    url: result.url,
+    headers: new globalThis.Headers(result.headers),
+  } as Response;
+};
+
+export const closeBackendProbe = (): void => {
+  probeView?.webContents.close();
+  probeView = null;
+};

--- a/ui/desktop/src/backendStatus.test.ts
+++ b/ui/desktop/src/backendStatus.test.ts
@@ -41,6 +41,35 @@ describe('checkBackendStatus', () => {
     ]);
   });
 
+  it('derives the resolved base URL from the redirected /acp probe', async () => {
+    const fetch = vi.fn(async (input: FetchInput) => {
+      const url = fetchInputUrl(input);
+      if (url === 'https://example.com/status') {
+        const response = new Response(null, { status: 200 });
+        Object.defineProperty(response, 'url', { value: 'https://backend.example.com/status' });
+        return response;
+      }
+      if (url === 'https://backend.example.com/acp?token=test-secret') {
+        const response = new Response(null, { status: 406 });
+        Object.defineProperty(response, 'url', {
+          value: 'https://backend.example.com/goose/acp?token=test-secret',
+        });
+        return response;
+      }
+
+      throw new Error(`Unexpected URL: ${url}`);
+    });
+
+    const result = await checkBackendStatus({
+      baseUrl: 'https://example.com',
+      serverSecret: 'test-secret',
+      fetch,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.resolvedBaseUrl).toBe('https://backend.example.com/goose');
+  });
+
   it('reports the rejected secret without retrying', async () => {
     const fetch = vi.fn(async (input: FetchInput) => {
       const url = fetchInputUrl(input);

--- a/ui/desktop/src/backendStatus.ts
+++ b/ui/desktop/src/backendStatus.ts
@@ -21,6 +21,7 @@ export interface BackendCheckResult {
   ok: boolean;
   steps: BackendCheckStep[];
   failure: string | null;
+  resolvedBaseUrl: string | null;
 }
 
 export interface BackendCheckParams {
@@ -34,6 +35,7 @@ interface Probe {
   ok: boolean;
   detail: string;
   retryable: boolean;
+  resolvedBaseUrl?: string;
 }
 
 const delay = (timeoutMs: number): Promise<void> =>
@@ -41,6 +43,17 @@ const delay = (timeoutMs: number): Promise<void> =>
 
 const errorText = (error: unknown): string =>
   error instanceof Error ? error.message : String(error);
+
+const baseUrlFromStatusUrl = (statusUrl: string): string | undefined => {
+  try {
+    const url = new URL(statusUrl);
+    return url.pathname.endsWith('/status')
+      ? `${url.origin}${url.pathname.slice(0, -'/status'.length)}`
+      : undefined;
+  } catch {
+    return undefined;
+  }
+};
 
 const proxyNote = (response: Response): string => {
   const doormanError = response.headers.get('x-sq-cf-doorman-error');
@@ -78,7 +91,12 @@ const probeStatus = (
     { headers: { 'X-Secret-Key': secret } },
     (response) =>
       response.ok
-        ? { ok: true, detail: `GET /status returned ${response.status}.`, retryable: false }
+        ? {
+            ok: true,
+            detail: `GET /status returned ${response.status}.`,
+            retryable: false,
+            resolvedBaseUrl: baseUrlFromStatusUrl(response.url),
+          }
         : {
             ok: false,
             detail: `GET /status returned ${response.status} ${response.statusText}.${proxyNote(response)}`,
@@ -119,7 +137,7 @@ export const checkBackendStatus = async ({
 }: BackendCheckParams): Promise<BackendCheckResult> => {
   const steps: BackendCheckStep[] = [];
 
-  const run = async (name: string, probe: () => Promise<Probe>): Promise<boolean> => {
+  const run = async (name: string, probe: () => Promise<Probe>): Promise<Probe> => {
     const deadline = Date.now() + RETRY_BUDGET_MS;
     let result = await probe();
     while (
@@ -132,7 +150,7 @@ export const checkBackendStatus = async ({
       result = await probe();
     }
     steps.push({ name, ok: result.ok, detail: result.detail });
-    return result.ok;
+    return result;
   };
 
   let normalizedBaseUrl = '';
@@ -143,12 +161,17 @@ export const checkBackendStatus = async ({
     steps.push({ name: 'URL', ok: false, detail: errorText(error) });
   }
 
+  let resolvedBaseUrl = normalizedBaseUrl || null;
   if (normalizedBaseUrl) {
     const reachable = await run('Reachable', () =>
       probeStatus(fetch, normalizedBaseUrl, serverSecret)
     );
-    if (reachable) {
-      await run('Secret key', () => probeSecret(fetch, normalizedBaseUrl, serverSecret));
+    if (reachable.ok) {
+      resolvedBaseUrl = reachable.resolvedBaseUrl ?? normalizedBaseUrl;
+      if (resolvedBaseUrl !== normalizedBaseUrl) {
+        steps.push({ name: 'Redirect', ok: true, detail: `Followed to ${resolvedBaseUrl}.` });
+      }
+      await run('Secret key', () => probeSecret(fetch, resolvedBaseUrl!, serverSecret));
     }
   }
 
@@ -157,5 +180,6 @@ export const checkBackendStatus = async ({
     ok: !failed,
     steps,
     failure: failed ? `${failed.name}: ${failed.detail}`.trim() : null,
+    resolvedBaseUrl: failed ? null : resolvedBaseUrl,
   };
 };

--- a/ui/desktop/src/backendStatus.ts
+++ b/ui/desktop/src/backendStatus.ts
@@ -44,11 +44,14 @@ const delay = (timeoutMs: number): Promise<void> =>
 const errorText = (error: unknown): string =>
   error instanceof Error ? error.message : String(error);
 
-const baseUrlFromStatusUrl = (statusUrl: string): string | undefined => {
+const baseUrlFromEndpointUrl = (
+  endpointUrl: string,
+  endpoint: '/status' | '/acp'
+): string | undefined => {
   try {
-    const url = new URL(statusUrl);
-    return url.pathname.endsWith('/status')
-      ? `${url.origin}${url.pathname.slice(0, -'/status'.length)}`
+    const url = new URL(endpointUrl);
+    return url.pathname.endsWith(endpoint)
+      ? `${url.origin}${url.pathname.slice(0, -endpoint.length)}`
       : undefined;
   } catch {
     return undefined;
@@ -95,7 +98,7 @@ const probeStatus = (
             ok: true,
             detail: `GET /status returned ${response.status}.`,
             retryable: false,
-            resolvedBaseUrl: baseUrlFromStatusUrl(response.url),
+            resolvedBaseUrl: baseUrlFromEndpointUrl(response.url, '/status'),
           }
         : {
             ok: false,
@@ -111,7 +114,12 @@ const probeSecret = (
 ): Promise<Probe> =>
   request(fetch, acpHttpUrlFromHttpBase(baseUrl, secret), {}, (response) => {
     if (response.status === 406) {
-      return { ok: true, detail: 'The backend accepted the secret key.', retryable: false };
+      return {
+        ok: true,
+        detail: 'The backend accepted the secret key.',
+        retryable: false,
+        resolvedBaseUrl: baseUrlFromEndpointUrl(response.url, '/acp'),
+      };
     }
     if (response.status === 401 || response.status === 403) {
       return {
@@ -167,11 +175,14 @@ export const checkBackendStatus = async ({
       probeStatus(fetch, normalizedBaseUrl, serverSecret)
     );
     if (reachable.ok) {
-      resolvedBaseUrl = reachable.resolvedBaseUrl ?? normalizedBaseUrl;
-      if (resolvedBaseUrl !== normalizedBaseUrl) {
+      const statusBaseUrl = reachable.resolvedBaseUrl ?? normalizedBaseUrl;
+      const accepted = await run('Secret key', () =>
+        probeSecret(fetch, statusBaseUrl, serverSecret)
+      );
+      resolvedBaseUrl = accepted.resolvedBaseUrl ?? statusBaseUrl;
+      if (accepted.ok && resolvedBaseUrl !== normalizedBaseUrl) {
         steps.push({ name: 'Redirect', ok: true, detail: `Followed to ${resolvedBaseUrl}.` });
       }
-      await run('Secret key', () => probeSecret(fetch, resolvedBaseUrl!, serverSecret));
     }
   }
 

--- a/ui/desktop/src/components/Hub.test.tsx
+++ b/ui/desktop/src/components/Hub.test.tsx
@@ -34,7 +34,7 @@ vi.mock('../sessions', () => ({ createSession: vi.fn() }));
 
 vi.mock('../utils/workingDir', () => ({
   getInitialWorkingDir: () => '/tmp/goose',
-  getEffectiveWorkingDir: () => Promise.resolve('/tmp/goose'),
+  refreshWorkingDir: () => Promise.resolve('/tmp/goose'),
 }));
 
 vi.mock('../utils/nextChatExtensions', () => ({

--- a/ui/desktop/src/components/Hub.tsx
+++ b/ui/desktop/src/components/Hub.tsx
@@ -16,7 +16,7 @@ import { ChatState } from '../types/chatState';
 import 'react-toastify/dist/ReactToastify.css';
 import { View, ViewOptions } from '../utils/navigationUtils';
 import { useConfig } from './ConfigContext';
-import { getEffectiveWorkingDir, getInitialWorkingDir } from '../utils/workingDir';
+import { getInitialWorkingDir, refreshWorkingDir } from '../utils/workingDir';
 import { createSession } from '../sessions';
 import LoadingGoose from './LoadingGoose';
 import { UserInput } from '../types/message';
@@ -63,11 +63,11 @@ export default function Hub({
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const { time, meridiem, hour } = useClock();
 
-  // Re-resolve the working dir on mount: GOOSE_WORKING_DIR is fixed at window
-  // creation, so a configured remote directory may have changed since then.
+  // Re-resolve the working dir on mount: the window's backend lease is the
+  // authority and may differ from the value baked in at window creation.
   useEffect(() => {
     let active = true;
-    void getEffectiveWorkingDir().then((dir) => {
+    void refreshWorkingDir().then((dir) => {
       if (active && !userSelectedWorkingDirRef.current) setWorkingDir(dir);
     });
     return () => {
@@ -121,7 +121,7 @@ export default function Hub({
 
       // Resolve the effective directory at submit time: the IPC lookup may still
       // be pending when the user submits, and an explicit pick must win.
-      const dir = userSelectedWorkingDirRef.current ? workingDir : await getEffectiveWorkingDir();
+      const dir = userSelectedWorkingDirRef.current ? workingDir : await refreshWorkingDir();
       const session = await createSession(dir, sessionOptions);
       setNextChatExtensionDraft(null);
 

--- a/ui/desktop/src/components/onboarding/OnboardingGuard.tsx
+++ b/ui/desktop/src/components/onboarding/OnboardingGuard.tsx
@@ -15,6 +15,8 @@ import {
   setTelemetryEnabled as setAnalyticsTelemetryEnabled,
 } from '../../utils/analytics';
 import { defineMessages, useIntl } from '../../i18n';
+import { reconnectAcpToNewBackend } from '../../acp/acpConnection';
+import { setWorkingDir } from '../../utils/workingDir';
 
 const i18n = defineMessages({
   welcomeTitle: {
@@ -37,6 +39,18 @@ const i18n = defineMessages({
     id: 'onboardingGuard.retry',
     defaultMessage: 'Retry',
   },
+  externalBackendErrorTitle: {
+    id: 'onboardingGuard.externalBackendErrorTitle',
+    defaultMessage: 'Unable to connect to the external backend',
+  },
+  switchToLocal: {
+    id: 'onboardingGuard.switchToLocal',
+    defaultMessage: 'Switch to Local',
+  },
+  retrying: {
+    id: 'onboardingGuard.retrying',
+    defaultMessage: 'Retrying…',
+  },
 });
 
 const TELEMETRY_CONFIG_KEY = 'GOOSE_TELEMETRY_ENABLED';
@@ -44,6 +58,9 @@ const TELEMETRY_CONFIG_KEY = 'GOOSE_TELEMETRY_ENABLED';
 interface OnboardingGuardProps {
   children: React.ReactNode;
 }
+
+const initialExternalBackendError = (): string =>
+  (window.appConfig?.get('GOOSE_EXTERNAL_BACKEND_ERROR') as string) ?? '';
 
 export default function OnboardingGuard({ children }: OnboardingGuardProps) {
   const intl = useIntl();
@@ -61,6 +78,8 @@ export default function OnboardingGuard({ children }: OnboardingGuardProps) {
   );
   const [configuredModel, setConfiguredModel] = useState<string | null>(null);
   const hasTrackedOnboardingStart = useRef(false);
+  const [externalBackendError, setExternalBackendError] = useState(initialExternalBackendError);
+  const [isRetrying, setIsRetrying] = useState(false);
 
   const checkProvider = async (retries = 3, delay = 1000) => {
     setIsCheckingProvider(true);
@@ -106,7 +125,12 @@ export default function OnboardingGuard({ children }: OnboardingGuardProps) {
   }, []);
 
   useEffect(() => {
-    if (!isCheckingProvider && !hasProvider && !checkProviderError && !hasTrackedOnboardingStart.current) {
+    if (
+      !isCheckingProvider &&
+      !hasProvider &&
+      !checkProviderError &&
+      !hasTrackedOnboardingStart.current
+    ) {
       trackOnboardingStarted();
       hasTrackedOnboardingStart.current = true;
     }
@@ -141,6 +165,66 @@ export default function OnboardingGuard({ children }: OnboardingGuardProps) {
     setHasProvider(true);
   };
 
+  const retryExternalBackend = async () => {
+    setIsRetrying(true);
+    try {
+      const result = await window.electron.switchBackend();
+      if (!result.ok) {
+        setExternalBackendError(result.error ?? 'Unknown error');
+        return;
+      }
+      setWorkingDir(result.workingDir ?? null);
+      reconnectAcpToNewBackend();
+      setExternalBackendError('');
+      await checkProvider();
+    } finally {
+      setIsRetrying(false);
+    }
+  };
+
+  const switchToLocalBackend = async () => {
+    setIsRetrying(true);
+    try {
+      const result = await window.electron.disconnectBackend();
+      if (!result.ok) {
+        setExternalBackendError(result.error ?? 'Unknown error');
+        return;
+      }
+      setWorkingDir(result.workingDir ?? null);
+      reconnectAcpToNewBackend();
+      setExternalBackendError('');
+      await checkProvider();
+    } finally {
+      setIsRetrying(false);
+    }
+  };
+
+  if (externalBackendError) {
+    return (
+      <div className="h-screen w-full bg-background-default flex flex-col items-center justify-center">
+        <div className="text-center max-w-md">
+          <div className="mb-4">
+            <Goose className="size-8 mx-auto" />
+          </div>
+          <h1 className="text-xl font-light mb-3">
+            {intl.formatMessage(i18n.externalBackendErrorTitle)}
+          </h1>
+          <p className="text-text-muted mb-6 whitespace-pre-line break-words">
+            {externalBackendError}
+          </p>
+          <div className="flex items-center justify-center gap-2">
+            <Button onClick={retryExternalBackend} disabled={isRetrying}>
+              {intl.formatMessage(isRetrying ? i18n.retrying : i18n.retry)}
+            </Button>
+            <Button variant="outline" onClick={switchToLocalBackend} disabled={isRetrying}>
+              {intl.formatMessage(i18n.switchToLocal)}
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   if (isCheckingProvider) {
     return null;
   }
@@ -152,11 +236,13 @@ export default function OnboardingGuard({ children }: OnboardingGuardProps) {
           <div className="mb-4">
             <Goose className="size-8 mx-auto" />
           </div>
-          <h1 className="text-xl font-light mb-3">{intl.formatMessage(i18n.checkProviderErrorTitle)}</h1>
-          <p className="text-text-muted mb-6">{intl.formatMessage(i18n.checkProviderErrorDescription)}</p>
-          <Button onClick={() => checkProvider()}>
-            {intl.formatMessage(i18n.retry)}
-          </Button>
+          <h1 className="text-xl font-light mb-3">
+            {intl.formatMessage(i18n.checkProviderErrorTitle)}
+          </h1>
+          <p className="text-text-muted mb-6">
+            {intl.formatMessage(i18n.checkProviderErrorDescription)}
+          </p>
+          <Button onClick={() => checkProvider()}>{intl.formatMessage(i18n.retry)}</Button>
         </div>
       </div>
     );
@@ -185,7 +271,9 @@ export default function OnboardingGuard({ children }: OnboardingGuardProps) {
               <div className="mb-4">
                 <Goose className="size-8" />
               </div>
-              <h1 className="text-2xl sm:text-4xl font-light mb-3">{intl.formatMessage(i18n.welcomeTitle)}</h1>
+              <h1 className="text-2xl sm:text-4xl font-light mb-3">
+                {intl.formatMessage(i18n.welcomeTitle)}
+              </h1>
               <p className="text-text-muted text-base sm:text-lg">
                 {intl.formatMessage(i18n.welcomeDescription)}
               </p>

--- a/ui/desktop/src/components/sessions/SessionListView.tsx
+++ b/ui/desktop/src/components/sessions/SessionListView.tsx
@@ -492,6 +492,20 @@ const SessionListView: React.FC<SessionListViewProps> = React.memo(({ onSelectSe
     };
   }, [loadSessions, debouncedSearchTerm, includeAcpSessions]);
 
+  // Sessions belong to the backend that served them, so drop the old list and
+  // reload from the new one.
+  useEffect(() => {
+    const handleBackendSwitched = () => {
+      loadGenerationRef.current += 1;
+      hasLoadedRef.current = false;
+      setSessions([]);
+      void loadSessions();
+    };
+
+    window.addEventListener(AppEvents.BACKEND_SWITCHED, handleBackendSwitched);
+    return () => window.removeEventListener(AppEvents.BACKEND_SWITCHED, handleBackendSwitched);
+  }, [loadSessions]);
+
   // Hide Nostr sharing when explicitly disabled via env var (restricted/enterprise bundles)
   useEffect(() => {
     const config = window.electron.getConfig();
@@ -1045,54 +1059,56 @@ const SessionListView: React.FC<SessionListViewProps> = React.memo(({ onSelectSe
           visibleGroupsCount >= activeDateGroups.length &&
           memoizedScheduledDateGroups.length > 0 && (
             <div className="space-y-4">
-            <button
-              onClick={() => setIsScheduledExpanded((v) => !v)}
-              aria-expanded={isScheduledExpanded}
-              aria-controls="scheduled-job-sessions"
-              className="sticky top-0 z-10 w-full flex items-center justify-between bg-background-primary/95 backdrop-blur-sm py-2 px-1 rounded-lg hover:bg-background-secondary transition-colors cursor-pointer"
-            >
-              <div className="flex items-center gap-2">
-                <Clock className="w-4 h-4 text-text-secondary" />
-                <h2 className="text-text-secondary font-medium">
-                  {intl.formatMessage(i18n.scheduledJobs)}
-                </h2>
-                <span className="text-xs text-text-tertiary bg-background-secondary px-2 py-0.5 rounded-full">
-                  {intl.formatMessage(i18n.scheduledJobsCount, { count: scheduledSessions.length })}
-                </span>
-              </div>
-              {isScheduledExpanded ? (
-                <ChevronDown className="w-4 h-4 text-text-secondary" />
-              ) : (
-                <ChevronRight className="w-4 h-4 text-text-secondary" />
-              )}
-            </button>
+              <button
+                onClick={() => setIsScheduledExpanded((v) => !v)}
+                aria-expanded={isScheduledExpanded}
+                aria-controls="scheduled-job-sessions"
+                className="sticky top-0 z-10 w-full flex items-center justify-between bg-background-primary/95 backdrop-blur-sm py-2 px-1 rounded-lg hover:bg-background-secondary transition-colors cursor-pointer"
+              >
+                <div className="flex items-center gap-2">
+                  <Clock className="w-4 h-4 text-text-secondary" />
+                  <h2 className="text-text-secondary font-medium">
+                    {intl.formatMessage(i18n.scheduledJobs)}
+                  </h2>
+                  <span className="text-xs text-text-tertiary bg-background-secondary px-2 py-0.5 rounded-full">
+                    {intl.formatMessage(i18n.scheduledJobsCount, {
+                      count: scheduledSessions.length,
+                    })}
+                  </span>
+                </div>
+                {isScheduledExpanded ? (
+                  <ChevronDown className="w-4 h-4 text-text-secondary" />
+                ) : (
+                  <ChevronRight className="w-4 h-4 text-text-secondary" />
+                )}
+              </button>
 
-            {isScheduledExpanded && (
-              <div id="scheduled-job-sessions" className="space-y-8">
-                {memoizedScheduledDateGroups.map((group) => (
-                  <div key={group.label} className="space-y-4">
-                    <div className="sticky top-0 z-10 bg-background-primary/95 backdrop-blur-sm">
-                      <h2 className="text-text-secondary">{group.label}</h2>
+              {isScheduledExpanded && (
+                <div id="scheduled-job-sessions" className="space-y-8">
+                  {memoizedScheduledDateGroups.map((group) => (
+                    <div key={group.label} className="space-y-4">
+                      <div className="sticky top-0 z-10 bg-background-primary/95 backdrop-blur-sm">
+                        <h2 className="text-text-secondary">{group.label}</h2>
+                      </div>
+                      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-4">
+                        {group.sessions.map((session) => (
+                          <SessionItem
+                            key={session.id}
+                            session={session}
+                            onEditClick={handleEditSession}
+                            onDuplicateClick={handleDuplicateSession}
+                            onDeleteClick={handleDeleteSession}
+                            onExportClick={handleExportSession}
+                            onShareClick={handleShareSessionNostr}
+                            onOpenInNewWindow={handleOpenInNewWindow}
+                            isSharing={sharingSessionId === session.id}
+                          />
+                        ))}
+                      </div>
                     </div>
-                    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-4">
-                      {group.sessions.map((session) => (
-                        <SessionItem
-                          key={session.id}
-                          session={session}
-                          onEditClick={handleEditSession}
-                          onDuplicateClick={handleDuplicateSession}
-                          onDeleteClick={handleDeleteSession}
-                          onExportClick={handleExportSession}
-                          onShareClick={handleShareSessionNostr}
-                          onOpenInNewWindow={handleOpenInNewWindow}
-                          isSharing={sharingSessionId === session.id}
-                        />
-                      ))}
-                    </div>
-                  </div>
-                ))}
-              </div>
-            )}
+                  ))}
+                </div>
+              )}
             </div>
           )}
 

--- a/ui/desktop/src/components/settings/app/ExternalBackendSection.tsx
+++ b/ui/desktop/src/components/settings/app/ExternalBackendSection.tsx
@@ -116,6 +116,15 @@ const i18n = defineMessages({
     id: 'externalBackendSection.connectFailed',
     defaultMessage: 'Could not connect: {error}',
   },
+  diagnosticsHeading: {
+    id: 'externalBackendSection.diagnosticsHeading',
+    defaultMessage: 'Connection checks',
+  },
+  diagnosticsHint: {
+    id: 'externalBackendSection.diagnosticsHint',
+    defaultMessage:
+      'The first failed check above is where the connection stopped. Confirm the backend is running and reachable from this machine, that its secret key matches, and that any proxy or VPN in between allows /status and /acp.',
+  },
 });
 
 export default function ExternalBackendSection() {
@@ -126,7 +135,7 @@ export default function ExternalBackendSection() {
   const [isConnecting, setIsConnecting] = useState(false);
   const [outcome, setOutcome] = useState<{
     steps: BackendCheckStep[];
-    message: string | null;
+    message: string;
     ok: boolean;
   } | null>(null);
 
@@ -350,7 +359,7 @@ export default function ExternalBackendSection() {
             </p>
           </div>
 
-          <div className="space-y-2">
+          <div className="space-y-3">
             <div className="flex items-center gap-2">
               <Button
                 size="sm"
@@ -370,25 +379,44 @@ export default function ExternalBackendSection() {
               </Button>
             </div>
 
-            {outcome?.steps.map((step) => (
-              <p key={step.name} className="flex gap-2 text-xs">
-                {step.ok ? (
-                  <Check className="size-3 mt-0.5 shrink-0 text-green-600" />
-                ) : (
-                  <X className="size-3 mt-0.5 shrink-0 text-red-600" />
-                )}
-                <span className="text-text-primary">{step.name}</span>
-                <span className="text-text-secondary break-words">{step.detail}</span>
-              </p>
-            ))}
+            {outcome && (
+              <div className="space-y-2">
+                <p
+                  className={`text-xs flex items-start gap-1 ${outcome.ok ? 'text-text-secondary' : 'text-red-500'}`}
+                >
+                  {outcome.ok ? (
+                    <Check className="size-3 mt-0.5 shrink-0 text-green-600" />
+                  ) : (
+                    <AlertCircle size={12} className="mt-0.5 shrink-0" />
+                  )}
+                  <span className="break-words">{outcome.message}</span>
+                </p>
 
-            {outcome?.message && (
-              <p
-                className={`text-xs flex items-start gap-1 ${outcome.ok ? 'text-text-secondary' : 'text-red-500'}`}
-              >
-                {!outcome.ok && <AlertCircle size={12} className="mt-0.5 shrink-0" />}
-                <span className="break-words">{outcome.message}</span>
-              </p>
+                {outcome.steps.length > 0 && (
+                  <div className="rounded-md border border-border-subtle bg-background-muted p-2 space-y-1">
+                    <p className="text-xs text-text-secondary">
+                      {intl.formatMessage(i18n.diagnosticsHeading)}
+                    </p>
+                    {outcome.steps.map((step) => (
+                      <p key={step.name} className="flex gap-2 text-xs">
+                        {step.ok ? (
+                          <Check className="size-3 mt-0.5 shrink-0 text-green-600" />
+                        ) : (
+                          <X className="size-3 mt-0.5 shrink-0 text-red-600" />
+                        )}
+                        <span className="text-text-primary shrink-0">{step.name}</span>
+                        <span className="text-text-secondary break-all">{step.detail}</span>
+                      </p>
+                    ))}
+                  </div>
+                )}
+
+                {!outcome.ok && (
+                  <p className="text-xs text-text-secondary">
+                    {intl.formatMessage(i18n.diagnosticsHint)}
+                  </p>
+                )}
+              </div>
             )}
           </div>
         </CardContent>

--- a/ui/desktop/src/components/settings/app/ExternalBackendSection.tsx
+++ b/ui/desktop/src/components/settings/app/ExternalBackendSection.tsx
@@ -1,11 +1,14 @@
 import { useState, useEffect } from 'react';
-import { Switch } from '../../ui/switch';
 import { Input } from '../../ui/input';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../../ui/card';
-import { AlertCircle } from 'lucide-react';
+import { Button } from '../../ui/button';
+import { AlertCircle, Check, Loader2, X } from 'lucide-react';
 import { ExternalBackendConfig, defaultSettings } from '../../../utils/settings';
 import { defineMessages, useIntl } from '../../../i18n';
 import { normalizeAcpHttpBaseUrl } from '../../../acp/url';
+import type { BackendCheckStep } from '../../../backendStatus';
+import { reconnectAcpToNewBackend } from '../../../acp/acpConnection';
+import { setWorkingDir } from '../../../utils/workingDir';
 
 const i18n = defineMessages({
   title: {
@@ -17,13 +20,33 @@ const i18n = defineMessages({
     defaultMessage:
       'By default Goose starts a local backend. Use this to connect to an external ACP-compatible backend.',
   },
-  useExternalServer: {
-    id: 'externalBackendSection.useExternalServer',
-    defaultMessage: 'Use external backend',
+  connect: {
+    id: 'externalBackendSection.connect',
+    defaultMessage: 'Connect',
   },
-  useExternalServerDescription: {
-    id: 'externalBackendSection.useExternalServerDescription',
-    defaultMessage: 'Connect to an ACP-compatible backend running elsewhere.',
+  connecting: {
+    id: 'externalBackendSection.connecting',
+    defaultMessage: 'Connecting…',
+  },
+  disconnect: {
+    id: 'externalBackendSection.disconnect',
+    defaultMessage: 'Disconnect',
+  },
+  disconnecting: {
+    id: 'externalBackendSection.disconnecting',
+    defaultMessage: 'Disconnecting…',
+  },
+  connected: {
+    id: 'externalBackendSection.connected',
+    defaultMessage: 'This window is now using the external backend.',
+  },
+  disconnected: {
+    id: 'externalBackendSection.disconnected',
+    defaultMessage: 'This window is now using the local backend.',
+  },
+  disconnectFailed: {
+    id: 'externalBackendSection.disconnectFailed',
+    defaultMessage: 'Could not disconnect: {error}',
   },
   serverUrl: {
     id: 'externalBackendSection.serverUrl',
@@ -72,10 +95,6 @@ const i18n = defineMessages({
     defaultMessage:
       'Pin a specific TLS certificate fingerprint. If omitted, the certificate is trusted on first use (TOFU).',
   },
-  restartNote: {
-    id: 'externalBackendSection.restartNote',
-    defaultMessage: 'Changes apply to new chat windows. Restart Goose to update existing windows.',
-  },
   urlProtocolError: {
     id: 'externalBackendSection.urlProtocolError',
     defaultMessage: 'URL must use http or https protocol',
@@ -93,6 +112,10 @@ const i18n = defineMessages({
     defaultMessage:
       'URL must be the backend base URL before /acp, without query parameters or fragments',
   },
+  connectFailed: {
+    id: 'externalBackendSection.connectFailed',
+    defaultMessage: 'Could not connect: {error}',
+  },
 });
 
 export default function ExternalBackendSection() {
@@ -100,6 +123,12 @@ export default function ExternalBackendSection() {
   const [config, setConfig] = useState<ExternalBackendConfig>(defaultSettings.externalGoosed);
   const [isSaving, setIsSaving] = useState(false);
   const [urlError, setUrlError] = useState<string | null>(null);
+  const [isConnecting, setIsConnecting] = useState(false);
+  const [outcome, setOutcome] = useState<{
+    steps: BackendCheckStep[];
+    message: string | null;
+    ok: boolean;
+  } | null>(null);
 
   useEffect(() => {
     const loadSettings = async () => {
@@ -181,122 +210,187 @@ export default function ExternalBackendSection() {
     }
   };
 
+  const connect = async () => {
+    setIsConnecting(true);
+    setOutcome(null);
+    try {
+      await saveConfig(updateField('enabled', true));
+      const result = await window.electron.switchBackend();
+      if (!result.ok) {
+        // Leaving this enabled would block the next launch on the startup dialog.
+        await saveConfig(updateField('enabled', false));
+        setOutcome({
+          steps: result.steps,
+          message: intl.formatMessage(i18n.connectFailed, {
+            error: result.error ?? 'Unknown error',
+          }),
+          ok: false,
+        });
+        return;
+      }
+
+      setWorkingDir(result.workingDir ?? null);
+      reconnectAcpToNewBackend();
+      setOutcome({
+        steps: result.steps,
+        message: intl.formatMessage(i18n.connected),
+        ok: true,
+      });
+    } finally {
+      setIsConnecting(false);
+    }
+  };
+
+  const disconnect = async () => {
+    setIsConnecting(true);
+    setOutcome(null);
+    try {
+      const result = await window.electron.disconnectBackend();
+      if (!result.ok) {
+        setOutcome({
+          steps: [],
+          message: intl.formatMessage(i18n.disconnectFailed, {
+            error: result.error ?? 'Unknown error',
+          }),
+          ok: false,
+        });
+        return;
+      }
+
+      setConfig((prev) => ({ ...prev, enabled: false }));
+      setWorkingDir(result.workingDir ?? null);
+      reconnectAcpToNewBackend();
+      setOutcome({ steps: [], message: intl.formatMessage(i18n.disconnected), ok: true });
+    } finally {
+      setIsConnecting(false);
+    }
+  };
+
+  const busy = isConnecting || isSaving;
+
   return (
     <section id="external-backend" className="space-y-4 pr-4 mt-1">
-      <Card className="pb-2">
+      <Card className="pb-4">
         <CardHeader className="pb-0">
           <CardTitle>{intl.formatMessage(i18n.title)}</CardTitle>
           <CardDescription>{intl.formatMessage(i18n.description)}</CardDescription>
         </CardHeader>
         <CardContent className="pt-4 space-y-4 px-4">
-          <div className="flex items-center justify-between">
-            <div>
-              <h3 className="text-text-primary text-xs">
-                {intl.formatMessage(i18n.useExternalServer)}
-              </h3>
-              <p className="text-xs text-text-secondary max-w-md mt-[2px]">
-                {intl.formatMessage(i18n.useExternalServerDescription)}
+          <div className="space-y-2">
+            <label htmlFor="external-url" className="text-text-primary text-xs">
+              {intl.formatMessage(i18n.serverUrl)}
+            </label>
+            <Input
+              id="external-url"
+              type="url"
+              placeholder="http://127.0.0.1:3000"
+              value={config.url}
+              onChange={(e) => handleUrlChange(e.target.value)}
+              onBlur={handleUrlBlur}
+              disabled={isSaving}
+              className={urlError ? 'border-red-500' : ''}
+            />
+            {urlError && (
+              <p className="text-xs text-red-500 flex items-center gap-1">
+                <AlertCircle size={12} />
+                {urlError}
               </p>
-            </div>
-            <div className="flex items-center">
-              <Switch
-                checked={config.enabled}
-                onCheckedChange={(checked) => saveConfig(updateField('enabled', checked))}
-                disabled={isSaving}
-                variant="mono"
-              />
-            </div>
+            )}
+            <p className="text-xs text-text-secondary">{intl.formatMessage(i18n.serverUrlHelp)}</p>
           </div>
 
-          {config.enabled && (
-            <>
-              <div className="space-y-2">
-                <label htmlFor="external-url" className="text-text-primary text-xs">
-                  {intl.formatMessage(i18n.serverUrl)}
-                </label>
-                <Input
-                  id="external-url"
-                  type="url"
-                  placeholder="http://127.0.0.1:3000"
-                  value={config.url}
-                  onChange={(e) => handleUrlChange(e.target.value)}
-                  onBlur={handleUrlBlur}
-                  disabled={isSaving}
-                  className={urlError ? 'border-red-500' : ''}
-                />
-                {urlError && (
-                  <p className="text-xs text-red-500 flex items-center gap-1">
-                    <AlertCircle size={12} />
-                    {urlError}
-                  </p>
+          <div className="space-y-2">
+            <label htmlFor="external-working-dir" className="text-text-primary text-xs">
+              {intl.formatMessage(i18n.workingDir)}
+            </label>
+            <Input
+              id="external-working-dir"
+              type="text"
+              placeholder={intl.formatMessage(i18n.workingDirPlaceholder)}
+              value={config.workingDir || ''}
+              onChange={(e) => updateField('workingDir', e.target.value)}
+              onBlur={() => saveConfig(config)}
+              disabled={isSaving}
+            />
+            <p className="text-xs text-text-secondary">{intl.formatMessage(i18n.workingDirHelp)}</p>
+          </div>
+
+          <div className="space-y-2">
+            <label htmlFor="external-secret" className="text-text-primary text-xs">
+              {intl.formatMessage(i18n.secretKey)}
+            </label>
+            <Input
+              id="external-secret"
+              type="password"
+              placeholder={intl.formatMessage(i18n.secretKeyPlaceholder)}
+              value={config.secret}
+              onChange={(e) => updateField('secret', e.target.value)}
+              onBlur={() => saveConfig(config)}
+              disabled={isSaving}
+            />
+            <p className="text-xs text-text-secondary">{intl.formatMessage(i18n.secretKeyHelp)}</p>
+          </div>
+
+          <div className="space-y-2">
+            <label htmlFor="external-cert-fingerprint" className="text-text-primary text-xs">
+              {intl.formatMessage(i18n.certFingerprint)}
+            </label>
+            <Input
+              id="external-cert-fingerprint"
+              type="text"
+              placeholder={intl.formatMessage(i18n.certFingerprintPlaceholder)}
+              value={config.certFingerprint || ''}
+              onChange={(e) => handleCertFingerprintChange(e.target.value)}
+              onBlur={handleCertFingerprintBlur}
+              disabled={isSaving}
+              className="font-mono text-xs"
+            />
+            <p className="text-xs text-text-secondary">
+              {intl.formatMessage(i18n.certFingerprintHelp)}
+            </p>
+          </div>
+
+          <div className="space-y-2">
+            <div className="flex items-center gap-2">
+              <Button
+                size="sm"
+                onClick={config.enabled ? disconnect : connect}
+                disabled={busy || (!config.enabled && !config.url.trim())}
+              >
+                {isConnecting && <Loader2 className="size-3 animate-spin" />}
+                {intl.formatMessage(
+                  config.enabled
+                    ? isConnecting
+                      ? i18n.disconnecting
+                      : i18n.disconnect
+                    : isConnecting
+                      ? i18n.connecting
+                      : i18n.connect
                 )}
-                <p className="text-xs text-text-secondary">
-                  {intl.formatMessage(i18n.serverUrlHelp)}
-                </p>
-              </div>
+              </Button>
+            </div>
 
-              <div className="space-y-2">
-                <label htmlFor="external-working-dir" className="text-text-primary text-xs">
-                  {intl.formatMessage(i18n.workingDir)}
-                </label>
-                <Input
-                  id="external-working-dir"
-                  type="text"
-                  placeholder={intl.formatMessage(i18n.workingDirPlaceholder)}
-                  value={config.workingDir || ''}
-                  onChange={(e) => updateField('workingDir', e.target.value)}
-                  onBlur={() => saveConfig(config)}
-                  disabled={isSaving}
-                />
-                <p className="text-xs text-text-secondary">
-                  {intl.formatMessage(i18n.workingDirHelp)}
-                </p>
-              </div>
+            {outcome?.steps.map((step) => (
+              <p key={step.name} className="flex gap-2 text-xs">
+                {step.ok ? (
+                  <Check className="size-3 mt-0.5 shrink-0 text-green-600" />
+                ) : (
+                  <X className="size-3 mt-0.5 shrink-0 text-red-600" />
+                )}
+                <span className="text-text-primary">{step.name}</span>
+                <span className="text-text-secondary break-words">{step.detail}</span>
+              </p>
+            ))}
 
-              <div className="space-y-2">
-                <label htmlFor="external-secret" className="text-text-primary text-xs">
-                  {intl.formatMessage(i18n.secretKey)}
-                </label>
-                <Input
-                  id="external-secret"
-                  type="password"
-                  placeholder={intl.formatMessage(i18n.secretKeyPlaceholder)}
-                  value={config.secret}
-                  onChange={(e) => updateField('secret', e.target.value)}
-                  onBlur={() => saveConfig(config)}
-                  disabled={isSaving}
-                />
-                <p className="text-xs text-text-secondary">
-                  {intl.formatMessage(i18n.secretKeyHelp)}
-                </p>
-              </div>
-
-              <div className="space-y-2">
-                <label htmlFor="external-cert-fingerprint" className="text-text-primary text-xs">
-                  {intl.formatMessage(i18n.certFingerprint)}
-                </label>
-                <Input
-                  id="external-cert-fingerprint"
-                  type="text"
-                  placeholder={intl.formatMessage(i18n.certFingerprintPlaceholder)}
-                  value={config.certFingerprint || ''}
-                  onChange={(e) => handleCertFingerprintChange(e.target.value)}
-                  onBlur={handleCertFingerprintBlur}
-                  disabled={isSaving}
-                  className="font-mono text-xs"
-                />
-                <p className="text-xs text-text-secondary">
-                  {intl.formatMessage(i18n.certFingerprintHelp)}
-                </p>
-              </div>
-
-              <div className="bg-amber-50 dark:bg-amber-950 border border-amber-200 dark:border-amber-800 rounded-md p-3">
-                <p className="text-xs text-amber-800 dark:text-amber-200">
-                  <strong>Note:</strong> {intl.formatMessage(i18n.restartNote)}
-                </p>
-              </div>
-            </>
-          )}
+            {outcome?.message && (
+              <p
+                className={`text-xs flex items-start gap-1 ${outcome.ok ? 'text-text-secondary' : 'text-red-500'}`}
+              >
+                {!outcome.ok && <AlertCircle size={12} className="mt-0.5 shrink-0" />}
+                <span className="break-words">{outcome.message}</span>
+              </p>
+            )}
+          </div>
         </CardContent>
       </Card>
     </section>

--- a/ui/desktop/src/constants/events.ts
+++ b/ui/desktop/src/constants/events.ts
@@ -13,4 +13,5 @@ export enum AppEvents {
   SCROLL_CHAT_TO_BOTTOM = 'scroll-chat-to-bottom',
   HIDE_ALERT_POPOVER = 'hide-alert-popover',
   RESPONSE_STYLE_CHANGED = 'responseStyleChanged',
+  BACKEND_SWITCHED = 'backend-switched',
 }

--- a/ui/desktop/src/gooseServeLeaseRegistry.test.ts
+++ b/ui/desktop/src/gooseServeLeaseRegistry.test.ts
@@ -35,7 +35,7 @@ function createGooseServeResult(
 describe('GooseServeLeaseRegistry', () => {
   it('returns the ACP URL for an attached live lease', () => {
     const store = new GooseServeLeaseRegistry(createLogger());
-    const lease = store.create(createGooseServeResult(), 'local-secret');
+    const lease = store.create(createGooseServeResult(), 'local-secret', '/tmp/goose');
 
     store.attachWindow(1, lease);
 
@@ -47,7 +47,7 @@ describe('GooseServeLeaseRegistry', () => {
     const logger = createLogger();
     const store = new GooseServeLeaseRegistry(logger);
     const result = createGooseServeResult();
-    const lease = store.create(result, 'local-secret');
+    const lease = store.create(result, 'local-secret', '/tmp/goose');
     store.attachWindow(1, lease);
 
     result.process.emit('exit', 1, null);
@@ -67,7 +67,8 @@ describe('GooseServeLeaseRegistry', () => {
         hasExited: () => true,
         getExitDetails: () => ({ code: null, signal: 'SIGTERM' }),
       }),
-      'local-secret'
+      'local-secret',
+      '/tmp/goose'
     );
 
     store.attachWindow(1, lease);
@@ -78,7 +79,7 @@ describe('GooseServeLeaseRegistry', () => {
   it('cleans up once after the last attached window is released', async () => {
     const cleanup = vi.fn(async () => undefined);
     const store = new GooseServeLeaseRegistry(createLogger());
-    const lease = store.create(createGooseServeResult({ cleanup }), 'local-secret');
+    const lease = store.create(createGooseServeResult({ cleanup }), 'local-secret', '/tmp/goose');
     store.attachWindow(1, lease);
     store.attachWindow(2, lease);
 
@@ -95,7 +96,11 @@ describe('GooseServeLeaseRegistry', () => {
 
   it('creates an external ACP lease without process cleanup', async () => {
     const store = new GooseServeLeaseRegistry(createLogger());
-    const lease = store.createExternal('wss://example.com/goose/acp?token=test', 'external-secret');
+    const lease = store.createExternal(
+      'wss://example.com/goose/acp?token=test',
+      'external-secret',
+      '/remote/work'
+    );
 
     store.attachWindow(1, lease);
 
@@ -113,6 +118,7 @@ describe('GooseServeLeaseRegistry', () => {
     const lease = store.createExternal(
       'wss://example.com/goose/acp?token=test',
       'external-secret',
+      '/remote/work',
       cleanup
     );
     store.attachWindow(1, lease);

--- a/ui/desktop/src/gooseServeLeaseRegistry.ts
+++ b/ui/desktop/src/gooseServeLeaseRegistry.ts
@@ -6,6 +6,7 @@ export const GOOSE_SERVE_EXITED_USER_MESSAGE =
 export interface GooseServeLease {
   acpUrl: string;
   secretKey: string;
+  workingDir: string;
   cleanup: () => Promise<void>;
   windowIds: Set<number>;
   cleanedUp: boolean;
@@ -19,10 +20,11 @@ export class GooseServeLeaseRegistry {
 
   constructor(private readonly logger: Logger) {}
 
-  create(result: GooseServeResult, secretKey: string): GooseServeLease {
+  create(result: GooseServeResult, secretKey: string, workingDir: string): GooseServeLease {
     const lease: GooseServeLease = {
       acpUrl: result.acpUrl,
       secretKey,
+      workingDir,
       cleanup: result.cleanup,
       windowIds: new Set<number>(),
       cleanedUp: false,
@@ -73,11 +75,13 @@ export class GooseServeLeaseRegistry {
   createExternal(
     acpUrl: string,
     secretKey: string,
+    workingDir: string,
     cleanup: () => Promise<void> = async () => undefined
   ): GooseServeLease {
     return {
       acpUrl,
       secretKey,
+      workingDir,
       cleanup,
       windowIds: new Set<number>(),
       cleanedUp: false,
@@ -100,6 +104,10 @@ export class GooseServeLeaseRegistry {
       throw new Error(GOOSE_SERVE_EXITED_USER_MESSAGE);
     }
     return lease.acpUrl;
+  }
+
+  getWorkingDir(windowId: number): string | null {
+    return this.get(windowId)?.workingDir ?? null;
   }
 
   getSecretKey(windowId: number): string | null {

--- a/ui/desktop/src/hooks/useNavigationSessions.ts
+++ b/ui/desktop/src/hooks/useNavigationSessions.ts
@@ -86,6 +86,19 @@ export function useNavigationSessions() {
     }
   }, []);
 
+  // Sessions belong to the backend that served them, so drop the old list and
+  // reload from the newly connected one.
+  useEffect(() => {
+    const handleBackendSwitched = () => {
+      setRecentSessions([]);
+      lastSessionIdRef.current = null;
+      void fetchSessions();
+    };
+
+    window.addEventListener(AppEvents.BACKEND_SWITCHED, handleBackendSwitched);
+    return () => window.removeEventListener(AppEvents.BACKEND_SWITCHED, handleBackendSwitched);
+  }, [fetchSessions]);
+
   useEffect(() => {
     if (!activeSessionId) return;
     if (recentSessions.some((s) => s.id === activeSessionId)) return;

--- a/ui/desktop/src/i18n/messages/de.json
+++ b/ui/desktop/src/i18n/messages/de.json
@@ -1214,9 +1214,6 @@
   "externalBackendSection.fingerprintRequiresHttps": {
     "defaultMessage": "Certificate fingerprint requires an https URL"
   },
-  "externalBackendSection.restartNote": {
-    "defaultMessage": "Änderungen werden erst nach einem Neustart von Goose wirksam. Neue Chat-Fenster verbinden sich mit dem externen Server."
-  },
   "externalBackendSection.secretKey": {
     "defaultMessage": "Geheimer Schlüssel"
   },
@@ -1232,6 +1229,30 @@
   "externalBackendSection.serverUrlHelp": {
     "defaultMessage": "Enter the HTTP(S) base URL. Goose checks /status and connects to /acp under this base."
   },
+  "externalBackendSection.connect": {
+    "defaultMessage": "Verbinden"
+  },
+  "externalBackendSection.connectFailed": {
+    "defaultMessage": "Verbindung fehlgeschlagen: {error}"
+  },
+  "externalBackendSection.connected": {
+    "defaultMessage": "Dieses Fenster verwendet jetzt das externe Backend."
+  },
+  "externalBackendSection.connecting": {
+    "defaultMessage": "Verbinde…"
+  },
+  "externalBackendSection.disconnect": {
+    "defaultMessage": "Trennen"
+  },
+  "externalBackendSection.disconnectFailed": {
+    "defaultMessage": "Trennen fehlgeschlagen: {error}"
+  },
+  "externalBackendSection.disconnected": {
+    "defaultMessage": "Dieses Fenster verwendet jetzt das lokale Backend."
+  },
+  "externalBackendSection.disconnecting": {
+    "defaultMessage": "Trenne…"
+  },
   "externalBackendSection.title": {
     "defaultMessage": "Goose-Server"
   },
@@ -1243,12 +1264,6 @@
   },
   "externalBackendSection.urlProtocolError": {
     "defaultMessage": "Die URL muss das Protokoll http oder https verwenden"
-  },
-  "externalBackendSection.useExternalServer": {
-    "defaultMessage": "Externen Server verwenden"
-  },
-  "externalBackendSection.useExternalServerDescription": {
-    "defaultMessage": "Verbindung zu einem anderswo laufenden goose-Server herstellen (erfordert Neustart der App)"
   },
   "externalBackendSection.workingDir": {
     "defaultMessage": "Remote-Arbeitsverzeichnis (optional)"
@@ -2390,8 +2405,17 @@
   "onboardingGuard.checkProviderErrorTitle": {
     "defaultMessage": "Verbindung zum Goose-Server nicht möglich"
   },
+  "onboardingGuard.externalBackendErrorTitle": {
+    "defaultMessage": "Verbindung zum externen Backend nicht möglich"
+  },
   "onboardingGuard.retry": {
     "defaultMessage": "Erneut versuchen"
+  },
+  "onboardingGuard.retrying": {
+    "defaultMessage": "Erneut versuchen…"
+  },
+  "onboardingGuard.switchToLocal": {
+    "defaultMessage": "Zu lokalem Backend wechseln"
   },
   "onboardingGuard.welcomeDescription": {
     "defaultMessage": "Ihr lokaler KI-Agent. Verbinden Sie einen KI-Modellanbieter, um zu beginnen."

--- a/ui/desktop/src/i18n/messages/de.json
+++ b/ui/desktop/src/i18n/messages/de.json
@@ -1229,6 +1229,12 @@
   "externalBackendSection.serverUrlHelp": {
     "defaultMessage": "Enter the HTTP(S) base URL. Goose checks /status and connects to /acp under this base."
   },
+  "externalBackendSection.diagnosticsHeading": {
+    "defaultMessage": "Verbindungsprüfungen"
+  },
+  "externalBackendSection.diagnosticsHint": {
+    "defaultMessage": "Die erste fehlgeschlagene Prüfung oben zeigt, wo die Verbindung abgebrochen ist. Prüfen Sie, ob das Backend läuft und von diesem Computer erreichbar ist, ob der Secret Key übereinstimmt und ob ein zwischengeschalteter Proxy oder VPN /status und /acp zulässt."
+  },
   "externalBackendSection.connect": {
     "defaultMessage": "Verbinden"
   },

--- a/ui/desktop/src/i18n/messages/en.json
+++ b/ui/desktop/src/i18n/messages/en.json
@@ -1232,6 +1232,12 @@
   "externalBackendSection.description": {
     "defaultMessage": "By default Goose starts a local backend. Use this to connect to an external ACP-compatible backend."
   },
+  "externalBackendSection.diagnosticsHeading": {
+    "defaultMessage": "Connection checks"
+  },
+  "externalBackendSection.diagnosticsHint": {
+    "defaultMessage": "The first failed check above is where the connection stopped. Confirm the backend is running and reachable from this machine, that its secret key matches, and that any proxy or VPN in between allows /status and /acp."
+  },
   "externalBackendSection.disconnect": {
     "defaultMessage": "Disconnect"
   },

--- a/ui/desktop/src/i18n/messages/en.json
+++ b/ui/desktop/src/i18n/messages/en.json
@@ -1217,14 +1217,35 @@
   "externalBackendSection.certFingerprintPlaceholder": {
     "defaultMessage": "AA:BB:CC:... or sha256/base64"
   },
+  "externalBackendSection.connect": {
+    "defaultMessage": "Connect"
+  },
+  "externalBackendSection.connectFailed": {
+    "defaultMessage": "Could not connect: {error}"
+  },
+  "externalBackendSection.connected": {
+    "defaultMessage": "This window is now using the external backend."
+  },
+  "externalBackendSection.connecting": {
+    "defaultMessage": "Connecting…"
+  },
   "externalBackendSection.description": {
     "defaultMessage": "By default Goose starts a local backend. Use this to connect to an external ACP-compatible backend."
   },
+  "externalBackendSection.disconnect": {
+    "defaultMessage": "Disconnect"
+  },
+  "externalBackendSection.disconnectFailed": {
+    "defaultMessage": "Could not disconnect: {error}"
+  },
+  "externalBackendSection.disconnected": {
+    "defaultMessage": "This window is now using the local backend."
+  },
+  "externalBackendSection.disconnecting": {
+    "defaultMessage": "Disconnecting…"
+  },
   "externalBackendSection.fingerprintRequiresHttps": {
     "defaultMessage": "Certificate fingerprint requires an https URL"
-  },
-  "externalBackendSection.restartNote": {
-    "defaultMessage": "Changes apply to new chat windows. Restart Goose to update existing windows."
   },
   "externalBackendSection.secretKey": {
     "defaultMessage": "Secret Key"
@@ -1252,12 +1273,6 @@
   },
   "externalBackendSection.urlProtocolError": {
     "defaultMessage": "URL must use http or https protocol"
-  },
-  "externalBackendSection.useExternalServer": {
-    "defaultMessage": "Use external backend"
-  },
-  "externalBackendSection.useExternalServerDescription": {
-    "defaultMessage": "Connect to an ACP-compatible backend running elsewhere."
   },
   "externalBackendSection.workingDir": {
     "defaultMessage": "Remote Working Directory (optional)"
@@ -2414,8 +2429,17 @@
   "onboardingGuard.checkProviderErrorTitle": {
     "defaultMessage": "Unable to connect to Goose server"
   },
+  "onboardingGuard.externalBackendErrorTitle": {
+    "defaultMessage": "Unable to connect to the external backend"
+  },
   "onboardingGuard.retry": {
     "defaultMessage": "Retry"
+  },
+  "onboardingGuard.retrying": {
+    "defaultMessage": "Retrying…"
+  },
+  "onboardingGuard.switchToLocal": {
+    "defaultMessage": "Switch to Local"
   },
   "onboardingGuard.welcomeDescription": {
     "defaultMessage": "Your local AI agent. Connect an AI model provider to get started."

--- a/ui/desktop/src/i18n/messages/es.json
+++ b/ui/desktop/src/i18n/messages/es.json
@@ -1214,9 +1214,6 @@
   "externalBackendSection.fingerprintRequiresHttps": {
     "defaultMessage": "Certificate fingerprint requires an https URL"
   },
-  "externalBackendSection.restartNote": {
-    "defaultMessage": "Los cambios requieren reiniciar Goose para que surtan efecto. Las nuevas ventanas de chat se conectarán al servidor externo."
-  },
   "externalBackendSection.secretKey": {
     "defaultMessage": "Secret Key"
   },
@@ -1232,6 +1229,30 @@
   "externalBackendSection.serverUrlHelp": {
     "defaultMessage": "Enter the HTTP(S) base URL. Goose checks /status and connects to /acp under this base."
   },
+  "externalBackendSection.connect": {
+    "defaultMessage": "Conectar"
+  },
+  "externalBackendSection.connectFailed": {
+    "defaultMessage": "No se pudo conectar: {error}"
+  },
+  "externalBackendSection.connected": {
+    "defaultMessage": "Esta ventana ahora usa el backend externo."
+  },
+  "externalBackendSection.connecting": {
+    "defaultMessage": "Conectando…"
+  },
+  "externalBackendSection.disconnect": {
+    "defaultMessage": "Desconectar"
+  },
+  "externalBackendSection.disconnectFailed": {
+    "defaultMessage": "No se pudo desconectar: {error}"
+  },
+  "externalBackendSection.disconnected": {
+    "defaultMessage": "Esta ventana ahora usa el backend local."
+  },
+  "externalBackendSection.disconnecting": {
+    "defaultMessage": "Desconectando…"
+  },
   "externalBackendSection.title": {
     "defaultMessage": "Goose Server"
   },
@@ -1243,12 +1264,6 @@
   },
   "externalBackendSection.urlProtocolError": {
     "defaultMessage": "La URL debe usar el protocolo http o https"
-  },
-  "externalBackendSection.useExternalServer": {
-    "defaultMessage": "Usar servidor externo"
-  },
-  "externalBackendSection.useExternalServerDescription": {
-    "defaultMessage": "Conéctate a un servidor goose que se ejecuta en otro lugar (requiere reiniciar la app)"
   },
   "externalBackendSection.workingDir": {
     "defaultMessage": "Directorio de trabajo remoto (opcional)"
@@ -2390,8 +2405,17 @@
   "onboardingGuard.checkProviderErrorTitle": {
     "defaultMessage": "No se pudo conectar con el servidor de Goose"
   },
+  "onboardingGuard.externalBackendErrorTitle": {
+    "defaultMessage": "No se pudo conectar al backend externo"
+  },
   "onboardingGuard.retry": {
     "defaultMessage": "Reintentar"
+  },
+  "onboardingGuard.retrying": {
+    "defaultMessage": "Reintentando…"
+  },
+  "onboardingGuard.switchToLocal": {
+    "defaultMessage": "Cambiar a local"
   },
   "onboardingGuard.welcomeDescription": {
     "defaultMessage": "Tu agente de IA local. Conecta un proveedor de modelos de IA para empezar."

--- a/ui/desktop/src/i18n/messages/es.json
+++ b/ui/desktop/src/i18n/messages/es.json
@@ -1229,6 +1229,12 @@
   "externalBackendSection.serverUrlHelp": {
     "defaultMessage": "Enter the HTTP(S) base URL. Goose checks /status and connects to /acp under this base."
   },
+  "externalBackendSection.diagnosticsHeading": {
+    "defaultMessage": "Comprobaciones de conexión"
+  },
+  "externalBackendSection.diagnosticsHint": {
+    "defaultMessage": "La primera comprobación fallida de arriba indica dónde se detuvo la conexión. Confirma que el backend está en ejecución y accesible desde este equipo, que su clave secreta coincide y que cualquier proxy o VPN intermedio permite /status y /acp."
+  },
   "externalBackendSection.connect": {
     "defaultMessage": "Conectar"
   },

--- a/ui/desktop/src/i18n/messages/fr.json
+++ b/ui/desktop/src/i18n/messages/fr.json
@@ -1229,6 +1229,12 @@
   "externalBackendSection.serverUrlHelp": {
     "defaultMessage": "Enter the HTTP(S) base URL. Goose checks /status and connects to /acp under this base."
   },
+  "externalBackendSection.diagnosticsHeading": {
+    "defaultMessage": "Vérifications de connexion"
+  },
+  "externalBackendSection.diagnosticsHint": {
+    "defaultMessage": "La première vérification échouée ci-dessus indique où la connexion s'est arrêtée. Vérifiez que le backend est en cours d'exécution et accessible depuis cette machine, que sa clé secrète correspond et que tout proxy ou VPN intermédiaire autorise /status et /acp."
+  },
   "externalBackendSection.connect": {
     "defaultMessage": "Connecter"
   },

--- a/ui/desktop/src/i18n/messages/fr.json
+++ b/ui/desktop/src/i18n/messages/fr.json
@@ -1214,9 +1214,6 @@
   "externalBackendSection.fingerprintRequiresHttps": {
     "defaultMessage": "Certificate fingerprint requires an https URL"
   },
-  "externalBackendSection.restartNote": {
-    "defaultMessage": "Les modifications nécessitent le redémarrage de Goose pour prendre effet. Les nouvelles fenêtres de discussion se connecteront au serveur externe."
-  },
   "externalBackendSection.secretKey": {
     "defaultMessage": "Clé secrète"
   },
@@ -1232,6 +1229,30 @@
   "externalBackendSection.serverUrlHelp": {
     "defaultMessage": "Enter the HTTP(S) base URL. Goose checks /status and connects to /acp under this base."
   },
+  "externalBackendSection.connect": {
+    "defaultMessage": "Connecter"
+  },
+  "externalBackendSection.connectFailed": {
+    "defaultMessage": "Connexion impossible : {error}"
+  },
+  "externalBackendSection.connected": {
+    "defaultMessage": "Cette fenêtre utilise maintenant le backend externe."
+  },
+  "externalBackendSection.connecting": {
+    "defaultMessage": "Connexion…"
+  },
+  "externalBackendSection.disconnect": {
+    "defaultMessage": "Déconnecter"
+  },
+  "externalBackendSection.disconnectFailed": {
+    "defaultMessage": "Déconnexion impossible : {error}"
+  },
+  "externalBackendSection.disconnected": {
+    "defaultMessage": "Cette fenêtre utilise maintenant le backend local."
+  },
+  "externalBackendSection.disconnecting": {
+    "defaultMessage": "Déconnexion…"
+  },
   "externalBackendSection.title": {
     "defaultMessage": "Serveur Goose"
   },
@@ -1243,12 +1264,6 @@
   },
   "externalBackendSection.urlProtocolError": {
     "defaultMessage": "L'URL doit utiliser le protocole http ou https"
-  },
-  "externalBackendSection.useExternalServer": {
-    "defaultMessage": "Utiliser un serveur externe"
-  },
-  "externalBackendSection.useExternalServerDescription": {
-    "defaultMessage": "Se connecter à un serveur goose exécuté ailleurs (nécessite le redémarrage de l'application)"
   },
   "externalBackendSection.workingDir": {
     "defaultMessage": "Répertoire de travail distant (facultatif)"
@@ -2390,8 +2405,17 @@
   "onboardingGuard.checkProviderErrorTitle": {
     "defaultMessage": "Impossible de se connecter au serveur Goose"
   },
+  "onboardingGuard.externalBackendErrorTitle": {
+    "defaultMessage": "Impossible de se connecter au backend externe"
+  },
   "onboardingGuard.retry": {
     "defaultMessage": "Réessayer"
+  },
+  "onboardingGuard.retrying": {
+    "defaultMessage": "Nouvelle tentative…"
+  },
+  "onboardingGuard.switchToLocal": {
+    "defaultMessage": "Passer en local"
   },
   "onboardingGuard.welcomeDescription": {
     "defaultMessage": "Votre agent IA local. Connectez un fournisseur de modèle IA pour commencer."

--- a/ui/desktop/src/i18n/messages/hi.json
+++ b/ui/desktop/src/i18n/messages/hi.json
@@ -1214,9 +1214,6 @@
   "externalBackendSection.fingerprintRequiresHttps": {
     "defaultMessage": "Certificate fingerprint requires an https URL"
   },
-  "externalBackendSection.restartNote": {
-    "defaultMessage": "परिवर्तनों को प्रभावी होने के लिए Goose को पुनः आरंभ करने की आवश्यकता है। नई चैट विंडो बाहरी सर्वर से कनेक्ट होंगी."
-  },
   "externalBackendSection.secretKey": {
     "defaultMessage": "गुप्त कुंजी"
   },
@@ -1232,6 +1229,30 @@
   "externalBackendSection.serverUrlHelp": {
     "defaultMessage": "Enter the HTTP(S) base URL. Goose checks /status and connects to /acp under this base."
   },
+  "externalBackendSection.connect": {
+    "defaultMessage": "कनेक्ट करें"
+  },
+  "externalBackendSection.connectFailed": {
+    "defaultMessage": "कनेक्ट नहीं हो सका: {error}"
+  },
+  "externalBackendSection.connected": {
+    "defaultMessage": "यह विंडो अब बाहरी बैकेंड का उपयोग कर रही है।"
+  },
+  "externalBackendSection.connecting": {
+    "defaultMessage": "कनेक्ट हो रहा है…"
+  },
+  "externalBackendSection.disconnect": {
+    "defaultMessage": "डिस्कनेक्ट करें"
+  },
+  "externalBackendSection.disconnectFailed": {
+    "defaultMessage": "डिस्कनेक्ट नहीं हो सका: {error}"
+  },
+  "externalBackendSection.disconnected": {
+    "defaultMessage": "यह विंडो अब स्थानीय बैकेंड का उपयोग कर रही है।"
+  },
+  "externalBackendSection.disconnecting": {
+    "defaultMessage": "डिस्कनेक्ट हो रहा है…"
+  },
   "externalBackendSection.title": {
     "defaultMessage": "Goose सर्वर"
   },
@@ -1243,12 +1264,6 @@
   },
   "externalBackendSection.urlProtocolError": {
     "defaultMessage": "URL को http या https प्रोटोकॉल का उपयोग करना चाहिए"
-  },
-  "externalBackendSection.useExternalServer": {
-    "defaultMessage": "बाहरी सर्वर का प्रयोग करें"
-  },
-  "externalBackendSection.useExternalServerDescription": {
-    "defaultMessage": "कहीं और चल रहे goose सर्वर से कनेक्ट करें (ऐप पुनरारंभ की आवश्यकता है)"
   },
   "externalBackendSection.workingDir": {
     "defaultMessage": "रिमोट कार्य निर्देशिका (वैकल्पिक)"
@@ -2390,8 +2405,17 @@
   "onboardingGuard.checkProviderErrorTitle": {
     "defaultMessage": "Goose सर्वर से कनेक्ट करने में असमर्थ"
   },
+  "onboardingGuard.externalBackendErrorTitle": {
+    "defaultMessage": "बाहरी बैकेंड से कनेक्ट नहीं हो सका"
+  },
   "onboardingGuard.retry": {
     "defaultMessage": "पुनः प्रयास करें"
+  },
+  "onboardingGuard.retrying": {
+    "defaultMessage": "पुन: प्रयास हो रहा है…"
+  },
+  "onboardingGuard.switchToLocal": {
+    "defaultMessage": "स्थानीय पर स्विच करें"
   },
   "onboardingGuard.welcomeDescription": {
     "defaultMessage": "आपका स्थानीय एआई एजेंट। आरंभ करने के लिए किसी AI मॉडल प्रदाता से कनेक्ट करें।"

--- a/ui/desktop/src/i18n/messages/hi.json
+++ b/ui/desktop/src/i18n/messages/hi.json
@@ -1229,6 +1229,12 @@
   "externalBackendSection.serverUrlHelp": {
     "defaultMessage": "Enter the HTTP(S) base URL. Goose checks /status and connects to /acp under this base."
   },
+  "externalBackendSection.diagnosticsHeading": {
+    "defaultMessage": "कनेक्शन जाँच"
+  },
+  "externalBackendSection.diagnosticsHint": {
+    "defaultMessage": "ऊपर पहली विफल जाँच वही जगह है जहाँ कनेक्शन रुका। पुष्टि करें कि बैकएंड चल रहा है और इस मशीन से पहुँच योग्य है, उसकी सीक्रेट की मेल खाती है, और बीच का कोई भी प्रॉक्सी या VPN /status और /acp की अनुमति देता है।"
+  },
   "externalBackendSection.connect": {
     "defaultMessage": "कनेक्ट करें"
   },

--- a/ui/desktop/src/i18n/messages/id.json
+++ b/ui/desktop/src/i18n/messages/id.json
@@ -1214,9 +1214,6 @@
   "externalBackendSection.fingerprintRequiresHttps": {
     "defaultMessage": "Certificate fingerprint requires an https URL"
   },
-  "externalBackendSection.restartNote": {
-    "defaultMessage": "Perubahan memerlukan mulai ulang Goose agar berlaku. Jendela obrolan baru akan terhubung ke server eksternal."
-  },
   "externalBackendSection.secretKey": {
     "defaultMessage": "Kunci Rahasia"
   },
@@ -1232,6 +1229,30 @@
   "externalBackendSection.serverUrlHelp": {
     "defaultMessage": "Enter the HTTP(S) base URL. Goose checks /status and connects to /acp under this base."
   },
+  "externalBackendSection.connect": {
+    "defaultMessage": "Hubungkan"
+  },
+  "externalBackendSection.connectFailed": {
+    "defaultMessage": "Tidak dapat terhubung: {error}"
+  },
+  "externalBackendSection.connected": {
+    "defaultMessage": "Jendela ini sekarang menggunakan backend eksternal."
+  },
+  "externalBackendSection.connecting": {
+    "defaultMessage": "Menghubungkan…"
+  },
+  "externalBackendSection.disconnect": {
+    "defaultMessage": "Putuskan"
+  },
+  "externalBackendSection.disconnectFailed": {
+    "defaultMessage": "Tidak dapat memutuskan: {error}"
+  },
+  "externalBackendSection.disconnected": {
+    "defaultMessage": "Jendela ini sekarang menggunakan backend lokal."
+  },
+  "externalBackendSection.disconnecting": {
+    "defaultMessage": "Memutuskan…"
+  },
   "externalBackendSection.title": {
     "defaultMessage": "Server Goose"
   },
@@ -1243,12 +1264,6 @@
   },
   "externalBackendSection.urlProtocolError": {
     "defaultMessage": "URL harus menggunakan protokol http atau https"
-  },
-  "externalBackendSection.useExternalServer": {
-    "defaultMessage": "Gunakan server eksternal"
-  },
-  "externalBackendSection.useExternalServerDescription": {
-    "defaultMessage": "Terhubung ke server goose yang berjalan di tempat lain (memerlukan mulai ulang aplikasi)"
   },
   "externalBackendSection.workingDir": {
     "defaultMessage": "Direktori kerja jarak jauh (opsional)"
@@ -2390,8 +2405,17 @@
   "onboardingGuard.checkProviderErrorTitle": {
     "defaultMessage": "Tidak dapat terhubung ke server Goose"
   },
+  "onboardingGuard.externalBackendErrorTitle": {
+    "defaultMessage": "Tidak dapat terhubung ke backend eksternal"
+  },
   "onboardingGuard.retry": {
     "defaultMessage": "Coba Lagi"
+  },
+  "onboardingGuard.retrying": {
+    "defaultMessage": "Mencoba lagi…"
+  },
+  "onboardingGuard.switchToLocal": {
+    "defaultMessage": "Beralih ke lokal"
   },
   "onboardingGuard.welcomeDescription": {
     "defaultMessage": "Agen AI lokal Anda. Hubungkan penyedia model AI untuk memulai."

--- a/ui/desktop/src/i18n/messages/id.json
+++ b/ui/desktop/src/i18n/messages/id.json
@@ -1229,6 +1229,12 @@
   "externalBackendSection.serverUrlHelp": {
     "defaultMessage": "Enter the HTTP(S) base URL. Goose checks /status and connects to /acp under this base."
   },
+  "externalBackendSection.diagnosticsHeading": {
+    "defaultMessage": "Pemeriksaan koneksi"
+  },
+  "externalBackendSection.diagnosticsHint": {
+    "defaultMessage": "Pemeriksaan pertama yang gagal di atas adalah tempat koneksi berhenti. Pastikan backend berjalan dan dapat dijangkau dari mesin ini, kunci rahasianya cocok, dan proxy atau VPN di antaranya mengizinkan /status dan /acp."
+  },
   "externalBackendSection.connect": {
     "defaultMessage": "Hubungkan"
   },

--- a/ui/desktop/src/i18n/messages/it.json
+++ b/ui/desktop/src/i18n/messages/it.json
@@ -1229,6 +1229,12 @@
   "externalBackendSection.serverUrlHelp": {
     "defaultMessage": "Enter the HTTP(S) base URL. Goose checks /status and connects to /acp under this base."
   },
+  "externalBackendSection.diagnosticsHeading": {
+    "defaultMessage": "Verifiche di connessione"
+  },
+  "externalBackendSection.diagnosticsHint": {
+    "defaultMessage": "La prima verifica non superata qui sopra indica dove la connessione si è interrotta. Verifica che il backend sia in esecuzione e raggiungibile da questo computer, che la sua chiave segreta corrisponda e che eventuali proxy o VPN intermedi consentano /status e /acp."
+  },
   "externalBackendSection.connect": {
     "defaultMessage": "Connetti"
   },

--- a/ui/desktop/src/i18n/messages/it.json
+++ b/ui/desktop/src/i18n/messages/it.json
@@ -1214,9 +1214,6 @@
   "externalBackendSection.fingerprintRequiresHttps": {
     "defaultMessage": "Certificate fingerprint requires an https URL"
   },
-  "externalBackendSection.restartNote": {
-    "defaultMessage": "Le modifiche richiedono il riavvio di Goose per avere effetto. Le nuove finestre di chat si connetteranno al server esterno."
-  },
   "externalBackendSection.secretKey": {
     "defaultMessage": "Chiave segreta"
   },
@@ -1232,6 +1229,30 @@
   "externalBackendSection.serverUrlHelp": {
     "defaultMessage": "Enter the HTTP(S) base URL. Goose checks /status and connects to /acp under this base."
   },
+  "externalBackendSection.connect": {
+    "defaultMessage": "Connetti"
+  },
+  "externalBackendSection.connectFailed": {
+    "defaultMessage": "Impossibile connettersi: {error}"
+  },
+  "externalBackendSection.connected": {
+    "defaultMessage": "Questa finestra ora usa il backend esterno."
+  },
+  "externalBackendSection.connecting": {
+    "defaultMessage": "Connessione…"
+  },
+  "externalBackendSection.disconnect": {
+    "defaultMessage": "Disconnetti"
+  },
+  "externalBackendSection.disconnectFailed": {
+    "defaultMessage": "Impossibile disconnettersi: {error}"
+  },
+  "externalBackendSection.disconnected": {
+    "defaultMessage": "Questa finestra ora usa il backend locale."
+  },
+  "externalBackendSection.disconnecting": {
+    "defaultMessage": "Disconnessione…"
+  },
   "externalBackendSection.title": {
     "defaultMessage": "Server Goose"
   },
@@ -1243,12 +1264,6 @@
   },
   "externalBackendSection.urlProtocolError": {
     "defaultMessage": "L'URL deve usare il protocollo http o https"
-  },
-  "externalBackendSection.useExternalServer": {
-    "defaultMessage": "Usa un server esterno"
-  },
-  "externalBackendSection.useExternalServerDescription": {
-    "defaultMessage": "Connettiti a un server goose in esecuzione altrove (richiede il riavvio dell'app)"
   },
   "externalBackendSection.workingDir": {
     "defaultMessage": "Directory di lavoro remota (facoltativa)"
@@ -2390,8 +2405,17 @@
   "onboardingGuard.checkProviderErrorTitle": {
     "defaultMessage": "Impossibile connettersi al server Goose"
   },
+  "onboardingGuard.externalBackendErrorTitle": {
+    "defaultMessage": "Impossibile connettersi al backend esterno"
+  },
   "onboardingGuard.retry": {
     "defaultMessage": "Riprova"
+  },
+  "onboardingGuard.retrying": {
+    "defaultMessage": "Nuovo tentativo…"
+  },
+  "onboardingGuard.switchToLocal": {
+    "defaultMessage": "Passa a locale"
   },
   "onboardingGuard.welcomeDescription": {
     "defaultMessage": "Il tuo agente IA locale. Collega un provider di modelli IA per iniziare."

--- a/ui/desktop/src/i18n/messages/ja.json
+++ b/ui/desktop/src/i18n/messages/ja.json
@@ -1229,6 +1229,12 @@
   "externalBackendSection.serverUrlHelp": {
     "defaultMessage": "Enter the HTTP(S) base URL. Goose checks /status and connects to /acp under this base."
   },
+  "externalBackendSection.diagnosticsHeading": {
+    "defaultMessage": "接続チェック"
+  },
+  "externalBackendSection.diagnosticsHint": {
+    "defaultMessage": "上記で最初に失敗したチェックが、接続が止まった箇所です。バックエンドが起動しこのマシンから到達可能か、シークレットキーが一致しているか、間にあるプロキシや VPN が /status と /acp を許可しているかを確認してください。"
+  },
   "externalBackendSection.connect": {
     "defaultMessage": "接続"
   },

--- a/ui/desktop/src/i18n/messages/ja.json
+++ b/ui/desktop/src/i18n/messages/ja.json
@@ -1214,9 +1214,6 @@
   "externalBackendSection.fingerprintRequiresHttps": {
     "defaultMessage": "Certificate fingerprint requires an https URL"
   },
-  "externalBackendSection.restartNote": {
-    "defaultMessage": "変更を有効にするには Goose の再起動が必要です。新しいチャットウィンドウは外部サーバーに接続します。"
-  },
   "externalBackendSection.secretKey": {
     "defaultMessage": "シークレットキー"
   },
@@ -1232,6 +1229,30 @@
   "externalBackendSection.serverUrlHelp": {
     "defaultMessage": "Enter the HTTP(S) base URL. Goose checks /status and connects to /acp under this base."
   },
+  "externalBackendSection.connect": {
+    "defaultMessage": "接続"
+  },
+  "externalBackendSection.connectFailed": {
+    "defaultMessage": "接続できませんでした: {error}"
+  },
+  "externalBackendSection.connected": {
+    "defaultMessage": "このウィンドウは外部バックエンドを使用しています。"
+  },
+  "externalBackendSection.connecting": {
+    "defaultMessage": "接続中…"
+  },
+  "externalBackendSection.disconnect": {
+    "defaultMessage": "切断"
+  },
+  "externalBackendSection.disconnectFailed": {
+    "defaultMessage": "切断できませんでした: {error}"
+  },
+  "externalBackendSection.disconnected": {
+    "defaultMessage": "このウィンドウはローカルバックエンドを使用しています。"
+  },
+  "externalBackendSection.disconnecting": {
+    "defaultMessage": "切断中…"
+  },
   "externalBackendSection.title": {
     "defaultMessage": "Goose Server"
   },
@@ -1243,12 +1264,6 @@
   },
   "externalBackendSection.urlProtocolError": {
     "defaultMessage": "URLは http または https プロトコルを使用する必要があります"
-  },
-  "externalBackendSection.useExternalServer": {
-    "defaultMessage": "外部サーバーを使用"
-  },
-  "externalBackendSection.useExternalServerDescription": {
-    "defaultMessage": "別の場所で実行中の goose サーバーに接続します（アプリの再起動が必要）"
   },
   "externalBackendSection.workingDir": {
     "defaultMessage": "リモート作業ディレクトリ（任意）"
@@ -2390,8 +2405,17 @@
   "onboardingGuard.checkProviderErrorTitle": {
     "defaultMessage": "gooseサーバーに接続できません"
   },
+  "onboardingGuard.externalBackendErrorTitle": {
+    "defaultMessage": "外部バックエンドに接続できません"
+  },
   "onboardingGuard.retry": {
     "defaultMessage": "再試行"
+  },
+  "onboardingGuard.retrying": {
+    "defaultMessage": "再試行中…"
+  },
+  "onboardingGuard.switchToLocal": {
+    "defaultMessage": "ローカルに切り替え"
   },
   "onboardingGuard.welcomeDescription": {
     "defaultMessage": "ローカルAIエージェントです。始めるにはAIモデルプロバイダーに接続してください。"

--- a/ui/desktop/src/i18n/messages/ko.json
+++ b/ui/desktop/src/i18n/messages/ko.json
@@ -1214,9 +1214,6 @@
   "externalBackendSection.fingerprintRequiresHttps": {
     "defaultMessage": "인증서 지문은 https URL이 필요합니다"
   },
-  "externalBackendSection.restartNote": {
-    "defaultMessage": "변경 사항은 새 채팅 창에 적용됩니다. 기존 창을 업데이트하려면 goose를 다시 시작하세요."
-  },
   "externalBackendSection.secretKey": {
     "defaultMessage": "비밀 키"
   },
@@ -1232,6 +1229,30 @@
   "externalBackendSection.serverUrlHelp": {
     "defaultMessage": "HTTP(S) 기본 URL을 입력하세요. goose는 /status를 확인하고 이 기본 주소 아래의 /acp에 연결합니다."
   },
+  "externalBackendSection.connect": {
+    "defaultMessage": "연결"
+  },
+  "externalBackendSection.connectFailed": {
+    "defaultMessage": "연결할 수 없음: {error}"
+  },
+  "externalBackendSection.connected": {
+    "defaultMessage": "이 윈도우는 이제 외부 백엔드를 사용합니다."
+  },
+  "externalBackendSection.connecting": {
+    "defaultMessage": "연결 중…"
+  },
+  "externalBackendSection.disconnect": {
+    "defaultMessage": "연결 해제"
+  },
+  "externalBackendSection.disconnectFailed": {
+    "defaultMessage": "연결을 해제할 수 없음: {error}"
+  },
+  "externalBackendSection.disconnected": {
+    "defaultMessage": "이 윈도우는 이제 로컬 백엔드를 사용합니다."
+  },
+  "externalBackendSection.disconnecting": {
+    "defaultMessage": "연결 해제 중…"
+  },
   "externalBackendSection.title": {
     "defaultMessage": "외부 백엔드 (ACP)"
   },
@@ -1243,12 +1264,6 @@
   },
   "externalBackendSection.urlProtocolError": {
     "defaultMessage": "URL은 반드시 http 또는 https 프로토콜을 사용해야 합니다."
-  },
-  "externalBackendSection.useExternalServer": {
-    "defaultMessage": "외부 서버 사용"
-  },
-  "externalBackendSection.useExternalServerDescription": {
-    "defaultMessage": "다른 곳에서 실행 중인 ACP 호환 백엔드에 연결합니다."
   },
   "externalBackendSection.workingDir": {
     "defaultMessage": "원격 작업 디렉터리(선택 사항)"
@@ -2390,8 +2405,17 @@
   "onboardingGuard.checkProviderErrorTitle": {
     "defaultMessage": "goose 서버에 접속할 수 없습니다"
   },
+  "onboardingGuard.externalBackendErrorTitle": {
+    "defaultMessage": "외부 백엔드에 연결할 수 없습니다"
+  },
   "onboardingGuard.retry": {
     "defaultMessage": "다시 시도"
+  },
+  "onboardingGuard.retrying": {
+    "defaultMessage": "다시 시도 중…"
+  },
+  "onboardingGuard.switchToLocal": {
+    "defaultMessage": "로컬로 전환"
   },
   "onboardingGuard.welcomeDescription": {
     "defaultMessage": "로컬 AI 에이전트입니다. 시작하려면 AI 모델 제공업체를 연결하세요."

--- a/ui/desktop/src/i18n/messages/ko.json
+++ b/ui/desktop/src/i18n/messages/ko.json
@@ -1229,6 +1229,12 @@
   "externalBackendSection.serverUrlHelp": {
     "defaultMessage": "HTTP(S) 기본 URL을 입력하세요. goose는 /status를 확인하고 이 기본 주소 아래의 /acp에 연결합니다."
   },
+  "externalBackendSection.diagnosticsHeading": {
+    "defaultMessage": "연결 확인"
+  },
+  "externalBackendSection.diagnosticsHint": {
+    "defaultMessage": "위에서 처음 실패한 확인 항목이 연결이 중단된 지점입니다. 백엔드가 실행 중이고 이 컴퓨터에서 연결 가능한지, 시크릿 키가 일치하는지, 중간의 프록시나 VPN이 /status와 /acp를 허용하는지 확인하세요."
+  },
   "externalBackendSection.connect": {
     "defaultMessage": "연결"
   },

--- a/ui/desktop/src/i18n/messages/ms.json
+++ b/ui/desktop/src/i18n/messages/ms.json
@@ -1214,9 +1214,6 @@
   "externalBackendSection.fingerprintRequiresHttps": {
     "defaultMessage": "Certificate fingerprint requires an https URL"
   },
-  "externalBackendSection.restartNote": {
-    "defaultMessage": "Perubahan memerlukan memulakan semula Goose untuk berkuat kuasa. Tetingkap sembang baharu akan menyambung ke pelayan luaran."
-  },
   "externalBackendSection.secretKey": {
     "defaultMessage": "Kunci Rahsia"
   },
@@ -1232,6 +1229,30 @@
   "externalBackendSection.serverUrlHelp": {
     "defaultMessage": "Enter the HTTP(S) base URL. Goose checks /status and connects to /acp under this base."
   },
+  "externalBackendSection.connect": {
+    "defaultMessage": "Sambung"
+  },
+  "externalBackendSection.connectFailed": {
+    "defaultMessage": "Tidak dapat menyambung: {error}"
+  },
+  "externalBackendSection.connected": {
+    "defaultMessage": "Tetingkap ini kini menggunakan backend luaran."
+  },
+  "externalBackendSection.connecting": {
+    "defaultMessage": "Menyambung…"
+  },
+  "externalBackendSection.disconnect": {
+    "defaultMessage": "Putuskan"
+  },
+  "externalBackendSection.disconnectFailed": {
+    "defaultMessage": "Tidak dapat memutuskan: {error}"
+  },
+  "externalBackendSection.disconnected": {
+    "defaultMessage": "Tetingkap ini kini menggunakan backend tempatan."
+  },
+  "externalBackendSection.disconnecting": {
+    "defaultMessage": "Memutuskan…"
+  },
   "externalBackendSection.title": {
     "defaultMessage": "Pelayan Goose"
   },
@@ -1243,12 +1264,6 @@
   },
   "externalBackendSection.urlProtocolError": {
     "defaultMessage": "URL mesti menggunakan protokol http atau https"
-  },
-  "externalBackendSection.useExternalServer": {
-    "defaultMessage": "Gunakan pelayan luaran"
-  },
-  "externalBackendSection.useExternalServerDescription": {
-    "defaultMessage": "Sambung ke pelayan goose yang berjalan di tempat lain (memerlukan memulakan semula aplikasi)"
   },
   "externalBackendSection.workingDir": {
     "defaultMessage": "Direktori kerja jauh (pilihan)"
@@ -2390,8 +2405,17 @@
   "onboardingGuard.checkProviderErrorTitle": {
     "defaultMessage": "Tidak dapat menyambung ke pelayan Goose"
   },
+  "onboardingGuard.externalBackendErrorTitle": {
+    "defaultMessage": "Tidak dapat menyambung ke backend luaran"
+  },
   "onboardingGuard.retry": {
     "defaultMessage": "Cuba Semula"
+  },
+  "onboardingGuard.retrying": {
+    "defaultMessage": "Mencuba semula…"
+  },
+  "onboardingGuard.switchToLocal": {
+    "defaultMessage": "Tukar ke tempatan"
   },
   "onboardingGuard.welcomeDescription": {
     "defaultMessage": "Ejen AI tempatan anda. Sambungkan penyedia model AI untuk bermula."

--- a/ui/desktop/src/i18n/messages/ms.json
+++ b/ui/desktop/src/i18n/messages/ms.json
@@ -1229,6 +1229,12 @@
   "externalBackendSection.serverUrlHelp": {
     "defaultMessage": "Enter the HTTP(S) base URL. Goose checks /status and connects to /acp under this base."
   },
+  "externalBackendSection.diagnosticsHeading": {
+    "defaultMessage": "Pemeriksaan sambungan"
+  },
+  "externalBackendSection.diagnosticsHint": {
+    "defaultMessage": "Pemeriksaan pertama yang gagal di atas ialah tempat sambungan terhenti. Pastikan backend sedang berjalan dan boleh dihubungi dari mesin ini, kunci rahsianya sepadan, dan sebarang proksi atau VPN di antaranya membenarkan /status dan /acp."
+  },
   "externalBackendSection.connect": {
     "defaultMessage": "Sambung"
   },

--- a/ui/desktop/src/i18n/messages/pt.json
+++ b/ui/desktop/src/i18n/messages/pt.json
@@ -1229,6 +1229,12 @@
   "externalBackendSection.serverUrlHelp": {
     "defaultMessage": "Enter the HTTP(S) base URL. Goose checks /status and connects to /acp under this base."
   },
+  "externalBackendSection.diagnosticsHeading": {
+    "defaultMessage": "Verificações de conexão"
+  },
+  "externalBackendSection.diagnosticsHint": {
+    "defaultMessage": "A primeira verificação com falha acima indica onde a conexão parou. Confirme que o backend está em execução e acessível a partir desta máquina, que a chave secreta corresponde e que qualquer proxy ou VPN intermediário permite /status e /acp."
+  },
   "externalBackendSection.connect": {
     "defaultMessage": "Conectar"
   },

--- a/ui/desktop/src/i18n/messages/pt.json
+++ b/ui/desktop/src/i18n/messages/pt.json
@@ -1214,9 +1214,6 @@
   "externalBackendSection.fingerprintRequiresHttps": {
     "defaultMessage": "Certificate fingerprint requires an https URL"
   },
-  "externalBackendSection.restartNote": {
-    "defaultMessage": "As alterações exigem reiniciar o Goose para entrar em vigor. As novas janelas de chat se conectarão ao servidor externo."
-  },
   "externalBackendSection.secretKey": {
     "defaultMessage": "Chave secreta"
   },
@@ -1232,6 +1229,30 @@
   "externalBackendSection.serverUrlHelp": {
     "defaultMessage": "Enter the HTTP(S) base URL. Goose checks /status and connects to /acp under this base."
   },
+  "externalBackendSection.connect": {
+    "defaultMessage": "Conectar"
+  },
+  "externalBackendSection.connectFailed": {
+    "defaultMessage": "Não foi possível conectar: {error}"
+  },
+  "externalBackendSection.connected": {
+    "defaultMessage": "Esta janela está agora a usar o backend externo."
+  },
+  "externalBackendSection.connecting": {
+    "defaultMessage": "A conectar…"
+  },
+  "externalBackendSection.disconnect": {
+    "defaultMessage": "Desconectar"
+  },
+  "externalBackendSection.disconnectFailed": {
+    "defaultMessage": "Não foi possível desconectar: {error}"
+  },
+  "externalBackendSection.disconnected": {
+    "defaultMessage": "Esta janela está agora a usar o backend local."
+  },
+  "externalBackendSection.disconnecting": {
+    "defaultMessage": "A desconectar…"
+  },
   "externalBackendSection.title": {
     "defaultMessage": "Servidor Goose"
   },
@@ -1243,12 +1264,6 @@
   },
   "externalBackendSection.urlProtocolError": {
     "defaultMessage": "A URL deve usar o protocolo http ou https"
-  },
-  "externalBackendSection.useExternalServer": {
-    "defaultMessage": "Usar servidor externo"
-  },
-  "externalBackendSection.useExternalServerDescription": {
-    "defaultMessage": "Conecte-se a um servidor goose em execução em outro lugar (requer reinicialização do app)"
   },
   "externalBackendSection.workingDir": {
     "defaultMessage": "Diretório de trabalho remoto (opcional)"
@@ -2390,8 +2405,17 @@
   "onboardingGuard.checkProviderErrorTitle": {
     "defaultMessage": "Não foi possível ligar ao servidor Goose"
   },
+  "onboardingGuard.externalBackendErrorTitle": {
+    "defaultMessage": "Não foi possível conectar ao backend externo"
+  },
   "onboardingGuard.retry": {
     "defaultMessage": "Tentar novamente"
+  },
+  "onboardingGuard.retrying": {
+    "defaultMessage": "A tentar novamente…"
+  },
+  "onboardingGuard.switchToLocal": {
+    "defaultMessage": "Mudar para local"
   },
   "onboardingGuard.welcomeDescription": {
     "defaultMessage": "O seu agente de IA local. Ligue um fornecedor de modelos de IA para começar."

--- a/ui/desktop/src/i18n/messages/ru.json
+++ b/ui/desktop/src/i18n/messages/ru.json
@@ -1229,6 +1229,12 @@
   "externalBackendSection.serverUrlHelp": {
     "defaultMessage": "Enter the HTTP(S) base URL. Goose checks /status and connects to /acp under this base."
   },
+  "externalBackendSection.diagnosticsHeading": {
+    "defaultMessage": "Проверки подключения"
+  },
+  "externalBackendSection.diagnosticsHint": {
+    "defaultMessage": "Первая неудачная проверка выше показывает, где остановилось подключение. Убедитесь, что бэкенд запущен и доступен с этого компьютера, что его секретный ключ совпадает, и что прокси или VPN между ними разрешают /status и /acp."
+  },
   "externalBackendSection.connect": {
     "defaultMessage": "Подключить"
   },

--- a/ui/desktop/src/i18n/messages/ru.json
+++ b/ui/desktop/src/i18n/messages/ru.json
@@ -1214,9 +1214,6 @@
   "externalBackendSection.fingerprintRequiresHttps": {
     "defaultMessage": "Certificate fingerprint requires an https URL"
   },
-  "externalBackendSection.restartNote": {
-    "defaultMessage": "Чтобы изменения вступили в силу, требуется перезапуск Goose. Новые окна чата будут подключаться к внешнему серверу."
-  },
   "externalBackendSection.secretKey": {
     "defaultMessage": "Секретный ключ"
   },
@@ -1232,6 +1229,30 @@
   "externalBackendSection.serverUrlHelp": {
     "defaultMessage": "Enter the HTTP(S) base URL. Goose checks /status and connects to /acp under this base."
   },
+  "externalBackendSection.connect": {
+    "defaultMessage": "Подключить"
+  },
+  "externalBackendSection.connectFailed": {
+    "defaultMessage": "Не удалось подключиться: {error}"
+  },
+  "externalBackendSection.connected": {
+    "defaultMessage": "Это окно теперь использует внешний бэкенд."
+  },
+  "externalBackendSection.connecting": {
+    "defaultMessage": "Подключение…"
+  },
+  "externalBackendSection.disconnect": {
+    "defaultMessage": "Отключить"
+  },
+  "externalBackendSection.disconnectFailed": {
+    "defaultMessage": "Не удалось отключиться: {error}"
+  },
+  "externalBackendSection.disconnected": {
+    "defaultMessage": "Это окно теперь использует локальный бэкенд."
+  },
+  "externalBackendSection.disconnecting": {
+    "defaultMessage": "Отключение…"
+  },
   "externalBackendSection.title": {
     "defaultMessage": "Сервер Goose"
   },
@@ -1243,12 +1264,6 @@
   },
   "externalBackendSection.urlProtocolError": {
     "defaultMessage": "URL должен использовать протокол http или https"
-  },
-  "externalBackendSection.useExternalServer": {
-    "defaultMessage": "Использовать внешний сервер"
-  },
-  "externalBackendSection.useExternalServerDescription": {
-    "defaultMessage": "Подключиться к серверу goose, запущенному в другом месте (требуется перезапуск приложения)"
   },
   "externalBackendSection.workingDir": {
     "defaultMessage": "Удалённый рабочий каталог (необязательно)"
@@ -2390,8 +2405,17 @@
   "onboardingGuard.checkProviderErrorTitle": {
     "defaultMessage": "Не удалось подключиться к серверу Goose"
   },
+  "onboardingGuard.externalBackendErrorTitle": {
+    "defaultMessage": "Не удалось подключиться к внешнему бэкенду"
+  },
   "onboardingGuard.retry": {
     "defaultMessage": "Повторить"
+  },
+  "onboardingGuard.retrying": {
+    "defaultMessage": "Повторная попытка…"
+  },
+  "onboardingGuard.switchToLocal": {
+    "defaultMessage": "Переключиться на локальный"
   },
   "onboardingGuard.welcomeDescription": {
     "defaultMessage": "Ваш локальный ИИ-агент. Подключите провайдера ИИ-модели, чтобы начать."

--- a/ui/desktop/src/i18n/messages/tr.json
+++ b/ui/desktop/src/i18n/messages/tr.json
@@ -1214,9 +1214,6 @@
   "externalBackendSection.fingerprintRequiresHttps": {
     "defaultMessage": "Certificate fingerprint requires an https URL"
   },
-  "externalBackendSection.restartNote": {
-    "defaultMessage": "Değişikliklerin etkili olması için Goose'nin yeniden başlatılması gerekir. Yeni sohbet pencereleri harici sunucuya bağlanacaktır."
-  },
   "externalBackendSection.secretKey": {
     "defaultMessage": "Gizli Anahtar"
   },
@@ -1232,6 +1229,30 @@
   "externalBackendSection.serverUrlHelp": {
     "defaultMessage": "Enter the HTTP(S) base URL. Goose checks /status and connects to /acp under this base."
   },
+  "externalBackendSection.connect": {
+    "defaultMessage": "Bağlan"
+  },
+  "externalBackendSection.connectFailed": {
+    "defaultMessage": "Bağlanılamadı: {error}"
+  },
+  "externalBackendSection.connected": {
+    "defaultMessage": "Bu pencere artık harici arka uç kullanıyor."
+  },
+  "externalBackendSection.connecting": {
+    "defaultMessage": "Bağlanıyor…"
+  },
+  "externalBackendSection.disconnect": {
+    "defaultMessage": "Bağlantıyı kes"
+  },
+  "externalBackendSection.disconnectFailed": {
+    "defaultMessage": "Bağlantı kesilemedi: {error}"
+  },
+  "externalBackendSection.disconnected": {
+    "defaultMessage": "Bu pencere artık yerel arka uç kullanıyor."
+  },
+  "externalBackendSection.disconnecting": {
+    "defaultMessage": "Bağlantı kesiliyor…"
+  },
   "externalBackendSection.title": {
     "defaultMessage": "Goose Sunucu"
   },
@@ -1243,12 +1264,6 @@
   },
   "externalBackendSection.urlProtocolError": {
     "defaultMessage": "URL, http veya https protokolünü kullanmalıdır"
-  },
-  "externalBackendSection.useExternalServer": {
-    "defaultMessage": "Harici sunucu kullan"
-  },
-  "externalBackendSection.useExternalServerDescription": {
-    "defaultMessage": "Başka bir yerde çalışan bir goose sunucusuna bağlanın (uygulamanın yeniden başlatılmasını gerektirir)"
   },
   "externalBackendSection.workingDir": {
     "defaultMessage": "Uzak çalışma dizini (isteğe bağlı)"
@@ -2390,8 +2405,17 @@
   "onboardingGuard.checkProviderErrorTitle": {
     "defaultMessage": "Goose sunucusuna bağlanılamıyor"
   },
+  "onboardingGuard.externalBackendErrorTitle": {
+    "defaultMessage": "Harici arka uca bağlanılamadı"
+  },
   "onboardingGuard.retry": {
     "defaultMessage": "Yeniden dene"
+  },
+  "onboardingGuard.retrying": {
+    "defaultMessage": "Yeniden deneniyor…"
+  },
+  "onboardingGuard.switchToLocal": {
+    "defaultMessage": "Yerele geç"
   },
   "onboardingGuard.welcomeDescription": {
     "defaultMessage": "Yerel AI temsilciniz. Başlamak için bir AI model sağlayıcısına bağlanın."

--- a/ui/desktop/src/i18n/messages/tr.json
+++ b/ui/desktop/src/i18n/messages/tr.json
@@ -1229,6 +1229,12 @@
   "externalBackendSection.serverUrlHelp": {
     "defaultMessage": "Enter the HTTP(S) base URL. Goose checks /status and connects to /acp under this base."
   },
+  "externalBackendSection.diagnosticsHeading": {
+    "defaultMessage": "Bağlantı kontrolleri"
+  },
+  "externalBackendSection.diagnosticsHint": {
+    "defaultMessage": "Yukarıdaki ilk başarısız kontrol, bağlantının durduğu yerdir. Arka ucun çalıştığını ve bu makineden erişilebilir olduğunu, gizli anahtarının eşleştiğini ve aradaki proxy ya da VPN'in /status ve /acp'ye izin verdiğini doğrulayın."
+  },
   "externalBackendSection.connect": {
     "defaultMessage": "Bağlan"
   },

--- a/ui/desktop/src/i18n/messages/vi.json
+++ b/ui/desktop/src/i18n/messages/vi.json
@@ -1214,9 +1214,6 @@
   "externalBackendSection.fingerprintRequiresHttps": {
     "defaultMessage": "Certificate fingerprint requires an https URL"
   },
-  "externalBackendSection.restartNote": {
-    "defaultMessage": "Các thay đổi cần khởi động lại Goose để có hiệu lực. Các cửa sổ trò chuyện mới sẽ kết nối tới máy chủ bên ngoài."
-  },
   "externalBackendSection.secretKey": {
     "defaultMessage": "Khóa bí mật"
   },
@@ -1232,6 +1229,30 @@
   "externalBackendSection.serverUrlHelp": {
     "defaultMessage": "Enter the HTTP(S) base URL. Goose checks /status and connects to /acp under this base."
   },
+  "externalBackendSection.connect": {
+    "defaultMessage": "Kết nối"
+  },
+  "externalBackendSection.connectFailed": {
+    "defaultMessage": "Không thể kết nối: {error}"
+  },
+  "externalBackendSection.connected": {
+    "defaultMessage": "Cửa sổ này hiện đang dùng backend bên ngoài."
+  },
+  "externalBackendSection.connecting": {
+    "defaultMessage": "Đang kết nối…"
+  },
+  "externalBackendSection.disconnect": {
+    "defaultMessage": "Ngắt kết nối"
+  },
+  "externalBackendSection.disconnectFailed": {
+    "defaultMessage": "Không thể ngắt kết nối: {error}"
+  },
+  "externalBackendSection.disconnected": {
+    "defaultMessage": "Cửa sổ này hiện đang dùng backend cục bộ."
+  },
+  "externalBackendSection.disconnecting": {
+    "defaultMessage": "Đang ngắt kết nối…"
+  },
   "externalBackendSection.title": {
     "defaultMessage": "Máy chủ Goose"
   },
@@ -1243,12 +1264,6 @@
   },
   "externalBackendSection.urlProtocolError": {
     "defaultMessage": "URL phải sử dụng giao thức http hoặc https"
-  },
-  "externalBackendSection.useExternalServer": {
-    "defaultMessage": "Sử dụng máy chủ bên ngoài"
-  },
-  "externalBackendSection.useExternalServerDescription": {
-    "defaultMessage": "Kết nối tới một máy chủ goose đang chạy ở nơi khác (cần khởi động lại ứng dụng)"
   },
   "externalBackendSection.workingDir": {
     "defaultMessage": "Thư mục làm việc từ xa (tùy chọn)"
@@ -2390,8 +2405,17 @@
   "onboardingGuard.checkProviderErrorTitle": {
     "defaultMessage": "Không thể kết nối với máy chủ Goose"
   },
+  "onboardingGuard.externalBackendErrorTitle": {
+    "defaultMessage": "Không thể kết nối tới backend bên ngoài"
+  },
   "onboardingGuard.retry": {
     "defaultMessage": "Thử lại"
+  },
+  "onboardingGuard.retrying": {
+    "defaultMessage": "Đang thử lại…"
+  },
+  "onboardingGuard.switchToLocal": {
+    "defaultMessage": "Chuyển sang cục bộ"
   },
   "onboardingGuard.welcomeDescription": {
     "defaultMessage": "Tác nhân AI cục bộ của bạn. Kết nối một nhà cung cấp mô hình AI để bắt đầu."

--- a/ui/desktop/src/i18n/messages/vi.json
+++ b/ui/desktop/src/i18n/messages/vi.json
@@ -1229,6 +1229,12 @@
   "externalBackendSection.serverUrlHelp": {
     "defaultMessage": "Enter the HTTP(S) base URL. Goose checks /status and connects to /acp under this base."
   },
+  "externalBackendSection.diagnosticsHeading": {
+    "defaultMessage": "Kiểm tra kết nối"
+  },
+  "externalBackendSection.diagnosticsHint": {
+    "defaultMessage": "Bước kiểm tra thất bại đầu tiên ở trên là nơi kết nối bị dừng. Hãy xác nhận backend đang chạy và có thể truy cập từ máy này, khóa bí mật của nó trùng khớp, và mọi proxy hoặc VPN ở giữa cho phép /status và /acp."
+  },
   "externalBackendSection.connect": {
     "defaultMessage": "Kết nối"
   },

--- a/ui/desktop/src/i18n/messages/zh-CN.json
+++ b/ui/desktop/src/i18n/messages/zh-CN.json
@@ -1214,9 +1214,6 @@
   "externalBackendSection.fingerprintRequiresHttps": {
     "defaultMessage": "Certificate fingerprint requires an https URL"
   },
-  "externalBackendSection.restartNote": {
-    "defaultMessage": "更改需要重启 Goose 才能生效。新的聊天窗口将连接到外部服务器。"
-  },
   "externalBackendSection.secretKey": {
     "defaultMessage": "密钥"
   },
@@ -1232,6 +1229,30 @@
   "externalBackendSection.serverUrlHelp": {
     "defaultMessage": "Enter the HTTP(S) base URL. Goose checks /status and connects to /acp under this base."
   },
+  "externalBackendSection.connect": {
+    "defaultMessage": "连接"
+  },
+  "externalBackendSection.connectFailed": {
+    "defaultMessage": "无法连接：{error}"
+  },
+  "externalBackendSection.connected": {
+    "defaultMessage": "此窗口现在使用外部后端。"
+  },
+  "externalBackendSection.connecting": {
+    "defaultMessage": "正在连接…"
+  },
+  "externalBackendSection.disconnect": {
+    "defaultMessage": "断开连接"
+  },
+  "externalBackendSection.disconnectFailed": {
+    "defaultMessage": "无法断开连接：{error}"
+  },
+  "externalBackendSection.disconnected": {
+    "defaultMessage": "此窗口现在使用本地后端。"
+  },
+  "externalBackendSection.disconnecting": {
+    "defaultMessage": "正在断开…"
+  },
   "externalBackendSection.title": {
     "defaultMessage": "Goose 服务器"
   },
@@ -1243,12 +1264,6 @@
   },
   "externalBackendSection.urlProtocolError": {
     "defaultMessage": "URL 必须使用 http 或 https 协议"
-  },
-  "externalBackendSection.useExternalServer": {
-    "defaultMessage": "使用外部服务器"
-  },
-  "externalBackendSection.useExternalServerDescription": {
-    "defaultMessage": "连接到运行在其他位置的 goose 服务器（需要重启应用）"
   },
   "externalBackendSection.workingDir": {
     "defaultMessage": "远程工作目录（可选）"
@@ -2390,8 +2405,17 @@
   "onboardingGuard.checkProviderErrorTitle": {
     "defaultMessage": "无法连接到 Goose 服务器"
   },
+  "onboardingGuard.externalBackendErrorTitle": {
+    "defaultMessage": "无法连接到外部后端"
+  },
   "onboardingGuard.retry": {
     "defaultMessage": "重试"
+  },
+  "onboardingGuard.retrying": {
+    "defaultMessage": "正在重试…"
+  },
+  "onboardingGuard.switchToLocal": {
+    "defaultMessage": "切换到本地"
   },
   "onboardingGuard.welcomeDescription": {
     "defaultMessage": "你的本地 AI agent。连接 AI 模型提供商即可开始。"

--- a/ui/desktop/src/i18n/messages/zh-CN.json
+++ b/ui/desktop/src/i18n/messages/zh-CN.json
@@ -1229,6 +1229,12 @@
   "externalBackendSection.serverUrlHelp": {
     "defaultMessage": "Enter the HTTP(S) base URL. Goose checks /status and connects to /acp under this base."
   },
+  "externalBackendSection.diagnosticsHeading": {
+    "defaultMessage": "连接检查"
+  },
+  "externalBackendSection.diagnosticsHint": {
+    "defaultMessage": "上面第一个失败的检查就是连接中断的位置。请确认后端正在运行且可从本机访问、其密钥一致，并且中间的任何代理或 VPN 允许访问 /status 和 /acp。"
+  },
   "externalBackendSection.connect": {
     "defaultMessage": "连接"
   },

--- a/ui/desktop/src/i18n/messages/zh-TW.json
+++ b/ui/desktop/src/i18n/messages/zh-TW.json
@@ -1214,9 +1214,6 @@
   "externalBackendSection.fingerprintRequiresHttps": {
     "defaultMessage": "Certificate fingerprint requires an https URL"
   },
-  "externalBackendSection.restartNote": {
-    "defaultMessage": "變更需要重新啟動 Goose 才會生效。新的聊天視窗將連線至外部伺服器。"
-  },
   "externalBackendSection.secretKey": {
     "defaultMessage": "密鑰"
   },
@@ -1232,6 +1229,30 @@
   "externalBackendSection.serverUrlHelp": {
     "defaultMessage": "Enter the HTTP(S) base URL. Goose checks /status and connects to /acp under this base."
   },
+  "externalBackendSection.connect": {
+    "defaultMessage": "連線"
+  },
+  "externalBackendSection.connectFailed": {
+    "defaultMessage": "無法連線：{error}"
+  },
+  "externalBackendSection.connected": {
+    "defaultMessage": "此視窗現在使用外部後端。"
+  },
+  "externalBackendSection.connecting": {
+    "defaultMessage": "正在連線…"
+  },
+  "externalBackendSection.disconnect": {
+    "defaultMessage": "中斷連線"
+  },
+  "externalBackendSection.disconnectFailed": {
+    "defaultMessage": "無法中斷連線：{error}"
+  },
+  "externalBackendSection.disconnected": {
+    "defaultMessage": "此視窗現在使用本機後端。"
+  },
+  "externalBackendSection.disconnecting": {
+    "defaultMessage": "正在中斷…"
+  },
   "externalBackendSection.title": {
     "defaultMessage": "Goose 伺服器"
   },
@@ -1243,12 +1264,6 @@
   },
   "externalBackendSection.urlProtocolError": {
     "defaultMessage": "URL 必須使用 http 或 https 通訊協定"
-  },
-  "externalBackendSection.useExternalServer": {
-    "defaultMessage": "使用外部伺服器"
-  },
-  "externalBackendSection.useExternalServerDescription": {
-    "defaultMessage": "連線至在其他位置執行的 goose 伺服器（需要重新啟動應用程式）"
   },
   "externalBackendSection.workingDir": {
     "defaultMessage": "遠端工作目錄（選用）"
@@ -2390,8 +2405,17 @@
   "onboardingGuard.checkProviderErrorTitle": {
     "defaultMessage": "無法連線到 Goose 伺服器"
   },
+  "onboardingGuard.externalBackendErrorTitle": {
+    "defaultMessage": "無法連線到外部後端"
+  },
   "onboardingGuard.retry": {
     "defaultMessage": "重試"
+  },
+  "onboardingGuard.retrying": {
+    "defaultMessage": "正在重試…"
+  },
+  "onboardingGuard.switchToLocal": {
+    "defaultMessage": "切換到本機"
   },
   "onboardingGuard.welcomeDescription": {
     "defaultMessage": "您的本機 AI 代理。連線 AI 模型供應商即可開始使用。"

--- a/ui/desktop/src/i18n/messages/zh-TW.json
+++ b/ui/desktop/src/i18n/messages/zh-TW.json
@@ -1229,6 +1229,12 @@
   "externalBackendSection.serverUrlHelp": {
     "defaultMessage": "Enter the HTTP(S) base URL. Goose checks /status and connects to /acp under this base."
   },
+  "externalBackendSection.diagnosticsHeading": {
+    "defaultMessage": "連線檢查"
+  },
+  "externalBackendSection.diagnosticsHint": {
+    "defaultMessage": "上方第一個失敗的檢查就是連線中斷的位置。請確認後端正在執行且可從本機連線、其密鑰一致，並且中間的任何代理或 VPN 允許存取 /status 與 /acp。"
+  },
   "externalBackendSection.connect": {
     "defaultMessage": "連線"
   },

--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -59,7 +59,7 @@ import type { GooseApp } from './types/apps';
 import installExtension, { REACT_DEVELOPER_TOOLS } from 'electron-devtools-installer';
 import { WEB_PROTOCOLS } from './utils/urlSecurity';
 import { openExternalUrl } from './utils/openExternalUrl';
-import { buildCSP } from './utils/csp';
+import { allowBackendOrigin, buildCSP } from './utils/csp';
 import { resolveWorkingDir } from './utils/workingDir';
 import {
   DesktopFileAccess,
@@ -1150,10 +1150,13 @@ const createChat = async (
         return;
       }
 
+      const resolvedBaseUrl = externalBackendCheck.resolvedBaseUrl ?? externalBaseUrl;
+      allowBackendOrigin(resolvedBaseUrl);
+
       const leaseCertificateTrust = externalCertificateTrust;
       externalCertificateTrust = null;
       gooseServeLease = gooseServeLeases.createExternal(
-        acpWebSocketUrlFromHttpBase(externalBaseUrl, serverSecret),
+        acpWebSocketUrlFromHttpBase(resolvedBaseUrl, serverSecret),
         serverSecret,
         leaseCertificateTrust ? async () => leaseCertificateTrust.release() : undefined
       );

--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -1102,7 +1102,8 @@ const createExternalBackendLease = async (
     };
   } catch (error) {
     certificateTrust?.release();
-    return { ok: false, error: errorMessage(error), steps: [] };
+    const detail = errorMessage(error);
+    return { ok: false, error: detail, steps: [{ name: 'URL', ok: false, detail }] };
   }
 };
 

--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -27,6 +27,7 @@ import os from 'node:os';
 import { execFileSync, spawn, execFile } from 'child_process';
 import 'dotenv/config';
 import { checkBackendStatus } from './backendStatus';
+import { closeBackendProbe, probeFetch } from './backendProbe';
 import { installBackendCertificateVerifiers } from './backendCertificateVerifier';
 import { configureProxy } from './proxy';
 import { startGooseServe } from './gooseServe';
@@ -374,6 +375,8 @@ function isTrustedHost(hostname: string): boolean {
   return getBackendCertificateTrusts(hostname).length > 0;
 }
 
+const clientCertificatesByHost = new Map<string, string>();
+
 // Renderer requests: pin to the exact cert once known.
 app.on('certificate-error', (event, _webContents, url, _error, certificate, callback) => {
   const parsed = new URL(url);
@@ -384,6 +387,23 @@ app.on('certificate-error', (event, _webContents, url, _error, certificate, call
 
   event.preventDefault();
   callback(verifyBackendCertificate(parsed.hostname, certificate.fingerprint));
+});
+
+// Electron answers Chromium's client-auth callback with the first certificate the
+// server's acceptable-CA list matched, which is left in place so the full chain is
+// sent. This only records what went out so the connection test can report it.
+app.on('select-client-certificate', (_event, _webContents, url, certificates) => {
+  const [certificate] = certificates;
+  const { hostname } = new URL(url);
+  if (!certificate) {
+    clientCertificatesByHost.delete(hostname);
+    return;
+  }
+
+  clientCertificatesByHost.set(hostname, certificate.subjectName);
+  log.info(
+    `[Main] Sending client certificate "${certificate.subjectName}" to ${url} (${certificates.length} offered)`
+  );
 });
 
 app.whenReady().then(() => {
@@ -1119,7 +1139,7 @@ const createChat = async (
       const externalBackendCheck = await checkBackendStatus({
         baseUrl: externalBaseUrl,
         serverSecret,
-        fetch: net.fetch as unknown as typeof globalThis.fetch,
+        fetch: probeFetch,
       });
       if (!externalBackendCheck.ok) {
         externalCertificateTrust?.release();
@@ -3192,6 +3212,10 @@ app.on('will-quit', async () => {
   windowPowerSaveBlockers.clear();
 
   globalShortcut.unregisterAll();
+});
+
+app.on('before-quit', () => {
+  closeBackendProbe();
 });
 
 app.on('window-all-closed', () => {

--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -26,7 +26,7 @@ import path from 'node:path';
 import os from 'node:os';
 import { execFileSync, spawn, execFile } from 'child_process';
 import 'dotenv/config';
-import { checkBackendStatus } from './backendStatus';
+import { checkBackendStatus, type BackendCheckStep } from './backendStatus';
 import { closeBackendProbe, probeFetch } from './backendProbe';
 import { installBackendCertificateVerifiers } from './backendCertificateVerifier';
 import { configureProxy } from './proxy';
@@ -376,6 +376,20 @@ function isTrustedHost(hostname: string): boolean {
 }
 
 const clientCertificatesByHost = new Map<string, string>();
+
+const withClientCertificateStep = (steps: BackendCheckStep[], url: string): BackendCheckStep[] => {
+  let hostname: string;
+  try {
+    hostname = new URL(normalizeAcpHttpBaseUrl(url)).hostname;
+  } catch {
+    return steps;
+  }
+
+  const clientCertificate = clientCertificatesByHost.get(hostname);
+  return clientCertificate
+    ? [...steps, { name: 'Client certificate', ok: true, detail: clientCertificate }]
+    : steps;
+};
 
 // Renderer requests: pin to the exact cert once known.
 app.on('certificate-error', (event, _webContents, url, _error, certificate, callback) => {
@@ -997,6 +1011,7 @@ let appConfig = {
   GOOSE_EXTERNAL_BACKEND: false,
   GOOSE_EXTERNAL_BACKEND_URL: '',
   GOOSE_EXTERNAL_BACKEND_SOURCE: '',
+  GOOSE_EXTERNAL_BACKEND_ERROR: '',
   // Start with the env-var override; the OS region locale is filled in after app.ready
   // (see updateLocaleFromSystem below) since getSystemLocale() cannot be called earlier.
   GOOSE_LOCALE: process.env.GOOSE_LOCALE || undefined,
@@ -1039,6 +1054,120 @@ const windowPowerSaveBlockers = new Map<number, number>(); // windowId -> blocke
 // Track pending initial messages per window
 const pendingInitialMessages = new Map<number, string>(); // windowId -> initialMessage
 const pendingInitialMessageNoAutoSubmit = new Set<number>(); // windowIds whose initialMessage should NOT auto-submit
+
+type ExternalBackendLease =
+  | { ok: true; lease: GooseServeLease; steps: BackendCheckStep[] }
+  | { ok: false; error: string; steps: BackendCheckStep[] };
+
+const createExternalBackendLease = async (
+  externalBackend: ExternalBackend,
+  workingDir: string
+): Promise<ExternalBackendLease> => {
+  let certificateTrust: BackendCertificateTrustRegistration | null = null;
+
+  try {
+    const externalBaseUrl = normalizeAcpHttpBaseUrl(externalBackend.url);
+    const { protocol, hostname } = new URL(externalBaseUrl);
+    if (protocol === 'https:') {
+      certificateTrust = trustBackendCertificate(hostname, externalBackend.certFingerprint ?? null);
+    }
+
+    const check = await checkBackendStatus({
+      baseUrl: externalBaseUrl,
+      serverSecret: externalBackend.secret,
+      fetch: probeFetch,
+    });
+    if (!check.ok) {
+      certificateTrust?.release();
+      return {
+        ok: false,
+        error: check.failure ?? 'The backend did not respond as an ACP server.',
+        steps: check.steps,
+      };
+    }
+
+    const resolvedBaseUrl = check.resolvedBaseUrl ?? externalBaseUrl;
+    allowBackendOrigin(resolvedBaseUrl);
+
+    const leaseCertificateTrust = certificateTrust;
+    return {
+      ok: true,
+      steps: check.steps,
+      lease: gooseServeLeases.createExternal(
+        acpWebSocketUrlFromHttpBase(resolvedBaseUrl, externalBackend.secret),
+        externalBackend.secret,
+        workingDir,
+        leaseCertificateTrust ? async () => leaseCertificateTrust.release() : undefined
+      ),
+    };
+  } catch (error) {
+    certificateTrust?.release();
+    return { ok: false, error: errorMessage(error), steps: [] };
+  }
+};
+
+type LocalBackendLease =
+  { ok: true; lease: GooseServeLease; workingDir: string } | { ok: false; error: string };
+
+const createLocalBackendLease = async (
+  serverSecret: string,
+  requestedWorkingDir: string
+): Promise<LocalBackendLease> => {
+  const localCertificateTrust = trustBackendCertificate('127.0.0.1', null);
+  const loginShellPath = await getLoginShellPath(log);
+
+  let gooseServeResult: Awaited<ReturnType<typeof startGooseServe>>;
+  try {
+    gooseServeResult = await startGooseServe({
+      serverSecret,
+      dir: requestedWorkingDir,
+      tls: true,
+      env: {
+        GOOSE_PATH_ROOT: appConfig.GOOSE_PATH_ROOT as string | undefined,
+      },
+      loginShellPath,
+      isPackaged: app.isPackaged,
+      resourcesPath: app.isPackaged ? process.resourcesPath : undefined,
+      logger: log,
+      diagnosticsDir: STARTUP_LOGS_DIR,
+      readinessFetch: net.fetch as unknown as typeof globalThis.fetch,
+    });
+    if (!gooseServeResult.certFingerprint) {
+      await gooseServeResult.cleanup();
+      throw new Error('goose serve started with TLS but did not return a certificate fingerprint');
+    }
+
+    const localCertFingerprint = normalizeFingerprint(gooseServeResult.certFingerprint);
+    if (
+      localCertificateTrust.trust.fingerprint &&
+      localCertificateTrust.trust.fingerprint !== localCertFingerprint
+    ) {
+      await gooseServeResult.cleanup();
+      throw new Error('goose serve TLS certificate fingerprint did not match readiness probe');
+    }
+    localCertificateTrust.trust.fingerprint = localCertFingerprint;
+  } catch (error) {
+    localCertificateTrust.release();
+    log.error('goose serve failed to start', error);
+    return { ok: false, error: errorMessage(error) };
+  }
+
+  const workingDir = gooseServeResult.workingDir;
+  const cleanupGooseServe = gooseServeResult.cleanup;
+  gooseServeResult.cleanup = async () => {
+    try {
+      await cleanupGooseServe();
+    } finally {
+      localCertificateTrust.release();
+    }
+  };
+
+  return {
+    ok: true,
+    workingDir,
+    lease: gooseServeLeases.create(gooseServeResult, serverSecret, workingDir),
+  };
+};
 
 interface CreateChatOptions {
   initialMessage?: string;
@@ -1084,170 +1213,48 @@ const createChat = async (
     return;
   }
 
+  let externalBackendError: string | null = null;
+
   if (externalBackend?.certFingerprint) {
-    const url = externalBackend.url;
     const usesHttps = (() => {
       try {
-        return new URL(url).protocol === 'https:';
+        return new URL(externalBackend.url).protocol === 'https:';
       } catch {
         return false;
       }
     })();
 
     if (!usesHttps) {
-      const response = dialog.showMessageBoxSync({
-        type: 'error',
-        title: 'External Backend Misconfigured',
-        message: 'Certificate fingerprint requires an HTTPS external backend URL.',
-        detail: 'Use an https:// URL or remove the configured certificate fingerprint.',
-        buttons: ['Disable External Backend & Retry', 'Quit'],
-        defaultId: 0,
-        cancelId: 1,
-      });
-
-      if (response === 0) {
-        updateSettings((s) => {
-          if (s.externalGoosed) {
-            s.externalGoosed.enabled = false;
-          }
-        });
-        return createChat(app, options);
-      }
-
-      app.quit();
-      return;
+      externalBackendError =
+        'Certificate fingerprint requires an https:// external backend URL. Use an https:// URL or remove the configured certificate fingerprint.';
+      log.error(externalBackendError);
+      externalBackend = null;
     }
   }
 
-  const serverSecret = externalBackend ? externalBackend.secret : GENERATED_SECRET;
+  let serverSecret = externalBackend ? externalBackend.secret : GENERATED_SECRET;
   let workingDir = resolveWorkingDir(externalBackend?.workingDir, dir, os.homedir());
   let gooseServeLease: GooseServeLease | null = null;
 
   if (externalBackend) {
-    let externalCertificateTrust: BackendCertificateTrustRegistration | null = null;
+    const attempt = await createExternalBackendLease(externalBackend, workingDir);
 
-    try {
-      const externalBaseUrl = normalizeAcpHttpBaseUrl(externalBackend.url);
-      const externalBase = new URL(externalBaseUrl);
-      if (externalBase.protocol === 'https:') {
-        externalCertificateTrust = trustBackendCertificate(
-          externalBase.hostname,
-          externalBackend.certFingerprint ?? null
-        );
-      }
-
-      const externalBackendCheck = await checkBackendStatus({
-        baseUrl: externalBaseUrl,
-        serverSecret,
-        fetch: probeFetch,
-      });
-      if (!externalBackendCheck.ok) {
-        externalCertificateTrust?.release();
-        log.error(`External backend check failed: ${externalBackendCheck.failure}`);
-        const canDisableExternalBackend = externalBackend.source === 'settings';
-        const response = dialog.showMessageBoxSync({
-          type: 'error',
-          title: 'External Backend Unreachable',
-          message: `Could not connect to external backend at ${externalBaseUrl}`,
-          detail: externalBackendCheck.failure ?? undefined,
-          buttons: canDisableExternalBackend
-            ? ['Disable External Backend & Retry', 'Quit']
-            : ['Quit'],
-          defaultId: 0,
-          cancelId: canDisableExternalBackend ? 1 : 0,
-        });
-
-        if (canDisableExternalBackend && response === 0) {
-          updateSettings((s) => {
-            if (s.externalGoosed) {
-              s.externalGoosed.enabled = false;
-            }
-          });
-          return createChat(app, options);
-        }
-
-        app.quit();
-        return;
-      }
-
-      const resolvedBaseUrl = externalBackendCheck.resolvedBaseUrl ?? externalBaseUrl;
-      allowBackendOrigin(resolvedBaseUrl);
-
-      const leaseCertificateTrust = externalCertificateTrust;
-      externalCertificateTrust = null;
-      gooseServeLease = gooseServeLeases.createExternal(
-        acpWebSocketUrlFromHttpBase(resolvedBaseUrl, serverSecret),
-        serverSecret,
-        leaseCertificateTrust ? async () => leaseCertificateTrust.release() : undefined
-      );
-    } catch (error) {
-      externalCertificateTrust?.release();
-      log.error('External ACP backend is misconfigured', error);
-      const canDisableExternalBackend = externalBackend.source === 'settings';
-      const response = dialog.showMessageBoxSync({
-        type: 'error',
-        title: 'External Backend Misconfigured',
-        message: 'The external backend URL is invalid.',
-        detail: errorMessage(error),
-        buttons: canDisableExternalBackend
-          ? ['Disable External Backend & Retry', 'Quit']
-          : ['Quit'],
-        defaultId: 0,
-        cancelId: canDisableExternalBackend ? 1 : 0,
-      });
-
-      if (canDisableExternalBackend && response === 0) {
-        updateSettings((s) => {
-          if (s.externalGoosed) {
-            s.externalGoosed.enabled = false;
-          }
-        });
-        return createChat(app, options);
-      }
-
-      app.quit();
-      return;
+    if (attempt.ok) {
+      gooseServeLease = attempt.lease;
+    } else {
+      // Start on the local backend instead of blocking startup, and let the
+      // renderer offer Retry / Switch to Local.
+      externalBackendError = `Could not connect to external backend at ${externalBackend.url}\n\n${attempt.error}`;
+      log.error(`External backend is unavailable: ${attempt.error}`);
+      externalBackend = null;
+      serverSecret = GENERATED_SECRET;
+      workingDir = resolveWorkingDir(undefined, dir, os.homedir());
     }
-  } else {
-    const localCertificateTrust = trustBackendCertificate('127.0.0.1', null);
+  }
 
-    const loginShellPath = await getLoginShellPath(log);
-
-    let gooseServeResult: Awaited<ReturnType<typeof startGooseServe>>;
-    try {
-      gooseServeResult = await startGooseServe({
-        serverSecret,
-        dir: workingDir,
-        tls: true,
-        env: {
-          GOOSE_PATH_ROOT: appConfig.GOOSE_PATH_ROOT as string | undefined,
-        },
-        loginShellPath,
-        isPackaged: app.isPackaged,
-        resourcesPath: app.isPackaged ? process.resourcesPath : undefined,
-        logger: log,
-        diagnosticsDir: STARTUP_LOGS_DIR,
-        readinessFetch: net.fetch as unknown as typeof globalThis.fetch,
-      });
-      if (!gooseServeResult.certFingerprint) {
-        await gooseServeResult.cleanup();
-        throw new Error(
-          'goose serve started with TLS but did not return a certificate fingerprint'
-        );
-      }
-
-      const localCertFingerprint = normalizeFingerprint(gooseServeResult.certFingerprint);
-      if (
-        localCertificateTrust.trust.fingerprint &&
-        localCertificateTrust.trust.fingerprint !== localCertFingerprint
-      ) {
-        await gooseServeResult.cleanup();
-        throw new Error('goose serve TLS certificate fingerprint did not match readiness probe');
-      }
-      localCertificateTrust.trust.fingerprint = localCertFingerprint;
-    } catch (error) {
-      localCertificateTrust.release();
-      log.error('goose serve failed to start', error);
+  if (!gooseServeLease) {
+    const local = await createLocalBackendLease(serverSecret, workingDir);
+    if (!local.ok) {
       dialog.showMessageBoxSync({
         type: 'error',
         title: 'Goose Failed to Start',
@@ -1255,7 +1262,7 @@ const createChat = async (
         detail: [
           'Backend: goose serve',
           'Readiness check: HTTPS GET /status',
-          `Startup error:\n${errorMessage(error)}`,
+          `Startup error:\n${local.error}`,
         ].join('\n\n'),
         buttons: ['OK'],
       });
@@ -1263,16 +1270,8 @@ const createChat = async (
       return;
     }
 
-    workingDir = gooseServeResult.workingDir;
-    const cleanupGooseServe = gooseServeResult.cleanup;
-    gooseServeResult.cleanup = async () => {
-      try {
-        await cleanupGooseServe();
-      } finally {
-        localCertificateTrust.release();
-      }
-    };
-    gooseServeLease = gooseServeLeases.create(gooseServeResult, serverSecret);
+    workingDir = local.workingDir;
+    gooseServeLease = local.lease;
   }
 
   const cleanupUnregisteredGooseServeLease = async () => {
@@ -1325,6 +1324,7 @@ const createChat = async (
             GOOSE_EXTERNAL_BACKEND: externalBackend !== null,
             GOOSE_EXTERNAL_BACKEND_URL: externalBackend?.url ?? '',
             GOOSE_EXTERNAL_BACKEND_SOURCE: externalBackend?.source ?? '',
+            GOOSE_EXTERNAL_BACKEND_ERROR: externalBackendError ?? '',
             REQUEST_DIR: dir,
             GOOSE_VERSION: version,
             recipeDeeplink: recipeDeeplink,
@@ -2041,6 +2041,71 @@ ipcMain.handle('get-acp-url', async (event) => {
     return null;
   }
   return gooseServeLeases.getAcpUrl(windowId) ?? null;
+});
+
+ipcMain.handle('get-working-dir', (event) => {
+  const windowId = BrowserWindow.fromWebContents(event.sender)?.id;
+  return windowId ? gooseServeLeases.getWorkingDir(windowId) : null;
+});
+
+ipcMain.handle('switch-backend', async (event) => {
+  const window = BrowserWindow.fromWebContents(event.sender);
+  if (!window) {
+    return { ok: false, error: 'This window is no longer available.', steps: [] };
+  }
+
+  let externalBackend: ExternalBackend | null;
+  try {
+    externalBackend = getActiveExternalBackend(getSettings());
+  } catch (error) {
+    return { ok: false, error: errorMessage(error), steps: [] };
+  }
+
+  if (!externalBackend) {
+    return {
+      ok: false,
+      error: 'Enable the external backend before connecting.',
+      steps: [],
+    };
+  }
+
+  const workingDir = resolveWorkingDir(externalBackend.workingDir, undefined, os.homedir());
+  const attempt = await createExternalBackendLease(externalBackend, workingDir);
+  const steps = withClientCertificateStep(attempt.steps, externalBackend.url);
+  if (!attempt.ok) {
+    log.error(`Failed to switch this window to the external backend: ${attempt.error}`);
+    return { ok: false, error: attempt.error, steps };
+  }
+
+  await gooseServeLeases.releaseWindow(window.id);
+  gooseServeLeases.attachWindow(window.id, attempt.lease);
+  await desktopFileAccess.bindWindow(window.id, workingDir);
+  return { ok: true, workingDir, steps };
+});
+
+ipcMain.handle('disconnect-backend', async (event) => {
+  const window = BrowserWindow.fromWebContents(event.sender);
+  if (!window) {
+    return { ok: false, error: 'This window is no longer available.' };
+  }
+
+  updateSettings((s) => {
+    if (s.externalGoosed) {
+      s.externalGoosed.enabled = false;
+    }
+  });
+
+  const workingDir = resolveWorkingDir(undefined, undefined, os.homedir());
+  const local = await createLocalBackendLease(GENERATED_SECRET, workingDir);
+  if (!local.ok) {
+    log.error(`Failed to switch this window to the local backend: ${local.error}`);
+    return { ok: false, error: local.error };
+  }
+
+  await gooseServeLeases.releaseWindow(window.id);
+  gooseServeLeases.attachWindow(window.id, local.lease);
+  await desktopFileAccess.bindWindow(window.id, local.workingDir);
+  return { ok: true, workingDir: local.workingDir };
 });
 
 // Handle menu bar icon visibility

--- a/ui/desktop/src/preload.ts
+++ b/ui/desktop/src/preload.ts
@@ -4,6 +4,7 @@ import type { GooseApp } from './types/apps';
 import type { Settings, SettingKey } from './utils/settings';
 import { defaultSettings } from './utils/settings';
 import type { OpenExternalUrlResult } from './utils/urlSecurity';
+import type { BackendCheckStep } from './backendStatus';
 
 // Mapping from settings keys to their old localStorage keys for lazy migration
 const localStorageKeyMap: Partial<Record<SettingKey, string>> = {
@@ -135,6 +136,14 @@ type ElectronAPI = {
   setSetting: <K extends SettingKey>(key: K, value: Settings[K]) => Promise<void>;
   getSecretKey: () => Promise<string | null>;
   getAcpUrl: () => Promise<string | null>;
+  getWorkingDir: () => Promise<string | null>;
+  switchBackend: () => Promise<{
+    ok: boolean;
+    error?: string;
+    workingDir?: string;
+    steps: BackendCheckStep[];
+  }>;
+  disconnectBackend: () => Promise<{ ok: boolean; error?: string; workingDir?: string }>;
   setWakelock: (enable: boolean) => Promise<boolean>;
   getWakelockState: () => Promise<boolean>;
   setSpellcheck: (enable: boolean) => Promise<boolean>;
@@ -262,6 +271,9 @@ const electronAPI: ElectronAPI = {
   },
   getSecretKey: () => ipcRenderer.invoke('get-secret-key'),
   getAcpUrl: () => ipcRenderer.invoke('get-acp-url'),
+  getWorkingDir: () => ipcRenderer.invoke('get-working-dir'),
+  switchBackend: () => ipcRenderer.invoke('switch-backend'),
+  disconnectBackend: () => ipcRenderer.invoke('disconnect-backend'),
   setWakelock: (enable: boolean) => ipcRenderer.invoke('set-wakelock', enable),
   getWakelockState: () => ipcRenderer.invoke('get-wakelock-state'),
   setSpellcheck: (enable: boolean) => ipcRenderer.invoke('set-spellcheck', enable),

--- a/ui/desktop/src/utils/__tests__/workingDir.test.ts
+++ b/ui/desktop/src/utils/__tests__/workingDir.test.ts
@@ -1,5 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { getEffectiveWorkingDir, resolveWorkingDir } from '../workingDir';
+import {
+  getInitialWorkingDir,
+  refreshWorkingDir,
+  resolveWorkingDir,
+  setWorkingDir,
+} from '../workingDir';
 
 describe('resolveWorkingDir', () => {
   it('uses the configured external backend directory when present', () => {
@@ -11,86 +16,48 @@ describe('resolveWorkingDir', () => {
   });
 });
 
-describe('getEffectiveWorkingDir', () => {
-  const getSettingMock = vi.fn();
-  const appConfigGetMock = vi.fn();
-
-  const mockWindow = (externalBackend: boolean, boundUrl: string, source = 'settings') => {
-    appConfigGetMock.mockImplementation((key: string) => {
-      if (key === 'GOOSE_EXTERNAL_BACKEND') return externalBackend;
-      if (key === 'GOOSE_EXTERNAL_BACKEND_URL') return boundUrl;
-      if (key === 'GOOSE_EXTERNAL_BACKEND_SOURCE') return source;
-      if (key === 'GOOSE_WORKING_DIR') return '/Users/johannes/home/workspace';
-      return undefined;
-    });
-  };
+describe('the leased working directory', () => {
+  const getWorkingDir = vi.fn();
 
   beforeEach(() => {
-    getSettingMock.mockReset();
-    appConfigGetMock.mockReset();
+    getWorkingDir.mockReset();
+    setWorkingDir(null);
     (globalThis as Record<string, unknown>).window = {
-      appConfig: { get: appConfigGetMock },
-      electron: { getSetting: getSettingMock },
+      appConfig: { get: (key: string) => (key === 'GOOSE_WORKING_DIR' ? '/local/dir' : undefined) },
+      electron: { getWorkingDir },
     } as unknown as typeof globalThis;
   });
 
-  it('prefers the configured remote directory when bound to the matching external backend', async () => {
-    mockWindow(true, 'http://remote:3000/');
-    getSettingMock.mockResolvedValue({
-      enabled: true,
-      url: 'http://remote:3000',
-      workingDir: ' /home/goose/workspace ',
-    });
-    await expect(getEffectiveWorkingDir()).resolves.toBe('/home/goose/workspace');
+  it('falls back to the directory baked in at window creation', () => {
+    expect(getInitialWorkingDir()).toBe('/local/dir');
   });
 
-  it('honors the configured remote directory for env-mode backends regardless of enabled/url', async () => {
-    mockWindow(true, 'http://env-backend:3000', 'env');
-    getSettingMock.mockResolvedValue({
-      enabled: false,
-      url: 'http://unrelated:4000',
-      workingDir: '/home/goose/workspace',
-    });
-    await expect(getEffectiveWorkingDir()).resolves.toBe('/home/goose/workspace');
+  it('adopts the directory the window is currently leased to', async () => {
+    getWorkingDir.mockResolvedValue('/remote/work');
+
+    await expect(refreshWorkingDir()).resolves.toBe('/remote/work');
+    expect(getInitialWorkingDir()).toBe('/remote/work');
   });
 
-  it('falls back to the remembered directory for env-mode backends without a configured dir', async () => {
-    mockWindow(true, 'http://env-backend:3000', 'env');
-    getSettingMock.mockResolvedValue({ enabled: false, workingDir: '   ' });
-    await expect(getEffectiveWorkingDir()).resolves.toBe('/Users/johannes/home/workspace');
+  it('keeps the last known directory when the lease cannot be read', async () => {
+    setWorkingDir('/remote/work');
+    getWorkingDir.mockRejectedValue(new Error('no lease'));
+
+    await expect(refreshWorkingDir()).resolves.toBe('/remote/work');
   });
 
-  it('ignores the remote directory when the window is bound to the local backend', async () => {
-    mockWindow(false, '');
-    getSettingMock.mockResolvedValue({ enabled: true, workingDir: '/home/goose/workspace' });
-    await expect(getEffectiveWorkingDir()).resolves.toBe('/Users/johannes/home/workspace');
+  it('ignores an empty directory from the lease', async () => {
+    setWorkingDir('/remote/work');
+    getWorkingDir.mockResolvedValue('');
+
+    await expect(refreshWorkingDir()).resolves.toBe('/remote/work');
   });
 
-  it('falls back to the remembered directory when the bound backend no longer matches settings', async () => {
-    mockWindow(true, 'http://server-a:3000');
-    getSettingMock.mockResolvedValue({
-      enabled: true,
-      url: 'http://server-b:3000',
-      workingDir: '/home/goose/workspace',
-    });
-    await expect(getEffectiveWorkingDir()).resolves.toBe('/Users/johannes/home/workspace');
-  });
+  it('clears back to the window default when reset', () => {
+    setWorkingDir('/remote/work');
+    expect(getInitialWorkingDir()).toBe('/remote/work');
 
-  it('falls back to the remembered directory when the external backend is disabled', async () => {
-    mockWindow(true, 'http://remote:3000');
-    getSettingMock.mockResolvedValue({ enabled: false, workingDir: '/home/goose/workspace' });
-    await expect(getEffectiveWorkingDir()).resolves.toBe('/Users/johannes/home/workspace');
-  });
-
-  it('falls back to the remembered directory when the remote directory is blank', async () => {
-    mockWindow(true, 'http://remote:3000');
-    getSettingMock.mockResolvedValue({ enabled: true, workingDir: '   ' });
-    await expect(getEffectiveWorkingDir()).resolves.toBe('/Users/johannes/home/workspace');
-  });
-
-  it('falls back to the remembered directory when the setting cannot be read', async () => {
-    mockWindow(true, 'http://remote:3000');
-    getSettingMock.mockRejectedValue(new Error('settings unavailable'));
-    await expect(getEffectiveWorkingDir()).resolves.toBe('/Users/johannes/home/workspace');
+    setWorkingDir(null);
+    expect(getInitialWorkingDir()).toBe('/local/dir');
   });
 });

--- a/ui/desktop/src/utils/csp.ts
+++ b/ui/desktop/src/utils/csp.ts
@@ -15,8 +15,23 @@ const DEFAULT_CONNECT_SOURCES = [
   'https://objects.githubusercontent.com',
 ];
 
+const extraBackendOrigins = new Set<string>();
+
+// A backend that redirects serves ACP from the final origin, which the renderer
+// must be allowed to open a WebSocket to.
+export function allowBackendOrigin(url: string): void {
+  try {
+    const parsed = new URL(url);
+    extraBackendOrigins.add(parsed.origin);
+    parsed.protocol = parsed.protocol === 'https:' ? 'wss:' : 'ws:';
+    extraBackendOrigins.add(parsed.origin);
+  } catch {
+    console.warn('Invalid backend URL, skipping CSP entry');
+  }
+}
+
 export function buildConnectSrc(externalBackend?: ExternalBackendConfig): string {
-  const sources = [...DEFAULT_CONNECT_SOURCES];
+  const sources = [...DEFAULT_CONNECT_SOURCES, ...extraBackendOrigins];
 
   if (externalBackend?.enabled && externalBackend.url) {
     try {

--- a/ui/desktop/src/utils/workingDir.ts
+++ b/ui/desktop/src/utils/workingDir.ts
@@ -1,56 +1,23 @@
-export const getInitialWorkingDir = (): string => {
-  // Fall back to initial config from app startup
-  return (window.appConfig?.get('GOOSE_WORKING_DIR') as string) ?? '';
+let leasedWorkingDir: string | null = null;
+
+export const getInitialWorkingDir = (): string =>
+  leasedWorkingDir ?? (window.appConfig?.get('GOOSE_WORKING_DIR') as string) ?? '';
+
+export const setWorkingDir = (workingDir: string | null): void => {
+  leasedWorkingDir = workingDir?.trim() ? workingDir : null;
 };
 
-/**
- * Resolve the working directory for a new chat in the current window.
- *
- * GOOSE_WORKING_DIR is fixed when the window is created, so it goes stale when
- * the user switches to an external backend (or changes the configured remote
- * directory) afterwards. The configured remote directory is only applied when
- * the window is actually bound to an external backend (fixed at window creation
- * via the gooseServeLeases) and that backend still matches the current
- * settings; otherwise the remote path would be sent to the local (or a
- * different remote) server, where it fails the cwd existence validation.
- * Editing the remote working directory in settings still takes effect for new
- * chats in the same window. Env-mode backends (GOOSE_EXTERNAL_BACKEND) always
- * use the configured directory (matching getActiveExternalBackend), while
- * settings-mode backends require the window-bound backend to still match.
- */
-export const getEffectiveWorkingDir = async (): Promise<string> => {
-  const initial = getInitialWorkingDir();
-  const boundUrl = window.appConfig?.get('GOOSE_EXTERNAL_BACKEND_URL') as string | undefined;
-  const source = window.appConfig?.get('GOOSE_EXTERNAL_BACKEND_SOURCE') as string | undefined;
-  if (window.appConfig?.get('GOOSE_EXTERNAL_BACKEND') !== true || !boundUrl) {
-    return initial;
-  }
+export const refreshWorkingDir = async (): Promise<string> => {
   try {
-    const external = await window.electron.getSetting('externalGoosed');
-    const remote = external?.workingDir?.trim();
-    if (!remote) {
-      return initial;
-    }
-    // Env-mode backends use settings.externalGoosed.workingDir regardless of the
-    // enabled flag or URL (see getActiveExternalBackend); settings-mode requires
-    // the backend to still match the window-bound URL.
-    if (source === 'env') {
-      return remote;
-    }
-    if (
-      external?.enabled &&
-      external?.url &&
-      normalizeUrl(boundUrl) === normalizeUrl(external.url)
-    ) {
-      return remote;
+    const workingDir = await window.electron.getWorkingDir();
+    if (workingDir) {
+      setWorkingDir(workingDir);
     }
   } catch {
-    // Settings unavailable; fall back to the remembered directory.
+    // ignore
   }
-  return initial;
+  return getInitialWorkingDir();
 };
-
-const normalizeUrl = (url: string): string => url.trim().replace(/\/+$/, '');
 
 export const resolveWorkingDir = (
   externalWorkingDir: string | undefined,


### PR DESCRIPTION
Combined view of the 5-PR stack that splits up #11794, following the agreed breakdown in [this comment](https://github.com/aaif-goose/goose/issues/11793#issuecomment-5517487728) on #11793. Rebased onto current `main`.

This is a draft for reviewing the external backend work as a whole. The commits are unchanged and still map one-to-one to the stacked PRs, which remain the place to leave review comments:

| Commit | PR |
| --- | --- |
| report the real cause of external backend connection failures | #11828 |
| connect the external backend ACP socket to the redirect-resolved backend URL | #11829 |
| send OS keystore client certificates for mTLS external backends | #11830 |
| switch the current window to the external backend in place instead of requiring a new window | #11831 |
| tidy up the external backend settings UX | #11832 |

### Testing
Cherry-picked cleanly onto `main` with no conflicts; the resulting tree is byte-identical to the tip of the original stack.
