### PR TITLE
test: avoid ETXTBSY when creating command auth fixture

### DIFF
--- a/crates/goose/src/providers/command_auth.rs
+++ b/crates/goose/src/providers/command_auth.rs
@@ -458,8 +458,11 @@ mod tests {
 
         let dir = tempfile::tempdir().unwrap();
         let script_path = dir.path().join("get-token.sh");
-        std::fs::write(&script_path, "#!/bin/sh\npwd\n").unwrap();
-        std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let temp_script_path = dir.path().join("get-token.sh.tmp");
+        std::fs::write(&temp_script_path, "#!/bin/sh\npwd\n").unwrap();
+        std::fs::set_permissions(&temp_script_path, std::fs::Permissions::from_mode(0o755))
+            .unwrap();
+        std::fs::rename(&temp_script_path, &script_path).unwrap();
 
         let mut config = auth_config("./get-token.sh", Vec::<&str>::new(), 3600);
         config.cwd = Some(dir.path().to_string_lossy().to_string());


### PR DESCRIPTION
Fixes: #11946

> [!IMPORTANT]
> Goose follows an [issues-first contribution process](https://github.com/aaif-goose/goose/blob/main/CONTRIBUTING.md#from-issue-to-pull-request). Before opening an external pull request, make sure the linked issue is on the [Goose Issues board](https://github.com/orgs/aaif-goose/projects/1) with the **Ready** status. Pull requests for issues in **Inbox**, **Needs info**, or **Accepted / design** are not ready for implementation. PRs without a linked issue or an issue in the wrong state can be closed with a one-liner "no correct issue".

## Summary
The command-auth test sometimes exposed its executable before preparation finished, causing Linux `ETXTBSY`. Publish a completed, executable temporary file with an atomic rename before running it.

### Testing
- `cargo fmt --check`
- `git diff --check`
- The focused Cargo test was not completed locally because the shared Cargo cache was locked and the offline cache lacked `umya-spreadsheet`; CI should run the focused test.

### Related Issues
Discussion: None

### Screenshots/Demos (for UX changes)
Before: Not applicable

After: Not applicable

### Reviewers
@jamadeo @lifeizhou-ap