### PR TITLE
fix: bind working-directory refreshes to backend credentials

### DIFF
--- a/ui/desktop/src/utils/__tests__/workingDir.test.ts
+++ b/ui/desktop/src/utils/__tests__/workingDir.test.ts
@@ -13,6 +13,7 @@ describe('resolveWorkingDir', () => {
 
 describe('getEffectiveWorkingDir', () => {
   const getSettingMock = vi.fn();
+  const getSecretKeyMock = vi.fn();
   const appConfigGetMock = vi.fn();
 
   const mockWindow = (externalBackend: boolean, boundUrl: string, source = 'settings') => {
@@ -27,10 +28,11 @@ describe('getEffectiveWorkingDir', () => {
 
   beforeEach(() => {
     getSettingMock.mockReset();
+    getSecretKeyMock.mockReset().mockResolvedValue('window-bound-secret');
     appConfigGetMock.mockReset();
     (globalThis as Record<string, unknown>).window = {
       appConfig: { get: appConfigGetMock },
-      electron: { getSetting: getSettingMock },
+      electron: { getSetting: getSettingMock, getSecretKey: getSecretKeyMock },
     } as unknown as typeof globalThis;
   });
 
@@ -39,9 +41,90 @@ describe('getEffectiveWorkingDir', () => {
     getSettingMock.mockResolvedValue({
       enabled: true,
       url: 'http://remote:3000',
+      secret: 'window-bound-secret',
       workingDir: ' /home/goose/workspace ',
     });
     await expect(getEffectiveWorkingDir()).resolves.toBe('/home/goose/workspace');
+  });
+
+  it('rejects a directory configured for a different backend credential', async () => {
+    mockWindow(true, 'https://shared.example');
+    getSettingMock.mockResolvedValue({
+      enabled: true,
+      url: 'https://shared.example',
+      secret: 'new-backend-secret',
+      workingDir: '/tenant-b/private-project',
+    });
+
+    await expect(getEffectiveWorkingDir()).resolves.toBe('/Users/johannes/home/workspace');
+  });
+
+  it('refreshes same-credential directories but rejects settings after credential rotation', async () => {
+    mockWindow(true, 'https://shared.example');
+    getSettingMock
+      .mockResolvedValueOnce({
+        enabled: true,
+        url: 'https://shared.example',
+        secret: 'window-bound-secret',
+        workingDir: '/tenant-a/first-project',
+      })
+      .mockResolvedValueOnce({
+        enabled: true,
+        url: 'https://shared.example',
+        secret: 'window-bound-secret',
+        workingDir: ' /tenant-a/second-project ',
+      })
+      .mockResolvedValueOnce({
+        enabled: true,
+        url: 'https://shared.example',
+        secret: 'new-backend-secret',
+        workingDir: '/tenant-b/private-project',
+      });
+
+    await expect(getEffectiveWorkingDir()).resolves.toBe('/tenant-a/first-project');
+    await expect(getEffectiveWorkingDir()).resolves.toBe('/tenant-a/second-project');
+    await expect(getEffectiveWorkingDir()).resolves.toBe('/Users/johannes/home/workspace');
+  });
+
+  it.each([undefined, '', ' window-bound-secret '])(
+    'rejects a missing, empty, or non-identical configured secret (%s)',
+    async (secret) => {
+      mockWindow(true, 'https://shared.example');
+      getSettingMock.mockResolvedValue({
+        enabled: true,
+        url: 'https://shared.example',
+        secret,
+        workingDir: '/remote/project',
+      });
+
+      await expect(getEffectiveWorkingDir()).resolves.toBe('/Users/johannes/home/workspace');
+    }
+  );
+
+  it('falls back to the remembered directory when the bound lease is unavailable', async () => {
+    mockWindow(true, 'https://shared.example');
+    getSecretKeyMock.mockResolvedValue(null);
+    getSettingMock.mockResolvedValue({
+      enabled: true,
+      url: 'https://shared.example',
+      secret: 'window-bound-secret',
+      workingDir: '/remote/project',
+    });
+
+    await expect(getEffectiveWorkingDir()).resolves.toBe('/Users/johannes/home/workspace');
+  });
+
+  it('falls back to the remembered directory when the bound secret cannot be read', async () => {
+    mockWindow(true, 'https://shared.example');
+    getSecretKeyMock.mockRejectedValue(new Error('lease unavailable'));
+    getSettingMock.mockResolvedValue({
+      enabled: true,
+      url: 'https://shared.example',
+      secret: 'window-bound-secret',
+      workingDir: '/remote/project',
+    });
+
+    await expect(getEffectiveWorkingDir()).resolves.toBe('/Users/johannes/home/workspace');
   });
 
   it('honors the configured remote directory for env-mode backends regardless of enabled/url', async () => {
@@ -49,15 +132,18 @@ describe('getEffectiveWorkingDir', () => {
     getSettingMock.mockResolvedValue({
       enabled: false,
       url: 'http://unrelated:4000',
+      secret: 'different-settings-secret',
       workingDir: '/home/goose/workspace',
     });
     await expect(getEffectiveWorkingDir()).resolves.toBe('/home/goose/workspace');
+    expect(getSecretKeyMock).not.toHaveBeenCalled();
   });
 
   it('falls back to the remembered directory for env-mode backends without a configured dir', async () => {
     mockWindow(true, 'http://env-backend:3000', 'env');
     getSettingMock.mockResolvedValue({ enabled: false, workingDir: '   ' });
     await expect(getEffectiveWorkingDir()).resolves.toBe('/Users/johannes/home/workspace');
+    expect(getSecretKeyMock).not.toHaveBeenCalled();
   });
 
   it('ignores the remote directory when the window is bound to the local backend', async () => {

--- a/ui/desktop/src/utils/workingDir.ts
+++ b/ui/desktop/src/utils/workingDir.ts
@@ -33,14 +33,16 @@ export const getEffectiveWorkingDir = async (): Promise<string> => {
     }
     // Env-mode backends use settings.externalGoosed.workingDir regardless of the
     // enabled flag or URL (see getActiveExternalBackend); settings-mode requires
-    // the backend to still match the window-bound URL.
+    // the backend to still match the window-bound URL and credential.
     if (source === 'env') {
       return remote;
     }
     if (
       external?.enabled &&
       external?.url &&
-      normalizeUrl(boundUrl) === normalizeUrl(external.url)
+      external?.secret &&
+      normalizeUrl(boundUrl) === normalizeUrl(external.url) &&
+      external.secret === (await window.electron.getSecretKey())
     ) {
       return remote;
     }


### PR DESCRIPTION
Refresh a settings-backed remote working directory only when both its URL and credential match the backend bound to the current window. Otherwise retain the window's remembered directory. Environment-backed behavior remains unchanged.

Added coverage for credential rotation, missing or mismatched secrets, unavailable leases, same-credential updates, and environment-backed settings.

Validation: 28 focused tests and all 844 Desktop tests passed; Desktop typecheck, ESLint, locale checks, formatting, and the production renderer build passed. Rust sources and build inputs are identical to the revision that passed `cargo clippy -p goose --all-targets -- -D warnings` for the parallel UI-only change; clippy was not rerun in this worktree.

*This finding was discovered by [Project Loupe](https://github.com/project-loupe/loupe)*