### PR TITLE
fix(recipe): strip inert parameters from session snapshots

### DIFF
--- a/crates/goose/src/recipe/validate_recipe.rs
+++ b/crates/goose/src/recipe/validate_recipe.rs
@@ -415,11 +415,9 @@ response:
 
         let error =
             validate_recipe_template_from_content(&recipe.to_yaml().unwrap(), None).unwrap_err();
-        assert!(
-            error
-                .to_string()
-                .contains("Unnecessary parameter definitions: message")
-        );
+        assert!(error
+            .to_string()
+            .contains("Unnecessary parameter definitions: message"));
     }
 
     #[test]
@@ -472,10 +470,8 @@ parameters:
     description: unused
 "#;
         let error = validate_recipe_template_from_content(recipe_content, None).unwrap_err();
-        assert!(
-            error
-                .to_string()
-                .contains("Unnecessary parameter definitions: message")
-        );
+        assert!(error
+            .to_string()
+            .contains("Unnecessary parameter definitions: message"));
     }
 }

--- a/crates/goose/src/recipe/validate_recipe.rs
+++ b/crates/goose/src/recipe/validate_recipe.rs
@@ -46,6 +46,34 @@ fn validate_recipe_parameters(recipe: &Recipe, template_variables: &HashSet<Stri
     validate_parameters_in_template(&recipe.parameters, template_variables)
 }
 
+/// Drop parameter keys that no longer appear as `{{ }}` (session snapshots).
+pub fn strip_unreferenced_parameters(mut recipe: Recipe) -> Recipe {
+    if recipe
+        .parameters
+        .as_ref()
+        .is_none_or(|parameters| parameters.is_empty())
+    {
+        recipe.parameters = None;
+        return recipe;
+    }
+
+    let Ok(yaml) = recipe.to_yaml() else {
+        return recipe;
+    };
+    let Ok((_, mut template_variables)) = parse_recipe_content(&yaml, None) else {
+        return recipe;
+    };
+    template_variables.remove(BUILT_IN_RECIPE_DIR_PARAM);
+
+    if let Some(parameters) = recipe.parameters.as_mut() {
+        parameters.retain(|parameter| template_variables.contains(&parameter.key));
+        if parameters.is_empty() {
+            recipe.parameters = None;
+        }
+    }
+    recipe
+}
+
 fn validate_json_schema(schema: &serde_json::Value) -> Result<()> {
     let schema_object = schema
         .as_object()
@@ -362,5 +390,92 @@ response:
         let error = validate_recipe_template_from_content(recipe_content, None).unwrap_err();
 
         assert!(error.to_string().contains("JSON schema validation failed"));
+    }
+
+    fn string_param(key: &str) -> RecipeParameter {
+        RecipeParameter {
+            key: key.to_string(),
+            input_type: RecipeParameterInputType::String,
+            requirement: RecipeParameterRequirement::Required,
+            description: format!("{key} parameter"),
+            default: None,
+            options: None,
+        }
+    }
+
+    #[test]
+    fn rendered_snapshot_with_leftover_parameters_fails_template_validation() {
+        let recipe = Recipe::builder()
+            .title("snapshot")
+            .description("rendered")
+            .prompt("hello")
+            .parameters(vec![string_param("message")])
+            .build()
+            .unwrap();
+
+        let error =
+            validate_recipe_template_from_content(&recipe.to_yaml().unwrap(), None).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("Unnecessary parameter definitions: message")
+        );
+    }
+
+    #[test]
+    fn strip_unreferenced_parameters_lets_rendered_snapshot_validate() {
+        let recipe = Recipe::builder()
+            .title("snapshot")
+            .description("rendered")
+            .prompt("hello")
+            .parameters(vec![string_param("message")])
+            .build()
+            .unwrap();
+
+        let stripped = strip_unreferenced_parameters(recipe);
+        assert!(stripped.parameters.is_none());
+        validate_recipe_template_from_content(&stripped.to_yaml().unwrap(), None).unwrap();
+    }
+
+    #[test]
+    fn strip_unreferenced_parameters_keeps_keys_still_in_the_template() {
+        let recipe = Recipe::builder()
+            .title("template")
+            .description("unrendered")
+            .prompt("{{ message }}")
+            .parameters(vec![string_param("message")])
+            .build()
+            .unwrap();
+
+        let stripped = strip_unreferenced_parameters(recipe);
+        let keys: Vec<_> = stripped
+            .parameters
+            .as_ref()
+            .unwrap()
+            .iter()
+            .map(|parameter| parameter.key.as_str())
+            .collect();
+        assert_eq!(keys, ["message"]);
+    }
+
+    #[test]
+    fn authoring_unused_parameter_still_fails_after_strip_helper_exists() {
+        let recipe_content = r#"
+version: 1.0.0
+title: Unused
+description: Unused parameter
+instructions: no templates here
+parameters:
+  - key: message
+    input_type: string
+    requirement: required
+    description: unused
+"#;
+        let error = validate_recipe_template_from_content(recipe_content, None).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("Unnecessary parameter definitions: message")
+        );
     }
 }

