### PR TITLE
Add Syfert Legal Research (remote legal-research MCP server) to servers.json

### DIFF
--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -722,6 +722,25 @@
     ]
   },
   {
+    "id": "syfert",
+    "name": "Syfert Legal Research",
+    "description": "Verify legal citations, check whether a case is still good law, audit a whole brief, and search statutes for all 50 states",
+    "type": "streamable-http",
+    "url": "https://mcp.syfert.com/mcp",
+    "link": "https://github.com/Gwonk1/syfert-mcp",
+    "installation_notes": "Remote Streamable HTTP extension. Get a free token at https://syfert.com/mcp/ (one email click), then supply it as the request header Authorization: Bearer <YOUR_SYFERT_TOKEN>.",
+    "is_builtin": false,
+    "endorsed": false,
+    "environmentVariables": [],
+    "headers": [
+      {
+        "name": "Authorization",
+        "description": "Bearer <YOUR_SYFERT_TOKEN>",
+        "required": true
+      }
+    ]
+  },
+  {
     "id": "tavily",
     "name": "Tavily Web Search",
     "description": "Web search capabilities powered by Tavily",


### PR DESCRIPTION
Adds **Syfert Legal Research** to `documentation/static/servers.json` — one entry, nothing else touched.

Syfert is a hosted Streamable HTTP MCP server for U.S. legal research: 13 read-only tools over 10.7M opinions from every state and federal court, a citator ("is this case still good law?"), a whole-brief citation audit, and statutes for all 50 states + D.C. plus the U.S. Code and C.F.R. The positioning is verification — checking the citations an agent just produced before they reach a filing.

- Endpoint: `https://mcp.syfert.com/mcp`, `type: streamable-http`
- Auth: required request header `Authorization: Bearer <token>`, declared in the `headers` array so Goose prompts for it
- Free tokens: one email click at https://syfert.com/mcp/ — no card
- Manifests / docs: https://github.com/Gwonk1/syfert-mcp
- Maintainer: Graham W. Syfert, Esq., P.A. — graham@syfert.com

Searches are not logged (queries, case names and pasted briefs are discarded); only tool name, success and duration are retained. Privacy: https://syfert.com/privacy

Entry inserted alphabetically between `supabase` and `tavily`; the file still parses (60 entries) and `endorsed` is left `false`.
