### PR TITLE
docs: add Pixelesq to the MCP servers directory

### DIFF
--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -827,6 +827,18 @@
       "required": false
     }
   ]
+},
+{
+  "id": "pixelesq",
+  "name": "Pixelesq",
+  "description": "Build and manage your Pixelesq website: pages, sections, content, SEO and analytics, with every edit saved as a draft until you publish",
+  "url": "https://mcp.pixelesq.app/mcp",
+  "link": "https://www.pixelesq.com/docs/integrations/claude",
+  "installation_notes": "Remote server with OAuth sign-in. Add it as a Streamable HTTP extension with the URL above and sign in with your Pixelesq account when prompted.",
+  "is_builtin": false,
+  "endorsed": false,
+  "environmentVariables": [],
+  "type": "streamable-http"
 }
 
 ]


### PR DESCRIPTION
Adds Pixelesq (https://www.pixelesq.com), a remote Streamable HTTP MCP server for building and managing Pixelesq websites: pages, sections, content, SEO and analytics, with every edit saved as a draft until the user publishes.

URL: `https://mcp.pixelesq.app/mcp`, OAuth 2.1 sign-in (PKCE, dynamic client registration). No environment variables. Docs: https://www.pixelesq.com/docs/integrations/claude