### PR TITLE
docs: update Claude ACP

### DIFF
--- a/documentation/blog/2026-03-19-use-goose-with-your-ai-subscription/index.md
+++ b/documentation/blog/2026-03-19-use-goose-with-your-ai-subscription/index.md
@@ -32,6 +32,7 @@ Then configure goose to use it via the claude acp extension (CLI or GUI)
 Or set it via environment variables:
 
 ```bash
+export GOOSE_PROVIDER=claude-acp
 goose
 ```
 
@@ -59,7 +60,7 @@ Goose previously supported `claude-code`, `codex`, and `gemini-cli` as "pass-thr
 
 | Subscription | Provider | Install | Extensions |
 |---|---|---|---|
-| Claude Code | `claude-acp` | `npm install -g @zed-industries/claude-agent-acp` | ✅ via MCP |
+| Claude Code | `claude-acp` | `npm install -g @agentclientprotocol/claude-agent-acp` | ✅ via MCP |
 | ChatGPT Plus/Pro | `chatgpt_codex` | Nothing — OAuth sign-in | ✅ via MCP |
 | Gemini | `gemini_oauth` | Nothing — OAuth sign-in | ✅ native |
 

--- a/documentation/blog/2026-03-19-use-goose-with-your-ai-subscription/index.md
+++ b/documentation/blog/2026-03-19-use-goose-with-your-ai-subscription/index.md
@@ -24,16 +24,14 @@ With ACP you are using the tools that are (mostly) in the underlying agent. Code
 If you have a Claude Code subscription, you can use it through goose via the [Agent Client Protocol (ACP)](https://agentclientprotocol.com/). This requires installing a small adapter package:
 
 ```bash
-npm install -g @zed-industries/claude-agent-acp
+npm install -g @agentclientprotocol/claude-agent-acp
 ```
 
 Then configure goose to use it via the claude acp extension (CLI or GUI)
 
-
 Or set it via environment variables:
 
 ```bash
-export GOOSE_PROVIDER=claude-acp
 goose
 ```
 


### PR DESCRIPTION
Fixes: No issue link

## Summary
1. Updated installation command for the Claude ACP adapter because export is not required anymore
2. Corrected environment variable usage since @zed-industries/claude-agent-acp has been renamed to @agentclientprotocol/claude-agent-acp


### Testing
Not required since this is just documentation change

### Related Issues
Discussion:  [In Discord](https://discord.com/channels/1287729918100246654/1540727934732599346) 
 


### Screenshots/Demos (for UX changes)
Before:  Not applicable

After: Not applicable
