### PR TITLE
Add Clipwave to servers directory

### DIFF
--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -827,6 +827,17 @@
       "required": false
     }
   ]
-}
-
+},
+  {
+    "id": "clipwave",
+    "name": "Clipwave",
+    "description": "Generate video and images, then cut them on a multi-track timeline and export an MP4",
+    "url": "https://clipwave.io/api/mcp",
+    "link": "https://clipwave.io/mcp",
+    "installation_notes": "Hosted remote server. Sign in with your Clipwave account via OAuth on first connect.",
+    "is_builtin": false,
+    "endorsed": false,
+    "environmentVariables": [],
+    "type": "streamable-http"
+  }
 ]


### PR DESCRIPTION
Adds **Clipwave** to `documentation/static/servers.json`.

Clipwave is a hosted media server: video and image generation plus a multi-track timeline editor that exports MP4. Remote `streamable-http` at `https://clipwave.io/api/mcp`, OAuth (dynamic client registration) on first connect. Official entry, maintained by the Clipwave team.

The entry follows the existing `glif` remote/OAuth entry byte for byte (`environmentVariables: []` present, `url` instead of `command`). No docs page added, as with the Glif and pngmeta entries.
