### PR TITLE
fix(desktop): show output for failed tool calls

### DIFF
--- a/ui/desktop/src/acp/__tests__/sessionNotificationAdapter.test.ts
+++ b/ui/desktop/src/acp/__tests__/sessionNotificationAdapter.test.ts
@@ -507,7 +507,7 @@ describe('createAcpSessionNotificationAdapter', () => {
         });
       });
 
-      it('maps failed tool responses to error results', () => {
+      it('preserves failed tool responses as results with error status', () => {
         const adapter = createAcpSessionNotificationAdapter();
 
         const failedToolStateChanges = adapter.apply(
@@ -527,8 +527,12 @@ describe('createAcpSessionNotificationAdapter', () => {
           type: 'toolResponse',
           id: 'tool-1',
           toolResult: {
-            status: 'error',
-            error: 'permission denied',
+            status: 'success',
+            value: {
+              content: [{ type: 'text', text: 'permission denied' }],
+              structuredContent: 'permission denied',
+              isError: true,
+            },
           },
           metadata: {
             title: 'Read file',
@@ -687,8 +691,11 @@ describe('createAcpSessionNotificationAdapter', () => {
             content,
           },
           toolResult: {
-            status: 'error',
-            error: 'file not found',
+            status: 'success',
+            value: {
+              content: [{ type: 'text', text: 'file not found' }],
+              isError: true,
+            },
           },
         });
       });

--- a/ui/desktop/src/acp/adapter/tools.ts
+++ b/ui/desktop/src/acp/adapter/tools.ts
@@ -80,13 +80,14 @@ export function applyToolCallUpdate(
   message.content.push({
     type: 'toolResponse',
     id: update.toolCallId,
-    toolResult:
-      toolCallState.status === 'failed'
-        ? { status: 'error', error: toolError(toolCallState) }
-        : {
-            status: 'success',
-            value: toolResultValue(toolCallState, mcpAppMetadata(update)),
-          },
+    toolResult: {
+      status: 'success',
+      value: toolResultValue(
+        toolCallState,
+        mcpAppMetadata(update),
+        toolCallState.status === 'failed'
+      ),
+    },
     ...(metadata ? { metadata } : {}),
   });
 
@@ -210,11 +211,21 @@ function baseToolMetadata(
 
 function toolResultValue(
   update: ToolCallUpdate,
-  mcpAppMeta: DesktopMcpAppMeta | undefined
+  mcpAppMeta: DesktopMcpAppMeta | undefined,
+  isError: boolean
 ): ToolResultValue {
+  const content = toolResultContent(update);
+  if (isError && content.length === 0) {
+    const errorText =
+      typeof update.rawOutput === 'string' && update.rawOutput.trim()
+        ? update.rawOutput
+        : (update.title ?? 'Tool call failed');
+    content.push({ type: 'text', text: errorText });
+  }
+
   const toolResult: ToolResultValue = {
-    content: toolResultContent(update),
-    isError: false,
+    content,
+    isError,
     ...(mcpAppMeta ? { _meta: mcpAppMeta } : {}),
   };
 
@@ -313,22 +324,6 @@ function apiResourceContentsFromAcpResource(
     ...(resource.mimeType ? { mimeType: resource.mimeType } : {}),
     ...(resource._meta ? { _meta: resource._meta } : {}),
   };
-}
-
-function toolError(update: ToolCallUpdate): string {
-  if (typeof update.rawOutput === 'string' && update.rawOutput.trim()) {
-    return update.rawOutput;
-  }
-
-  const contentText = toolResultContent(update)
-    .flatMap((content) => (content.type === 'text' ? [content.text] : []))
-    .filter((text) => text.trim().length > 0)
-    .join('\n');
-  if (contentText) {
-    return contentText;
-  }
-
-  return update.title ?? 'Tool call failed';
 }
 
 interface DesktopMcpAppMeta extends Record<string, unknown> {

--- a/ui/desktop/src/components/ToolCallWithResponse.test.tsx
+++ b/ui/desktop/src/components/ToolCallWithResponse.test.tsx
@@ -69,6 +69,23 @@ const toolResponse: ToolResponseMessageContent = {
   },
 };
 
+const failedToolResponse: ToolResponseMessageContent = {
+  type: 'toolResponse',
+  id: 'tool-1',
+  toolResult: {
+    status: 'success',
+    value: {
+      content: [
+        {
+          type: 'text',
+          text: 'this output is important',
+        },
+      ],
+      isError: true,
+    },
+  },
+};
+
 function renderToolCall(response?: ToolResponseMessageContent) {
   return render(
     <ToolCallWithResponse
@@ -107,6 +124,12 @@ describe('ToolCallWithResponse live output', () => {
 
     expect(screen.queryByText(/starting/)).not.toBeInTheDocument();
     expect(await screen.findByText('final result')).toBeInTheDocument();
+  });
+
+  it('renders output from a failed tool call', async () => {
+    renderToolCall(failedToolResponse);
+
+    expect(await screen.findByText('this output is important')).toBeInTheDocument();
   });
 
   it('passes the current ACP permission generation through inline approval', async () => {

--- a/ui/desktop/src/components/ToolCallWithResponse.tsx
+++ b/ui/desktop/src/components/ToolCallWithResponse.tsx
@@ -141,6 +141,9 @@ function getSubagentSessionId(
 }
 
 function getToolResultContent(toolResult: Record<string, unknown>): ContentBlock[] {
+  if (toolResult.status === 'error') {
+    return typeof toolResult.error === 'string' ? [{ type: 'text', text: toolResult.error }] : [];
+  }
   if (toolResult.status !== 'success') {
     return [];
   }
@@ -534,12 +537,14 @@ function ToolCallView({
   // This is a workaround for cases where the backend doesn't send tool responses
   const isStreamingComplete = !isStreamingMessage;
   const shouldShowAsComplete = isStreamingComplete && !toolResponse;
+  const toolResult = toolResponse?.toolResult as Record<string, unknown> | undefined;
+  const toolResultValue = toolResult?.value as ToolResultValue | undefined;
 
   const loadingStatus: LoadingStatus = !toolResponse
     ? shouldShowAsComplete
       ? 'success'
       : 'loading'
-    : (toolResponse.toolResult as Record<string, unknown>).status === 'error'
+    : toolResult?.status === 'error' || toolResultValue?.isError
       ? 'error'
       : 'success';
 
@@ -553,10 +558,7 @@ function ToolCallView({
     }
   }, [toolResponse, startTime]);
 
-  const toolResults =
-    loadingStatus === 'success' && toolResponse?.toolResult
-      ? getToolResultContent(toolResponse.toolResult)
-      : [];
+  const toolResults = toolResult ? getToolResultContent(toolResult) : [];
   const liveOutput = toolResponse ? '' : liveOutputToString(notifications);
 
   const logs = notifications


### PR DESCRIPTION
## Summary

Show tool output in the desktop UI when a tool call fails.

Failed ACP results now preserve their content and use `isError` to retain the red failure status without hiding the output.

Addresses the output-rendering problem in #11835. It does not change how non-zero shell exit codes are classified.

### Testing
Unit and manual

### Related Issues
Discussion: #11835

### Screenshots/Demos (for UX changes)
Before:  
<img width="1152" height="372" alt="Screenshot 2026-09-09 at 2 22 40 pm" src="https://github.com/user-attachments/assets/8539a818-ae0a-477e-bf06-91b893838a0a" />

After:
<img width="1164" height="699" alt="Screenshot 2026-09-09 at 3 53 13 pm" src="https://github.com/user-attachments/assets/3157b803-523c-4008-b4c6-d32002005722" />
