### PR TITLE
fix(hints): deliver subdirectory hints as an agent-only user message

### DIFF
--- a/crates/goose-provider-types/src/conversation.rs
+++ b/crates/goose-provider-types/src/conversation.rs
@@ -511,8 +511,8 @@ fn fix_tool_calling(mut messages: Vec<Message>) -> (Vec<Message>, Vec<String>) {
     (messages, issues)
 }
 
-/// Never merges across visibility or turn-context boundaries, so the result
-/// is safe to persist.
+/// Never merges across visibility, turn-context, or operation-note boundaries,
+/// so the result is safe to persist.
 pub fn merge_consecutive_messages(messages: Vec<Message>) -> (Vec<Message>, Vec<String>) {
     merge_consecutive(messages, false)
 }
@@ -536,7 +536,8 @@ fn merge_consecutive(
             if effective_role(last) == effective
                 && (across_visibility
                     || (last.metadata.user_visible == message.metadata.user_visible
-                        && last.metadata.turn_context == message.metadata.turn_context))
+                        && last.metadata.turn_context == message.metadata.turn_context
+                        && last.metadata.operations == message.metadata.operations))
             {
                 last.content.extend(message.content);
                 issues.push(format!("Merged consecutive {} messages", effective));
@@ -1090,6 +1091,27 @@ mod tests {
         } else {
             panic!("Expected second item to be an image");
         }
+    }
+
+    #[test]
+    fn test_operation_notes_keep_consecutive_messages_separate_when_persisting() {
+        let noted = |dir: &str| {
+            let mut metadata = MessageMetadata::agent_only();
+            metadata.set_operation_note("subdir_hints", "dir", serde_json::json!(dir));
+            Message::user().with_text(dir).with_metadata(metadata)
+        };
+        let messages = vec![noted("/a"), noted("/b")];
+
+        assert_eq!(
+            crate::conversation::merge_consecutive_messages(messages.clone())
+                .0
+                .len(),
+            2
+        );
+        assert_eq!(
+            crate::conversation::merge_consecutive_messages_for_request(messages).len(),
+            1
+        );
     }
 
     #[test]

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -58,6 +58,7 @@ use crate::conversation::message::{
     SystemNotificationType,
 };
 use crate::conversation::{debug_conversation_fix, fix_conversation, Conversation};
+use crate::hints::pending_hint_carriers;
 use crate::permission::permission_inspector::PermissionInspector;
 use crate::permission::permission_judge::PermissionCheckResult;
 use crate::permission::{Permission, PermissionConfirmation};
@@ -1086,11 +1087,6 @@ impl Agent {
             tracing::Span::current().record("input", tracing::field::display(&input_summary));
         }
         gen_ai_telemetry::record_tool_arguments(&tracing::Span::current(), &tool_call);
-
-        self.prompt_manager
-            .lock()
-            .await
-            .record_tool_arguments(&tool_call.arguments, &session.working_dir);
 
         let tool_input_for_hooks = tool_call
             .arguments
@@ -2646,6 +2642,16 @@ impl Agent {
                     break;
                 }
 
