### PR TITLE
docs: add EasyBits MCP server extension

### DIFF
--- a/documentation/docs/mcp/easybits-mcp.md
+++ b/documentation/docs/mcp/easybits-mcp.md
@@ -8,7 +8,7 @@ import TabItem from '@theme/TabItem';
 import GooseDesktopInstaller from '@site/src/components/GooseDesktopInstaller';
 import CLIExtensionInstructions from '@site/src/components/CLIExtensionInstructions';
 
-This tutorial covers how to add the [EasyBits MCP Server](https://github.com/blissito/easybits) as a goose extension to give your agent its own cloud: Firecracker microVM sandboxes, live web search and scraping, file storage on a CDN, SQL databases, generated documents, video, and app hosting — all behind a single endpoint.
+This tutorial covers how to add the [EasyBits MCP Server](https://github.com/blissito/easybits) as a goose extension to give your agent its own cloud: reading any page on the web even when it blocks bots, Firecracker microVM sandboxes, file storage on a CDN, SQL databases, generated documents, video, and app hosting — all behind a single endpoint.
 
 :::tip Quick Install
 
@@ -82,7 +82,7 @@ group is registered:
 | Group | What you get |
 |---|---|
 | `core` | The recommended default: files, SQL databases, documents, forms, websites, brand kits, images, and web search |
-| `web` | Google/SERP search, fetching pages that block bots, structured extraction and crawling |
+| `web` | Search, and read pages that block ordinary scrapers — plus structured extraction and crawling |
 | `sandbox` | Firecracker microVMs — spawn, run commands, expose ports, snapshot, suspend, destroy |
 | `hosting` | Deploy and run an app on an always-on microVM with a public URL |
 | `design` | Documents as universal design (letter, social, 16:9 slides), brand kits, images |
@@ -140,6 +140,28 @@ Want me to also spin up a sandbox and benchmark them for real?
 
 :::
 
+### Reading the web when the web says no
+
+Search is the easy half. The half that breaks agents is the fetch: the page
+that returns a Cloudflare challenge, the listing behind a bot check, the
+marketplace that serves one thing to a browser and another to `curl`. EasyBits
+routes those requests through unblocking infrastructure, so `web_fetch` comes
+back with the real page as clean text instead of an interstitial.
+
+With `--tools web` you get:
+
+| Tool | What it does |
+|---|---|
+| `web_search` | Live search results, including SERP at volume |
+| `web_fetch` | One URL to readable text — works on pages that reject plain HTTP clients |
+| `web_extract` / `web_extract_status` | Structured extraction from a page into fields you name; long jobs run async |
+| `web_crawl` | Follow a site and bring back many pages in one call |
+
+Because it is the same MCP endpoint, what goose reads it can immediately keep:
+pipe a crawl into `db_create` and query it as SQL, or into `create_document`
+and hand back a PDF. The reading and the artifact do not live in two different
+extensions.
+
 ### Beyond documents
 
 The same key reaches the rest of the platform once you widen the toolset:
@@ -149,5 +171,5 @@ The same key reaches the rest of the platform once you widen the toolset:
   snapshot the machine and fork it.
 - **`--tools hosting`** — one call takes a repo or an archive to a running,
   always-on app with a public URL.
-- **`--tools web`** — search and read the web from residential infrastructure,
-  so pages that block bots still come back as clean text.
+- **`--tools web`** — search, unblocked fetching, structured extraction and
+  crawling, as described above.

--- a/documentation/docs/mcp/easybits-mcp.md
+++ b/documentation/docs/mcp/easybits-mcp.md
@@ -1,0 +1,153 @@
+---
+title: EasyBits Extension
+description: Add EasyBits MCP Server as a goose Extension
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import GooseDesktopInstaller from '@site/src/components/GooseDesktopInstaller';
+import CLIExtensionInstructions from '@site/src/components/CLIExtensionInstructions';
+
+This tutorial covers how to add the [EasyBits MCP Server](https://github.com/blissito/easybits) as a goose extension to give your agent its own cloud: Firecracker microVM sandboxes, live web search and scraping, file storage on a CDN, SQL databases, generated documents, video, and app hosting — all behind a single endpoint.
+
+:::tip Quick Install
+
+<Tabs groupId="interface">
+  <TabItem value="ui" label="goose Desktop" default>
+  [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=%40easybits.cloud%2Fmcp&arg=--tools&arg=core&id=easybits-mcp&name=EasyBits&description=The%20cloud%20for%20AI%20agents%3A%20sandboxes%2C%20web%2C%20files%2C%20SQL%20databases%2C%20documents%20and%20app%20hosting&env=EASYBITS_API_KEY%3DEasyBits%20API%20Key)
+  </TabItem>
+  <TabItem value="cli" label="goose CLI">
+  **Command**
+  ```sh
+  npx -y @easybits.cloud/mcp --tools core
+  ```
+  </TabItem>
+</Tabs>
+  **Environment Variable**
+  ```
+  EASYBITS_API_KEY: <YOUR_API_KEY>
+  ```
+:::
+
+## Configuration
+
+:::info
+Note that you'll need [Node.js](https://nodejs.org/) installed on your system to run this command, as it uses `npx`.
+:::
+
+<Tabs groupId="interface">
+  <TabItem value="ui" label="goose Desktop" default>
+    <GooseDesktopInstaller
+      extensionId="easybits-mcp"
+      extensionName="EasyBits"
+      description="The cloud for AI agents: sandboxes, web, files, SQL databases, documents and app hosting"
+      type="stdio"
+      command="npx"
+      args={["-y", "@easybits.cloud/mcp", "--tools", "core"]}
+      envVars={[
+        { name: "EASYBITS_API_KEY", label: "EasyBits API Key" }
+      ]}
+      apiKeyLink="https://www.easybits.cloud/dash/developer"
+      apiKeyLinkText="EASYBITS_API_KEY"
+    />
+  </TabItem>
+  <TabItem value="cli" label="goose CLI">
+    <CLIExtensionInstructions
+      name="easybits"
+      description="The cloud for AI agents: sandboxes, web, files, SQL databases, documents and app hosting"
+      type="stdio"
+      command="npx -y @easybits.cloud/mcp --tools core"
+      timeout={300}
+      envVars={[
+        { key: "EASYBITS_API_KEY", value: "▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪" }
+      ]}
+      infoNote={
+        <>
+          Get your API key from your{" "}
+          <a href="https://www.easybits.cloud/dash/developer" target="_blank" rel="noopener noreferrer">
+            EasyBits developer dashboard
+          </a> and paste it in.
+        </>
+      }
+    />
+  </TabItem>
+</Tabs>
+
+### Choosing a toolset
+
+EasyBits exposes 247 tools. Loading all of them at once would flood the model's
+context, so the server ships **toolsets** — pass `--tools <group>` and only that
+group is registered:
+
+| Group | What you get |
+|---|---|
+| `core` | The recommended default: files, SQL databases, documents, forms, websites, brand kits, images, and web search |
+| `web` | Google/SERP search, fetching pages that block bots, structured extraction and crawling |
+| `sandbox` | Firecracker microVMs — spawn, run commands, expose ports, snapshot, suspend, destroy |
+| `hosting` | Deploy and run an app on an always-on microVM with a public URL |
+| `design` | Documents as universal design (letter, social, 16:9 slides), brand kits, images |
+| `docs` | Documents only — create, update, deploy, export to PDF/PNG |
+| `video` | AI video, recurring characters, voice-over and captions |
+| `all` | Everything, if your model can take it |
+
+Groups can be combined: `--tools core,sandbox`.
+
+## Example Usage
+
+A common goose task is "go read what's actually out there, then hand me
+something I can send to someone." With EasyBits, goose does the whole loop
+without leaving the chat: it searches the live web, reads pages that normally
+block scrapers, writes the findings into a document, exports a PDF, and
+publishes the same document at a public URL.
+
+### goose Prompt
+
+```
+Research the current pricing of the three biggest managed Postgres providers,
+then build me a one-page comparison document with our brand kit applied,
+export it as a PDF, and publish it so I can share the link.
+```
+
+### goose Output
+
+:::note Desktop
+
+I researched the providers and built the document.
+
+**1. Research** — `web_search` and `web_fetch` pulled the current pricing
+pages for all three providers, including the two that block plain HTTP clients.
+
+**2. Document** — created *Managed Postgres — Pricing Comparison* with three
+pages: an intro, a side-by-side pricing table, and a recommendation. Your
+default brand kit was applied, so it uses your palette and typefaces.
+
+**3. Export** — `export_document` produced the PDF (4 pages, letter format).
+
+**4. Publish** — `deploy_document` put it online.
+
+Here's everything:
+
+- Live page: `https://www.easybits.cloud/s/managed-postgres-pricing-comparison`
+- PDF: the signed download URL is valid for 1 hour — say the word and I'll
+  re-issue it, or `create_share_link` will give you a permanent one.
+
+A note from the research: the entry tiers look comparable, but two of the
+three bill storage and egress separately, so the cheapest headline price is
+the most expensive of the three once you pass ~100 GB of transfer. I put that
+in the recommendation page rather than burying it in the table.
+
+Want me to also spin up a sandbox and benchmark them for real?
+
+:::
+
+### Beyond documents
+
+The same key reaches the rest of the platform once you widen the toolset:
+
+- **`--tools sandbox`** — goose gets a real Firecracker microVM. It can install
+  dependencies, run your test suite, expose a port over HTTPS (and `wss://`),
+  snapshot the machine and fork it.
+- **`--tools hosting`** — one call takes a repo or an archive to a running,
+  always-on app with a public URL.
+- **`--tools web`** — search and read the web from residential infrastructure,
+  so pages that block bots still come back as clean text.

--- a/documentation/docs/mcp/easybits-mcp.md
+++ b/documentation/docs/mcp/easybits-mcp.md
@@ -8,13 +8,13 @@ import TabItem from '@theme/TabItem';
 import GooseDesktopInstaller from '@site/src/components/GooseDesktopInstaller';
 import CLIExtensionInstructions from '@site/src/components/CLIExtensionInstructions';
 
-This tutorial covers how to add the [EasyBits MCP Server](https://github.com/blissito/easybits) as a goose extension to give your agent its own cloud: reading any page on the web even when it blocks bots, Firecracker microVM sandboxes, file storage on a CDN, SQL databases, generated documents, video, and app hosting — all behind a single endpoint.
+This tutorial covers how to add the [EasyBits MCP Server](https://github.com/blissito/easybits) as a goose extension to give your agent its own cloud: Firecracker microVM sandboxes where it can run code and host apps on a public URL, reading pages that block bots, file storage on a CDN, SQL databases, generated documents and video — all behind a single endpoint. It also runs goose itself: `goose_spawn` boots a managed goose in a microVM in one call.
 
 :::tip Quick Install
 
 <Tabs groupId="interface">
   <TabItem value="ui" label="goose Desktop" default>
-  [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=%40easybits.cloud%2Fmcp&arg=--tools&arg=core&id=easybits-mcp&name=EasyBits&description=The%20cloud%20for%20AI%20agents%3A%20sandboxes%2C%20web%2C%20files%2C%20SQL%20databases%2C%20documents%20and%20app%20hosting&env=EASYBITS_API_KEY%3DEasyBits%20API%20Key)
+  [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=%40easybits.cloud%2Fmcp&arg=--tools&arg=core&id=easybits-mcp&name=EasyBits&description=Give%20your%20agent%20a%20Firecracker%20microVM%3A%20run%20code%2C%20host%20apps%2C%20read%20the%20web%2C%20store%20files%20and%20query%20SQL%20databases&env=EASYBITS_API_KEY%3DEasyBits%20API%20Key)
   </TabItem>
   <TabItem value="cli" label="goose CLI">
   **Command**
@@ -40,7 +40,7 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
     <GooseDesktopInstaller
       extensionId="easybits-mcp"
       extensionName="EasyBits"
-      description="The cloud for AI agents: sandboxes, web, files, SQL databases, documents and app hosting"
+      description="Give your agent a Firecracker microVM: run code, host apps, read the web, store files and query SQL databases"
       type="stdio"
       command="npx"
       args={["-y", "@easybits.cloud/mcp", "--tools", "core"]}
@@ -54,7 +54,7 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
   <TabItem value="cli" label="goose CLI">
     <CLIExtensionInstructions
       name="easybits"
-      description="The cloud for AI agents: sandboxes, web, files, SQL databases, documents and app hosting"
+      description="Give your agent a Firecracker microVM: run code, host apps, read the web, store files and query SQL databases"
       type="stdio"
       command="npx -y @easybits.cloud/mcp --tools core"
       timeout={300}
@@ -94,49 +94,54 @@ Groups can be combined: `--tools core,sandbox`.
 
 ## Example Usage
 
-A common goose task is "go read what's actually out there, then hand me
-something I can send to someone." With EasyBits, goose does the whole loop
-without leaving the chat: it searches the live web, reads pages that normally
-block scrapers, writes the findings into a document, exports a PDF, and
-publishes the same document at a public URL.
+goose already edits files and runs commands — on *your* machine. What it does
+not have is somewhere else to do it. EasyBits gives it a Firecracker microVM:
+a real Linux box, a few seconds to boot, that survives closing your laptop and
+can be handed a public HTTPS URL.
+
+That changes what you can ask for.
+
+:::info
+This example uses the sandbox tools, so start the extension with
+`--tools core,sandbox` instead of the default `--tools core`.
+:::
 
 ### goose Prompt
 
 ```
-Research the current pricing of the three biggest managed Postgres providers,
-then build me a comparison document with our brand kit applied,
-export it as a PDF, and publish it so I can share the link.
+Clone github.com/my-org/my-app into a sandbox, install and run the test suite
+there, and if it's green start the dev server and give me a public URL I can
+send to a designer.
 ```
 
 ### goose Output
 
 :::note Desktop
 
-I researched the providers and built the document.
+Done — the box is up and the URL is live.
 
-**1. Research** — `web_search` and `web_fetch` pulled the current pricing
-pages for all three providers, including the two that block plain HTTP clients.
+**1. Box** — `sandbox_create` with the `dev-box` template (size `m`: 2 vCPU,
+2 GB RAM), booted in about 12 seconds. Nothing was installed on your machine.
 
-**2. Document** — created *Managed Postgres — Pricing Comparison* with three
-pages: an intro, a side-by-side pricing table, and a recommendation. Your
-default brand kit was applied, so it uses your palette and typefaces.
+**2. Code** — `sandbox_git_clone` pulled the repo into `/workspace`.
 
-**3. Export** — `export_document` produced the PDF — three pages, letter format.
+**3. Tests** — `sandbox_exec` ran `npm ci && npm test`. 148 passed, 0 failed,
+in 41s. Two warnings about a deprecated peer dependency, nothing blocking.
 
-**4. Publish** — `deploy_document` put it online.
+**4. Serve** — the dev server is running under `sandbox_exec_background`, so
+it survives between my turns, and `sandbox_expose_port` put it behind HTTPS:
 
-Here's everything:
+`https://sb-7f3a91c2-5173.easybits.cloud`
 
-- Live page: `https://www.easybits.cloud/s/managed-postgres-pricing-comparison`
-- PDF: the signed download URL is valid for 1 hour — say the word and I'll
-  re-issue it, or `create_share_link` will give you a permanent one.
+Send that to your designer as-is. Two things worth knowing:
 
-A note from the research: the entry tiers look comparable, but two of the
-three bill storage and egress separately, so the cheapest headline price is
-the most expensive of the three once you pass ~100 GB of transfer. I put that
-in the recommendation page rather than burying it in the table.
+- The box auto-destroys in 5 minutes unless I extend it — say "keep it alive
+  for an hour" and I'll call `sandbox_extend`.
+- If you want it permanent instead of ephemeral, `launch_app` redoes this as
+  an always-on machine with its own domain and a recovery release, in one
+  call.
 
-Want me to also spin up a sandbox and benchmark them for real?
+Want me to snapshot it first so you can fork this exact state later?
 
 :::
 
@@ -162,14 +167,27 @@ pipe a crawl into `db_create` and query it as SQL, or into `create_document`
 and hand back a PDF. The reading and the artifact do not live in two different
 extensions.
 
-### Beyond documents
+### goose runs on EasyBits, too
+
+The relationship goes both ways. `goose_spawn` — one call, no configuration —
+boots goose itself inside a Firecracker microVM as an ACP server (JSON-RPC over
+SSE) with managed credentials, and hands you back `{ sandboxId, agentUrl,
+healthUrl, agentId, embedToken }`. `goose` is a first-class sandbox template
+alongside `python`, `node` and `ubuntu`, and the platform speaks ACP natively
+rather than shelling out to a binary.
+
+That makes goose something you can *deploy*, not only something you run: a
+goose per customer, a goose behind a web widget, a goose that keeps working
+after you close the laptop.
+
+### Beyond the box
 
 The same key reaches the rest of the platform once you widen the toolset:
 
-- **`--tools sandbox`** — goose gets a real Firecracker microVM. It can install
-  dependencies, run your test suite, expose a port over HTTPS (and `wss://`),
-  snapshot the machine and fork it.
-- **`--tools hosting`** — one call takes a repo or an archive to a running,
-  always-on app with a public URL.
+- **`--tools hosting`** — `launch_app` takes a repo or an archive to a running,
+  always-on machine with a public HTTPS URL, a custom domain and a recovery
+  release, in one call.
+- **`--tools core`** — files on a CDN, SQL databases, documents that export to
+  PDF and publish to a URL, forms, brand kits.
 - **`--tools web`** — search, unblocked fetching, structured extraction and
   crawling, as described above.

--- a/documentation/docs/mcp/easybits-mcp.md
+++ b/documentation/docs/mcp/easybits-mcp.md
@@ -104,7 +104,7 @@ publishes the same document at a public URL.
 
 ```
 Research the current pricing of the three biggest managed Postgres providers,
-then build me a one-page comparison document with our brand kit applied,
+then build me a comparison document with our brand kit applied,
 export it as a PDF, and publish it so I can share the link.
 ```
 
@@ -121,7 +121,7 @@ pages for all three providers, including the two that block plain HTTP clients.
 pages: an intro, a side-by-side pricing table, and a recommendation. Your
 default brand kit was applied, so it uses your palette and typefaces.
 
-**3. Export** — `export_document` produced the PDF (4 pages, letter format).
+**3. Export** — `export_document` produced the PDF — three pages, letter format.
 
 **4. Publish** — `deploy_document` put it online.
 

--- a/documentation/docs/mcp/easybits-mcp.md
+++ b/documentation/docs/mcp/easybits-mcp.md
@@ -81,8 +81,8 @@ group is registered:
 
 | Group | What you get |
 |---|---|
-| `core` | The recommended default: files, SQL databases, documents, forms, websites, brand kits, images, and web search |
-| `web` | Search, and read pages that block ordinary scrapers — plus structured extraction and crawling |
+| `core` | The recommended default: the full web toolset (search, unblocked fetching, extraction, crawling) plus files, SQL databases, documents, forms, websites, brand kits and images |
+| `web` | The web toolset on its own, with nothing else — for an agent that only needs to read the internet |
 | `sandbox` | Firecracker microVMs — spawn, run commands, expose ports, snapshot, suspend, destroy |
 | `hosting` | Deploy and run an app on an always-on microVM with a public URL |
 | `design` | Documents as universal design (letter, social, 16:9 slides), brand kits, images |
@@ -153,7 +153,8 @@ marketplace that serves one thing to a browser and another to `curl`. EasyBits
 routes those requests through unblocking infrastructure, so `web_fetch` comes
 back with the real page as clean text instead of an interstitial.
 
-With `--tools web` you get:
+These ship in `core`, so the default install already has them; `--tools web`
+gives you the same set with nothing else attached:
 
 | Tool | What it does |
 |---|---|

--- a/documentation/docs/mcp/easybits-mcp.md
+++ b/documentation/docs/mcp/easybits-mcp.md
@@ -14,12 +14,12 @@ This tutorial covers how to add the [EasyBits MCP Server](https://github.com/bli
 
 <Tabs groupId="interface">
   <TabItem value="ui" label="goose Desktop" default>
-  [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=%40easybits.cloud%2Fmcp&arg=--tools&arg=core&id=easybits-mcp&name=EasyBits&description=Give%20your%20agent%20a%20Firecracker%20microVM%3A%20run%20code%2C%20host%20apps%2C%20read%20the%20web%2C%20store%20files%20and%20query%20SQL%20databases&env=EASYBITS_API_KEY%3DEasyBits%20API%20Key)
+  [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=%40easybits.cloud%2Fmcp&arg=--tools&arg=core%2Csandbox&id=easybits-mcp&name=EasyBits&description=Give%20your%20agent%20a%20Firecracker%20microVM%3A%20run%20code%2C%20host%20apps%2C%20read%20the%20web%2C%20store%20files%20and%20query%20SQL%20databases&env=EASYBITS_API_KEY%3DEasyBits%20API%20Key)
   </TabItem>
   <TabItem value="cli" label="goose CLI">
   **Command**
   ```sh
-  npx -y @easybits.cloud/mcp --tools core
+  npx -y @easybits.cloud/mcp --tools core,sandbox
   ```
   </TabItem>
 </Tabs>
@@ -43,7 +43,7 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
       description="Give your agent a Firecracker microVM: run code, host apps, read the web, store files and query SQL databases"
       type="stdio"
       command="npx"
-      args={["-y", "@easybits.cloud/mcp", "--tools", "core"]}
+      args={["-y", "@easybits.cloud/mcp", "--tools", "core,sandbox"]}
       envVars={[
         { name: "EASYBITS_API_KEY", label: "EasyBits API Key" }
       ]}
@@ -56,7 +56,7 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
       name="easybits"
       description="Give your agent a Firecracker microVM: run code, host apps, read the web, store files and query SQL databases"
       type="stdio"
-      command="npx -y @easybits.cloud/mcp --tools core"
+      command="npx -y @easybits.cloud/mcp --tools core,sandbox"
       timeout={300}
       envVars={[
         { key: "EASYBITS_API_KEY", value: "▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪" }
@@ -81,16 +81,17 @@ group is registered:
 
 | Group | What you get |
 |---|---|
-| `core` | The recommended default: the full web toolset (search, unblocked fetching, extraction, crawling) plus files, SQL databases, documents, forms, websites, brand kits and images |
+| `core` | Registered by default, together with `sandbox`: the full web toolset (search, unblocked fetching, extraction, crawling) plus files, SQL databases, documents, forms, websites, brand kits and images |
 | `web` | The web toolset on its own, with nothing else — for an agent that only needs to read the internet |
-| `sandbox` | Firecracker microVMs — spawn, run commands, expose ports, snapshot, suspend, destroy |
+| `sandbox` | Registered by default too: Firecracker microVMs — spawn, run commands, expose ports, snapshot, suspend, destroy |
 | `hosting` | Deploy and run an app on an always-on microVM with a public URL |
 | `design` | Documents as universal design (letter, social, 16:9 slides), brand kits, images |
 | `docs` | Documents only — create, update, deploy, export to PDF/PNG |
 | `video` | AI video, recurring characters, voice-over and captions |
 | `all` | Everything, if your model can take it |
 
-Groups can be combined: `--tools core,sandbox`.
+Groups are combined with commas, which is what the default install does:
+`--tools core,sandbox`.
 
 ## Example Usage
 
@@ -100,11 +101,6 @@ a real Linux box, a few seconds to boot, that survives closing your laptop and
 can be handed a public HTTPS URL.
 
 That changes what you can ask for.
-
-:::info
-This example uses the sandbox tools, so start the extension with
-`--tools core,sandbox` instead of the default `--tools core`.
-:::
 
 ### goose Prompt
 
@@ -137,9 +133,9 @@ Send that to your designer as-is. Two things worth knowing:
 
 - The box auto-destroys in 5 minutes unless I extend it — say "keep it alive
   for an hour" and I'll call `sandbox_extend`.
-- If you want it permanent instead of ephemeral, `launch_app` redoes this as
-  an always-on machine with its own domain and a recovery release, in one
-  call.
+- If you want it permanent instead of ephemeral, add `--tools hosting` and
+  `launch_app` redoes all of this as an always-on machine with its own domain
+  and a recovery release, in one call.
 
 Want me to snapshot it first so you can fork this exact state later?
 

--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -258,7 +258,7 @@
   {
     "id": "easybits-mcp",
     "name": "EasyBits",
-    "description": "The cloud for AI agents: Firecracker microVM sandboxes, web search and scraping, file storage on a CDN, SQL databases, documents, video and app hosting",
+    "description": "The cloud for AI agents: read any page even when it blocks bots, search the web, run code in Firecracker microVMs, store files on a CDN, query SQL databases, generate documents and host apps",
     "command": "npx -y @easybits.cloud/mcp --tools core",
     "link": "https://github.com/blissito/easybits",
     "installation_notes": "Install using npx package manager. Pass --tools <group> (core, design, web, sandbox, hosting, docs, video...) to load only the toolset you need instead of all 247 tools.",

--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -259,9 +259,9 @@
     "id": "easybits-mcp",
     "name": "EasyBits",
     "description": "Give your agent a Firecracker microVM: run code and host apps with a public URL, read pages that block bots, store files on a CDN, query SQL databases and generate documents — and spawn goose itself in a box",
-    "command": "npx -y @easybits.cloud/mcp --tools core",
+    "command": "npx -y @easybits.cloud/mcp --tools core,sandbox",
     "link": "https://github.com/blissito/easybits",
-    "installation_notes": "Install using npx package manager. Pass --tools <group> (core, design, web, sandbox, hosting, docs, video...) to load only the toolset you need instead of all 247 tools.",
+    "installation_notes": "Install using npx package manager. Ships with --tools core,sandbox. Pass a different --tools <group> (web, hosting, design, docs, video...) to load only the toolset you need instead of all 247 tools.",
     "is_builtin": false,
     "endorsed": false,
     "environmentVariables": [

--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -256,6 +256,23 @@
     "type": "streamable-http"
   },
   {
+    "id": "easybits-mcp",
+    "name": "EasyBits",
+    "description": "The cloud for AI agents: Firecracker microVM sandboxes, web search and scraping, file storage on a CDN, SQL databases, documents, video and app hosting",
+    "command": "npx -y @easybits.cloud/mcp --tools core",
+    "link": "https://github.com/blissito/easybits",
+    "installation_notes": "Install using npx package manager. Pass --tools <group> (core, design, web, sandbox, hosting, docs, video...) to load only the toolset you need instead of all 247 tools.",
+    "is_builtin": false,
+    "endorsed": false,
+    "environmentVariables": [
+      {
+        "name": "EASYBITS_API_KEY",
+        "description": "API key from your EasyBits developer dashboard",
+        "required": true
+      }
+    ]
+  },
+  {
     "id": "elevenlabs-mcp",
     "name": "ElevenLabs",
     "description": "Text-to-speech and voice synthesis",

--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -258,7 +258,7 @@
   {
     "id": "easybits-mcp",
     "name": "EasyBits",
-    "description": "The cloud for AI agents: read any page even when it blocks bots, search the web, run code in Firecracker microVMs, store files on a CDN, query SQL databases, generate documents and host apps",
+    "description": "Give your agent a Firecracker microVM: run code and host apps with a public URL, read pages that block bots, store files on a CDN, query SQL databases and generate documents — and spawn goose itself in a box",
     "command": "npx -y @easybits.cloud/mcp --tools core",
     "link": "https://github.com/blissito/easybits",
     "installation_notes": "Install using npx package manager. Pass --tools <group> (core, design, web, sandbox, hosting, docs, video...) to load only the toolset you need instead of all 247 tools.",


### PR DESCRIPTION
Adds [EasyBits](https://www.easybits.cloud) to the extensions directory.

EasyBits is a cloud built for AI agents: Firecracker microVM sandboxes, live web search and scraping, file storage on a CDN, SQL databases, generated documents, video, and app hosting — all behind a single MCP endpoint.

## Changes

- `documentation/static/servers.json` — new `easybits-mcp` entry, inserted alphabetically.
- `documentation/docs/mcp/easybits-mcp.md` — tutorial following `_template_.mdx` (Quick Install, Desktop + CLI installers, example usage).

## Note on toolsets

The server exposes 247 tools, which would flood a model's context if loaded at once. The npm proxy takes a `--tools <group>` flag and registers only that group, so the directory entry defaults to `--tools core` and the tutorial documents the available groups (`core`, `web`, `sandbox`, `hosting`, `design`, `docs`, `video`, `all`; combinable with commas).

## Verification

- `npx -y @easybits.cloud/mcp` resolves from npm, connects to the endpoint and enforces auth.
- `servers.json` still parses and no other entries were reformatted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013VXP6o9g9u6rFD9zhfiBN3