--- a/crates/goose/src/session/session_manager.rs
+++ b/crates/goose/src/session/session_manager.rs
@@ -4,6 +4,7 @@ use crate::conversation::message::{Message, MessageUsage, TokenState};
 use crate::conversation::Conversation;
 use crate::providers::base::CostSource;
 use crate::providers::base::Provider;
+use crate::recipe::validate_recipe::strip_unreferenced_parameters;
 use crate::recipe::Recipe;
 use crate::session::export_markdown::export_session_to_markdown;
 use crate::session::extension_data::ExtensionData;
@@ -265,7 +266,7 @@ impl<'a> SessionUpdateBuilder<'a> {
     }
 
     pub fn recipe(mut self, recipe: Option<Recipe>) -> Self {
-        self.recipe = Some(recipe);
+        self.recipe = Some(recipe.map(strip_unreferenced_parameters));
         self
     }
 
@@ -1180,7 +1181,9 @@ impl SessionStorage {
         let mut tx = pool.begin_with("BEGIN IMMEDIATE").await?;
 
         let recipe_json = match &session.recipe {
-            Some(recipe) => Some(serde_json::to_string(recipe)?),
+            Some(recipe) => Some(serde_json::to_string(&strip_unreferenced_parameters(
+                recipe.clone(),
+            ))?),
             None => None,
         };
 
@@ -3525,6 +3528,61 @@ mod tests {
             .await
             .unwrap();
         assert!(update.is_none());
+    }
+
+    #[tokio::test]
+    async fn storing_a_rendered_recipe_strips_inert_parameters() {
+        use crate::recipe::{
+            RecipeParameter, RecipeParameterInputType, RecipeParameterRequirement,
+        };
+
+        let temp_dir = TempDir::new().unwrap();
+        let sm = SessionManager::new(temp_dir.path().to_path_buf());
+        let session = sm
+            .create_session(
+                temp_dir.path().to_path_buf(),
+                "Recipe snapshot".to_string(),
+                SessionType::User,
+                GooseMode::default(),
+            )
+            .await
+            .unwrap();
+
+        let rendered = Recipe::builder()
+            .title("snapshot")
+            .description("rendered")
+            .prompt("hello")
+            .parameters(vec![RecipeParameter {
+                key: "message".to_string(),
+                input_type: RecipeParameterInputType::String,
+                requirement: RecipeParameterRequirement::Required,
+                description: "message parameter".to_string(),
+                default: None,
+                options: None,
+            }])
+            .build()
+            .unwrap();
+
+        crate::recipe::validate_recipe::validate_recipe_template_from_content(
+            &rendered.to_yaml().unwrap(),
+            None,
+        )
+        .unwrap_err();
+
+        sm.update(&session.id)
+            .recipe(Some(rendered))
+            .apply()
+            .await
+            .unwrap();
+
+        let stored = sm.get_session(&session.id, false).await.unwrap();
+        let stored_recipe = stored.recipe.expect("recipe should be stored");
+        assert!(stored_recipe.parameters.is_none());
+        crate::recipe::validate_recipe::validate_recipe_template_from_content(
+            &stored_recipe.to_yaml().unwrap(),
+            None,
+        )
+        .unwrap();
     }
 
     #[tokio::test]


### PR DESCRIPTION
Fixes #10931

## Summary
Parameterized `goose run` stores a **rendered** `Recipe` in `recipe_json` while keeping the `parameters:` block. Desktop re-validates that snapshot as a template, so unused keys fail with `Unnecessary parameter definitions` and the recipe cannot load.

**Option B:** at session write, drop parameter keys that no longer appear as `{{ }}`. Authoring `goose recipe validate` on disk templates is unchanged. Leaves #10113 open (separate issue).

### Testing
- `cargo test -p goose --lib -- strip_unreferenced rendered_snapshot_with_leftover storing_a_rendered_recipe authoring_unused_parameter` — 6 passed (red without strip, green with strip, unused-param authoring still fails)
- `cargo clippy -p goose --lib -- -D warnings` — clean

—
*Assisted by Grok · Approved by James Wolfe*


