### PR TITLE
feat(providers): add llmman as a declarative Ollama-compatible provider

### DIFF
--- a/crates/goose-providers/src/declarative.rs
+++ b/crates/goose-providers/src/declarative.rs
@@ -28,6 +28,7 @@ pub(crate) mod declarative_providers {
         iflytek_astron,
         inception,
         llama_swap,
+        llmman,
         lmstudio,
         lynkr,
         meta,

--- a/crates/goose-providers/src/declarative/definitions/llmman.json
+++ b/crates/goose-providers/src/declarative/definitions/llmman.json
@@ -1,0 +1,35 @@
+{
+  "name": "llmman",
+  "engine": "ollama",
+  "display_name": "llmman",
+  "description": "Run local models pulled as OCI artifacts from any container registry with llmman",
+  "api_key_env": "",
+  "base_url": "${LLMMAN_HOST}",
+  "env_vars": [
+    {
+      "name": "LLMMAN_HOST",
+      "required": false,
+      "secret": false,
+      "primary": true,
+      "default": "http://localhost:17434",
+      "description": "Base URL of the llmman server (default: http://localhost:17434)"
+    }
+  ],
+  "dynamic_models": true,
+  "models": [],
+  "supports_streaming": true,
+  "requires_auth": false,
+  "skip_canonical_filtering": true,
+  "setup": {
+    "category": "model",
+    "setup_method": "config_fields",
+    "group": "additional",
+    "docs_url": "https://github.com/llmmanorg/llmman",
+    "field_overrides": [{
+      "key": "LLMMAN_HOST",
+      "label": "Host URL",
+      "placeholder": "http://localhost:17434",
+      "default_value": "http://localhost:17434"
+    }]
+  }
+}

--- a/crates/goose/src/providers/init.rs
+++ b/crates/goose/src/providers/init.rs
@@ -347,6 +347,21 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_llmman_provider_registry_wiring() {
+        let llmman = get_from_registry("llmman")
+            .await
+            .expect("llmman provider should be registered");
+        let meta = llmman.metadata();
+
+        assert_eq!(meta.name, "llmman");
+        assert_eq!(meta.display_name, "llmman");
+        assert!(meta.config_keys.iter().all(|key| !key.secret));
+        assert!(meta.config_keys.iter().any(|key| {
+            key.name == "LLMMAN_HOST" && key.default.as_deref() == Some("http://localhost:17434")
+        }));
+    }
+
+    #[tokio::test]
     async fn test_gondola_provider_registry_wiring() {
         let gondola = get_from_registry("gondola")
             .await

--- a/documentation/docs/getting-started/providers.md
+++ b/documentation/docs/getting-started/providers.md
@@ -44,6 +44,7 @@ goose is compatible with a wide range of LLM providers, allowing you to choose a
 | [iFlytek Spark](https://www.xfyun.cn/doc/spark/HTTP%E8%B0%83%E7%94%A8%E6%96%87%E6%A1%A3.html) | iFlytek Spark (讯飞星火) models (4.0Ultra, generalv3.5, max-32k) via the OpenAI-compatible HTTP API. Best for chat: Spark needs `tool_calls_switch=true` (not injectable here) to return OpenAI-style tool calls. | `SPARK_API_PASSWORD` |
 | [iFlytek Astron MaaS](https://maas.xfyun.cn/)                               | iFlytek Astron MaaS (讯飞星辰) hosting Spark X2, DeepSeek, GLM, Kimi, MiniMax, Qwen, and Astron coding models via an OpenAI-compatible API. Set `ASTRON_BASE_URL` to switch between the Token Plan and Coding Plan endpoints. | `ASTRON_API_KEY`, `ASTRON_BASE_URL` (optional) |
 | [LiteLLM](https://docs.litellm.ai/docs/) | LiteLLM proxy supporting multiple models with automatic prompt caching and unified API access. | `LITELLM_HOST`, `LITELLM_BASE_PATH` (optional), `LITELLM_API_KEY` (optional), `LITELLM_CUSTOM_HEADERS` (optional), `LITELLM_TIMEOUT` (optional) |
+| [llmman](https://github.com/llmmanorg/llmman)                              | Local model runner that pulls models as [OCI](https://opencontainers.org/) artifacts ([CNCF ModelPack](https://github.com/modelpack/model-spec)) from any container registry and serves them over the Ollama API. **Because this provider runs locally, you must first [pull a model](#local-llms).** | None required. Connects to local server at `localhost:17434` by default.                                                                                                            |
 | [LM Studio](https://lmstudio.ai/)                                          | Run local models with LM Studio's OpenAI-compatible server. **Because this provider runs locally, you must first [download a model](#local-llms).**                                                           | None required. Connects to local server at `localhost:1234` by default.                                                                                                             |
 | [Meta](https://dev.meta.ai/)                                                | Meta's Model API, home of the Muse Spark models.                                                                                                                                | `META_MODEL_API_KEY`                                                                                                                                                                |
 | [Mistral AI](https://mistral.ai/)                                           | Provides access to Mistral models including general-purpose models, specialized coding models (Codestral), and multimodal models (Pixtral).                                                                   | `MISTRAL_API_KEY`                                                                                                 |
@@ -1357,6 +1358,61 @@ Here are some local providers we support:
 
     :::tip Model Name
     Make sure the model name you enter in goose matches the model identifier shown in LM Studio's server panel.
+    :::
+  </TabItem>
+  <TabItem value="llmman" label="llmman">
+    [llmman](https://github.com/llmmanorg/llmman) runs models pulled as OCI artifacts from any container registry and exposes an Ollama-compatible API. Model identifiers are registry references, so the models available are whatever you have pulled.
+
+    1. [Install llmman](https://github.com/llmmanorg/llmman#install).
+    2. Pull a model that supports tool calling, for example:
+        ```sh
+        llmman pull qwen3.8
+        ```
+        Short names resolve to Docker Hub's `ai/` namespace; full references such as `ghcr.io/org/model:tag` or `hf.co/owner/repo` also work.
+    3. Start the server. It listens on `http://localhost:17434` by default:
+        ```sh
+        llmman serve
+        ```
+    4. Configure goose to use llmman:
+
+    <Tabs groupId="interface">
+      <TabItem value="ui" label="goose Desktop" default>
+        1. Click the <PanelLeft className="inline" size={16} /> button in the top-left to open the sidebar.
+        2. Click the `Settings` button on the sidebar.
+        3. Click the `Models` tab.
+        4. Click `Configure providers`.
+        5. Choose `llmman` from the provider list and click `Configure`.
+        6. Click `Submit` (no API key is needed).
+        7. Select a model you have pulled.
+      </TabItem>
+      <TabItem value="cli" label="goose CLI">
+        1. Run:
+        ```sh
+        goose configure
+        ```
+        2. Select `Configure Providers` from the menu.
+        3. Choose `llmman` as the provider.
+        4. Enter the model reference you pulled.
+
+        ```
+        ┌   goose-configure
+        │
+        ◇  What would you like to configure?
+        │  Configure Providers
+        │
+        ◇  Which model provider should we use?
+        │  llmman
+        │
+        ◇  Enter a model from that provider:
+        │  qwen3.8
+        │
+        └  Configuration saved successfully
+        ```
+      </TabItem>
+    </Tabs>
+
+    :::tip Host
+    If `llmman serve` listens on a different address, set `LLMMAN_HOST` in goose to match (scheme, host, and port only).
     :::
   </TabItem>
   <TabItem value="atomic-chat" label="Atomic Chat">


### PR DESCRIPTION
Fixes: #11692

## Summary

Adds `llmman` as a declarative provider, per the scope agreed in #11692: a single JSON definition defaulting the host to `http://localhost:17434`, no API key, dynamic model discovery.

[llmman](https://github.com/llmmanorg/llmman) pulls models as OCI artifacts from any container registry and serves them locally over the Ollama API, so the definition uses `engine: "ollama"`. The only difference from the built-in Ollama provider is the port. Models are discovered via `/api/tags` and identified by registry reference (e.g. `qwen3.8`, `hf.co/owner/repo`), resolved server-side. No new crate dependency.

### Testing

- `cargo fmt` and `cargo clippy -p goose-providers -p goose --all-targets -- -D warnings` clean
- `cargo test -p goose-providers declarative` and `cargo test -p goose provider_registry_wiring` pass, including the new `test_llmman_provider_registry_wiring`
- Manual end-to-end against a live `llmman serve`: `GOOSE_PROVIDER=llmman GOOSE_MODEL=qwen3.5:0.8b goose run --no-session --text "Reply with exactly the word: pong"` returns `pong`

### Related Issues
Discussion: https://github.com/aaif-goose/goose/issues/11692
