### PR TITLE
ci: pin remaining GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/cargo-deny.yml
+++ b/.github/workflows/cargo-deny.yml
@@ -22,7 +22,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       # https://github.com/EmbarkStudios/cargo-deny-action v2.0.15
       - uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25
         with:

--- a/.github/workflows/pr-smoke-test.yml
+++ b/.github/workflows/pr-smoke-test.yml
@@ -93,7 +93,7 @@ jobs:
         run: chmod +x target/debug/goose
 
       - name: Set up Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
           node-version: '22'
 
@@ -127,7 +127,7 @@ jobs:
         working-directory: ui/desktop
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: '3.12'
 
@@ -224,7 +224,7 @@ jobs:
         run: chmod +x target/debug/goose
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
           python-version: '3.12'
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -73,6 +73,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@v4.37.9
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938  # v4.37.9
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
Fixes #11914.

Four `uses:` references still pointed at mutable tags instead of pinned commit SHAs, inconsistent with the rest of `.github/workflows/`:

| File | Line | Before | After |
|---|---|---|---|
| `cargo-deny.yml` | 25 | `actions/checkout@v7.0.1` | `actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1` |
| `pr-smoke-test.yml` | 96 | `actions/setup-node@v7` | `actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0` |
| `pr-smoke-test.yml` | 130, 227 | `actions/setup-python@v7` | `actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0` |
| `scorecard.yml` | 76 | `codeql-action/upload-sarif@v4.37.9` | `codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938  # v4.37.9` |

**Verification:**
- Resolved each SHA live against the upstream action repo's current tag ref (`gh api repos/<owner>/<repo>/git/refs/tags/<tag>`).
- Cross-checked the `checkout@v7.0.1`, `setup-node@v7.0.0`, and `setup-python@v7.0.0` SHAs against identical pins already used for the same released versions elsewhere in this repo's own `.github/workflows/` — they match exactly, so this is consistent with, not a deviation from, existing practice.
- All three edited YAML files parse cleanly with PyYAML after the change.
- No behavior change: each SHA corresponds exactly to the tag that was previously in use.

**One discrepancy from the issue text, noted for transparency:** the issue named `codeql-action@v4.37.8`, but by the time I picked this up, `main` had already moved to `v4.37.9` (bumped, but still as an unpinned tag). I pinned the current value on `main` rather than reintroducing a now-stale version.