### PR TITLE
Stop clearing MCP OAuth credentials on transient refresh failures

### DIFF
--- a/crates/goose/src/oauth/mod.rs
+++ b/crates/goose/src/oauth/mod.rs
@@ -302,6 +302,48 @@ fn build_authorization_request(
     request
 }
 
+async fn credentials_replaced_since(
+    credential_store: &GooseCredentialStore,
+    attempted_refresh_token: Option<&str>,
+) -> bool {
+    match credential_store.load().await {
+        Ok(Some(current)) => {
+            current.token_response.as_ref().and_then(|response| {
+                response
+                    .refresh_token()
+                    .map(|token| token.secret().as_str())
+            }) != attempted_refresh_token
+        }
+        _ => false,
+    }
+}
+
+/// Try to build an authorization manager from credentials another goose
+/// process stored after rotating the refresh token, so a lost refresh race
+/// does not force an interactive re-authorization.
+async fn reuse_rotated_credentials(
+    mcp_server_url: &String,
+    credential_store: &GooseCredentialStore,
+    static_client: Option<&StaticOAuthClientConfig>,
+) -> Result<Option<AuthorizationManager>, anyhow::Error> {
+    let mut auth_manager = AuthorizationManager::new(mcp_server_url).await?;
+    auth_manager.set_credential_store(credential_store.clone());
+
+    let stored_credentials = credential_store.load().await?;
+    if !auth_manager.initialize_from_store().await? {
+        return Ok(None);
+    }
+    let stored_credentials = stored_credentials
+        .as_ref()
+        .ok_or_else(|| anyhow::anyhow!("OAuth credentials disappeared during startup"))?;
+
+    configure_static_client(&mut auth_manager, static_client, mcp_server_url)?;
+    if access_token_needs_refresh(stored_credentials) {
+        return Ok(None);
+    }
+    Ok(Some(auth_manager))
+}
+
 pub async fn oauth_flow(
     mcp_server_url: &String,
     name: &String,
@@ -319,11 +361,20 @@ pub async fn oauth_flow_with_challenge(
     let env_client = env_static_oauth_client();
     let static_client = static_client.or(env_client.as_ref());
     let credential_store = GooseCredentialStore::new(name.clone());
+    let mut keep_stored_credentials = false;
     let mut auth_manager = AuthorizationManager::new(mcp_server_url).await?;
     auth_manager.set_credential_store(credential_store.clone());
 
     let stored_credentials = credential_store.load().await?;
     let previous_requested_scopes = credential_store.load_requested_scopes()?;
+    let attempted_refresh_token = stored_credentials
+        .as_ref()
+        .and_then(|stored| stored.token_response.as_ref())
+        .and_then(|response| {
+            response
+                .refresh_token()
+                .map(|token| token.secret().to_string())
+        });
     let previously_granted_scopes = stored_credentials
         .as_ref()
         .map(|stored| stored.granted_scopes.clone())
@@ -396,16 +447,56 @@ pub async fn oauth_flow_with_challenge(
                     return Ok(auth_manager);
                 }
                 Err(e) => {
-                    warn!(
-                        "[OAuth:{}] Token refresh failed: {} - clearing stored credentials and falling back to browser auth",
-                        name, e
-                    );
+                    let definitive_rejection = matches!(e, AuthError::TokenRefreshRejected(_));
+                    if definitive_rejection
+                        && credentials_replaced_since(
+                            &credential_store,
+                            attempted_refresh_token.as_deref(),
+                        )
+                        .await
+                    {
+                        // Another goose process (the desktop and CLI share
+                        // the credential store) refreshed first and rotated
+                        // the refresh token: our rejection is stale, so pick
+                        // up the replacement instead of clobbering it.
+                        warn!(
+                            "[OAuth:{}] Refresh token rejected but stored credentials were replaced by another goose process; retrying with them",
+                            name
+                        );
+                        if let Some(rotated_manager) = reuse_rotated_credentials(
+                            mcp_server_url,
+                            &credential_store,
+                            static_client,
+                        )
+                        .await?
+                        {
+                            return Ok(rotated_manager);
+                        }
+                        keep_stored_credentials = true;
+                    } else if definitive_rejection {
+                        warn!(
+                            "[OAuth:{}] Token refresh rejected: {} - clearing stored credentials and falling back to browser auth",
+                            name, e
+                        );
+                    } else {
+                        // Transient failure (server 5xx, network error): the
+                        // stored refresh token may still be valid. Keep it so
+                        // the next session can refresh again; only this
+                        // session falls back to browser auth.
+                        warn!(
+                            "[OAuth:{}] Token refresh failed: {} - keeping stored credentials, falling back to browser auth",
+                            name, e
+                        );
+                        keep_stored_credentials = true;
+                    }
                 }
             }
         }
 
