### PR TITLE
fix: stop mapping Astra Off to reasoning.effort none

### DIFF
--- a/crates/goose-provider-types/src/formats/openai.rs
+++ b/crates/goose-provider-types/src/formats/openai.rs
@@ -1929,7 +1929,6 @@ pub(crate) fn openai_reasoning_efforts_for_model(model_name: &str) -> &'static [
             || normalized.contains("gpt-5-5")
             || normalized.contains("gpt-5.6")
             || normalized.contains("gpt-5-6")
-            || normalized.contains("gpt-6")
         {
             &["none", "low", "medium", "high", "xhigh"]
         } else {
@@ -3284,6 +3283,43 @@ mod tests {
         assert!(obj.get("thinking_effort").is_none());
 
         Ok(())
+    }
+
+    #[test]
+    fn test_openai_reasoning_effort_gpt6_does_not_support_none() {
+        for model in [
+            "gpt-6-astra",
+            "data_workflow_tools.goose.goose-gpt-6-astra",
+            "openrouter/openai/gpt-6-astra",
+        ] {
+            assert_eq!(
+                openai_reasoning_effort_for_thinking(model, ThinkingEffort::Off),
+                Some("low".to_string()),
+                "{model} Off should map to low, not none"
+            );
+            assert_eq!(
+                openai_reasoning_effort_for_thinking(model, ThinkingEffort::Medium),
+                Some("medium".to_string()),
+                "{model} medium should remain medium"
+            );
+            assert!(
+                !openai_reasoning_efforts_for_model(model).contains(&"none"),
+                "{model} must not advertise none"
+            );
+        }
+
+        assert_eq!(
+            openai_reasoning_effort_for_thinking("gpt-5.6-luna", ThinkingEffort::Off),
+            Some("none".to_string())
+        );
+        assert_eq!(
+            openai_reasoning_effort_for_thinking("gpt-5.4", ThinkingEffort::Off),
+            Some("none".to_string())
+        );
+        assert_eq!(
+            openai_reasoning_effort_for_thinking("gpt-5", ThinkingEffort::Off),
+            Some("low".to_string())
+        );
     }
 
     #[test]

--- a/crates/goose-provider-types/src/formats/openai_responses.rs
+++ b/crates/goose-provider-types/src/formats/openai_responses.rs
@@ -2042,10 +2042,7 @@ mod tests {
 
     #[test]
     fn test_responses_request_gpt6_astra_off_uses_low_not_none() {
-        for model_name in [
-            "gpt-6-astra",
-            "data_workflow_tools.goose.goose-gpt-6-astra",
-        ] {
+        for model_name in ["gpt-6-astra", "data_workflow_tools.goose.goose-gpt-6-astra"] {
             let model_config = ModelConfig::new(model_name)
                 .with_thinking_effort(crate::thinking::ThinkingEffort::Off);
 

--- a/crates/goose-provider-types/src/formats/openai_responses.rs
+++ b/crates/goose-provider-types/src/formats/openai_responses.rs
@@ -2041,6 +2041,31 @@ mod tests {
     }
 
     #[test]
+    fn test_responses_request_gpt6_astra_off_uses_low_not_none() {
+        for model_name in [
+            "gpt-6-astra",
+            "data_workflow_tools.goose.goose-gpt-6-astra",
+        ] {
+            let model_config = ModelConfig::new(model_name)
+                .with_thinking_effort(crate::thinking::ThinkingEffort::Off);
+
+            let result =
+                create_responses_request(&model_config, "You are helpful.", &[], &[]).unwrap();
+
+            assert_eq!(result["model"], model_name, "{model_name}");
+            assert_eq!(
+                result["reasoning"]["effort"], "low",
+                "{model_name} Off should serialize as low, not none"
+            );
+        }
+
+        let model_config = ModelConfig::new("gpt-5.6-luna")
+            .with_thinking_effort(crate::thinking::ThinkingEffort::Off);
+        let result = create_responses_request(&model_config, "You are helpful.", &[], &[]).unwrap();
+        assert_eq!(result["reasoning"]["effort"], "none");
+    }
+
+    #[test]
     fn test_responses_request_supports_gpt_5_6_reasoning_mode() {
         for model_name in [
             "gpt-5.6-sol",


### PR DESCRIPTION
Fixes: #11971

## Summary

Astra session naming turns thinking off, and Goose sent `reasoning.effort: "none"` because every `gpt-6*` id shared the GPT-5.6 effort table. Astra rejects that with HTTP 400 and the chat keeps the default title.

Drop `gpt-6` from that table so Astra Off maps to `low`. GPT-5.6 still gets `none`. The responses request is the path that was 400ing.

## Test plan

- [x] `cargo test -p goose-provider-types --lib gpt6`
- [x] `cargo test -p goose-provider-types --lib` (602 passed)
