### PR TITLE
fix(developer): stop `tree` hydrating cloud placeholders it lists

### DIFF
--- a/crates/goose/src/agents/platform_extensions/developer/mod.rs
+++ b/crates/goose/src/agents/platform_extensions/developer/mod.rs
@@ -159,7 +159,10 @@ impl DeveloperClient {
             )),
             Tool::new(
                 "tree".to_string(),
-                "List a directory tree with line counts. Traversal respects .gitignore rules.".to_string(),
+                "List a directory tree with line counts. Traversal respects .gitignore rules. \
+                 Cloud-storage placeholders that are not downloaded to this machine are listed \
+                 by size instead of being read."
+                    .to_string(),
                 Self::schema::<TreeParams>(),
             )
             .annotate(ToolAnnotations::from_raw(

--- a/crates/goose/src/agents/platform_extensions/developer/tree.rs
+++ b/crates/goose/src/agents/platform_extensions/developer/tree.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Component, Path, PathBuf};
 
-use ignore::WalkBuilder;
+use ignore::{DirEntry, WalkBuilder};
 use rmcp::model::{CallToolResult, ContentBlock};
 use schemars::JsonSchema;
 use serde::Deserialize;
@@ -87,8 +87,15 @@ impl Default for TreeTool {
 #[derive(Default)]
 struct DirectoryNode {
     dirs: BTreeMap<String, DirectoryNode>,
-    files: BTreeMap<String, usize>,
+    files: BTreeMap<String, FileMeasure>,
     total_lines: usize,
+}
+
+/// What a listing knows about a file: a line count from reading it, or - for a cloud placeholder
+/// that was deliberately not read - the size the directory entry already advertised.
+enum FileMeasure {
+    Lines(usize),
+    Placeholder(u64),
 }
 
 impl DirectoryNode {
@@ -99,7 +106,7 @@ impl DirectoryNode {
         }
     }
 
-    fn insert_file(&mut self, components: &[String], line_count: usize) {
+    fn insert_file(&mut self, components: &[String], measure: FileMeasure) {
         if components.is_empty() {
             return;
         }
@@ -110,7 +117,7 @@ impl DirectoryNode {
         }
 
         let filename = components[components.len() - 1].clone();
-        node.files.insert(filename, line_count);
+        node.files.insert(filename, measure);
     }
 
     fn compute_total_lines(&mut self) -> usize {
@@ -119,7 +126,14 @@ impl DirectoryNode {
             .values_mut()
             .map(DirectoryNode::compute_total_lines)
             .sum();
-        let file_lines: usize = self.files.values().copied().sum();
+        let file_lines: usize = self
+            .files
+            .values()
+            .map(|measure| match measure {
+                FileMeasure::Lines(lines) => *lines,
+                FileMeasure::Placeholder(_) => 0,
+            })
+            .sum();
         self.total_lines = dir_lines + file_lines;
         self.total_lines
     }
@@ -137,13 +151,12 @@ impl DirectoryNode {
             dir.render_into(depth + 1, out);
         }
 
-        for (name, line_count) in &self.files {
-            out.push_str(&format!(
-                "{}{}  {}\n",
-                indent,
-                name,
-                format_lines(*line_count)
-            ));
+        for (name, measure) in &self.files {
+            let rendered = match measure {
+                FileMeasure::Lines(lines) => format_lines(*lines),
+                FileMeasure::Placeholder(bytes) => format!("[cloud-only, {}]", format_size(*bytes)),
+            };
+            out.push_str(&format!("{}{}  {}\n", indent, name, rendered));
         }
     }
 }
@@ -181,7 +194,7 @@ fn collect_tree(root: &Path, max_depth: Option<usize>) -> DirectoryNode {
         if entry.file_type().is_some_and(|t| t.is_dir()) {
             tree.insert_dir(&components);
         } else if entry.file_type().is_some_and(|t| t.is_file()) {
-            tree.insert_file(&components, count_file_lines(path));
+            tree.insert_file(&components, measure_file(&entry));
         }
     }
 
@@ -204,10 +217,70 @@ fn relative_components(path: &Path) -> Option<Vec<String>> {
     }
 }
 
-fn count_file_lines(path: &Path) -> usize {
-    match fs::read_to_string(path) {
-        Ok(content) => content.lines().count(),
-        Err(_) => 0,
+// OneDrive Files On-Demand, iCloud Drive and other File Provider backends leave "cloud-only"
+// files on disk as placeholders that hold no data. Enumerating a directory and stat-ing its
+// entries sees them for free, but OPENING one for data blocks while the provider downloads the
+// whole file. Counting lines opens every file in the walk, so listing a synced folder used to
+// pull the entire remote tree down - unprompted, since `tree` is annotated read-only and so
+// never asks for approval. Report the size the placeholder already advertises instead.
+const FILE_ATTRIBUTE_OFFLINE: u32 = 0x0000_1000;
+const FILE_ATTRIBUTE_RECALL_ON_OPEN: u32 = 0x0004_0000;
+const FILE_ATTRIBUTE_RECALL_ON_DATA_ACCESS: u32 = 0x0040_0000;
+const SF_DATALESS: u32 = 0x4000_0000;
+
+// Both predicates compile everywhere so both stay unit-testable on any host; only the accessor
+// that feeds them is platform-gated.
+#[cfg_attr(not(windows), allow(dead_code))]
+fn windows_attributes_are_placeholder(attributes: u32) -> bool {
+    let mask = FILE_ATTRIBUTE_OFFLINE
+        | FILE_ATTRIBUTE_RECALL_ON_OPEN
+        | FILE_ATTRIBUTE_RECALL_ON_DATA_ACCESS;
+    attributes & mask != 0
+}
+
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+fn macos_flags_are_placeholder(flags: u32) -> bool {
+    flags & SF_DATALESS != 0
+}
+
+#[cfg(windows)]
+fn is_cloud_placeholder(metadata: &fs::Metadata) -> bool {
+    use std::os::windows::fs::MetadataExt;
+    windows_attributes_are_placeholder(metadata.file_attributes())
+}
+
+#[cfg(target_os = "macos")]
+fn is_cloud_placeholder(metadata: &fs::Metadata) -> bool {
+    use std::os::macos::fs::MetadataExt;
+    macos_flags_are_placeholder(metadata.st_flags())
+}
+
+#[cfg(not(any(windows, target_os = "macos")))]
+fn is_cloud_placeholder(_metadata: &fs::Metadata) -> bool {
+    false
+}
+
+fn measure_file(entry: &DirEntry) -> FileMeasure {
+    measure_file_with(entry, is_cloud_placeholder)
+}
+
+// The placeholder verdict is a parameter so a test can assert the read is skipped: a stub that
+// answers "placeholder" can only produce Placeholder if nothing opened the file.
+fn measure_file_with(
+    entry: &DirEntry,
+    is_placeholder: impl Fn(&fs::Metadata) -> bool,
+) -> FileMeasure {
+    let Ok(metadata) = entry.metadata() else {
+        return FileMeasure::Lines(0);
+    };
+
+    if is_placeholder(&metadata) {
+        return FileMeasure::Placeholder(metadata.len());
+    }
+
+    match fs::read_to_string(entry.path()) {
+        Ok(content) => FileMeasure::Lines(content.lines().count()),
+        Err(_) => FileMeasure::Lines(0),
     }
 }
 
@@ -216,6 +289,22 @@ fn format_lines(lines: usize) -> String {
         format!("[{}K]", lines / 1000)
     } else {
         format!("[{}]", lines)
+    }
+}
+
+fn format_size(bytes: u64) -> String {
+    const KB: u64 = 1024;
+    const MB: u64 = KB * 1024;
+    const GB: u64 = MB * 1024;
+
+    if bytes >= GB {
+        format!("{:.1} GB", bytes as f64 / GB as f64)
+    } else if bytes >= MB {
+        format!("{:.1} MB", bytes as f64 / MB as f64)
+    } else if bytes >= KB {
+        format!("{} KB", bytes / KB)
+    } else {
+        format!("{bytes} B")
     }
 }
 
@@ -255,7 +344,11 @@ mod tests {
         let text = extract_text(&result);
         assert!(text.contains("src/"));
         assert!(text.contains("tests/"));
-        assert!(text.contains("main.rs"));
+        // The bracket a local file renders is part of the contract, so assert it here and not
+        // just the name: a placeholder verdict that answered "yes" for every file would print
+        // `[cloud-only, ...]` on each line and zero every directory total.
+        assert!(text.contains("main.rs  [1]"), "{text}");
+        assert!(text.contains("src/  [2]"), "{text}");
     }
 
     #[test]
@@ -274,6 +367,78 @@ mod tests {
         assert!(text.contains("a/"));
         assert!(text.contains("b/"));
         assert!(!text.contains("deep.rs"));
+    }
+
+    #[test]
+    fn placeholder_predicates_match_each_provider_flag() {
+        // A cloud-only file carries at least one of these; a normal file carries none of them.
+        assert!(windows_attributes_are_placeholder(
+            FILE_ATTRIBUTE_RECALL_ON_DATA_ACCESS
+        ));
+        assert!(windows_attributes_are_placeholder(FILE_ATTRIBUTE_OFFLINE));
+        assert!(windows_attributes_are_placeholder(
+            FILE_ATTRIBUTE_RECALL_ON_OPEN
+        ));
+        assert!(macos_flags_are_placeholder(SF_DATALESS));
+
+        // FILE_ATTRIBUTE_ARCHIVE | FILE_ATTRIBUTE_NORMAL - an ordinary local file.
+        assert!(!windows_attributes_are_placeholder(0x20 | 0x80));
+        assert!(!windows_attributes_are_placeholder(0));
+        // Archive | SparseFile | ReparsePoint: a reparse point alone is not a placeholder.
+        assert!(!windows_attributes_are_placeholder(0x620));
+        // The word measured on a OneDrive cloud-only file: those three plus OFFLINE and
+        // RECALL_ON_DATA_ACCESS.
+        assert!(windows_attributes_are_placeholder(0x40_1620));
+        assert!(!macos_flags_are_placeholder(0));
+        // UF_HIDDEN is not SF_DATALESS.
+        assert!(!macos_flags_are_placeholder(0x8000));
+        // UF_COMPRESSED | UF_TRACKED: the word a locally-present file carries inside an
+        // iCloud root (a dataless one there measured 0x40000060, these plus SF_DATALESS).
+        assert!(!macos_flags_are_placeholder(0x60));
+    }
+
+    #[test]
+    fn cloud_only_placeholders_render_as_size() {
+        // Constructed directly: creating a real placeholder needs a File Provider backend.
+        let mut node = DirectoryNode::default();
+        node.insert_file(
+            &["archive.zip".to_string()],
+            FileMeasure::Placeholder(323 * 1024 * 1024),
+        );
+        node.compute_total_lines();
+
+        let mut out = String::new();
+        node.render_into(0, &mut out);
+
+        assert!(out.contains("archive.zip  [cloud-only, 323.0 MB]"), "{out}");
+        assert_eq!(node.total_lines, 0);
+    }
+
+    #[test]
+    fn a_file_judged_a_placeholder_is_not_read() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("three_lines.txt");
+        fs::write(&path, "a\nb\nc\n").unwrap();
+
+        let entry = WalkBuilder::new(&path)
+            .build()
+            .flatten()
+            .find(|entry| entry.file_type().is_some_and(|t| t.is_file()))
+            .expect("the walk yields the file");
+
+        // Stubbing the verdict is what makes the skip observable without a File Provider
+        // backend: had measure_file_with reached the read, it would report Lines(3).
+        match measure_file_with(&entry, |_| true) {
+            FileMeasure::Placeholder(bytes) => assert_eq!(bytes, 6),
+            FileMeasure::Lines(lines) => panic!("the file was read: counted {lines} lines"),
+        }
+
+        // The same entry with a local-file verdict still gets its line count, so the gate skips
+        // placeholders rather than everything.
+        match measure_file_with(&entry, |_| false) {
+            FileMeasure::Lines(lines) => assert_eq!(lines, 3),
+            FileMeasure::Placeholder(bytes) => panic!("a local file was skipped: {bytes} B"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
Fixes: #11549

> [!IMPORTANT]
> Goose follows an [issues-first contribution process](https://github.com/aaif-goose/goose/blob/main/CONTRIBUTING.md#from-issue-to-pull-request). Before opening an external pull request, make sure the linked issue is on the [Goose Issues board](https://github.com/orgs/aaif-goose/projects/1) with the **Ready** status. Pull requests for issues in **Inbox**, **Needs info**, or **Accepted / design** are not ready for implementation. PRs without a linked issue or an issue in the wrong state can be closed with a one-liner "no correct issue".

## Summary

`tree` prints a line count next to each file, and gets that count by calling `fs::read_to_string` on every file in the walk. Opening a file for data is what hydrates a cloud placeholder: OneDrive Files On-Demand, iCloud Drive and other File Provider backends leave "cloud-only" files on disk holding no data, and enumerating or stat-ing them is free, but reading one blocks while the provider downloads the whole file. Listing a synced folder therefore pulled the entire remote tree down. Nothing warned the user: `tree` is annotated `read_only_hint = true`, so `permission_inspector.rs` auto-approves it, and the `developer` extension is `default_enabled: true`. On Windows with Known Folder Move, Documents and Desktop *are* OneDrive, so pointing the agent at its own working directory is enough to trigger it.

`measure_file` now decides from the metadata the walk already holds, and skips the read when that metadata marks the file as offline or recall-on-access:

- **Windows** - `FILE_ATTRIBUTE_OFFLINE | FILE_ATTRIBUTE_RECALL_ON_OPEN | FILE_ATTRIBUTE_RECALL_ON_DATA_ACCESS`, read through `std::os::windows::fs::MetadataExt::file_attributes`.
- **macOS** - `SF_DATALESS` (`0x40000000`) in `std::os::macos::fs::MetadataExt::st_flags`.
- **Everywhere else** - nothing is treated as a placeholder, so behaviour is unchanged.

Both bit predicates take a raw attribute word and compile on every host, so the mask logic is unit-testable on any platform rather than only the one that owns it.

Rendering. Only the placeholder path changes. A skipped placeholder is rendered distinctly rather than as `[0]`, and everything else renders exactly as before:

| case | rendered |
| --- | --- |
| read succeeded | `[412]`, `[3K]` (unchanged) |
| read attempted and failed | `[0]` (unchanged) |
| cloud-only placeholder, read skipped | `[cloud-only, 323.0 MB]` |

A placeholder contributes 0 to directory totals, so a total stays the lines that were actually counted. The tool description gains one sentence saying that cloud-storage placeholders which are not downloaded to this machine are listed by size instead of being read.

**Intentionally not in this PR.** The issue also discusses an entry ceiling on the walk, a cap on the reply size, and skipping files above a byte threshold. Traversal and output caps are out of scope for this fix per the Ready scope, and a size-based skip would change what `tree` reports for files it can read, which is a separate decision. This PR only stops reads that hydrate remote data.

macOS is included because the marker was verified today on macOS 26.6.2 (build 25G83) against both iCloud Drive and OneDrive File Provider placeholders; it is not carried on assumption.

### Testing

Unit tests, all in `crates/goose/src/agents/platform_extensions/developer/tree.rs`:

- `a_file_judged_a_placeholder_is_not_read` - **the test that covers the skip itself.** `measure_file` delegates to `measure_file_with(entry, is_placeholder)`, so a test can supply the verdict. Given a real 6-byte, 3-line temp file, a stub verdict of "placeholder" must return `Placeholder(6)`; a `Lines(3)` result would prove the file had been opened, and the test fails with `the file was read: counted 3 lines`. The same entry with a "local file" verdict must still return `Lines(3)`, so the gate skips placeholders rather than everything. Deleting the two-line gate from `measure_file_with` turns this test red - that mutation left the previous test set fully green, which is why the seam is here.
- `placeholder_predicates_match_each_provider_flag` - each provider bit is recognised; `0` and `Archive | Normal` are not; `Archive | SparseFile | ReparsePoint` alone (`0x620`) is **not** a placeholder, while the word measured on a real cloud-only file (`0x401620`) **is**; `SF_DATALESS` matches, while `UF_HIDDEN` and `UF_COMPRESSED | UF_TRACKED` (`0x60`, the word a locally-present file carries inside an iCloud root) do not.
- `tree_lists_files_and_directories` - **the test that covers the production wiring**, `measure_file` -> `is_cloud_placeholder`. It asserts the bracket a local file renders (`main.rs  [1]`) and a directory total (`src/  [2]`), not only that the names appear. Hard-coding the real verdict to always-true renders every ordinary local file `[cloud-only, N B]` and drops every total to `[0]`; that mutation left the other five tests green, because they either stub the verdict or build a `FileMeasure` by hand, and this assertion is what catches it.
- `cloud_only_placeholders_render_as_size` - drives the render path with a constructed `FileMeasure`, so it needs no real placeholder, and asserts both the `[cloud-only, 323.0 MB]` text and that the file adds 0 to the directory total.

One gap, stated rather than left silent: the mirror mutation - the real verdict forced always-false, which is the original bug - is killed by none of these tests, because it needs a real placeholder and none can be fabricated in a unit test on macOS (`SF_DATALESS` is outside `SF_SUPPORTED`, so `chflags` cannot set it). A Windows-only test that sets `FILE_ATTRIBUTE_OFFLINE` on a temp file could cover it; that needs a shell-out or a dev-dependency and was left out of this fix. The measured runs below are what cover that direction.

`cargo fmt`, `cargo clippy -p goose --all-targets -- -D warnings`, and `cargo test -p goose --lib -- platform_extensions::developer::tree` (**6 passed, 0 failed**) are clean on macOS. For the Windows accessor: a whole-crate `cargo check -p goose --target x86_64-pc-windows-msvc` does not run on a Mac - a transitive C dependency, `zstd-sys`, needs the MSVC CRT headers and its build script dies on `#include <string.h>` - so the platform block was type-checked against the `x86_64-pc-windows-msvc` std out of tree instead, with the toolchain this repo pins (`rustc 1.96.1`, `--crate-type lib --emit=metadata -D warnings`): exit 0, zero diagnostics, which also shows the `#[cfg(windows)]` shape raises no dead-code warning there. The attribute mask itself is covered by the predicate test, which compiles and runs on every host.

**Local output is unchanged, measured rather than asserted.** Rendering both the upstream `tree` and this one over the same local repo directory through the same harness gives byte-identical output: `documentation` at depth 1, 173 rendered lines, zero differing lines; a temp directory holding one 3-line text file and one 4-byte invalid-UTF-8 blob renders `[3]` and `[0]` on both.

**Windows, against a real OneDrive sync root** (Windows Server 2022, build 20348). Cloud-only files carry attributes `0x401620` - `FILE_ATTRIBUTE_OFFLINE` and `FILE_ATTRIBUTE_RECALL_ON_DATA_ACCESS` set alongside Archive, SparseFile and ReparsePoint - while locally-present files in the same tree carry `0x420` and none of the mask bits, so the gate neither misses a placeholder nor skips a local file. 3394 of a 4000-file sample of that root were cloud-only. One `tree` call at the default depth reaches 304 files, of which 2.06 GB is cloud-only and would have been pulled over the network to produce line counts.

**macOS, against two live sync roots** (macOS 26.6.2, build 25G83). A dataless file reports `st_flags` `0x40000060` and `/bin/ls -lO` shows `dataless`; a locally-present file in the same root reports `0x00000000`. Only the patched build was ever run against these directories. Both rows were re-measured after the review fixes and came back identical; the only later changes are assertions inside `mod tests`, so the production code that was measured is byte-identical to this revision.

| sync root | files | dataless before | `[cloud-only, …]` lines | dataless after |
| --- | --- | --- | --- | --- |
| iCloud Drive, one flat subdirectory | 86 | 86 | 86 | 86 |
| OneDrive File Provider, one flat subdirectory | 103 | 103 | 103 | 103 |

Every placeholder was seen by the gate (cloud-only lines equal the dataless count) and none was hydrated (the dataless count is identical before and after). Between them the two runs avoided reading 189 placeholders advertising 19.6 MB, measured from metadata without opening anything.

### Related Issues
#11549 - the maintainer's Ready scope comment there is what this PR is scoped to.


### Screenshots/Demos (for UX changes)

Terminal output only; the measured evidence is the table above. Filenames are redacted because the sync roots used are personal and corporate.

Three consecutive lines from the patched run over the iCloud Drive subdirectory, as captured:

```
<name>  [cloud-only, 34 KB]
<name>  [cloud-only, 90 KB]
<name>  [cloud-only, 22 KB]
```

There is no matching "before" capture, deliberately: producing one means running the unpatched build over a real sync root, which is the download this PR exists to prevent. For the record, the pre-patch behaviour on these files was not `[0]` - each file was silently downloaded in full and then printed a correct line count. `[0]` is what a placeholder would print only if its downloaded bytes failed UTF-8 decoding.
