### PR TITLE
i18n(zh): use 词元/詞元 for model tokens, not 令牌/權杖

### DIFF
--- a/ui/desktop/src/i18n/messages/zh-CN.json
+++ b/ui/desktop/src/i18n/messages/zh-CN.json
@@ -330,10 +330,10 @@
     "defaultMessage": "Goose 请求用户输入前的最大 agent 轮次"
   },
   "costTracker.costUnavailable": {
-    "defaultMessage": "无法获取 {model} 的费用数据（输入 {inputTokens}、输出 {outputTokens} 令牌）"
+    "defaultMessage": "无法获取 {model} 的费用数据（输入 {inputTokens}、输出 {outputTokens} 词元）"
   },
   "costTracker.inputOutputTooltip": {
-    "defaultMessage": "输入：{inputTokens} 令牌（{inputCost}）| 输出：{outputTokens} 令牌（{outputCost}）"
+    "defaultMessage": "输入：{inputTokens} 词元（{inputCost}）| 输出：{outputTokens} 词元（{outputCost}）"
   },
   "costTracker.pricingUnavailable": {
     "defaultMessage": "无法获取 {model} 的定价数据"
@@ -2040,7 +2040,7 @@
     "defaultMessage": "（估算）"
   },
   "messageUsageStats.firstToken": {
-    "defaultMessage": "首个令牌"
+    "defaultMessage": "首个词元"
   },
   "messageUsageStats.input": {
     "defaultMessage": "输入"
@@ -2217,10 +2217,10 @@
     "defaultMessage": "防止模型被交换到磁盘"
   },
   "modelSettingsPanel.maxOutputTokens": {
-    "defaultMessage": "最大输出令牌"
+    "defaultMessage": "最大输出词元"
   },
   "modelSettingsPanel.maxOutputTokensDescription": {
-    "defaultMessage": "生成令牌上限"
+    "defaultMessage": "生成词元上限"
   },
   "modelSettingsPanel.minP": {
     "defaultMessage": "Min P"
@@ -2244,7 +2244,7 @@
     "defaultMessage": "重复窗口"
   },
   "modelSettingsPanel.repeatWindowDescription": {
-    "defaultMessage": "回看的令牌数"
+    "defaultMessage": "回看的词元数"
   },
   "modelSettingsPanel.repetitionPenalty": {
     "defaultMessage": "重复惩罚"
@@ -2580,7 +2580,7 @@
     "defaultMessage": "使用的提供商和模型"
   },
   "privacyInfoModal.collectSession": {
-    "defaultMessage": "会话指标（时长、交互次数、令牌用量）"
+    "defaultMessage": "会话指标（时长、交互次数、词元用量）"
   },
   "privacyInfoModal.collectVersion": {
     "defaultMessage": "goose 版本和安装方式"
@@ -4308,7 +4308,7 @@
     "defaultMessage": "中 - 适度思考"
   },
   "switchModelModal.claudeEnabled": {
-    "defaultMessage": "启用 - 固定思考令牌预算"
+    "defaultMessage": "启用 - 固定思考词元预算"
   },
   "switchModelModal.couldNotContactProvider": {
     "defaultMessage": "无法连接提供商"
@@ -4374,7 +4374,7 @@
     "defaultMessage": "选择思考模式"
   },
   "switchModelModal.thinkingBudget": {
-    "defaultMessage": "思考预算（令牌）"
+    "defaultMessage": "思考预算（词元）"
   },
   "switchModelModal.thinkingEffort": {
     "defaultMessage": "思考努力"

--- a/ui/desktop/src/i18n/messages/zh-TW.json
+++ b/ui/desktop/src/i18n/messages/zh-TW.json
@@ -330,10 +330,10 @@
     "defaultMessage": "Goose 要求使用者輸入前的最大代理回合數"
   },
   "costTracker.costUnavailable": {
-    "defaultMessage": "{model} 無可用的費用資料（輸入 {inputTokens} 個權杖，輸出 {outputTokens} 個權杖）"
+    "defaultMessage": "{model} 無可用的費用資料（輸入 {inputTokens} 個詞元，輸出 {outputTokens} 個詞元）"
   },
   "costTracker.inputOutputTooltip": {
-    "defaultMessage": "輸入：{inputTokens} 個權杖（{inputCost}）｜輸出：{outputTokens} 個權杖（{outputCost}）"
+    "defaultMessage": "輸入：{inputTokens} 個詞元（{inputCost}）｜輸出：{outputTokens} 個詞元（{outputCost}）"
   },
   "costTracker.pricingUnavailable": {
     "defaultMessage": "{model} 無可用的定價資料"
@@ -2040,7 +2040,7 @@
     "defaultMessage": "（估算）"
   },
   "messageUsageStats.firstToken": {
-    "defaultMessage": "首個權杖"
+    "defaultMessage": "首個詞元"
   },
   "messageUsageStats.input": {
     "defaultMessage": "輸入"
@@ -2217,10 +2217,10 @@
     "defaultMessage": "防止模型被置換到磁碟"
   },
   "modelSettingsPanel.maxOutputTokens": {
-    "defaultMessage": "最大輸出 token 數"
+    "defaultMessage": "最大輸出詞元數"
   },
   "modelSettingsPanel.maxOutputTokensDescription": {
-    "defaultMessage": "生成 token 的上限"
+    "defaultMessage": "生成詞元的上限"
   },
   "modelSettingsPanel.minP": {
     "defaultMessage": "Min P"
@@ -2244,7 +2244,7 @@
     "defaultMessage": "重複視窗"
   },
   "modelSettingsPanel.repeatWindowDescription": {
-    "defaultMessage": "回溯的 token 數"
+    "defaultMessage": "回溯的詞元數"
   },
   "modelSettingsPanel.repetitionPenalty": {
     "defaultMessage": "重複懲罰"
@@ -2580,7 +2580,7 @@
     "defaultMessage": "所使用的提供者與模型"
   },
   "privacyInfoModal.collectSession": {
-    "defaultMessage": "工作階段指標（持續時間、互動次數、權杖用量）"
+    "defaultMessage": "工作階段指標（持續時間、互動次數、詞元用量）"
   },
   "privacyInfoModal.collectVersion": {
     "defaultMessage": "goose 版本與安裝方式"
@@ -4308,7 +4308,7 @@
     "defaultMessage": "中 - 適度思考"
   },
   "switchModelModal.claudeEnabled": {
-    "defaultMessage": "啟用 - 思考使用固定的權杖預算"
+    "defaultMessage": "啟用 - 思考使用固定的詞元預算"
   },
   "switchModelModal.couldNotContactProvider": {
     "defaultMessage": "無法連絡提供者"
@@ -4374,7 +4374,7 @@
     "defaultMessage": "選擇思考模式"
   },
   "switchModelModal.thinkingBudget": {
-    "defaultMessage": "思考預算（權杖）"
+    "defaultMessage": "思考預算（詞元）"
   },
   "switchModelModal.thinkingEffort": {
     "defaultMessage": "思考用力程度"


### PR DESCRIPTION
Reported and verified by a native Chinese speaker.

Chinese used 令牌 (zh-CN) and 權杖 (zh-TW) for both meanings of "token": the units a model reads and writes, and an authentication credential. Those two words mean the credential only - an authentication token and an LLM token are different words in Chinese, not one word with two senses. The standard term for the model unit is 词元 / 詞元, so today the token counters, thinking budget and cost tooltips read as security jargon to a Chinese user.

This moves the model-token strings to 词元 / 詞元 (9 keys per locale), and also normalises three zh-TW model-settings strings that had kept the English word "token", so one term is used throughout.

Changed: `costTracker.costUnavailable`, `costTracker.inputOutputTooltip`, `messageUsageStats.firstToken`, `modelSettingsPanel.maxOutputTokens`, `modelSettingsPanel.maxOutputTokensDescription`, `modelSettingsPanel.repeatWindowDescription`, `privacyInfoModal.collectSession`, `switchModelModal.claudeEnabled`, `switchModelModal.thinkingBudget`.

Deliberately unchanged: `providerConfigurationModal.huggingFaceOAuthDescription` and the `securityToggle.*` API-token strings, where 令牌 / 權杖 is the correct word because those really are authentication tokens.

Translations only - no source strings, placeholders or keys change. `i18n:validate-locale` passes for both locales (1557 messages each).
