### PR TITLE
fix: retry provider restore instead of caching provider-less agents

### DIFF
--- a/crates/goose/src/execution/manager.rs
+++ b/crates/goose/src/execution/manager.rs
@@ -202,6 +202,7 @@ impl AgentManager {
         config.session_name_update_tx = runtime_context.session_name_update_tx;
         let agent = Arc::new(Agent::with_config(config));
         let mut extension_results = Vec::new();
+        let mut provider_restore_error = None;
 
         if let Ok(session) = self
             .agent_config
@@ -223,6 +224,7 @@ impl AgentManager {
                         session_id,
                         error
                     );
+                    provider_restore_error = Some(error);
                 }
             }
             extension_results = agent.load_extensions_from_session(&session).await;
@@ -255,6 +257,18 @@ impl AgentManager {
                     .update_mode(session_id, mode)
                     .await
                     .map_err(|e| anyhow::anyhow!("Failed to propagate mode to provider: {}", e))?;
+            }
+        }
+
+        // A session whose record names a provider must not be cached with a
+        // provider-less agent: the cache fast path would keep returning the
+        // broken agent, so every subsequent load fails with "Provider not
+        // set" until the process restarts — even after the underlying issue
+        // (e.g. expired cloud credentials) is fixed.  Surface the restore
+        // error instead so the next attempt runs the restore again.
+        if agent.provider().await.is_err() {
+            if let Some(error) = provider_restore_error {
+                return Err(error);
             }
         }
 
@@ -705,6 +719,135 @@ mod tests {
         assert!(
             !manager.has_session(&session_id).await,
             "failed creation must not insert into the LRU cache"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_failed_provider_restore_is_not_cached_and_can_recover() {
+        // Regression test: a session whose record names a provider used to
+        // be cached with a provider-less agent when the provider could not
+        // be recreated (e.g. expired cloud credentials).  The cache fast
+        // path then returned the broken agent forever, so every session
+        // load failed with "Provider not set" until the process restarted —
+        // even after the credentials were fixed.
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        use async_trait::async_trait;
+        use futures::future::BoxFuture;
+        use rmcp::model::Tool;
+
+        use crate::conversation::message::Message;
+        use crate::providers::base::{
+            MessageStream, Provider, ProviderDef, ProviderDescriptor, ProviderMetadata,
+        };
+        use goose_providers::conversation::token_usage::{ProviderUsage, Usage};
+        use goose_providers::model::ModelConfig;
+
+        const PROVIDER_NAME: &str = "restore-failure-test-provider";
+        static CREATION_FAILS: AtomicBool = AtomicBool::new(true);
+
+        struct StubProvider;
+
+        #[async_trait]
+        impl Provider for StubProvider {
+            fn get_name(&self) -> &str {
+                PROVIDER_NAME
+            }
+
+            async fn stream(
+                &self,
+                _model_config: &ModelConfig,
+                _system: &str,
+                _messages: &[Message],
+                _tools: &[Tool],
+            ) -> std::result::Result<MessageStream, goose_providers::errors::ProviderError>
+            {
+                Ok(crate::providers::base::stream_from_single_message(
+                    Message::assistant().with_text("unused"),
+                    ProviderUsage::new(PROVIDER_NAME.into(), Usage::default()),
+                ))
+            }
+        }
+
+        struct RestoreFailureProviderDef;
+
+        impl ProviderDescriptor for RestoreFailureProviderDef {
+            fn metadata() -> ProviderMetadata {
+                ProviderMetadata::new(
+                    PROVIDER_NAME,
+                    "Restore Failure Test",
+                    "Test-only provider whose creation can be toggled to fail",
+                    "test-model",
+                    vec!["test-model"],
+                    "",
+                    vec![],
+                )
+            }
+        }
+
+        impl ProviderDef for RestoreFailureProviderDef {
+            type Provider = StubProvider;
+
+            fn from_env(
+                _extensions: Vec<crate::config::ExtensionConfig>,
+                _tls_config: Option<crate::providers::api_client::TlsConfig>,
+            ) -> BoxFuture<'static, anyhow::Result<StubProvider>> {
+                Box::pin(async {
+                    if CREATION_FAILS.load(Ordering::SeqCst) {
+                        Err(anyhow::anyhow!("credentials expired"))
+                    } else {
+                        Ok(StubProvider)
+                    }
+                })
+            }
+        }
+
+        crate::providers::register_provider_for_tests::<RestoreFailureProviderDef>().await;
+
+        let temp_dir = TempDir::new().unwrap();
+        let manager = create_test_manager(&temp_dir).await;
+
+        let session = manager
+            .session_manager()
+            .create_session(
+                temp_dir.path().to_path_buf(),
+                "restore-failure".into(),
+                crate::session::SessionType::User,
+                GooseMode::default(),
+            )
+            .await
+            .unwrap();
+        manager
+            .session_manager()
+            .update(&session.id)
+            .provider_name(PROVIDER_NAME)
+            .model_config(ModelConfig::new("test-model"))
+            .apply()
+            .await
+            .unwrap();
+
+        CREATION_FAILS.store(true, Ordering::SeqCst);
+        let result = manager.get_or_create_agent(session.id.clone()).await;
+        assert!(
+            result.is_err(),
+            "failed provider restore must propagate instead of caching a provider-less agent"
+        );
+        assert!(
+            !manager.has_session(&session.id).await,
+            "session with failed provider restore must not be cached"
+        );
+
+        // Simulate the user fixing the underlying issue (e.g. re-running
+        // `aws sso login`): the next attempt must run the restore again and
+        // succeed without a process restart.
+        CREATION_FAILS.store(false, Ordering::SeqCst);
+        let agent = manager
+            .get_or_create_agent(session.id.clone())
+            .await
+            .expect("retry after fixing credentials must succeed");
+        assert!(
+            agent.provider().await.is_ok(),
+            "retry must restore the session provider"
         );
     }
 

--- a/crates/goose/src/gateway/handler.rs
+++ b/crates/goose/src/gateway/handler.rs
@@ -482,7 +482,20 @@ impl GatewayHandler {
                     .await?;
                 return Ok(());
             }
-            Err(error) => return Err(error),
+            Err(error) => {
+                // Agent creation also fails when the session's provider
+                // cannot be restored (e.g. expired credentials); tell the
+                // user instead of dropping their message silently.
+                self.gateway
+                    .send_message(
+                        &message.user,
+                        OutgoingMessage::Text {
+                            body: format!("⚠️ Failed to load session: {error}"),
+                        },
+                    )
+                    .await?;
+                return Err(error);
+            }
         };
 
         // Re-read the session after sync so restore picks up the new values.

