### PR TITLE
Add `GOOSE_MODEL` environment variable to all subprocesses

### DIFF
--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -1160,6 +1160,7 @@ impl Agent {
             Some(session.working_dir.clone()),
             Some(request_id.clone()),
         );
+        let ctx = ctx.with_model_from_session(session);
 
         debug!("WAITING_TOOL_START: {}", tool_call.name);
         let result = self

--- a/crates/goose/src/agents/extension_manager.rs
+++ b/crates/goose/src/agents/extension_manager.rs
@@ -426,6 +426,7 @@ struct ResolvedTool {
 async fn child_process_client(
     mut command: Command,
     timeout: &Option<u64>,
+    model_name: Option<&str>,
     provider: SharedProvider,
     working_dir: &PathBuf,
     docker_container: Option<String>,
@@ -436,6 +437,11 @@ async fn child_process_client(
 ) -> ExtensionResult<McpClient> {
     if let Ok(path) = SearchPaths::builder().path() {
         command.env("PATH", path);
+    }
+    if let Some(model_name) = model_name {
+        command.env("GOOSE_MODEL", model_name);
+    } else {
+        command.env_remove("GOOSE_MODEL");
     }
 
     if working_dir.exists() && working_dir.is_dir() {
@@ -1464,6 +1470,16 @@ impl ExtensionManager {
             .clone()
             .or_else(|| std::env::var("GOOSE_WORKING_DIR").ok().map(PathBuf::from))
             .unwrap_or_else(|| std::env::current_dir().unwrap_or_default());
+        let session_model_name = match session_id {
+            Some(session_id) => self
+                .context
+                .session_manager
+                .get_session(session_id, false)
+                .await
+                .ok()
+                .and_then(|session| session.model_config.map(|config| config.model_name)),
+            None => None,
+        };
 
         let client: Box<dyn McpClientTrait> = match &config {
             ExtensionConfig::StreamableHttp {
@@ -1554,9 +1570,11 @@ impl ExtensionManager {
                             "Starting builtin extension inside Docker container"
                         );
                         let command = Command::new("docker").configure(|command| {
+                            command.arg("exec").arg("-i").arg("-e").arg(format!(
+                                "GOOSE_MODEL={}",
+                                session_model_name.as_deref().unwrap_or_default()
+                            ));
                             command
-                                .arg("exec")
-                                .arg("-i")
                                 .arg(container_id)
                                 .arg("goose")
                                 .arg("mcp")
@@ -1566,6 +1584,7 @@ impl ExtensionManager {
                         let client = child_process_client(
                             command,
                             &Some(timeout_secs),
+                            session_model_name.as_deref(),
                             self.provider.clone(),
                             &effective_working_dir,
                             Some(container_id.to_string()),
@@ -1633,7 +1652,13 @@ impl ExtensionManager {
                         for (key, value) in &all_envs {
                             command.arg("-e").arg(format!("{}={}", key, value));
                         }
-                        command.arg(container_id);
+                        command
+                            .arg("-e")
+                            .arg(format!(
+                                "GOOSE_MODEL={}",
+                                session_model_name.as_deref().unwrap_or_default()
+                            ))
+                            .arg(container_id);
                         command.arg(cmd);
                         command.args(args);
                     })
@@ -1647,6 +1672,7 @@ impl ExtensionManager {
                 let client = child_process_client(
                     command,
                     timeout,
+                    session_model_name.as_deref(),
                     self.provider.clone(),
                     &process_working_dir,
                     container.map(|c| c.id().to_string()),
@@ -2350,6 +2376,10 @@ impl ExtensionManager {
             ctx.working_dir.clone(),
             ctx.tool_call_request_id.clone(),
         );
+        let owned_ctx = match ctx.model_name.clone() {
+            Some(model_name) => owned_ctx.with_model_name(model_name),
+            None => owned_ctx,
+        };
         let (owned_ctx, tool_call_notifications_receiver) =
             if let Some(notification_emitter) = ctx.notification_emitter().cloned() {
                 (

--- a/crates/goose/src/agents/platform_extensions/developer/mod.rs
+++ b/crates/goose/src/agents/platform_extensions/developer/mod.rs
@@ -217,6 +217,7 @@ impl McpClientTrait for DeveloperClient {
                         params,
                         working_dir,
                         Some(&ctx.session_id),
+                        ctx.model_name.as_deref(),
                         ctx.notification_emitter().cloned(),
                         cancel_token,
                     )
@@ -401,5 +402,30 @@ mod tests {
         let observed = std::fs::canonicalize(first_text(&result)).unwrap();
         let expected = std::fs::canonicalize(&cwd).unwrap();
         assert_eq!(observed, expected);
+    }
+
+    #[cfg(not(windows))]
+    #[tokio::test]
+    async fn developer_client_exports_model_name_to_shell_tool() {
+        let temp = tempfile::tempdir().unwrap();
+        let client = DeveloperClient::new(test_context(temp.path().join("sessions"))).unwrap();
+        let expected_model = "session-model";
+        let ctx =
+            ToolCallContext::new("session".to_owned(), None, None).with_model_name(expected_model);
+
+        let result = client
+            .call_tool(
+                &ctx,
+                "shell",
+                Some(object!({
+                    "command": "printf 'model=%s' \"$GOOSE_MODEL\""
+                })),
+                CancellationToken::new(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.is_error, Some(false));
+        assert_eq!(first_text(&result), format!("model={expected_model}"));
     }
 }

--- a/crates/goose/src/agents/platform_extensions/developer/shell.rs
+++ b/crates/goose/src/agents/platform_extensions/developer/shell.rs
@@ -373,8 +373,15 @@ impl ShellTool {
         session_id: Option<&str>,
         cancellation_token: CancellationToken,
     ) -> CallToolResult {
-        self.shell_with_cwd_and_emitter(params, working_dir, session_id, None, cancellation_token)
-            .await
+        self.shell_with_cwd_and_emitter(
+            params,
+            working_dir,
+            session_id,
+            None,
+            None,
+            cancellation_token,
+        )
+        .await
     }
 
     pub(crate) async fn shell_with_cwd_and_emitter(
@@ -382,6 +389,7 @@ impl ShellTool {
         params: ShellParams,
         working_dir: Option<&std::path::Path>,
         session_id: Option<&str>,
+        model_name: Option<&str>,
         notification_emitter: Option<ToolCallNotificationEmitter>,
         cancellation_token: CancellationToken,
     ) -> CallToolResult {
@@ -412,6 +420,7 @@ impl ShellTool {
             working_dir,
             login_path_ref,
             session_id,
+            model_name,
             notification_emitter,
             cancellation_token,
         )
@@ -554,18 +563,26 @@ fn resolve_shell_timeout(timeout_secs: Option<u64>) -> u64 {
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn run_command(
     command_line: &str,
     timeout_secs: Option<u64>,
     working_dir: Option<&std::path::Path>,
     login_path: Option<&str>,
     session_id: Option<&str>,
+    model_name: Option<&str>,
     notification_emitter: Option<ToolCallNotificationEmitter>,
     cancellation_token: CancellationToken,
 ) -> Result<ExecutionOutput, String> {
     let timeout_secs = Some(resolve_shell_timeout(timeout_secs));
 
-    let mut command = build_shell_command(command_line, working_dir, login_path, session_id);
+    let mut command = build_shell_command(
+        command_line,
+        working_dir,
+        login_path,
+        session_id,
+        model_name,
+    );
 
     command.stdout(Stdio::piped());
     command.stderr(Stdio::piped());
@@ -684,6 +701,7 @@ fn build_shell_command(
     working_dir: Option<&std::path::Path>,
     login_path: Option<&str>,
     session_id: Option<&str>,
+    model_name: Option<&str>,
 ) -> tokio::process::Command {
     #[cfg(windows)]
     let mut command = {
@@ -724,6 +742,7 @@ fn build_shell_command(
                 command.arg(format!("--env=PATH={}", path));
             }
             apply_flatpak_session_environment(&mut command, session_id);
+            apply_flatpak_model_environment(&mut command, model_name);
             command
                 .arg(&shell)
                 .args(unix_shell_command_args(command_line));
@@ -738,12 +757,16 @@ fn build_shell_command(
                 command.env("PATH", path);
             }
             apply_session_environment(&mut command, session_id);
+            apply_model_environment(&mut command, model_name);
             command
         }
     };
 
     #[cfg(windows)]
-    apply_session_environment(&mut command, session_id);
+    {
+        apply_session_environment(&mut command, session_id);
+        apply_model_environment(&mut command, model_name);
+    }
     command.set_no_window();
     command
 }
@@ -756,6 +779,14 @@ fn apply_session_environment(command: &mut tokio::process::Command, session_id: 
     }
 }
 
+fn apply_model_environment(command: &mut tokio::process::Command, model_name: Option<&str>) {
+    if let Some(model_name) = model_name {
+        command.env("GOOSE_MODEL", model_name);
+    } else {
+        command.env_remove("GOOSE_MODEL");
+    }
+}
+
 #[cfg(not(windows))]
 fn apply_flatpak_session_environment(
     command: &mut tokio::process::Command,
@@ -765,6 +796,18 @@ fn apply_flatpak_session_environment(
         command.arg(format!("--env=AGENT_SESSION_ID={session_id}"));
     } else {
         command.arg("--unset-env=AGENT_SESSION_ID");
+    }
+}
+
+#[cfg(not(windows))]
+fn apply_flatpak_model_environment(
+    command: &mut tokio::process::Command,
+    model_name: Option<&str>,
+) {
+    if let Some(model_name) = model_name {
+        command.arg(format!("--env=GOOSE_MODEL={model_name}"));
+    } else {
+        command.arg("--unset-env=GOOSE_MODEL");
     }
 }
 
@@ -993,6 +1036,7 @@ mod tests {
                 },
                 None,
                 None,
+                None,
                 Some(ToolCallNotificationEmitter::new(sender)),
                 CancellationToken::new(),
             )
@@ -1003,6 +1047,52 @@ mod tests {
         assert_eq!(shell_output.stdout, "out-1\nout-2");
         assert_eq!(shell_output.stderr, "err-1\nerr-2");
         assert_eq!(shell_output.exit_code, Some(0));
+    }
+
+    #[cfg(not(windows))]
+    #[tokio::test]
+    async fn shell_exports_model_name() {
+        let tool = ShellTool::new_for_test().unwrap();
+        let expected_model = "session-model";
+        let result = tool
+            .shell_with_cwd_and_emitter(
+                ShellParams {
+                    command: "printf '%s' \"$GOOSE_MODEL\"".to_string(),
+                    timeout_secs: None,
+                },
+                None,
+                None,
+                Some(expected_model),
+                None,
+                CancellationToken::new(),
+            )
+            .await;
+
+        assert_eq!(result.is_error, Some(false));
+        assert_eq!(extract_text(&result), expected_model);
+    }
+
+    #[cfg(not(windows))]
+    #[tokio::test]
+    async fn shell_removes_inherited_model_name_when_not_provided() {
+        let _env = env_lock::lock_env([("GOOSE_MODEL", Some("stale-model"))]);
+        let tool = ShellTool::new_for_test().unwrap();
+        let result = tool
+            .shell_with_cwd_and_emitter(
+                ShellParams {
+                    command: "if [ -n \"$GOOSE_MODEL\" ]; then printf '%s' \"$GOOSE_MODEL\"; else printf '<unset>'; fi".to_string(),
+                    timeout_secs: None,
+                },
+                None,
+                None,
+                None,
+                None,
+                CancellationToken::new(),
+            )
+            .await;
+
+        assert_eq!(result.is_error, Some(false));
+        assert_eq!(extract_text(&result), "<unset>");
     }
 
     #[cfg(not(windows))]
@@ -1044,6 +1134,30 @@ mod tests {
     }
 
     #[test]
+    fn model_environment_is_set_or_removed() {
+        for (model_name, expected) in [
+            (
+                Some("session-model"),
+                Some(Some(std::ffi::OsStr::new("session-model"))),
+            ),
+            (None, Some(None)),
+        ] {
+            let mut command = tokio::process::Command::new("ignored");
+            command.env("GOOSE_MODEL", "stale-model");
+
+            apply_model_environment(&mut command, model_name);
+
+            assert_eq!(
+                command
+                    .as_std()
+                    .get_envs()
+                    .find_map(|(key, value)| (key == "GOOSE_MODEL").then_some(value)),
+                expected
+            );
+        }
+    }
+
+    #[test]
     fn session_environment_is_set_or_removed() {
         for (session_id, expected) in [
             (
@@ -1069,14 +1183,26 @@ mod tests {
 
     #[cfg(not(windows))]
     #[test]
-    fn flatpak_session_environment_is_set_or_unset() {
-        for (session_id, expected) in [
-            (Some("session-123"), "--env=AGENT_SESSION_ID=session-123"),
-            (None, "--unset-env=AGENT_SESSION_ID"),
+    fn flatpak_environment_is_set_or_unset() {
+        for (session_id, model_name, expected) in [
+            (
+                Some("session-123"),
+                Some("session-model"),
+                vec![
+                    "--env=AGENT_SESSION_ID=session-123",
+                    "--env=GOOSE_MODEL=session-model",
+                ],
+            ),
+            (
+                None,
+                None,
+                vec!["--unset-env=AGENT_SESSION_ID", "--unset-env=GOOSE_MODEL"],
+            ),
         ] {
             let mut command = tokio::process::Command::new("flatpak-spawn");
 
             apply_flatpak_session_environment(&mut command, session_id);
+            apply_flatpak_model_environment(&mut command, model_name);
 
             assert_eq!(
                 command
@@ -1084,7 +1210,7 @@ mod tests {
                     .get_args()
                     .map(|arg| arg.to_string_lossy().into_owned())
                     .collect::<Vec<_>>(),
-                vec![expected]
+                expected
             );
         }
     }

--- a/crates/goose/src/agents/state_machine/ops_toolcalling.rs
+++ b/crates/goose/src/agents/state_machine/ops_toolcalling.rs
@@ -369,6 +369,7 @@ impl<'a> ToolExecutionOperation<'a> {
                 Some(session.working_dir.clone()),
                 Some(request_id.clone()),
             );
+            let context = context.with_model_from_session(session);
             let result = self
                 .extension_manager
                 .dispatch_tool_call(&context, tool_call.clone(), cancellation_token)

--- a/crates/goose/src/agents/tool_execution.rs
+++ b/crates/goose/src/agents/tool_execution.rs
@@ -37,6 +37,7 @@ impl ToolCallNotificationEmitter {
 pub struct ToolCallContext {
     pub session_id: String,
     pub working_dir: Option<PathBuf>,
+    pub model_name: Option<String>,
     pub tool_call_request_id: Option<String>,
     notification_emitter: Option<ToolCallNotificationEmitter>,
 }
@@ -50,8 +51,21 @@ impl ToolCallContext {
         Self {
             session_id,
             working_dir,
+            model_name: None,
             tool_call_request_id,
             notification_emitter: None,
+        }
+    }
+
+    pub fn with_model_name(mut self, model_name: impl Into<String>) -> Self {
+        self.model_name = Some(model_name.into());
+        self
+    }
+
+    pub fn with_model_from_session(self, session: &Session) -> Self {
+        match session.model_config.as_ref() {
+            Some(model_config) => self.with_model_name(model_config.model_name.clone()),
+            None => self,
         }
     }
 


### PR DESCRIPTION
Assisted-by: Goose:gpt-5.6-luna
Assisted-by: Goose:glm-5.3
Fixes: #11714

## Summary

Propagate the active session model through both agent execution paths and make it available to developer shells and MCP subprocesses via GOOSE_MODEL. Add coverage for model export and stale environment removal.

### Testing

> [!WARNING]
> TODO!

### Related Issues

Discussed and approved in #11714.
