### PR TITLE
fix(desktop): window large transcripts to the first 20 and last 200 rows

### DIFF
--- a/ui/desktop/src/components/BaseChat.tsx
+++ b/ui/desktop/src/components/BaseChat.tsx
@@ -4,7 +4,7 @@ import { defineMessages, useIntl } from '../i18n';
 import { useLocation, useNavigate } from 'react-router';
 import { SearchView } from './conversation/SearchView';
 import LoadingGoose from './LoadingGoose';
-import ProgressiveMessageList from './ProgressiveMessageList';
+import TranscriptWindow from './TranscriptWindow';
 import { MainPanelLayout } from './Layout/MainPanelLayout';
 import ChatInput from './ChatInput';
 import { ChatInputCard } from './ChatInputCard';
@@ -472,7 +472,7 @@ export default function BaseChat({
             {messages.length > 0 || recipe ? (
               <>
                 <SearchView>
-                  <ProgressiveMessageList
+                  <TranscriptWindow
                     messages={messages}
                     sessionId={sessionId}
                     toolCallNotifications={toolCallNotifications}

--- a/ui/desktop/src/components/ProgressiveMessageList.test.tsx
+++ b/ui/desktop/src/components/ProgressiveMessageList.test.tsx
@@ -254,3 +254,78 @@ describe('ProgressiveMessageList batching', () => {
     expect(onRenderingComplete).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('ProgressiveMessageList insertAfter', () => {
+  const divider = <div data-testid="insert-divider">divider</div>;
+
+  function renderWithInsert(
+    messages: Message[],
+    insertAfter: { index: number; node: React.ReactNode },
+    renderMessage?: (message: Message, index: number) => React.ReactNode | null
+  ) {
+    return render(
+      <IntlTestWrapper>
+        <ProgressiveMessageList
+          messages={messages}
+          sessionId="test-session"
+          append={append}
+          isUserMessage={isUserMessage}
+          insertAfter={insertAfter}
+          renderMessage={renderMessage}
+        />
+      </IntlTestWrapper>
+    );
+  }
+
+  it('inserts the node after the given raw message index', () => {
+    const messages = [
+      message('a-1', 'user', [{ type: 'text', text: 'One' }]),
+      message('a-2', 'user', [{ type: 'text', text: 'Two' }]),
+      message('a-3', 'user', [{ type: 'text', text: 'Three' }]),
+    ];
+    renderWithInsert(messages, { index: 1, node: divider });
+
+    const first = screen.getByText('a-1');
+    const second = screen.getByText('a-2');
+    const inserted = screen.getByTestId('insert-divider');
+    const third = screen.getByText('a-3');
+    expect(first.compareDocumentPosition(inserted) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(
+      second.compareDocumentPosition(inserted) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+    expect(inserted.compareDocumentPosition(third) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it('still renders the node when the row at the index is not user-visible', () => {
+    const messages = [
+      message('a-1', 'user', [{ type: 'text', text: 'One' }]),
+      {
+        ...message('a-2', 'user', [{ type: 'text', text: 'Two' }]),
+        metadata: { ...visibleMetadata, userVisible: false },
+      },
+      message('a-3', 'user', [{ type: 'text', text: 'Three' }]),
+    ];
+    renderWithInsert(messages, { index: 1, node: divider });
+
+    expect(screen.getByTestId('insert-divider')).not.toBeNull();
+    expect(screen.queryByText('a-2')).toBeNull();
+  });
+
+  it('ignores an out-of-range index', () => {
+    const messages = [message('a-1', 'user', [{ type: 'text', text: 'One' }])];
+    renderWithInsert(messages, { index: 5, node: divider });
+
+    expect(screen.queryByTestId('insert-divider')).toBeNull();
+    expect(screen.getByText('a-1')).not.toBeNull();
+  });
+
+  it('renders the node even when renderMessage returns null for the row', () => {
+    const messages = [
+      message('a-1', 'user', [{ type: 'text', text: 'One' }]),
+      message('a-2', 'user', [{ type: 'text', text: 'Two' }]),
+    ];
+    renderWithInsert(messages, { index: 1, node: divider }, () => null);
+
+    expect(screen.getByTestId('insert-divider')).not.toBeNull();
+  });
+});

--- a/ui/desktop/src/components/ProgressiveMessageList.tsx
+++ b/ui/desktop/src/components/ProgressiveMessageList.tsx
@@ -147,7 +147,7 @@ function MessageRowComponent({
 
 const MessageRow = memo(MessageRowComponent, isEqual);
 
-interface ProgressiveMessageListProps {
+export interface ProgressiveMessageListProps {
   messages: Message[];
   sessionId: string;
   toolCallNotifications?: Map<string, NotificationEvent[]>;
@@ -169,6 +169,8 @@ interface ProgressiveMessageListProps {
     elicitationId: string,
     userData: Record<string, unknown>
   ) => Promise<boolean>;
+  insertAfter?: { index: number; node: React.ReactNode };
+  rowContexts?: MessageRowContext[];
 }
 
 export default function ProgressiveMessageList({
@@ -185,6 +187,8 @@ export default function ProgressiveMessageList({
   onMessageUpdate,
   onRenderingComplete,
   submitElicitationResponse,
+  insertAfter,
+  rowContexts: rowContextsOverride,
 }: ProgressiveMessageListProps) {
   const intl = useIntl();
   const [renderedCount, setRenderedCount] = useState(() =>
@@ -238,53 +242,68 @@ export default function ProgressiveMessageList({
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [isLoading, messages.length]);
 
-  const rowContexts = useMemo(() => deriveMessageRowContexts(messages), [messages]);
+  const rowContexts = useMemo(
+    () => rowContextsOverride ?? deriveMessageRowContexts(messages),
+    [messages, rowContextsOverride]
+  );
   const messagesToRender = messages.slice(0, renderedCount);
+
+  const renderRow = (message: Message, index: number) => {
+    if (!message.metadata.userVisible) return null;
+    if (renderMessage) return renderMessage(message, index);
+
+    const isUser = isUserMessage(message);
+    const messageIdentifier = message.id ?? `msg-${index}-${message.created}`;
+    const messageKey = getSystemNotification(message)
+      ? `notification-${messageIdentifier}`
+      : messageIdentifier;
+    const rowContext = rowContexts[index];
+    const currentResolvedModel = getResolvedModel(message);
+    const modelChangeMessage =
+      currentResolvedModel &&
+      rowContext.previousResolvedModel &&
+      currentResolvedModel !== rowContext.previousResolvedModel
+        ? intl.formatMessage(i18n.modelChanged, {
+            previousModel: getModelDisplayName(rowContext.previousResolvedModel),
+            currentModel: getModelDisplayName(currentResolvedModel),
+          })
+        : null;
+    const toolNotifications = rowContext.toolStates.map((toolState) =>
+      toolCallNotifications.get(toolState.requestId)
+    );
+
+    return (
+      <MessageRow
+        key={messageKey}
+        append={append}
+        index={index}
+        isStreaming={
+          isStreamingMessage &&
+          !isUser &&
+          index === messagesToRender.length - 1 &&
+          message.role === 'assistant'
+        }
+        isUser={isUser}
+        message={message}
+        modelChangeMessage={modelChangeMessage}
+        onMessageUpdate={onMessageUpdate}
+        rowContext={rowContext}
+        sessionId={sessionId}
+        submitElicitationResponse={submitElicitationResponse}
+        toolNotifications={toolNotifications}
+      />
+    );
+  };
+
   const messageRows = messagesToRender
     .map((message, index) => {
-      if (!message.metadata.userVisible) return null;
-      if (renderMessage) return renderMessage(message, index);
-
-      const isUser = isUserMessage(message);
-      const messageIdentifier = message.id ?? `msg-${index}-${message.created}`;
-      const messageKey = getSystemNotification(message)
-        ? `notification-${messageIdentifier}`
-        : messageIdentifier;
-      const rowContext = rowContexts[index];
-      const currentResolvedModel = getResolvedModel(message);
-      const modelChangeMessage =
-        currentResolvedModel &&
-        rowContext.previousResolvedModel &&
-        currentResolvedModel !== rowContext.previousResolvedModel
-          ? intl.formatMessage(i18n.modelChanged, {
-              previousModel: getModelDisplayName(rowContext.previousResolvedModel),
-              currentModel: getModelDisplayName(currentResolvedModel),
-            })
-          : null;
-      const toolNotifications = rowContext.toolStates.map((toolState) =>
-        toolCallNotifications.get(toolState.requestId)
-      );
-
+      const row = renderRow(message, index);
+      if (!insertAfter || index !== insertAfter.index) return row;
       return (
-        <MessageRow
-          key={messageKey}
-          append={append}
-          index={index}
-          isStreaming={
-            isStreamingMessage &&
-            !isUser &&
-            index === messagesToRender.length - 1 &&
-            message.role === 'assistant'
-          }
-          isUser={isUser}
-          message={message}
-          modelChangeMessage={modelChangeMessage}
-          onMessageUpdate={onMessageUpdate}
-          rowContext={rowContext}
-          sessionId={sessionId}
-          submitElicitationResponse={submitElicitationResponse}
-          toolNotifications={toolNotifications}
-        />
+        <Fragment key={`insert-after-${index}`}>
+          {row}
+          {insertAfter.node}
+        </Fragment>
       );
     })
     .filter(Boolean);

--- a/ui/desktop/src/components/ProgressiveMessageList.tsx
+++ b/ui/desktop/src/components/ProgressiveMessageList.tsx
@@ -171,6 +171,7 @@ export interface ProgressiveMessageListProps {
   ) => Promise<boolean>;
   insertAfter?: { index: number; node: React.ReactNode };
   rowContexts?: MessageRowContext[];
+  toRawIndex?: (index: number) => number;
 }
 
 export default function ProgressiveMessageList({
@@ -189,11 +190,22 @@ export default function ProgressiveMessageList({
   submitElicitationResponse,
   insertAfter,
   rowContexts: rowContextsOverride,
+  toRawIndex,
 }: ProgressiveMessageListProps) {
   const intl = useIntl();
   const [renderedCount, setRenderedCount] = useState(() =>
     messages.length <= showLoadingThreshold ? messages.length : Math.min(batchSize, messages.length)
   );
+  // A raised threshold (e.g. transcript-window expansion) must take effect in
+  // the same commit: updating renderedCount in an effect would paint a frame
+  // with the already-mounted tail sliced off.
+  const [lastShowLoadingThreshold, setLastShowLoadingThreshold] = useState(showLoadingThreshold);
+  if (showLoadingThreshold !== lastShowLoadingThreshold) {
+    setLastShowLoadingThreshold(showLoadingThreshold);
+    if (messages.length <= showLoadingThreshold) {
+      setRenderedCount(messages.length);
+    }
+  }
   const completedMessageKeyRef = useRef<string | null>(null);
   const isLoading = renderedCount < messages.length;
 
@@ -253,7 +265,8 @@ export default function ProgressiveMessageList({
     if (renderMessage) return renderMessage(message, index);
 
     const isUser = isUserMessage(message);
-    const messageIdentifier = message.id ?? `msg-${index}-${message.created}`;
+    const messageIdentifier =
+      message.id ?? `msg-${toRawIndex ? toRawIndex(index) : index}-${message.created}`;
     const messageKey = getSystemNotification(message)
       ? `notification-${messageIdentifier}`
       : messageIdentifier;
@@ -276,7 +289,7 @@ export default function ProgressiveMessageList({
       <MessageRow
         key={messageKey}
         append={append}
-        index={index}
+        index={toRawIndex ? toRawIndex(index) : index}
         isStreaming={
           isStreamingMessage &&
           !isUser &&

--- a/ui/desktop/src/components/TranscriptWindow.test.tsx
+++ b/ui/desktop/src/components/TranscriptWindow.test.tsx
@@ -1,0 +1,259 @@
+import { StrictMode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import type { Message } from '../types/message';
+import { IntlTestWrapper } from '../i18n/test-utils';
+import TranscriptWindow from './TranscriptWindow';
+
+vi.mock('./GooseMessage', () => ({
+  default: ({ message }: { message: Message }) => <div>{message.id}</div>,
+}));
+
+vi.mock('./UserMessage', () => ({
+  default: ({ message }: { message: Message }) => <div>{message.id}</div>,
+}));
+
+const visibleMetadata: Message['metadata'] = { agentVisible: true, userVisible: true };
+const append = vi.fn();
+const isUserMessage = (message: Message) => message.role === 'user';
+
+function makeMessage(id: string): Message {
+  return {
+    id,
+    role: 'user',
+    created: 1,
+    content: [{ type: 'text', text: `body-${id}` }],
+    metadata: visibleMetadata,
+  };
+}
+
+function makeMessages(count: number, prefix = 'm'): Message[] {
+  return Array.from({ length: count }, (_, index) => makeMessage(`${prefix}-${index}`));
+}
+
+function makeAssistantMessage(id: string, resolvedModel: string): Message {
+  return {
+    id,
+    role: 'assistant',
+    created: 1,
+    content: [{ type: 'text', text: `body-${id}` }],
+    metadata: {
+      agentVisible: true,
+      userVisible: true,
+      inference: { provider: 'test', requestedModel: resolvedModel, resolvedModel },
+    },
+  };
+}
+
+function renderWindow(messages: Message[], sessionId = 'test-session') {
+  return render(
+    <StrictMode>
+      <IntlTestWrapper>
+        <TranscriptWindow
+          messages={messages}
+          sessionId={sessionId}
+          append={append}
+          isUserMessage={isUserMessage}
+        />
+      </IntlTestWrapper>
+    </StrictMode>
+  );
+}
+
+function rerenderWindow(
+  rerender: (node: React.ReactElement) => void,
+  messages: Message[],
+  sessionId = 'test-session'
+) {
+  rerender(
+    <StrictMode>
+      <IntlTestWrapper>
+        <TranscriptWindow
+          messages={messages}
+          sessionId={sessionId}
+          append={append}
+          isUserMessage={isUserMessage}
+        />
+      </IntlTestWrapper>
+    </StrictMode>
+  );
+}
+
+function flushRendering() {
+  for (let tick = 0; tick < 300; tick++) {
+    act(() => {
+      vi.advanceTimersByTime(20);
+    });
+  }
+}
+
+describe('TranscriptWindow', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders every message without a divider for short transcripts', () => {
+    renderWindow(makeMessages(100));
+    flushRendering();
+
+    expect(screen.queryByTestId('hidden-messages-divider')).toBeNull();
+    expect(screen.queryByText('m-0')).not.toBeNull();
+    expect(screen.queryByText('m-99')).not.toBeNull();
+  });
+
+  it('does not window a transcript that fits the window', () => {
+    renderWindow(makeMessages(220));
+    flushRendering();
+
+    expect(screen.queryByTestId('hidden-messages-divider')).toBeNull();
+    expect(screen.queryByText('m-219')).not.toBeNull();
+  });
+
+  it('windows a long transcript to the first 20 and last 200 messages', () => {
+    renderWindow(makeMessages(241));
+    flushRendering();
+
+    expect(screen.getByTestId('hidden-messages-count')).toHaveTextContent('21 messages hidden');
+    expect(screen.queryByText('m-0')).not.toBeNull();
+    expect(screen.queryByText('m-19')).not.toBeNull();
+    expect(screen.queryByText('m-20')).toBeNull();
+    expect(screen.queryByText('m-40')).toBeNull();
+    expect(screen.queryByText('m-41')).not.toBeNull();
+    expect(screen.queryByText('m-240')).not.toBeNull();
+  });
+
+  it('uses the singular form for a single hidden message', () => {
+    renderWindow(makeMessages(221));
+    flushRendering();
+
+    expect(screen.getByTestId('hidden-messages-count')).toHaveTextContent('1 message hidden');
+  });
+
+  it('expands in chunks of 200 until the transcript is fully visible', () => {
+    renderWindow(makeMessages(1000));
+
+    flushRendering();
+    expect(screen.getByTestId('hidden-messages-count')).toHaveTextContent('780 messages hidden');
+
+    fireEvent.click(screen.getByTestId('load-earlier-messages'));
+    expect(screen.getByTestId('hidden-messages-count')).toHaveTextContent('580 messages hidden');
+    expect(screen.queryByText('m-600')).not.toBeNull();
+    expect(screen.queryByText('m-999')).not.toBeNull();
+
+    fireEvent.click(screen.getByTestId('load-earlier-messages'));
+    expect(screen.getByTestId('hidden-messages-count')).toHaveTextContent('380 messages hidden');
+    expect(screen.queryByText('m-400')).not.toBeNull();
+    expect(screen.queryByText('m-999')).not.toBeNull();
+
+    fireEvent.click(screen.getByTestId('load-earlier-messages'));
+    expect(screen.getByTestId('hidden-messages-count')).toHaveTextContent('180 messages hidden');
+    expect(screen.queryByText('m-999')).not.toBeNull();
+
+    fireEvent.click(screen.getByTestId('load-earlier-messages'));
+    expect(screen.queryByTestId('hidden-messages-divider')).toBeNull();
+    expect(screen.queryByText('m-500')).not.toBeNull();
+    expect(screen.queryByText('m-999')).not.toBeNull();
+  });
+
+  it('reveals the full transcript on the search shortcut', () => {
+    renderWindow(makeMessages(241));
+    flushRendering();
+    expect(screen.queryByText('m-30')).toBeNull();
+
+    fireEvent.keyDown(window, { metaKey: true, key: 'f' });
+    flushRendering();
+
+    expect(screen.queryByTestId('hidden-messages-divider')).toBeNull();
+    expect(screen.queryByText('m-30')).not.toBeNull();
+    expect(screen.queryByText('m-240')).not.toBeNull();
+  });
+
+  it('resets expansion when the session changes', () => {
+    const { rerender } = renderWindow(makeMessages(241));
+    flushRendering();
+
+    fireEvent.keyDown(window, { metaKey: true, key: 'f' });
+    flushRendering();
+    expect(screen.queryByTestId('hidden-messages-divider')).toBeNull();
+
+    rerenderWindow(rerender, makeMessages(241, 'next'), 'session-two');
+    flushRendering();
+
+    expect(screen.getByTestId('hidden-messages-count')).toHaveTextContent('21 messages hidden');
+    expect(screen.queryByText('next-40')).toBeNull();
+  });
+
+  it('keeps the tail window on the latest messages while streaming', () => {
+    const messages = makeMessages(241);
+    const { rerender } = renderWindow(messages);
+    flushRendering();
+    expect(screen.queryByText('m-41')).not.toBeNull();
+
+    rerenderWindow(rerender, [...messages, makeMessage('m-241')]);
+    flushRendering();
+
+    expect(screen.getByTestId('hidden-messages-count')).toHaveTextContent('22 messages hidden');
+    expect(screen.queryByText('m-41')).toBeNull();
+    expect(screen.queryByText('m-241')).not.toBeNull();
+  });
+
+  it('derives row contexts from the full transcript, not the window', () => {
+    const messages = [
+      ...Array.from({ length: 20 }, (_, index) => makeAssistantMessage(`a-${index}`, 'model-a')),
+      ...Array.from({ length: 221 }, (_, index) => makeAssistantMessage(`b-${index}`, 'model-b')),
+    ];
+    renderWindow(messages);
+    flushRendering();
+
+    expect(screen.queryByText('b-21')).not.toBeNull();
+    expect(screen.queryByText(/Model changed/)).toBeNull();
+  });
+
+  it('places the divider between the head and tail sections', () => {
+    renderWindow(makeMessages(241));
+    flushRendering();
+
+    const divider = screen.getByTestId('hidden-messages-divider');
+    const head = screen.getByText('m-19');
+    const tail = screen.getByText('m-41');
+    expect(head.compareDocumentPosition(divider) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(divider.compareDocumentPosition(tail) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it('expands the currently hidden messages with the non-mac search shortcut', () => {
+    window.electron.platform = 'win32';
+    try {
+      renderWindow(makeMessages(241));
+      flushRendering();
+      expect(screen.queryByText('m-30')).toBeNull();
+
+      fireEvent.keyDown(window, { ctrlKey: true, key: 'f' });
+      flushRendering();
+
+      expect(screen.queryByTestId('hidden-messages-divider')).toBeNull();
+      expect(screen.queryByText('m-30')).not.toBeNull();
+    } finally {
+      window.electron.platform = 'darwin';
+    }
+  });
+
+  it('re-arms the window when the transcript grows after a search expansion', () => {
+    const messages = makeMessages(241);
+    const { rerender } = renderWindow(messages);
+    flushRendering();
+
+    fireEvent.keyDown(window, { metaKey: true, key: 'f' });
+    flushRendering();
+    expect(screen.queryByTestId('hidden-messages-divider')).toBeNull();
+
+    rerenderWindow(rerender, [...messages, makeMessage('m-241')]);
+    flushRendering();
+
+    expect(screen.getByTestId('hidden-messages-count')).toHaveTextContent('1 message hidden');
+    expect(screen.queryByText('m-241')).not.toBeNull();
+  });
+});

--- a/ui/desktop/src/components/TranscriptWindow.test.tsx
+++ b/ui/desktop/src/components/TranscriptWindow.test.tsx
@@ -5,13 +5,26 @@ import type { Message } from '../types/message';
 import { IntlTestWrapper } from '../i18n/test-utils';
 import TranscriptWindow from './TranscriptWindow';
 
+const renderCounts = vi.hoisted(() => new Map<string, number>());
+
 vi.mock('./GooseMessage', () => ({
-  default: ({ message }: { message: Message }) => <div>{message.id}</div>,
+  default: ({ message }: { message: Message }) => {
+    const id = message.id ?? textKey(message);
+    renderCounts.set(id, (renderCounts.get(id) ?? 0) + 1);
+    return <div>{id}</div>;
+  },
 }));
 
 vi.mock('./UserMessage', () => ({
-  default: ({ message }: { message: Message }) => <div>{message.id}</div>,
+  default: ({ message }: { message: Message }) => {
+    return <div>{message.id}</div>;
+  },
 }));
+
+function textKey(message: Message): string {
+  const first = message.content[0];
+  return first && first.type === 'text' ? first.text : 'missing-key';
+}
 
 const visibleMetadata: Message['metadata'] = { agentVisible: true, userVisible: true };
 const append = vi.fn();
@@ -255,5 +268,61 @@ describe('TranscriptWindow', () => {
 
     expect(screen.getByTestId('hidden-messages-count')).toHaveTextContent('1 message hidden');
     expect(screen.queryByText('m-241')).not.toBeNull();
+  });
+
+  it('expands the transcript when find is opened via the renderer find command', () => {
+    renderWindow(makeMessages(241));
+    flushRendering();
+    expect(screen.queryByText('m-30')).toBeNull();
+
+    const onMock = window.electron.on as unknown as {
+      mock: { calls: [string, () => void][] };
+    };
+    const findCommandCalls = onMock.mock.calls.filter(([event]) => event === 'find-command');
+    const findCommandHandler = findCommandCalls[findCommandCalls.length - 1]?.[1];
+    expect(findCommandHandler).toBeTypeOf('function');
+    act(() => findCommandHandler());
+    flushRendering();
+
+    expect(screen.queryByTestId('hidden-messages-divider')).toBeNull();
+    expect(screen.queryByText('m-30')).not.toBeNull();
+  });
+
+  it('clamps load earlier to the currently hidden count', () => {
+    const messages = makeMessages(221);
+    const { rerender } = renderWindow(messages);
+    flushRendering();
+    expect(screen.getByTestId('hidden-messages-count')).toHaveTextContent('1 message hidden');
+
+    fireEvent.click(screen.getByTestId('load-earlier-messages'));
+    flushRendering();
+    expect(screen.queryByTestId('hidden-messages-divider')).toBeNull();
+
+    rerenderWindow(rerender, [...messages, makeMessage('m-221')]);
+    flushRendering();
+
+    expect(screen.getByTestId('hidden-messages-count')).toHaveTextContent('1 message hidden');
+    expect(screen.queryByText('m-221')).not.toBeNull();
+  });
+
+  it('keeps stable fallback keys for id-less messages when the window slides', () => {
+    renderCounts.clear();
+    const idLessMessages: Message[] = Array.from({ length: 241 }, (_, index) => ({
+      role: 'assistant' as const,
+      created: 1,
+      content: [{ type: 'text' as const, text: `body-${index}` }],
+      metadata: visibleMetadata,
+    }));
+    const { rerender } = renderWindow(idLessMessages);
+    flushRendering();
+    const body100BeforeSlide = renderCounts.get('body-100');
+    expect(body100BeforeSlide).toBeGreaterThan(0);
+
+    rerenderWindow(rerender, [...idLessMessages, makeMessage('appended')]);
+    flushRendering();
+
+    expect(renderCounts.get('body-100')).toBe(body100BeforeSlide);
+    expect(screen.queryByText('body-100')).not.toBeNull();
+    expect(screen.queryByText('appended')).not.toBeNull();
   });
 });

--- a/ui/desktop/src/components/TranscriptWindow.tsx
+++ b/ui/desktop/src/components/TranscriptWindow.tsx
@@ -1,0 +1,134 @@
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { defineMessages, useIntl } from '../i18n';
+import { deriveMessageRowContexts } from './messageRowContext';
+import ProgressiveMessageList, { type ProgressiveMessageListProps } from './ProgressiveMessageList';
+
+const HEAD_COUNT = 20;
+const TAIL_COUNT = 200;
+const EXPAND_CHUNK = 200;
+const FULL_WINDOW_COUNT = HEAD_COUNT + TAIL_COUNT;
+
+const i18n = defineMessages({
+  hiddenMessages: {
+    id: 'transcriptWindow.hiddenMessages',
+    defaultMessage:
+      '{count, plural, one {# message hidden} other {# messages hidden}} for performance purposes',
+  },
+  loadEarlier: {
+    id: 'transcriptWindow.loadEarlier',
+    defaultMessage: 'Load earlier messages',
+  },
+});
+
+type TranscriptWindowProps = Omit<ProgressiveMessageListProps, 'insertAfter' | 'rowContexts'>;
+
+export default function TranscriptWindow(props: TranscriptWindowProps) {
+  const { messages, sessionId, showLoadingThreshold } = props;
+  const intl = useIntl();
+  const [extraTailCount, setExtraTailCount] = useState(0);
+  const [lastSessionId, setLastSessionId] = useState(sessionId);
+
+  if (sessionId !== lastSessionId) {
+    setLastSessionId(sessionId);
+    setExtraTailCount(0);
+  }
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const isMac = window.electron.platform === 'darwin';
+      const isSearchShortcut = (isMac ? event.metaKey : event.ctrlKey) && event.key === 'f';
+      if (isSearchShortcut) {
+        // Expand only what is currently hidden so later growth re-arms the window.
+        setExtraTailCount(
+          (current) => current + Math.max(0, messages.length - FULL_WINDOW_COUNT - current)
+        );
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [messages.length]);
+
+  const hiddenCount = Math.max(0, messages.length - FULL_WINDOW_COUNT - extraTailCount);
+  const isWindowed = hiddenCount > 0;
+
+  const tailStartIndex = useMemo(
+    () => Math.max(HEAD_COUNT, messages.length - TAIL_COUNT - extraTailCount),
+    [messages.length, extraTailCount]
+  );
+
+  const visibleMessages = useMemo(() => {
+    if (!isWindowed) return messages;
+    return [...messages.slice(0, HEAD_COUNT), ...messages.slice(tailStartIndex)];
+  }, [messages, isWindowed, tailStartIndex]);
+
+  // Contexts must be derived from the full transcript: tool request/response
+  // pairs and model-change chains that straddle the hidden gap would otherwise
+  // render as pending or spuriously announced at the window boundary.
+  const allRowContexts = useMemo(() => deriveMessageRowContexts(messages), [messages]);
+  const visibleRowContexts = useMemo(() => {
+    if (!isWindowed) return allRowContexts;
+    return [...allRowContexts.slice(0, HEAD_COUNT), ...allRowContexts.slice(tailStartIndex)];
+  }, [allRowContexts, isWindowed, tailStartIndex]);
+
+  const anchorElementRef = useRef<HTMLElement | null>(null);
+  const anchorViewportOffsetRef = useRef(0);
+
+  useLayoutEffect(() => {
+    const anchor = anchorElementRef.current;
+    if (!anchor) return;
+    const viewport = anchor.closest<HTMLElement>('[data-radix-scroll-area-viewport]');
+    anchorElementRef.current = null;
+    if (!viewport?.contains(anchor)) return;
+    const anchorOffset = anchor.getBoundingClientRect().top - viewport.getBoundingClientRect().top;
+    viewport.scrollTop += anchorOffset - anchorViewportOffsetRef.current;
+  }, [visibleMessages]);
+
+  const handleLoadEarlier = (event: React.MouseEvent<HTMLButtonElement>) => {
+    const viewport = event.currentTarget.closest<HTMLElement>('[data-radix-scroll-area-viewport]');
+    const anchor = viewport?.querySelectorAll<HTMLElement>('[data-testid="message-container"]')[
+      HEAD_COUNT
+    ];
+    if (viewport && anchor) {
+      anchorElementRef.current = anchor;
+      anchorViewportOffsetRef.current =
+        anchor.getBoundingClientRect().top - viewport.getBoundingClientRect().top;
+    }
+    setExtraTailCount((current) => current + EXPAND_CHUNK);
+  };
+
+  // Progressive rendering indexes from the front of the array; when older rows
+  // are spliced in ahead of already-mounted ones, resuming the batch count
+  // would briefly unmount the tail (including any live streaming row), so any
+  // expansion beyond the default window mounts the visible set immediately.
+  const hasExpandedWindow = extraTailCount > 0 && messages.length > FULL_WINDOW_COUNT;
+
+  const hiddenMessagesDivider = isWindowed ? (
+    <div
+      data-testid="hidden-messages-divider"
+      className="my-6 flex flex-col items-center gap-1 text-xs text-text-secondary"
+    >
+      <span data-testid="hidden-messages-count" aria-live="polite">
+        {intl.formatMessage(i18n.hiddenMessages, { count: hiddenCount })}
+      </span>
+      <button
+        type="button"
+        data-testid="load-earlier-messages"
+        className="rounded underline underline-offset-2 focus-visible:outline-2 focus-visible:outline-text-primary hover:opacity-80"
+        onClick={handleLoadEarlier}
+      >
+        {intl.formatMessage(i18n.loadEarlier)}
+      </button>
+    </div>
+  ) : undefined;
+
+  return (
+    <ProgressiveMessageList
+      {...props}
+      messages={visibleMessages}
+      showLoadingThreshold={hasExpandedWindow ? visibleMessages.length : showLoadingThreshold}
+      rowContexts={visibleRowContexts}
+      insertAfter={isWindowed ? { index: HEAD_COUNT - 1, node: hiddenMessagesDivider } : undefined}
+    />
+  );
+}

--- a/ui/desktop/src/components/TranscriptWindow.tsx
+++ b/ui/desktop/src/components/TranscriptWindow.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { defineMessages, useIntl } from '../i18n';
 import { deriveMessageRowContexts } from './messageRowContext';
 import ProgressiveMessageList, { type ProgressiveMessageListProps } from './ProgressiveMessageList';
@@ -33,21 +33,31 @@ export default function TranscriptWindow(props: TranscriptWindowProps) {
     setExtraTailCount(0);
   }
 
+  const expandHiddenMessages = useCallback(() => {
+    // Expand only what is currently hidden so later growth re-arms the window.
+    setExtraTailCount(
+      (current) => current + Math.max(0, messages.length - FULL_WINDOW_COUNT - current)
+    );
+  }, [messages.length]);
+
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       const isMac = window.electron.platform === 'darwin';
       const isSearchShortcut = (isMac ? event.metaKey : event.ctrlKey) && event.key === 'f';
       if (isSearchShortcut) {
-        // Expand only what is currently hidden so later growth re-arms the window.
-        setExtraTailCount(
-          (current) => current + Math.max(0, messages.length - FULL_WINDOW_COUNT - current)
-        );
+        expandHiddenMessages();
       }
     };
 
+    const handleFindCommand = () => expandHiddenMessages();
+
     window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [messages.length]);
+    window.electron.on('find-command', handleFindCommand);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+      window.electron.off('find-command', handleFindCommand);
+    };
+  }, [expandHiddenMessages]);
 
   const hiddenCount = Math.max(0, messages.length - FULL_WINDOW_COUNT - extraTailCount);
   const isWindowed = hiddenCount > 0;
@@ -94,7 +104,10 @@ export default function TranscriptWindow(props: TranscriptWindowProps) {
       anchorViewportOffsetRef.current =
         anchor.getBoundingClientRect().top - viewport.getBoundingClientRect().top;
     }
-    setExtraTailCount((current) => current + EXPAND_CHUNK);
+    setExtraTailCount(
+      (current) =>
+        current + Math.min(EXPAND_CHUNK, Math.max(0, messages.length - FULL_WINDOW_COUNT - current))
+    );
   };
 
   // Progressive rendering indexes from the front of the array; when older rows
@@ -129,6 +142,11 @@ export default function TranscriptWindow(props: TranscriptWindowProps) {
       showLoadingThreshold={hasExpandedWindow ? visibleMessages.length : showLoadingThreshold}
       rowContexts={visibleRowContexts}
       insertAfter={isWindowed ? { index: HEAD_COUNT - 1, node: hiddenMessagesDivider } : undefined}
+      toRawIndex={
+        isWindowed
+          ? (index) => (index < HEAD_COUNT ? index : index - HEAD_COUNT + tailStartIndex)
+          : undefined
+      }
     />
   );
 }

--- a/ui/desktop/src/i18n/messages/de.json
+++ b/ui/desktop/src/i18n/messages/de.json
@@ -4514,6 +4514,12 @@
   "toolConfirmation.gooseWouldLikeToCallWithName": {
     "defaultMessage": "Goose möchte {toolName} aufrufen. Erlauben?"
   },
+  "transcriptWindow.hiddenMessages": {
+    "defaultMessage": "{count, plural, one {# Nachricht ausgeblendet} other {# Nachrichten ausgeblendet}} zur Leistungsverbesserung"
+  },
+  "transcriptWindow.loadEarlier": {
+    "defaultMessage": "Frühere Nachrichten laden"
+  },
   "updateSection.autoDownload": {
     "defaultMessage": "Goose lädt das Update im Hintergrund herunter und installiert es beim nächsten Beenden oder Neustart."
   },

--- a/ui/desktop/src/i18n/messages/en.json
+++ b/ui/desktop/src/i18n/messages/en.json
@@ -4562,6 +4562,12 @@
   "toolConfirmation.gooseWouldLikeToCallWithName": {
     "defaultMessage": "Goose would like to call {toolName}. Allow?"
   },
+  "transcriptWindow.hiddenMessages": {
+    "defaultMessage": "{count,plural,one{# message hidden for performance purposes} other{# messages hidden for performance purposes}}"
+  },
+  "transcriptWindow.loadEarlier": {
+    "defaultMessage": "Load earlier messages"
+  },
   "updateSection.autoDownload": {
     "defaultMessage": "Goose will download the update in the background and install it the next time you quit or restart."
   },

--- a/ui/desktop/src/i18n/messages/es.json
+++ b/ui/desktop/src/i18n/messages/es.json
@@ -4514,6 +4514,12 @@
   "toolConfirmation.gooseWouldLikeToCallWithName": {
     "defaultMessage": "Goose quiere invocar {toolName}. ¿Permitir?"
   },
+  "transcriptWindow.hiddenMessages": {
+    "defaultMessage": "{count, plural, one {# mensaje oculto} other {# mensajes ocultos}} por motivos de rendimiento"
+  },
+  "transcriptWindow.loadEarlier": {
+    "defaultMessage": "Cargar mensajes anteriores"
+  },
   "updateSection.autoDownload": {
     "defaultMessage": "La actualización se descargará automáticamente en segundo plano."
   },

--- a/ui/desktop/src/i18n/messages/fr.json
+++ b/ui/desktop/src/i18n/messages/fr.json
@@ -4514,6 +4514,12 @@
   "toolConfirmation.gooseWouldLikeToCallWithName": {
     "defaultMessage": "Goose souhaite appeler {toolName}. Autoriser ?"
   },
+  "transcriptWindow.hiddenMessages": {
+    "defaultMessage": "{count, plural, one {# message masqué} other {# messages masqués}} pour des raisons de performance"
+  },
+  "transcriptWindow.loadEarlier": {
+    "defaultMessage": "Charger les messages précédents"
+  },
   "updateSection.autoDownload": {
     "defaultMessage": "Goose téléchargera la mise à jour en arrière-plan et l'installera lors de votre prochaine fermeture ou redémarrage."
   },

--- a/ui/desktop/src/i18n/messages/hi.json
+++ b/ui/desktop/src/i18n/messages/hi.json
@@ -4514,6 +4514,12 @@
   "toolConfirmation.gooseWouldLikeToCallWithName": {
     "defaultMessage": "Goose {toolName} को कॉल करना चाहेंगे। अनुमति दें?"
   },
+  "transcriptWindow.hiddenMessages": {
+    "defaultMessage": "{count, plural, one {# संदेश छिपाया गया} other {# संदेश छिपाए गए}} प्रदर्शन हेतु"
+  },
+  "transcriptWindow.loadEarlier": {
+    "defaultMessage": "पुराने संदेश लोड करें"
+  },
   "updateSection.autoDownload": {
     "defaultMessage": "अपडेट बैकग्राउंड में अपने आप डाउनलोड हो जाएगा."
   },

--- a/ui/desktop/src/i18n/messages/id.json
+++ b/ui/desktop/src/i18n/messages/id.json
@@ -4514,6 +4514,12 @@
   "toolConfirmation.gooseWouldLikeToCallWithName": {
     "defaultMessage": "Goose ingin memanggil {toolName}. Izinkan?"
   },
+  "transcriptWindow.hiddenMessages": {
+    "defaultMessage": "{count, plural, other {# pesan disembunyikan}} demi performa"
+  },
+  "transcriptWindow.loadEarlier": {
+    "defaultMessage": "Muat pesan lebih awal"
+  },
   "updateSection.autoDownload": {
     "defaultMessage": "Goose akan mengunduh pembaruan di latar belakang dan menginstalnya saat Anda keluar atau memulai ulang berikutnya."
   },

--- a/ui/desktop/src/i18n/messages/it.json
+++ b/ui/desktop/src/i18n/messages/it.json
@@ -4514,6 +4514,12 @@
   "toolConfirmation.gooseWouldLikeToCallWithName": {
     "defaultMessage": "Goose desidera richiamare {toolName}. Consentire?"
   },
+  "transcriptWindow.hiddenMessages": {
+    "defaultMessage": "{count, plural, one {# messaggio nascosto} other {# messaggi nascosti}} per motivi di prestazioni"
+  },
+  "transcriptWindow.loadEarlier": {
+    "defaultMessage": "Carica i messaggi precedenti"
+  },
   "updateSection.autoDownload": {
     "defaultMessage": "Goose scaricherà l'aggiornamento in background e lo installerà al prossimo arresto o riavvio."
   },

--- a/ui/desktop/src/i18n/messages/ja.json
+++ b/ui/desktop/src/i18n/messages/ja.json
@@ -4514,6 +4514,12 @@
   "toolConfirmation.gooseWouldLikeToCallWithName": {
     "defaultMessage": "Gooseが{toolName}を実行しようとしています。許可しますか？"
   },
+  "transcriptWindow.hiddenMessages": {
+    "defaultMessage": "{count, plural, other {# 件のメッセージを非表示}} パフォーマンスのため"
+  },
+  "transcriptWindow.loadEarlier": {
+    "defaultMessage": "以前のメッセージを読み込む"
+  },
   "updateSection.autoDownload": {
     "defaultMessage": "アップデートはバックグラウンドで自動的にダウンロードされます。"
   },

--- a/ui/desktop/src/i18n/messages/ko.json
+++ b/ui/desktop/src/i18n/messages/ko.json
@@ -4514,6 +4514,12 @@
   "toolConfirmation.gooseWouldLikeToCallWithName": {
     "defaultMessage": "goose가 {toolName}을 호출하려고 합니다. 허용하시겠습니까?"
   },
+  "transcriptWindow.hiddenMessages": {
+    "defaultMessage": "성능을 위해 {count, plural, other {#개의 메시지}}를 숨겼습니다"
+  },
+  "transcriptWindow.loadEarlier": {
+    "defaultMessage": "이전 메시지 불러오기"
+  },
   "updateSection.autoDownload": {
     "defaultMessage": "goose가 백그라운드에서 업데이트를 다운로드하며, 종료하거나 다시 시작할 때 설치합니다."
   },

--- a/ui/desktop/src/i18n/messages/ms.json
+++ b/ui/desktop/src/i18n/messages/ms.json
@@ -4514,6 +4514,12 @@
   "toolConfirmation.gooseWouldLikeToCallWithName": {
     "defaultMessage": "Goose ingin memanggil {toolName}. Benarkan?"
   },
+  "transcriptWindow.hiddenMessages": {
+    "defaultMessage": "{count, plural, other {# mesej disembunyikan}} untuk prestasi"
+  },
+  "transcriptWindow.loadEarlier": {
+    "defaultMessage": "Muat mesej terdahulu"
+  },
   "updateSection.autoDownload": {
     "defaultMessage": "Goose akan memuat turun kemas kini di latar belakang dan memasangnya pada kali seterusnya anda keluar atau mula semula."
   },

--- a/ui/desktop/src/i18n/messages/pt.json
+++ b/ui/desktop/src/i18n/messages/pt.json
@@ -4514,6 +4514,12 @@
   "toolConfirmation.gooseWouldLikeToCallWithName": {
     "defaultMessage": "O Goose gostaria de invocar {toolName}. Permitir?"
   },
+  "transcriptWindow.hiddenMessages": {
+    "defaultMessage": "{count, plural, one {# mensagem oculta} other {# mensagens ocultas}} por motivos de desempenho"
+  },
+  "transcriptWindow.loadEarlier": {
+    "defaultMessage": "Carregar mensagens anteriores"
+  },
   "updateSection.autoDownload": {
     "defaultMessage": "O Goose transferirá a atualização em segundo plano e instalá-la-á da próxima vez que sair ou reiniciar."
   },

--- a/ui/desktop/src/i18n/messages/ru.json
+++ b/ui/desktop/src/i18n/messages/ru.json
@@ -4514,6 +4514,12 @@
   "toolConfirmation.gooseWouldLikeToCallWithName": {
     "defaultMessage": "Goose хочет вызвать {toolName}. Разрешить?"
   },
+  "transcriptWindow.hiddenMessages": {
+    "defaultMessage": "{count, plural, one {# сообщение скрыто} few {# сообщения скрыты} many {# сообщений скрыто} other {# сообщений скрыто}} для производительности"
+  },
+  "transcriptWindow.loadEarlier": {
+    "defaultMessage": "Загрузить более ранние сообщения"
+  },
   "updateSection.autoDownload": {
     "defaultMessage": "Обновление будет автоматически скачано в фоновом режиме."
   },

--- a/ui/desktop/src/i18n/messages/tr.json
+++ b/ui/desktop/src/i18n/messages/tr.json
@@ -4514,6 +4514,12 @@
   "toolConfirmation.gooseWouldLikeToCallWithName": {
     "defaultMessage": "Goose, {toolName}'yi aramak istiyor. İzin vermek?"
   },
+  "transcriptWindow.hiddenMessages": {
+    "defaultMessage": "{count, plural, other {# mesaj gizlendi}} performans amaçlı"
+  },
+  "transcriptWindow.loadEarlier": {
+    "defaultMessage": "Daha önceki mesajları yükle"
+  },
   "updateSection.autoDownload": {
     "defaultMessage": "Güncelleme arka planda otomatik olarak indirilecektir."
   },

--- a/ui/desktop/src/i18n/messages/vi.json
+++ b/ui/desktop/src/i18n/messages/vi.json
@@ -4514,6 +4514,12 @@
   "toolConfirmation.gooseWouldLikeToCallWithName": {
     "defaultMessage": "Goose muốn gọi {toolName}. Cho phép?"
   },
+  "transcriptWindow.hiddenMessages": {
+    "defaultMessage": "{count, plural, other {# tin nhắn đã bị ẩn}} để tối ưu hiệu suất"
+  },
+  "transcriptWindow.loadEarlier": {
+    "defaultMessage": "Tải các tin nhắn trước đó"
+  },
   "updateSection.autoDownload": {
     "defaultMessage": "Goose sẽ tải bản cập nhật ở chế độ nền và cài đặt vào lần tiếp theo khi bạn thoát hoặc khởi động lại."
   },

--- a/ui/desktop/src/i18n/messages/zh-CN.json
+++ b/ui/desktop/src/i18n/messages/zh-CN.json
@@ -4514,6 +4514,12 @@
   "toolConfirmation.gooseWouldLikeToCallWithName": {
     "defaultMessage": "Goose 想调用 {toolName}，允许吗？"
   },
+  "transcriptWindow.hiddenMessages": {
+    "defaultMessage": "为提升性能，已隐藏 {count, plural, other {# 条消息}}"
+  },
+  "transcriptWindow.loadEarlier": {
+    "defaultMessage": "加载更早的消息"
+  },
   "updateSection.autoDownload": {
     "defaultMessage": "更新将在后台自动下载。"
   },

--- a/ui/desktop/src/i18n/messages/zh-TW.json
+++ b/ui/desktop/src/i18n/messages/zh-TW.json
@@ -4514,6 +4514,12 @@
   "toolConfirmation.gooseWouldLikeToCallWithName": {
     "defaultMessage": "Goose 想要呼叫 {toolName}。要允許嗎？"
   },
+  "transcriptWindow.hiddenMessages": {
+    "defaultMessage": "為提升效能，已隱藏 {count, plural, other {# 則訊息}}"
+  },
+  "transcriptWindow.loadEarlier": {
+    "defaultMessage": "載入較早的訊息"
+  },
   "updateSection.autoDownload": {
     "defaultMessage": "Goose 會在背景下載更新，並於您下次結束或重新啟動時安裝。"
   },


### PR DESCRIPTION
## Summary
- Opening a large session currently progressive-renders and keeps mounted the entire conversation; switching to a long chat is slow and stays expensive after first paint
- Closes #11348: keep all messages in memory, render only the first 20 and last 200 rows, with a divider between them ("N messages hidden for performance purposes") and a Load-earlier button that expands in chunks of 200
- Cmd/Ctrl+F expands everything so in-page find still sees hidden rows (matches today's expand-on-search behavior); the window re-arms if the transcript grows afterwards
- New `TranscriptWindow` wraps the existing `ProgressiveMessageList` (unchanged behavior when idle); PML gains an opt-in `insertAfter` node and a `rowContexts` override so tool chains, timestamps, and model-change banners that straddle the hidden gap still render correctly
- Expansion mounts instantly (so the live streaming tail is never unmounted), keeps the reader's scroll anchored, and session switches reset expansion during render (no stale window flash)

Non-goals (per the issue thread): server-side paging/replay changes (#11559), memory reduction, session-list perf (fixed in #11521).

Fixes #11348

## Test plan
- [x] `cd ui/desktop && pnpm test` — 855 passing, incl. 12 new `TranscriptWindow` tests: windowing boundaries (220/221), singular/plural divider count, chunked expansion, search-shortcut expansion (mac + non-mac), expansion reset on session switch, tail slide while streaming, full-transcript row contexts (no spurious Model-changed banner at the gap), divider DOM order between head and tail
- [x] 4 new `ProgressiveMessageList` tests for `insertAfter`: ordering, non-visible row at the index, out-of-range index, renderMessage null
- [x] `pnpm run lint:check` (typecheck + eslint + i18n) green; new i18n keys added to all 16 locales with ICU placeholders preserved
- [x] Manual: bundled this into a fork build and opened multi-thousand-message sessions — instant open at 220 rows, Load-earlier keeps scroll position, Cmd/F finds hidden text
