### PR TITLE
fix(moonshot): map provider name to moonshotai for canonical model lookup

### DIFF
--- a/crates/goose-provider-types/src/canonical/name_builder.rs
+++ b/crates/goose-provider-types/src/canonical/name_builder.rs
@@ -51,6 +51,7 @@ pub fn map_provider_name(provider: &str) -> &str {
         "gemini_oauth" => "google",
         "databricks_v2" => "databricks",
         "zhipu" => "zhipuai",
+        "moonshot" => "moonshotai",
         "novita" => "novita-ai",
         "opencode_go" => "opencode-go",
         "opencode_zen" => "opencode",
@@ -353,6 +354,14 @@ mod tests {
         assert_eq!(
             map_to_canonical_model("opencode_zen", "kimi-k3", r),
             Some("opencode/kimi-k3".to_string())
+        );
+        assert_eq!(
+            map_to_canonical_model("moonshot", "kimi-k3", r),
+            Some("moonshotai/kimi-k3".to_string())
+        );
+        assert_eq!(
+            map_to_canonical_model("moonshot", "kimi-k2.6", r),
+            Some("moonshotai/kimi-k2.6".to_string())
         );
 
         // === OpenRouter ===

--- a/crates/goose-provider-types/src/model.rs
+++ b/crates/goose-provider-types/src/model.rs
@@ -811,6 +811,17 @@ mod tests {
         }
 
         #[test]
+        fn restores_vision_support_for_moonshot_provider() {
+            let _guard = env_lock::lock_env([
+                ("GOOSE_MAX_TOKENS", None::<&str>),
+                ("GOOSE_CONTEXT_LIMIT", None::<&str>),
+            ]);
+            let config = ModelConfig::new("kimi-k3").with_canonical_limits("moonshot");
+            assert_eq!(config.supports_vision, Some(true));
+            assert_eq!(config.reasoning, Some(true));
+        }
+
+        #[test]
         fn resolves_claude_sonnet_5_on_aws_bedrock() {
             let _guard = env_lock::lock_env([
                 ("GOOSE_MAX_TOKENS", None::<&str>),


### PR DESCRIPTION
Fixes: #11814

## Summary

The Moonshot provider drops image attachments, answering `[image omitted: model does not support vision]` for `kimi-k3` even though the model accepts images.

Goose names this provider `moonshot`, while the canonical model registry keys its models under `moonshotai`. `map_provider_name()` lacks a mapping between the two, so canonical lookup for `kimi-k3` finds nothing; `supports_vision` is `None`, and the OpenAI chat-completions formatter treats `None` as "no vision" and replaces the image with a placeholder.

Add `"moonshot" => "moonshotai"` to `map_provider_name()`, following the `xai` and `zhipu` entries. The registry lists `moonshotai/kimi-k3` with `modalities.input: [text, image, video]`, and the China endpoint entry (`moonshotai-cn`) carries the same modality data, so one mapping covers both.

### Testing

- `cargo test -p goose-provider-types` — 605 unit tests and 8 integration tests pass.
- `cargo fmt --check -p goose-provider-types` — clean.
- `cargo clippy -p goose-provider-types --all-targets -- -D warnings` — clean.

New regression tests:

- `map_to_canonical_model("moonshot", "kimi-k3")` resolves to `moonshotai/kimi-k3`, and `kimi-k2.6` resolves to `moonshotai/kimi-k2.6`, so the mapping is not a one-model special case.
- `ModelConfig::new("kimi-k3").with_canonical_limits("moonshot")` fills in `supports_vision` and `reasoning`.
- `test_moonshot_image_reaches_the_request_payload` builds a request from that config and asserts the user message carries an `image_url` part. The test fails without the mapping, because the image becomes a placeholder.