### PR TITLE
fix(session): normalize stale timestamp before max comparison on session resume

### DIFF
--- a/crates/goose/src/session/session_manager.rs
+++ b/crates/goose/src/session/session_manager.rs
@@ -1920,7 +1920,19 @@ impl SessionStorage {
                 .bind(session_id)
                 .fetch_one(&mut *tx)
                 .await?;
-        let created = message.created.max(latest.unwrap_or(message.created));
+        // Normalize the latest timestamp to seconds before comparing, to
+        // prevent stale or mismatched-unit values (e.g. millisecond timestamps
+        // from older Goose versions) from clobbering new message timestamps.
+        let latest_normalized = latest
+            .map(|t| {
+                if t > MILLISECOND_TIMESTAMP_THRESHOLD {
+                    t / 1000
+                } else {
+                    t
+                }
+            })
+            .unwrap_or(message.created);
+        let created = message.created.max(latest_normalized);
 
         let message_id = message
             .id
@@ -4955,5 +4967,69 @@ mod tests {
                 .await
                 .unwrap();
         assert_eq!(remaining, 0);
+    }
+
+    #[tokio::test]
+    async fn test_add_message_normalizes_stale_millisecond_timestamp() {
+        // When a session contains millisecond-scale timestamps from an older
+        // Goose version, the MAX(created_timestamp) returns a 13-digit value.
+        // Without normalization, .max() picks this stale ms value over the
+        // current time (seconds), and every new message gets stamped with it.
+        // With normalization, the ms value is converted to seconds before
+        // comparison, so the new message keeps its correct current timestamp.
+        let temp_dir = TempDir::new().unwrap();
+        let sm = SessionManager::new(temp_dir.path().to_path_buf());
+
+        let session = sm
+            .create_session(
+                PathBuf::from("/tmp/test-stale-ts"),
+                "test-session".to_string(),
+                SessionType::User,
+                GooseMode::default(),
+            )
+            .await
+            .unwrap();
+
+        // Insert a message with a millisecond timestamp (simulating old Goose)
+        add_message_at_millis(&sm, &session.id, "old message", "2025-01-01T00:00:00Z").await;
+
+        // Verify the old message has a ms-scale timestamp
+        let pool = sm.storage().pool().await.unwrap();
+        let old_ts: i64 =
+            sqlx::query_scalar("SELECT created_timestamp FROM messages WHERE session_id = ?")
+                .bind(&session.id)
+                .fetch_one(pool)
+                .await
+                .unwrap();
+        assert!(
+            old_ts > MILLISECOND_TIMESTAMP_THRESHOLD,
+            "old message should have ms-scale timestamp"
+        );
+
+        // Now add a new message normally (current time in seconds)
+        sm.add_message(&session.id, &Message::user().with_text("new message"))
+            .await
+            .unwrap();
+
+        // The new message's created_timestamp should be in seconds, not the
+        // stale ms value from the old message.
+        let pool = sm.storage().pool().await.unwrap();
+        let timestamps: Vec<i64> = sqlx::query_scalar(
+            "SELECT created_timestamp FROM messages WHERE session_id = ? ORDER BY id",
+        )
+        .bind(&session.id)
+        .fetch_all(pool)
+        .await
+        .unwrap();
+
+        assert_eq!(timestamps.len(), 2);
+        // Old message: ms-scale (from add_message_at_millis)
+        assert!(timestamps[0] > MILLISECOND_TIMESTAMP_THRESHOLD);
+        // New message: seconds-scale (not clobbered by the stale ms value)
+        assert!(
+            timestamps[1] < MILLISECOND_TIMESTAMP_THRESHOLD,
+            "new message timestamp should be in seconds, not clobbered by stale ms value: {}",
+            timestamps[1]
+        );
     }
 }


### PR DESCRIPTION
Fixes #12003

## Summary

When a session contains millisecond-scale timestamps from an older Goose version, `MAX(created_timestamp)` returns a 13-digit value. The `.max()` comparison with the current time (seconds, 10 digits) always picks the larger ms value, stamping every new message with the stale timestamp. The UI sorts by this column, hiding recent messages and making them appear lost.

- Root cause: `message.created.max(latest)` compares seconds and milliseconds without normalizing, so stale ms values always win
- Fix: normalize the `latest` value to seconds using the existing `MILLISECOND_TIMESTAMP_THRESHOLD` before the `.max()` comparison

## What this changes

- `crates/goose/src/session/session_manager.rs`: normalizes `latest` from milliseconds to seconds before comparing with `message.created`
- Uses the existing `MILLISECOND_TIMESTAMP_THRESHOLD` constant already defined in the same file
- No changes to how timestamps are stored or read elsewhere

## Testing

- `cargo test -p goose --lib -- test_add_message_normalizes_stale_millisecond` passes
- New test: `test_add_message_normalizes_stale_millisecond_timestamp` verifies that a new message added to a session with ms-scale timestamps gets a correct seconds-scale timestamp instead of the stale ms value
- `cargo fmt --check` passes