### PR TITLE
fix: send session ID header for OpenCode Go

### DIFF
--- a/crates/goose-providers/src/declarative.rs
+++ b/crates/goose-providers/src/declarative.rs
@@ -155,6 +155,9 @@ pub struct DeclarativeProviderConfig {
     pub base_url: String,
     pub models: Vec<ModelInfo>,
     pub headers: Option<HashMap<String, String>>,
+    /// Overrides the default `agent-session-id` header name for session ID propagation.
+    #[serde(default)]
+    pub session_id_header_override: Option<String>,
     pub timeout_seconds: Option<u64>,
     pub supports_streaming: Option<bool>,
     #[serde(default = "default_requires_auth")]
@@ -533,6 +536,20 @@ mod tests {
         }
 
         assert!(!seen_ids.is_empty(), "no bundled providers were found");
+    }
+
+    #[test]
+    fn opencode_go_overrides_session_id_header() {
+        let config = fixed_provider_configs()
+            .expect("bundled providers should load")
+            .into_iter()
+            .find(|config| config.name == "opencode_go")
+            .expect("opencode_go should be bundled");
+
+        assert_eq!(
+            config.session_id_header_override.as_deref(),
+            Some("x-opencode-session")
+        );
     }
 
     #[test]

--- a/crates/goose-providers/src/declarative/definitions/opencode_go.json
+++ b/crates/goose-providers/src/declarative/definitions/opencode_go.json
@@ -5,6 +5,7 @@
   "description": "OpenCode Go models via OpenAI-compatible API.",
   "api_key_env": "OPENCODE_API_KEY",
   "base_url": "https://opencode.ai/zen/go/v1",
+  "session_id_header_override": "x-opencode-session",
   "catalog_provider_id": "opencode-go",
   "dynamic_models": true,
   "model_doc_link": "https://opencode.ai/docs/zen",

