### PR TITLE
test(desktop): make the updater target test pass on Windows

### DIFF
--- a/ui/desktop/src/utils/githubUpdater.target.test.ts
+++ b/ui/desktop/src/utils/githubUpdater.target.test.ts
@@ -36,11 +36,15 @@ afterEach(async () => {
 describe('resolveInstallTarget', () => {
   it('resolves the .app bundle on macOS', async () => {
     setPlatform('darwin');
-    const exePath = '/Applications/Goose.app/Contents/MacOS/Goose';
+    // The mocked platform does not change `path`, which stays the host
+    // implementation, so build the expectation the same way the code under test
+    // does instead of hardcoding POSIX separators.
+    const bundlePath = path.resolve('/Applications/Goose.app');
+    const exePath = path.join(bundlePath, 'Contents', 'MacOS', 'Goose');
 
     await expect(resolveInstallTarget(exePath)).resolves.toEqual({
-      targetPath: '/Applications/Goose.app',
-      relaunchPath: '/Applications/Goose.app',
+      targetPath: bundlePath,
+      relaunchPath: bundlePath,
       executableRelativePath: path.join('Contents', 'MacOS', 'Goose'),
     });
   });


### PR DESCRIPTION
## Description

`resolveInstallTarget` is fine; the test around it was platform-bound.

`githubUpdater.target.test.ts` overrides `process.platform` with `darwin`, but that does not change `path`, which stays the host implementation. On Windows `path.resolve('/Applications/Goose.app/Contents/MacOS/Goose')` prepends the current drive, so the function under test returns `C:\Applications\Goose.app` while the assertion compared it against the POSIX literal. One test failed, and with it the whole `ui/desktop` suite, for every contributor on Windows.

CI never saw this: `Test and Lint Electron Desktop App` runs on `macos-latest`, where the literals happen to match.

The fix builds the expected paths with the same `path.resolve` the code under test uses. The third field of the same assertion already did this with `path.join`, so this only extends to the other two fields what the test was doing for one.

Both sides of the comparison now come from the same resolve, so the test is also independent of which drive the checkout lives on.

## Related Issue

Fixes #11915

## Verification

On Windows 11, in `ui/desktop`:

- before: `pnpm test:run` reported `1 failed | 794 passed`, the failure being this test
- after: `92 passed | 1 skipped` test files, `790 passed | 17 skipped` tests, nothing failing
- `pnpm lint:check` passes

The test still discriminates: temporarily changing `resolveInstallTarget` to climb two directories instead of three makes it fail again, and restoring the third climb makes it pass. So it is not passing by construction.

On macOS the expectation is unchanged - `path.resolve` on an already absolute POSIX path returns the same string that was hardcoded - which the macOS CI job covers.

## What I did not do

I have no macOS or Linux machine here, so those runs are reasoning plus CI rather than something I measured. I also left the other seven tests in the file alone; they build their paths from real temp directories and pass on Windows as they are.

## Checklist

- [x] Tests added/updated
- [x] Linter passes
- [x] Commits signed off (DCO)