-        if let Err(e) = credential_store.clear().await {
-            warn!("[OAuth:{}] error clearing bad credentials: {}", name, e);
+        if !keep_stored_credentials {
+            if let Err(e) = credential_store.clear().await {
+                warn!("[OAuth:{}] error clearing bad credentials: {}", name, e);
+            }
         }
     }
 

--- a/crates/goose/src/oauth/persist.rs
+++ b/crates/goose/src/oauth/persist.rs
@@ -1,7 +1,7 @@
 use rmcp::transport::auth::{AuthError, CredentialStore, StoredCredentials};
 use serde::{Deserialize, Serialize};
 
-use crate::config::Config;
+use crate::config::{Config, ConfigError};
 
 #[derive(Serialize, Deserialize)]
 struct PersistedCredentials {
@@ -36,7 +36,16 @@ impl GooseCredentialStore {
 
         match config.get_secret::<PersistedCredentials>(&key) {
             Ok(credentials) => Ok(Some(credentials)),
-            Err(_) => Ok(None),
+            Err(ConfigError::NotFound(_)) => Ok(None),
+            Err(e) => {
+                tracing::warn!(
+                    "[OAuth:{}] failed to read stored credentials for key {}: {}",
+                    self.name,
+                    key,
+                    e
+                );
+                Ok(None)
+            }
         }
     }
 

--- a/crates/goose/tests/oauth_stored_credentials_test.rs
+++ b/crates/goose/tests/oauth_stored_credentials_test.rs
@@ -1,0 +1,234 @@
+use goose::oauth::{oauth_flow, GooseCredentialStore, StaticOAuthClientConfig};
+use rmcp::transport::auth::{CredentialStore, OAuthTokenResponse, StoredCredentials};
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+use wiremock::matchers::{body_string_contains, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn now_epoch() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+}
+
+fn token_response(access_token: &str, refresh_token: &str) -> OAuthTokenResponse {
+    serde_json::from_value(serde_json::json!({
+        "access_token": access_token,
+        "token_type": "bearer",
+        "expires_in": 3600,
+        "refresh_token": refresh_token,
+    }))
+    .expect("valid token response JSON")
+}
+
+fn expired_credentials() -> StoredCredentials {
+    StoredCredentials::new(
+        "test-client".to_string(),
+        Some(token_response(
+            "expired-access-token",
+            "expired-refresh-token",
+        )),
+        vec![],
+        Some(now_epoch() - 7200),
+    )
+}
+
+fn fresh_credentials(access_token: &str, refresh_token: &str) -> StoredCredentials {
+    StoredCredentials::new(
+        "test-client".to_string(),
+        Some(token_response(access_token, refresh_token)),
+        vec![],
+        Some(now_epoch()),
+    )
+}
+
+async fn seed_expired_credentials(store: &GooseCredentialStore) {
+    store.clear().await.unwrap();
+    store
+        .save_with_requested_scopes(expired_credentials(), Some(vec![]))
+        .unwrap();
+}
+
+fn static_client() -> StaticOAuthClientConfig {
+    StaticOAuthClientConfig {
+        client_id: "test-client".to_string(),
+        client_secret: None,
+        scopes: vec![],
+    }
+}
+
+async fn mount_authorization_server_metadata(server: &MockServer) {
+    Mock::given(method("GET"))
+        .and(path("/.well-known/oauth-authorization-server"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "issuer": server.uri(),
+            "authorization_endpoint": format!("{}/authorize", server.uri()),
+            "token_endpoint": format!("{}/token", server.uri()),
+            "response_types_supported": ["code"],
+            "grant_types_supported": ["authorization_code", "refresh_token"],
+            "code_challenge_methods_supported": ["S256"],
+            "token_endpoint_auth_methods_supported": ["none"],
+        })))
+        .mount(server)
+        .await;
+}
+
+/// The browser leg of the flow fails fast: `GOOSE_OAUTH_AUTOMATIC_CALLBACK`
+/// makes goose request the authorization URL directly, and a 500 response
+/// (no redirect) aborts the flow without opening a browser.
+async fn mount_failing_authorization_endpoint(server: &MockServer, expected_hits: u64) {
+    Mock::given(method("GET"))
+        .and(path("/authorize"))
+        .respond_with(ResponseTemplate::new(500))
+        .expect(expected_hits)
+        .mount(server)
+        .await;
+}
+
+async fn refresh_token_of(store: &GooseCredentialStore) -> Option<String> {
+    store
+        .load()
+        .await
+        .unwrap()
+        .and_then(|credentials| credentials.token_response)
+        .and_then(|response| {
+            use oauth2::TokenResponse;
+            response.refresh_token().map(|t| t.secret().to_string())
+        })
+}
+
+#[tokio::test]
+async fn oauth_refresh_failures_preserve_credentials_correctly() {
+    let temp_dir = tempfile::tempdir().expect("tempdir");
+    let root = temp_dir.path().to_string_lossy().to_string();
+    let _guard = env_lock::lock_env([
+        ("GOOSE_PATH_ROOT", Some(root.as_str())),
+        ("GOOSE_DISABLE_KEYRING", Some("1")),
+        ("GOOSE_ADDITIONAL_CONFIG_FILES", None::<&str>),
+        ("GOOSE_OAUTH_CALLBACK_TIMEOUT", Some("5")),
+        ("GOOSE_OAUTH_AUTOMATIC_CALLBACK", Some("1")),
+        ("GOOSE_MCP_OAUTH_CLIENT_ID", None::<&str>),
+        ("GOOSE_MCP_OAUTH_CLIENT_SECRET", None::<&str>),
+    ]);
+
+    let name = "test-oauth-ext".to_string();
+    let store = GooseCredentialStore::new(name.clone());
+    let server = MockServer::start().await;
+    let mcp_url = format!("{}/mcp", server.uri());
+    let client = static_client();
+
+    // Scenario 1: a transient refresh failure (server 5xx) must keep the
+    // stored credentials so the next session can refresh again, instead of
+    // wiping them and forcing browser re-authentication on every session.
+    seed_expired_credentials(&store).await;
+    mount_authorization_server_metadata(&server).await;
+    mount_failing_authorization_endpoint(&server, 1).await;
+    Mock::given(method("POST"))
+        .and(path("/token"))
+        .and(body_string_contains("grant_type=refresh_token"))
+        .respond_with(ResponseTemplate::new(503).set_body_string("upstream unavailable"))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let result = oauth_flow(&mcp_url, &name, Some(&client)).await;
+    assert!(
+        result.is_err(),
+        "browser auth cannot complete in this scenario"
+    );
+    assert_eq!(
+        refresh_token_of(&store).await.as_deref(),
+        Some("expired-refresh-token"),
+        "transient refresh failures must not clear stored credentials"
+    );
+    server.reset().await;
+
+    // Scenario 2: a successful refresh stores the refreshed credentials and
+    // never touches the authorization endpoint.
+    seed_expired_credentials(&store).await;
+    mount_authorization_server_metadata(&server).await;
+    mount_failing_authorization_endpoint(&server, 0).await;
+    Mock::given(method("POST"))
+        .and(path("/token"))
+        .and(body_string_contains("grant_type=refresh_token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "access_token": "refreshed-access-token",
+            "token_type": "bearer",
+            "expires_in": 3600,
+            "refresh_token": "refreshed-refresh-token",
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let manager = oauth_flow(&mcp_url, &name, Some(&client))
+        .await
+        .expect("refresh must succeed");
+    server.verify().await;
+    assert!(manager.get_access_token().await.is_ok());
+    assert_eq!(
+        refresh_token_of(&store).await.as_deref(),
+        Some("refreshed-refresh-token"),
+        "refreshed credentials must be persisted"
+    );
+    server.reset().await;
+
+    // Scenario 3: a definitive rejection (invalid_grant) with no concurrent
+    // rotation still clears the stored credentials.
+    seed_expired_credentials(&store).await;
+    mount_authorization_server_metadata(&server).await;
+    mount_failing_authorization_endpoint(&server, 1).await;
+    Mock::given(method("POST"))
+        .and(path("/token"))
+        .and(body_string_contains("grant_type=refresh_token"))
+        .respond_with(
+            ResponseTemplate::new(400).set_body_json(serde_json::json!({"error": "invalid_grant"})),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let result = oauth_flow(&mcp_url, &name, Some(&client)).await;
+    assert!(result.is_err());
+    assert!(
+        store.load().await.unwrap().is_none(),
+        "a rejected refresh token must be cleared"
+    );
+    server.reset().await;
+
+    // Scenario 4: a definitive rejection after ANOTHER goose process already
+    // rotated the stored refresh token must reuse the replacement instead of
+    // clobbering it (desktop + CLI share one credential store).
+    seed_expired_credentials(&store).await;
+    mount_authorization_server_metadata(&server).await;
+    mount_failing_authorization_endpoint(&server, 0).await;
+    let rotation_store = Arc::new(store.clone());
+    let rotating_rejection = move |_: &wiremock::Request| {
+        rotation_store
+            .save_with_requested_scopes(
+                fresh_credentials("rotated-access-token", "rotated-refresh-token"),
+                Some(vec![]),
+            )
+            .unwrap();
+        ResponseTemplate::new(400).set_body_json(serde_json::json!({"error": "invalid_grant"}))
+    };
+    Mock::given(method("POST"))
+        .and(path("/token"))
+        .and(body_string_contains("grant_type=refresh_token"))
+        .respond_with(rotating_rejection)
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let manager = oauth_flow(&mcp_url, &name, Some(&client))
+        .await
+        .expect("rotated credentials from another process must be reused");
+    server.verify().await;
+    assert_eq!(
+        refresh_token_of(&store).await.as_deref(),
+        Some("rotated-refresh-token"),
+        "credentials refreshed by another process must survive a lost refresh race"
+    );
+    drop(manager);
+}


### PR DESCRIPTION
## Summary
- Every new goose session could trigger a fresh interactive OAuth authorization for MCP servers: any token-refresh failure — including transient ones like an authorization-server 5xx or a network error — cleared the stored credentials (access *and* refresh token), so the next session had nothing to reuse and fell back to browser auth again.
- Root cause: `oauth_flow_with_challenge` treated all refresh errors identically, ignoring rmcp's distinction between `TokenRefreshRejected` (definitive `invalid_grant`) and `TokenRefreshFailed` (transient/retryable).
- A second variant hit setups running multiple goose processes (desktop `goose serve` + CLI share one credential store): with servers that rotate refresh tokens on every use (e.g. Atlassian/Trello, Composio), the process that loses the refresh race got `invalid_grant` and cleared the *winner's* freshly stored credentials. Goose now detects that the stored refresh token changed since the attempt began and reuses the replacement instead of clobbering it.
- Stored-credential read errors in `GooseCredentialStore` were silently mapped to "no credentials"; they are now logged.

## Test plan
- [ ] CI passes
- [x] `cargo test -p goose --test oauth_stored_credentials_test` — new regression test covering: transient 5xx preserves stored credentials (fails on `main`, passes with the fix), successful refresh persists rotated tokens without touching the authorization endpoint, definitive `invalid_grant` still clears, and a lost rotation race reuses the other process's credentials
- [x] `cargo clippy --all-targets -- -D warnings`, `cargo fmt`


Closes #12016
