### PR TITLE
feat(gateway): operator allowlist for who can pair

### DIFF
--- a/crates/goose-cli/src/cli.rs
+++ b/crates/goose-cli/src/cli.rs
@@ -2345,7 +2345,10 @@ async fn handle_gateway_command(command: GatewayCommand) -> Result<()> {
             gateway_type,
             bot_token,
         } => {
-            let platform_config = serde_json::json!({ "bot_token": bot_token });
+            let mut platform_config = serde_json::json!({ "bot_token": bot_token });
+            if let Some(ids) = goose::gateway::manager::saved_allowed_user_ids(&gateway_type) {
+                platform_config["allowed_user_ids"] = serde_json::json!(ids);
+            }
             gateway::handle_gateway_start(gateway_type, platform_config).await
         }
         GatewayCommand::Stop { gateway_type } => gateway::handle_gateway_stop(gateway_type).await,

--- a/crates/goose/src/gateway/handler.rs
+++ b/crates/goose/src/gateway/handler.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
@@ -60,6 +60,8 @@ pub struct GatewayHandler {
     turn_locks: PerUserLocks,
     /// Serializes confirmation replies without waiting for the active turn to finish.
     confirmation_reply_locks: PerUserLocks,
+    /// When set, only platform user IDs in this list may enter the pairing flow.
+    allowed_user_ids: Option<HashSet<String>>,
 }
 
 impl GatewayHandler {
@@ -69,6 +71,7 @@ impl GatewayHandler {
         gateway: Arc<dyn Gateway>,
         config: GatewayConfig,
     ) -> Self {
+        let allowed_user_ids = allowed_user_ids_from_config(&config);
         Self {
             agent_manager,
             pairing_store,
@@ -77,6 +80,7 @@ impl GatewayHandler {
             pending_confirmations: Arc::new(Mutex::new(HashMap::new())),
             turn_locks: Arc::new(Mutex::new(HashMap::new())),
             confirmation_reply_locks: Arc::new(Mutex::new(HashMap::new())),
+            allowed_user_ids,
         }
     }
 
@@ -121,6 +125,15 @@ impl GatewayHandler {
     }
 
     pub async fn handle_message(&self, message: IncomingMessage) -> anyhow::Result<()> {
+        if !is_user_allowed(&self.allowed_user_ids, &message.user) {
+            tracing::info!(
+                platform = %message.user.platform,
+                user_id = %message.user.user_id,
+                "gateway allowlist denied unlisted user"
+            );
+            return Ok(());
+        }
+
         let pairing = self.pairing_store.get(&message.user).await?;
 
         match pairing {
@@ -825,6 +838,34 @@ fn gateway_working_dir(platform: &str, user_id: &str) -> PathBuf {
         .join(user_id)
 }
 
+/// Operator-configured list of platform user IDs that may pair with the gateway,
+/// read from `platform_config.allowed_user_ids`. An absent or empty list keeps
+/// the default behavior of letting anyone attempt pairing.
+fn allowed_user_ids_from_config(config: &GatewayConfig) -> Option<HashSet<String>> {
+    let ids: HashSet<String> = config.platform_config["allowed_user_ids"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter_map(|id| {
+            id.as_str()
+                .map(ToOwned::to_owned)
+                .or_else(|| id.as_u64().map(|n| n.to_string()))
+        })
+        .collect();
+    if ids.is_empty() {
+        None
+    } else {
+        Some(ids)
+    }
+}
+
+fn is_user_allowed(allowed: &Option<HashSet<String>>, user: &PlatformUser) -> bool {
+    match allowed {
+        None => true,
+        Some(ids) => ids.contains(&user.user_id),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -850,5 +891,54 @@ mod tests {
     #[test]
     fn gateway_override_used_when_global_unset() {
         assert_eq!(resolve_gateway_max_turns(Some(25), None), 25);
+    }
+
+    fn platform_user(user_id: &str) -> PlatformUser {
+        PlatformUser {
+            platform: "telegram".to_string(),
+            user_id: user_id.to_string(),
+            display_name: None,
+        }
+    }
+
+    fn config_with_platform(platform_config: serde_json::Value) -> GatewayConfig {
+        GatewayConfig {
+            gateway_type: "telegram".to_string(),
+            platform_config,
+            max_sessions: 1,
+        }
+    }
+
+    #[test]
+    fn allowlist_absent_or_empty_allows_everyone() {
+        for platform_config in [
+            serde_json::json!({}),
+            serde_json::json!({"allowed_user_ids": []}),
+        ] {
+            let allowed = allowed_user_ids_from_config(&config_with_platform(platform_config));
+            assert!(allowed.is_none());
+            assert!(is_user_allowed(&allowed, &platform_user("999999")));
+        }
+    }
+
+    #[test]
+    fn allowlist_admits_listed_and_blocks_unlisted_users() {
+        let config = config_with_platform(serde_json::json!({"allowed_user_ids": ["111", 222]}));
+        let allowed = allowed_user_ids_from_config(&config).expect("allowlist should be set");
+        assert_eq!(allowed.len(), 2);
+        assert!(is_user_allowed(
+            &Some(allowed.clone()),
+            &platform_user("111")
+        ));
+        assert!(is_user_allowed(&Some(allowed), &platform_user("222")));
+
+        let allowed = allowed_user_ids_from_config(&config).expect("allowlist should be set");
+        assert!(!is_user_allowed(&Some(allowed), &platform_user("333")));
+    }
+
+    #[test]
+    fn allowlist_ignores_non_id_values() {
+        let config = config_with_platform(serde_json::json!({"allowed_user_ids": [true, null]}));
+        assert!(allowed_user_ids_from_config(&config).is_none());
     }
 }

--- a/crates/goose/src/gateway/manager.rs
+++ b/crates/goose/src/gateway/manager.rs
@@ -23,6 +23,39 @@ fn secret_key_for(gateway_type: &str) -> String {
 struct SavedGatewayEntry {
     gateway_type: String,
     max_sessions: usize,
+    #[serde(default)]
+    allowed_user_ids: Option<Vec<String>>,
+}
+
+/// Extract the operator allowlist from a platform_config value, if present.
+fn allowed_user_ids_from_platform_config(
+    platform_config: &serde_json::Value,
+) -> Option<Vec<String>> {
+    platform_config
+        .get("allowed_user_ids")
+        .and_then(|v| v.as_array())
+        .map(|ids| {
+            ids.iter()
+                .filter_map(|id| {
+                    id.as_str()
+                        .map(ToOwned::to_owned)
+                        .or_else(|| id.as_u64().map(|n| n.to_string()))
+                })
+                .collect()
+        })
+        .filter(|ids: &Vec<String>| !ids.is_empty())
+}
+
+/// Operator allowlist saved for a gateway type, if any.
+pub fn saved_allowed_user_ids(gateway_type: &str) -> Option<Vec<String>> {
+    let entries: Vec<SavedGatewayEntry> = match Config::global().get_param(GATEWAY_CONFIGS_KEY) {
+        Ok(entries) => entries,
+        Err(_) => return None,
+    };
+    entries
+        .into_iter()
+        .find(|entry| entry.gateway_type == gateway_type)
+        .and_then(|entry| entry.allowed_user_ids)
 }
 
 #[allow(dead_code)]
@@ -344,6 +377,11 @@ impl GatewayManager {
                     }
                 };
 
+            let mut platform_config = platform_config;
+            if let Some(ids) = &entry.allowed_user_ids {
+                platform_config["allowed_user_ids"] = serde_json::json!(ids);
+            }
+
             configs.push(GatewayConfig {
                 gateway_type: entry.gateway_type,
                 platform_config,
@@ -372,6 +410,7 @@ impl GatewayManager {
         entries.push(SavedGatewayEntry {
             gateway_type: gw_config.gateway_type.clone(),
             max_sessions: gw_config.max_sessions,
+            allowed_user_ids: allowed_user_ids_from_platform_config(&gw_config.platform_config),
         });
 
         config


### PR DESCRIPTION
Fixes #11906

Adds an optional `allowed_user_ids` list to gateway `platform_config`. When the list is present and non-empty, messages from unlisted platform user IDs are dropped before the pairing flow starts: no reply is sent, no pairing state is written, and an info log records the rejected attempt. An absent or empty list keeps current behavior, so existing configs are unaffected.

Details:
- The check runs at the top of `GatewayHandler::handle_message`, before the pairing lookup, so it also applies to already-paired users. Removing an ID from the list revokes that user's access.
- IDs are matched as strings; both string and numeric JSON values are accepted.
- `goose gateway start` re-reads the saved allowlist from `gateway_configs` so the setting survives restarts.

Verification:
- `cargo check -p goose` and `cargo fmt --check` pass on current main.
- Unit tests cover the absent/empty list allowing everyone, listed users being admitted while unlisted ones are blocked, and non-ID JSON values being ignored.
- Full build and test run happen in CI on this PR.