### PR TITLE
Keep provider identity visible in model labels

### DIFF
--- a/ui/desktop/src/components/settings/models/bottom_bar/ModelsBottomBar.test.tsx
+++ b/ui/desktop/src/components/settings/models/bottom_bar/ModelsBottomBar.test.tsx
@@ -1,5 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { fireEvent, render, type RenderOptions, screen } from '@testing-library/react';
+import {
+  fireEvent,
+  render,
+  type RenderOptions,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react';
 import ModelsBottomBar from './ModelsBottomBar';
 import { IntlTestWrapper } from '../../../../i18n/test-utils';
 
@@ -14,11 +21,13 @@ let mockCurrentProvider: string | null = 'config-provider';
 const mockGetProviders = vi.fn();
 const mockOnModelChanged = vi.fn();
 const mockPreventCloseAutoFocus = vi.fn();
+const mockChangeModel = vi.fn();
 
 vi.mock('../../../ModelAndProviderContext', () => ({
   useModelAndProvider: () => ({
     currentModel: mockCurrentModel,
     currentProvider: mockCurrentProvider,
+    changeModel: mockChangeModel,
   }),
 }));
 
@@ -35,6 +44,10 @@ vi.mock('../modelInterface', () => ({
 
 vi.mock('../predefinedModelsUtils', () => ({
   getModelDisplayName: (model: string) => `Display ${model}`,
+}));
+
+vi.mock('../../../../acp/providers', () => ({
+  acpReadThinkingEffort: vi.fn().mockResolvedValue(null),
 }));
 
 vi.mock('../../../bottom_menu/BottomMenuAlertPopover', () => ({
@@ -74,10 +87,12 @@ vi.mock('../../../ui/dropdown-menu', () => ({
   DropdownMenuItem: ({
     children,
     onSelect,
+    onClick,
   }: {
     children: React.ReactNode;
     onSelect?: () => void;
-  }) => <button onClick={onSelect}>{children}</button>,
+    onClick?: () => void;
+  }) => <button onClick={onClick ?? onSelect}>{children}</button>,
   DropdownMenuSeparator: () => null,
 }));
 
@@ -99,6 +114,8 @@ describe('ModelsBottomBar', () => {
     mockCurrentModel = 'config-model';
     mockCurrentProvider = 'config-provider';
     mockGetProviders.mockResolvedValue([]);
+    mockChangeModel.mockResolvedValue(true);
+    vi.mocked(window.electron.getSetting).mockResolvedValue(undefined);
   });
 
   it('shows a loading placeholder while the active session model is still loading', async () => {
@@ -183,5 +200,76 @@ describe('ModelsBottomBar', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Complete model menu close' }));
     expect(screen.getByTestId('switch-model-modal')).toBeInTheDocument();
     expect(mockPreventCloseAutoFocus).toHaveBeenCalledOnce();
+  });
+
+  it('isolates the current model alias from its provider', async () => {
+    const model = '\u202elacoL';
+    renderWithIntl(
+      <ModelsBottomBar
+        sessionId="session-123"
+        dropdownRef={createDropdownRef()}
+        setView={vi.fn()}
+        sessionModel={model}
+        sessionProvider="session-provider"
+        onModelChanged={mockOnModelChanged}
+        sessionLoaded={true}
+      />
+    );
+
+    const provider = await screen.findByText('Config Provider', { exact: true });
+    const label = screen.getByTitle(`Display ${model}`);
+    expect(label.tagName).toBe('BDI');
+    expect(label).toHaveAttribute('dir', 'auto');
+    expect(label).toHaveTextContent(`Display ${model}`);
+    expect(provider.tagName).toBe('BDI');
+    expect(provider).toHaveAttribute('dir', 'auto');
+    expect(provider.parentElement).toHaveClass('flex-shrink-0');
+    expect(label).not.toContainElement(provider);
+  });
+
+  it.each([
+    ['ordinary', 'remote-model'],
+    ['RTL', 'نموذج محلي'],
+    ['bidi controls', '\u202elacoL'],
+    ['long', 'Trusted Local Model — local ' + 'padding-'.repeat(80)],
+  ])('keeps the provider separate and routes the raw %s recent model', async (_, model) => {
+    vi.mocked(window.electron.getSetting).mockResolvedValue([
+      { model, provider: 'attacker-cloud' },
+    ]);
+    renderWithIntl(
+      <ModelsBottomBar
+        sessionId="session-123"
+        dropdownRef={createDropdownRef()}
+        setView={vi.fn()}
+        sessionModel="safe-model"
+        sessionProvider="safe-provider"
+        onModelChanged={mockOnModelChanged}
+        sessionLoaded={true}
+      />
+    );
+
+    const provider = await screen.findByText('attacker-cloud', { exact: true });
+    const label = screen.getByTitle(`Display ${model}`);
+    expect(label.tagName).toBe('BDI');
+    expect(label).toHaveAttribute('dir', 'auto');
+    expect(label).toHaveClass('min-w-0', 'truncate');
+    expect(label).toHaveTextContent(`Display ${model}`);
+    expect(provider.tagName).toBe('BDI');
+    expect(provider).toHaveAttribute('dir', 'auto');
+    expect(provider.parentElement).toHaveClass('flex-shrink-0');
+    expect(provider.parentElement).not.toHaveClass('truncate');
+    expect(label).not.toContainElement(provider);
+
+    const item = provider.closest('button')!;
+    expect(within(item).getByTitle(`Display ${model}`)).toBe(label);
+    expect(item).toHaveAccessibleName(`Display ${model}— attacker-cloud`);
+    fireEvent.click(item);
+    await waitFor(() =>
+      expect(mockChangeModel).toHaveBeenCalledWith('session-123', {
+        name: model,
+        provider: 'attacker-cloud',
+      })
+    );
+    expect(mockOnModelChanged).toHaveBeenCalledWith({ model, provider: 'attacker-cloud' });
   });
 });

--- a/ui/desktop/src/components/settings/models/bottom_bar/ModelsBottomBar.tsx
+++ b/ui/desktop/src/components/settings/models/bottom_bar/ModelsBottomBar.tsx
@@ -247,9 +247,15 @@ export default function ModelsBottomBar({
           <h6 className="text-xs text-text-primary mt-2 ml-2">
             {intl.formatMessage(i18n.currentModel)}
           </h6>
-          <p className="flex items-center justify-between text-sm mx-2 pb-2 border-b mb-2">
-            {menuModelLabel}
-            {!isModelLoading && displayProvider && ` — ${displayProvider}`}
+          <p className="flex items-center justify-between gap-1 text-sm mx-2 pb-2 border-b mb-2">
+            <bdi dir="auto" className="min-w-0 truncate" title={menuModelLabel}>
+              {menuModelLabel}
+            </bdi>
+            {!isModelLoading && displayProvider && (
+              <span className="flex-shrink-0">
+                — <bdi dir="auto">{displayProvider}</bdi>
+              </span>
+            )}
           </p>
           {shouldShowResolvedModel && resolvedDisplayModelName && (
             <div className="mx-2 pb-2 border-b mb-2">
@@ -272,8 +278,15 @@ export default function ModelsBottomBar({
                   onClick={() => void handleRecentModelClick(recent)}
                 >
                   <History className="mr-2 h-3.5 w-3.5 flex-shrink-0 text-text-secondary" />
-                  <span className="truncate">
-                    {getModelDisplayName(recent.model)} — {recent.provider}
+                  <bdi
+                    dir="auto"
+                    className="min-w-0 truncate"
+                    title={getModelDisplayName(recent.model)}
+                  >
+                    {getModelDisplayName(recent.model)}
+                  </bdi>
+                  <span className="flex-shrink-0">
+                    — <bdi dir="auto">{recent.provider}</bdi>
                   </span>
                 </DropdownMenuItem>
               ))}


### PR DESCRIPTION
## Summary

Keep the destination provider separate from model text in current and recent model labels. Only the model label can truncate, and bidirectional text is isolated so it cannot change the provider's display.

Preserves raw model/provider routing, display aliases, and normal RTL names. Full model labels remain available through titles and accessible text.

## Verification

- Component regressions: 9 passed; full Desktop suite: 95 files, 842 tests passed.
- Desktop typecheck, ESLint, i18n validation, scoped Prettier check, `bin/cargo fmt`, and renderer build passed.
- Chromium rendering checks covered long labels, bidi controls, ordinary and RTL labels at production and wide menu widths. This used a local DOM/CSS fixture, not full Electron.
- Reused successful `bin/cargo clippy -p goose --all-targets -- -D warnings` verification after checking identical Rust sources, Cargo files, toolchain, and build configuration; this change touches only Desktop source/tests.

*This finding was discovered by [Project Loupe](https://github.com/project-loupe/loupe)*