### PR TITLE
fix(providers): detect SSE keepalive-masked stream stalls on the OpenAI and Anthropic paths

### DIFF
--- a/crates/goose-providers/src/anthropic.rs
+++ b/crates/goose-providers/src/anthropic.rs
@@ -274,8 +274,8 @@ impl AnthropicProvider {
     }
 }
 
-/// Streams an Anthropic SSE response, guarded by the event-layer idle timeout
-/// so keepalive comment frames cannot mask a stalled stream.
+/// Streams an Anthropic SSE response with the idle-timeout guard so keepalive
+/// comment frames cannot mask a stalled stream.
 fn stream_anthropic_with_idle_timeout(
     response: Response,
     mut log: Option<Box<dyn RequestLogHandle>>,
@@ -773,92 +773,40 @@ mod tests {
         );
     }
 
-    /// Serves the #11679 failure signature on the Anthropic wire format:
-    /// healthy SSE frames, then keepalive comment frames forever. The bytes
-    /// keep arriving, so byte-level read timeouts never fire.
-    async fn serve_keepalive_masked_stall(mut sock: tokio::net::TcpStream) {
-        use std::time::Duration;
-        use tokio::io::{AsyncReadExt, AsyncWriteExt};
-
-        let mut buf = [0u8; 8192];
-        let _ = sock.read(&mut buf).await;
-        let headers = concat!(
-            "HTTP/1.1 200 OK\r\n",
-            "content-type: text/event-stream\r\n",
-            "transfer-encoding: chunked\r\n\r\n"
-        );
-        if sock.write_all(headers.as_bytes()).await.is_err() {
-            return;
-        }
-        let chunk = |data: &str| format!("{:x}\r\n{data}\r\n", data.len());
-        let frames = [
-            concat!(
-                "event: message_start\n",
-                r#"data: {"type":"message_start","message":{"id":"msg_1","role":"assistant","content":[],"model":"claude-sonnet-4-5","usage":{"input_tokens":10,"output_tokens":0}}}"#,
-                "\n\n"
-            ),
-            concat!(
-                r#"data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hi"}}"#,
-                "\n\n"
-            ),
-        ];
-        for frame in frames {
-            if sock.write_all(chunk(frame).as_bytes()).await.is_err() {
-                return;
-            }
-        }
-        loop {
-            tokio::time::sleep(Duration::from_millis(100)).await;
-            if sock
-                .write_all(chunk(": ping\n\n").as_bytes())
-                .await
-                .is_err()
-            {
-                return;
-            }
-        }
-    }
-
+    /// The #11679 failure signature on the Anthropic wire format: healthy SSE
+    /// frames, then keepalive comment frames forever. Bytes keep flowing, so
+    /// byte-level read timeouts never fire.
     #[tokio::test]
     async fn keepalive_masked_stall_errors_instead_of_hanging() {
+        use crate::sse_test_harness::{drain_within, post_stream, spawn_server, Chunk, Tail};
         use std::time::Duration;
-        use tokio::net::TcpListener;
-        use tokio_stream::StreamExt;
 
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        tokio::spawn(async move {
-            loop {
-                let Ok((sock, _)) = listener.accept().await else {
-                    break;
-                };
-                tokio::spawn(serve_keepalive_masked_stall(sock));
-            }
-        });
+        let addr = spawn_server(
+            vec![
+                Chunk::immediate(concat!(
+                    "event: message_start\n",
+                    r#"data: {"type":"message_start","message":{"id":"msg_1","role":"assistant","content":[],"model":"claude-sonnet-4-5","usage":{"input_tokens":10,"output_tokens":0}}}"#,
+                    "\n\n"
+                )),
+                Chunk::immediate(concat!(
+                    r#"data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hi"}}"#,
+                    "\n\n"
+                )),
+            ],
+            Tail::KeepaliveForever,
+        )
+        .await;
 
-        let http = reqwest::Client::builder().no_proxy().build().unwrap();
-        let response = http
-            .post(format!("http://{addr}/v1/messages"))
-            .json(&json!({"model": "claude-sonnet-4-5", "stream": true, "messages": []}))
-            .send()
-            .await
-            .unwrap();
-        let mut stream = stream_anthropic_with_idle_timeout(response, None, 1);
+        let response = post_stream(
+            addr,
+            "/v1/messages",
+            json!({"model": "claude-sonnet-4-5", "stream": true, "messages": []}),
+        )
+        .await;
+        let stream = stream_anthropic_with_idle_timeout(response, None, 1);
 
-        let mut items = 0usize;
-        let outcome = tokio::time::timeout(Duration::from_secs(15), async {
-            while let Some(item) = stream.next().await {
-                match item {
-                    Ok(_) => items += 1,
-                    Err(e) => return Some(e),
-                }
-            }
-            None
-        })
-        .await
-        .expect("stream did not terminate within 15s");
-
-        let err = outcome.expect("stream ended without an error");
+        let (items, err) = drain_within(stream, Duration::from_secs(15)).await;
+        let err = err.expect("stream ended without an error");
         assert!(
             items > 0,
             "healthy frames should have been yielded before the stall"

--- a/crates/goose-providers/src/anthropic.rs
+++ b/crates/goose-providers/src/anthropic.rs
@@ -19,9 +19,7 @@ use super::formats::anthropic::{
     create_request_for_model, response_to_streaming_message, AnthropicFormatOptions,
     ANTHROPIC_PROVIDER_NAME,
 };
-use super::openai_compatible::{
-    handle_status, with_data_line_idle_timeout, STREAM_IDLE_TIMEOUT_SECS,
-};
+use super::openai_compatible::{handle_status, with_sse_idle_timeout, STREAM_IDLE_TIMEOUT_SECS};
 use super::retry::ProviderRetry;
 use crate::conversation::message::Message;
 use crate::model::ModelConfig;
@@ -275,8 +273,10 @@ impl AnthropicProvider {
 }
 
 /// Streams an Anthropic SSE response with the idle-timeout guard so keepalive
-/// comment frames cannot mask a stalled stream.
-fn stream_anthropic_with_idle_timeout(
+/// comment frames cannot mask a stalled stream. Shared by
+/// [`crate::anthropic::AnthropicProvider`] and the Databricks v2 Anthropic
+/// route, which speak the same wire format.
+pub(crate) fn stream_anthropic_with_idle_timeout(
     response: Response,
     mut log: Option<Box<dyn RequestLogHandle>>,
     idle_timeout_secs: u64,
@@ -285,7 +285,7 @@ fn stream_anthropic_with_idle_timeout(
     Box::pin(try_stream! {
         let reader = StreamReader::new(stream);
         let framed = tokio_util::codec::FramedRead::new(reader, tokio_util::codec::LinesCodec::new()).map_err(anyhow::Error::from);
-        let timed_lines = with_data_line_idle_timeout(framed, idle_timeout_secs);
+        let timed_lines = with_sse_idle_timeout(framed, idle_timeout_secs);
         let messages = response_to_streaming_message(timed_lines);
         pin!(messages);
         while let Some(message) = futures::StreamExt::next(&mut messages).await {
@@ -813,5 +813,89 @@ mod tests {
         );
         assert!(err.to_string().contains("Stream stalled"), "got: {err}");
         assert!(matches!(err, ProviderError::NetworkError(_)));
+    }
+
+    /// The same failure signature with Anthropic's payload-bearing keepalive
+    /// (`data: {"type":"ping"}`) instead of comment frames: bytes keep
+    /// flowing, but no model output ever arrives.
+    #[tokio::test]
+    async fn ping_masked_stall_errors_instead_of_hanging() {
+        use crate::sse_test_harness::{drain_within, post_stream, spawn_server, Chunk, Tail};
+        use std::time::Duration;
+
+        let addr = spawn_server(
+            vec![
+                Chunk::immediate(concat!(
+                    r#"data: {"type":"message_start","message":{"id":"msg_1","role":"assistant","content":[],"model":"claude-sonnet-4-5","usage":{"input_tokens":10,"output_tokens":0}}}"#,
+                    "\n\n"
+                )),
+                Chunk::immediate(concat!(
+                    r#"data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hi"}}"#,
+                    "\n\n"
+                )),
+            ],
+            Tail::KeepaliveDataForever("data: {\"type\":\"ping\"}\n\n"),
+        )
+        .await;
+
+        let response = post_stream(
+            addr,
+            "/v1/messages",
+            json!({"model": "claude-sonnet-4-5", "stream": true, "messages": []}),
+        )
+        .await;
+        let stream = stream_anthropic_with_idle_timeout(response, None, 1);
+
+        let (items, err) = drain_within(stream, Duration::from_secs(15)).await;
+        let err = err.expect("stream ended without an error");
+        assert!(
+            items > 0,
+            "healthy frames should have been yielded before the stall"
+        );
+        assert!(err.to_string().contains("Stream stalled"), "got: {err}");
+        assert!(matches!(err, ProviderError::NetworkError(_)));
+    }
+
+    /// `message_start` and `ping` events precede the first content delta and
+    /// carry no model output; neither may arm the idle deadline, or a first
+    /// token slower than the idle timeout (e.g. a long pre-generation pause
+    /// bridged by pings) would be killed mid-generation.
+    #[tokio::test]
+    async fn lifecycle_prelude_before_first_token_does_not_trip_the_idle_timeout() {
+        use crate::sse_test_harness::{drain_within, post_stream, spawn_server, Chunk, Tail};
+        use std::time::Duration;
+
+        // message_start + pings for ~1.8s against a 1s idle timeout, then the
+        // first content delta and a clean close.
+        let mut script = vec![Chunk::immediate(concat!(
+            r#"data: {"type":"message_start","message":{"id":"msg_1","role":"assistant","content":[],"model":"claude-sonnet-4-5","usage":{"input_tokens":10,"output_tokens":0}}}"#,
+            "\n\n"
+        ))];
+        for _ in 0..3 {
+            script.push(Chunk {
+                after: Duration::from_millis(600),
+                body: "data: {\"type\":\"ping\"}\n\n".to_string(),
+            });
+        }
+        script.push(Chunk::immediate(concat!(
+            r#"data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hi"}}"#,
+            "\n\n"
+        )));
+        let addr = spawn_server(script, Tail::Close).await;
+
+        let response = post_stream(
+            addr,
+            "/v1/messages",
+            json!({"model": "claude-sonnet-4-5", "stream": true, "messages": []}),
+        )
+        .await;
+        let stream = stream_anthropic_with_idle_timeout(response, None, 1);
+
+        let (items, err) = drain_within(stream, Duration::from_secs(15)).await;
+        assert!(
+            err.is_none(),
+            "stream with slow first token errored: {err:?}"
+        );
+        assert!(items > 0, "content deltas should have been yielded");
     }
 }

--- a/crates/goose-providers/src/anthropic.rs
+++ b/crates/goose-providers/src/anthropic.rs
@@ -2,12 +2,12 @@ use crate::api_client::{AuthMethod, TlsConfig};
 use crate::base::ProviderDescriptor;
 use crate::declarative::{DeclarativeProviderConfig, KeyResolver};
 use crate::errors::ProviderError;
-use crate::request_log::{start_log, LoggerHandleExt};
+use crate::request_log::{start_log, LoggerHandleExt, RequestLogHandle};
 use anyhow::Result;
 use async_stream::try_stream;
 use async_trait::async_trait;
 use futures::TryStreamExt;
-use reqwest::StatusCode;
+use reqwest::{Response, StatusCode};
 use serde_json::Value;
 use std::io;
 use tokio::pin;
@@ -19,7 +19,9 @@ use super::formats::anthropic::{
     create_request_for_model, response_to_streaming_message, AnthropicFormatOptions,
     ANTHROPIC_PROVIDER_NAME,
 };
-use super::openai_compatible::handle_status;
+use super::openai_compatible::{
+    handle_status, with_data_line_idle_timeout, STREAM_IDLE_TIMEOUT_SECS,
+};
 use super::retry::ProviderRetry;
 use crate::conversation::message::Message;
 use crate::model::ModelConfig;
@@ -197,18 +199,11 @@ impl AnthropicProvider {
             .inspect_err(|e| {
                 let _ = log.error(e);
             })?;
-        let stream = response.bytes_stream().map_err(io::Error::other);
-        Ok(Box::pin(try_stream! {
-            let reader = StreamReader::new(stream);
-            let framed = tokio_util::codec::FramedRead::new(reader, tokio_util::codec::LinesCodec::new()).map_err(anyhow::Error::from);
-            let messages = response_to_streaming_message(framed);
-            pin!(messages);
-            while let Some(message) = futures::StreamExt::next(&mut messages).await {
-                let (message, usage) = message.map_err(ProviderError::from_stream_error)?;
-                log.write(&message, usage.as_ref().map(|f| f.usage).as_ref())?;
-                yield (message, usage);
-            }
-        }))
+        Ok(stream_anthropic_with_idle_timeout(
+            response,
+            log,
+            STREAM_IDLE_TIMEOUT_SECS,
+        ))
     }
 
     async fn fetch_models_from_api(&self) -> Result<Vec<String>, ProviderError> {
@@ -277,6 +272,28 @@ impl AnthropicProvider {
         models.sort();
         Ok(models)
     }
+}
+
+/// Streams an Anthropic SSE response, guarded by the event-layer idle timeout
+/// so keepalive comment frames cannot mask a stalled stream.
+fn stream_anthropic_with_idle_timeout(
+    response: Response,
+    mut log: Option<Box<dyn RequestLogHandle>>,
+    idle_timeout_secs: u64,
+) -> MessageStream {
+    let stream = response.bytes_stream().map_err(io::Error::other);
+    Box::pin(try_stream! {
+        let reader = StreamReader::new(stream);
+        let framed = tokio_util::codec::FramedRead::new(reader, tokio_util::codec::LinesCodec::new()).map_err(anyhow::Error::from);
+        let timed_lines = with_data_line_idle_timeout(framed, idle_timeout_secs);
+        let messages = response_to_streaming_message(timed_lines);
+        pin!(messages);
+        while let Some(message) = futures::StreamExt::next(&mut messages).await {
+            let (message, usage) = message.map_err(ProviderError::from_stream_error)?;
+            log.write(&message, usage.as_ref().map(|f| f.usage).as_ref())?;
+            yield (message, usage);
+        }
+    })
 }
 
 impl ProviderDescriptor for AnthropicProvider {
@@ -754,5 +771,99 @@ mod tests {
             "expected Authentication error, got: {:?}",
             err
         );
+    }
+
+    /// Serves the #11679 failure signature on the Anthropic wire format:
+    /// healthy SSE frames, then keepalive comment frames forever. The bytes
+    /// keep arriving, so byte-level read timeouts never fire.
+    async fn serve_keepalive_masked_stall(mut sock: tokio::net::TcpStream) {
+        use std::time::Duration;
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let mut buf = [0u8; 8192];
+        let _ = sock.read(&mut buf).await;
+        let headers = concat!(
+            "HTTP/1.1 200 OK\r\n",
+            "content-type: text/event-stream\r\n",
+            "transfer-encoding: chunked\r\n\r\n"
+        );
+        if sock.write_all(headers.as_bytes()).await.is_err() {
+            return;
+        }
+        let chunk = |data: &str| format!("{:x}\r\n{data}\r\n", data.len());
+        let frames = [
+            concat!(
+                "event: message_start\n",
+                r#"data: {"type":"message_start","message":{"id":"msg_1","role":"assistant","content":[],"model":"claude-sonnet-4-5","usage":{"input_tokens":10,"output_tokens":0}}}"#,
+                "\n\n"
+            ),
+            concat!(
+                r#"data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hi"}}"#,
+                "\n\n"
+            ),
+        ];
+        for frame in frames {
+            if sock.write_all(chunk(frame).as_bytes()).await.is_err() {
+                return;
+            }
+        }
+        loop {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            if sock
+                .write_all(chunk(": ping\n\n").as_bytes())
+                .await
+                .is_err()
+            {
+                return;
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn keepalive_masked_stall_errors_instead_of_hanging() {
+        use std::time::Duration;
+        use tokio::net::TcpListener;
+        use tokio_stream::StreamExt;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            loop {
+                let Ok((sock, _)) = listener.accept().await else {
+                    break;
+                };
+                tokio::spawn(serve_keepalive_masked_stall(sock));
+            }
+        });
+
+        let http = reqwest::Client::builder().no_proxy().build().unwrap();
+        let response = http
+            .post(format!("http://{addr}/v1/messages"))
+            .json(&json!({"model": "claude-sonnet-4-5", "stream": true, "messages": []}))
+            .send()
+            .await
+            .unwrap();
+        let mut stream = stream_anthropic_with_idle_timeout(response, None, 1);
+
+        let mut items = 0usize;
+        let outcome = tokio::time::timeout(Duration::from_secs(15), async {
+            while let Some(item) = stream.next().await {
+                match item {
+                    Ok(_) => items += 1,
+                    Err(e) => return Some(e),
+                }
+            }
+            None
+        })
+        .await
+        .expect("stream did not terminate within 15s");
+
+        let err = outcome.expect("stream ended without an error");
+        assert!(
+            items > 0,
+            "healthy frames should have been yielded before the stall"
+        );
+        assert!(err.to_string().contains("Stream stalled"), "got: {err}");
+        assert!(matches!(err, ProviderError::NetworkError(_)));
     }
 }

--- a/crates/goose-providers/src/databricks_v2.rs
+++ b/crates/goose-providers/src/databricks_v2.rs
@@ -3,17 +3,12 @@ use crate::formats::openai::{self, extract_reasoning_effort, is_openai_responses
 use crate::http_status::{read_error_body, read_json_response};
 use crate::images::ImageFormat;
 use anyhow::{anyhow, Result};
-use async_stream::try_stream;
 use async_trait::async_trait;
-use futures::TryStreamExt;
 use serde::Serialize;
 use serde_json::Value;
 use std::collections::HashSet;
-use std::io;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
-use tokio::pin;
-use tokio_util::io::StreamReader;
 
 use crate::api_client::{ApiClient, AuthMethod, TlsConfig};
 use crate::base::{ConfigKey, MessageStream, Provider, ProviderMetadata};
@@ -27,7 +22,9 @@ use crate::errors::ProviderError;
 use crate::formats::anthropic;
 use crate::formats::openai_responses;
 use crate::model::ModelConfig;
-use crate::openai_compatible::{handle_status, stream_openai_compat, stream_responses_compat};
+use crate::openai_compatible::{
+    handle_status, stream_openai_compat, stream_responses_compat, STREAM_IDLE_TIMEOUT_SECS,
+};
 use crate::request_log::{start_log, LoggerHandleExt};
 use crate::retry::ProviderRetry;
 use crate::retry::{
@@ -432,21 +429,11 @@ impl DatabricksV2Provider {
                 let _ = log.error(e);
             })?;
 
-        let stream = response.bytes_stream().map_err(io::Error::other);
-
-        Ok(Box::pin(try_stream! {
-            let stream_reader = StreamReader::new(stream);
-            let framed = tokio_util::codec::FramedRead::new(stream_reader, tokio_util::codec::LinesCodec::new())
-                .map_err(anyhow::Error::from);
-
-            let message_stream = anthropic::response_to_streaming_message(framed);
-            pin!(message_stream);
-            while let Some(message) = futures::StreamExt::next(&mut message_stream).await {
-                let (message, usage) = message.map_err(ProviderError::from_stream_error)?;
-                log.write(&message, usage.as_ref().map(|f| f.usage).as_ref())?;
-                yield (message, usage);
-            }
-        }))
+        Ok(crate::anthropic::stream_anthropic_with_idle_timeout(
+            response,
+            log,
+            STREAM_IDLE_TIMEOUT_SECS,
+        ))
     }
 }
 

--- a/crates/goose-providers/src/lib.rs
+++ b/crates/goose-providers/src/lib.rs
@@ -21,4 +21,7 @@ pub mod openrouter_format;
 
 pub use declarative::declarative_providers::*;
 
+#[cfg(test)]
+mod sse_test_harness;
+
 pub mod snowflake;

--- a/crates/goose-providers/src/openai_compatible.rs
+++ b/crates/goose-providers/src/openai_compatible.rs
@@ -243,8 +243,22 @@ pub use super::http_status::handle_response as handle_response_openai_compat;
 /// instead of hanging the turn forever.
 pub(crate) const STREAM_IDLE_TIMEOUT_SECS: u64 = 120;
 
+/// Whether a framed SSE line carries progress for the downstream parsers:
+/// a `data:` field with a nonempty value — the only field any wrapped parser
+/// consumes — or a line that itself parses as JSON, which the Responses
+/// parser accepts as a bare frame. Comment frames, blank separators, control
+/// fields (`event:`, `id:`, `retry:`), other extension fields, and empty
+/// `data:` events are heartbeat shapes every parser discards; letting any of
+/// them reset the deadline would mask the exact keepalive-hidden stall this
+/// watchdog exists to catch. A heartbeat that carries a payload (e.g. a
+/// `data: {"type":"keepalive"}` event) still resets the deadline — telling it
+/// apart from progress needs the parser's payload knowledge, which this
+/// line-level watchdog does not have.
 fn is_data_bearing_line(line: &str) -> bool {
-    !line.trim().is_empty() && !line.starts_with(':')
+    match line.strip_prefix("data:") {
+        Some(value) => !value.trim().is_empty(),
+        None => serde_json::from_str::<Value>(line).is_ok(),
+    }
 }
 
 /// Wraps framed SSE lines with the idle timeout, between `LinesCodec` framing
@@ -323,7 +337,15 @@ fn stream_openai_compat_with_idle_timeout(
 
 pub fn stream_responses_compat(
     response: Response,
+    log: Option<Box<dyn RequestLogHandle>>,
+) -> Result<MessageStream, ProviderError> {
+    stream_responses_compat_with_idle_timeout(response, log, STREAM_IDLE_TIMEOUT_SECS)
+}
+
+fn stream_responses_compat_with_idle_timeout(
+    response: Response,
     mut log: Option<Box<dyn RequestLogHandle>>,
+    idle_timeout_secs: u64,
 ) -> Result<MessageStream, ProviderError> {
     let stream = response.bytes_stream().map_err(std::io::Error::other);
 
@@ -332,7 +354,8 @@ pub fn stream_responses_compat(
         let framed = FramedRead::new(stream_reader, LinesCodec::new())
             .map_err(Error::from);
 
-        let message_stream = responses_api_to_streaming_message(framed);
+        let timed_lines = with_data_line_idle_timeout(framed, idle_timeout_secs);
+        let message_stream = responses_api_to_streaming_message(timed_lines);
         pin!(message_stream);
         while let Some(message) = message_stream.next().await {
             let (message, usage) = message.map_err(|e|
@@ -529,6 +552,41 @@ mod tests {
         format!("data: {payload}\n\n")
     }
 
+    #[test]
+    fn sse_heartbeat_lines_are_not_data_bearing() {
+        // Heartbeat shapes every downstream parser discards: comments, blank
+        // separators, control fields, unknown extension fields, and empty
+        // `data:` events.
+        for line in [
+            ": ping",
+            "",
+            "   ",
+            "event: ping",
+            "id: 7",
+            "retry: 3000",
+            "x-heartbeat: ping",
+            "data:",
+            "data:   ",
+        ] {
+            assert!(
+                !is_data_bearing_line(line),
+                "{line:?} should be a keepalive"
+            );
+        }
+    }
+
+    #[test]
+    fn payload_lines_are_data_bearing() {
+        for line in [
+            "data: {\"a\":1}",
+            "data:{\"a\":1}", // space after the colon is optional
+            "data: [DONE]",
+            "{\"a\":1}", // bare JSON frame, accepted by the Responses parser
+        ] {
+            assert!(is_data_bearing_line(line), "{line:?} should be payload");
+        }
+    }
+
     /// The #11679 failure signature: healthy data frames, then keepalive
     /// comment frames forever. Bytes keep flowing, so byte-based read
     /// timeouts never fire.
@@ -562,6 +620,51 @@ mod tests {
         assert!(err.to_string().contains("Stream stalled"), "got: {err}");
         assert!(matches!(err, ProviderError::NetworkError(_)));
         assert!(should_retry(&err, &RetryConfig::default()));
+    }
+
+    fn responses_delta(content: &str) -> String {
+        let payload = json!({
+            "type": "response.output_text.delta",
+            "sequence_number": 1,
+            "item_id": "m1",
+            "output_index": 0,
+            "content_index": 0,
+            "delta": content,
+        });
+        format!("data: {payload}\n\n")
+    }
+
+    /// The Responses API route (GPT-5/GPT-6/o-series, Databricks Responses
+    /// streams) shares the #11679 failure signature; the watchdog must apply
+    /// there too, not only to Chat Completions.
+    #[tokio::test]
+    async fn keepalive_masked_stall_errors_instead_of_hanging_on_responses_streams() {
+        use crate::sse_test_harness::{drain_within, post_stream, spawn_server, Chunk, Tail};
+        use std::time::Duration;
+
+        let delta = responses_delta("Hi");
+        let addr = spawn_server(
+            vec![Chunk::immediate(delta.clone()), Chunk::immediate(delta)],
+            Tail::KeepaliveForever,
+        )
+        .await;
+
+        let response = post_stream(
+            addr,
+            "/responses",
+            json!({"model": "m", "stream": true, "input": []}),
+        )
+        .await;
+        let stream = stream_responses_compat_with_idle_timeout(response, None, 1).unwrap();
+
+        let (items, err) = drain_within(stream, Duration::from_secs(15)).await;
+        let err = err.expect("stream ended without an error");
+        assert!(
+            items > 0,
+            "healthy frames should have been yielded before the stall"
+        );
+        assert!(err.to_string().contains("Stream stalled"), "got: {err}");
+        assert!(matches!(err, ProviderError::NetworkError(_)));
     }
 
     #[tokio::test]

--- a/crates/goose-providers/src/openai_compatible.rs
+++ b/crates/goose-providers/src/openai_compatible.rs
@@ -236,31 +236,28 @@ pub use super::http_status::{
 // Legacy alias kept for callers that haven't migrated their import path yet.
 pub use super::http_status::handle_response as handle_response_openai_compat;
 
-/// Default event-layer idle timeout for streaming responses (seconds): how
-/// long a stream may go without a data-bearing SSE line before it is
-/// considered stalled. Unlike reqwest's byte-level read timeout, SSE comment
-/// keepalives (`: ping`) and blank separator lines do not reset this deadline,
-/// so a provider that wedges mid-stream while emitting keepalives is detected
+/// Idle timeout for streaming responses: how long a stream may go without a
+/// data-bearing SSE line before it is considered stalled. SSE comment
+/// keepalives (`: ping`) and blank separators do not reset the deadline, so a
+/// provider that wedges mid-stream while emitting keepalives is detected
 /// instead of hanging the turn forever.
 pub(crate) const STREAM_IDLE_TIMEOUT_SECS: u64 = 120;
 
-/// Wraps a framed SSE line stream with the event-layer idle timeout, to be
-/// inserted between `LinesCodec` framing and the format parser.
-///
-/// The deadline is not enforced until the stream yields its first line, so
-/// time-to-first-token stays governed by the request timeout. Afterwards only
-/// data-bearing lines — anything that is not blank and does not start with
-/// `:` — reset the deadline; keepalive comment frames and blank separators
-/// cannot mask a stall. On timeout the stream errors with a retryable
+fn is_data_bearing_line(line: &str) -> bool {
+    !line.trim().is_empty() && !line.starts_with(':')
+}
+
+/// Wraps framed SSE lines with the idle timeout, between `LinesCodec` framing
+/// and the format parser. The deadline applies only after the first line, so
+/// time-to-first-token stays governed by the request timeout; afterwards only
+/// data-bearing lines reset it. On timeout the stream errors with a retryable
 /// [`ProviderError::NetworkError`].
 pub(crate) fn with_data_line_idle_timeout(
-    stream: impl Stream<Item = anyhow::Result<String>> + Unpin + Send + 'static,
+    mut stream: impl Stream<Item = anyhow::Result<String>> + Unpin + Send + 'static,
     idle_timeout_secs: u64,
 ) -> Pin<Box<dyn Stream<Item = anyhow::Result<String>> + Send>> {
     let idle_timeout = Duration::from_secs(idle_timeout_secs);
     Box::pin(try_stream! {
-        let mut stream = stream;
-
         let first_line = match stream.next().await {
             Some(first) => first?,
             None => return,
@@ -272,7 +269,7 @@ pub(crate) fn with_data_line_idle_timeout(
             match tokio::time::timeout_at(deadline, stream.next()).await {
                 Ok(Some(item)) => {
                     let line = item?;
-                    if !line.trim().is_empty() && !line.starts_with(':') {
+                    if is_data_bearing_line(&line) {
                         deadline = tokio::time::Instant::now() + idle_timeout;
                     }
                     yield line;
@@ -519,87 +516,45 @@ mod tests {
         );
     }
 
-    /// Serves the #11679 failure signature: healthy SSE data frames, then
-    /// keepalive comment frames forever, never terminating. At the byte level
-    /// the connection stays alive indefinitely, so byte-based read timeouts
-    /// never fire.
-    async fn serve_keepalive_masked_stall(mut sock: tokio::net::TcpStream) {
-        use std::time::Duration;
-        use tokio::io::{AsyncReadExt, AsyncWriteExt};
-
-        let mut buf = [0u8; 8192];
-        let _ = sock.read(&mut buf).await;
-        let headers = concat!(
-            "HTTP/1.1 200 OK\r\n",
-            "content-type: text/event-stream\r\n",
-            "transfer-encoding: chunked\r\n\r\n"
-        );
-        if sock.write_all(headers.as_bytes()).await.is_err() {
-            return;
-        }
-        let chunk = |data: &str| format!("{:x}\r\n{data}\r\n", data.len());
-        let delta = concat!(
-            r#"data: {"id":"1","model":"m","choices":[{"index":0,"delta":{"role":"assistant","content":"Hi"},"finish_reason":null}]}"#,
-            "\n\n"
-        );
-        for data in [delta, delta] {
-            if sock.write_all(chunk(data).as_bytes()).await.is_err() {
-                return;
-            }
-        }
-        loop {
-            tokio::time::sleep(Duration::from_millis(100)).await;
-            if sock
-                .write_all(chunk(": ping\n\n").as_bytes())
-                .await
-                .is_err()
-            {
-                return;
-            }
-        }
+    fn chat_delta(content: &str) -> String {
+        let payload = json!({
+            "id": "1",
+            "model": "m",
+            "choices": [{
+                "index": 0,
+                "delta": {"role": "assistant", "content": content},
+                "finish_reason": null,
+            }],
+        });
+        format!("data: {payload}\n\n")
     }
 
+    /// The #11679 failure signature: healthy data frames, then keepalive
+    /// comment frames forever. Bytes keep flowing, so byte-based read
+    /// timeouts never fire.
     #[tokio::test]
     async fn keepalive_masked_stall_errors_instead_of_hanging() {
         use crate::retry::{should_retry, RetryConfig};
+        use crate::sse_test_harness::{drain_within, post_stream, spawn_server, Chunk, Tail};
         use std::time::Duration;
-        use tokio::net::TcpListener;
-        use tokio_stream::StreamExt;
 
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        tokio::spawn(async move {
-            loop {
-                let Ok((sock, _)) = listener.accept().await else {
-                    break;
-                };
-                tokio::spawn(serve_keepalive_masked_stall(sock));
-            }
-        });
+        let delta = chat_delta("Hi");
+        let addr = spawn_server(
+            vec![Chunk::immediate(delta.clone()), Chunk::immediate(delta)],
+            Tail::KeepaliveForever,
+        )
+        .await;
 
-        let http = reqwest::Client::builder().no_proxy().build().unwrap();
-        let response = http
-            .post(format!("http://{addr}/chat/completions"))
-            .json(&json!({"model": "m", "stream": true, "messages": []}))
-            .send()
-            .await
-            .unwrap();
-        let mut stream = stream_openai_compat_with_idle_timeout(response, None, 1).unwrap();
+        let response = post_stream(
+            addr,
+            "/chat/completions",
+            json!({"model": "m", "stream": true, "messages": []}),
+        )
+        .await;
+        let stream = stream_openai_compat_with_idle_timeout(response, None, 1).unwrap();
 
-        let mut items = 0usize;
-        let outcome = tokio::time::timeout(Duration::from_secs(15), async {
-            while let Some(item) = stream.next().await {
-                match item {
-                    Ok(_) => items += 1,
-                    Err(e) => return Some(e),
-                }
-            }
-            None
-        })
-        .await
-        .expect("stream did not terminate within 15s");
-
-        let err = outcome.expect("stream ended without an error");
+        let (items, err) = drain_within(stream, Duration::from_secs(15)).await;
+        let err = err.expect("stream ended without an error");
         assert!(
             items > 0,
             "healthy frames should have been yielded before the stall"
@@ -611,90 +566,35 @@ mod tests {
 
     #[tokio::test]
     async fn slow_but_live_data_lines_do_not_trip_the_idle_timeout() {
+        use crate::sse_test_harness::{drain_within, post_stream, spawn_server, Chunk, Tail};
         use std::time::Duration;
-        use tokio::io::AsyncWriteExt;
-        use tokio::net::{TcpListener, TcpStream};
-        use tokio_stream::StreamExt;
 
-        // Data frames (with interleaved keepalive comments) every 300ms while
-        // the idle timeout is 1s: a live-but-slow stream must not be killed.
-        async fn serve(mut sock: TcpStream) {
-            use tokio::io::AsyncReadExt;
-
-            let mut buf = [0u8; 8192];
-            let _ = sock.read(&mut buf).await;
-            let headers = concat!(
-                "HTTP/1.1 200 OK\r\n",
-                "content-type: text/event-stream\r\n",
-                "transfer-encoding: chunked\r\n\r\n"
-            );
-            if sock.write_all(headers.as_bytes()).await.is_err() {
-                return;
-            }
-            let chunk = |data: &str| format!("{:x}\r\n{data}\r\n", data.len());
-            for i in 0..5 {
-                tokio::time::sleep(Duration::from_millis(150)).await;
-                if sock
-                    .write_all(chunk(": ping\n\n").as_bytes())
-                    .await
-                    .is_err()
-                {
-                    return;
-                }
-                tokio::time::sleep(Duration::from_millis(150)).await;
-                let delta = format!(
-                    concat!(
-                        r#"data: {{"id":"1","model":"m","choices":[{{"index":0,"delta":{{"role":"assistant","content":"Hi {}"}},"finish_reason":null}}]}}"#,
-                        "\n\n"
-                    ),
-                    i
-                );
-                if sock.write_all(chunk(&delta).as_bytes()).await.is_err() {
-                    return;
-                }
-            }
-            let _ = sock.write_all(chunk("data: [DONE]\n\n").as_bytes()).await;
-            let _ = sock.write_all(b"0\r\n\r\n").await;
+        // Data frames interleaved with keepalive comments every 300ms against
+        // a 1s idle timeout: a live-but-slow stream must not be killed.
+        let mut script = Vec::new();
+        for i in 0..5 {
+            script.push(Chunk {
+                after: Duration::from_millis(150),
+                body: ": ping\n\n".to_string(),
+            });
+            script.push(Chunk {
+                after: Duration::from_millis(150),
+                body: chat_delta(&format!("Hi {i}")),
+            });
         }
+        script.push(Chunk::immediate("data: [DONE]\n\n"));
+        let addr = spawn_server(script, Tail::Close).await;
 
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        tokio::spawn(async move {
-            loop {
-                let Ok((sock, _)) = listener.accept().await else {
-                    break;
-                };
-                tokio::spawn(serve(sock));
-            }
-        });
+        let response = post_stream(
+            addr,
+            "/chat/completions",
+            json!({"model": "m", "stream": true, "messages": []}),
+        )
+        .await;
+        let stream = stream_openai_compat_with_idle_timeout(response, None, 1).unwrap();
 
-        let http = reqwest::Client::builder().no_proxy().build().unwrap();
-        let response = http
-            .post(format!("http://{addr}/chat/completions"))
-            .json(&json!({"model": "m", "stream": true, "messages": []}))
-            .send()
-            .await
-            .unwrap();
-        let mut stream = stream_openai_compat_with_idle_timeout(response, None, 1).unwrap();
-
-        let mut items = 0usize;
-        let outcome = tokio::time::timeout(Duration::from_secs(15), async {
-            while let Some(item) = stream.next().await {
-                match item {
-                    Ok(_) => items += 1,
-                    Err(e) => return Some(e),
-                }
-            }
-            None
-        })
-        .await
-        .expect("stream did not terminate within 15s");
-
-        assert!(
-            outcome.is_none(),
-            "live stream errored: {:?}",
-            outcome.unwrap()
-        );
+        let (items, err) = drain_within(stream, Duration::from_secs(15)).await;
+        assert!(err.is_none(), "live stream errored: {err:?}");
         assert!(items > 0, "data frames should have been yielded");
     }
 }

--- a/crates/goose-providers/src/openai_compatible.rs
+++ b/crates/goose-providers/src/openai_compatible.rs
@@ -248,29 +248,29 @@ fn is_data_bearing_line(line: &str) -> bool {
 }
 
 /// Wraps framed SSE lines with the idle timeout, between `LinesCodec` framing
-/// and the format parser. The deadline applies only after the first line, so
-/// time-to-first-token stays governed by the request timeout; afterwards only
-/// data-bearing lines reset it. On timeout the stream errors with a retryable
-/// [`ProviderError::NetworkError`].
+/// and the format parser. The deadline arms only once the first data-bearing
+/// line has arrived, so time-to-first-token stays governed by the request
+/// timeout and pre-first-token keepalives cannot start the clock; afterwards
+/// only data-bearing lines reset it. On timeout the stream errors with a
+/// retryable [`ProviderError::NetworkError`].
 pub(crate) fn with_data_line_idle_timeout(
     mut stream: impl Stream<Item = anyhow::Result<String>> + Unpin + Send + 'static,
     idle_timeout_secs: u64,
 ) -> Pin<Box<dyn Stream<Item = anyhow::Result<String>> + Send>> {
     let idle_timeout = Duration::from_secs(idle_timeout_secs);
     Box::pin(try_stream! {
-        let first_line = match stream.next().await {
-            Some(first) => first?,
-            None => return,
-        };
-        yield first_line;
-        let mut deadline = tokio::time::Instant::now() + idle_timeout;
+        let mut deadline: Option<tokio::time::Instant> = None;
 
         loop {
-            match tokio::time::timeout_at(deadline, stream.next()).await {
+            let next = match deadline {
+                Some(deadline) => tokio::time::timeout_at(deadline, stream.next()).await,
+                None => Ok(stream.next().await),
+            };
+            match next {
                 Ok(Some(item)) => {
                     let line = item?;
                     if is_data_bearing_line(&line) {
-                        deadline = tokio::time::Instant::now() + idle_timeout;
+                        deadline = Some(tokio::time::Instant::now() + idle_timeout);
                     }
                     yield line;
                 }
@@ -595,6 +595,44 @@ mod tests {
 
         let (items, err) = drain_within(stream, Duration::from_secs(15)).await;
         assert!(err.is_none(), "live stream errored: {err:?}");
+        assert!(items > 0, "data frames should have been yielded");
+    }
+
+    /// Keepalives sent while the model is still producing its first token are
+    /// a liveness signal, not a stall: the deadline must not start until the
+    /// first data-bearing line arrives, even when the keepalive prelude alone
+    /// outlasts the idle timeout.
+    #[tokio::test]
+    async fn keepalive_prelude_before_first_token_does_not_trip_the_idle_timeout() {
+        use crate::sse_test_harness::{drain_within, post_stream, spawn_server, Chunk, Tail};
+        use std::time::Duration;
+
+        // Keepalives for 1.8s against a 1s idle timeout, then the first data
+        // frame and a clean close.
+        let mut script = Vec::new();
+        for _ in 0..3 {
+            script.push(Chunk {
+                after: Duration::from_millis(600),
+                body: ": ping\n\n".to_string(),
+            });
+        }
+        script.push(Chunk::immediate(chat_delta("Hi")));
+        script.push(Chunk::immediate("data: [DONE]\n\n"));
+        let addr = spawn_server(script, Tail::Close).await;
+
+        let response = post_stream(
+            addr,
+            "/chat/completions",
+            json!({"model": "m", "stream": true, "messages": []}),
+        )
+        .await;
+        let stream = stream_openai_compat_with_idle_timeout(response, None, 1).unwrap();
+
+        let (items, err) = drain_within(stream, Duration::from_secs(15)).await;
+        assert!(
+            err.is_none(),
+            "stream with slow first token errored: {err:?}"
+        );
         assert!(items > 0, "data frames should have been yielded");
     }
 }

--- a/crates/goose-providers/src/openai_compatible.rs
+++ b/crates/goose-providers/src/openai_compatible.rs
@@ -259,20 +259,22 @@ const NON_PROGRESS_EVENT_TYPES: [&str; 5] = [
 ];
 
 /// Whether a framed SSE line carries model progress for the downstream
-/// parsers. Two shapes never count:
+/// parsers. Three shapes never count:
 ///
 /// - Structural heartbeats: comment frames, blank separators, control fields
 ///   (`event:`, `id:`, `retry:`), other extension fields, and empty `data:`
 ///   events — discarded by every wrapped parser.
 /// - Payloads whose `type` is one of [`NON_PROGRESS_EVENT_TYPES`]: lifecycle
-///   preambles and keepalive events, which yield no assistant output. Letting
-///   either shape arm or reset the deadline would either kill a slow first
-///   token mid-generation or mask the exact keepalive-hidden stall this
-///   watchdog exists to catch.
+///   preambles and keepalive events, which yield no assistant output.
+/// - Chat-completions chunks whose deltas carry no output (see
+///   [`chat_chunk_carries_output`]): role priming, empty strings, empty
+///   arrays, and finish-only frames.
 ///
-/// Everything else — nonempty `data:` values such as `[DONE]`, JSON payloads
-/// of any other type, and bare JSON frames, which the Responses parser
-/// accepts — counts as progress.
+/// Letting any of these arm or reset the deadline would either kill a slow
+/// first token mid-generation or mask the exact keepalive-hidden stall this
+/// watchdog exists to catch. Everything else — nonempty `data:` values such
+/// as `[DONE]`, JSON payloads of any other type, and bare JSON frames, which
+/// the Responses parser accepts — counts as progress.
 fn is_progress_line(line: &str) -> bool {
     let payload = match line.strip_prefix("data:") {
         Some(value) => value.trim(),
@@ -291,17 +293,55 @@ fn is_progress_line(line: &str) -> bool {
         if let Some(event_type) = value.get("type").and_then(Value::as_str) {
             return !NON_PROGRESS_EVENT_TYPES.contains(&event_type);
         }
+        if value.get("choices").is_some() {
+            return chat_chunk_carries_output(&value);
+        }
     }
     true
 }
 
+/// Whether a chat-completions chunk carries model output in any choice's
+/// delta. Gateways prime the stream with deltas that yield nothing —
+/// OpenRouter's first frame sets `content: ""` alongside the role — and
+/// finish-only or usage-only frames likewise produce no assistant output.
+/// Mirrors what the chat parser actually reads: `content`,
+/// `reasoning`/`reasoning_content` (nonempty strings, as `reasoning_text()`
+/// filters empties), `reasoning_details`, and `tool_calls`.
+fn chat_chunk_carries_output(value: &Value) -> bool {
+    let Some(choices) = value.get("choices").and_then(Value::as_array) else {
+        return false;
+    };
+    choices.iter().any(|choice| {
+        let Some(delta) = choice.get("delta") else {
+            return false;
+        };
+        let nonempty_text = |key: &str| {
+            delta
+                .get(key)
+                .and_then(Value::as_str)
+                .is_some_and(|text| !text.is_empty())
+        };
+        nonempty_text("content")
+            || nonempty_text("reasoning")
+            || nonempty_text("reasoning_content")
+            || delta
+                .get("reasoning_details")
+                .and_then(Value::as_array)
+                .is_some_and(|details| !details.is_empty())
+            || delta
+                .get("tool_calls")
+                .and_then(Value::as_array)
+                .is_some_and(|calls| !calls.is_empty())
+    })
+}
+
 /// Wraps framed SSE lines with the idle timeout, between `LinesCodec` framing
 /// and the format parser. The deadline arms only once the first
-/// model-progress line has arrived — lifecycle preambles and keepalives,
-/// whether comment frames or payload events, do not start the clock — so
-/// time-to-first-token stays governed by the request timeout; afterwards
-/// only progress lines reset it. On timeout the stream errors with a
-/// retryable [`ProviderError::NetworkError`].
+/// model-progress line has arrived — lifecycle preambles, keepalives, and
+/// no-op chat deltas do not start the clock — so time-to-first-token stays
+/// governed by the request timeout; afterwards only progress lines reset it.
+/// On timeout the stream errors with a retryable
+/// [`ProviderError::NetworkError`].
 pub(crate) fn with_sse_idle_timeout(
     mut stream: impl Stream<Item = anyhow::Result<String>> + Unpin + Send + 'static,
     idle_timeout_secs: u64,
@@ -589,10 +629,13 @@ mod tests {
 
     #[test]
     fn sse_heartbeat_lines_are_not_progress() {
-        // Heartbeat shapes every downstream parser discards: comments, blank
+        // Shapes every downstream parser discards: comments, blank
         // separators, control fields, unknown extension fields, and empty
-        // `data:` events — plus payload-bearing keepalive and lifecycle
-        // preamble events, which yield no model output.
+        // `data:` events; payload-bearing keepalive and lifecycle preamble
+        // events, which yield no model output; and chat chunks whose deltas
+        // carry no output — role priming, empty strings and arrays
+        // (OpenRouter's first frame), finish-only frames, and the
+        // empty-choices usage chunk.
         for line in [
             ": ping",
             "",
@@ -608,6 +651,11 @@ mod tests {
             r#"data: {"type":"message_start","message":{}}"#,
             r#"data: {"type":"response.created","response":{}}"#,
             r#"data: {"type":"response.in_progress"}"#,
+            r#"data: {"choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null}]}"#,
+            r#"data: {"choices":[{"index":0,"delta":{"reasoning":"","reasoning_details":[]},"finish_reason":null}]}"#,
+            r#"data: {"choices":[{"index":0,"delta":{"tool_calls":[]},"finish_reason":null}]}"#,
+            r#"data: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}"#,
+            r#"data: {"choices":[],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}"#,
         ] {
             assert!(!is_progress_line(line), "{line:?} should not be progress");
         }
@@ -625,6 +673,11 @@ mod tests {
             r#"data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"Hi"}}"#,
             r#"data: {"type":"response.output_item.added"}"#,
             r#"data: {"type":"response.output_text.delta","delta":"Hi"}"#,
+            // Chat chunks whose deltas carry output
+            r#"data: {"choices":[{"index":0,"delta":{"content":"Hi"},"finish_reason":null}]}"#,
+            r#"data: {"choices":[{"index":0,"delta":{"reasoning_content":"thinking"},"finish_reason":null}]}"#,
+            r#"data: {"choices":[{"index":0,"delta":{"reasoning_details":[{"type":"thinking","thinking":"deep"}]}}]}"#,
+            r#"data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"name":"f","arguments":""}}]}}]}"#,
             // Unknown event types stay progress: only the fixed
             // NON_PROGRESS_EVENT_TYPES set is excluded, so a provider adding
             // a new output event cannot stall undetected.
@@ -864,5 +917,80 @@ mod tests {
             "stream with slow first token errored: {err:?}"
         );
         assert!(items > 0, "data frames should have been yielded");
+    }
+
+    /// Gateways (e.g. OpenRouter) prime the stream with an initial chunk
+    /// whose only delta is `content: ""`; the chat parser yields nothing for
+    /// it, so it must not arm the idle deadline — otherwise a first token
+    /// slower than the idle timeout would be killed mid-generation.
+    #[tokio::test]
+    async fn empty_delta_prelude_before_first_token_does_not_trip_the_idle_timeout() {
+        use crate::sse_test_harness::{drain_within, post_stream, spawn_server, Chunk, Tail};
+        use std::time::Duration;
+
+        // Role-priming empty delta, then keepalives for 1.8s against a 1s
+        // idle timeout, then the first real token and a clean close.
+        let mut script = vec![Chunk::immediate(chat_delta(""))];
+        for _ in 0..3 {
+            script.push(Chunk {
+                after: Duration::from_millis(600),
+                body: ": ping\n\n".to_string(),
+            });
+        }
+        script.push(Chunk::immediate(chat_delta("Hi")));
+        script.push(Chunk::immediate("data: [DONE]\n\n"));
+        let addr = spawn_server(script, Tail::Close).await;
+
+        let response = post_stream(
+            addr,
+            "/chat/completions",
+            json!({"model": "m", "stream": true, "messages": []}),
+        )
+        .await;
+        let stream = stream_openai_compat_with_idle_timeout(response, None, 1).unwrap();
+
+        let (items, err) = drain_within(stream, Duration::from_secs(15)).await;
+        assert!(
+            err.is_none(),
+            "stream with empty-delta prelude errored: {err:?}"
+        );
+        assert!(items > 0, "data frames should have been yielded");
+    }
+
+    /// The inverse shape: after real output, a stream wedged behind
+    /// empty-delta chunks (a gateway's payload keepalives) yields nothing
+    /// and must trip the watchdog just like comment keepalives.
+    #[tokio::test]
+    async fn empty_delta_masked_stall_errors_instead_of_hanging() {
+        use crate::sse_test_harness::{drain_within, post_stream, spawn_server, Chunk, Tail};
+        use std::time::Duration;
+
+        let addr = spawn_server(
+            vec![Chunk::immediate(chat_delta("Hi")), Chunk::immediate(chat_delta("Hi"))],
+            Tail::KeepaliveDataForever(
+                concat!(
+                    r#"data: {"id":"1","model":"m","choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null}]}"#,
+                    "\n\n"
+                ),
+            ),
+        )
+        .await;
+
+        let response = post_stream(
+            addr,
+            "/chat/completions",
+            json!({"model": "m", "stream": true, "messages": []}),
+        )
+        .await;
+        let stream = stream_openai_compat_with_idle_timeout(response, None, 1).unwrap();
+
+        let (items, err) = drain_within(stream, Duration::from_secs(15)).await;
+        let err = err.expect("stream ended without an error");
+        assert!(
+            items > 0,
+            "healthy frames should have been yielded before the stall"
+        );
+        assert!(err.to_string().contains("Stream stalled"), "got: {err}");
+        assert!(matches!(err, ProviderError::NetworkError(_)));
     }
 }

--- a/crates/goose-providers/src/openai_compatible.rs
+++ b/crates/goose-providers/src/openai_compatible.rs
@@ -243,31 +243,66 @@ pub use super::http_status::handle_response as handle_response_openai_compat;
 /// instead of hanging the turn forever.
 pub(crate) const STREAM_IDLE_TIMEOUT_SECS: u64 = 120;
 
-/// Whether a framed SSE line carries progress for the downstream parsers:
-/// a `data:` field with a nonempty value — the only field any wrapped parser
-/// consumes — or a line that itself parses as JSON, which the Responses
-/// parser accepts as a bare frame. Comment frames, blank separators, control
-/// fields (`event:`, `id:`, `retry:`), other extension fields, and empty
-/// `data:` events are heartbeat shapes every parser discards; letting any of
-/// them reset the deadline would mask the exact keepalive-hidden stall this
-/// watchdog exists to catch. A heartbeat that carries a payload (e.g. a
-/// `data: {"type":"keepalive"}` event) still resets the deadline — telling it
-/// apart from progress needs the parser's payload knowledge, which this
-/// line-level watchdog does not have.
-fn is_data_bearing_line(line: &str) -> bool {
-    match line.strip_prefix("data:") {
-        Some(value) => !value.trim().is_empty(),
-        None => serde_json::from_str::<Value>(line).is_ok(),
+/// SSE payload event types that carry no model progress across the wrapped
+/// formats: lifecycle preambles that arrive at request acceptance and are
+/// recorded as metadata at most (`message_start`, `response.created`,
+/// `response.in_progress`), and payload-bearing keepalive events (`ping`,
+/// `keepalive`). Only this fixed, cross-format set is excluded — unknown
+/// event types still count as progress, so a provider adding a new output
+/// event cannot stall undetected.
+const NON_PROGRESS_EVENT_TYPES: [&str; 5] = [
+    "message_start",
+    "ping",
+    "response.created",
+    "response.in_progress",
+    "keepalive",
+];
+
+/// Whether a framed SSE line carries model progress for the downstream
+/// parsers. Two shapes never count:
+///
+/// - Structural heartbeats: comment frames, blank separators, control fields
+///   (`event:`, `id:`, `retry:`), other extension fields, and empty `data:`
+///   events — discarded by every wrapped parser.
+/// - Payloads whose `type` is one of [`NON_PROGRESS_EVENT_TYPES`]: lifecycle
+///   preambles and keepalive events, which yield no assistant output. Letting
+///   either shape arm or reset the deadline would either kill a slow first
+///   token mid-generation or mask the exact keepalive-hidden stall this
+///   watchdog exists to catch.
+///
+/// Everything else — nonempty `data:` values such as `[DONE]`, JSON payloads
+/// of any other type, and bare JSON frames, which the Responses parser
+/// accepts — counts as progress.
+fn is_progress_line(line: &str) -> bool {
+    let payload = match line.strip_prefix("data:") {
+        Some(value) => value.trim(),
+        None => {
+            if serde_json::from_str::<Value>(line).is_ok() {
+                line.trim()
+            } else {
+                return false;
+            }
+        }
+    };
+    if payload.is_empty() {
+        return false;
     }
+    if let Ok(value) = serde_json::from_str::<Value>(payload) {
+        if let Some(event_type) = value.get("type").and_then(Value::as_str) {
+            return !NON_PROGRESS_EVENT_TYPES.contains(&event_type);
+        }
+    }
+    true
 }
 
 /// Wraps framed SSE lines with the idle timeout, between `LinesCodec` framing
-/// and the format parser. The deadline arms only once the first data-bearing
-/// line has arrived, so time-to-first-token stays governed by the request
-/// timeout and pre-first-token keepalives cannot start the clock; afterwards
-/// only data-bearing lines reset it. On timeout the stream errors with a
+/// and the format parser. The deadline arms only once the first
+/// model-progress line has arrived — lifecycle preambles and keepalives,
+/// whether comment frames or payload events, do not start the clock — so
+/// time-to-first-token stays governed by the request timeout; afterwards
+/// only progress lines reset it. On timeout the stream errors with a
 /// retryable [`ProviderError::NetworkError`].
-pub(crate) fn with_data_line_idle_timeout(
+pub(crate) fn with_sse_idle_timeout(
     mut stream: impl Stream<Item = anyhow::Result<String>> + Unpin + Send + 'static,
     idle_timeout_secs: u64,
 ) -> Pin<Box<dyn Stream<Item = anyhow::Result<String>> + Send>> {
@@ -283,7 +318,7 @@ pub(crate) fn with_data_line_idle_timeout(
             match next {
                 Ok(Some(item)) => {
                     let line = item?;
-                    if is_data_bearing_line(&line) {
+                    if is_progress_line(&line) {
                         deadline = Some(tokio::time::Instant::now() + idle_timeout);
                     }
                     yield line;
@@ -291,9 +326,9 @@ pub(crate) fn with_data_line_idle_timeout(
                 Ok(None) => break,
                 Err(_) => {
                     let err = ProviderError::NetworkError(format!(
-                        "Stream stalled: no data-bearing SSE line received for \
-                         {idle_timeout_secs}s (keepalive comment frames do not count \
-                         as progress)"
+                        "Stream stalled: no SSE progress line received for \
+                         {idle_timeout_secs}s (keepalives and lifecycle events \
+                         do not count as progress)"
                     ));
                     Err::<(), anyhow::Error>(err.into())?;
                 }
@@ -321,7 +356,7 @@ fn stream_openai_compat_with_idle_timeout(
         let framed = FramedRead::new(stream_reader, LinesCodec::new())
             .map_err(Error::from);
 
-        let timed_lines = with_data_line_idle_timeout(framed, idle_timeout_secs);
+        let timed_lines = with_sse_idle_timeout(framed, idle_timeout_secs);
         let message_stream = response_to_streaming_message(timed_lines);
         pin!(message_stream);
         while let Some(message) = message_stream.next().await {
@@ -354,7 +389,7 @@ fn stream_responses_compat_with_idle_timeout(
         let framed = FramedRead::new(stream_reader, LinesCodec::new())
             .map_err(Error::from);
 
-        let timed_lines = with_data_line_idle_timeout(framed, idle_timeout_secs);
+        let timed_lines = with_sse_idle_timeout(framed, idle_timeout_secs);
         let message_stream = responses_api_to_streaming_message(timed_lines);
         pin!(message_stream);
         while let Some(message) = message_stream.next().await {
@@ -553,10 +588,11 @@ mod tests {
     }
 
     #[test]
-    fn sse_heartbeat_lines_are_not_data_bearing() {
+    fn sse_heartbeat_lines_are_not_progress() {
         // Heartbeat shapes every downstream parser discards: comments, blank
         // separators, control fields, unknown extension fields, and empty
-        // `data:` events.
+        // `data:` events — plus payload-bearing keepalive and lifecycle
+        // preamble events, which yield no model output.
         for line in [
             ": ping",
             "",
@@ -567,23 +603,34 @@ mod tests {
             "x-heartbeat: ping",
             "data:",
             "data:   ",
+            r#"data: {"type":"ping"}"#,
+            r#"data: {"type":"keepalive"}"#,
+            r#"data: {"type":"message_start","message":{}}"#,
+            r#"data: {"type":"response.created","response":{}}"#,
+            r#"data: {"type":"response.in_progress"}"#,
         ] {
-            assert!(
-                !is_data_bearing_line(line),
-                "{line:?} should be a keepalive"
-            );
+            assert!(!is_progress_line(line), "{line:?} should not be progress");
         }
     }
 
     #[test]
-    fn payload_lines_are_data_bearing() {
+    fn model_output_lines_are_progress() {
         for line in [
             "data: {\"a\":1}",
             "data:{\"a\":1}", // space after the colon is optional
             "data: [DONE]",
-            "{\"a\":1}", // bare JSON frame, accepted by the Responses parser
+            r#"{"a":1}"#, // bare JSON frame, accepted by the Responses parser
+            // Output-bearing events from every wrapped format
+            r#"data: {"type":"content_block_start"}"#,
+            r#"data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"Hi"}}"#,
+            r#"data: {"type":"response.output_item.added"}"#,
+            r#"data: {"type":"response.output_text.delta","delta":"Hi"}"#,
+            // Unknown event types stay progress: only the fixed
+            // NON_PROGRESS_EVENT_TYPES set is excluded, so a provider adding
+            // a new output event cannot stall undetected.
+            r#"data: {"type":"some_future_output_event"}"#,
         ] {
-            assert!(is_data_bearing_line(line), "{line:?} should be payload");
+            assert!(is_progress_line(line), "{line:?} should be progress");
         }
     }
 
@@ -634,6 +681,11 @@ mod tests {
         format!("data: {payload}\n\n")
     }
 
+    /// A framed Responses payload event of the given type.
+    fn responses_event(event_type: &str) -> String {
+        format!("data: {{\"type\":\"{event_type}\"}}\n\n")
+    }
+
     /// The Responses API route (GPT-5/GPT-6/o-series, Databricks Responses
     /// streams) shares the #11679 failure signature; the watchdog must apply
     /// there too, not only to Chat Completions.
@@ -665,6 +717,81 @@ mod tests {
         );
         assert!(err.to_string().contains("Stream stalled"), "got: {err}");
         assert!(matches!(err, ProviderError::NetworkError(_)));
+    }
+
+    /// A stall bridged by payload-bearing keepalive events — the Responses
+    /// API's own `data: {"type":"keepalive"}` frames — must be detected too,
+    /// not only comment-frame keepalives.
+    #[tokio::test]
+    async fn keepalive_payload_masked_stall_errors_instead_of_hanging() {
+        use crate::sse_test_harness::{drain_within, post_stream, spawn_server, Chunk, Tail};
+        use std::time::Duration;
+
+        let delta = responses_delta("Hi");
+        let addr = spawn_server(
+            vec![Chunk::immediate(delta.clone()), Chunk::immediate(delta)],
+            Tail::KeepaliveDataForever("data: {\"type\":\"keepalive\"}\n\n"),
+        )
+        .await;
+
+        let response = post_stream(
+            addr,
+            "/responses",
+            json!({"model": "m", "stream": true, "input": []}),
+        )
+        .await;
+        let stream = stream_responses_compat_with_idle_timeout(response, None, 1).unwrap();
+
+        let (items, err) = drain_within(stream, Duration::from_secs(15)).await;
+        let err = err.expect("stream ended without an error");
+        assert!(
+            items > 0,
+            "healthy frames should have been yielded before the stall"
+        );
+        assert!(err.to_string().contains("Stream stalled"), "got: {err}");
+        assert!(matches!(err, ProviderError::NetworkError(_)));
+    }
+
+    /// Lifecycle preambles (`response.created`) and keepalive events arrive
+    /// before the first token on the Responses route; neither carries model
+    /// output, so they must not arm the idle deadline — otherwise a first
+    /// token slower than the idle timeout would be killed mid-generation.
+    #[tokio::test]
+    async fn lifecycle_prelude_before_first_token_does_not_trip_the_idle_timeout() {
+        use crate::sse_test_harness::{drain_within, post_stream, spawn_server, Chunk, Tail};
+        use std::time::Duration;
+
+        // Preamble + keepalives for ~1.8s against a 1s idle timeout, then the
+        // first data frame and a clean close.
+        let created = concat!(
+            r#"data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_1","object":"response","created_at":1737368310,"status":"in_progress","model":"m","output":[]}}"#,
+            "\n\n"
+        );
+        let mut script = vec![Chunk::immediate(created)];
+        for _ in 0..3 {
+            script.push(Chunk {
+                after: Duration::from_millis(600),
+                body: responses_event("keepalive"),
+            });
+        }
+        script.push(Chunk::immediate(responses_delta("Hi")));
+        script.push(Chunk::immediate("data: [DONE]\n\n"));
+        let addr = spawn_server(script, Tail::Close).await;
+
+        let response = post_stream(
+            addr,
+            "/responses",
+            json!({"model": "m", "stream": true, "input": []}),
+        )
+        .await;
+        let stream = stream_responses_compat_with_idle_timeout(response, None, 1).unwrap();
+
+        let (items, err) = drain_within(stream, Duration::from_secs(15)).await;
+        assert!(
+            err.is_none(),
+            "stream with slow first token errored: {err:?}"
+        );
+        assert!(items > 0, "data frames should have been yielded");
     }
 
     #[tokio::test]

--- a/crates/goose-providers/src/openai_compatible.rs
+++ b/crates/goose-providers/src/openai_compatible.rs
@@ -3,11 +3,13 @@ use crate::http_status::read_json_response;
 use crate::images::ImageFormat;
 use anyhow::Error;
 use async_stream::try_stream;
-use futures::TryStreamExt;
+use futures::{Stream, TryStreamExt};
 use reqwest::Response;
 #[cfg(test)]
 use reqwest::StatusCode;
 use serde_json::Value;
+use std::pin::Pin;
+use std::time::Duration;
 use tokio::pin;
 use tokio_stream::StreamExt;
 use tokio_util::codec::{FramedRead, LinesCodec};
@@ -234,9 +236,72 @@ pub use super::http_status::{
 // Legacy alias kept for callers that haven't migrated their import path yet.
 pub use super::http_status::handle_response as handle_response_openai_compat;
 
+/// Default event-layer idle timeout for streaming responses (seconds): how
+/// long a stream may go without a data-bearing SSE line before it is
+/// considered stalled. Unlike reqwest's byte-level read timeout, SSE comment
+/// keepalives (`: ping`) and blank separator lines do not reset this deadline,
+/// so a provider that wedges mid-stream while emitting keepalives is detected
+/// instead of hanging the turn forever.
+pub(crate) const STREAM_IDLE_TIMEOUT_SECS: u64 = 120;
+
+/// Wraps a framed SSE line stream with the event-layer idle timeout, to be
+/// inserted between `LinesCodec` framing and the format parser.
+///
+/// The deadline is not enforced until the stream yields its first line, so
+/// time-to-first-token stays governed by the request timeout. Afterwards only
+/// data-bearing lines — anything that is not blank and does not start with
+/// `:` — reset the deadline; keepalive comment frames and blank separators
+/// cannot mask a stall. On timeout the stream errors with a retryable
+/// [`ProviderError::NetworkError`].
+pub(crate) fn with_data_line_idle_timeout(
+    stream: impl Stream<Item = anyhow::Result<String>> + Unpin + Send + 'static,
+    idle_timeout_secs: u64,
+) -> Pin<Box<dyn Stream<Item = anyhow::Result<String>> + Send>> {
+    let idle_timeout = Duration::from_secs(idle_timeout_secs);
+    Box::pin(try_stream! {
+        let mut stream = stream;
+
+        let first_line = match stream.next().await {
+            Some(first) => first?,
+            None => return,
+        };
+        yield first_line;
+        let mut deadline = tokio::time::Instant::now() + idle_timeout;
+
+        loop {
+            match tokio::time::timeout_at(deadline, stream.next()).await {
+                Ok(Some(item)) => {
+                    let line = item?;
+                    if !line.trim().is_empty() && !line.starts_with(':') {
+                        deadline = tokio::time::Instant::now() + idle_timeout;
+                    }
+                    yield line;
+                }
+                Ok(None) => break,
+                Err(_) => {
+                    let err = ProviderError::NetworkError(format!(
+                        "Stream stalled: no data-bearing SSE line received for \
+                         {idle_timeout_secs}s (keepalive comment frames do not count \
+                         as progress)"
+                    ));
+                    Err::<(), anyhow::Error>(err.into())?;
+                }
+            }
+        }
+    })
+}
+
 pub fn stream_openai_compat(
     response: Response,
+    log: Option<Box<dyn RequestLogHandle>>,
+) -> Result<MessageStream, ProviderError> {
+    stream_openai_compat_with_idle_timeout(response, log, STREAM_IDLE_TIMEOUT_SECS)
+}
+
+fn stream_openai_compat_with_idle_timeout(
+    response: Response,
     mut log: Option<Box<dyn RequestLogHandle>>,
+    idle_timeout_secs: u64,
 ) -> Result<MessageStream, ProviderError> {
     let stream = response.bytes_stream().map_err(std::io::Error::other);
 
@@ -245,7 +310,8 @@ pub fn stream_openai_compat(
         let framed = FramedRead::new(stream_reader, LinesCodec::new())
             .map_err(Error::from);
 
-        let message_stream = response_to_streaming_message(framed);
+        let timed_lines = with_data_line_idle_timeout(framed, idle_timeout_secs);
+        let message_stream = response_to_streaming_message(timed_lines);
         pin!(message_stream);
         while let Some(message) = message_stream.next().await {
             let (message, usage) = message.map_err(|e|
@@ -451,5 +517,184 @@ mod tests {
             err.to_string().contains("response body exceeds"),
             "got: {err}"
         );
+    }
+
+    /// Serves the #11679 failure signature: healthy SSE data frames, then
+    /// keepalive comment frames forever, never terminating. At the byte level
+    /// the connection stays alive indefinitely, so byte-based read timeouts
+    /// never fire.
+    async fn serve_keepalive_masked_stall(mut sock: tokio::net::TcpStream) {
+        use std::time::Duration;
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let mut buf = [0u8; 8192];
+        let _ = sock.read(&mut buf).await;
+        let headers = concat!(
+            "HTTP/1.1 200 OK\r\n",
+            "content-type: text/event-stream\r\n",
+            "transfer-encoding: chunked\r\n\r\n"
+        );
+        if sock.write_all(headers.as_bytes()).await.is_err() {
+            return;
+        }
+        let chunk = |data: &str| format!("{:x}\r\n{data}\r\n", data.len());
+        let delta = concat!(
+            r#"data: {"id":"1","model":"m","choices":[{"index":0,"delta":{"role":"assistant","content":"Hi"},"finish_reason":null}]}"#,
+            "\n\n"
+        );
+        for data in [delta, delta] {
+            if sock.write_all(chunk(data).as_bytes()).await.is_err() {
+                return;
+            }
+        }
+        loop {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            if sock
+                .write_all(chunk(": ping\n\n").as_bytes())
+                .await
+                .is_err()
+            {
+                return;
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn keepalive_masked_stall_errors_instead_of_hanging() {
+        use crate::retry::{should_retry, RetryConfig};
+        use std::time::Duration;
+        use tokio::net::TcpListener;
+        use tokio_stream::StreamExt;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            loop {
+                let Ok((sock, _)) = listener.accept().await else {
+                    break;
+                };
+                tokio::spawn(serve_keepalive_masked_stall(sock));
+            }
+        });
+
+        let http = reqwest::Client::builder().no_proxy().build().unwrap();
+        let response = http
+            .post(format!("http://{addr}/chat/completions"))
+            .json(&json!({"model": "m", "stream": true, "messages": []}))
+            .send()
+            .await
+            .unwrap();
+        let mut stream = stream_openai_compat_with_idle_timeout(response, None, 1).unwrap();
+
+        let mut items = 0usize;
+        let outcome = tokio::time::timeout(Duration::from_secs(15), async {
+            while let Some(item) = stream.next().await {
+                match item {
+                    Ok(_) => items += 1,
+                    Err(e) => return Some(e),
+                }
+            }
+            None
+        })
+        .await
+        .expect("stream did not terminate within 15s");
+
+        let err = outcome.expect("stream ended without an error");
+        assert!(
+            items > 0,
+            "healthy frames should have been yielded before the stall"
+        );
+        assert!(err.to_string().contains("Stream stalled"), "got: {err}");
+        assert!(matches!(err, ProviderError::NetworkError(_)));
+        assert!(should_retry(&err, &RetryConfig::default()));
+    }
+
+    #[tokio::test]
+    async fn slow_but_live_data_lines_do_not_trip_the_idle_timeout() {
+        use std::time::Duration;
+        use tokio::io::AsyncWriteExt;
+        use tokio::net::{TcpListener, TcpStream};
+        use tokio_stream::StreamExt;
+
+        // Data frames (with interleaved keepalive comments) every 300ms while
+        // the idle timeout is 1s: a live-but-slow stream must not be killed.
+        async fn serve(mut sock: TcpStream) {
+            use tokio::io::AsyncReadExt;
+
+            let mut buf = [0u8; 8192];
+            let _ = sock.read(&mut buf).await;
+            let headers = concat!(
+                "HTTP/1.1 200 OK\r\n",
+                "content-type: text/event-stream\r\n",
+                "transfer-encoding: chunked\r\n\r\n"
+            );
+            if sock.write_all(headers.as_bytes()).await.is_err() {
+                return;
+            }
+            let chunk = |data: &str| format!("{:x}\r\n{data}\r\n", data.len());
+            for i in 0..5 {
+                tokio::time::sleep(Duration::from_millis(150)).await;
+                if sock
+                    .write_all(chunk(": ping\n\n").as_bytes())
+                    .await
+                    .is_err()
+                {
+                    return;
+                }
+                tokio::time::sleep(Duration::from_millis(150)).await;
+                let delta = format!(
+                    concat!(
+                        r#"data: {{"id":"1","model":"m","choices":[{{"index":0,"delta":{{"role":"assistant","content":"Hi {}"}},"finish_reason":null}}]}}"#,
+                        "\n\n"
+                    ),
+                    i
+                );
+                if sock.write_all(chunk(&delta).as_bytes()).await.is_err() {
+                    return;
+                }
+            }
+            let _ = sock.write_all(chunk("data: [DONE]\n\n").as_bytes()).await;
+            let _ = sock.write_all(b"0\r\n\r\n").await;
+        }
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            loop {
+                let Ok((sock, _)) = listener.accept().await else {
+                    break;
+                };
+                tokio::spawn(serve(sock));
+            }
+        });
+
+        let http = reqwest::Client::builder().no_proxy().build().unwrap();
+        let response = http
+            .post(format!("http://{addr}/chat/completions"))
+            .json(&json!({"model": "m", "stream": true, "messages": []}))
+            .send()
+            .await
+            .unwrap();
+        let mut stream = stream_openai_compat_with_idle_timeout(response, None, 1).unwrap();
+
+        let mut items = 0usize;
+        let outcome = tokio::time::timeout(Duration::from_secs(15), async {
+            while let Some(item) = stream.next().await {
+                match item {
+                    Ok(_) => items += 1,
+                    Err(e) => return Some(e),
+                }
+            }
+            None
+        })
+        .await
+        .expect("stream did not terminate within 15s");
+
+        assert!(
+            outcome.is_none(),
+            "live stream errored: {:?}",
+            outcome.unwrap()
+        );
+        assert!(items > 0, "data frames should have been yielded");
     }
 }

--- a/crates/goose-providers/src/sse_test_harness.rs
+++ b/crates/goose-providers/src/sse_test_harness.rs
@@ -35,6 +35,10 @@ pub(crate) enum Tail {
     /// Emit `: ping` frames forever without terminating the response: the
     /// connection stays byte-alive while no data ever arrives.
     KeepaliveForever,
+    /// Emit payload-bearing keepalive events forever without terminating the
+    /// response: byte-alive like `KeepaliveForever`, but with `data:` frames
+    /// a naive watchdog would count as progress.
+    KeepaliveDataForever(&'static str),
     /// Terminate the chunked body and close the connection.
     Close,
 }
@@ -77,6 +81,12 @@ async fn serve(mut sock: TcpStream, script: Vec<Chunk>, tail: Tail) {
                 .await
                 .is_err()
             {
+                return;
+            }
+        },
+        Tail::KeepaliveDataForever(frame) => loop {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            if sock.write_all(chunk(frame).as_bytes()).await.is_err() {
                 return;
             }
         },

--- a/crates/goose-providers/src/sse_test_harness.rs
+++ b/crates/goose-providers/src/sse_test_harness.rs
@@ -1,0 +1,119 @@
+//! Test harness for exercising SSE streaming over a raw TCP server, where
+//! keepalive comment frames can be replayed exactly as a wedged provider
+//! sends them (which mock HTTP servers cannot express).
+
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use serde_json::Value;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio_stream::StreamExt;
+
+use crate::base::MessageStream;
+use crate::errors::ProviderError;
+
+/// A scripted SSE chunk: wait `after`, then write `body` as one HTTP chunk.
+#[derive(Clone)]
+pub(crate) struct Chunk {
+    pub(crate) after: Duration,
+    pub(crate) body: String,
+}
+
+impl Chunk {
+    pub(crate) fn immediate(body: impl Into<String>) -> Self {
+        Self {
+            after: Duration::ZERO,
+            body: body.into(),
+        }
+    }
+}
+
+/// What the server does after the scripted chunks.
+#[derive(Clone, Copy)]
+pub(crate) enum Tail {
+    /// Emit `: ping` frames forever without terminating the response: the
+    /// connection stays byte-alive while no data ever arrives.
+    KeepaliveForever,
+    /// Terminate the chunked body and close the connection.
+    Close,
+}
+
+pub(crate) async fn spawn_server(script: Vec<Chunk>, tail: Tail) -> SocketAddr {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        while let Ok((sock, _)) = listener.accept().await {
+            let script = script.clone();
+            tokio::spawn(serve(sock, script, tail));
+        }
+    });
+    addr
+}
+
+async fn serve(mut sock: TcpStream, script: Vec<Chunk>, tail: Tail) {
+    let mut buf = [0u8; 8192];
+    let _ = sock.read(&mut buf).await;
+    let headers = concat!(
+        "HTTP/1.1 200 OK\r\n",
+        "content-type: text/event-stream\r\n",
+        "transfer-encoding: chunked\r\n\r\n"
+    );
+    if sock.write_all(headers.as_bytes()).await.is_err() {
+        return;
+    }
+    let chunk = |data: &str| format!("{:x}\r\n{data}\r\n", data.len());
+    for step in script {
+        tokio::time::sleep(step.after).await;
+        if sock.write_all(chunk(&step.body).as_bytes()).await.is_err() {
+            return;
+        }
+    }
+    match tail {
+        Tail::KeepaliveForever => loop {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            if sock
+                .write_all(chunk(": ping\n\n").as_bytes())
+                .await
+                .is_err()
+            {
+                return;
+            }
+        },
+        Tail::Close => {
+            let _ = sock.write_all(b"0\r\n\r\n").await;
+        }
+    }
+}
+
+pub(crate) async fn post_stream(addr: SocketAddr, path: &str, body: Value) -> reqwest::Response {
+    reqwest::Client::builder()
+        .no_proxy()
+        .build()
+        .unwrap()
+        .post(format!("http://{addr}{path}"))
+        .json(&body)
+        .send()
+        .await
+        .unwrap()
+}
+
+/// Drains `stream` within `limit`, returning the item count and the error the
+/// stream terminated with, if any.
+pub(crate) async fn drain_within(
+    mut stream: MessageStream,
+    limit: Duration,
+) -> (usize, Option<ProviderError>) {
+    tokio::time::timeout(limit, async {
+        let mut items = 0;
+        while let Some(item) = stream.next().await {
+            match item {
+                Ok(_) => items += 1,
+                Err(e) => return (items, Some(e)),
+            }
+        }
+        (items, None)
+    })
+    .await
+    .expect("stream did not terminate within the deadline")
+}

--- a/crates/goose/src/providers/chatgpt_codex.rs
+++ b/crates/goose/src/providers/chatgpt_codex.rs
@@ -5,19 +5,16 @@ use crate::providers::base::{
     ConfigKey, MessageStream, Provider, ProviderDef, ProviderMetadata,
     DEFAULT_CONNECT_TIMEOUT_SECS, DEFAULT_PROVIDER_TIMEOUT_SECS,
 };
-use crate::providers::openai_compatible::handle_status;
+use crate::providers::openai_compatible::{handle_status, stream_responses_compat};
 use crate::providers::private_file::write_private_file;
 use crate::providers::retry::ProviderRetry;
 use anyhow::{anyhow, Result};
-use async_stream::try_stream;
 use async_trait::async_trait;
 use axum::{extract::Query, response::Html, routing::get, Router};
 use base64::Engine;
 use chrono::{DateTime, Utc};
 use futures::future::BoxFuture;
-use futures::{StreamExt, TryStreamExt};
 use goose_providers::errors::ProviderError;
-use goose_providers::formats::openai_responses::responses_api_to_streaming_message;
 use goose_providers::model::ModelConfig;
 use jsonwebtoken::jwk::JwkSet;
 use jsonwebtoken::{decode, decode_header, DecodingKey, Validation};
@@ -29,10 +26,7 @@ use std::io;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::{Arc, LazyLock};
-use tokio::pin;
 use tokio::sync::{oneshot, Mutex as TokioMutex};
-use tokio_util::codec::{FramedRead, LinesCodec};
-use tokio_util::io::StreamReader;
 
 const CLIENT_ID: &str = "app_EMoamEEZ73f0CkXaXp7hrann";
 const ISSUER: &str = "https://auth.openai.com";
@@ -1018,22 +1012,7 @@ impl Provider for ChatGptCodexProvider {
             })
             .await?;
 
-        let stream = response.bytes_stream().map_err(io::Error::other);
-
-        Ok(Box::pin(try_stream! {
-            let stream_reader = StreamReader::new(stream);
-            let framed = FramedRead::new(stream_reader, LinesCodec::new()).map_err(anyhow::Error::from);
-
-            let message_stream = responses_api_to_streaming_message(framed);
-            pin!(message_stream);
-            while let Some(message) = message_stream.next().await {
-                let (message, usage) = message.map_err(|e| {
-                    e.downcast::<ProviderError>()
-                        .unwrap_or_else(ProviderError::stream_decode_error)
-                })?;
-                yield (message, usage);
-            }
-        }))
+        stream_responses_compat(response, None)
     }
 
     async fn configure_oauth(&self) -> Result<(), ProviderError> {


### PR DESCRIPTION
Fixes #11679.

Mid-turn, a provider can wedge its SSE stream while still sending keepalive comment frames (`: ping`). Those bytes reset every byte-level timeout, so goose neither completes nor errors the request — the turn hangs silently: no reply, no error, no retry.

## What this does

One shared watchdog in `goose-providers`, wrapped around the framed SSE line stream at three points:

- `with_sse_idle_timeout` (`openai_compatible.rs`): once the first **model-progress** line has arrived, the stream must produce another one within 120s (`STREAM_IDLE_TIMEOUT_SECS`). Three shapes never count as progress: structural heartbeats — comment frames, blank separators, control fields (`event:`, `id:`, `retry:`), other extension fields, empty `data:` events; payloads whose `type` marks them as lifecycle or keepalive frames (`message_start`, `ping`, `response.created`, `response.in_progress`, `keepalive`), which the wrapped parsers record as metadata at most and yield no assistant content for; and chat-completions chunks whose deltas carry no output (role priming, empty `content`/`reasoning` strings, empty `tool_calls`, finish-only frames — e.g. OpenRouter's initial frame), which the chat parser yields nothing for. Unknown shapes still count, so a provider adding a new output event cannot stall undetected. The deadline arms only after the first model-progress line, so time-to-first-token stays governed by the existing request timeout — a keepalive, lifecycle, or empty-delta prelude while the model is still producing its first token cannot start the clock.
- On timeout it surfaces a `ProviderError::NetworkError`, which is classified as retryable. The existing retry loop (`crates/goose/src/agents/reply_parts.rs`) retries provider failures that occur **before the first item is delivered**; a mid-stream stall after output has been yielded is surfaced to the user as an error message instead of the previous silent indefinite hang. Automatically retrying post-item failures would resend the request and duplicate already-delivered output — that needs explicit partial-output handling in both agent loops and is out of scope here (adjacent to #10917).
- Wired into `stream_openai_compat` (covers the OpenAI Chat Completions engine, all declarative providers, Databricks/Azure/Snowflake), `stream_responses_compat` (the OpenAI Responses route for GPT-5/GPT-6/o-series, plus Databricks Responses streams and the ChatGPT Codex provider's Responses route), and the Anthropic streaming path shared by `AnthropicProvider` and the Databricks v2 Anthropic route.

## Verification

- New raw-TCP SSE test harness (`sse_test_harness.rs`, `#[cfg(test)]`) that replays the failure signature exactly as a wedged provider sends it: healthy frames, then `: ping` every 100ms forever without terminating the response. Mock HTTP servers can't express this, hence the raw socket.
- `keepalive_masked_stall_errors_instead_of_hanging` on the OpenAI, Responses, and Anthropic paths: the healthy frames are yielded, then the stream errors with a NetworkError instead of hanging. `keepalive_payload_masked_stall_errors_instead_of_hanging` and `ping_masked_stall_errors_instead_of_hanging` cover the payload-bearing variants (`data: {"type":"keepalive"}`, `data: {"type":"ping"}`); `empty_delta_masked_stall_errors_instead_of_hanging` covers empty-delta chunk floods.
- `slow_but_live_data_lines_do_not_trip_the_idle_timeout`: data frames interleaved with keepalives complete cleanly — guarding against the #8437-style inverse failure.
- `keepalive_prelude_before_first_token_does_not_trip_the_idle_timeout`, `lifecycle_prelude_before_first_token_does_not_trip_the_idle_timeout` (Anthropic and Responses routes), and `empty_delta_prelude_before_first_token_does_not_trip_the_idle_timeout`: a keepalive-only, lifecycle-preamble, or empty-delta prelude longer than the idle timeout, followed by a normal first token, completes cleanly — the deadline must not start before the first model-progress line, so a slow first token is never killed mid-generation.
- `sse_heartbeat_lines_are_not_progress` / `model_output_lines_are_progress`: the predicate classifies every heartbeat shape (`event:`, `id:`, `retry:`, unknown fields, empty `data:`, lifecycle and keepalive payload events, no-op chat deltas) as non-progress and every output-bearing shape (`data:` with value, optional space after the colon, bare JSON, unknown event types, chat deltas with content/reasoning/tool calls) as progress.
- `cargo test -p goose-providers`: 230 passed.
- Confirmed against the issue's reproducer (llm-mockingbird stall fault mode): the stalled request now errors at the deadline instead of hanging.

This is a reworked, narrower alternative to #11816, scoped to the streaming paths exercised by the issue's reproducer.