--- a/crates/goose/src/providers/init.rs
+++ b/crates/goose/src/providers/init.rs
@@ -250,6 +250,14 @@ pub async fn refresh_custom_providers() -> Result<()> {
     Ok(())
 }
 
+#[cfg(test)]
+pub(crate) async fn register_provider_for_tests<F>()
+where
+    F: super::base::ProviderDef + 'static,
+{
+    get_registry().await.write().unwrap().register::<F>(false);
+}
+
 pub async fn get_from_registry(name: &str) -> Result<ProviderEntry> {
     let guard = get_registry().await.read().unwrap();
     guard

--- a/crates/goose/src/providers/mod.rs
+++ b/crates/goose/src/providers/mod.rs
@@ -98,6 +98,8 @@ pub mod utils;
 pub mod xai;
 pub mod xai_oauth;
 
+#[cfg(test)]
+pub(crate) use init::register_provider_for_tests;
 pub use init::{
     cleanup_provider, create, create_with_default_model, create_with_named_model,
     create_with_working_dir, get_from_registry, inventory_identity, providers,


### PR DESCRIPTION
Fixes: #11981

## Summary

When a session's saved provider cannot be recreated (e.g. AWS Bedrock with an expired SSO token), `AgentManager::create_agent_locked` used to log a warning and cache the agent **without a provider**. The cache fast path then returned that broken agent forever: every subsequent `session/load` failed with the opaque `Provider not set` until the daemon was restarted — even after the user fixed their credentials and retried.

This PR propagates the restore error instead of caching a provider-less agent, when the session record names a provider and no default-provider fallback rescued it:

- the user sees the actual cause (`Failed to load AWS credentials ...`) instead of `Provider not set`;
- a retry after fixing the underlying issue re-runs the restore and succeeds without a daemon restart.

Auth-required errors already propagated out of `create_agent_locked` this way; this extends the same shape to other provider-creation failures. Fresh sessions without a `provider_name` are unaffected and still get a provider-less agent to configure later.

The chat gateway previously surfaced provider problems via its own later `restore_provider_from_session` call; since agent creation itself now fails, it messages the user there too instead of dropping their message silently.

### Testing

- New regression test `test_failed_provider_restore_is_not_cached_and_can_recover`: registers a test provider whose creation can be toggled to fail, verifies that a failed restore propagates and does not cache the agent, and that a retry after "re-auth" succeeds. Verified the test fails without the `manager.rs` change.
- `cargo test -p goose --lib execution::manager` — 18 passed.
- `cargo clippy -p goose --all-targets`, `cargo fmt` — clean.
- Manually reproduced the original bug on Goose Desktop 1.50.0 (aws_bedrock + expired SSO token): before the fix, retry after `aws sso login` kept failing with `Provider not set` and only a daemon restart helped; the logs in #11981 show the retries skipping the restore path.

### Related Issues

Discussion: #11981