+                for carrier in pending_hint_carriers(conversation.messages(), &working_dir) {
+                    persist_and_push_message_with_id(
+                        &session_manager,
+                        &session_config.id,
+                        &mut conversation,
+                        carrier,
+                    )
+                    .await?;
+                }
+
                 let mut stream = crate::agents::reply_parts::stream_response_from_provider(
                     self.provider().await?,
                     model_config.clone(),
@@ -3319,18 +3325,6 @@ impl Agent {
                 if tools_updated {
                     (tools, toolshim_tools, system_prompt, _) =
                         self.prepare_tools_and_prompt(&session_config.id, &session.working_dir).await?;
-                }
-
-                {
-                    let has_new_hints = self
-                        .prompt_manager
-                        .lock()
-                        .await
-                        .load_subdirectory_hints(&working_dir);
-                    if has_new_hints && !tools_updated {
-                        (tools, toolshim_tools, system_prompt, _) =
-                            self.prepare_tools_and_prompt(&session_config.id, &session.working_dir).await?;
-                    }
                 }
 
                 // An empty provider response — no tool calls, no text, and no error

--- a/crates/goose/src/agents/prompt_manager.rs
+++ b/crates/goose/src/agents/prompt_manager.rs
@@ -6,7 +6,7 @@ use serde::Serialize;
 
 use crate::agents::{extension::ExtensionInfo, moim};
 use crate::hints::load_hints::build_gitignore;
-use crate::hints::{get_context_filenames, load_hint_files, SubdirectoryHintTracker};
+use crate::hints::{get_context_filenames, load_hint_files};
 use crate::{
     config::{Config, GooseMode},
     prompt_template,
@@ -18,7 +18,6 @@ pub struct PromptManager {
     system_prompt_override: Option<String>,
     system_prompt_extras: IndexMap<String, String>,
     current_date_timestamp: String,
-    subdirectory_hint_tracker: SubdirectoryHintTracker,
 }
 
 impl Default for PromptManager {
@@ -185,7 +184,6 @@ impl PromptManager {
             // Use the fixed current date time so that prompt cache can be used.
             // Filtering to an hour to balance user time accuracy and multi session prompt cache hits.
             current_date_timestamp: Utc::now().format("%Y-%m-%d %H:00 %:z").to_string(),
-            subdirectory_hint_tracker: SubdirectoryHintTracker::new(),
         }
     }
 
@@ -195,7 +193,6 @@ impl PromptManager {
             system_prompt_override: None,
             system_prompt_extras: IndexMap::new(),
             current_date_timestamp: dt.format("%Y-%m-%d %H:%M:%S %:z").to_string(),
-            subdirectory_hint_tracker: SubdirectoryHintTracker::new(),
         }
     }
 
@@ -209,31 +206,12 @@ impl PromptManager {
         self.system_prompt_extras.shift_remove(key);
     }
 
-    pub fn record_tool_arguments(
-        &mut self,
-        arguments: &Option<serde_json::Map<String, serde_json::Value>>,
-        working_dir: &Path,
-    ) {
-        self.subdirectory_hint_tracker
-            .record_tool_arguments(arguments, working_dir);
-    }
-
-    pub fn load_subdirectory_hints(&mut self, working_dir: &Path) -> bool {
-        let new_hints = self.subdirectory_hint_tracker.load_new_hints(working_dir);
-        let has_new = !new_hints.is_empty();
-        for (key, content) in new_hints {
-            self.system_prompt_extras.insert(key, content);
-        }
-        has_new
-    }
-
     pub fn build_system_prompt(
         &mut self,
         working_dir: &Path,
         prompt_parts: Vec<(String, String)>,
         goose_mode: GooseMode,
     ) -> String {
-        self.load_subdirectory_hints(working_dir);
         self.builder()
             .with_prompt_extras(prompt_parts)
             .with_hints(working_dir)

--- a/crates/goose/src/agents/state_machine/inference_preparation.rs
+++ b/crates/goose/src/agents/state_machine/inference_preparation.rs
@@ -4,6 +4,7 @@
 use crate::agents::ExtensionManager;
 use crate::agents::PromptManager;
 use crate::config::GooseMode;
+use crate::hints::pending_hint_carriers;
 use crate::session::Session;
 use crate::tool_inspection::ToolInspectionManager;
 use anyhow::Result;
@@ -67,7 +68,7 @@ impl InferenceRequestPreparer<Session> for GooseInferenceRequestPreparer<'_> {
             .find(|message| message.is_turn_context())
             .map(Message::as_concat_text);
         let context_limit = Some(self.context_limit);
-        let additional_messages = crate::agents::moim::turn_context_event(
+        let mut additional_messages: Vec<Message> = crate::agents::moim::turn_context_event(
             &session.working_dir,
             context_limit,
             input.moim_parts,
@@ -76,6 +77,10 @@ impl InferenceRequestPreparer<Session> for GooseInferenceRequestPreparer<'_> {
         .filter(|event| Some(event.as_concat_text()) != last)
         .into_iter()
         .collect();
+        additional_messages.extend(pending_hint_carriers(
+            conversation.messages(),
+            &session.working_dir,
+        ));
         Ok(PreparedInferenceRequest {
             system_prompt,
             tools,

--- a/crates/goose/src/agents/state_machine/ops_toolcalling.rs
+++ b/crates/goose/src/agents/state_machine/ops_toolcalling.rs
@@ -22,7 +22,6 @@ use crate::agents::AgentEvent;
 use crate::config::GooseMode;
 use crate::conversation::message::{ActionRequiredData, Message, MessageContent, ToolRequest};
 use crate::conversation::Conversation;
-use crate::hints::load_hints::SubdirectoryHintTracker;
 use crate::hooks::{HookChainOutcome, HookContext, HookEvent, HookManager};
 use crate::session::{EnabledExtensionsState, ExtensionState, Session};
 use std::sync::Arc;
@@ -773,19 +772,9 @@ impl Operation<Session, GooseEffect> for ToolExecutionOperation<'_> {
     async fn prompt_parts(
         &self,
         session: &Session,
-        conversation: &Conversation,
+        _conversation: &Conversation,
     ) -> Result<Vec<(String, String)>> {
-        let mut hints = SubdirectoryHintTracker::new();
-        for message in conversation.messages() {
-            for content in &message.content {
-                if let MessageContent::ToolRequest(request) = content {
-                    if let Ok(tool_call) = &request.tool_call {
-                        hints.record_tool_arguments(&tool_call.arguments, &session.working_dir);
-                    }
-                }
-            }
-        }
-        let mut prompt_parts = hints.load_new_hints(&session.working_dir);
+        let mut prompt_parts = Vec::new();
 
         #[cfg(feature = "code-mode")]
         if self

--- a/crates/goose/src/agents/state_machine/tests/agent_reply.rs
+++ b/crates/goose/src/agents/state_machine/tests/agent_reply.rs
@@ -22,10 +22,12 @@ use crate::agents::{Agent, AgentConfig, AgentEvent, GoosePlatform, SessionConfig
 use crate::config::permission::PermissionManager;
 use crate::config::GooseMode;
 use crate::conversation::message::{ActionRequiredData, Message, MessageContent};
+use crate::hints::hint_carrier_dir;
 use crate::permission::Permission;
 use crate::providers::base::Provider;
 use crate::session::{SessionManager, SessionType};
 use goose_providers::model::ModelConfig;
+use serde_json::json;
 
 async fn agent_with_dummy_api() -> Result<(Agent, Arc<DummyApi>, String, tempfile::TempDir)> {
     let api = Arc::new(DummyApi::start(ProviderFeatures::default()).await);
@@ -527,4 +529,62 @@ async fn bang_shell_visibility_is_enforced_when_state_machine_is_disabled() -> R
 async fn bang_shell_visibility_is_enforced_when_state_machine_is_enabled() -> Result<()> {
     let _guard = env_lock::lock_env([("GOOSE_STATE_MACHINE", Some("1"))]);
     assert_bang_shell_uses_only_user_visible_content().await
+}
+
+async fn assert_subdirectory_hint_is_an_agent_only_message() -> Result<()> {
+    let (agent, api, session_id, _calculator, temp_dir) = agent_with_calculator().await?;
+    agent
+        .update_goose_mode(GooseMode::Auto, &session_id)
+        .await?;
+    let hint = "always run the nested tests before editing";
+    std::fs::create_dir(temp_dir.path().join("nested"))?;
+    std::fs::write(temp_dir.path().join("nested/.goosehints"), hint)?;
+
+    api.on("add one from nested")
+        .call(ADD, json!({ "value": 1, "path": "nested/file.txt" }));
+    api.on("result: 1").reply("done");
+    reply_messages(
+        &agent,
+        session_id.clone(),
+        Message::user().with_text("add one from nested"),
+    )
+    .await?;
+
+    let calls = api.calls();
+    assert_eq!(calls.len(), 2);
+    assert!(!calls[0].input_contains(hint));
+    assert!(calls[1].input_contains(hint));
+    assert!(!calls[1].system_contains(hint));
+    assert_eq!(calls[0].system(), calls[1].system());
+
+    let session_manager = &agent.config.session_manager;
+    let session = session_manager.get_session(&session_id, true).await?;
+    let carriers: Vec<&Message> = session
+        .conversation
+        .as_ref()
+        .unwrap()
+        .messages()
+        .iter()
+        .filter(|message| hint_carrier_dir(message).is_some())
+        .collect();
+    assert_eq!(carriers.len(), 1);
+    assert!(carriers[0].is_agent_visible() && !carriers[0].is_user_visible());
+    assert!(!session_manager
+        .export_session(&session_id)
+        .await?
+        .contains(hint));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn subdirectory_hint_is_an_agent_only_message_when_state_machine_is_disabled() -> Result<()> {
+    let _guard = env_lock::lock_env([("GOOSE_STATE_MACHINE", None::<&str>)]);
+    assert_subdirectory_hint_is_an_agent_only_message().await
+}
+
+#[tokio::test]
+async fn subdirectory_hint_is_an_agent_only_message_when_state_machine_is_enabled() -> Result<()> {
+    let _guard = env_lock::lock_env([("GOOSE_STATE_MACHINE", Some("1"))]);
+    assert_subdirectory_hint_is_an_agent_only_message().await
 }

--- a/crates/goose/src/agents/state_machine/tests/dummy_api.rs
+++ b/crates/goose/src/agents/state_machine/tests/dummy_api.rs
@@ -158,6 +158,10 @@ impl ApiCall {
         request_system(&self.body).contains(needle)
     }
 
+    pub(super) fn system(&self) -> String {
+        request_system(&self.body)
+    }
+
     pub(super) fn advertises_tool(&self, name: &str) -> bool {
         self.body["tools"]
             .as_array()

--- a/crates/goose/src/agents/state_machine/tests/prompt_skill_lifecycle.rs
+++ b/crates/goose/src/agents/state_machine/tests/prompt_skill_lifecycle.rs
@@ -35,8 +35,9 @@ async fn prompt_and_skill_lifecycle() -> Result<()> {
     api.on("result: 1").reply("nested work complete");
     pipeline.run(["work in nested"]).await?;
     let calls = api.calls();
-    assert!(!calls[calls.len() - 2].system_contains("NESTED_PROJECT_INSTRUCTION"));
-    assert!(calls[calls.len() - 1].system_contains("NESTED_PROJECT_INSTRUCTION"));
+    assert!(!calls[calls.len() - 2].input_contains("NESTED_PROJECT_INSTRUCTION"));
+    assert!(calls[calls.len() - 1].input_contains("NESTED_PROJECT_INSTRUCTION"));
+    assert!(!calls[calls.len() - 1].system_contains("NESTED_PROJECT_INSTRUCTION"));
 
     let skill_dir = pipeline.working_dir().join(".agents/skills/review");
     std::fs::create_dir_all(&skill_dir)?;

--- a/crates/goose/src/context_mgmt/mod.rs
+++ b/crates/goose/src/context_mgmt/mod.rs
@@ -3,6 +3,7 @@ pub use goose_context_management::structured;
 use crate::conversation::message::MessageMetadata;
 use crate::conversation::message::{Message, MessageContent};
 use crate::conversation::{merge_consecutive_messages, Conversation};
+use crate::hints::hint_carrier_dir;
 use crate::providers::base::Provider;
 #[cfg(test)]
 use crate::providers::base::{stream_from_single_message, MessageStream};
@@ -92,11 +93,12 @@ pub async fn compact_messages(
         has_text && !has_tool_content
     };
 
-    // Turn-context events are agent-appended, never the message to preserve.
+    // Turn-context events and hint carriers are agent-appended, never the message to preserve.
     let (preserved_user_message, preserved_idx, is_most_recent) = if !manual_compact {
         let found_msg = messages.iter().enumerate().rev().find_map(|(idx, msg)| {
             if !msg.is_agent_visible()
                 || msg.is_turn_context()
+                || hint_carrier_dir(msg).is_some()
                 || !matches!(msg.role, rmcp::model::Role::User)
             {
                 return None;
@@ -119,7 +121,9 @@ pub async fn compact_messages(
         });
 
         if let Some((idx, msg)) = found_msg {
-            let is_last = messages[idx + 1..].iter().all(Message::is_turn_context);
+            let is_last = messages[idx + 1..]
+                .iter()
+                .all(|msg| msg.is_turn_context() || hint_carrier_dir(msg).is_some());
             (Some(msg), Some(idx), is_last)
         } else {
             (None, None, false)
@@ -337,11 +341,11 @@ async fn do_compact(
     session_id: &str,
     messages: &[Message],
 ) -> Result<(Message, ProviderUsage), anyhow::Error> {
-    // Keep stale per-turn state out of the summary.
+    // Turn-context events and hint carriers are re-derived after compaction.
     let agent_visible_messages = Conversation::new_unvalidated(
         messages
             .iter()
-            .filter(|msg| !msg.is_turn_context())
+            .filter(|msg| !msg.is_turn_context() && hint_carrier_dir(msg).is_none())
             .cloned(),
     )
     .agent_visible_messages();

--- a/crates/goose/src/hints/load_hints.rs
+++ b/crates/goose/src/hints/load_hints.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use crate::config::paths::Paths;
+use crate::conversation::message::{Message, MessageContent, MessageMetadata};
 use crate::hints::import_files::read_referenced_files;
 
 pub const GOOSE_HINTS_FILENAME: &str = ".goosehints";
@@ -69,7 +70,11 @@ impl SubdirectoryHintTracker {
         }
     }
 
-    pub fn load_new_hints(&mut self, working_dir: &Path) -> Vec<(String, String)> {
+    pub fn mark_loaded(&mut self, dir: PathBuf) {
+        self.loaded_dirs.insert(dir);
+    }
+
+    pub fn load_new_hints(&mut self, working_dir: &Path) -> Vec<(PathBuf, String)> {
         let pending = std::mem::take(&mut self.pending_dirs);
         if pending.is_empty() {
             return Vec::new();
@@ -93,13 +98,62 @@ impl SubdirectoryHintTracker {
             if let Some(content) =
                 load_hints_from_directory(&dir, &working_dir, &self.hints_filenames)
             {
-                let key = format!("subdir_hints:{}", dir.display());
-                results.push((key, content));
+                results.push((dir.clone(), content));
             }
             self.loaded_dirs.insert(dir);
         }
         results
     }
+}
+
+const HINT_CARRIER_OPERATION: &str = "subdir_hints";
+const HINT_CARRIER_DIR_NOTE: &str = "dir";
+
+/// Agent-only messages announcing hints from subdirectories that tool calls
+/// touched and no agent-visible carrier has announced yet.
+pub fn pending_hint_carriers(messages: &[Message], working_dir: &Path) -> Vec<Message> {
+    let mut tracker = SubdirectoryHintTracker::new();
+    for message in messages {
+        if message.is_agent_visible() {
+            if let Some(dir) = hint_carrier_dir(message) {
+                tracker.mark_loaded(dir);
+            }
+        }
+        for content in &message.content {
+            if let MessageContent::ToolRequest(request) = content {
+                if let Ok(tool_call) = &request.tool_call {
+                    tracker.record_tool_arguments(&tool_call.arguments, working_dir);
+                }
+            }
+        }
+    }
+    tracker
+        .load_new_hints(working_dir)
+        .into_iter()
+        .map(|(dir, content)| hint_carrier(&dir, &content))
+        .collect()
+}
+
+pub(crate) fn hint_carrier(dir: &Path, content: &str) -> Message {
+    let mut metadata = MessageMetadata::agent_only();
+    metadata.set_operation_note(
+        HINT_CARRIER_OPERATION,
+        HINT_CARRIER_DIR_NOTE,
+        serde_json::Value::String(dir.to_string_lossy().into_owned()),
+    );
+    Message::user()
+        .with_text(format!(
+            "<subdirectory-hints>\n{content}\n</subdirectory-hints>"
+        ))
+        .with_metadata(metadata)
+}
+
+pub fn hint_carrier_dir(message: &Message) -> Option<PathBuf> {
+    message
+        .metadata
+        .operation_note(HINT_CARRIER_OPERATION, HINT_CARRIER_DIR_NOTE)?
+        .as_str()
+        .map(PathBuf::from)
 }
 
 fn resolve_to_parent_dir(token: &str, working_dir: &Path) -> Option<PathBuf> {
@@ -833,7 +887,7 @@ End of hints"#;
         tracker.record_tool_arguments(&Some(args), &project_root);
         let hints = tracker.load_new_hints(&project_root);
         assert_eq!(hints.len(), 1);
-        assert!(hints[0].0.contains("nested"));
+        assert!(hints[0].0.ends_with("nested"));
         assert!(hints[0].1.contains("nested subdirectory hints"));
     }
 

--- a/crates/goose/src/hints/mod.rs
+++ b/crates/goose/src/hints/mod.rs
@@ -2,6 +2,6 @@ mod import_files;
 pub mod load_hints;
 
 pub use load_hints::{
-    build_gitignore, get_context_filenames, load_hint_files, SubdirectoryHintTracker,
-    AGENTS_MD_FILENAME, GOOSE_HINTS_FILENAME,
+    build_gitignore, get_context_filenames, hint_carrier_dir, load_hint_files,
+    pending_hint_carriers, SubdirectoryHintTracker, AGENTS_MD_FILENAME, GOOSE_HINTS_FILENAME,
 };

--- a/crates/goose/src/session/session_manager.rs
+++ b/crates/goose/src/session/session_manager.rs
@@ -2,6 +2,7 @@ use crate::config::paths::Paths;
 use crate::config::GooseMode;
 use crate::conversation::message::{Message, MessageUsage, TokenState};
 use crate::conversation::Conversation;
+use crate::hints::hint_carrier_dir;
 use crate::providers::base::CostSource;
 use crate::providers::base::Provider;
 use crate::recipe::Recipe;
@@ -2457,7 +2458,14 @@ impl SessionStorage {
     }
 
     async fn export_session(&self, id: &str) -> Result<String> {
-        let session = self.get_session(id, true).await?;
+        let mut session = self.get_session(id, true).await?;
+        session.conversation = session.conversation.map(|conversation| {
+            Conversation::new_unvalidated(
+                conversation
+                    .into_iter()
+                    .filter(|message| hint_carrier_dir(message).is_none()),
+            )
+        });
         serde_json::to_string_pretty(&session).map_err(Into::into)
     }
 

--- a/documentation/docs/guides/context-engineering/using-goosehints.md
+++ b/documentation/docs/guides/context-engineering/using-goosehints.md
@@ -76,7 +76,7 @@ The `.goosehints` file can include any instructions or contextual details releva
 
 The `.goosehints` file supports natural language. Write clear, specific instructions using direct language that goose can easily understand and follow. Include relevant context about your project and workflow preferences, and prioritize your most important guidelines first.
 
-goose loads hints at the start of your session. As it accesses files in nested directories, it also loads the hint files for those directories. goose adds hints to the system prompt for every request. Because `.goosehints` content uses tokens, keeping it concise can reduce cost and improve performance.
+goose loads hints at the start of your session and adds them to the system prompt for every request. As it accesses files in nested directories, it also loads the hint files for those directories and appends them to the conversation as a message the model sees but you do not, so the system prompt stays unchanged mid-session. Because `.goosehints` content uses tokens, keeping it concise can reduce cost and improve performance.
 
 ### Example Global `.goosehints` File
 


### PR DESCRIPTION
Closes #10330
Part of #11800

## Summary

Subdirectory hints (`.goosehints` / `AGENTS.md` found when a tool call first touches a new directory) are now appended to the conversation as an agent-visible, user-invisible message right after that tool result, instead of being injected into the system prompt.

- The system prompt no longer changes mid-session, so the cached prefix survives hint discovery.
- Both loops (legacy and `GOOSE_STATE_MACHINE=1`) go through one shared function.
- No in-memory state. Pending hints are derived from the stored conversation on every inference: directories touched by tool requests, minus directories already announced by a visible carrier. Resume and compaction fall out of that for free.
- Compaction never picks a carrier as the preserved user prompt and keeps carriers out of the summary (same rule as turn-context events); the hidden carrier is simply re-derived on the next inference.
- Session export strips carriers.
- The persistable message merge keeps messages with different operation notes apart, so two adjacent carriers keep their identities.
- Session-start hints for the working directory stay in the system prompt.

Supersedes #11284. Credit to iroiro147 for the original work; this is the shape DOsinga proposed there.