--- a/crates/goose-providers/src/ollama.rs
+++ b/crates/goose-providers/src/ollama.rs
@@ -577,6 +577,7 @@ mod tests {
             base_url: base_url.to_string(),
             models,
             headers: None,
+            session_id_header_override: None,
             timeout_seconds: None,
             supports_streaming: None,
             requires_auth: false,

--- a/crates/goose-providers/src/openai.rs
+++ b/crates/goose-providers/src/openai.rs
@@ -1380,6 +1380,7 @@ mod tests {
             base_url: base_url.to_string(),
             models: vec![crate::base::ModelInfo::new("test-model").with_context_limit(4096)],
             headers: None,
+            session_id_header_override: None,
             timeout_seconds: None,
             supports_streaming: None,
             requires_auth: false,

--- a/crates/goose/src/config/declarative_providers.rs
+++ b/crates/goose/src/config/declarative_providers.rs
@@ -216,6 +216,7 @@ pub fn create_custom_provider(
         base_url: params.api_url,
         models: model_infos,
         headers: params.headers,
+        session_id_header_override: None,
         timeout_seconds: None,
         supports_streaming: params.supports_streaming,
         requires_auth: params.requires_auth,
@@ -335,6 +336,7 @@ pub fn update_custom_provider(params: UpdateCustomProviderParams) -> Result<()> 
                 Some(h) => Some(h),
                 None => existing_config.headers,
             },
+            session_id_header_override: existing_config.session_id_header_override,
             timeout_seconds: existing_config.timeout_seconds,
             supports_streaming: params.supports_streaming,
             requires_auth: params.requires_auth,
@@ -612,6 +614,7 @@ mod tests {
                 request_params: None,
             }],
             headers: None,
+            session_id_header_override: None,
             timeout_seconds: None,
             supports_streaming: Some(true),
             requires_auth: true,
@@ -646,6 +649,24 @@ mod tests {
             .unwrap();
 
         assert_ne!(native.inventory_key, toolshim.inventory_key);
+    }
+
+    #[test]
+    fn session_id_header_override_changes_declarative_inventory_identity() {
+        let _guard = env_lock::lock_env([("GOOSE_TOOLSHIM", None::<&str>)]);
+        let mut config = test_huggingface_config();
+
+        let default = declarative_inventory_identity(&config)
+            .unwrap()
+            .into_identity()
+            .unwrap();
+        config.session_id_header_override = Some("x-custom-session".to_string());
+        let overridden = declarative_inventory_identity(&config)
+            .unwrap()
+            .into_identity()
+            .unwrap();
+
+        assert_ne!(default.inventory_key, overridden.inventory_key);
     }
 
     #[test]

--- a/crates/goose/src/providers/anthropic_def.rs
+++ b/crates/goose/src/providers/anthropic_def.rs
@@ -7,6 +7,9 @@ use crate::{
         base::ProviderDef, command_auth::CommandAuthProvider,
         custom_provider_config::ConfigKeyResolver,
     },
+    session_context::{
+        session_id_request_builder, session_id_request_builder_with_header_override,
+    },
 };
 use goose_providers::{
     anthropic::{self, AnthropicProvider, AnthropicProviderBuilder, ANTHROPIC_API_VERSION},
@@ -62,7 +65,7 @@ async fn from_env(
         std::time::Duration::from_secs(timeout_secs),
         tls_config,
     )?
-    .with_request_builder(crate::session_context::session_id_request_builder())
+    .with_request_builder(session_id_request_builder())
     .with_header("anthropic-version", ANTHROPIC_API_VERSION)?;
 
     Ok(AnthropicProviderBuilder::new(api_client).build())
@@ -73,12 +76,14 @@ pub fn from_custom_config(
     tls_config: Option<TlsConfig>,
 ) -> Result<AnthropicProvider> {
     let auth_override = config.auth.clone();
+    let request_builder = session_id_request_builder_with_header_override(
+        config.session_id_header_override.as_deref(),
+    )?;
     anthropic::from_declarative_config(config, tls_config, ConfigKeyResolver::new(Config::global()))
         .map(|builder| {
             builder
                 .map_api_client(|api_client| {
-                    let api_client = api_client
-                        .with_request_builder(crate::session_context::session_id_request_builder());
+                    let api_client = api_client.with_request_builder(request_builder);
                     match auth_override {
                         Some(auth_config) => api_client.with_auth(AuthMethod::Custom(Box::new(
                             CommandAuthProvider::new(&auth_config, "x-api-key", ""),
@@ -133,6 +138,7 @@ mod tests {
             base_url: "http://localhost:1".to_string(),
             models,
             headers: None,
+            session_id_header_override: None,
             timeout_seconds: None,
             supports_streaming: Some(true),
             requires_auth: false,

--- a/crates/goose/src/providers/huggingface.rs
+++ b/crates/goose/src/providers/huggingface.rs
@@ -9,6 +9,9 @@ use super::openai_compatible::OpenAiCompatibleProvider;
 use crate::config::declarative_providers::DeclarativeProviderConfig;
 use crate::config::{Config, ConfigError};
 use crate::conversation::message::Message;
+use crate::session_context::{
+    session_id_request_builder, session_id_request_builder_with_header_override,
+};
 use anyhow::{anyhow, Result};
 use futures::future::BoxFuture;
 use goose_providers::errors::ProviderError;
@@ -97,6 +100,9 @@ impl HuggingFaceProvider {
         let (host, completions_prefix, query_params) =
             openai_compatible_endpoint_parts(&config.base_url, config.base_path.as_deref())?;
 
+        let request_builder = session_id_request_builder_with_header_override(
+            config.session_id_header_override.as_deref(),
+        )?;
         let timeout_secs = config
             .timeout_seconds
             .unwrap_or(DEFAULT_PROVIDER_TIMEOUT_SECS);
@@ -106,7 +112,7 @@ impl HuggingFaceProvider {
             std::time::Duration::from_secs(timeout_secs),
             tls_config,
         )?
-        .with_request_builder(crate::session_context::session_id_request_builder())
+        .with_request_builder(request_builder)
         .with_query(query_params);
 
         if let Some(headers) = &config.headers {
@@ -241,7 +247,7 @@ impl ProviderDef for HuggingFaceProvider {
                 .get_param("HF_HOST")
                 .unwrap_or_else(|_| HUGGINGFACE_API_HOST.to_string());
             let api_client = ApiClient::new_with_tls(host, auth_method, tls_config)?
-                .with_request_builder(crate::session_context::session_id_request_builder());
+                .with_request_builder(session_id_request_builder());
 
             Ok(Self {
                 inner: OpenAiCompatibleProvider::new(
@@ -570,6 +576,7 @@ mod tests {
             base_url: HUGGINGFACE_API_HOST.to_string(),
             models: Vec::new(),
             headers: None,
+            session_id_header_override: None,
             timeout_seconds: None,
             supports_streaming: Some(true),
             requires_auth: true,

--- a/crates/goose/src/providers/inventory/mod.rs
+++ b/crates/goose/src/providers/inventory/mod.rs
@@ -979,6 +979,12 @@ pub fn declarative_inventory_identity(
             .public_inputs
             .insert("headers".to_string(), serialize_string_map(headers)?);
     }
+    if let Some(header_name) = &config.session_id_header_override {
+        identity.public_inputs.insert(
+            "session_id_header_override".to_string(),
+            header_name.clone(),
+        );
+    }
     if !config.api_key_env.is_empty() {
         if let Some(value) = config_secret_value(global, &config.api_key_env) {
             identity

--- a/crates/goose/src/providers/ollama_cloud.rs
+++ b/crates/goose/src/providers/ollama_cloud.rs
@@ -2,6 +2,7 @@ use super::base::{ConfigKey, MessageStream, Provider, ProviderDef, ProviderMetad
 use crate::config::declarative_providers::DeclarativeProviderConfig;
 use crate::config::Config;
 use crate::conversation::message::Message;
+use crate::session_context::session_id_request_builder_with_header_override;
 use anyhow::Result;
 use futures::future::BoxFuture;
 use goose_providers::api_client::{ApiClient, AuthMethod, TlsConfig};
@@ -152,7 +153,10 @@ fn build_ollama_api_client(
         api_client = api_client.with_headers(header_map)?;
     }
 
-    Ok(api_client.with_request_builder(crate::session_context::session_id_request_builder()))
+    let request_builder = session_id_request_builder_with_header_override(
+        config.session_id_header_override.as_deref(),
+    )?;
+    Ok(api_client.with_request_builder(request_builder))
 }
 
 #[async_trait::async_trait]
@@ -475,6 +479,7 @@ mod tests {
             base_url,
             models,
             headers: None,
+            session_id_header_override: None,
             timeout_seconds: None,
             supports_streaming: Some(true),
             requires_auth: false,

--- a/crates/goose/src/providers/ollama_def.rs
+++ b/crates/goose/src/providers/ollama_def.rs
@@ -10,6 +10,9 @@ use crate::{
         base::ProviderDef, command_auth::CommandAuthProvider,
         custom_provider_config::ConfigKeyResolver,
     },
+    session_context::{
+        session_id_request_builder, session_id_request_builder_with_header_override,
+    },
 };
 use goose_providers::{
     api_client::{ApiClient, AuthMethod},
@@ -87,7 +90,7 @@ pub async fn from_env(
         timeout,
         tls_config,
     )?
-    .with_request_builder(crate::session_context::session_id_request_builder());
+    .with_request_builder(session_id_request_builder());
 
     Ok(OllamaProviderBuilder::new(api_client)
         .name(OLLAMA_PROVIDER_NAME)
@@ -100,12 +103,14 @@ pub fn from_custom_config(
     tls_config: Option<crate::providers::api_client::TlsConfig>,
 ) -> Result<OllamaProvider> {
     let auth_override = config.auth.clone();
+    let request_builder = session_id_request_builder_with_header_override(
+        config.session_id_header_override.as_deref(),
+    )?;
     ollama::from_declarative_config(config, tls_config, ConfigKeyResolver::new(Config::global()))
         .map(|builder| {
             builder
                 .map_api_client(|api_client| {
-                    let api_client = api_client
-                        .with_request_builder(crate::session_context::session_id_request_builder());
+                    let api_client = api_client.with_request_builder(request_builder);
                     match auth_override {
                         Some(auth_config) => api_client.with_auth(AuthMethod::Custom(Box::new(
                             CommandAuthProvider::new(&auth_config, "Authorization", "Bearer "),

--- a/crates/goose/src/providers/openai_def.rs
+++ b/crates/goose/src/providers/openai_def.rs
@@ -14,6 +14,9 @@ use goose_providers::openai::{
     OPEN_AI_DEFAULT_BASE_PATH, OPEN_AI_VERSIONLESS_BASE_PATH,
 };
 
+const OPENCODE_GO_PROVIDER_NAME: &str = "opencode_go";
+const OPENCODE_SESSION_ID_HEADER: &str = "x-opencode-session";
+
 pub struct OpenAiProviderDef;
 
 impl ProviderDescriptor for OpenAiProviderDef {
@@ -200,11 +203,22 @@ pub fn resolve_api_key(
     }
 }
 
+fn session_id_request_builder_for_provider(
+    provider_name: &str,
+) -> goose_providers::api_client::RequestBuilderDecorator {
+    if provider_name == OPENCODE_GO_PROVIDER_NAME {
+        crate::session_context::session_id_request_builder_with_header(OPENCODE_SESSION_ID_HEADER)
+    } else {
+        crate::session_context::session_id_request_builder()
+    }
+}
+
 pub fn from_custom_config(
     config: DeclarativeProviderConfig,
     tls_config: Option<goose_providers::api_client::TlsConfig>,
 ) -> Result<OpenAiProvider> {
     let auth_override = config.auth.clone();
+    let request_builder = session_id_request_builder_for_provider(&config.name);
     goose_providers::openai::from_declarative_config(
         config,
         tls_config,
@@ -213,8 +227,7 @@ pub fn from_custom_config(
     .map(|builder| {
         builder
             .map_api_client(|api_client| {
-                let api_client = api_client
-                    .with_request_builder(crate::session_context::session_id_request_builder());
+                let api_client = api_client.with_request_builder(request_builder);
                 match auth_override {
                     Some(auth_config) => api_client.with_auth(AuthMethod::Custom(Box::new(
                         CommandAuthProvider::new(&auth_config, "Authorization", "Bearer "),
@@ -392,5 +405,45 @@ mod tests {
     #[test]
     fn parse_base_url_rejects_whitespace_only() {
         assert!(parse_base_url("  ").is_err());
+    }
+
+    #[tokio::test]
+    async fn opencode_go_uses_opencode_session_header() {
+        crate::session_context::with_session_id(Some("test-session-123".to_string()), async {
+            let decorate = session_id_request_builder_for_provider("opencode_go");
+
+            let request = decorate(reqwest::Client::new().get("http://localhost"))
+                .unwrap()
+                .build()
+                .unwrap();
+
+            assert_eq!(
+                request.headers().get("x-opencode-session").unwrap(),
+                "test-session-123"
+            );
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn other_provider_uses_default_session_header() {
+        crate::session_context::with_session_id(Some("test-session-123".to_string()), async {
+            let decorate = session_id_request_builder_for_provider("other_provider");
+
+            let request = decorate(reqwest::Client::new().get("http://localhost"))
+                .unwrap()
+                .build()
+                .unwrap();
+
+            assert_eq!(
+                request
+                    .headers()
+                    .get(crate::session_context::SESSION_ID_HEADER)
+                    .unwrap(),
+                "test-session-123"
+            );
+            assert!(request.headers().get("x-opencode-session").is_none());
+        })
+        .await;
     }
 }

--- a/crates/goose/src/providers/openai_def.rs
+++ b/crates/goose/src/providers/openai_def.rs
@@ -8,14 +8,14 @@ use crate::config::Config;
 use crate::providers::base::{ProviderDef, DEFAULT_PROVIDER_TIMEOUT_SECS};
 use crate::providers::command_auth::CommandAuthProvider;
 use crate::providers::custom_provider_config::ConfigKeyResolver;
+use crate::session_context::{
+    session_id_request_builder, session_id_request_builder_with_header_override,
+};
 use goose_providers::api_client::{ApiClient, AuthMethod};
 use goose_providers::openai::{
     parse_custom_headers, parse_openai_base_url, OpenAiProvider, OpenAiProviderBuilder,
     OPEN_AI_DEFAULT_BASE_PATH, OPEN_AI_VERSIONLESS_BASE_PATH,
 };
-
-const OPENCODE_GO_PROVIDER_NAME: &str = "opencode_go";
-const OPENCODE_SESSION_ID_HEADER: &str = "x-opencode-session";
 
 pub struct OpenAiProviderDef;
 
@@ -118,7 +118,7 @@ pub async fn from_env(
         std::time::Duration::from_secs(timeout_secs),
         tls_config,
     )?
-    .with_request_builder(crate::session_context::session_id_request_builder());
+    .with_request_builder(session_id_request_builder());
 
     if !parsed.query_params.is_empty() {
         api_client = api_client.with_query(parsed.query_params);
@@ -203,22 +203,14 @@ pub fn resolve_api_key(
     }
 }
 
-fn session_id_request_builder_for_provider(
-    provider_name: &str,
-) -> goose_providers::api_client::RequestBuilderDecorator {
-    if provider_name == OPENCODE_GO_PROVIDER_NAME {
-        crate::session_context::session_id_request_builder_with_header(OPENCODE_SESSION_ID_HEADER)
-    } else {
-        crate::session_context::session_id_request_builder()
-    }
-}
-
 pub fn from_custom_config(
     config: DeclarativeProviderConfig,
     tls_config: Option<goose_providers::api_client::TlsConfig>,
 ) -> Result<OpenAiProvider> {
     let auth_override = config.auth.clone();
-    let request_builder = session_id_request_builder_for_provider(&config.name);
+    let request_builder = session_id_request_builder_with_header_override(
+        config.session_id_header_override.as_deref(),
+    )?;
     goose_providers::openai::from_declarative_config(
         config,
         tls_config,
@@ -405,45 +397,5 @@ mod tests {
     #[test]
     fn parse_base_url_rejects_whitespace_only() {
         assert!(parse_base_url("  ").is_err());
-    }
-
-    #[tokio::test]
-    async fn opencode_go_uses_opencode_session_header() {
-        crate::session_context::with_session_id(Some("test-session-123".to_string()), async {
-            let decorate = session_id_request_builder_for_provider("opencode_go");
-
-            let request = decorate(reqwest::Client::new().get("http://localhost"))
-                .unwrap()
-                .build()
-                .unwrap();
-
-            assert_eq!(
-                request.headers().get("x-opencode-session").unwrap(),
-                "test-session-123"
-            );
-        })
-        .await;
-    }
-
-    #[tokio::test]
-    async fn other_provider_uses_default_session_header() {
-        crate::session_context::with_session_id(Some("test-session-123".to_string()), async {
-            let decorate = session_id_request_builder_for_provider("other_provider");
-
-            let request = decorate(reqwest::Client::new().get("http://localhost"))
-                .unwrap()
-                .build()
-                .unwrap();
-
-            assert_eq!(
-                request
-                    .headers()
-                    .get(crate::session_context::SESSION_ID_HEADER)
-                    .unwrap(),
-                "test-session-123"
-            );
-            assert!(request.headers().get("x-opencode-session").is_none());
-        })
-        .await;
     }
 }

--- a/crates/goose/src/providers/provider_registry.rs
+++ b/crates/goose/src/providers/provider_registry.rs
@@ -378,6 +378,7 @@ mod tests {
             base_url: "https://router.huggingface.co/v1".to_string(),
             models: vec![ModelInfo::new("test-model").with_context_limit(128_000)],
             headers: None,
+            session_id_header_override: None,
             timeout_seconds: None,
             supports_streaming: Some(true),
             requires_auth: true,

--- a/crates/goose/src/session_context.rs
+++ b/crates/goose/src/session_context.rs
@@ -21,10 +21,16 @@ pub fn current_session_id() -> Option<String> {
 }
 
 pub fn session_id_request_builder() -> goose_providers::api_client::RequestBuilderDecorator {
-    std::sync::Arc::new(|request| {
+    session_id_request_builder_with_header(SESSION_ID_HEADER)
+}
+
+pub(crate) fn session_id_request_builder_with_header(
+    header_name: &'static str,
+) -> goose_providers::api_client::RequestBuilderDecorator {
+    std::sync::Arc::new(move |request| {
         let (client, request) = request.build_split();
         let mut request = request?;
-        let session_header = HeaderName::from_static(SESSION_ID_HEADER);
+        let session_header = HeaderName::from_static(header_name);
         request.headers_mut().remove(&session_header);
 
         if let Some(session_id) = current_session_id() {
@@ -118,6 +124,24 @@ mod tests {
             tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
 
             assert_eq!(current_session_id(), Some("persistent-session".to_string()));
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_session_id_request_builder_uses_custom_header() {
+        with_session_id(Some("test-session-123".to_string()), async {
+            let decorate = session_id_request_builder_with_header("x-opencode-session");
+
+            let request = decorate(reqwest::Client::new().get("http://localhost"))
+                .unwrap()
+                .build()
+                .unwrap();
+
+            assert_eq!(
+                request.headers().get("x-opencode-session").unwrap(),
+                "test-session-123"
+            );
         })
         .await;
     }

--- a/crates/goose/src/session_context.rs
+++ b/crates/goose/src/session_context.rs
@@ -21,16 +21,28 @@ pub fn current_session_id() -> Option<String> {
 }
 
 pub fn session_id_request_builder() -> goose_providers::api_client::RequestBuilderDecorator {
-    session_id_request_builder_with_header(SESSION_ID_HEADER)
+    session_id_request_builder_with_header_name(HeaderName::from_static(SESSION_ID_HEADER))
 }
 
-pub(crate) fn session_id_request_builder_with_header(
-    header_name: &'static str,
+pub(crate) fn session_id_request_builder_with_header_override(
+    header_name_override: Option<&str>,
+) -> Result<goose_providers::api_client::RequestBuilderDecorator, reqwest::header::InvalidHeaderName>
+{
+    let header_name = match header_name_override {
+        Some(header_name) => HeaderName::from_bytes(header_name.as_bytes())?,
+        None => HeaderName::from_static(SESSION_ID_HEADER),
+    };
+
+    Ok(session_id_request_builder_with_header_name(header_name))
+}
+
+fn session_id_request_builder_with_header_name(
+    header_name: HeaderName,
 ) -> goose_providers::api_client::RequestBuilderDecorator {
     std::sync::Arc::new(move |request| {
         let (client, request) = request.build_split();
         let mut request = request?;
-        let session_header = HeaderName::from_static(header_name);
+        let session_header = header_name.clone();
         request.headers_mut().remove(&session_header);
 
         if let Some(session_id) = current_session_id() {
@@ -131,7 +143,9 @@ mod tests {
     #[tokio::test]
     async fn test_session_id_request_builder_uses_custom_header() {
         with_session_id(Some("test-session-123".to_string()), async {
-            let decorate = session_id_request_builder_with_header("x-opencode-session");
+            let decorate =
+                session_id_request_builder_with_header_override(Some("x-opencode-session"))
+                    .unwrap();
 
             let request = decorate(reqwest::Client::new().get("http://localhost"))
                 .unwrap()
@@ -142,7 +156,31 @@ mod tests {
                 request.headers().get("x-opencode-session").unwrap(),
                 "test-session-123"
             );
+            assert!(request.headers().get(SESSION_ID_HEADER).is_none());
         })
         .await;
+    }
+
+    #[tokio::test]
+    async fn test_session_id_request_builder_uses_default_without_override() {
+        with_session_id(Some("test-session-123".to_string()), async {
+            let decorate = session_id_request_builder_with_header_override(None).unwrap();
+
+            let request = decorate(reqwest::Client::new().get("http://localhost"))
+                .unwrap()
+                .build()
+                .unwrap();
+
+            assert_eq!(
+                request.headers().get(SESSION_ID_HEADER).unwrap(),
+                "test-session-123"
+            );
+        })
+        .await;
+    }
+
+    #[test]
+    fn test_session_id_request_builder_rejects_invalid_header_override() {
+        assert!(session_id_request_builder_with_header_override(Some("invalid header")).is_err());
     }
 }

--- a/crates/goose/tests/custom_provider_command_auth_test.rs
+++ b/crates/goose/tests/custom_provider_command_auth_test.rs
@@ -24,6 +24,7 @@ fn custom_config_with_auth(base_url: &str, auth: AuthConfig) -> DeclarativeProvi
         base_url: base_url.to_string(),
         models: vec![goose_providers::base::ModelInfo::new("test-model")],
         headers: None,
+        session_id_header_override: None,
         timeout_seconds: None,
         supports_streaming: Some(true),
         requires_auth: true,


### PR DESCRIPTION
Fixes: #11900

## Summary
- Send the current Goose session ID as `x-opencode-session` for the built-in `opencode_go` provider.
- Preserve the existing `agent-session-id` header for other OpenAI-compatible providers.
- Add regression tests for both header-selection paths.

### Testing
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test -p goose --no-default-features --features rustls-tls,code-mode`
  - All 2210 library tests passed.
  - One unrelated integration test failed once and passed on an isolated rerun.
- Built `target/debug/goose` and manually tested `opencode_go` with `kimi-k2.6`:
  - 1:
```
./target/debug/goose run \
  --provider opencode_go \
  --model kimi-k2.6 \
  --name issue-11900-smoke \
  --text "Reply exactly: OK" \
  --no-profile \
  --max-turns 1 \
  --quiet
```
  Result:
```
  OK
```
  - 2:
```
./target/debug/goose run \
  --provider opencode_go \
  --model kimi-k2.6 \
  --resume \
  --name issue-11900-smoke \
  --text "Reply exactly: STILL_OK" \
  --no-profile \
  --max-turns 1 \
  --quiet
```
  Result:
```
  STILL_OK
```

### Related Issues
Discussion: LINK (if any)
None

### Screenshots/Demos (for UX changes)
N/A — no UX changes.